### PR TITLE
feat: surface trace id in events and run output

### DIFF
--- a/cookbook/observability/README.md
+++ b/cookbook/observability/README.md
@@ -23,6 +23,7 @@ Observability examples for tracing and monitoring Agno agents, teams, and workfl
 - `mlflow_via_setup_tracing.py`
 - `maxim_ops.py`
 - `opik_via_openinference.py`
+- `trace_id_on_run_output.py`
 - `trace_to_database.py`
 - `trace_to_database_and_langfuse.py`
 - `traceloop_op.py`

--- a/cookbook/observability/TEST_LOG.md
+++ b/cookbook/observability/TEST_LOG.md
@@ -28,6 +28,16 @@
 
 ---
 
+### trace_id_on_run_output.py
+
+**Status:** PASS
+
+**Description:** Verified the full flow against a mock model (no network): with setup_tracing(db=...) active, a streaming run with stream_events=True yields RunStarted carrying the trace_id before any content, a non-streaming run returns RunOutput with trace_id set and present in to_dict(), and the trace_id matches the trace row stored in the database (db.get_trace(run_id=...)). Full agent run with a real model was not performed (no OPENAI_API_KEY in the test environment).
+
+**Result:** trace_id surfaced on RunOutput and streamed events; identical to the database trace_id.
+
+---
+
 ### mlflow_via_setup_tracing.py
 
 **Status:** PASS

--- a/cookbook/observability/trace_id_on_run_output.py
+++ b/cookbook/observability/trace_id_on_run_output.py
@@ -1,0 +1,107 @@
+"""
+Trace ID On Run Output
+======================
+
+Demonstrates how the OpenTelemetry trace_id of a run is surfaced on the
+RunOutput and on every streamed event when tracing is enabled.
+
+The trace_id is captured synchronously from the OTel context at run start, so
+clients can correlate a run with its trace in real time - without querying
+the database and without waiting for the run to finish. The same trace_id
+identifies the trace in the Agno database, the AgentOS traces API, and any
+external OTLP destination (Langfuse, Arize Phoenix, MLflow) configured via
+setup_tracing(exporters=[...]).
+
+A typical use case is user feedback: read trace_id off the RunStarted event
+while the response is still streaming, then attach a thumbs up/down score to
+that trace in your observability platform.
+
+The agno.utils.otel.get_current_trace_id() helper used internally is also
+public - any code running inside the run (tools, hooks) can call it to tag
+its own logs or side effects with the active trace.
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.tracing import setup_tracing
+from agno.utils.otel import get_current_trace_id
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+# Set up database
+db = SqliteDb(db_file="tmp/traces.db")
+
+# Set up tracing - this instruments ALL agents automatically.
+# Pass exporters=[...] as well to also export to Langfuse/Phoenix/MLflow.
+setup_tracing(db=db)
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+def log_with_trace_context(message: str) -> str:
+    """Tool demonstrating direct use of the helper: any code running inside
+    the run (tools, hooks) can read the active trace_id from the OTel context."""
+    trace_id = get_current_trace_id()
+    print(f"  [inside tool] current trace_id: {trace_id}")
+    return f"Logged: {message}"
+
+
+agent = Agent(
+    name="Traced Agent",
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[log_with_trace_context],
+    db=db,
+    instructions="You are a helpful assistant. Use the log_with_trace_context tool once, then answer.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+def run_demo() -> None:
+    # --- Streaming: the trace_id arrives on the FIRST event, before any content
+    print("=" * 60)
+    print("Streaming run - trace_id is available immediately:")
+    print("=" * 60)
+    for event in agent.run(
+        "Log the message 'hello' and tell me a one-line joke.",
+        stream=True,
+        stream_events=True,
+    ):
+        if event.event in ("RunStarted", "RunCompleted"):
+            print(f"  event={event.event}  trace_id={event.trace_id}")
+
+    # --- Non-streaming: the trace_id is on the returned RunOutput
+    print("\n" + "=" * 60)
+    print("Non-streaming run - trace_id on the RunOutput:")
+    print("=" * 60)
+    response = agent.run("Say hi in three words.")
+    print(f"  response.run_id:   {response.run_id}")
+    print(f"  response.trace_id: {response.trace_id}")
+
+    # The serialized output (what AgentOS APIs return) carries it too
+    output_dict = response.to_dict()
+    print("\n  Serialized RunOutput (subset):")
+    for key in ("run_id", "trace_id", "agent_name", "status", "content"):
+        print(f"    {key}: {output_dict.get(key)}")
+
+    # --- Correlate: the same trace_id identifies the trace in the database
+    trace = db.get_trace(run_id=response.run_id)
+    if trace:
+        print("\n  Trace stored in database:")
+        print(f"    trace_id:    {trace.trace_id}")
+        print(f"    total_spans: {trace.total_spans}")
+        print(f"    matches RunOutput.trace_id: {trace.trace_id == response.trace_id}")
+        # The same id can be used with external tools, e.g. the Langfuse
+        # Scores API: langfuse.create_score(trace_id=response.trace_id, ...)
+    else:
+        print(
+            "\n  No trace found. Make sure openinference-instrumentation-agno is installed."
+        )
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -113,6 +113,7 @@ from agno.utils.log import (
     log_info,
     log_warning,
 )
+from agno.utils.otel import get_current_trace_id
 from agno.utils.response import get_paused_content
 
 # Strong references to background tasks so they aren't garbage-collected mid-execution.
@@ -371,6 +372,10 @@ def _run(
     15. Create session summary
     16. Cleanup and store the run response and session
     """
