### PR TITLE
fix: channel-scoped Slack session keys to prevent cross-channel collision

### DIFF
--- a/libs/agno/agno/os/interfaces/slack/event_handler.py
+++ b/libs/agno/agno/os/interfaces/slack/event_handler.py
@@ -11,11 +11,11 @@ from agno.os.interfaces.slack.events import process_event
 from agno.os.interfaces.slack.helpers import (
     BotNameResolver,
     build_run_metadata,
-    derive_session_id,
     download_event_files_async,
     extract_event_context,
     open_chat_stream,
     resolve_channel_name,
+    resolve_session_id,
     resolve_slack_user,
     send_slack_message_async,
     should_respond,
@@ -81,7 +81,7 @@ class SlackEventHandler:
         bot_name = await self.bot_name_resolver.resolve(client, bot_user_id) if bot_user_id else None
         message_text = strip_bot_mention(raw_ctx["message_text"], bot_user_id, bot_name)
 
-        session_id = derive_session_id(self.entity_id, raw_ctx["channel_id"], raw_ctx["thread_id"])
+        session_id = await resolve_session_id(self.entity, self.entity_id, raw_ctx["channel_id"], raw_ctx["thread_id"])
         team_id = data.get("team_id") or event.get("team")
 
         resolved_user_id = raw_ctx["user"]

--- a/libs/agno/agno/os/interfaces/slack/event_handler.py
+++ b/libs/agno/agno/os/interfaces/slack/event_handler.py
@@ -11,6 +11,7 @@ from agno.os.interfaces.slack.events import process_event
 from agno.os.interfaces.slack.helpers import (
     BotNameResolver,
     build_run_metadata,
+    derive_session_id,
     download_event_files_async,
     extract_event_context,
     open_chat_stream,
@@ -80,7 +81,7 @@ class SlackEventHandler:
         bot_name = await self.bot_name_resolver.resolve(client, bot_user_id) if bot_user_id else None
         message_text = strip_bot_mention(raw_ctx["message_text"], bot_user_id, bot_name)
 
-        session_id = f"{self.entity_id}:{raw_ctx['thread_id']}"
+        session_id = derive_session_id(self.entity_id, raw_ctx["channel_id"], raw_ctx["thread_id"])
         team_id = data.get("team_id") or event.get("team")
 
         resolved_user_id = raw_ctx["user"]

--- a/libs/agno/agno/os/interfaces/slack/helpers.py
+++ b/libs/agno/agno/os/interfaces/slack/helpers.py
@@ -23,6 +23,39 @@ def derive_session_id(entity_id: str, channel_id: str, thread_ts: str) -> str:
     return f"{entity_id}:{channel_id}:{thread_ts}"
 
 
+async def _session_exists(entity: Any, session_id: str) -> bool:
+    # Local Agent/Team/Workflow expose aget_session (returns None on miss);
+    # remote entities expose reads via db.get_session. Any probe failure
+    # counts as "not found" so we fall back to the new key.
+    try:
+        aget_session = getattr(entity, "aget_session", None)
+        if aget_session is not None:
+            return await aget_session(session_id=session_id) is not None
+        db = getattr(entity, "db", None)
+        if db is not None:
+            get_session = getattr(db, "get_session", None)
+            if get_session is not None:
+                import asyncio
+
+                if asyncio.iscoroutinefunction(get_session):
+                    return await get_session(session_id=session_id) is not None
+                return get_session(session_id=session_id) is not None
+    except Exception:
+        pass
+    return False
+
+
+async def resolve_session_id(entity: Any, entity_id: str, channel_id: str, thread_ts: str) -> str:
+    # Sessions created before channel-scoped keys were stored as
+    # "{entity_id}:{thread_ts}". Probe for existing legacy session so an
+    # upgrade doesn't orphan thread history; only genuinely new threads get
+    # the collision-safe channel-scoped key. Costs one session read per event.
+    legacy_id = f"{entity_id}:{thread_ts}"
+    if await _session_exists(entity, legacy_id):
+        return legacy_id
+    return derive_session_id(entity_id, channel_id, thread_ts)
+
+
 def task_id(agent_name: Optional[str], base_id: str) -> str:
     # Prefix card IDs per agent so concurrent tool calls from different
     # team members don't collide in the Slack stream

--- a/libs/agno/agno/os/interfaces/slack/helpers.py
+++ b/libs/agno/agno/os/interfaces/slack/helpers.py
@@ -17,17 +17,9 @@ def slack_error_code(exc: BaseException) -> Optional[str]:
     return None
 
 
-def derive_session_id(entity_id: str, channel_id: str, thread_ts: str) -> str:
-    # Slack `ts` values are only unique per channel — two threads in different
-    # channels can share a thread_ts. Including channel_id prevents collisions.
-    return f"{entity_id}:{channel_id}:{thread_ts}"
-
-
 async def resolve_session_id(entity: Any, entity_id: str, channel_id: str, thread_ts: str) -> str:
-    # Sessions created before channel-scoped keys were stored as
-    # "{entity_id}:{thread_ts}". Probe for existing legacy session so an
-    # upgrade doesn't orphan thread history; only genuinely new threads get
-    # the collision-safe channel-scoped key. Costs one session read per event.
+    # Sessions created before channel-scoped keys used "{entity_id}:{thread_ts}".
+    # Probe for existing legacy session so an upgrade doesn't orphan history.
     legacy_id = f"{entity_id}:{thread_ts}"
     try:
         session = await entity.aget_session(session_id=legacy_id)
@@ -35,7 +27,8 @@ async def resolve_session_id(entity: Any, entity_id: str, channel_id: str, threa
             return legacy_id
     except Exception:
         pass
-    return derive_session_id(entity_id, channel_id, thread_ts)
+    # New format includes channel_id to prevent cross-channel collisions
+    return f"{entity_id}:{channel_id}:{thread_ts}"
 
 
 def task_id(agent_name: Optional[str], base_id: str) -> str:

--- a/libs/agno/agno/os/interfaces/slack/helpers.py
+++ b/libs/agno/agno/os/interfaces/slack/helpers.py
@@ -17,6 +17,12 @@ def slack_error_code(exc: BaseException) -> Optional[str]:
     return None
 
 
+def derive_session_id(entity_id: str, channel_id: str, thread_ts: str) -> str:
+    # Slack `ts` values are only unique per channel — two threads in different
+    # channels can share a thread_ts. Including channel_id prevents collisions.
+    return f"{entity_id}:{channel_id}:{thread_ts}"
+
+
 def task_id(agent_name: Optional[str], base_id: str) -> str:
     # Prefix card IDs per agent so concurrent tool calls from different
     # team members don't collide in the Slack stream

--- a/libs/agno/agno/os/interfaces/slack/helpers.py
+++ b/libs/agno/agno/os/interfaces/slack/helpers.py
@@ -23,36 +23,18 @@ def derive_session_id(entity_id: str, channel_id: str, thread_ts: str) -> str:
     return f"{entity_id}:{channel_id}:{thread_ts}"
 
 
-async def _session_exists(entity: Any, session_id: str) -> bool:
-    # Local Agent/Team/Workflow expose aget_session (returns None on miss);
-    # remote entities expose reads via db.get_session. Any probe failure
-    # counts as "not found" so we fall back to the new key.
-    try:
-        aget_session = getattr(entity, "aget_session", None)
-        if aget_session is not None:
-            return await aget_session(session_id=session_id) is not None
-        db = getattr(entity, "db", None)
-        if db is not None:
-            get_session = getattr(db, "get_session", None)
-            if get_session is not None:
-                import asyncio
-
-                if asyncio.iscoroutinefunction(get_session):
-                    return await get_session(session_id=session_id) is not None
-                return get_session(session_id=session_id) is not None
-    except Exception:
-        pass
-    return False
-
-
 async def resolve_session_id(entity: Any, entity_id: str, channel_id: str, thread_ts: str) -> str:
     # Sessions created before channel-scoped keys were stored as
     # "{entity_id}:{thread_ts}". Probe for existing legacy session so an
     # upgrade doesn't orphan thread history; only genuinely new threads get
     # the collision-safe channel-scoped key. Costs one session read per event.
     legacy_id = f"{entity_id}:{thread_ts}"
-    if await _session_exists(entity, legacy_id):
-        return legacy_id
+    try:
+        session = await entity.aget_session(session_id=legacy_id)
+        if session is not None:
+            return legacy_id
+    except Exception:
+        pass
     return derive_session_id(entity_id, channel_id, thread_ts)
 
 

--- a/libs/agno/agno/os/interfaces/slack/hitl.py
+++ b/libs/agno/agno/os/interfaces/slack/hitl.py
@@ -138,6 +138,8 @@ class HITLHandler:
         ctx: SubmitContext,
         stream: Any,
         requirements: List[Any],
+        *,
+        session_id: str,
         user_id: Optional[str] = None,
     ) -> StreamState:
         state = StreamState(entity_name=self.entity_name, entity_type=self.entity_type)
@@ -145,7 +147,7 @@ class HITLHandler:
             response_stream: Any = self.entity.acontinue_run(  # type: ignore[union-attr, call-arg, call-overload]
                 run_id=ctx.run_id,
                 requirements=requirements,
-                session_id=ctx.session_id,
+                session_id=session_id,
                 user_id=user_id,
                 stream=True,
                 stream_events=True,
@@ -296,7 +298,6 @@ class HITLHandler:
 
         ctx = SubmitContext(
             run_id=run_id,
-            session_id=session_id,
             channel=channel,
             thread_ts=thread_ts,
             msg_ts=msg_ts,
@@ -314,7 +315,7 @@ class HITLHandler:
             self.task_display_mode,
             self.buffer_size,
         )
-        state = await self.stream_resumed_run(ctx, stream, requirements, user_id=run_user_id)
+        state = await self.stream_resumed_run(ctx, stream, requirements, session_id=session_id, user_id=run_user_id)
         await self.complete_or_repause(ctx, stream, state)
 
     async def handle_check_status(self, payload: Dict[str, Any]) -> None:
@@ -421,17 +422,16 @@ class HITLHandler:
             )
 
     async def handle_submit(self, payload: Dict[str, Any]) -> None:
-        ctx = extract_submit_context(payload, self.entity_id)
+        ctx = extract_submit_context(payload)
         if ctx is None:
             return
-        # Re-resolve session_id for backward compat with pre-channel-scoped keys
-        ctx.session_id = await resolve_session_id(self.entity, self.entity_id, ctx.channel, ctx.thread_ts)
+        session_id = await resolve_session_id(self.entity, self.entity_id, ctx.channel, ctx.thread_ts)
         log_info(f"[HITL] submit received: run_id={ctx.run_id} channel={ctx.channel}")
 
         await self.delete_awaiting_indicator(ctx.channel, ctx.awaiting_ts)
 
         try:
-            run_output = await self.entity.aget_run_output(run_id=ctx.run_id, session_id=ctx.session_id)  # type: ignore[union-attr]
+            run_output = await self.entity.aget_run_output(run_id=ctx.run_id, session_id=session_id)  # type: ignore[union-attr]
         except Exception as exc:
             log_error(f"[HITL] aget_run_output failed for run={ctx.run_id}: {exc}")
             run_output = None
@@ -464,7 +464,7 @@ class HITLHandler:
         )
 
         await self.post_denial_cards(stream, decisions, requirements, ctx.run_id)
-        state = await self.stream_resumed_run(ctx, stream, requirements, user_id=run_user_id)
+        state = await self.stream_resumed_run(ctx, stream, requirements, session_id=session_id, user_id=run_user_id)
         await self.complete_or_repause(ctx, stream, state)
 
     async def post_ephemeral(self, *, channel: str, user: str, text: str) -> None:

--- a/libs/agno/agno/os/interfaces/slack/hitl.py
+++ b/libs/agno/agno/os/interfaces/slack/hitl.py
@@ -16,7 +16,7 @@ from agno.os.interfaces.slack.builders import (
     select_confirmation_row,
 )
 from agno.os.interfaces.slack.events import process_event
-from agno.os.interfaces.slack.helpers import derive_session_id, open_chat_stream, slack_error_code
+from agno.os.interfaces.slack.helpers import open_chat_stream, resolve_session_id, slack_error_code
 from agno.os.interfaces.slack.ids import decode_admin_approval_button_value
 from agno.os.interfaces.slack.interactions import (
     apply_decisions,
@@ -275,7 +275,7 @@ class HITLHandler:
         awaiting_ts: Optional[str],
     ) -> None:
         """Resume a paused run after admin approval."""
-        session_id = derive_session_id(self.entity_id, channel, thread_ts)
+        session_id = await resolve_session_id(self.entity, self.entity_id, channel, thread_ts)
 
         try:
             run_output = await self.entity.aget_run_output(run_id=run_id, session_id=session_id)  # type: ignore[union-attr]
@@ -424,6 +424,8 @@ class HITLHandler:
         ctx = extract_submit_context(payload, self.entity_id)
         if ctx is None:
             return
+        # Re-resolve session_id for backward compat with pre-channel-scoped keys
+        ctx.session_id = await resolve_session_id(self.entity, self.entity_id, ctx.channel, ctx.thread_ts)
         log_info(f"[HITL] submit received: run_id={ctx.run_id} channel={ctx.channel}")
 
         await self.delete_awaiting_indicator(ctx.channel, ctx.awaiting_ts)

--- a/libs/agno/agno/os/interfaces/slack/hitl.py
+++ b/libs/agno/agno/os/interfaces/slack/hitl.py
@@ -16,7 +16,7 @@ from agno.os.interfaces.slack.builders import (
     select_confirmation_row,
 )
 from agno.os.interfaces.slack.events import process_event
-from agno.os.interfaces.slack.helpers import open_chat_stream, slack_error_code
+from agno.os.interfaces.slack.helpers import derive_session_id, open_chat_stream, slack_error_code
 from agno.os.interfaces.slack.ids import decode_admin_approval_button_value
 from agno.os.interfaces.slack.interactions import (
     apply_decisions,
@@ -275,7 +275,7 @@ class HITLHandler:
         awaiting_ts: Optional[str],
     ) -> None:
         """Resume a paused run after admin approval."""
-        session_id = f"{self.entity_id}:{thread_ts}"
+        session_id = derive_session_id(self.entity_id, channel, thread_ts)
 
         try:
             run_output = await self.entity.aget_run_output(run_id=run_id, session_id=session_id)  # type: ignore[union-attr]

--- a/libs/agno/agno/os/interfaces/slack/interactions.py
+++ b/libs/agno/agno/os/interfaces/slack/interactions.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from agno.os.interfaces.slack.helpers import derive_session_id
 from agno.os.interfaces.slack.ids import (
     ACTION_EXTERNAL_RESULT,
     ACTION_REJECT_REASON,
@@ -160,7 +159,7 @@ def extract_row_action_context(payload: Dict[str, Any]) -> Optional[RowActionCon
     )
 
 
-def extract_submit_context(payload: Dict[str, Any], entity_id: str) -> Optional[SubmitContext]:
+def extract_submit_context(payload: Dict[str, Any]) -> Optional[SubmitContext]:
     actions = payload.get("actions") or []
     if not actions:
         return None
@@ -178,15 +177,12 @@ def extract_submit_context(payload: Dict[str, Any], entity_id: str) -> Optional[
     thread_ts = message.get("thread_ts") or msg_ts
     button_value = actions[0].get("value") or ""
     _, awaiting_ts = decode_submit_button_value(button_value)
-    # Provisional new-format key; handle_submit re-resolves for backward compat
-    session_id = derive_session_id(entity_id, channel, thread_ts)
 
     return SubmitContext(
         run_id=run_id,
         channel=channel,
         msg_ts=msg_ts,
         thread_ts=thread_ts,
-        session_id=session_id,
         awaiting_ts=awaiting_ts,
         user_id=(payload.get("user") or {}).get("id", ""),
         team_id=(payload.get("team") or {}).get("id"),

--- a/libs/agno/agno/os/interfaces/slack/interactions.py
+++ b/libs/agno/agno/os/interfaces/slack/interactions.py
@@ -179,6 +179,7 @@ def extract_submit_context(payload: Dict[str, Any], entity_id: str) -> Optional[
     button_value = actions[0].get("value") or ""
     _, awaiting_ts = decode_submit_button_value(button_value)
 
+    # Provisional new-format key; handle_submit re-resolves for backward compat
     return SubmitContext(
         run_id=run_id,
         channel=channel,

--- a/libs/agno/agno/os/interfaces/slack/interactions.py
+++ b/libs/agno/agno/os/interfaces/slack/interactions.py
@@ -178,14 +178,15 @@ def extract_submit_context(payload: Dict[str, Any], entity_id: str) -> Optional[
     thread_ts = message.get("thread_ts") or msg_ts
     button_value = actions[0].get("value") or ""
     _, awaiting_ts = decode_submit_button_value(button_value)
-
     # Provisional new-format key; handle_submit re-resolves for backward compat
+    session_id = derive_session_id(entity_id, channel, thread_ts)
+
     return SubmitContext(
         run_id=run_id,
         channel=channel,
         msg_ts=msg_ts,
         thread_ts=thread_ts,
-        session_id=derive_session_id(entity_id, channel, thread_ts),
+        session_id=session_id,
         awaiting_ts=awaiting_ts,
         user_id=(payload.get("user") or {}).get("id", ""),
         team_id=(payload.get("team") or {}).get("id"),

--- a/libs/agno/agno/os/interfaces/slack/interactions.py
+++ b/libs/agno/agno/os/interfaces/slack/interactions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from agno.os.interfaces.slack.helpers import derive_session_id
 from agno.os.interfaces.slack.ids import (
     ACTION_EXTERNAL_RESULT,
     ACTION_REJECT_REASON,
@@ -183,7 +184,7 @@ def extract_submit_context(payload: Dict[str, Any], entity_id: str) -> Optional[
         channel=channel,
         msg_ts=msg_ts,
         thread_ts=thread_ts,
-        session_id=f"{entity_id}:{thread_ts}",
+        session_id=derive_session_id(entity_id, channel, thread_ts),
         awaiting_ts=awaiting_ts,
         user_id=(payload.get("user") or {}).get("id", ""),
         team_id=(payload.get("team") or {}).get("id"),

--- a/libs/agno/agno/os/interfaces/slack/types.py
+++ b/libs/agno/agno/os/interfaces/slack/types.py
@@ -45,7 +45,6 @@ class SubmitContext:
     channel: str
     msg_ts: str
     thread_ts: str
-    session_id: str
     awaiting_ts: Optional[str]
     user_id: str
     team_id: Optional[str]

--- a/libs/agno/tests/unit/os/routers/conftest.py
+++ b/libs/agno/tests/unit/os/routers/conftest.py
@@ -45,6 +45,8 @@ def make_agent_mock():
             status="OK", content="done", reasoning_content=None, images=None, files=None, videos=None, audio=None
         )
     )
+    # Session lookup returns None by default so resolve_session_id uses the new key format
+    agent_mock.aget_session = AsyncMock(return_value=None)
     return agent_mock
 
 

--- a/libs/agno/tests/unit/os/routers/conftest.py
+++ b/libs/agno/tests/unit/os/routers/conftest.py
@@ -160,6 +160,8 @@ def make_streaming_body(
 def make_streaming_agent(chunks=None):
     agent = AsyncMock()
     agent.name = "Test Agent"
+    # Session lookup returns None by default so resolve_session_id uses the new key format
+    agent.aget_session = AsyncMock(return_value=None)
 
     async def _arun_stream(*args, **kwargs):
         for c in chunks or []:

--- a/libs/agno/tests/unit/os/routers/test_slack_helpers.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_helpers.py
@@ -389,56 +389,65 @@ class TestStripBotMention:
         assert result == "Scout"
 
 
-class TestDeriveSessionId:
-    def test_includes_channel_to_prevent_collision(self):
-        key_a = derive_session_id("agent-1", "C_ENG", "111.222")
-        key_b = derive_session_id("agent-1", "C_SALES", "111.222")
-        assert key_a != key_b
-        assert key_a == "agent-1:C_ENG:111.222"
-        assert key_b == "agent-1:C_SALES:111.222"
-
-    def test_format_is_entity_channel_thread(self):
-        key = derive_session_id("my-bot", "C123", "1708123456.000100")
-        assert key == "my-bot:C123:1708123456.000100"
+# -- derive_session_id --
 
 
-class TestResolveSessionId:
-    @pytest.mark.asyncio
-    async def test_returns_legacy_key_when_session_exists(self):
-        entity = Mock()
-        entity.aget_session = AsyncMock(return_value={"session_id": "agent-1:111.222"})
+def test_derive_session_id_includes_channel_to_prevent_collision():
+    key_a = derive_session_id("agent-1", "C_ENG", "111.222")
+    key_b = derive_session_id("agent-1", "C_SALES", "111.222")
+    assert key_a != key_b
+    assert key_a == "agent-1:C_ENG:111.222"
+    assert key_b == "agent-1:C_SALES:111.222"
 
-        key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
-        assert key == "agent-1:111.222"
-        entity.aget_session.assert_awaited_once_with(session_id="agent-1:111.222")
 
-    @pytest.mark.asyncio
-    async def test_returns_new_key_when_no_legacy_session(self):
-        entity = Mock()
-        entity.aget_session = AsyncMock(return_value=None)
+def test_derive_session_id_format_is_entity_channel_thread():
+    key = derive_session_id("my-bot", "C123", "1708123456.000100")
+    assert key == "my-bot:C123:1708123456.000100"
 
-        key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
-        assert key == "agent-1:C123:111.222"
 
-    @pytest.mark.asyncio
-    async def test_returns_new_key_when_aget_session_raises(self):
-        entity = Mock()
-        entity.aget_session = AsyncMock(side_effect=Exception("DB error"))
+# -- resolve_session_id --
 
-        key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
-        assert key == "agent-1:C123:111.222"
 
-    @pytest.mark.asyncio
-    async def test_returns_new_key_for_remote_entities(self):
-        entity = Mock(spec=[])
+@pytest.mark.asyncio
+async def test_resolve_session_id_returns_legacy_key_when_session_exists():
+    entity = Mock()
+    entity.aget_session = AsyncMock(return_value={"session_id": "agent-1:111.222"})
 
-        key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
-        assert key == "agent-1:C123:111.222"
+    key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
+    assert key == "agent-1:111.222"
+    entity.aget_session.assert_awaited_once_with(session_id="agent-1:111.222")
 
-    @pytest.mark.asyncio
-    async def test_returns_new_key_when_no_db_access(self):
-        entity = Mock(spec=[])
-        entity.db = None
 
-        key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
-        assert key == "agent-1:C123:111.222"
+@pytest.mark.asyncio
+async def test_resolve_session_id_returns_new_key_when_no_legacy_session():
+    entity = Mock()
+    entity.aget_session = AsyncMock(return_value=None)
+
+    key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
+    assert key == "agent-1:C123:111.222"
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_id_returns_new_key_when_aget_session_raises():
+    entity = Mock()
+    entity.aget_session = AsyncMock(side_effect=Exception("DB error"))
+
+    key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
+    assert key == "agent-1:C123:111.222"
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_id_returns_new_key_for_remote_entities():
+    entity = Mock(spec=[])
+
+    key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
+    assert key == "agent-1:C123:111.222"
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_id_returns_new_key_when_no_db_access():
+    entity = Mock(spec=[])
+    entity.db = None
+
+    key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
+    assert key == "agent-1:C123:111.222"

--- a/libs/agno/tests/unit/os/routers/test_slack_helpers.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_helpers.py
@@ -4,7 +4,6 @@ import pytest
 
 from agno.os.interfaces.slack.helpers import (
     BotNameResolver,
-    derive_session_id,
     download_event_files_async,
     extract_event_context,
     member_name,
@@ -387,22 +386,6 @@ class TestStripBotMention:
     def test_mention_only_with_bot_name(self):
         result = strip_bot_mention("<@U0APCSS3MDH>", "U0APCSS3MDH", "Scout")
         assert result == "Scout"
-
-
-# -- derive_session_id --
-
-
-def test_derive_session_id_includes_channel_to_prevent_collision():
-    key_a = derive_session_id("agent-1", "C_ENG", "111.222")
-    key_b = derive_session_id("agent-1", "C_SALES", "111.222")
-    assert key_a != key_b
-    assert key_a == "agent-1:C_ENG:111.222"
-    assert key_b == "agent-1:C_SALES:111.222"
-
-
-def test_derive_session_id_format_is_entity_channel_thread():
-    key = derive_session_id("my-bot", "C123", "1708123456.000100")
-    assert key == "my-bot:C123:1708123456.000100"
 
 
 # -- resolve_session_id --

--- a/libs/agno/tests/unit/os/routers/test_slack_helpers.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_helpers.py
@@ -4,6 +4,7 @@ import pytest
 
 from agno.os.interfaces.slack.helpers import (
     BotNameResolver,
+    derive_session_id,
     download_event_files_async,
     extract_event_context,
     member_name,
@@ -385,3 +386,18 @@ class TestStripBotMention:
     def test_mention_only_with_bot_name(self):
         result = strip_bot_mention("<@U0APCSS3MDH>", "U0APCSS3MDH", "Scout")
         assert result == "Scout"
+
+
+class TestDeriveSessionId:
+    def test_includes_channel_to_prevent_collision(self):
+        # Slack ts values are only unique per channel — same thread_ts in two
+        # channels must produce different session keys
+        key_a = derive_session_id("agent-1", "C_ENG", "111.222")
+        key_b = derive_session_id("agent-1", "C_SALES", "111.222")
+        assert key_a != key_b
+        assert key_a == "agent-1:C_ENG:111.222"
+        assert key_b == "agent-1:C_SALES:111.222"
+
+    def test_format_is_entity_channel_thread(self):
+        key = derive_session_id("my-bot", "C123", "1708123456.000100")
+        assert key == "my-bot:C123:1708123456.000100"

--- a/libs/agno/tests/unit/os/routers/test_slack_helpers.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_helpers.py
@@ -442,19 +442,17 @@ class TestResolveSessionId:
         assert key == "agent-1:C123:111.222"
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_db_get_session_for_remote_entities(self):
-        from unittest.mock import AsyncMock, MagicMock
+    async def test_returns_new_key_for_remote_entities(self):
+        from unittest.mock import MagicMock
 
         from agno.os.interfaces.slack.helpers import resolve_session_id
 
-        # Remote entities don't have aget_session but have db.get_session
+        # Remote entities don't have aget_session — always use new key format
         entity = MagicMock(spec=[])
         del entity.aget_session
-        entity.db = MagicMock()
-        entity.db.get_session = AsyncMock(return_value={"session_id": "agent-1:111.222"})
 
         key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
-        assert key == "agent-1:111.222"
+        assert key == "agent-1:C123:111.222"
 
     @pytest.mark.asyncio
     async def test_returns_new_key_when_no_db_access(self):

--- a/libs/agno/tests/unit/os/routers/test_slack_helpers.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_helpers.py
@@ -401,3 +401,71 @@ class TestDeriveSessionId:
     def test_format_is_entity_channel_thread(self):
         key = derive_session_id("my-bot", "C123", "1708123456.000100")
         assert key == "my-bot:C123:1708123456.000100"
+
+
+class TestResolveSessionId:
+    @pytest.mark.asyncio
+    async def test_returns_legacy_key_when_session_exists(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from agno.os.interfaces.slack.helpers import resolve_session_id
+
+        entity = MagicMock()
+        entity.aget_session = AsyncMock(return_value={"session_id": "agent-1:111.222"})
+
+        key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
+        assert key == "agent-1:111.222"
+        entity.aget_session.assert_awaited_once_with(session_id="agent-1:111.222")
+
+    @pytest.mark.asyncio
+    async def test_returns_new_key_when_no_legacy_session(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from agno.os.interfaces.slack.helpers import resolve_session_id
+
+        entity = MagicMock()
+        entity.aget_session = AsyncMock(return_value=None)
+
+        key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
+        assert key == "agent-1:C123:111.222"
+
+    @pytest.mark.asyncio
+    async def test_returns_new_key_when_aget_session_raises(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from agno.os.interfaces.slack.helpers import resolve_session_id
+
+        entity = MagicMock()
+        entity.aget_session = AsyncMock(side_effect=Exception("DB error"))
+
+        key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
+        assert key == "agent-1:C123:111.222"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_db_get_session_for_remote_entities(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from agno.os.interfaces.slack.helpers import resolve_session_id
+
+        # Remote entities don't have aget_session but have db.get_session
+        entity = MagicMock(spec=[])
+        del entity.aget_session
+        entity.db = MagicMock()
+        entity.db.get_session = AsyncMock(return_value={"session_id": "agent-1:111.222"})
+
+        key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
+        assert key == "agent-1:111.222"
+
+    @pytest.mark.asyncio
+    async def test_returns_new_key_when_no_db_access(self):
+        from unittest.mock import MagicMock
+
+        from agno.os.interfaces.slack.helpers import resolve_session_id
+
+        # Entity with neither aget_session nor db
+        entity = MagicMock(spec=[])
+        del entity.aget_session
+        entity.db = None
+
+        key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
+        assert key == "agent-1:C123:111.222"

--- a/libs/agno/tests/unit/os/routers/test_slack_helpers.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_helpers.py
@@ -8,6 +8,7 @@ from agno.os.interfaces.slack.helpers import (
     download_event_files_async,
     extract_event_context,
     member_name,
+    resolve_session_id,
     resolve_slack_user,
     send_slack_message_async,
     should_respond,
@@ -390,8 +391,6 @@ class TestStripBotMention:
 
 class TestDeriveSessionId:
     def test_includes_channel_to_prevent_collision(self):
-        # Slack ts values are only unique per channel — same thread_ts in two
-        # channels must produce different session keys
         key_a = derive_session_id("agent-1", "C_ENG", "111.222")
         key_b = derive_session_id("agent-1", "C_SALES", "111.222")
         assert key_a != key_b
@@ -406,11 +405,7 @@ class TestDeriveSessionId:
 class TestResolveSessionId:
     @pytest.mark.asyncio
     async def test_returns_legacy_key_when_session_exists(self):
-        from unittest.mock import AsyncMock, MagicMock
-
-        from agno.os.interfaces.slack.helpers import resolve_session_id
-
-        entity = MagicMock()
+        entity = Mock()
         entity.aget_session = AsyncMock(return_value={"session_id": "agent-1:111.222"})
 
         key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
@@ -419,11 +414,7 @@ class TestResolveSessionId:
 
     @pytest.mark.asyncio
     async def test_returns_new_key_when_no_legacy_session(self):
-        from unittest.mock import AsyncMock, MagicMock
-
-        from agno.os.interfaces.slack.helpers import resolve_session_id
-
-        entity = MagicMock()
+        entity = Mock()
         entity.aget_session = AsyncMock(return_value=None)
 
         key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
@@ -431,11 +422,7 @@ class TestResolveSessionId:
 
     @pytest.mark.asyncio
     async def test_returns_new_key_when_aget_session_raises(self):
-        from unittest.mock import AsyncMock, MagicMock
-
-        from agno.os.interfaces.slack.helpers import resolve_session_id
-
-        entity = MagicMock()
+        entity = Mock()
         entity.aget_session = AsyncMock(side_effect=Exception("DB error"))
 
         key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
@@ -443,26 +430,14 @@ class TestResolveSessionId:
 
     @pytest.mark.asyncio
     async def test_returns_new_key_for_remote_entities(self):
-        from unittest.mock import MagicMock
-
-        from agno.os.interfaces.slack.helpers import resolve_session_id
-
-        # Remote entities don't have aget_session — always use new key format
-        entity = MagicMock(spec=[])
-        del entity.aget_session
+        entity = Mock(spec=[])
 
         key = await resolve_session_id(entity, "agent-1", "C123", "111.222")
         assert key == "agent-1:C123:111.222"
 
     @pytest.mark.asyncio
     async def test_returns_new_key_when_no_db_access(self):
-        from unittest.mock import MagicMock
-
-        from agno.os.interfaces.slack.helpers import resolve_session_id
-
-        # Entity with neither aget_session nor db
-        entity = MagicMock(spec=[])
-        del entity.aget_session
+        entity = Mock(spec=[])
         entity.db = None
 
         key = await resolve_session_id(entity, "agent-1", "C123", "111.222")

--- a/libs/agno/tests/unit/os/routers/test_slack_router.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_router.py
@@ -65,7 +65,7 @@ def _make_event_context(**overrides: Any) -> EventContext:
         "thread_id": "1708123456.000100",
         "user": "U123",
         "message_text": "Summarize the incident timeline",
-        "session_id": "agent-1:1708123456.000100",
+        "session_id": "agent-1:C123:1708123456.000100",
         "team_id": "T123",
         "resolved_user_id": "U123",
         "display_name": None,
@@ -253,7 +253,7 @@ class TestNonStreamingRoutes:
 
         assert resp.status_code == 200
         await wait_for_call(agent_mock.arun)
-        assert agent_mock.arun.call_args.kwargs["session_id"] == f"researcher:{thread_ts}"
+        assert agent_mock.arun.call_args.kwargs["session_id"] == f"researcher:C123:{thread_ts}"
 
     @pytest.mark.asyncio
     async def test_user_id_is_raw_slack_id_by_default(self):
@@ -923,7 +923,7 @@ class TestHITLFlow:
         ):
             await handler.handle_submit(payload)
 
-        entity.aget_run_output.assert_awaited_once_with(run_id="run-1", session_id="agent-1:111.222")
+        entity.aget_run_output.assert_awaited_once_with(run_id="run-1", session_id="agent-1:C123:111.222")
         assert requirement.confirmation is True
         mock_client.chat_delete.assert_awaited_once_with(channel="C123", ts="await-1")
         mock_open.assert_awaited_once_with(mock_client, "C123", "111.222", "U123", "T123", "plan", 100)

--- a/libs/agno/tests/unit/os/routers/test_slack_router.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_router.py
@@ -256,6 +256,45 @@ class TestNonStreamingRoutes:
         assert agent_mock.arun.call_args.kwargs["session_id"] == f"researcher:C123:{thread_ts}"
 
     @pytest.mark.asyncio
+    async def test_session_id_uses_legacy_key_when_session_exists(self):
+        """Backward compat: if a pre-channel-scoped session exists, use that key."""
+        agent_mock = make_agent_mock()
+        agent_mock.id = "researcher"
+        agent_mock.name = "Researcher"
+        thread_ts = "1708123456.000100"
+        # Simulate legacy session exists
+        agent_mock.aget_session = AsyncMock(return_value={"session_id": f"researcher:{thread_ts}"})
+        mock_slack = make_slack_mock(token="xoxb-test")
+
+        with (
+            patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
+            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack.event_handler.AsyncWebClient", return_value=make_async_client_mock()),
+        ):
+            app = build_app(agent_mock, reply_to_mentions_only=False)
+            from fastapi.testclient import TestClient
+
+            client = TestClient(app)
+            body = {
+                "type": "event_callback",
+                "event": {
+                    "type": "message",
+                    "channel_type": "channel",
+                    "text": "hello",
+                    "user": "U123",
+                    "channel": "C123",
+                    "ts": "1708123456.000200",
+                    "thread_ts": thread_ts,
+                },
+            }
+            resp = make_signed_request(client, body)
+
+        assert resp.status_code == 200
+        await wait_for_call(agent_mock.arun)
+        # Legacy key without channel_id
+        assert agent_mock.arun.call_args.kwargs["session_id"] == f"researcher:{thread_ts}"
+
+    @pytest.mark.asyncio
     async def test_user_id_is_raw_slack_id_by_default(self):
         agent_mock = make_agent_mock()
         mock_slack = make_slack_mock(token="xoxb-test")
@@ -884,6 +923,7 @@ class TestHITLFlow:
     async def test_submit_approval_opens_stream_with_shared_helper_and_continues_run(self):
         requirement = _make_requirement()
         entity = AsyncMock()
+        entity.aget_session = AsyncMock(return_value=None)
         entity.aget_run_output = AsyncMock(return_value=Mock(active_requirements=[requirement]))
         continued = {"called": False}
 
@@ -936,6 +976,7 @@ class TestHITLFlow:
         regular_req = _make_requirement(req_id="r1")
         required_req = _make_requirement(req_id="r2", approval_type="required", approval_id="appr-1")
         entity = AsyncMock()
+        entity.aget_session = AsyncMock(return_value=None)
         entity.aget_run_output = AsyncMock(
             return_value=Mock(active_requirements=[regular_req, required_req], user_id="user@test.com")
         )
@@ -1021,6 +1062,7 @@ class TestAdminApprovalFlow:
         """When admin has approved via dashboard, Check Status resumes the run."""
         requirement = _make_requirement(approval_type="required", approval_id="appr-1")
         entity = AsyncMock()
+        entity.aget_session = AsyncMock(return_value=None)
         entity.aget_run_output = AsyncMock(
             return_value=Mock(active_requirements=[requirement], user_id="user@test.com")
         )


### PR DESCRIPTION
## Summary

Fixes cross-channel session collision by including `channel_id` in the session key, with **backward-compatible migration** for existing sessions.

### The Bug
- **Before**: `{entity}:{thread_ts}` — could collide across channels (Slack `ts` values are only unique per channel)
- **After**: `{entity}:{channel}:{thread_ts}` — prevents collision

### Backward Compatibility
Adds `resolve_session_id()` that probes for existing legacy sessions before using the new format:
1. Try legacy key: `{entity}:{thread_ts}`
2. If session exists in DB → use legacy key (existing thread continues)
3. If not → use new format (new threads get collision-safe keys)

This ensures **existing threads continue seamlessly** on upgrade while new threads get the collision-safe format.

## Changes

- Add `derive_session_id()` helper in `helpers.py` (pure formatter)
- Add `resolve_session_id()` with legacy session probe (async, 1 DB read per event)
- Update all 3 derivation sites to use `resolve_session_id`:
  - Event handler (`event_handler.py`)
  - Admin-approval resume (`hitl.py`)
  - HITL submit handler (`hitl.py`)
- Add 6 tests for `resolve_session_id` and backward compat behavior

## Upgrade Notes

- **No breaking change for existing users** — existing threads continue with their original session
- New threads use the collision-safe channel-scoped key
- Performance: 1 extra DB read per Slack event (same order of magnitude as `resolve_channel_name()`)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Formatted and validated (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Added tests for `derive_session_id()` and `resolve_session_id()`
- [x] Updated existing test assertions and mocks
- [x] Verified backward compatibility with legacy session test