### PR TITLE
[fix] Preserve route completion after member HITL resume

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5882,12 +5882,14 @@ def _prepare_member_hitl_continuation(
     run_response: TeamRunOutput,
     run_messages: RunMessages,
     member_results: List[str],
-) -> None:
+    resolved_member_run_ids: set[str],
+) -> Optional[str]:
     """Prepare run_response and run_messages for member HITL continuation.
 
     Updates the delegate_task_to_member/delegate_task_to_members tool result in both
-    run_response.tools and the corresponding message in run_messages. Also resets run
-    state for continuation.
+    run_response.tools and the corresponding message in run_messages. The resolved
+    member run IDs prevent an older delegate from ending this continuation. Also
+    resets run state for continuation.
 
     This is called after the member agent's HITL has been resolved and we need to
     continue the team run with the member's results.
@@ -5895,22 +5897,31 @@ def _prepare_member_hitl_continuation(
 
     continuation_message = _build_continuation_message(member_results)
 
-    target_tool_call_ids: set[str] = set()
-    for tool in run_response.tools or []:
-        if tool.tool_name in {
-            "delegate_task_to_member",
-            "delegate_task_to_members",
-        } and _tool_result_requires_human_input(tool):
-            tool.result = continuation_message
-            if tool.tool_call_id is not None:
-                target_tool_call_ids.add(tool.tool_call_id)
+    delegate_tools = [
+        tool
+        for tool in run_response.tools or []
+        if tool.tool_name in {"delegate_task_to_member", "delegate_task_to_members"}
+        and _tool_result_requires_human_input(tool)
+    ]
+    resolved_delegate_tools = [tool for tool in delegate_tools if tool.child_run_id in resolved_member_run_ids]
+    target_tools = resolved_delegate_tools if resolved_member_run_ids else delegate_tools[-1:]
 
-    if not target_tool_call_ids:
-        for tool in run_response.tools or []:
+    target_tool_call_ids: set[str] = set()
+    stop_after_tool_call_result: Optional[str] = None
+    for tool in target_tools:
+        tool.result = continuation_message
+        if tool in resolved_delegate_tools and tool.stop_after_tool_call:
+            stop_after_tool_call_result = continuation_message
+        if tool.tool_call_id is not None:
+            target_tool_call_ids.add(tool.tool_call_id)
+
+    if not resolved_member_run_ids and not target_tool_call_ids:
+        for tool in reversed(run_response.tools or []):
             if _tool_result_requires_human_input(tool):
                 tool.result = continuation_message
                 if tool.tool_call_id is not None:
                     target_tool_call_ids.add(tool.tool_call_id)
+                break
 
     # Update the existing tool result messages in run_messages
     if target_tool_call_ids:
@@ -5921,6 +5932,7 @@ def _prepare_member_hitl_continuation(
     # Reset run state for continuation
     run_response.status = RunStatus.running
     run_response.content = None
+    return stop_after_tool_call_result
 
 
 async def _ahandle_model_response_for_continue(
@@ -6641,8 +6653,12 @@ def continue_run_dispatch(
 
     # Route member requirements to member agents
     member_results: List[str] = []
+    resolved_member_run_ids: set[str] = set()
     if has_member:
         member_reqs = [r for r in (run_response.requirements or []) if getattr(r, "member_agent_id", None) is not None]
+        resolved_member_run_ids = {
+            member_run_id for req in member_reqs if (member_run_id := getattr(req, "member_run_id", None)) is not None
+        }
         team_level_reqs = [r for r in (run_response.requirements or []) if getattr(r, "member_agent_id", None) is None]
         # Set only member reqs for routing; _route_requirements_to_members
         # may append newly propagated reqs via _propagate_member_pause (chained HITL).
@@ -6680,6 +6696,7 @@ def continue_run_dispatch(
                 run_response=run_response,
                 member_event_stream=member_event_stream,
                 member_results=member_results,
+                resolved_member_run_ids=resolved_member_run_ids,
                 original_member_req_ids=original_member_req_ids,
                 team_level_reqs=team_level_reqs,
                 has_team_level=has_team_level,
@@ -6829,7 +6846,9 @@ def continue_run_dispatch(
         )
 
         # Prepare for member HITL continuation
-        _prepare_member_hitl_continuation(run_response, run_messages, member_results)
+        precomputed_response_content = _prepare_member_hitl_continuation(
+            run_response, run_messages, member_results, resolved_member_run_ids
+        )
 
         log_debug(f"Team Continue Run (Member HITL): {run_response.run_id}", center=True)
 
@@ -6847,6 +6866,7 @@ def continue_run_dispatch(
                 yield_run_output=opts.yield_run_output,
                 debug_mode=debug_mode,
                 background_tasks=background_tasks,
+                precomputed_response_content=precomputed_response_content,
                 **kwargs,
             )
         else:
@@ -6861,6 +6881,7 @@ def continue_run_dispatch(
                 response_format=response_format,
                 debug_mode=debug_mode,
                 background_tasks=background_tasks,
+                precomputed_response_content=precomputed_response_content,
                 **kwargs,
             )
 
@@ -6875,6 +6896,7 @@ def _continue_run_dispatch_stream_with_member_events(
     run_response: TeamRunOutput,
     member_event_stream: Iterator[Union[TeamRunOutputEvent, RunOutputEvent]],
     member_results: List[str],
+    resolved_member_run_ids: set[str],
     original_member_req_ids: set,
     team_level_reqs: list,
     has_team_level: bool,
@@ -7030,7 +7052,9 @@ def _continue_run_dispatch_stream_with_member_events(
             run_context=run_context,
         )
 
-        _prepare_member_hitl_continuation(run_response, run_messages, member_results)
+        precomputed_response_content = _prepare_member_hitl_continuation(
+            run_response, run_messages, member_results, resolved_member_run_ids
+        )
 
         log_debug(f"Team Continue Run (Member HITL): {run_response.run_id}", center=True)
 
@@ -7047,6 +7071,7 @@ def _continue_run_dispatch_stream_with_member_events(
             yield_run_output=opts.yield_run_output,
             debug_mode=debug_mode,
             background_tasks=background_tasks,
+            precomputed_response_content=precomputed_response_content,
             **kwargs,
         )
         return
@@ -7069,6 +7094,7 @@ def _continue_run(
     response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
+    precomputed_response_content: Optional[str] = None,
     **kwargs: Any,
 ) -> TeamRunOutput:
     """Continue a paused team run (sync, non-streaming).