+    # Capture the OTel trace_id for this run while the tracing span is active
+    if run_response.trace_id is None:
+        run_response.trace_id = get_current_trace_id()
+
     from agno.agent._hooks import execute_post_hooks, execute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools
     from agno.agent._messages import get_run_messages
@@ -783,6 +788,10 @@ def _run_stream(
     12. Create session summary
     13. Cleanup and store the run response and session
     """
+    # Capture the OTel trace_id for this run while the tracing span is active
+    if run_response.trace_id is None:
+        run_response.trace_id = get_current_trace_id()
+
     from agno.agent._hooks import execute_post_hooks, execute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools
     from agno.agent._messages import get_run_messages
@@ -1504,6 +1513,10 @@ async def _arun(
     15. Create session summary
     16. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
     """
+    # Capture the OTel trace_id for this run while the tracing span is active
+    if run_response.trace_id is None:
+        run_response.trace_id = get_current_trace_id()
+
     from agno.agent._hooks import aexecute_post_hooks, aexecute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
     from agno.agent._messages import aget_run_messages
@@ -2178,6 +2191,10 @@ async def _arun_stream(
     12. Create session summary
     13. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
     """
+    # Capture the OTel trace_id for this run while the tracing span is active
+    if run_response.trace_id is None:
+        run_response.trace_id = get_current_trace_id()
+
     from agno.agent._hooks import aexecute_post_hooks, aexecute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
     from agno.agent._messages import aget_run_messages

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -202,6 +202,8 @@ class BaseAgentRunEvent(BaseRunOutputEvent):
     run_id: Optional[str] = None
     parent_run_id: Optional[str] = None
     session_id: Optional[str] = None
+    # OpenTelemetry trace_id (32-char hex) for this run, when tracing is active
+    trace_id: Optional[str] = None
 
     # Step context for workflow execution
     workflow_id: Optional[str] = None
@@ -613,6 +615,9 @@ class RunOutput:
     """Response returned by Agent.run() or Workflow.run() functions"""
 
     run_id: Optional[str] = None
+    # OpenTelemetry trace_id (32-char hex) for this run, when tracing is active.
+    # Matches the trace_id in the Agno traces table and in OTLP backends (Langfuse etc.)
+    trace_id: Optional[str] = None
     agent_id: Optional[str] = None
     agent_name: Optional[str] = None
     session_id: Optional[str] = None

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -196,6 +196,8 @@ class BaseTeamRunEvent(BaseRunOutputEvent):
     run_id: Optional[str] = None
     parent_run_id: Optional[str] = None
     session_id: Optional[str] = None
+    # OpenTelemetry trace_id (32-char hex) for this run, when tracing is active
+    trace_id: Optional[str] = None
 
     workflow_id: Optional[str] = None
     workflow_run_id: Optional[str] = None  # This is the workflow's run_id
@@ -741,6 +743,9 @@ class TeamRunOutput:
     """Response returned by Team.run() functions"""
 
     run_id: Optional[str] = None
+    # OpenTelemetry trace_id (32-char hex) for this run, when tracing is active.
+    # Matches the trace_id in the Agno traces table and in OTLP backends (Langfuse etc.)
+    trace_id: Optional[str] = None
     team_id: Optional[str] = None
     team_name: Optional[str] = None
     session_id: Optional[str] = None

--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -93,6 +93,8 @@ class BaseWorkflowRunOutputEvent(BaseRunOutputEvent):
     workflow_name: Optional[str] = None
     session_id: Optional[str] = None
     run_id: Optional[str] = None
+    # OpenTelemetry trace_id (32-char hex) for this run, when tracing is active
+    trace_id: Optional[str] = None
     step_id: Optional[str] = None
     parent_step_id: Optional[str] = None
 
@@ -705,6 +707,9 @@ class WorkflowRunOutput:
     workflow_name: Optional[str] = None
 
     run_id: Optional[str] = None
+    # OpenTelemetry trace_id (32-char hex) for this run, when tracing is active.
+    # Matches the trace_id in the Agno traces table and in OTLP backends (Langfuse etc.)
+    trace_id: Optional[str] = None
     session_id: Optional[str] = None
     user_id: Optional[str] = None
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -117,6 +117,7 @@ from agno.utils.log import (
     log_info,
     log_warning,
 )
+from agno.utils.otel import get_current_trace_id
 
 # Strong references to background tasks so they aren't garbage-collected mid-execution.
 # See: https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
@@ -1063,6 +1064,10 @@ def _run(
     12. Create session summary
     13. Cleanup and store (scrub, stop timer, add to session, calculate metrics, save session)
     """
+    # Capture the OTel trace_id for this run while the tracing span is active
+    if run_response.trace_id is None:
+        run_response.trace_id = get_current_trace_id()
+
     from agno.team._hooks import _execute_post_hooks, _execute_pre_hooks
     from agno.team._init import _disconnect_connectable_tools
     from agno.team._managers import _start_learning_future, _start_memory_future
@@ -1421,6 +1426,10 @@ def _run_stream(
     9. Create session summary
     10. Cleanup and store (scrub, add to session, calculate metrics, save session)
     """
+    # Capture the OTel trace_id for this run while the tracing span is active
+    if run_response.trace_id is None:
+        run_response.trace_id = get_current_trace_id()
+
     from agno.team._hooks import _execute_post_hooks, _execute_pre_hooks
     from agno.team._init import _disconnect_connectable_tools
     from agno.team._managers import _start_learning_future, _start_memory_future
@@ -2983,6 +2992,10 @@ async def _arun(
     12. Create session summary
     13. Cleanup and store (scrub, add to session, calculate metrics, save session)
     """
+    # Capture the OTel trace_id for this run while the tracing span is active
+    if run_response.trace_id is None:
+        run_response.trace_id = get_current_trace_id()
+
     from agno.team._hooks import _aexecute_post_hooks, _aexecute_pre_hooks
     from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
     from agno.team._managers import _astart_learning_task, _astart_memory_task
@@ -3608,6 +3621,10 @@ async def _arun_stream(
     9. Create session summary
     10. Cleanup and store (scrub, add to session, calculate metrics, save session)
     """
+    # Capture the OTel trace_id for this run while the tracing span is active
+    if run_response.trace_id is None:
+        run_response.trace_id = get_current_trace_id()
+
     from agno.team._hooks import _aexecute_post_hooks, _aexecute_pre_hooks
     from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
     from agno.team._managers import _astart_learning_task, _astart_memory_task

--- a/libs/agno/agno/utils/events.py
+++ b/libs/agno/agno/utils/events.py
@@ -1116,6 +1116,11 @@ def handle_event(
     events_to_skip: Optional[List[Union[RunEvent, TeamRunEvent]]] = None,
     store_events: bool = False,
 ) -> Union[RunOutputEvent, TeamRunOutputEvent]:
+    # Propagate the run's OTel trace_id to every event so clients can correlate
+    # streamed events with traces in real time
+    if getattr(event, "trace_id", None) is None:
+        event.trace_id = run_response.trace_id
+
     # We only store events that are not run_response_content events
     _events_to_skip: List[str] = [event.value for event in events_to_skip] if events_to_skip else []
     if store_events and event.event not in _events_to_skip:

--- a/libs/agno/agno/utils/otel.py
+++ b/libs/agno/agno/utils/otel.py
@@ -1,0 +1,30 @@
+"""Helpers for reading the active OpenTelemetry context.
+
+Kept free of any opentelemetry-sdk or agno.tracing imports so it is safe to
+use in the run hot path whether or not tracing is installed or enabled.
+"""
+
+from typing import Optional
+
+try:
+    from opentelemetry import trace as _trace_api  # type: ignore
+
+    OTEL_AVAILABLE = True
+except ImportError:
+    OTEL_AVAILABLE = False
+
+
+def get_current_trace_id() -> Optional[str]:
+    """Return the trace_id of the current OpenTelemetry span, if there is one.
+
+    Returns the 32-character lowercase hex form (the format used by OTLP
+    backends like Langfuse, Arize Phoenix and MLflow, and by Agno's trace
+    tables). Returns None when OpenTelemetry is not installed, tracing is not
+    set up, or there is no span in the current context.
+    """
+    if not OTEL_AVAILABLE:
+        return None
+    span_context = _trace_api.get_current_span().get_span_context()
+    if not span_context.is_valid:
+        return None
+    return format(span_context.trace_id, "032x")

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -107,6 +107,7 @@ from agno.utils.log import (
     set_log_level_to_info,
     use_workflow_logger,
 )
+from agno.utils.otel import get_current_trace_id
 from agno.utils.print_response.workflow import (
     aprint_response,
     aprint_response_stream,
@@ -1706,6 +1707,11 @@ class Workflow:
 
         if isinstance(event, (RunOutput, TeamRunOutput)):
             return event
+
+        # Propagate the run's OTel trace_id to every event so clients can correlate
+        # streamed events with traces in real time
+        if getattr(event, "trace_id", None) is None:
+            event.trace_id = workflow_run_response.trace_id
 
         if isinstance(event, WorkflowCompletedEvent) and event.metrics is None:
             event.metrics = workflow_run_response.metrics
@@ -4165,6 +4171,7 @@ class Workflow:
             workflow_name=self.name,
             created_at=int(datetime.now().timestamp()),
             status=RunStatus.pending,
+            trace_id=get_current_trace_id(),
         )
 
         # Start the run metrics timer
@@ -4308,6 +4315,7 @@ class Workflow:
             workflow_name=self.name,
             created_at=int(datetime.now().timestamp()),
             status=RunStatus.pending,
+            trace_id=get_current_trace_id(),
         )
 
         # Start the run metrics timer
@@ -9556,6 +9564,7 @@ class Workflow:
             workflow_id=self.id,
             workflow_name=self.name,
             created_at=int(datetime.now().timestamp()),
+            trace_id=get_current_trace_id(),
         )
 
         # Start the run metrics timer
@@ -9820,6 +9829,7 @@ class Workflow:
             workflow_id=self.id,
             workflow_name=self.name,
             created_at=int(datetime.now().timestamp()),
+            trace_id=get_current_trace_id(),
         )
 
         # Start the run metrics timer

--- a/libs/agno/tests/unit/tracing/test_trace_id_end_to_end.py
+++ b/libs/agno/tests/unit/tracing/test_trace_id_end_to_end.py
@@ -1,0 +1,127 @@
+"""
+End-to-end test: an instrumented agent run captures the OTel trace_id on its
+RunOutput and streamed events, matching the trace_id of the exported spans.
+
+Runs the full run() path against a mock model (no network) with
+AgnoInstrumentor active, the same way setup_tracing() instruments Agno.
+"""
+
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+from openinference.instrumentation.agno import AgnoInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from agno.agent.agent import Agent
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+
+TRACE_ID_HEX_LENGTH = 32
+
+
+class MockModel(Model):
+    """Minimal offline model: returns a canned text response without any network call."""
+
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.instructions = None
+        self._mock_response = ModelResponse(
+            content="ok",
+            role="assistant",
+            response_usage=MessageMetrics(),
+        )
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._mock_response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._mock_response
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._mock_response
+
+
+@pytest.fixture
+def span_exporter():
+    """Instrument Agno with a private tracer provider exporting to memory."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    instrumentor = AgnoInstrumentor()
+    if instrumentor.is_instrumented_by_opentelemetry:
+        instrumentor.uninstrument()
+    instrumentor.instrument(tracer_provider=provider)
+    yield exporter
+    instrumentor.uninstrument()
+
+
+def test_run_output_carries_trace_id_of_exported_spans(span_exporter):
+    agent = Agent(model=MockModel(), name="Traced Agent")
+
+    response = agent.run("hello")
+
+    assert response.trace_id is not None
+    assert len(response.trace_id) == TRACE_ID_HEX_LENGTH
+
+    exported_trace_ids = {format(span.context.trace_id, "032x") for span in span_exporter.get_finished_spans()}
+    assert exported_trace_ids == {response.trace_id}
+
+
+def test_streamed_events_carry_trace_id(span_exporter):
+    agent = Agent(model=MockModel(), name="Traced Agent")
+
+    events = list(agent.run("hello", stream=True))
+
+    assert len(events) > 0
+    trace_ids = {event.trace_id for event in events}
+    assert len(trace_ids) == 1
+    trace_id = trace_ids.pop()
+    assert trace_id is not None
+    assert len(trace_id) == TRACE_ID_HEX_LENGTH
+
+
+@pytest.mark.asyncio
+async def test_async_run_output_carries_trace_id(span_exporter):
+    agent = Agent(model=MockModel(), name="Traced Agent")
+
+    response = await agent.arun("hello")
+
+    assert response.trace_id is not None
+    assert len(response.trace_id) == TRACE_ID_HEX_LENGTH
+
+
+def test_run_output_trace_id_is_none_without_instrumentation():
+    agent = Agent(model=MockModel(), name="Untraced Agent")
+
+    response = agent.run("hello")
+
+    assert response.trace_id is None

--- a/libs/agno/tests/unit/tracing/test_trace_id_propagation.py
+++ b/libs/agno/tests/unit/tracing/test_trace_id_propagation.py
@@ -1,0 +1,115 @@
+"""
+Unit tests for synchronous trace_id propagation onto run outputs and events.
+
+The trace_id is captured from the active OTel span at run start (inside the
+instrumented run functions) and propagated to every streamed event via
+handle_event(), so clients can correlate runs with traces in real time
+without querying the database.
+"""
+
+from opentelemetry.sdk.trace import TracerProvider
+
+from agno.run.agent import RunOutput, RunStartedEvent
+from agno.run.team import RunContentEvent as TeamRunContentEvent
+from agno.run.team import TeamRunOutput
+from agno.run.workflow import WorkflowRunOutput, WorkflowStartedEvent
+from agno.utils.events import handle_event
+from agno.utils.otel import get_current_trace_id
+
+TRACE_ID_HEX_LENGTH = 32
+
+
+def _local_tracer():
+    """A private tracer whose spans do not touch the global provider."""
+    return TracerProvider().get_tracer("test")
+
+
+def test_get_current_trace_id_returns_none_outside_span():
+    assert get_current_trace_id() is None
+
+
+def test_get_current_trace_id_inside_span():
+    tracer = _local_tracer()
+    with tracer.start_as_current_span("run") as span:
+        trace_id = get_current_trace_id()
+
+    assert trace_id == format(span.get_span_context().trace_id, "032x")
+    assert len(trace_id) == TRACE_ID_HEX_LENGTH
+
+
+def test_run_outputs_accept_trace_id():
+    trace_id = "0" * 31 + "1"
+    assert RunOutput(trace_id=trace_id).trace_id == trace_id
+    assert TeamRunOutput(trace_id=trace_id).trace_id == trace_id
+    assert WorkflowRunOutput(trace_id=trace_id).trace_id == trace_id
+
+
+def test_run_output_serializes_trace_id():
+    trace_id = "ab" * 16
+    output = RunOutput(run_id="run_1", trace_id=trace_id)
+
+    as_dict = output.to_dict()
+    assert as_dict["trace_id"] == trace_id
+
+    restored = RunOutput.from_dict(as_dict)
+    assert restored.trace_id == trace_id
+
+
+def test_run_output_without_trace_id_omits_field():
+    assert "trace_id" not in RunOutput(run_id="run_1").to_dict()
+
+
+def test_event_serializes_trace_id():
+    trace_id = "cd" * 16
+    event = RunStartedEvent(run_id="run_1", trace_id=trace_id)
+
+    as_dict = event.to_dict()
+    assert as_dict["trace_id"] == trace_id
+
+    restored = RunStartedEvent.from_dict(as_dict)
+    assert restored.trace_id == trace_id
+
+
+def test_handle_event_stamps_trace_id_from_run_response():
+    trace_id = "ef" * 16
+    run_response = RunOutput(run_id="run_1", trace_id=trace_id)
+    event = RunStartedEvent(run_id="run_1")
+
+    handled = handle_event(event, run_response)
+
+    assert handled.trace_id == trace_id
+
+
+def test_handle_event_does_not_overwrite_existing_trace_id():
+    run_response = RunOutput(run_id="run_1", trace_id="aa" * 16)
+    event = RunStartedEvent(run_id="run_1", trace_id="bb" * 16)
+
+    handled = handle_event(event, run_response)
+
+    assert handled.trace_id == "bb" * 16
+
+
+def test_handle_event_with_no_trace_id_leaves_event_unset():
+    run_response = RunOutput(run_id="run_1")
+    event = RunStartedEvent(run_id="run_1")
+
+    handled = handle_event(event, run_response)
+
+    assert handled.trace_id is None
+
+
+def test_handle_event_stamps_team_events():
+    trace_id = "12" * 16
+    run_response = TeamRunOutput(run_id="run_1", trace_id=trace_id)
+    event = TeamRunContentEvent(run_id="run_1")
+
+    handled = handle_event(event, run_response)
+
+    assert handled.trace_id == trace_id
+
+
+def test_workflow_event_accepts_trace_id():
+    trace_id = "34" * 16
+    event = WorkflowStartedEvent(run_id="run_1", trace_id=trace_id)
+
+    assert event.to_dict()["trace_id"] == trace_id


### PR DESCRIPTION
## Summary

Surfaces the OpenTelemetry trace_id of a run synchronously on `RunOutput`,
`TeamRunOutput`, `WorkflowRunOutput`, and every streamed run event. Clients can now
correlate a run with its trace in real time - the `RunStarted` event carries the
trace_id before the model produces any output - without querying the database and
without waiting for the run to finish.

(If applicable, issue number: #8874)

**Motivation:** Follow-up to the `setup_tracing()` multi-exporter refactor. As requested
in #8874, users need the trace_id *during* a run (e.g. to wire up a thumbs up/down
button that calls the Langfuse Scores API) - retrieving it from the traces table after
export introduces latency and prevents real-time usage. The trace_id is now captured
once from the OTel context at run start and carried on the run's outputs and events.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
