### PR TITLE
fix: Timer.elapsed no longer recomputes live when elapsed_time is 0.0

### DIFF
--- a/libs/agno/agno/utils/timer.py
+++ b/libs/agno/agno/utils/timer.py
@@ -12,7 +12,11 @@ class Timer:
 
     @property
     def elapsed(self) -> float:
-        return self.elapsed_time or (perf_counter() - self.start_time) if self.start_time else 0.0
+        if self.elapsed_time is not None:
+            return self.elapsed_time
+        if self.start_time is not None:
+            return perf_counter() - self.start_time
+        return 0.0
 
     def start(self) -> float:
         self.start_time = perf_counter()

--- a/libs/agno/tests/unit/utils/test_timer.py
+++ b/libs/agno/tests/unit/utils/test_timer.py
@@ -1,12 +1,4 @@
-"""Regression tests for Timer.elapsed.
-
-`elapsed` previously returned `self.elapsed_time or (perf_counter() -
-self.start_time) if self.start_time else 0.0`, which Python parses as
-`(self.elapsed_time or (perf_counter() - self.start_time)) if self.start_time
-else 0.0`. Since 0.0 is falsy, a timer stopped with an elapsed_time of
-exactly 0.0 (a fast but real measurement) would silently recompute using the
-*current* time instead of returning the frozen, already-measured value.
-"""
+"""Unit tests for the Timer utility."""
 
 from unittest.mock import patch
 
@@ -39,3 +31,61 @@ def test_elapsed_recomputes_live_while_timer_is_still_running():
 def test_elapsed_is_zero_before_start():
     timer = Timer()
     assert timer.elapsed == 0.0
+
+
+def test_stop_records_the_elapsed_interval():
+    timer = Timer()
+
+    with patch("agno.utils.timer.perf_counter", side_effect=[100.0, 103.0]):
+        timer.start()
+        timer.stop()
+
+    assert timer.elapsed == 3.0
+
+
+def test_restart_measures_a_fresh_interval():
+    timer = Timer()
+
+    with patch("agno.utils.timer.perf_counter", side_effect=[0.0, 5.0, 100.0, 108.0]):
+        timer.start()
+        timer.stop()
+        timer.start()
+        timer.stop()
+
+    assert timer.elapsed == 8.0
+
+
+def test_stop_twice_extends_to_the_last_stop():
+    """Duration is wall-clock lifetime: a timer stopped more than once (e.g. a run paused
+    then continued) reports the time to the last stop, including the gap between them."""
+    timer = Timer()
+
+    with patch("agno.utils.timer.perf_counter", side_effect=[10.0, 11.0, 60.0]):
+        timer.start()
+        timer.stop()
+        timer.stop()
+
+    assert timer.elapsed == 50.0
+
+
+def test_context_manager_measures_the_block():
+    timer = Timer()
+
+    with patch("agno.utils.timer.perf_counter", side_effect=[10.0, 12.0]):
+        with timer:
+            pass
+
+    assert timer.elapsed == 2.0
+
+
+def test_to_dict_reports_start_end_and_elapsed():
+    timer = Timer()
+
+    with patch("agno.utils.timer.perf_counter", side_effect=[10.0, 13.0]):
+        timer.start()
+        timer.stop()
+
+    result = timer.to_dict()
+    assert result["start_time"] == "10.0"
+    assert result["end_time"] == "13.0"
+    assert result["elapsed"] == 3.0

--- a/libs/agno/tests/unit/utils/test_timer.py
+++ b/libs/agno/tests/unit/utils/test_timer.py
@@ -1,0 +1,41 @@
+"""Regression tests for Timer.elapsed.
+
+`elapsed` previously returned `self.elapsed_time or (perf_counter() -
+self.start_time) if self.start_time else 0.0`, which Python parses as
+`(self.elapsed_time or (perf_counter() - self.start_time)) if self.start_time
+else 0.0`. Since 0.0 is falsy, a timer stopped with an elapsed_time of
+exactly 0.0 (a fast but real measurement) would silently recompute using the
+*current* time instead of returning the frozen, already-measured value.
+"""
+
+from unittest.mock import patch
+
+from agno.utils.timer import Timer
+
+
+def test_elapsed_returns_frozen_zero_after_stop_not_a_live_recompute():
+    timer = Timer()
+
+    with patch("agno.utils.timer.perf_counter", return_value=100.0):
+        timer.start()
+        timer.stop()
+
+    assert timer.elapsed_time == 0.0
+
+    with patch("agno.utils.timer.perf_counter", return_value=250.0):
+        assert timer.elapsed == 0.0
+
+
+def test_elapsed_recomputes_live_while_timer_is_still_running():
+    timer = Timer()
+
+    with patch("agno.utils.timer.perf_counter", return_value=100.0):
+        timer.start()
+
+    with patch("agno.utils.timer.perf_counter", return_value=103.5):
+        assert timer.elapsed == 3.5
+
+
+def test_elapsed_is_zero_before_start():
+    timer = Timer()
+    assert timer.elapsed == 0.0


### PR DESCRIPTION
## Summary

`Timer.elapsed` was implemented as:

```python
return self.elapsed_time or (perf_counter() - self.start_time) if self.start_time else 0.0
```

Python parses this as `(self.elapsed_time or (perf_counter() - self.start_time)) if self.start_time else 0.0`. Since `0.0` is falsy, a timer stopped with an `elapsed_time` of exactly `0.0` (a fast but real measurement) silently falls through to recomputing using the **current** time instead of returning the frozen, already-measured value:

```python
t = Timer()
t.start()  # perf_counter() == 100.0
t.stop()   # perf_counter() == 100.0 -> elapsed_time = 0.0
...
t.elapsed  # perf_counter() now 250.0 -> returns 150.0 instead of 0.0
```

`Timer` is used across `metrics.py`, `models/base.py`, `agent/_messages.py`, `team/_messages.py`, `workflow/types.py`, and `eval/performance.py`, so any code path reading `.elapsed` after a very fast operation reports a growing, bogus duration instead of the true near-zero elapsed time.

## Fix

Rewrite as explicit `is not None` checks instead of relying on truthiness.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — n/a, no public API change
- [x] Examples and guides — n/a
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**AI-generated contribution disclosure:** I used an AI coding assistant (Claude) to help identify this bug and draft the fix. I independently reproduced the stale-value bug with a mocked `perf_counter` before writing the test, and ran the full local test suite plus the repo's required format/validate scripts before opening this PR.

## Testing

Added regression tests confirming: (1) a frozen `elapsed_time` of `0.0` is returned as-is rather than recomputed against a later `perf_counter()` call, (2) live recomputation still works correctly while the timer is running, (3) `elapsed` is `0.0` before `start()`. Confirmed (1) fails against the pre-fix code and passes after. Ran the full `tests/unit/utils/` suite (397 passed).