@@ -7110,53 +7136,56 @@ def _continue_run(
             try:
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # Generate model response
-                model_response: ModelResponse = call_model_with_fallback(
-                    team.model,
-                    team.fallback_config,
-                    messages=run_messages.messages,
-                    response_format=response_format,
-                    tools=tools,
-                    tool_choice=team.tool_choice,
-                    tool_call_limit=team.tool_call_limit,
-                    run_response=run_response,
-                    send_media_to_model=team.send_media_to_model,
-                    compression_manager=team.compression_manager if team.compress_tool_results else None,
-                    after_tool_results=build_team_after_tool_results_callback(
-                        team, run_response, session, run_messages, run_context
-                    ),
-                )
-
-                raise_if_cancelled(run_response.run_id)  # type: ignore
-
-                # Parse with output/parser models if needed
-                parse_response_with_output_model(team, model_response, run_messages, run_response=run_response)
-                parse_response_with_parser_model(
-                    team, model_response, run_messages, run_context=run_context, run_response=run_response
-                )
-
-                # Update run response
-                _update_run_response(
-                    team,
-                    model_response=model_response,
-                    run_response=run_response,
-                    run_messages=run_messages,
-                    run_context=run_context,
-                )
-
-                # Check for new pauses (team-level tools or member propagation)
-                if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
-                    from agno.team import _hooks
-
-                    return _hooks.handle_team_run_paused(
-                        team, run_response=run_response, session=session, run_context=run_context
+                if precomputed_response_content is None:
+                    # Generate model response
+                    model_response: ModelResponse = call_model_with_fallback(
+                        team.model,
+                        team.fallback_config,
+                        messages=run_messages.messages,
+                        response_format=response_format,
+                        tools=tools,
+                        tool_choice=team.tool_choice,
+                        tool_call_limit=team.tool_call_limit,
+                        run_response=run_response,
+                        send_media_to_model=team.send_media_to_model,
+                        compression_manager=team.compression_manager if team.compress_tool_results else None,
+                        after_tool_results=build_team_after_tool_results_callback(
+                            team, run_response, session, run_messages, run_context
+                        ),
                     )
 
-                # Convert to structured format
-                _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
+                    raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # Always add media to run_response for caller availability
-                store_media_util(run_response, model_response)
+                    # Parse with output/parser models if needed
+                    parse_response_with_output_model(team, model_response, run_messages, run_response=run_response)
+                    parse_response_with_parser_model(
+                        team, model_response, run_messages, run_context=run_context, run_response=run_response
+                    )
+
+                    # Update run response
+                    _update_run_response(
+                        team,
+                        model_response=model_response,
+                        run_response=run_response,
+                        run_messages=run_messages,
+                        run_context=run_context,
+                    )
+
+                    # Check for new pauses (team-level tools or member propagation)
+                    if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
+                        from agno.team import _hooks
+
+                        return _hooks.handle_team_run_paused(
+                            team, run_response=run_response, session=session, run_context=run_context
+                        )
+
+                    # Convert to structured format
+                    _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
+
+                    # Always add media to run_response for caller availability
+                    store_media_util(run_response, model_response)
+                else:
+                    run_response.content = precomputed_response_content
 
                 # Execute post-hooks
                 if team.post_hooks is not None:
@@ -7267,6 +7296,7 @@ def _continue_run_stream(
     yield_run_output: bool = False,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
+    precomputed_response_content: Optional[str] = None,
     **kwargs: Any,
 ) -> Iterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]:
     """Continue a paused team run (sync, streaming)."""
@@ -7297,87 +7327,90 @@ def _continue_run_stream(
 
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # Handle the updated tools (execute confirmed tools, etc.) with streaming
-                yield from _handle_team_tool_call_updates_stream(
-                    team,
-                    run_response=run_response,
-                    run_messages=run_messages,
-                    tools=tools,
-                    stream_events=stream_events,
-                )
-
-                # Stream model response
-                if team.output_model is None:
-                    for event in _handle_model_response_stream(
+                if precomputed_response_content is None:
+                    # Handle the updated tools (execute confirmed tools, etc.) with streaming
+                    yield from _handle_team_tool_call_updates_stream(
                         team,
-                        session=session,
                         run_response=run_response,
                         run_messages=run_messages,
                         tools=tools,
-                        response_format=response_format,
                         stream_events=stream_events,
-                        session_state=run_context.session_state,
-                        run_context=run_context,
-                    ):
-                        if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
-                            raise_if_cancelled(run_response.run_id)  # type: ignore
-                        yield event
-                else:
-                    from agno.run.team import IntermediateRunContentEvent, RunContentEvent
+                    )
 
-                    for event in _handle_model_response_stream(
-                        team,
-                        session=session,
-                        run_response=run_response,
-                        run_messages=run_messages,
-                        tools=tools,
-                        response_format=response_format,
-                        stream_events=stream_events,
-                        session_state=run_context.session_state,
-                        run_context=run_context,
-                    ):
-                        if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                    # Stream model response
+                    if team.output_model is None:
+                        for event in _handle_model_response_stream(
+                            team,
+                            session=session,
+                            run_response=run_response,
+                            run_messages=run_messages,
+                            tools=tools,
+                            response_format=response_format,
+                            stream_events=stream_events,
+                            session_state=run_context.session_state,
+                            run_context=run_context,
+                        ):
+                            if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                                raise_if_cancelled(run_response.run_id)  # type: ignore
+                            yield event
+                    else:
+                        from agno.run.team import IntermediateRunContentEvent, RunContentEvent
+
+                        for event in _handle_model_response_stream(
+                            team,
+                            session=session,
+                            run_response=run_response,
+                            run_messages=run_messages,
+                            tools=tools,
+                            response_format=response_format,
+                            stream_events=stream_events,
+                            session_state=run_context.session_state,
+                            run_context=run_context,
+                        ):
+                            if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                                raise_if_cancelled(run_response.run_id)  # type: ignore
+                            if isinstance(event, RunContentEvent):
+                                if stream_events:
+                                    yield IntermediateRunContentEvent(
+                                        content=event.content,
+                                        content_type=event.content_type,
+                                    )
+                            else:
+                                yield event
+
+                        for event in generate_response_with_output_model_stream(
+                            team,
+                            session=session,
+                            run_response=run_response,
+                            run_messages=run_messages,
+                            stream_events=stream_events,
+                        ):
                             raise_if_cancelled(run_response.run_id)  # type: ignore
-                        if isinstance(event, RunContentEvent):
-                            if stream_events:
-                                yield IntermediateRunContentEvent(
-                                    content=event.content,
-                                    content_type=event.content_type,
-                                )
-                        else:
                             yield event
 
-                    for event in generate_response_with_output_model_stream(
+                    raise_if_cancelled(run_response.run_id)  # type: ignore
+
+                    # Check for new pauses
+                    if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
+                        from agno.team import _hooks
+
+                        yield from _hooks.handle_team_run_paused_stream(
+                            team, run_response=run_response, session=session, run_context=run_context
+                        )
+                        if yield_run_output:
+                            yield run_response
+                        return
+
+                    # Parse response with parser model
+                    yield from parse_response_with_parser_model_stream(
                         team,
                         session=session,
                         run_response=run_response,
-                        run_messages=run_messages,
                         stream_events=stream_events,
-                    ):
-                        raise_if_cancelled(run_response.run_id)  # type: ignore
-                        yield event
-
-                raise_if_cancelled(run_response.run_id)  # type: ignore
-
-                # Check for new pauses
-                if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
-                    from agno.team import _hooks
-
-                    yield from _hooks.handle_team_run_paused_stream(
-                        team, run_response=run_response, session=session, run_context=run_context
+                        run_context=run_context,
                     )
-                    if yield_run_output:
-                        yield run_response
-                    return
-
-                # Parse response with parser model
-                yield from parse_response_with_parser_model_stream(
-                    team,
-                    session=session,
-                    run_response=run_response,
-                    stream_events=stream_events,
-                    run_context=run_context,
-                )
+                else:
+                    run_response.content = precomputed_response_content
 
                 # Content completed event
                 if stream_events:
@@ -8041,10 +8074,16 @@ async def _acontinue_run(
 
                 # Route member requirements
                 member_results: List[str] = []
+                resolved_member_run_ids: set[str] = set()
                 if has_member:
                     member_reqs = [
                         r for r in (run_response.requirements or []) if getattr(r, "member_agent_id", None) is not None
                     ]
+                    resolved_member_run_ids = {
+                        member_run_id
+                        for req in member_reqs
+                        if (member_run_id := getattr(req, "member_run_id", None)) is not None
+                    }
                     team_level_reqs = [
                         r for r in (run_response.requirements or []) if getattr(r, "member_agent_id", None) is None
                     ]
@@ -8164,22 +8203,27 @@ async def _acontinue_run(
                     )
 
                     # Prepare for member HITL continuation
-                    _prepare_member_hitl_continuation(run_response, run_messages, member_results)
+                    precomputed_response_content = _prepare_member_hitl_continuation(
+                        run_response, run_messages, member_results, resolved_member_run_ids
+                    )
 
                     log_debug(f"Team Continue Run (Member HITL): {run_response.run_id}", center=True)
 
-                    # Handle model response using shared helper
-                    paused_result = await _ahandle_model_response_for_continue(
-                        team,
-                        run_response=run_response,
-                        run_messages=run_messages,
-                        run_context=run_context,
-                        tools=_tools,
-                        team_session=team_session,
-                        response_format=response_format,
-                    )
-                    if paused_result is not None:
-                        return paused_result
+                    if precomputed_response_content is None:
+                        # Handle model response using shared helper
+                        paused_result = await _ahandle_model_response_for_continue(
+                            team,
+                            run_response=run_response,
+                            run_messages=run_messages,
+                            run_context=run_context,
+                            tools=_tools,
+                            team_session=team_session,
+                            response_format=response_format,
+                        )
+                        if paused_result is not None:
+                            return paused_result
+                    else:
+                        run_response.content = precomputed_response_content
 
                 # Post-hooks
                 if team.post_hooks is not None:
@@ -8468,10 +8512,16 @@ async def _acontinue_run_stream(
 
                 # Route member requirements
                 member_results: List[str] = []
+                resolved_member_run_ids: set[str] = set()
                 if has_member:
                     member_reqs = [
                         r for r in (run_response.requirements or []) if getattr(r, "member_agent_id", None) is not None
                     ]
+                    resolved_member_run_ids = {
+                        member_run_id
+                        for req in member_reqs
+                        if (member_run_id := getattr(req, "member_run_id", None)) is not None
+                    }
                     team_level_reqs = [
                         r for r in (run_response.requirements or []) if getattr(r, "member_agent_id", None) is None
                     ]
@@ -8683,7 +8733,9 @@ async def _acontinue_run_stream(
                     )
 
                     # Prepare for member HITL continuation
-                    _prepare_member_hitl_continuation(run_response, run_messages, member_results)
+                    precomputed_response_content = _prepare_member_hitl_continuation(
+                        run_response, run_messages, member_results, resolved_member_run_ids
+                    )
 
                     log_debug(f"Team Continue Run Stream (Member HITL): {run_response.run_id}", center=True)
 
@@ -8696,78 +8748,83 @@ async def _acontinue_run_stream(
                             store_events=team.store_events,
                         )
 
-                    # Stream model response
-                    if team.output_model is None:
-                        async for event in _ahandle_model_response_stream(
-                            team,
-                            session=team_session,
-                            run_response=run_response,
-                            run_messages=run_messages,
-                            tools=_tools,
-                            response_format=response_format,
-                            stream_events=stream_events,
-                            session_state=run_context.session_state,
-                            run_context=run_context,
-                        ):
-                            if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
-                                await araise_if_cancelled(run_response.run_id)  # type: ignore
-                            yield event
-                    else:
-                        from agno.run.team import IntermediateRunContentEvent, RunContentEvent
+                    if precomputed_response_content is None:
+                        # Stream model response
+                        if team.output_model is None:
+                            async for event in _ahandle_model_response_stream(
+                                team,
+                                session=team_session,
+                                run_response=run_response,
+                                run_messages=run_messages,
+                                tools=_tools,
+                                response_format=response_format,
+                                stream_events=stream_events,
+                                session_state=run_context.session_state,
+                                run_context=run_context,
+                            ):
+                                if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                                    await araise_if_cancelled(run_response.run_id)  # type: ignore
+                                yield event
+                        else:
+                            from agno.run.team import IntermediateRunContentEvent, RunContentEvent
 
-                        async for event in _ahandle_model_response_stream(
-                            team,
-                            session=team_session,
-                            run_response=run_response,
-                            run_messages=run_messages,
-                            tools=_tools,
-                            response_format=response_format,
-                            stream_events=stream_events,
-                            session_state=run_context.session_state,
-                            run_context=run_context,
-                        ):
-                            if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                            async for event in _ahandle_model_response_stream(
+                                team,
+                                session=team_session,
+                                run_response=run_response,
+                                run_messages=run_messages,
+                                tools=_tools,
+                                response_format=response_format,
+                                stream_events=stream_events,
+                                session_state=run_context.session_state,
+                                run_context=run_context,
+                            ):
+                                if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                                    await araise_if_cancelled(run_response.run_id)  # type: ignore
+                                if isinstance(event, RunContentEvent):
+                                    if stream_events:
+                                        yield IntermediateRunContentEvent(
+                                            content=event.content,
+                                            content_type=event.content_type,
+                                        )
+                                else:
+                                    yield event
+
+                            async for event in agenerate_response_with_output_model_stream(
+                                team,
+                                session=team_session,
+                                run_response=run_response,
+                                run_messages=run_messages,
+                                stream_events=stream_events,
+                            ):
                                 await araise_if_cancelled(run_response.run_id)  # type: ignore
-                            if isinstance(event, RunContentEvent):
-                                if stream_events:
-                                    yield IntermediateRunContentEvent(
-                                        content=event.content,
-                                        content_type=event.content_type,
-                                    )
-                            else:
                                 yield event
 
-                        async for event in agenerate_response_with_output_model_stream(
+                        # Check for new pauses
+                        if run_response.requirements and any(
+                            not req.is_resolved() for req in run_response.requirements
+                        ):
+                            from agno.team import _hooks
+
+                            async for item in _hooks.ahandle_team_run_paused_stream(
+                                team, run_response=run_response, session=team_session, run_context=run_context
+                            ):
+                                yield item
+                            if yield_run_output:
+                                yield run_response
+                            return
+
+                        # Parse response with parser model
+                        async for event in aparse_response_with_parser_model_stream(
                             team,
                             session=team_session,
                             run_response=run_response,
-                            run_messages=run_messages,
                             stream_events=stream_events,
+                            run_context=run_context,
                         ):
-                            await araise_if_cancelled(run_response.run_id)  # type: ignore
                             yield event
-
-                    # Check for new pauses
-                    if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
-                        from agno.team import _hooks
-
-                        async for item in _hooks.ahandle_team_run_paused_stream(
-                            team, run_response=run_response, session=team_session, run_context=run_context
-                        ):
-                            yield item
-                        if yield_run_output:
-                            yield run_response
-                        return
-
-                    # Parse response with parser model
-                    async for event in aparse_response_with_parser_model_stream(
-                        team,
-                        session=team_session,
-                        run_response=run_response,
-                        stream_events=stream_events,
-                        run_context=run_context,
-                    ):
-                        yield event
+                    else:
+                        run_response.content = precomputed_response_content
 
                 # Content completed
                 if stream_events:

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -736,12 +736,13 @@ class TestPrepareMemberHitlContinuation:
         tool = _make_tool_execution(
             tool_name="delegate_task_to_member",
             tool_call_id="tc-1",
+            child_run_id="member-run-1",
             result="Tool requires human input",
         )
         run_response = self._make_run_response_with_tools([tool])
         run_messages = self._make_run_messages(["tc-1"])
 
-        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"], {"member-run-1"})
 
         assert "requires human input" not in tool.result
         assert "Done" in tool.result
@@ -752,12 +753,13 @@ class TestPrepareMemberHitlContinuation:
         tool = _make_tool_execution(
             tool_name="delegate_task_to_members",
             tool_call_id="tc-1",
+            child_run_id="member-run-1",
             result="Tool requires human input",
         )
         run_response = self._make_run_response_with_tools([tool])
         run_messages = self._make_run_messages(["tc-1"])
 
-        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"], {"member-run-1"})
 
         assert "Done" in tool.result
 
@@ -767,17 +769,24 @@ class TestPrepareMemberHitlContinuation:
         tool1 = _make_tool_execution(
             tool_name="delegate_task_to_member",
             tool_call_id="tc-1",
+            child_run_id="member-run-1",
             result="requires human input",
         )
         tool2 = _make_tool_execution(
             tool_name="delegate_task_to_members",
             tool_call_id="tc-2",
+            child_run_id="member-run-2",
             result="requires human input",
         )
         run_response = self._make_run_response_with_tools([tool1, tool2])
         run_messages = self._make_run_messages(["tc-1", "tc-2"])
 
-        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+        _prepare_member_hitl_continuation(
+            run_response,
+            run_messages,
+            ["[Agent]: Done"],
+            {"member-run-1", "member-run-2"},
+        )
 
         assert "Done" in tool1.result
         assert "Done" in tool2.result
@@ -795,7 +804,7 @@ class TestPrepareMemberHitlContinuation:
         run_response = self._make_run_response_with_tools([tool])
         run_messages = self._make_run_messages(["tc-1"])
 
-        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"], set())
 
         assert "Done" in tool.result
 
@@ -805,6 +814,7 @@ class TestPrepareMemberHitlContinuation:
         tool = _make_tool_execution(
             tool_name="delegate_task_to_member",
             tool_call_id="tc-1",
+            child_run_id="member-run-1",
             result="requires human input",
         )
         run_response = self._make_run_response_with_tools([tool])
@@ -812,7 +822,7 @@ class TestPrepareMemberHitlContinuation:
         run_response.content = "old content"
         run_messages = self._make_run_messages(["tc-1"])
 
-        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"], {"member-run-1"})
 
         assert run_response.status == RunStatus.running
         assert run_response.content is None
@@ -820,6 +830,451 @@ class TestPrepareMemberHitlContinuation:
 
 # ===========================================================================
 # 14. Approval resolution fallback in continue_run_dispatch
+
+
+class TestMemberHitlStopAfterToolCall:
+    def test_prepare_returns_resolved_stopping_delegate_result(self):
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="tc-1",
+            child_run_id="member-run-1",
+            result="requires human input",
+            stop_after_tool_call=True,
+        )
+        run_response = TeamRunOutput(tools=[tool])
+        run_messages = MagicMock(messages=[])
+
+        result = _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"], {"member-run-1"})
+
+        assert result == tool.result
+        assert result == "Member results after human-in-the-loop resolution:\n[Agent]: Done"
+
+    def test_prepare_does_not_stop_for_non_terminal_delegate(self):
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="tc-1",
+            child_run_id="member-run-1",
+            result="requires human input",
+            stop_after_tool_call=False,
+        )
+        run_response = TeamRunOutput(tools=[tool])
+
+        result = _prepare_member_hitl_continuation(
+            run_response, MagicMock(messages=[]), ["[Agent]: Done"], {"member-run-1"}
+        )
+
+        assert result is None
+
+    def test_prepare_does_not_stop_for_fallback_tool(self):
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool = _make_tool_execution(
+            tool_name="some_other_tool",
+            tool_call_id="tc-1",
+            result="requires human input",
+            stop_after_tool_call=True,
+        )
+        run_response = TeamRunOutput(tools=[tool])
+
+        result = _prepare_member_hitl_continuation(
+            run_response, MagicMock(messages=[]), ["[Agent]: Done"], {"member-run-1"}
+        )
+
+        assert result is None
+
+    def test_prepare_ignores_stale_stopping_delegate(self):
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        stale_delegate = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="old-delegate",
+            child_run_id="old-member-run",
+            result="requires human input",
+            stop_after_tool_call=True,
+        )
+        active_delegate = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="active-delegate",
+            child_run_id="member-run-1",
+            result="requires human input",
+            stop_after_tool_call=False,
+        )
+        run_response = TeamRunOutput(tools=[stale_delegate, active_delegate])
+
+        result = _prepare_member_hitl_continuation(
+            run_response, MagicMock(messages=[]), ["[Agent]: Done"], {"member-run-1"}
+        )
+
+        assert result is None
+        assert stale_delegate.result == "requires human input"
+        assert "Done" in active_delegate.result
+
+    def test_prepare_does_not_fall_back_when_resolved_member_does_not_match(self):
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        unrelated_delegate = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="unrelated-delegate",
+            child_run_id="other-member-run",
+            result="requires human input",
+            stop_after_tool_call=True,
+        )
+        fallback_tool = _make_tool_execution(
+            tool_name="some_other_tool",
+            tool_call_id="fallback-tool",
+            result="requires human input",
+        )
+        run_response = TeamRunOutput(tools=[unrelated_delegate, fallback_tool])
+
+        result = _prepare_member_hitl_continuation(
+            run_response, MagicMock(messages=[]), ["[Agent]: Done"], {"member-run-1"}
+        )
+
+        assert result is None
+        assert unrelated_delegate.result == "requires human input"
+        assert fallback_tool.result == "requires human input"
+
+    def test_prepare_does_not_rewrite_fallback_for_matching_delegate_without_tool_call_id(self):
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        matching_delegate = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            child_run_id="member-run-1",
+            result="requires human input",
+            stop_after_tool_call=True,
+        )
+        fallback_tool = _make_tool_execution(
+            tool_name="some_other_tool",
+            tool_call_id="fallback-tool",
+            result="requires human input",
+        )
+        run_response = TeamRunOutput(tools=[matching_delegate, fallback_tool])
+
+        result = _prepare_member_hitl_continuation(
+            run_response, MagicMock(messages=[]), ["[Agent]: Done"], {"member-run-1"}
+        )
+
+        assert result == matching_delegate.result
+        assert "Done" in matching_delegate.result
+        assert fallback_tool.result == "requires human input"
+
+
+class TestPrecomputedMemberHitlContinuation:
+    @staticmethod
+    def _team():
+        return SimpleNamespace(
+            retries=0,
+            model=MagicMock(),
+            db=MagicMock(),
+            add_history_to_context=False,
+            parser_model=None,
+            post_hooks=None,
+            session_summary_manager=None,
+            events_to_skip=[],
+            store_events=False,
+        )
+
+    @staticmethod
+    def _async_case():
+        requirement = _make_requirement(requires_user_input=True)
+        requirement.member_agent_id = "member-1"
+        requirement.member_run_id = "member-run-1"
+        delegate = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="delegate-1",
+            child_run_id="member-run-1",
+            result="requires human input",
+            stop_after_tool_call=True,
+        )
+        run_response = TeamRunOutput(
+            run_id="run-1",
+            session_id="session-1",
+            status=RunStatus.paused,
+            messages=[],
+            requirements=[requirement],
+            tools=[delegate],
+        )
+        session = MagicMock(session_id="session-1", runs=[run_response])
+        run_context = MagicMock(
+            session_state={},
+            dependencies=None,
+            metadata=None,
+            knowledge_filters=None,
+        )
+        return run_response, session, run_context
+
+    def test_sync_continuation_skips_router_model(self):
+        from agno.team._run import _continue_run
+
+        team = self._team()
+        run_response = TeamRunOutput(run_id="run-1", session_id="session-1")
+        session = MagicMock(session_id="session-1")
+
+        with (
+            patch("agno.team._run.call_model_with_fallback") as model_call,
+            patch("agno.team._run.register_run"),
+            patch("agno.team._run.cleanup_run"),
+            patch("agno.team._run.handle_event", side_effect=lambda event, *_args, **_kwargs: event),
+            patch("agno.team._run._cleanup_and_store"),
+            patch("agno.team._telemetry.log_team_telemetry"),
+            patch("agno.team._init._disconnect_connectable_tools"),
+        ):
+            result = _continue_run(
+                team,
+                run_response=run_response,
+                run_messages=MagicMock(messages=[]),
+                run_context=MagicMock(session_state={}),
+                tools=[],
+                session=session,
+                precomputed_response_content="member result",
+            )
+
+        model_call.assert_not_called()
+        assert result.content == "member result"
+        assert result.status == RunStatus.completed
+
+    def test_sync_stream_continuation_skips_router_model(self):
+        from agno.team._run import _continue_run_stream
+
+        team = self._team()
+        run_response = TeamRunOutput(run_id="run-1", session_id="session-1")
+        session = MagicMock(session_id="session-1")
+
+        with (
+            patch("agno.team._run._handle_team_tool_call_updates_stream") as tool_updates,
+            patch("agno.team._response._handle_model_response_stream") as model_stream,
+            patch("agno.team._run.register_run"),
+            patch("agno.team._run.cleanup_run"),
+            patch("agno.team._run.handle_event", side_effect=lambda event, *_args, **_kwargs: event),
+            patch("agno.team._run._cleanup_and_store"),
+            patch("agno.team._telemetry.log_team_telemetry"),
+            patch("agno.team._init._disconnect_connectable_tools"),
+        ):
+            events = list(
+                _continue_run_stream(
+                    team,
+                    run_response=run_response,
+                    run_messages=MagicMock(messages=[]),
+                    run_context=MagicMock(session_state={}),
+                    tools=[],
+                    session=session,
+                    yield_run_output=True,
+                    precomputed_response_content="member result",
+                )
+            )
+
+        tool_updates.assert_not_called()
+        model_stream.assert_not_called()
+        assert events == [run_response]
+        assert run_response.content == "member result"
+        assert run_response.status == RunStatus.completed
+
+    def test_sync_dispatch_forwards_resolved_delegate_result(self):
+        from agno.team._run import continue_run_dispatch
+
+        team = self._team()
+        team.session_id = None
+        team.initialize_team = MagicMock()
+        run_response, session, run_context = self._async_case()
+        opts = SimpleNamespace(
+            stream=False,
+            stream_events=False,
+            yield_run_output=False,
+            dependencies=None,
+            knowledge_filters=None,
+            metadata=None,
+        )
+        sentinel = object()
+
+        with (
+            patch("agno.team._init._has_async_db", return_value=False),
+            patch("agno.team._init._initialize_session", return_value=("session-1", None)),
+            patch("agno.team._storage._read_or_create_session", return_value=session),
+            patch("agno.team._storage._update_metadata"),
+            patch("agno.team._storage._load_session_state", return_value={}),
+            patch("agno.team._run_options.resolve_run_options", return_value=opts),
+            patch("agno.team._run._resolve_continue_from_team", return_value=None),
+            patch(
+                "agno.team._run._normalize_regenerate_params_team",
+                return_value=(False, None, None),
+            ),
+            patch("agno.team._run._apply_continue_modifiers_team", return_value=run_response),
+            patch("agno.run.approval.check_and_apply_approval_resolution"),
+            patch("agno.team._run._route_requirements_to_members", return_value=["[member]: done"]),
+            patch("agno.team._response.get_response_format", return_value=None),
+            patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+            patch("agno.team._run._get_continue_run_messages", return_value=MagicMock(messages=[])),
+            patch("agno.team._run._continue_run", return_value=sentinel) as continue_run,
+        ):
+            result = continue_run_dispatch(team, run_response=run_response, run_context=run_context)
+
+        assert result is sentinel
+        assert continue_run.call_args.kwargs["precomputed_response_content"] == (
+            "Member results after human-in-the-loop resolution:\n[member]: done"
+        )
+
+    def test_sync_stream_dispatch_forwards_resolved_delegate_result(self):
+        from agno.team._run import continue_run_dispatch
+
+        team = self._team()
+        team.session_id = None
+        team.initialize_team = MagicMock()
+        team.stream_member_events = False
+        run_response, session, run_context = self._async_case()
+        opts = SimpleNamespace(
+            stream=True,
+            stream_events=False,
+            yield_run_output=False,
+            dependencies=None,
+            knowledge_filters=None,
+            metadata=None,
+        )
+        sentinel = object()
+
+        def route_member_results(*_args, member_results, **_kwargs):
+            member_results.append("[member]: done")
+            if False:
+                yield None
+
+        with (
+            patch("agno.team._init._has_async_db", return_value=False),
+            patch("agno.team._init._initialize_session", return_value=("session-1", None)),
+            patch("agno.team._storage._read_or_create_session", return_value=session),
+            patch("agno.team._storage._update_metadata"),
+            patch("agno.team._storage._load_session_state", return_value={}),
+            patch("agno.team._run_options.resolve_run_options", return_value=opts),
+            patch("agno.team._run._resolve_continue_from_team", return_value=None),
+            patch(
+                "agno.team._run._normalize_regenerate_params_team",
+                return_value=(False, None, None),
+            ),
+            patch("agno.team._run._apply_continue_modifiers_team", return_value=run_response),
+            patch("agno.run.approval.check_and_apply_approval_resolution"),
+            patch("agno.team._run._route_requirements_to_members_stream", side_effect=route_member_results),
+            patch("agno.team._response.get_response_format", return_value=None),
+            patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+            patch("agno.team._run._get_continue_run_messages", return_value=MagicMock(messages=[])),
+            patch("agno.team._run._continue_run_stream", return_value=iter([sentinel])) as continue_run_stream,
+        ):
+            events = list(continue_run_dispatch(team, run_response=run_response, run_context=run_context))
+
+        assert events == [sentinel]
+        assert continue_run_stream.call_args.kwargs["precomputed_response_content"] == (
+            "Member results after human-in-the-loop resolution:\n[member]: done"
+        )
+
+    def test_async_continuation_skips_router_model(self):
+        from agno.team._run import _acontinue_run
+
+        team = self._team()
+        run_response, session, run_context = self._async_case()
+
+        async def exercise():
+            with (
+                patch("agno.team._run._asetup_session", new=AsyncMock(return_value=session)),
+                patch("agno.team._run._resolve_continue_from_team", return_value=None),
+                patch(
+                    "agno.team._run._normalize_regenerate_params_team",
+                    return_value=(False, None, None),
+                ),
+                patch("agno.team._run._apply_continue_modifiers_team", return_value=run_response),
+                patch(
+                    "agno.run.approval.acheck_and_apply_approval_resolution",
+                    new=AsyncMock(),
+                ),
+                patch("agno.team._run.aregister_run", new=AsyncMock()),
+                patch("agno.team._run.handle_event", side_effect=lambda event, *_args, **_kwargs: event),
+                patch(
+                    "agno.team._run._aroute_requirements_to_members",
+                    new=AsyncMock(return_value=["[member]: done"]),
+                ),
+                patch("agno.team._tools._check_and_refresh_mcp_tools", new=AsyncMock()),
+                patch("agno.team._tools._aget_learning_tools", new=AsyncMock(return_value=[])),
+                patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+                patch("agno.team._run._get_continue_run_messages", return_value=MagicMock(messages=[])),
+                patch("agno.team._run._ahandle_model_response_for_continue", new=AsyncMock()) as model_response,
+                patch("agno.team._run._acleanup_and_store", new=AsyncMock()),
+                patch("agno.team._telemetry.alog_team_telemetry", new=AsyncMock()),
+                patch("agno.team._init._disconnect_connectable_tools"),
+                patch("agno.team._init._disconnect_mcp_tools", new=AsyncMock()),
+                patch("agno.team._run.acleanup_run", new=AsyncMock()),
+            ):
+                result = await _acontinue_run(
+                    team,
+                    session_id="session-1",
+                    run_context=run_context,
+                    run_response=run_response,
+                )
+
+            model_response.assert_not_awaited()
+            return result
+
+        result = asyncio.run(exercise())
+        assert result.content == "Member results after human-in-the-loop resolution:\n[member]: done"
+        assert result.status == RunStatus.completed
+
+    def test_async_stream_continuation_skips_router_model(self):
+        from agno.team._run import _acontinue_run_stream
+
+        team = self._team()
+        run_response, session, run_context = self._async_case()
+
+        async def route_member_results(*_args, member_results, **_kwargs):
+            member_results.append("[member]: done")
+            if False:
+                yield None
+
+        async def exercise():
+            with (
+                patch("agno.team._run._asetup_session", new=AsyncMock(return_value=session)),
+                patch("agno.team._run._resolve_continue_from_team", return_value=None),
+                patch(
+                    "agno.team._run._normalize_regenerate_params_team",
+                    return_value=(False, None, None),
+                ),
+                patch("agno.team._run._apply_continue_modifiers_team", return_value=run_response),
+                patch(
+                    "agno.run.approval.acheck_and_apply_approval_resolution",
+                    new=AsyncMock(),
+                ),
+                patch("agno.team._run.aregister_run", new=AsyncMock()),
+                patch("agno.team._run._aroute_requirements_to_members_stream", side_effect=route_member_results),
+                patch("agno.team._tools._check_and_refresh_mcp_tools", new=AsyncMock()),
+                patch("agno.team._tools._aget_learning_tools", new=AsyncMock(return_value=[])),
+                patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+                patch("agno.team._run._get_continue_run_messages", return_value=MagicMock(messages=[])),
+                patch("agno.team._response._ahandle_model_response_stream") as model_stream,
+                patch("agno.team._run.handle_event", side_effect=lambda event, *_args, **_kwargs: event),
+                patch("agno.team._run._acleanup_and_store", new=AsyncMock()),
+                patch("agno.team._telemetry.alog_team_telemetry", new=AsyncMock()),
+                patch("agno.team._init._disconnect_connectable_tools"),
+                patch("agno.team._init._disconnect_mcp_tools", new=AsyncMock()),
+                patch("agno.team._run.acleanup_run", new=AsyncMock()),
+            ):
+                events = [
+                    event
+                    async for event in _acontinue_run_stream(
+                        team,
+                        session_id="session-1",
+                        run_context=run_context,
+                        run_response=run_response,
+                        yield_run_output=True,
+                    )
+                ]
+
+            model_stream.assert_not_called()
+            return events
+
+        events = asyncio.run(exercise())
+        assert events == [run_response]
+        assert run_response.content == "Member results after human-in-the-loop resolution:\n[member]: done"
+        assert run_response.status == RunStatus.completed
+
+
 # ===========================================================================
 
 


