### PR TITLE
[feat] Add Tenki sandbox tools

### DIFF
--- a/cookbook/91_tools/TEST_LOG.md
+++ b/cookbook/91_tools/TEST_LOG.md
@@ -1,5 +1,15 @@
 # Test Log
 
+### tenki_tools.py
+
+**Status:** PASS
+
+**Description:** Adds a Tenki-backed coding agent cookbook plus `TenkiTools` coverage for sync and native async command execution, persistent session reuse, project/workspace scope discovery and fallback, paused/terminated/missing sandbox recovery, safe filesystem paths, working-directory state, status reporting, and confirmation-gated termination.
+
+**Result:** All 28 focused Tenki unit tests passed, including explicit, environment-based, single-scope, and multiple-scope project/workspace selection for sync and async clients. A 222-test core toolkit/function/approval/workspace regression set also passed. The `agno[tenki]` extra resolved in fresh Python 3.10 and 3.12 environments, and toolkit initialization was verified with the published `tenki-sandbox==0.3.6` package. Live scope fallback selected an accessible workspace/project, created a running sandbox without explicit IDs, wrote and read `/home/tenki/scope-test.txt` on the first attempt, and terminated the sandbox successfully. That flow also verified the regression fix that avoids passing the protected `/home/tenki` workdir root to `mkdir`. The full agent cookbook passed in `.venvs/demo`: the agent executed Python in Tenki, wrote `/home/tenki/fibonacci.txt`, returned `[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]`, and reported the correct sum of `88`. An earlier live toolkit smoke test completed Python execution and nested file create/read/list plus cleanup, with the first filesystem operation requiring one retry because of a Tenki runtime-readiness issue tracked by `LuxorLabs/tenki.app#4485`. The full tools test directory was attempted but could not collect because the development environment does not contain 38 unrelated optional tool dependencies.
+
+---
+
 ### file_tools.py (Examples 6-8: exclude_patterns)
 
 **Status:** PASS

--- a/cookbook/91_tools/tenki_tools.py
+++ b/cookbook/91_tools/tenki_tools.py
@@ -1,0 +1,58 @@
+"""Agent with Tenki tools.
+
+This example runs Agent-generated code in a persistent Tenki cloud sandbox.
+
+Prerequisites:
+1. Use Python 3.10 or newer.
+2. Create a Tenki API key: https://tenki.cloud/docs/sandbox/sdk
+3. Set the API key:
+   export TENKI_API_KEY=<your_api_key>
+4. If your account has multiple workspaces or projects, select them explicitly:
+   export TENKI_WORKSPACE_ID=<your_workspace_id>
+   export TENKI_PROJECT_ID=<your_project_id>
+5. Install the dependencies:
+   uv pip install "agno[tenki]" openai
+
+TenkiTools automatically selects an accessible workspace and project. Set the optional scope variables to choose a
+specific workspace or project when multiple are available.
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.tenki import TenkiTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    name="Coding Agent with Tenki tools",
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[
+        TenkiTools(
+            add_instructions=True,
+            sandbox_options={
+                "name": "agno-tenki-example",
+                "max_duration": 900,
+                "metadata": {"created_by": "agno"},
+            },
+        )
+    ],
+    instructions=[
+        "Write clear Python code and execute it in the Tenki sandbox.",
+        "Use the file tools when the task asks you to create or inspect files.",
+        "Report the actual command output and explain any errors.",
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Write Python code that generates the first 10 Fibonacci numbers, saves them to fibonacci.txt, "
+        "then reads the file and reports the numbers and their sum.",
+        stream=True,
+    )

--- a/cookbook/91_tools/tenki_tools.py
+++ b/cookbook/91_tools/tenki_tools.py
@@ -18,7 +18,6 @@ specific workspace or project when multiple are available.
 """
 
 from agno.agent import Agent
-from agno.models.openai import OpenAIResponses
 from agno.tools.tenki import TenkiTools
 
 # ---------------------------------------------------------------------------
