### PR TITLE
[feat] emit AG-UI message snapshots from persisted sessions

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/agui.py
+++ b/libs/agno/agno/os/interfaces/agui/agui.py
@@ -23,6 +23,7 @@ class AGUI(BaseInterface):
         team: Optional[Union[Team, RemoteTeam]] = None,
         prefix: str = "",
         tags: Optional[List[str]] = None,
+        emit_messages_snapshot: bool = False,
     ):
         """
         Initialize the AGUI interface.
@@ -32,11 +33,13 @@ class AGUI(BaseInterface):
             team: The team to expose via AG-UI
             prefix: Custom prefix for the router (e.g., "/agui/v1", "/chat/public")
             tags: Custom tags for the router (e.g., ["AGUI", "Chat"], defaults to ["AGUI"])
+            emit_messages_snapshot: Emit persisted session history as one AG-UI MESSAGES_SNAPSHOT before live events
         """
         self.agent = agent
         self.team = team
         self.prefix = prefix
         self.tags = tags or ["AGUI"]
+        self.emit_messages_snapshot = emit_messages_snapshot
 
         if not (self.agent or self.team):
             raise ValueError("AGUI requires an agent or a team")
@@ -44,7 +47,12 @@ class AGUI(BaseInterface):
     def get_router(self) -> APIRouter:
         self.router = APIRouter(prefix=self.prefix, tags=self.tags)  # type: ignore
 
-        self.router = attach_routes(router=self.router, agent=self.agent, team=self.team)
+        self.router = attach_routes(
+            router=self.router,
+            agent=self.agent,
+            team=self.team,
+            emit_messages_snapshot=self.emit_messages_snapshot,
+        )
 
         return self.router
 

--- a/libs/agno/agno/os/interfaces/agui/history.py
+++ b/libs/agno/agno/os/interfaces/agui/history.py
@@ -1,0 +1,99 @@
+import uuid
+from typing import List, Optional, Tuple, Union
+
+from ag_ui.core import EventType, MessagesSnapshotEvent, RunAgentInput
+from ag_ui.core.types import AssistantMessage, ToolMessage, UserMessage
+from ag_ui.core.types import Message as AGUIMessage
+
+from agno.agent import Agent, RemoteAgent
+from agno.os.interfaces.agui.input import extract_user_input
+from agno.session.agent import AgentSession
+from agno.session.team import TeamSession
+from agno.team import Team
+from agno.team.remote import RemoteTeam
+from agno.utils.log import log_warning
+
+Entity = Union[Agent, RemoteAgent, Team, RemoteTeam]
+LocalEntity = Union[Agent, Team]
+Session = Union[AgentSession, TeamSession]
+
+
+def _history_messages(session: Session) -> List[AGUIMessage]:
+    messages: List[AGUIMessage] = []
+    for message in session.get_chat_history():
+        content = message.get_content_string()
+        if not content:
+            continue
+        message_id = str(message.id) if message.id is not None else str(uuid.uuid4())
+        if message.role == "user":
+            messages.append(UserMessage(id=message_id, content=content))
+        elif message.role == "assistant":
+            messages.append(AssistantMessage(id=message_id, content=content))
+    return messages
+
+
+def _payload_messages(run_input: RunAgentInput) -> Tuple[List[AGUIMessage], List[AGUIMessage]]:
+    head: List[AGUIMessage] = [
+        message for message in run_input.messages or [] if message.role in ("system", "developer")
+    ]
+    user_input = extract_user_input(run_input.messages or [])
+    tail: List[AGUIMessage] = []
+    if user_input:
+        tail.append(UserMessage(id=str(uuid.uuid4()), content=user_input))
+    return head, tail
+
+
+def _snapshot_from_session(session: Session, run_input: RunAgentInput) -> Optional[MessagesSnapshotEvent]:
+    history = _history_messages(session)
+    if not history:
+        return None
+    head, tail = _payload_messages(run_input)
+    return MessagesSnapshotEvent(type=EventType.MESSAGES_SNAPSHOT, messages=head + history + tail)
+
+
+def _local_entity(entity: Entity, run_input: RunAgentInput, tool_messages: List[ToolMessage]) -> Optional[LocalEntity]:
+    if tool_messages:
+        return None
+    if any(message.role == "assistant" for message in run_input.messages or []):
+        return None
+    if not isinstance(entity, (Agent, Team)) or entity.db is None:
+        return None
+    return entity
+
+
+def session_history_snapshot(
+    entity: Entity,
+    run_input: RunAgentInput,
+    tool_messages: List[ToolMessage],
+    user_id: Optional[str] = None,
+) -> Optional[MessagesSnapshotEvent]:
+    try:
+        local_entity = _local_entity(entity, run_input, tool_messages)
+        if local_entity is None:
+            return None
+        session = local_entity.get_session(session_id=run_input.thread_id, user_id=user_id)
+        if not isinstance(session, (AgentSession, TeamSession)):
+            return None
+        return _snapshot_from_session(session, run_input)
+    except Exception as e:
+        log_warning(f"Failed to build AG-UI messages snapshot for session {run_input.thread_id}: {e}")
+        return None
+
+
+async def asession_history_snapshot(
+    entity: Entity,
+    run_input: RunAgentInput,
+    tool_messages: List[ToolMessage],
+    user_id: Optional[str] = None,
+) -> Optional[MessagesSnapshotEvent]:
+    try:
+        local_entity = _local_entity(entity, run_input, tool_messages)
+        if local_entity is None:
+            return None
+        session = await local_entity.aget_session(session_id=run_input.thread_id, user_id=user_id)
+        if not isinstance(session, (AgentSession, TeamSession)):
+            return None
+        return _snapshot_from_session(session, run_input)
+    except Exception as e:
+        log_warning(f"Failed to build AG-UI messages snapshot for session {run_input.thread_id}: {e}")
+        return None

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
 from agno.agent import Agent, RemoteAgent
