### PR TITLE
fix: CSVReader/ExcelReader no longer share one mutable default RowChunking instance

### DIFF
--- a/libs/agno/agno/knowledge/reader/csv_reader.py
+++ b/libs/agno/agno/knowledge/reader/csv_reader.py
@@ -41,8 +41,8 @@ class CSVReader(Reader):
         ```
     """
 
-    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = RowChunking(), **kwargs):
-        super().__init__(chunking_strategy=chunking_strategy, **kwargs)
+    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
+        super().__init__(chunking_strategy=chunking_strategy or RowChunking(), **kwargs)
 
     @classmethod
     def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:

--- a/libs/agno/agno/knowledge/reader/csv_reader.py
+++ b/libs/agno/agno/knowledge/reader/csv_reader.py
@@ -42,7 +42,9 @@ class CSVReader(Reader):
     """
 
     def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
-        super().__init__(chunking_strategy=chunking_strategy or RowChunking(), **kwargs)
+        if chunking_strategy is None:
+            chunking_strategy = RowChunking()
+        super().__init__(chunking_strategy=chunking_strategy, **kwargs)
 
     @classmethod
     def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:

--- a/libs/agno/agno/knowledge/reader/excel_reader.py
+++ b/libs/agno/agno/knowledge/reader/excel_reader.py
@@ -23,10 +23,10 @@ class ExcelReader(Reader):
     def __init__(
         self,
         sheets: Optional[List[Union[str, int]]] = None,
-        chunking_strategy: Optional[ChunkingStrategy] = RowChunking(),
+        chunking_strategy: Optional[ChunkingStrategy] = None,
         **kwargs,
     ):
-        super().__init__(chunking_strategy=chunking_strategy, **kwargs)
+        super().__init__(chunking_strategy=chunking_strategy or RowChunking(), **kwargs)
         self.sheets = sheets
 
     @classmethod

--- a/libs/agno/agno/knowledge/reader/excel_reader.py
+++ b/libs/agno/agno/knowledge/reader/excel_reader.py
@@ -26,7 +26,9 @@ class ExcelReader(Reader):
         chunking_strategy: Optional[ChunkingStrategy] = None,
         **kwargs,
     ):
-        super().__init__(chunking_strategy=chunking_strategy or RowChunking(), **kwargs)
+        if chunking_strategy is None:
+            chunking_strategy = RowChunking()
+        super().__init__(chunking_strategy=chunking_strategy, **kwargs)
         self.sheets = sheets
 
     @classmethod

--- a/libs/agno/tests/unit/knowledge/test_excel_reader.py
+++ b/libs/agno/tests/unit/knowledge/test_excel_reader.py
@@ -2048,3 +2048,17 @@ def test_excel_reader_xls_encoding_parameter_passed_to_xlrd(tmp_path: Path):
     assert len(docs) == 1
     assert "name" in docs[0].content
     assert "test" in docs[0].content
+
+
+def test_default_chunking_strategy_is_not_shared_between_instances():
+    """Each ExcelReader() created without an explicit chunking_strategy must
+    get its own RowChunking instance, not a shared mutable default
+    constructed once at import time."""
+    reader_a = ExcelReader()
+    reader_b = ExcelReader()
+
+    assert reader_a.chunking_strategy is not reader_b.chunking_strategy
+
+    reader_a.chunking_strategy.skip_header = True
+
+    assert reader_b.chunking_strategy.skip_header is False

--- a/libs/agno/tests/unit/reader/test_csv_reader.py
+++ b/libs/agno/tests/unit/reader/test_csv_reader.py
@@ -321,3 +321,17 @@ async def test_async_read_path_with_custom_encoding(temp_dir):
     content = documents[0].content
     assert "José" in content
     assert "São Paulo" in content
+
+
+def test_default_chunking_strategy_is_not_shared_between_instances():
+    """Each CSVReader() created without an explicit chunking_strategy must get
+    its own RowChunking instance, not a shared mutable default constructed
+    once at import time."""
+    reader_a = CSVReader()
+    reader_b = CSVReader()
+
+    assert reader_a.chunking_strategy is not reader_b.chunking_strategy
+
+    reader_a.chunking_strategy.skip_header = True
+
+    assert reader_b.chunking_strategy.skip_header is False


### PR DESCRIPTION
## Summary

`CSVReader.__init__` and `ExcelReader.__init__` both used `chunking_strategy: Optional[ChunkingStrategy] = RowChunking()` as a default argument. Python evaluates that default exactly once, at class-definition time — so every `CSVReader()` (and separately every `ExcelReader()`) created without an explicit `chunking_strategy` shares the exact same `RowChunking` instance. Mutating one reader's strategy (e.g. `reader.chunking_strategy.skip_header = True`) silently changes behavior for every other reader of that type in the same process.

```python
r1 = CSVReader()
r2 = CSVReader()
r1.chunking_strategy is r2.chunking_strategy  # True -- should be False
r1.chunking_strategy.skip_header = True
r2.chunking_strategy.skip_header  # True -- r2 was never configured this way
```

Fix: switch to the standard `= None` sentinel and construct the default inside `__init__`, matching the pattern the base `Reader` class already uses correctly for `FixedSizeChunking` in `chunk_document`/`achunk_document`.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — n/a, no public API/docstring change
- [x] Examples and guides — n/a, internal bug fix, no user-facing behavior change beyond correctness
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**AI-generated contribution disclosure:** I used an AI coding assistant (Claude) to help identify this bug and draft the fix. I independently reproduced the shared-instance behavior, wrote/verified the regression tests in both red and green states, and ran the full local test suite plus the repo's required format/validate scripts before opening this PR.

## Testing

Added a regression test to each reader's existing test file (`test_csv_reader.py`, `test_excel_reader.py`) confirming two default-constructed instances get distinct `RowChunking` objects and mutating one doesn't affect the other. Both fail against the pre-fix code (identical shared object) and pass after. Ran the full `test_csv_reader.py` + `test_excel_reader.py` suites (96 passed).