@@ -27,7 +26,6 @@ from agno.tools.tenki import TenkiTools
 
 agent = Agent(
     name="Coding Agent with Tenki tools",
-    model=OpenAIResponses(id="gpt-5.5"),
     tools=[
         TenkiTools(
             add_instructions=True,

--- a/libs/agno/agno/tools/tenki.py
+++ b/libs/agno/agno/tools/tenki.py
@@ -1,0 +1,567 @@
+import json
+import posixpath
+from os import getenv
+from textwrap import dedent
+from typing import Any, Callable, Dict, Optional
+
+from agno.run import RunContext
+from agno.tools import Toolkit
+from agno.utils.code_execution import prepare_python_code
+from agno.utils.log import log_warning
+
+DEFAULT_WORKING_DIRECTORY = "/home/tenki"
+SANDBOX_ID_STATE_KEY = "tenki_sandbox_id"
+WORKING_DIRECTORY_STATE_KEY = "tenki_working_directory"
+
+DEFAULT_INSTRUCTIONS = dedent(
+    """\
+    You have access to a persistent Tenki sandbox for remote code execution and file operations.
+    - Use `run_code` to execute Python code.
+    - Use `run_shell_command` for shell commands and package installation.
+    - Use `create_file`, `read_file`, `list_files`, and `delete_file` to manage sandbox files.
+    - Use `change_directory` to update the working directory used by subsequent tools.
+    - Use `get_sandbox_status` to inspect the active sandbox.
+    Always report actual command output and errors instead of claiming that unexecuted code works.
+    """
+)
+
+
+class TenkiTools(Toolkit):
+    """Tools for executing commands and managing files in a persistent Tenki sandbox."""
+
+    def __init__(
+        self,
+        auth_token: Optional[str] = None,
+        base_url: Optional[str] = None,
+        workspace_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        timeout: int = 180,
+        command_timeout: int = 30,
+        sandbox_id: Optional[str] = None,
+        auto_create_sandbox: bool = True,
+        enable_terminate_sandbox: bool = False,
+        allow_inbound: bool = False,
+        allow_outbound: bool = True,
+        sandbox_options: Optional[Dict[str, Any]] = None,
+        instructions: Optional[str] = None,
+        add_instructions: bool = False,
+        client: Optional[Any] = None,
+        async_client: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> None:
+        if client is None or async_client is None:
+            try:
+                from tenki_sandbox import AsyncClient, Client
+            except ImportError:
+                raise ImportError(
+                    "`tenki-sandbox` not installed. Please install it with `pip install tenki-sandbox` "
+                    "using Python 3.10 or newer."
+                )
+
+            client_options: Dict[str, Any] = {"timeout": timeout}
+            if auth_token is not None:
+                client_options["auth_token"] = auth_token
+            if base_url is not None:
+                client_options["base_url"] = base_url
+            client = client or Client(**client_options)
+            async_client = async_client or AsyncClient(**client_options)
+
+        assert client is not None
+        assert async_client is not None
+        self.client = client
+        self.async_client = async_client
+        self.command_timeout = command_timeout
+        self.sandbox_timeout = timeout
+        self.sandbox_id = sandbox_id
+        self.auto_create_sandbox = auto_create_sandbox
+        self.sandbox_options: Dict[str, Any] = {
+            "allow_inbound": allow_inbound,
+            "allow_outbound": allow_outbound,
+            "timeout": timeout,
+        }
+        self.sandbox_options.update(sandbox_options or {})
+        if workspace_id is not None:
+            self.sandbox_options["workspace_id"] = workspace_id
+        elif not self.sandbox_options.get("workspace_id") and getenv("TENKI_WORKSPACE_ID"):
+            self.sandbox_options["workspace_id"] = getenv("TENKI_WORKSPACE_ID")
+        if project_id is not None:
+            self.sandbox_options["project_id"] = project_id
+        elif not self.sandbox_options.get("project_id") and getenv("TENKI_PROJECT_ID"):
+            self.sandbox_options["project_id"] = getenv("TENKI_PROJECT_ID")
+        self.instructions = instructions or DEFAULT_INSTRUCTIONS
+
+        tools: list[Callable[..., Any]] = [
+            self.run_code,
+            self.run_shell_command,
+            self.create_file,
+            self.read_file,
+            self.list_files,
+            self.delete_file,
+            self.change_directory,
+            self.get_sandbox_status,
+        ]
+        async_tools: list[tuple[Callable[..., Any], str]] = [
+            (self.arun_code, "run_code"),
+            (self.arun_shell_command, "run_shell_command"),
+            (self.acreate_file, "create_file"),
+            (self.aread_file, "read_file"),
+            (self.alist_files, "list_files"),
+            (self.adelete_file, "delete_file"),
+            (self.achange_directory, "change_directory"),
+            (self.aget_sandbox_status, "get_sandbox_status"),
+        ]
+        requires_confirmation_tools = list(kwargs.pop("requires_confirmation_tools", None) or [])
+        if enable_terminate_sandbox:
+            tools.append(self.terminate_sandbox)
+            async_tools.append((self.aterminate_sandbox, "terminate_sandbox"))
+            if "terminate_sandbox" not in requires_confirmation_tools:
+                requires_confirmation_tools.append("terminate_sandbox")
+
+        super().__init__(
+            name="tenki_tools",
+            tools=tools,
+            async_tools=async_tools,
+            instructions=self.instructions,
+            add_instructions=add_instructions,
+            requires_confirmation_tools=requires_confirmation_tools,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _session_state(run_context: RunContext) -> Dict[str, Any]:
+        if run_context.session_state is None:
+            run_context.session_state = {}
+        run_context.session_state.setdefault(WORKING_DIRECTORY_STATE_KEY, DEFAULT_WORKING_DIRECTORY)
+        return run_context.session_state
+
+    @staticmethod
+    def _scope_choices(scopes: Any) -> str:
+        return ", ".join(f"{scope.name} ({scope.id})" for scope in scopes)
+
+    @classmethod
+    def _resolve_sandbox_scope(cls, sandbox_options: Dict[str, Any], identity: Any) -> Dict[str, Any]:
+        options = dict(sandbox_options)
+        if options.get("project_id") or str(getattr(identity, "owner_type", "")).upper() == "SERVICE":
+            return options
+
+        workspaces = sorted(getattr(identity, "workspaces", ()) or (), key=lambda item: item.id)
+        if not workspaces:
+            raise ValueError(
+                "No accessible Tenki workspace was found. Set workspace_id or TENKI_WORKSPACE_ID explicitly."
+            )
+
+        workspace_id = options.get("workspace_id")
+        if workspace_id:
+            matching_workspace = next((item for item in workspaces if item.id == workspace_id), None)
+            if matching_workspace is None:
+                raise ValueError(
+                    f"Tenki workspace {workspace_id!r} is not accessible. Set workspace_id or TENKI_WORKSPACE_ID "
+                    f"to one of: {cls._scope_choices(workspaces) or 'none'}"
+                )
+            workspace: Any = matching_workspace
+        else:
+            workspace = workspaces[0]
+            options["workspace_id"] = workspace.id
+            if len(workspaces) > 1:
+                log_warning(
+                    f"Multiple Tenki workspaces are available; using {workspace.name} ({workspace.id}). "
+                    "Set workspace_id or TENKI_WORKSPACE_ID to choose another workspace."
+                )
+
+        projects = sorted(getattr(workspace, "projects", ()) or (), key=lambda item: item.id)
+        if not projects:
+            raise ValueError(
+                f"No Tenki project was found in workspace {workspace.name} ({workspace.id}). "
+                "Set project_id or TENKI_PROJECT_ID explicitly."
+            )
+
+        project = projects[0]
+        options["project_id"] = project.id
+        if len(projects) > 1:
+            log_warning(
+                f"Multiple Tenki projects are available in {workspace.name} ({workspace.id}); "
+                f"using {project.name} ({project.id}). Set project_id or TENKI_PROJECT_ID to choose another project."
+            )
+        return options
+
+    def _sandbox_create_options(self) -> Dict[str, Any]:
+        if not self.sandbox_options.get("project_id"):
+            self.sandbox_options = self._resolve_sandbox_scope(self.sandbox_options, self.client.who_am_i())
+        return self.sandbox_options
+
+    async def _asandbox_create_options(self) -> Dict[str, Any]:
+        if not self.sandbox_options.get("project_id"):
+            identity = await self.async_client.who_am_i()
+            self.sandbox_options = self._resolve_sandbox_scope(self.sandbox_options, identity)
+        return self.sandbox_options
+
+    def _get_or_create_sandbox(self, run_context: RunContext) -> Any:
+        state = self._session_state(run_context)
+        sandbox_id = self.sandbox_id or state.get(SANDBOX_ID_STATE_KEY)
+        if sandbox_id:
+            try:
+                sandbox = self.client.get(sandbox_id)
+            except Exception as error:
+                if self.sandbox_id or not self._is_missing_sandbox_error(error):
+                    raise
+                state.pop(SANDBOX_ID_STATE_KEY, None)
+            else:
+                if sandbox.state in {"TERMINATING", "TERMINATED", "USER_SHUTDOWN"}:
+                    if self.sandbox_id:
+                        raise RuntimeError(f"Tenki sandbox {sandbox.id} is in terminal state {sandbox.state}")
+                    state.pop(SANDBOX_ID_STATE_KEY, None)
+                else:
+                    state[SANDBOX_ID_STATE_KEY] = sandbox.id
+                    return self._prepare_sandbox(sandbox)
+        if not self.auto_create_sandbox:
+            raise RuntimeError("No Tenki sandbox is associated with this session and auto-creation is disabled")
+        sandbox = self.client.create(**self._sandbox_create_options())
+        state[SANDBOX_ID_STATE_KEY] = sandbox.id
+        state[WORKING_DIRECTORY_STATE_KEY] = DEFAULT_WORKING_DIRECTORY
+        return self._prepare_sandbox(sandbox)
+
+    async def _aget_or_create_sandbox(self, run_context: RunContext) -> Any:
+        state = self._session_state(run_context)
+        sandbox_id = self.sandbox_id or state.get(SANDBOX_ID_STATE_KEY)
+        if sandbox_id:
+            try:
+                sandbox = await self.async_client.get(sandbox_id)
+            except Exception as error:
+                if self.sandbox_id or not self._is_missing_sandbox_error(error):
+                    raise
+                state.pop(SANDBOX_ID_STATE_KEY, None)
+            else:
+                if sandbox.state in {"TERMINATING", "TERMINATED", "USER_SHUTDOWN"}:
+                    if self.sandbox_id:
+                        raise RuntimeError(f"Tenki sandbox {sandbox.id} is in terminal state {sandbox.state}")
+                    state.pop(SANDBOX_ID_STATE_KEY, None)
+                else:
+                    state[SANDBOX_ID_STATE_KEY] = sandbox.id
+                    return await self._aprepare_sandbox(sandbox)
+        if not self.auto_create_sandbox:
+            raise RuntimeError("No Tenki sandbox is associated with this session and auto-creation is disabled")
+        sandbox = await self.async_client.create(**await self._asandbox_create_options())
+        state[SANDBOX_ID_STATE_KEY] = sandbox.id
+        state[WORKING_DIRECTORY_STATE_KEY] = DEFAULT_WORKING_DIRECTORY
+        return await self._aprepare_sandbox(sandbox)
+
+    def _get_existing_sandbox(self, run_context: RunContext) -> Any:
+        state = self._session_state(run_context)
+        sandbox_id = self.sandbox_id or state.get(SANDBOX_ID_STATE_KEY)
+        if not sandbox_id:
+            raise RuntimeError("No Tenki sandbox is associated with this session")
+        try:
+            return self.client.get(sandbox_id)
+        except Exception as error:
+            if not self.sandbox_id and self._is_missing_sandbox_error(error):
+                state.pop(SANDBOX_ID_STATE_KEY, None)
+                raise RuntimeError("No Tenki sandbox is associated with this session") from error
+            raise
+
+    async def _aget_existing_sandbox(self, run_context: RunContext) -> Any:
+        state = self._session_state(run_context)
+        sandbox_id = self.sandbox_id or state.get(SANDBOX_ID_STATE_KEY)
+        if not sandbox_id:
+            raise RuntimeError("No Tenki sandbox is associated with this session")
+        try:
+            return await self.async_client.get(sandbox_id)
+        except Exception as error:
+            if not self.sandbox_id and self._is_missing_sandbox_error(error):
+                state.pop(SANDBOX_ID_STATE_KEY, None)
+                raise RuntimeError("No Tenki sandbox is associated with this session") from error
+            raise
+
+    def _prepare_sandbox(self, sandbox: Any) -> Any:
+        if sandbox.state == "PAUSED":
+            sandbox.resume()
+        if sandbox.state in {"CREATING", "RESUMING", "UNSPECIFIED"}:
+            sandbox.wait_ready(self.sandbox_timeout)
+        return sandbox
+
+    async def _aprepare_sandbox(self, sandbox: Any) -> Any:
+        if sandbox.state == "PAUSED":
+            await sandbox.resume()
+        if sandbox.state in {"CREATING", "RESUMING", "UNSPECIFIED"}:
+            await sandbox.wait_ready(self.sandbox_timeout)
+        return sandbox
+
+    @staticmethod
+    def _is_missing_sandbox_error(error: Exception) -> bool:
+        return isinstance(error, KeyError) or error.__class__.__name__ == "SessionNotFoundError"
+
+    @staticmethod
+    def _format_command_result(result: Any) -> str:
+        return json.dumps(
+            {
+                "status": "success" if result.ok else "error",
+                "exit_code": result.exit_code,
+                "stdout": result.stdout_text,
+                "stderr": result.stderr_text,
+            }
+        )
+
+    @staticmethod
+    def _resolve_path(run_context: RunContext, path: str) -> str:
+        state = TenkiTools._session_state(run_context)
+        working_directory = state[WORKING_DIRECTORY_STATE_KEY]
+        resolved_path = posixpath.normpath(path if posixpath.isabs(path) else posixpath.join(working_directory, path))
+        if posixpath.commonpath([DEFAULT_WORKING_DIRECTORY, resolved_path]) != DEFAULT_WORKING_DIRECTORY:
+            raise ValueError(f"Path must remain within {DEFAULT_WORKING_DIRECTORY}: {path}")
+        return resolved_path
+
+    def run_code(self, run_context: RunContext, code: str) -> str:
+        """Execute Python code in the Tenki sandbox and return its output.
+
+        Args:
+            code: Python code to execute.
+        """
+        sandbox = self._get_or_create_sandbox(run_context)
+        result = sandbox.exec(
+            "python3",
+            "-c",
+            prepare_python_code(code),
+            cwd=self._session_state(run_context)[WORKING_DIRECTORY_STATE_KEY],
+            timeout=self.command_timeout,
+        )
+        return self._format_command_result(result)
+
+    async def arun_code(self, run_context: RunContext, code: str) -> str:
+        """Execute Python code asynchronously in the Tenki sandbox and return its output.
+
+        Args:
+            code: Python code to execute.
+        """
+        sandbox = await self._aget_or_create_sandbox(run_context)
+        result = await sandbox.exec(
+            "python3",
+            "-c",
+            prepare_python_code(code),
+            cwd=self._session_state(run_context)[WORKING_DIRECTORY_STATE_KEY],
+            timeout=self.command_timeout,
+        )
+        return self._format_command_result(result)
+
+    def run_shell_command(self, run_context: RunContext, command: str) -> str:
+        """Execute a Bash command in the Tenki sandbox and return its output.
+
+        Args:
+            command: Bash command to execute.
+        """
+        sandbox = self._get_or_create_sandbox(run_context)
+        result = sandbox.shell(
+            command,
+            cwd=self._session_state(run_context)[WORKING_DIRECTORY_STATE_KEY],
+            timeout=self.command_timeout,
+        )
+        return self._format_command_result(result)
+
+    async def arun_shell_command(self, run_context: RunContext, command: str) -> str:
+        """Execute a Bash command asynchronously in the Tenki sandbox and return its output.
+
+        Args:
+            command: Bash command to execute.
+        """
+        sandbox = await self._aget_or_create_sandbox(run_context)
+        result = await sandbox.shell(
+            command,
+            cwd=self._session_state(run_context)[WORKING_DIRECTORY_STATE_KEY],
+            timeout=self.command_timeout,
+        )
+        return self._format_command_result(result)
+
+    def create_file(self, run_context: RunContext, path: str, content: str) -> str:
+        """Create or overwrite a text file in the Tenki sandbox.
+
+        Args:
+            path: File path relative to the current working directory.
+            content: Text content to write.
+        """
+        resolved_path = self._resolve_path(run_context, path)
+        sandbox = self._get_or_create_sandbox(run_context)
+        parent_directory = posixpath.dirname(resolved_path)
+        if parent_directory != DEFAULT_WORKING_DIRECTORY:
+            sandbox.fs.mkdir(parent_directory, recursive=True)
+        sandbox.fs.write_text(resolved_path, content)
+        return json.dumps({"status": "success", "path": resolved_path})
+
+    async def acreate_file(self, run_context: RunContext, path: str, content: str) -> str:
+        """Create or overwrite a text file asynchronously in the Tenki sandbox.
+
+        Args:
+            path: File path relative to the current working directory.
+            content: Text content to write.
+        """
+        resolved_path = self._resolve_path(run_context, path)
+        sandbox = await self._aget_or_create_sandbox(run_context)
+        parent_directory = posixpath.dirname(resolved_path)
+        if parent_directory != DEFAULT_WORKING_DIRECTORY:
+            await sandbox.fs.mkdir(parent_directory, recursive=True)
+        await sandbox.fs.write_text(resolved_path, content)
+        return json.dumps({"status": "success", "path": resolved_path})
+
+    def read_file(self, run_context: RunContext, path: str) -> str:
+        """Read a text file from the Tenki sandbox.
+
+        Args:
+            path: File path relative to the current working directory.
+        """
+        resolved_path = self._resolve_path(run_context, path)
+        sandbox = self._get_or_create_sandbox(run_context)
+        return sandbox.fs.read_text(resolved_path)
+
+    async def aread_file(self, run_context: RunContext, path: str) -> str:
+        """Read a text file asynchronously from the Tenki sandbox.
+
+        Args:
+            path: File path relative to the current working directory.
+        """
+        resolved_path = self._resolve_path(run_context, path)
+        sandbox = await self._aget_or_create_sandbox(run_context)
+        return await sandbox.fs.read_text(resolved_path)
+
+    @staticmethod
+    def _file_info(file_info: Any) -> Dict[str, Any]:
+        return {
+            "path": file_info.path,
+            "size": file_info.size,
+            "mode": file_info.mode,
+            "is_dir": file_info.is_dir,
+            "modified_unix_ns": file_info.modified_unix_ns,
+            "is_symlink": file_info.is_symlink,
+            "symlink_target": file_info.symlink_target,
+        }
+
+    def list_files(self, run_context: RunContext, path: str = ".", include_hidden: bool = False) -> str:
+        """List files in a Tenki sandbox directory.
+
+        Args:
+            path: Directory path relative to the current working directory.
+            include_hidden: Include hidden directory entries.
+        """
+        resolved_path = self._resolve_path(run_context, path)
+        sandbox = self._get_or_create_sandbox(run_context)
+        files = sorted(sandbox.fs.list(resolved_path, include_hidden=include_hidden), key=lambda item: item.path)
+        return json.dumps(
+            {
+                "status": "success",
+                "path": resolved_path,
+                "files": [self._file_info(file_info) for file_info in files],
+            }
+        )
+
+    async def alist_files(self, run_context: RunContext, path: str = ".", include_hidden: bool = False) -> str:
+        """List files asynchronously in a Tenki sandbox directory.
+
+        Args:
+            path: Directory path relative to the current working directory.
+            include_hidden: Include hidden directory entries.
+        """
+        resolved_path = self._resolve_path(run_context, path)
+        sandbox = await self._aget_or_create_sandbox(run_context)
+        files = sorted(await sandbox.fs.list(resolved_path, include_hidden=include_hidden), key=lambda item: item.path)
+        return json.dumps(
+            {
+                "status": "success",
+                "path": resolved_path,
+                "files": [self._file_info(file_info) for file_info in files],
+            }
+        )
+
+    def delete_file(self, run_context: RunContext, path: str) -> str:
+        """Delete a file or directory from the Tenki sandbox.
+
+        Args:
+            path: Path relative to the current working directory.
+        """
+        resolved_path = self._resolve_path(run_context, path)
+        if resolved_path == self._session_state(run_context)[WORKING_DIRECTORY_STATE_KEY]:
+            raise ValueError("Cannot delete the current Tenki working directory")
+        sandbox = self._get_or_create_sandbox(run_context)
+        sandbox.fs.remove(resolved_path, recursive=True)
+        return json.dumps({"status": "success", "path": resolved_path})
+
+    async def adelete_file(self, run_context: RunContext, path: str) -> str:
+        """Delete a file or directory asynchronously from the Tenki sandbox.
+
+        Args:
+            path: Path relative to the current working directory.
+        """
+        resolved_path = self._resolve_path(run_context, path)
+        if resolved_path == self._session_state(run_context)[WORKING_DIRECTORY_STATE_KEY]:
+            raise ValueError("Cannot delete the current Tenki working directory")
+        sandbox = await self._aget_or_create_sandbox(run_context)
+        await sandbox.fs.remove(resolved_path, recursive=True)
+        return json.dumps({"status": "success", "path": resolved_path})
+
+    def change_directory(self, run_context: RunContext, path: str) -> str:
+        """Change the working directory used by subsequent Tenki tools.
+
+        Args:
+            path: Directory path relative to the current working directory.
+        """
+        resolved_path = self._resolve_path(run_context, path)
+        sandbox = self._get_or_create_sandbox(run_context)
+        if not sandbox.fs.stat(resolved_path).is_dir:
+            raise NotADirectoryError(resolved_path)
+        state = self._session_state(run_context)
+        state[WORKING_DIRECTORY_STATE_KEY] = resolved_path
+        return json.dumps({"status": "success", "working_directory": resolved_path})
+
+    async def achange_directory(self, run_context: RunContext, path: str) -> str:
+        """Change the working directory asynchronously for subsequent Tenki tools.
+
+        Args:
+            path: Directory path relative to the current working directory.
+        """
+        resolved_path = self._resolve_path(run_context, path)
+        sandbox = await self._aget_or_create_sandbox(run_context)
+        if not (await sandbox.fs.stat(resolved_path)).is_dir:
+            raise NotADirectoryError(resolved_path)
+        state = self._session_state(run_context)
+        state[WORKING_DIRECTORY_STATE_KEY] = resolved_path
+        return json.dumps({"status": "success", "working_directory": resolved_path})
+
+    @staticmethod
+    def _format_sandbox_status(run_context: RunContext, sandbox: Any) -> str:
+        return json.dumps(
+            {
+                "status": "success",
+                "sandbox_id": sandbox.id,
+                "name": sandbox.info.name,
+                "state": sandbox.state,
+                "working_directory": TenkiTools._session_state(run_context)[WORKING_DIRECTORY_STATE_KEY],
+            }
+        )
+
+    def get_sandbox_status(self, run_context: RunContext) -> str:
+        """Get the current Tenki sandbox status and working directory."""
+        sandbox = self._get_or_create_sandbox(run_context)
+        return self._format_sandbox_status(run_context, sandbox)
+
+    async def aget_sandbox_status(self, run_context: RunContext) -> str:
+        """Get the current Tenki sandbox status asynchronously."""
+        sandbox = await self._aget_or_create_sandbox(run_context)
+        return self._format_sandbox_status(run_context, sandbox)
+
+    def terminate_sandbox(self, run_context: RunContext) -> str:
+        """Terminate the current Tenki sandbox."""
+        sandbox = self._get_existing_sandbox(run_context)
+        if sandbox.state not in {"TERMINATING", "TERMINATED", "USER_SHUTDOWN"}:
+            sandbox.close()
+        state = self._session_state(run_context)
+        state.pop(SANDBOX_ID_STATE_KEY, None)
+        if self.sandbox_id == sandbox.id:
+            self.sandbox_id = None
+        return json.dumps({"status": "success", "sandbox_id": sandbox.id, "state": sandbox.state})
+
+    async def aterminate_sandbox(self, run_context: RunContext) -> str:
+        """Terminate the current Tenki sandbox asynchronously."""
+        sandbox = await self._aget_existing_sandbox(run_context)
+        if sandbox.state not in {"TERMINATING", "TERMINATED", "USER_SHUTDOWN"}:
+            await sandbox.close()
+        state = self._session_state(run_context)
+        state.pop(SANDBOX_ID_STATE_KEY, None)
+        if self.sandbox_id == sandbox.id:
+            self.sandbox_id = None
+        return json.dumps({"status": "success", "sandbox_id": sandbox.id, "state": sandbox.state})

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -147,6 +147,7 @@ scrapegraph = ["scrapegraph-py>=2.0.0"]
 seltz = ["seltz>=0.2.0"]
 tavily = ["tavily-python"]
 telegram = ["pyTelegramBotAPI>=4.32.0", "aiohttp"]
+tenki = ["tenki-sandbox>=0.3.6"]
 todoist = ["todoist-api-python"]
 trafilatura = ["trafilatura"]
 twelvelabs = ["twelvelabs>=1.2.8"]
@@ -292,6 +293,7 @@ tools = [
   "agno[seltz]",
   "agno[tavily]",
   "agno[telegram]",
+  # "agno[tenki]",  # Excluded: tenki-sandbox requires protobuf>=6.31, while memori currently requires protobuf<6
   "agno[todoist]",
   "agno[trafilatura]",
   "agno[twelvelabs]",
@@ -595,6 +597,7 @@ module = [
   "streamlit.*",
   "tavily.*",
   "telebot.*",
+  "tenki_sandbox.*",
   "textract.*",
   "timeout_decorator.*",
   "tiktoken.*",

--- a/libs/agno/tests/unit/tools/test_tenki.py
+++ b/libs/agno/tests/unit/tools/test_tenki.py
@@ -1,0 +1,760 @@
+import json
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agno.run import RunContext
+from agno.tools.tenki import TenkiTools
+
+
+@dataclass
+class FakeCommandResult:
+    exit_code: int = 0
+    stdout_text: str = "hello from tenki\n"
+    stderr_text: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.exit_code == 0
+
+
+class FakeFileSystem:
+    def __init__(self) -> None:
+        self.files: dict[str, str] = {}
+        self.directories: set[str] = {"/home/tenki"}
+
+    def mkdir(self, path: str, *, recursive: bool = True) -> None:
+        if path == "/home/tenki":
+            raise PermissionError("guest_error: path outside workdir: /home/tenki")
+        self.directories.add(path)
+
+    def write_text(self, path: str, text: str) -> None:
+        self.files[path] = text
+
+    def read_text(self, path: str) -> str:
+        return self.files[path]
+
+    def stat(self, path: str):
+        if path in self.directories:
+            return SimpleNamespace(path=path, is_dir=True)
+        if path in self.files:
+            return SimpleNamespace(path=path, is_dir=False)
+        raise FileNotFoundError(path)
+
+    def list(self, path: str, *, include_hidden: bool = False):
+        prefix = f"{path.rstrip('/')}/"
+        entries = []
+        for file_path, content in self.files.items():
+            relative_path = file_path.removeprefix(prefix)
+            if file_path.startswith(prefix) and "/" not in relative_path:
+                entries.append(
+                    SimpleNamespace(
+                        path=file_path,
+                        size=len(content),
+                        mode=0o644,
+                        is_dir=False,
+                        modified_unix_ns=1,
+                        is_symlink=False,
+                        symlink_target="",
+                    )
+                )
+        return entries
+
+    def remove(self, path: str, *, recursive: bool = True) -> None:
+        del self.files[path]
+
+
+class FakeAsyncFileSystem:
+    def __init__(self) -> None:
+        self.files: dict[str, str] = {}
+        self.directories: set[str] = {"/home/tenki"}
+
+    async def mkdir(self, path: str, *, recursive: bool = True) -> None:
+        if path == "/home/tenki":
+            raise PermissionError("guest_error: path outside workdir: /home/tenki")
+        self.directories.add(path)
+
+    async def write_text(self, path: str, text: str) -> None:
+        self.files[path] = text
+
+    async def read_text(self, path: str) -> str:
+        return self.files[path]
+
+    async def stat(self, path: str):
+        if path in self.directories:
+            return SimpleNamespace(path=path, is_dir=True)
+        if path in self.files:
+            return SimpleNamespace(path=path, is_dir=False)
+        raise FileNotFoundError(path)
+
+    async def list(self, path: str, *, include_hidden: bool = False):
+        prefix = f"{path.rstrip('/')}/"
+        entries = []
+        for file_path, content in self.files.items():
+            relative_path = file_path.removeprefix(prefix)
+            if file_path.startswith(prefix) and "/" not in relative_path:
+                entries.append(
+                    SimpleNamespace(
+                        path=file_path,
+                        size=len(content),
+                        mode=0o644,
+                        is_dir=False,
+                        modified_unix_ns=1,
+                        is_symlink=False,
+                        symlink_target="",
+                    )
+                )
+        return entries
+
+    async def remove(self, path: str, *, recursive: bool = True) -> None:
+        del self.files[path]
+
+
+class FakeSandbox:
+    def __init__(self, sandbox_id: str = "sandbox-1") -> None:
+        self.id = sandbox_id
+        self.state = "RUNNING"
+        self.info = SimpleNamespace(name="agno-tenki")
+        self.fs = FakeFileSystem()
+        self.exec_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        self.resume_calls = 0
+        self.wait_ready_calls: list[float] = []
+        self.close_calls = 0
+
+    def exec(self, *args, **kwargs):
+        self.exec_calls.append((args, kwargs))
+        return FakeCommandResult()
+
+    def shell(self, command: str, **kwargs):
+        return FakeCommandResult(exit_code=2, stdout_text="partial output\n", stderr_text="command failed\n")
+
+    def resume(self) -> None:
+        self.resume_calls += 1
+        self.state = "RESUMING"
+
+    def wait_ready(self, timeout: float = 180) -> None:
+        self.wait_ready_calls.append(timeout)
+        self.state = "RUNNING"
+
+    def close(self) -> None:
+        self.close_calls += 1
+        self.state = "TERMINATED"
+
+
+class FakeClient:
+    def __init__(self, identity=None) -> None:
+        self.sandboxes: dict[str, FakeSandbox] = {}
+        self.created_ids: list[str] = []
+        self.create_options: list[dict[str, Any]] = []
+        self.identity = identity or SimpleNamespace(owner_type="SERVICE", owner_id="service-1", workspaces=())
+        self.who_am_i_calls = 0
+
+    def who_am_i(self):
+        self.who_am_i_calls += 1
+        return self.identity
+
+    def create(self, **kwargs):
+        self.create_options.append(kwargs)
+        sandbox_id = f"sandbox-{len(self.created_ids) + 1}"
+        sandbox = FakeSandbox(sandbox_id)
+        self.sandboxes[sandbox_id] = sandbox
+        self.created_ids.append(sandbox_id)
+        return sandbox
+
+    def get(self, sandbox_id: str):
+        return self.sandboxes[sandbox_id]
+
+
+class FakeAsyncSandbox:
+    def __init__(self, sandbox_id: str = "async-sandbox-1") -> None:
+        self.id = sandbox_id
+        self.state = "RUNNING"
+        self.info = SimpleNamespace(name="agno-tenki")
+        self.fs = FakeAsyncFileSystem()
+        self.exec_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        self.resume_calls = 0
+        self.wait_ready_calls: list[float] = []
+        self.close_calls = 0
+
+    async def exec(self, *args, **kwargs):
+        self.exec_calls.append((args, kwargs))
+        return FakeCommandResult(stdout_text="hello async\n")
+
+    async def shell(self, command: str, **kwargs):
+        return FakeCommandResult(exit_code=2, stdout_text="partial output\n", stderr_text="command failed\n")
+
+    async def resume(self) -> None:
+        self.resume_calls += 1
+        self.state = "RESUMING"
+
+    async def wait_ready(self, timeout: float = 180) -> None:
+        self.wait_ready_calls.append(timeout)
+        self.state = "RUNNING"
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self.state = "TERMINATED"
+
+
+class FakeAsyncClient:
+    def __init__(self, identity=None) -> None:
+        self.sandboxes: dict[str, FakeAsyncSandbox] = {}
+        self.created_ids: list[str] = []
+        self.create_options: list[dict[str, Any]] = []
+        self.identity = identity or SimpleNamespace(owner_type="SERVICE", owner_id="service-1", workspaces=())
+        self.who_am_i_calls = 0
+
+    async def who_am_i(self):
+        self.who_am_i_calls += 1
+        return self.identity
+
+    async def create(self, **kwargs):
+        self.create_options.append(kwargs)
+        sandbox_id = f"async-sandbox-{len(self.created_ids) + 1}"
+        sandbox = FakeAsyncSandbox(sandbox_id)
+        self.sandboxes[sandbox_id] = sandbox
+        self.created_ids.append(sandbox_id)
+        return sandbox
+
+    async def get(self, sandbox_id: str):
+        return self.sandboxes[sandbox_id]
+
+
+def test_run_code_creates_a_session_and_returns_command_output() -> None:
+    client = FakeClient()
+    tools = TenkiTools(client=client, async_client=SimpleNamespace())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    result = json.loads(tools.run_code(run_context, "print('hello from tenki')"))
+
+    assert result == {
+        "status": "success",
+        "exit_code": 0,
+        "stdout": "hello from tenki\n",
+        "stderr": "",
+    }
+    assert run_context.session_state == {
+        "tenki_sandbox_id": "sandbox-1",
+        "tenki_working_directory": "/home/tenki",
+    }
+
+
+def test_run_code_reuses_the_session_recorded_in_run_context() -> None:
+    client = FakeClient()
+    tools = TenkiTools(client=client, async_client=SimpleNamespace())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    tools.run_code(run_context, "print('first')")
+    tools.run_code(run_context, "print('second')")
+
+    assert client.created_ids == ["sandbox-1"]
+    session_state = run_context.session_state
+    assert session_state is not None
+    assert session_state["tenki_sandbox_id"] == "sandbox-1"
+
+
+def test_new_sandboxes_disable_inbound_network_access_by_default() -> None:
+    client = FakeClient()
+    tools = TenkiTools(
+        client=client,
+        async_client=FakeAsyncClient(),
+        sandbox_options={"name": "agno-example"},
+    )
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    tools.run_code(run_context, "print('network defaults')")
+
+    assert client.create_options == [
+        {
+            "allow_inbound": False,
+            "allow_outbound": True,
+            "name": "agno-example",
+            "timeout": 180,
+        }
+    ]
+
+
+def test_single_workspace_and_project_are_selected_automatically() -> None:
+    identity = SimpleNamespace(
+        owner_type="USER",
+        owner_id="user-1",
+        workspaces=(
+            SimpleNamespace(
+                id="workspace-1",
+                name="Acme",
+                projects=(SimpleNamespace(id="project-1", name="Backend"),),
+            ),
+        ),
+    )
+    client = FakeClient(identity)
+    tools = TenkiTools(client=client, async_client=FakeAsyncClient())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    tools.run_code(run_context, "print('automatic scope')")
+
+    assert client.who_am_i_calls == 1
+    assert client.create_options[0]["workspace_id"] == "workspace-1"
+    assert client.create_options[0]["project_id"] == "project-1"
+
+
+def test_explicit_project_id_skips_scope_discovery() -> None:
+    client = FakeClient()
+    tools = TenkiTools(
+        client=client,
+        async_client=FakeAsyncClient(),
+        workspace_id="workspace-1",
+        project_id="project-1",
+    )
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    tools.run_code(run_context, "print('explicit scope')")
+
+    assert client.who_am_i_calls == 0
+    assert client.create_options[0]["workspace_id"] == "workspace-1"
+    assert client.create_options[0]["project_id"] == "project-1"
+
+
+def test_scope_ids_fall_back_to_environment_variables(monkeypatch) -> None:
+    monkeypatch.setenv("TENKI_WORKSPACE_ID", "workspace-from-env")
+    monkeypatch.setenv("TENKI_PROJECT_ID", "project-from-env")
+    client = FakeClient()
+    tools = TenkiTools(client=client, async_client=FakeAsyncClient())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    tools.run_code(run_context, "print('environment scope')")
+
+    assert client.who_am_i_calls == 0
+    assert client.create_options[0]["workspace_id"] == "workspace-from-env"
+    assert client.create_options[0]["project_id"] == "project-from-env"
+
+
+def test_multiple_workspaces_fall_back_to_the_first_workspace() -> None:
+    identity = SimpleNamespace(
+        owner_type="USER",
+        owner_id="user-1",
+        workspaces=(
+            SimpleNamespace(
+                id="workspace-2",
+                name="Beta",
+                projects=(SimpleNamespace(id="project-2", name="Frontend"),),
+            ),
+            SimpleNamespace(
+                id="workspace-1",
+                name="Acme",
+                projects=(SimpleNamespace(id="project-1", name="Backend"),),
+            ),
+        ),
+    )
+    client = FakeClient(identity)
+    tools = TenkiTools(client=client, async_client=FakeAsyncClient())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    tools.run_code(run_context, "print('fallback workspace')")
+
+    assert client.create_options[0]["workspace_id"] == "workspace-1"
+    assert client.create_options[0]["project_id"] == "project-1"
+
+
+def test_multiple_projects_fall_back_to_the_first_project() -> None:
+    identity = SimpleNamespace(
+        owner_type="WORKSPACE",
+        owner_id="workspace-1",
+        workspaces=(
+            SimpleNamespace(
+                id="workspace-1",
+                name="Acme",
+                projects=(
+                    SimpleNamespace(id="project-2", name="Frontend"),
+                    SimpleNamespace(id="project-1", name="Backend"),
+                ),
+            ),
+        ),
+    )
+    client = FakeClient(identity)
+    tools = TenkiTools(client=client, async_client=FakeAsyncClient())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    tools.run_code(run_context, "print('fallback project')")
+
+    assert client.create_options[0]["workspace_id"] == "workspace-1"
+    assert client.create_options[0]["project_id"] == "project-1"
+
+
+@pytest.mark.asyncio
+async def test_async_single_workspace_and_project_are_selected_automatically() -> None:
+    identity = SimpleNamespace(
+        owner_type="USER",
+        owner_id="user-1",
+        workspaces=(
+            SimpleNamespace(
+                id="workspace-1",
+                name="Acme",
+                projects=(SimpleNamespace(id="project-1", name="Backend"),),
+            ),
+        ),
+    )
+    async_client = FakeAsyncClient(identity)
+    tools = TenkiTools(client=FakeClient(), async_client=async_client)
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    await tools.arun_code(run_context, "print('automatic async scope')")
+
+    assert async_client.who_am_i_calls == 1
+    assert async_client.create_options[0]["workspace_id"] == "workspace-1"
+    assert async_client.create_options[0]["project_id"] == "project-1"
+
+
+def test_explicit_sandbox_id_is_reused_without_creating_a_sandbox() -> None:
+    client = FakeClient()
+    client.sandboxes["existing-sandbox"] = FakeSandbox("existing-sandbox")
+    tools = TenkiTools(
+        client=client,
+        async_client=FakeAsyncClient(),
+        sandbox_id="existing-sandbox",
+    )
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    tools.run_code(run_context, "print('existing')")
+
+    assert client.created_ids == []
+    session_state = run_context.session_state
+    assert session_state is not None
+    assert session_state["tenki_sandbox_id"] == "existing-sandbox"
+
+
+def test_paused_session_sandbox_is_resumed_before_use() -> None:
+    client = FakeClient()
+    sandbox = FakeSandbox("paused-sandbox")
+    sandbox.state = "PAUSED"
+    client.sandboxes[sandbox.id] = sandbox
+    tools = TenkiTools(client=client, async_client=FakeAsyncClient(), timeout=42)
+    run_context = RunContext(
+        run_id="run-1",
+        session_id="session-1",
+        session_state={"tenki_sandbox_id": sandbox.id},
+    )
+
+    tools.run_code(run_context, "print('resumed')")
+
+    assert sandbox.resume_calls == 1
+    assert sandbox.wait_ready_calls == [42]
+    assert sandbox.exec_calls
+
+
+def test_terminated_session_sandbox_is_replaced_automatically() -> None:
+    client = FakeClient()
+    expired = FakeSandbox("expired-sandbox")
+    expired.state = "TERMINATED"
+    client.sandboxes[expired.id] = expired
+    tools = TenkiTools(client=client, async_client=FakeAsyncClient())
+    run_context = RunContext(
+        run_id="run-1",
+        session_id="session-1",
+        session_state={
+            "tenki_sandbox_id": expired.id,
+            "tenki_working_directory": "/home/tenki/old-project",
+        },
+    )
+
+    tools.run_code(run_context, "print('replacement')")
+
+    assert client.created_ids == ["sandbox-1"]
+    session_state = run_context.session_state
+    assert session_state is not None
+    assert session_state["tenki_sandbox_id"] == "sandbox-1"
+    assert session_state["tenki_working_directory"] == "/home/tenki"
+    assert client.sandboxes["sandbox-1"].exec_calls[-1][1]["cwd"] == "/home/tenki"
+
+
+def test_missing_session_sandbox_is_replaced_automatically() -> None:
+    client = FakeClient()
+    tools = TenkiTools(client=client, async_client=FakeAsyncClient())
+    run_context = RunContext(
+        run_id="run-1",
+        session_id="session-1",
+        session_state={"tenki_sandbox_id": "missing-sandbox"},
+    )
+
+    tools.run_code(run_context, "print('replacement')")
+
+    assert client.created_ids == ["sandbox-1"]
+    session_state = run_context.session_state
+    assert session_state is not None
+    assert session_state["tenki_sandbox_id"] == "sandbox-1"
+
+
+def test_auto_create_can_be_disabled() -> None:
+    client = FakeClient()
+    tools = TenkiTools(
+        client=client,
+        async_client=FakeAsyncClient(),
+        auto_create_sandbox=False,
+    )
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    with pytest.raises(RuntimeError, match="No Tenki sandbox is associated with this session"):
+        tools.run_code(run_context, "print('not created')")
+
+    assert client.created_ids == []
+
+
+def test_get_sandbox_status_reports_session_details() -> None:
+    tools = TenkiTools(client=FakeClient(), async_client=FakeAsyncClient())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    status = json.loads(tools.get_sandbox_status(run_context))
+
+    assert status == {
+        "status": "success",
+        "sandbox_id": "sandbox-1",
+        "name": "agno-tenki",
+        "state": "RUNNING",
+        "working_directory": "/home/tenki",
+    }
+
+
+def test_terminate_sandbox_is_opt_in_and_requires_confirmation() -> None:
+    client = FakeClient()
+    default_tools = TenkiTools(client=FakeClient(), async_client=FakeAsyncClient())
+    tools = TenkiTools(
+        client=client,
+        async_client=FakeAsyncClient(),
+        enable_terminate_sandbox=True,
+    )
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+    tools.run_code(run_context, "print('create')")
+
+    result = json.loads(tools.terminate_sandbox(run_context))
+
+    assert "terminate_sandbox" not in default_tools.get_functions()
+    assert tools.get_functions()["terminate_sandbox"].requires_confirmation is True
+    assert tools.get_async_functions()["terminate_sandbox"].requires_confirmation is True
+    assert result == {"status": "success", "sandbox_id": "sandbox-1", "state": "TERMINATED"}
+    session_state = run_context.session_state
+    assert session_state is not None
+    assert "tenki_sandbox_id" not in session_state
+
+
+def test_terminate_sandbox_never_creates_or_resumes_a_sandbox() -> None:
+    empty_client = FakeClient()
+    empty_tools = TenkiTools(
+        client=empty_client,
+        async_client=FakeAsyncClient(),
+        enable_terminate_sandbox=True,
+    )
+    empty_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    with pytest.raises(RuntimeError, match="No Tenki sandbox is associated with this session"):
+        empty_tools.terminate_sandbox(empty_context)
+
+    paused_client = FakeClient()
+    paused = FakeSandbox("paused-sandbox")
+    paused.state = "PAUSED"
+    paused_client.sandboxes[paused.id] = paused
+    paused_tools = TenkiTools(
+        client=paused_client,
+        async_client=FakeAsyncClient(),
+        enable_terminate_sandbox=True,
+    )
+    paused_context = RunContext(
+        run_id="run-2",
+        session_id="session-2",
+        session_state={"tenki_sandbox_id": paused.id},
+    )
+
+    paused_tools.terminate_sandbox(paused_context)
+
+    assert empty_client.created_ids == []
+    assert paused.resume_calls == 0
+    assert paused.close_calls == 1
+
+
+async def test_async_run_code_uses_the_native_async_client() -> None:
+    async_client = FakeAsyncClient()
+    tools = TenkiTools(client=FakeClient(), async_client=async_client)
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    result = json.loads(await tools.arun_code(run_context, "print('hello async')"))
+
+    assert result["status"] == "success"
+    assert result["stdout"] == "hello async\n"
+    session_state = run_context.session_state
+    assert session_state is not None
+    assert session_state["tenki_sandbox_id"] == "async-sandbox-1"
+    assert tools.get_async_functions()["run_code"].entrypoint == tools.arun_code
+
+
+async def test_async_terminate_uses_the_native_async_client() -> None:
+    async_client = FakeAsyncClient()
+    tools = TenkiTools(
+        client=FakeClient(),
+        async_client=async_client,
+        enable_terminate_sandbox=True,
+    )
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+    await tools.arun_code(run_context, "print('create')")
+
+    result = json.loads(await tools.aterminate_sandbox(run_context))
+
+    assert result == {
+        "status": "success",
+        "sandbox_id": "async-sandbox-1",
+        "state": "TERMINATED",
+    }
+    assert async_client.sandboxes["async-sandbox-1"].close_calls == 1
+    session_state = run_context.session_state
+    assert session_state is not None
+    assert "tenki_sandbox_id" not in session_state
+
+
+def test_run_shell_command_preserves_failed_command_output() -> None:
+    tools = TenkiTools(client=FakeClient(), async_client=FakeAsyncClient())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    result = json.loads(tools.run_shell_command(run_context, "make test"))
+
+    assert result == {
+        "status": "error",
+        "exit_code": 2,
+        "stdout": "partial output\n",
+        "stderr": "command failed\n",
+    }
+
+
+def test_create_and_read_file_use_the_session_working_directory() -> None:
+    client = FakeClient()
+    tools = TenkiTools(client=client, async_client=FakeAsyncClient())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    created = json.loads(tools.create_file(run_context, "reports/result.txt", "complete"))
+    content = tools.read_file(run_context, "reports/result.txt")
+
+    assert created == {
+        "status": "success",
+        "path": "/home/tenki/reports/result.txt",
+    }
+    assert content == "complete"
+
+
+def test_create_file_does_not_try_to_create_the_working_directory_root() -> None:
+    tools = TenkiTools(client=FakeClient(), async_client=FakeAsyncClient())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    created = json.loads(tools.create_file(run_context, "scope-test.txt", "scope fallback works"))
+
+    assert created == {
+        "status": "success",
+        "path": "/home/tenki/scope-test.txt",
+    }
+
+
+async def test_async_create_file_does_not_try_to_create_the_working_directory_root() -> None:
+    tools = TenkiTools(client=FakeClient(), async_client=FakeAsyncClient())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    created = json.loads(await tools.acreate_file(run_context, "scope-test.txt", "scope fallback works"))
+
+    assert created == {
+        "status": "success",
+        "path": "/home/tenki/scope-test.txt",
+    }
+
+
+def test_file_paths_cannot_escape_the_tenki_working_directory() -> None:
+    client = FakeClient()
+    tools = TenkiTools(client=client, async_client=FakeAsyncClient())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    with pytest.raises(ValueError, match="Path must remain within /home/tenki"):
+        tools.create_file(run_context, "../../etc/passwd", "blocked")
+
+    assert client.created_ids == []
+
+
+def test_delete_file_cannot_delete_the_current_working_directory() -> None:
+    client = FakeClient()
+    tools = TenkiTools(client=client, async_client=FakeAsyncClient())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    with pytest.raises(ValueError, match="Cannot delete the current Tenki working directory"):
+        tools.delete_file(run_context, ".")
+
+    assert client.created_ids == []
+
+
+def test_change_directory_updates_the_cwd_used_by_commands() -> None:
+    client = FakeClient()
+    tools = TenkiTools(client=client, async_client=FakeAsyncClient())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+    tools.run_code(run_context, "print('create sandbox')")
+    sandbox = client.sandboxes["sandbox-1"]
+    sandbox.fs.directories.add("/home/tenki/project")
+
+    result = json.loads(tools.change_directory(run_context, "project"))
+    tools.run_code(run_context, "print('new cwd')")
+
+    assert result == {
+        "status": "success",
+        "working_directory": "/home/tenki/project",
+    }
+    session_state = run_context.session_state
+    assert session_state is not None
+    assert session_state["tenki_working_directory"] == "/home/tenki/project"
+    assert sandbox.exec_calls[-1][1]["cwd"] == "/home/tenki/project"
+
+
+def test_list_and_delete_files_use_the_native_filesystem_api() -> None:
+    tools = TenkiTools(client=FakeClient(), async_client=FakeAsyncClient())
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+    tools.create_file(run_context, "one.txt", "one")
+    tools.create_file(run_context, "two.txt", "second")
+
+    listing = json.loads(tools.list_files(run_context))
+    deleted = json.loads(tools.delete_file(run_context, "one.txt"))
+    listing_after_delete = json.loads(tools.list_files(run_context))
+
+    assert listing == {
+        "status": "success",
+        "path": "/home/tenki",
+        "files": [
+            {
+                "path": "/home/tenki/one.txt",
+                "size": 3,
+                "mode": 0o644,
+                "is_dir": False,
+                "modified_unix_ns": 1,
+                "is_symlink": False,
+                "symlink_target": "",
+            },
+            {
+                "path": "/home/tenki/two.txt",
+                "size": 6,
+                "mode": 0o644,
+                "is_dir": False,
+                "modified_unix_ns": 1,
+                "is_symlink": False,
+                "symlink_target": "",
+            },
+        ],
+    }
+    assert deleted == {"status": "success", "path": "/home/tenki/one.txt"}
+    assert [entry["path"] for entry in listing_after_delete["files"]] == ["/home/tenki/two.txt"]
+
+
+async def test_async_filesystem_tools_use_the_native_async_client() -> None:
+    async_client = FakeAsyncClient()
+    tools = TenkiTools(client=FakeClient(), async_client=async_client)
+    run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+    await tools.acreate_file(run_context, "project/result.txt", "complete")
+    content = await tools.aread_file(run_context, "project/result.txt")
+    listing = json.loads(await tools.alist_files(run_context, "project"))
+    await tools.achange_directory(run_context, "project")
+    deleted = json.loads(await tools.adelete_file(run_context, "result.txt"))
+
+    assert content == "complete"
+    assert [entry["path"] for entry in listing["files"]] == ["/home/tenki/project/result.txt"]
+    assert deleted == {"status": "success", "path": "/home/tenki/project/result.txt"}
+    assert tools.get_async_functions()["create_file"].entrypoint == tools.acreate_file


### PR DESCRIPTION
## Summary

Adds `TenkiTools`, a persistent Tenki cloud sandbox toolkit for Agno agents.

- Supports sync and native async Python execution, shell commands, filesystem operations, working-directory state, sandbox status, and confirmation-gated termination.
- Reuses a sandbox through `RunContext.session_state` and recovers from paused, terminated, or missing sessions.
- Resolves workspace/project scope from constructor arguments, environment variables, or accessible Tenki scopes, with deterministic fallback and explicit warnings when multiple scopes exist.
- Adds the `agno[tenki]` optional dependency, focused unit coverage, a cookbook example, and live test results.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Verification: 28 focused Tenki tests and a 222-test toolkit/function/approval/workspace regression set passed.
- `./scripts/format.sh` and `./scripts/validate.sh` pass.
- The cookbook passed end to end using `.venvs/demo`: the agent executed code in Tenki, wrote and read `fibonacci.txt`, returned the first ten Fibonacci numbers, and reported the correct sum of 88.
- Live testing also covered automatic project fallback, root and nested filesystem operations, session cleanup, and dependency resolution on Python 3.10 and 3.12.
- `agno[tenki]` is intentionally excluded from the aggregate `agno[tools]` extra because `tenki-sandbox` requires `protobuf>=6.31` while Memori currently requires `protobuf<6`.
- This implementation was developed with Codex. I reviewed the changes and manually smoke tested the integration using a real Tenki sandbox.