+from agno.os.interfaces.agui.history import asession_history_snapshot
 from agno.os.interfaces.agui.input import (
     extract_context,
     extract_media,
@@ -41,6 +42,7 @@ async def run_entity(
     entity: Union[Agent, RemoteAgent, Team, RemoteTeam],
     run_input: RunAgentInput,
     user_id: Optional[str] = None,
+    emit_messages_snapshot: bool = False,
 ) -> AsyncIterator[BaseEvent]:
     """Shared handler for running an Agent or Team with AG-UI input/output mapping.
 
@@ -67,6 +69,16 @@ async def run_entity(
 
         if session_state is not None:
             yield StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=copy.deepcopy(session_state))
+
+        if emit_messages_snapshot:
+            history_snapshot = await asession_history_snapshot(
+                entity=entity,
+                run_input=run_input,
+                tool_messages=tool_messages,
+                user_id=user_id,
+            )
+            if history_snapshot is not None:
+                yield history_snapshot
 
         ui_deps = extract_context(run_input.context)
 
@@ -125,12 +137,16 @@ async def run_entity(
 
 
 def attach_routes(
-    router: APIRouter, agent: Optional[Union[Agent, RemoteAgent]] = None, team: Optional[Union[Team, RemoteTeam]] = None
+    router: APIRouter,
+    agent: Optional[Union[Agent, RemoteAgent]] = None,
+    team: Optional[Union[Team, RemoteTeam]] = None,
+    emit_messages_snapshot: bool = False,
 ) -> APIRouter:
     if agent is None and team is None:
         raise ValueError("Either agent or team must be provided.")
 
     entity = agent or team
+    assert entity is not None
     encoder = EventEncoder()
 
     @router.post("/agui", name="run_agent")
@@ -140,7 +156,12 @@ def attach_routes(
         user_id = resolve_run_user_id(request, client_user_id)
 
         async def event_generator():
-            async for event in run_entity(entity, run_input, user_id=user_id):  # type: ignore
+            async for event in run_entity(
+                entity,
+                run_input,
+                user_id=user_id,
+                emit_messages_snapshot=emit_messages_snapshot,
+            ):
                 yield encoder.encode(event)
 
         return StreamingResponse(

--- a/libs/agno/tests/unit/os/interfaces/test_agui_messages_snapshot.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_messages_snapshot.py
@@ -1,0 +1,274 @@
+import json
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import EventType, RunAgentInput
+from ag_ui.core.types import AssistantMessage as AGUIAssistantMessage
+from ag_ui.core.types import ToolMessage as AGUIToolMessage
+from ag_ui.core.types import UserMessage as AGUIUserMessage
+
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.models.base import Model
+from agno.models.message import Message
+from agno.models.response import ModelResponse, ModelResponseEvent
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+from agno.os.interfaces.agui.history import asession_history_snapshot, session_history_snapshot
+from agno.os.interfaces.agui.router import run_entity
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.team import TeamRunOutput
+from agno.session.agent import AgentSession
+from agno.session.team import TeamSession
+from agno.team import Team
+
+
+class _TextModel(Model):
+    def __init__(self, content: str):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.content = content
+
+    def _response(self) -> ModelResponse:
+        response = ModelResponse(role="assistant", content=self.content)
+        response.event = ModelResponseEvent.assistant_response.value
+        return response
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._response()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._response()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield self._response()
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        yield self._response()
+
+    def parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+
+def _run_input(messages=None, run_id: str = "run-2") -> RunAgentInput:
+    return RunAgentInput(
+        threadId="thread-1",
+        runId=run_id,
+        state=None,
+        messages=messages or [AGUIUserMessage(id="current-user", content="current question")],
+        tools=[],
+        context=[],
+        forwardedProps={},
+    )
+
+
+def _agent_with_history(user_id: str = "user-1") -> Agent:
+    db = InMemoryDb()
+    agent = Agent(id="history-agent", db=db, model=_TextModel("current answer"), telemetry=False)
+    db.upsert_session(
+        AgentSession(
+            session_id="thread-1",
+            user_id=user_id,
+            agent_id=agent.id,
+            runs=[
+                RunOutput(
+                    run_id="run-1",
+                    agent_id=agent.id,
+                    status=RunStatus.completed,
+                    messages=[
+                        Message(id="history-user", role="user", content="previous question"),
+                        Message(id="history-assistant", role="assistant", content="previous answer"),
+                    ],
+                )
+            ],
+        )
+    )
+    return agent
+
+
+def _team_with_history() -> Team:
+    db = InMemoryDb()
+    member = Agent(id="member", model=_TextModel("member answer"), telemetry=False)
+    team = Team(id="history-team", members=[member], db=db, model=_TextModel("team answer"), telemetry=False)
+    db.upsert_session(
+        TeamSession(
+            session_id="thread-1",
+            user_id="user-1",
+            team_id=team.id,
+            runs=[
+                TeamRunOutput(
+                    run_id="run-1",
+                    team_id=team.id,
+                    status=RunStatus.completed,
+                    messages=[
+                        Message(id="team-user", role="user", content="team question"),
+                        Message(id="team-assistant", role="assistant", content="team answer"),
+                    ],
+                )
+            ],
+        )
+    )
+    return team
+
+
+def test_session_history_snapshot_maps_agent_history_and_current_input():
+    snapshot = session_history_snapshot(_agent_with_history(), _run_input(), [], user_id="user-1")
+
+    assert snapshot is not None
+    assert [(message.role, message.content) for message in snapshot.messages] == [
+        ("user", "previous question"),
+        ("assistant", "previous answer"),
+        ("user", "current question"),
+    ]
+    assert snapshot.messages[0].id == "history-user"
+    assert snapshot.messages[1].id == "history-assistant"
+    assert snapshot.messages[-1].id != "current-user"
+
+
+@pytest.mark.asyncio
+async def test_asession_history_snapshot_maps_team_history():
+    snapshot = await asession_history_snapshot(_team_with_history(), _run_input(), [], user_id="user-1")
+
+    assert snapshot is not None
+    assert [(message.role, message.content) for message in snapshot.messages] == [
+        ("user", "team question"),
+        ("assistant", "team answer"),
+        ("user", "current question"),
+    ]
+
+
+def test_session_history_snapshot_respects_user_id():
+    snapshot = session_history_snapshot(_agent_with_history(user_id="owner"), _run_input(), [], user_id="other")
+
+    assert snapshot is None
+
+
+@pytest.mark.parametrize(
+    "messages,tool_messages",
+    [
+        (
+            [
+                AGUIUserMessage(id="prior-user", content="previous question"),
+                AGUIAssistantMessage(id="prior-assistant", content="previous answer"),
+                AGUIUserMessage(id="current-user", content="current question"),
+            ],
+            [],
+        ),
+        (
+            [AGUIUserMessage(id="current-user", content="current question")],
+            [AGUIToolMessage(id="tool-message", tool_call_id="tool-call", content="tool result")],
+        ),
+    ],
+)
+def test_session_history_snapshot_skips_stateful_and_resume_payloads(messages, tool_messages):
+    snapshot = session_history_snapshot(_agent_with_history(), _run_input(messages=messages), tool_messages)
+
+    assert snapshot is None
+
+
+@pytest.mark.asyncio
+async def test_run_entity_emits_one_snapshot_before_live_messages():
+    events = [
+        event
+        async for event in run_entity(
+            _agent_with_history(),
+            _run_input(),
+            user_id="user-1",
+            emit_messages_snapshot=True,
+        )
+    ]
+    event_types = [event.type for event in events]
+    snapshots = [event for event in events if event.type == EventType.MESSAGES_SNAPSHOT]
+
+    assert len(snapshots) == 1
+    assert event_types.index(EventType.MESSAGES_SNAPSHOT) < event_types.index(EventType.TEXT_MESSAGE_START)
+    assert [message.content for message in snapshots[0].messages] == [
+        "previous question",
+        "previous answer",
+        "current question",
+    ]
+    assert "current answer" not in [message.content for message in snapshots[0].messages]
+
+
+@pytest.mark.asyncio
+async def test_run_entity_preserves_existing_behavior_when_disabled_or_empty():
+    disabled_events = [event async for event in run_entity(_agent_with_history(), _run_input(), user_id="user-1")]
+    empty_agent = Agent(id="empty-agent", db=InMemoryDb(), model=_TextModel("answer"), telemetry=False)
+    empty_events = [
+        event
+        async for event in run_entity(
+            empty_agent,
+            _run_input(),
+            user_id="user-1",
+            emit_messages_snapshot=True,
+        )
+    ]
+
+    assert EventType.MESSAGES_SNAPSHOT not in [event.type for event in disabled_events]
+    assert EventType.MESSAGES_SNAPSHOT not in [event.type for event in empty_events]
+    assert EventType.RUN_FINISHED in [event.type for event in empty_events]
+
+
+@pytest.mark.asyncio
+async def test_run_entity_continues_when_session_read_fails(monkeypatch):
+    agent = _agent_with_history()
+
+    async def fail_session_read(*args: Any, **kwargs: Any):
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(agent, "aget_session", fail_session_read)
+    events = [
+        event
+        async for event in run_entity(
+            agent,
+            _run_input(),
+            user_id="user-1",
+            emit_messages_snapshot=True,
+        )
+    ]
+
+    assert EventType.MESSAGES_SNAPSHOT not in [event.type for event in events]
+    assert EventType.RUN_FINISHED in [event.type for event in events]
+    assert EventType.RUN_ERROR not in [event.type for event in events]
+
+
+def test_agui_http_route_emits_snapshot_when_enabled():
+    agent = _agent_with_history()
+    app = AgentOS(agents=[agent], interfaces=[AGUI(agent=agent, emit_messages_snapshot=True)]).get_app()
+    response = TestClient(app).post(
+        "/agui",
+        json={
+            "threadId": "thread-1",
+            "runId": "run-2",
+            "state": None,
+            "messages": [{"id": "current-user", "role": "user", "content": "current question"}],
+            "tools": [],
+            "context": [],
+            "forwardedProps": {"user_id": "user-1"},
+        },
+    )
+
+    assert response.status_code == 200
+    payloads = [
+        json.loads(line.removeprefix("data: ")) for line in response.text.splitlines() if line.startswith("data: ")
+    ]
+    snapshots = [payload for payload in payloads if payload["type"] == EventType.MESSAGES_SNAPSHOT]
+    assert len(snapshots) == 1
+    assert [message["content"] for message in snapshots[0]["messages"]] == [
+        "previous question",
+        "previous answer",
+        "current question",
+    ]


### PR DESCRIPTION
## Summary

Add opt-in AG-UI conversation rehydration for persisted Agent and Team sessions.

`AGUI(emit_messages_snapshot=True)` now emits one ordered `MESSAGES_SNAPSHOT` after `RUN_STARTED` and the optional initial `STATE_SNAPSHOT`, but before live message events. The snapshot contains persisted user/assistant turns plus the current user input with a new ID.

The implementation is intentionally guarded and best-effort:

- disabled by default, preserving the existing wire behavior;
- skips resume payloads containing tool messages;
- skips stateful clients that already send assistant history;
- scopes session reads with the server-resolved `user_id`;
- no-ops for remote entities, missing databases, empty sessions, and failed session reads.

Fixes #8843

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

PR #8710 previously contained a similar session-rehydration change, but a maintainer collaborator explicitly removed it in commit `930423a5c721170f148ed86d2684a8b8732435c2` because it belongs in a separate PR. This PR implements only the scope requested by #8843 and does not include the workflow-progress changes from #8710.

Codex assisted with the implementation. I reviewed the diff and verified it with:

- 9 focused message-snapshot tests, including Agent, Team, HTTP wiring, user isolation, ordering, duplicate prevention, empty sessions, and database failures;
- 87 passing AG-UI-related tests;
- `./scripts/format.sh`;
- `./scripts/validate.sh` (ruff, mypy, and cookbook checks).
