### PR TITLE
feat: in-memory access count tracking for knowledge documents

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -55,6 +55,8 @@ class Knowledge(RemoteKnowledge):
     # Requires re-indexing existing data to add linked_to metadata.
     # Default is False for backwards compatibility with existing data.
     isolate_vector_search: bool = False
+    # In-memory access counts, flushed to DB during content updates
+    _access_counts: Dict[str, int] = None  # type: ignore
 
     def __post_init__(self):
         from agno.vectordb import VectorDb
@@ -64,6 +66,59 @@ class Knowledge(RemoteKnowledge):
             self.vector_db.create()
 
         self.construct_readers()
+
+        if self._access_counts is None:
+            self._access_counts = {}
+
+    def _track_access(self, documents: List[Document]) -> None:
+        """Track access counts for documents in memory. Flushed on content updates."""
+        for doc in documents:
+            if doc.content_id:
+                self._access_counts[doc.content_id] = self._access_counts.get(doc.content_id, 0) + 1
+
+    def flush_access_counts(self) -> None:
+        """Flush all pending access counts to the database."""
+        if not self.contents_db or not self._access_counts:
+            return
+
+        if isinstance(self.contents_db, AsyncBaseDb):
+            raise ValueError("flush_access_counts() is not supported with async DB. Use aflush_access_counts().")
+
+        for content_id, count in list(self._access_counts.items()):
+            try:
+                content_row = self.contents_db.get_knowledge_content(content_id)
+                if content_row:
+                    current_count = content_row.access_count or 0
+                    content_row.access_count = current_count + count
+                    content_row.updated_at = int(time.time())
+                    self.contents_db.upsert_knowledge_content(knowledge_row=content_row)
+                    del self._access_counts[content_id]
+            except Exception as e:
+                log_debug(f"Failed to flush access count for {content_id}: {e}")
+
+    async def aflush_access_counts(self) -> None:
+        """Async version: Flush all pending access counts to the database."""
+        if not self.contents_db or not self._access_counts:
+            return
+
+        for content_id, count in list(self._access_counts.items()):
+            try:
+                if isinstance(self.contents_db, AsyncBaseDb):
+                    content_row = await self.contents_db.get_knowledge_content(content_id)
+                else:
+                    content_row = self.contents_db.get_knowledge_content(content_id)
+
+                if content_row:
+                    current_count = content_row.access_count or 0
+                    content_row.access_count = current_count + count
+                    content_row.updated_at = int(time.time())
+                    if isinstance(self.contents_db, AsyncBaseDb):
+                        await self.contents_db.upsert_knowledge_content(knowledge_row=content_row)
+                    else:
+                        self.contents_db.upsert_knowledge_content(knowledge_row=content_row)
+                    del self._access_counts[content_id]
+            except Exception as e:
+                log_debug(f"Failed to flush access count for {content_id}: {e}")
 
     # ==========================================
     # PUBLIC API - INSERT METHODS
@@ -542,7 +597,9 @@ class Knowledge(RemoteKnowledge):
 
             _max_results = max_results or self.max_results
             log_debug(f"Getting {_max_results} relevant documents for query: {query}")
-            return self.vector_db.search(query=query, limit=_max_results, filters=search_filters)
+            results = self.vector_db.search(query=query, limit=_max_results, filters=search_filters)
+            self._track_access(results)
+            return results
         except Exception as e:
             log_error(f"Error searching for documents: {str(e)}")
             return []
@@ -583,10 +640,12 @@ class Knowledge(RemoteKnowledge):
             _max_results = max_results or self.max_results
             log_debug(f"Getting {_max_results} relevant documents for query: {query}")
             try:
-                return await self.vector_db.async_search(query=query, limit=_max_results, filters=search_filters)
+                results = await self.vector_db.async_search(query=query, limit=_max_results, filters=search_filters)
             except NotImplementedError:
                 log_info("Vector db does not support async search")
-                return self.vector_db.search(query=query, limit=_max_results, filters=search_filters)
+                results = self.vector_db.search(query=query, limit=_max_results, filters=search_filters)
+            self._track_access(results)
+            return results
         except Exception as e:
             log_error(f"Error searching for documents: {str(e)}")
             return []
@@ -2559,6 +2618,11 @@ class Knowledge(RemoteKnowledge):
                 content_row.external_id = self._ensure_string_field(
                     content.external_id, "content.external_id", default=""
                 )
+            # Apply pending access count if tracked
+            if content.id in self._access_counts:
+                current_count = content_row.access_count or 0
+                content_row.access_count = current_count + self._access_counts.pop(content.id)
+
             content_row.updated_at = int(time.time())
             self.contents_db.upsert_knowledge_content(knowledge_row=content_row)
 
@@ -2606,6 +2670,11 @@ class Knowledge(RemoteKnowledge):
                 content_row.external_id = self._ensure_string_field(
                     content.external_id, "content.external_id", default=""
                 )
+
+            # Apply pending access count if tracked
+            if content.id in self._access_counts:
+                current_count = content_row.access_count or 0
+                content_row.access_count = current_count + self._access_counts.pop(content.id)
 
             content_row.updated_at = int(time.time())
             if isinstance(self.contents_db, AsyncBaseDb):

