### PR TITLE
[fix] Emit ReasoningContentDeltaEvent for native model reasoning content

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1442,6 +1442,21 @@ def handle_model_response_chunk(
                     model_response.reasoning_content += model_response_event.redacted_reasoning_content
                 run_response.reasoning_content = model_response.reasoning_content
 
+            # Emit ReasoningContentDeltaEvent for streaming consumers (AG-UI, /runs, etc.)
+            # model_response_event.reasoning_content is the per-chunk delta;
+            # the accumulated value is already on run_response.reasoning_content above.
+            reasoning_delta = model_response_event.reasoning_content or model_response_event.redacted_reasoning_content
+            if stream_events and reasoning_delta:
+                yield handle_event(  # type: ignore
+                    create_reasoning_content_delta_event(
+                        from_run_response=run_response,
+                        reasoning_content=reasoning_delta,
+                    ),
+                    run_response,
+                    events_to_skip=agent.events_to_skip,  # type: ignore
+                    store_events=agent.store_events,
+                )
+
             # Handle provider data (one chunk)
             if model_response_event.provider_data is not None:
                 run_response.model_provider_data = model_response_event.provider_data

--- a/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
+++ b/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
@@ -298,3 +298,100 @@ def test_message_reasoning_content_optional():
     msg = Message(role="assistant", content="Just content")
     # Should not raise, reasoning_content should be None or not set
     assert msg.content == "Just content"
+
+
+# ============================================================================
+# Test handle_model_response_chunk emits ReasoningContentDeltaEvent
+# ============================================================================
+
+
+def _make_chunk_handler_mocks():
+    """Create minimal mocks for handle_model_response_chunk."""
+    from unittest.mock import MagicMock
+
+    from agno.models.response import ModelResponse
+    from agno.run.agent import RunOutput
+    from agno.session.agent import AgentSession
+
+    agent = MagicMock()
+    agent.id = "test-agent"
+    agent.name = "TestAgent"
+    agent.events_to_skip = []
+    agent.store_events = True
+
+    session = MagicMock(spec=AgentSession)
+    session.session_id = "test-session"
+
+    run_response = RunOutput(run_id="test-run", session_id="test-session", content="")
+    model_response = ModelResponse(content="")
+
+    return agent, session, run_response, model_response
+
+
+def test_handle_model_response_chunk_emits_reasoning_delta_when_streaming():
+    """handle_model_response_chunk must yield ReasoningContentDeltaEvent
+    for model chunks that carry reasoning_content when stream_events=True."""
+    from agno.agent._response import handle_model_response_chunk
+    from agno.models.message import MessageMetrics
+    from agno.models.response import ModelResponse, ModelResponseEvent
+    from agno.run.agent import ReasoningContentDeltaEvent, RunEvent
+
+    agent, session, run_response, model_response = _make_chunk_handler_mocks()
+
+    # Simulate a model chunk with only reasoning_content (like MiMo / DeepSeek / o4-mini)
+    chunk = ModelResponse(
+        event=ModelResponseEvent.assistant_response.value,
+        reasoning_content="Thinking step 1",
+    )
+
+    events = list(
+        handle_model_response_chunk(
+            agent=agent,
+            session=session,
+            run_response=run_response,
+            model_response=model_response,
+            model_response_event=chunk,
+            reasoning_state={"reasoning_started": False, "reasoning_time_taken": 0.0},
+            stream_events=True,
+        )
+    )
+
+    reasoning_deltas = [e for e in events if isinstance(e, ReasoningContentDeltaEvent)]
+    assert len(reasoning_deltas) == 1, (
+        f"Expected 1 ReasoningContentDeltaEvent, got {len(reasoning_deltas)}. "
+        f"Events: {[type(e).__name__ for e in events]}"
+    )
+    assert reasoning_deltas[0].reasoning_content == "Thinking step 1"
+    assert reasoning_deltas[0].event == RunEvent.reasoning_content_delta
+
+
+def test_handle_model_response_chunk_no_reasoning_delta_when_not_streaming():
+    """handle_model_response_chunk must NOT yield ReasoningContentDeltaEvent
+    when stream_events=False (backward compat for non-event consumers)."""
+    from agno.agent._response import handle_model_response_chunk
+    from agno.models.response import ModelResponse, ModelResponseEvent
+    from agno.run.agent import ReasoningContentDeltaEvent
+
+    agent, session, run_response, model_response = _make_chunk_handler_mocks()
+
+    chunk = ModelResponse(
+        event=ModelResponseEvent.assistant_response.value,
+        reasoning_content="Thinking step 1",
+    )
+
+    events = list(
+        handle_model_response_chunk(
+            agent=agent,
+            session=session,
+            run_response=run_response,
+            model_response=model_response,
+            model_response_event=chunk,
+            reasoning_state={"reasoning_started": False, "reasoning_time_taken": 0.0},
+            stream_events=False,
+        )
+    )
+
+    reasoning_deltas = [e for e in events if isinstance(e, ReasoningContentDeltaEvent)]
+    assert len(reasoning_deltas) == 0, (
+        f"Expected 0 ReasoningContentDeltaEvent when stream_events=False, got {len(reasoning_deltas)}"
+    )


### PR DESCRIPTION
## Summary

Fixes #8400

When an OpenAI-compatible model (MiMo, DeepSeek, OpenAI o-series, Claude extended thinking, etc.) returns `reasoning_content` in streaming chunks, `handle_model_response_chunk()` accumulates it onto `run_response.reasoning_content` but only emits a generic `RunContentEvent`. Downstream consumers like AG-UI (`/agui`) never receive `ReasoningContentDelta` / `REASONING_MESSAGE_CONTENT` events, so the frontend cannot display the model's thinking process.

This fix adds a `ReasoningContentDeltaEvent` yield after the reasoning content accumulation, gated on `stream_events=True`. The per-chunk delta (not the accumulated value) is emitted, preserving correct streaming semantics.

### Why this approach over #8418?

#8418 takes a heavier approach: it adds 3 state variables (`reasoning_started`, `reasoning_content_streamed`, `reasoning_completed`), modifies the `RunContentEvent` construction (strips `reasoning_content` when `stream_events=True`), and changes 3 functions. This PR:

- **15 lines** vs 77+ lines
- **No new state variables** — relies on the existing `reasoning_content is not None` check
- **No change to `RunContentEvent` construction** — zero regression risk for existing consumers
- **Emits the delta, not accumulated** — each chunk carries just the new reasoning text

The AG-UI handler already correctly processes `ReasoningContentDeltaEvent` (merged in #7429), so no handler changes are needed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue with this approach
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] This PR was developed with AI assistance (Hermes Agent / Claude). The author has reviewed and understands all changes.

---

## Additional Notes

**Testing:** 2 new unit tests added to `libs/agno/tests/unit/reasoning/test_reasoning_streaming.py`:
- `test_handle_model_response_chunk_emits_reasoning_delta_when_streaming` — verifies `ReasoningContentDeltaEvent` is yielded when `stream_events=True`
- `test_handle_model_response_chunk_no_reasoning_delta_when_not_streaming` — verifies backward compat when `stream_events=False`

All 20 tests in the file pass.