### PR DESCRIPTION
## Summary

Fixes #8528.

Route-mode member HITL resumes currently write the resolved member output back to the delegate tool, then invoke the router model again. This change preserves the original stop-after-tool-call boundary by:

- matching delegate tools to the member runs resolved by this continuation via `child_run_id`
- using the resolved delegate result directly only when that exact delegate has `stop_after_tool_call=True`
- skipping the redundant router call across sync/async and stream/non-stream continuations while preserving hooks, summaries, persistence, telemetry, and completion events
- keeping non-terminal delegates, fallback tools, mismatched member IDs, and stale historical delegates on their existing continuation path

An existing PR, #8529, addresses the same report but selects the latest delegate whenever `respond_directly=True`. This implementation instead follows the delegate's actual `stop_after_tool_call` contract and scopes it to the member run resolved in this continuation, so an unrelated or historical delegate cannot terminate the run.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

AI-assisted with Codex; the final implementation and tests were independently reviewed and validated before submission.

Metric: `agno_route_hitl_resume_router_model_calls` decreased from `1` to `0`. The strict evaluator also requires twelve regressions covering terminal and non-terminal delegates, stale and mismatched delegates, fallback behavior, missing tool-call IDs, and all four continuation variants.

Autoresearch trajectory: https://dashboard.weco.ai/share/MoL9_QF11SB0sDQFY8WuzSJof-BcXaKE

Validation:

- `uvx ruff check --fix .` -> passed
- `uvx ruff format --check libs/agno/agno/team/_run.py libs/agno/tests/unit/team/test_continue_run_requirements.py` -> passed
- `pytest libs/agno/tests/unit/team` -> 525 passed, 2 skipped
- strict baseline/candidate evaluator -> 1 router call to 0; all correctness gates passed
- `git diff --check` -> clean