--- a/libs/agno/tests/unit/knowledge/test_knowledge_access_count.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_access_count.py
@@ -1,0 +1,114 @@
+"""Tests for in-memory access count tracking in Knowledge.
+
+Access counts are tracked in memory during search and flushed to the database
+during content updates or via explicit flush_access_counts() call.
+"""
+
+import pytest
+
+from agno.db.schemas.knowledge import KnowledgeRow
+from agno.db.sqlite import SqliteDb
+from agno.knowledge.document import Document
+from agno.knowledge.knowledge import Knowledge
+
+
+@pytest.fixture
+def db():
+    return SqliteDb(db_url="sqlite:///:memory:")
+
+
+@pytest.fixture
+def knowledge(db):
+    return Knowledge(name="test_knowledge", contents_db=db)
+
+
+def seed_content(db, content_id, access_count=None):
+    row = KnowledgeRow(
+        id=content_id,
+        name="doc.txt",
+        description="Test document",
+        access_count=access_count,
+    )
+    db.upsert_knowledge_content(knowledge_row=row)
+
+
+class TestAccessCountTracking:
+    def test_access_counts_initialized_empty(self):
+        knowledge = Knowledge(name="test")
+        assert knowledge._access_counts == {}
+
+    def test_track_access_increments_counts(self):
+        knowledge = Knowledge(name="test")
+        docs = [
+            Document(content="doc1", content_id="id-1"),
+            Document(content="doc2", content_id="id-2"),
+            Document(content="doc3", content_id="id-1"),
+        ]
+        knowledge._track_access(docs)
+        assert knowledge._access_counts == {"id-1": 2, "id-2": 1}
+
+    def test_track_access_ignores_none_content_id(self):
+        knowledge = Knowledge(name="test")
+        docs = [
+            Document(content="doc1", content_id="id-1"),
+            Document(content="doc2", content_id=None),
+        ]
+        knowledge._track_access(docs)
+        assert knowledge._access_counts == {"id-1": 1}
+
+
+class TestFlushAccessCounts:
+    def test_flush_persists_to_db(self, db, knowledge):
+        seed_content(db, "content-1")
+
+        knowledge._track_access(
+            [
+                Document(content="chunk one", content_id="content-1"),
+                Document(content="chunk two", content_id="content-1"),
+            ]
+        )
+        knowledge._track_access([Document(content="chunk three", content_id="content-1")])
+
+        assert knowledge._access_counts == {"content-1": 3}
+
+        knowledge.flush_access_counts()
+
+        stored = db.get_knowledge_content("content-1")
+        assert stored is not None
+        assert stored.access_count == 3
+        assert stored.updated_at is not None
+        assert knowledge._access_counts == {}
+
+    def test_flush_accumulates_onto_existing_count(self, db, knowledge):
+        seed_content(db, "content-1", access_count=5)
+
+        knowledge._track_access([Document(content="chunk one", content_id="content-1")])
+        knowledge._track_access([Document(content="chunk two", content_id="content-1")])
+        knowledge.flush_access_counts()
+
+        stored = db.get_knowledge_content("content-1")
+        assert stored.access_count == 7
+
+    def test_flush_keeps_counts_for_unknown_content(self, db, knowledge):
+        seed_content(db, "content-1")
+
+        knowledge._track_access(
+            [
+                Document(content="chunk one", content_id="content-1"),
+                Document(content="stale chunk", content_id="deleted-content"),
+            ]
+        )
+        knowledge.flush_access_counts()
+
+        assert db.get_knowledge_content("content-1").access_count == 1
+        assert knowledge._access_counts == {"deleted-content": 1}
+
+    def test_flush_noop_when_empty(self, db, knowledge):
+        knowledge.flush_access_counts()
+        assert knowledge._access_counts == {}
+
+    def test_flush_noop_without_contents_db(self):
+        knowledge = Knowledge(name="test")
+        knowledge._access_counts = {"id-1": 5}
+        knowledge.flush_access_counts()
+        assert knowledge._access_counts == {"id-1": 5}


### PR DESCRIPTION
## Summary
Track document access counts in memory during search, flush to DB only during existing content updates. This avoids N database writes per search query.

**Changes:**
- Add `_access_counts` dict to Knowledge class for in-memory tracking
- Track access in `search()` and `asearch()` without DB calls
- Flush pending counts when content is updated via `_update_content`
- Add `flush_access_counts()` / `aflush_access_counts()` for explicit flush

## Why this approach?
The original implementation (#5004 by @siddartha-10) added a DB UPDATE call for each unique document returned by search. This adds unnecessary write load and latency to every search operation.

This implementation:
- **Zero overhead on search**: Just increments a dict in memory
- **Piggybacks on existing writes**: Counts flush when content metadata is updated anyway
- **Explicit flush available**: For shutdown or manual persistence scenarios

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Both sync and async variants provided (`flush_access_counts` / `aflush_access_counts`)
- [x] Unit tests added (8 tests in `test_knowledge_access_count.py`)
- [x] Tests use real SQLite DB (in-memory)
- [x] Code passes format.sh and validate.sh

Fixes #4873
Supersedes #5004