### PR TITLE
fix: surface a clean tool error when the MCP server dies mid-call

### DIFF
--- a/libs/agno/agno/utils/mcp.py
+++ b/libs/agno/agno/utils/mcp.py
@@ -1,12 +1,14 @@
+import asyncio
 import json
 from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 from uuid import uuid4
 
-from agno.utils.log import log_debug, log_exception
+from agno.utils.log import log_debug, log_error, log_exception
 
 try:
     from mcp import ClientSession
+    from mcp.shared.exceptions import McpError
     from mcp.types import CallToolResult, EmbeddedResource, ImageContent, TextContent
     from mcp.types import Tool as MCPTool
 except (ImportError, ModuleNotFoundError):
@@ -252,6 +254,12 @@ def get_entrypoint_for_tool(
                 return await _call_with_session(active_session)
 
             return await _call_with_session(session)
+        except asyncio.CancelledError:
+            raise
+        except McpError as e:
+            msg = f"MCP tool '{tool_name}' failed: {e}. The MCP server may be unreachable or the request timed out."
+            log_error(msg)
+            return ToolResult(content=msg)
         except Exception as e:
             log_exception(f"Failed to call MCP tool '{tool_name}': {e}")
             return ToolResult(content=f"Error: {e}")

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1269,6 +1270,69 @@ def test_tool_result_model_dump_roundtrip_preserves_metadata():
     payload = tool_result.model_dump()
     restored = ToolResult.model_validate(payload)
     assert restored.metadata == {"trace_id": "abc-123"}
+
+
+# =============================================================================
+# Connection-failure error surfacing
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_mcperror_returns_actionable_tool_result():
+    """When the MCP server dies mid-call, call_tool raises McpError. The wrapper
+    must return a short, actionable ToolResult."""
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    mock_tool = MagicMock()
+    mock_tool.name = "slow_tool"
+
+    session = AsyncMock()
+    session.send_ping = AsyncMock()
+    session.call_tool = AsyncMock(
+        side_effect=McpError(ErrorData(code=-32001, message="Timed out while waiting for response to ClientRequest."))
+    )
+
+    entrypoint = get_entrypoint_for_tool(mock_tool, session)
+    result = await entrypoint()
+
+    assert isinstance(result, ToolResult)
+    assert "slow_tool" in result.content
+    assert "MCP server may be unreachable" in result.content
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_cancelled_error_propagates():
+    """CancelledError must propagate so cooperative cancellation still works."""
+    mock_tool = MagicMock()
+    mock_tool.name = "slow_tool"
+
+    session = AsyncMock()
+    session.send_ping = AsyncMock()
+    session.call_tool = AsyncMock(side_effect=asyncio.CancelledError())
+
+    entrypoint = get_entrypoint_for_tool(mock_tool, session)
+
+    with pytest.raises(asyncio.CancelledError):
+        await entrypoint()
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_generic_exception_still_returns_tool_result():
+    """Non-MCP, non-cancellation exceptions must be caught and surfaced
+    as a ToolResult so the agent run loop keeps moving."""
+    mock_tool = MagicMock()
+    mock_tool.name = "flaky_tool"
+
+    session = AsyncMock()
+    session.send_ping = AsyncMock()
+    session.call_tool = AsyncMock(side_effect=RuntimeError("something else broke"))
+
+    entrypoint = get_entrypoint_for_tool(mock_tool, session)
+    result = await entrypoint()
+
+    assert isinstance(result, ToolResult)
+    assert "something else broke" in result.content
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

When an MCP server becomes unreachable during a tool call, the MCP eventually raises `McpError` after `MCPTools.timeout_seconds`. Before this change, that error was caught by a broad `except Exception` and returned to the model wrapped in a large traceback log. This produced a lot of noise instead of an actionable and a clear message. 

`asyncio.CancelledError` was also caught by the same broad handler, which meant cooperative cancellation of a run mid-tool-call could be silently converted into a `ToolResult` instead of propagating.   

For the user's concern regarding app restarts: the next agent run auto reconnects and no app restart needed when `refresh_connection=True`. This is verified using a reproducible sample. 

Closes https://github.com/agno-agi/agno/issues/5493 

## How to reproduce                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                        
  1. Start a FastMCP `streamable-http` server exposing a tool that `asyncio.sleep`s.                                                                                                                    
  2. Run an agent that asks the model to call that tool.                                                                                                                                                         
  3. `SIGKILL` the server ~5 s into the run (while tool is still sleeping).                                                                                                                                      
  4. Observe the tool call error path.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
