### PR TITLE
fix: return generated images from OpenRouter responses

### DIFF
--- a/cookbook/90_models/openrouter/chat/image_generation.py
+++ b/cookbook/90_models/openrouter/chat/image_generation.py
@@ -1,0 +1,26 @@
+from io import BytesIO
+
+from agno.agent import Agent, RunOutput  # noqa
+from agno.models.openrouter import OpenRouter
+from PIL import Image
+
+# Request both image and text modalities so OpenRouter returns generated images
+agent = Agent(
+    model=OpenRouter(
+        id="google/gemini-2.5-flash-image",
+        modalities=["image", "text"],
+    )
+)
+
+run_response = agent.run("Make me an image of a cat in a tree.")
+
+if run_response and isinstance(run_response, RunOutput) and run_response.images:
+    for image_response in run_response.images:
+        image_bytes = image_response.content
+        if image_bytes:
+            image = Image.open(BytesIO(image_bytes))
+            image.show()
+            # Save the image to a file
+            # image.save("generated_image.png")
+else:
+    print("No images found in run response")

--- a/libs/agno/agno/models/openrouter/openrouter.py
+++ b/libs/agno/agno/models/openrouter/openrouter.py
@@ -6,6 +6,7 @@ from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from pydantic import BaseModel
 
 from agno.exceptions import ModelAuthenticationError
+from agno.media import Image
 from agno.models.message import Message
 from agno.models.openai.like import OpenAILike
 from agno.models.response import ModelResponse
@@ -99,6 +100,29 @@ class OpenRouter(OpenAILike):
 
         return message_dict
 
+    def _add_openrouter_images(self, extra: Optional[Any], model_response: ModelResponse) -> None:
+        """Append generated images from OpenRouter's ``model_extra["images"]`` to model_response.
+
+        OpenRouter returns generated images as data URLs under the assistant message's
+        (and streamed delta's) ``images`` field, e.g.
+        ``{"image_url": {"url": "data:image/png;base64,..."}}``.
+        """
+        if not isinstance(extra, dict) or not isinstance(extra.get("images"), list):
+            return
+        for item in extra["images"]:
+            image_url = item.get("image_url") if isinstance(item, dict) else None
+            url = image_url.get("url") if isinstance(image_url, dict) else None
+            # Only data URLs are expected here. Skip remote URLs rather than fetch a
+            # provider-controlled address server-side (SSRF risk via Image.get_content_bytes).
+            if not url or not url.startswith("data:"):
+                continue
+            header, _, payload = url.partition(",")
+            mime_type = header[len("data:") :].split(";")[0] or None
+            image = Image.from_base64(payload, mime_type=mime_type)
+            if model_response.images is None:
+                model_response.images = []
+            model_response.images.append(image)
+
     def _parse_provider_response(
         self,
         response: ChatCompletion,
@@ -119,6 +143,9 @@ class OpenRouter(OpenAILike):
                         model_response.provider_data = {}
                     model_response.provider_data["reasoning_details"] = extra["reasoning_details"]
 
+            # Generated images arrive under model_extra["images"] (buffered response)
+            self._add_openrouter_images(getattr(response_message, "model_extra", None), model_response)
+
         return model_response
 
     def _parse_provider_response_delta(self, response_delta: ChatCompletionChunk) -> ModelResponse:
@@ -130,5 +157,8 @@ class OpenRouter(OpenAILike):
                 if model_response.provider_data is None:
                     model_response.provider_data = {}
                 model_response.provider_data["reasoning_details"] = choice_delta.reasoning_details
+
+            # Streamed generated images arrive under delta.images (same shape as buffered)
+            self._add_openrouter_images(getattr(choice_delta, "model_extra", None), model_response)
 
         return model_response

--- a/libs/agno/tests/unit/models/openrouter_model/test_openrouter_image_generation.py
+++ b/libs/agno/tests/unit/models/openrouter_model/test_openrouter_image_generation.py
@@ -1,0 +1,108 @@
+"""Tests for OpenRouter image-generation response parsing.
+
+OpenRouter returns generated images under the chat message's model_extra["images"]
+as data URLs, both in the buffered response and in streamed deltas. Both parsers
+must surface them as Image artifacts on model_response.images (matching the Gemini
+image-output pattern).
+"""
+
+import base64
+
+from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
+from openai.types.chat.chat_completion_chunk import ChoiceDelta
+
+from agno.media import Image
+from agno.models.openrouter import OpenRouter
+
+# 1x1 transparent PNG
+_PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+
+def _completion_with_extra(message_extra: dict) -> ChatCompletion:
+    message = ChatCompletionMessage.model_validate({"role": "assistant", "content": "", **message_extra})
+    choice = Choice(index=0, message=message, finish_reason="stop")
+    return ChatCompletion(
+        id="test",
+        choices=[choice],
+        created=0,
+        model="google/gemini-2.5-flash-image",
+        object="chat.completion",
+    )
+
+
+def _chunk_with_extra(delta_extra: dict) -> ChatCompletionChunk:
+    delta = ChoiceDelta.model_validate({"role": "assistant", "content": "", **delta_extra})
+    choice = ChunkChoice(index=0, delta=delta, finish_reason=None)
+    return ChatCompletionChunk(
+        id="test",
+        choices=[choice],
+        created=0,
+        model="google/gemini-2.5-flash-image",
+        object="chat.completion.chunk",
+    )
+
+
+def test_generated_image_parsed_from_data_url():
+    """A data-URL image is decoded into an Image artifact with content bytes."""
+    response = _completion_with_extra(
+        {"images": [{"type": "image_url", "image_url": {"url": f"data:image/png;base64,{_PNG_B64}"}}]}
+    )
+    model_response = OpenRouter(api_key="test-key")._parse_provider_response(response)
+
+    assert model_response.images is not None
+    assert len(model_response.images) == 1
+    image = model_response.images[0]
+    assert isinstance(image, Image)
+    assert image.content == base64.b64decode(_PNG_B64)
+    assert image.mime_type == "image/png"
+
+
+def test_no_images_when_extra_absent():
+    """A normal response without images leaves model_response.images unset."""
+    response = _completion_with_extra({})
+    model_response = OpenRouter(api_key="test-key")._parse_provider_response(response)
+    assert model_response.images is None
+
+
+def test_non_data_url_skipped():
+    """A non-data URL is skipped: OpenRouter only emits data URLs, and fetching a
+    provider-supplied remote URL server-side would be an SSRF risk."""
+    response = _completion_with_extra(
+        {"images": [{"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}}]}
+    )
+    model_response = OpenRouter(api_key="test-key")._parse_provider_response(response)
+
+    assert model_response.images is None
+
+
+def test_image_without_type_field_is_parsed():
+    """An entry omitting the optional `type` field is still parsed (robustness)."""
+    response = _completion_with_extra({"images": [{"image_url": {"url": f"data:image/png;base64,{_PNG_B64}"}}]})
+    model_response = OpenRouter(api_key="test-key")._parse_provider_response(response)
+
+    assert model_response.images is not None
+    assert model_response.images[0].content == base64.b64decode(_PNG_B64)
+
+
+def test_generated_image_parsed_from_streaming_delta():
+    """A streamed delta image is decoded into an Image artifact (stream=True path)."""
+    chunk = _chunk_with_extra(
+        {"images": [{"type": "image_url", "image_url": {"url": f"data:image/png;base64,{_PNG_B64}"}}]}
+    )
+    model_response = OpenRouter(api_key="test-key")._parse_provider_response_delta(chunk)
+
+    assert model_response.images is not None
+    assert len(model_response.images) == 1
+    image = model_response.images[0]
+    assert isinstance(image, Image)
+    assert image.content == base64.b64decode(_PNG_B64)
+    assert image.mime_type == "image/png"
+
+
+def test_no_images_when_delta_is_plain_text():
+    """A normal text delta leaves model_response.images unset."""
+    chunk = _chunk_with_extra({})
+    model_response = OpenRouter(api_key="test-key")._parse_provider_response_delta(chunk)
+    assert model_response.images is None


### PR DESCRIPTION
## Summary

OpenRouter returns generated images in the chat response under the assistant message's `images` field as data URLs (`choices[0].message.images[].image_url.url`). Agno's OpenRouter model did not parse this, so `response.images` was always empty for image models such as `google/gemini-2.5-flash-image`.

This adds image extraction to both `OpenRouter._parse_provider_response` (buffered) and `_parse_provider_response_delta` (streaming) via a shared helper that decodes the data URLs into `Image` artifacts (content bytes, matching the Gemini pattern). Handling lives at the OpenRouter class level because `message.images` is an OpenRouter-specific extension; other OpenAI-compatible providers use the separate `/images/generations` endpoint. Non-data URLs are skipped to avoid a provider-controlled server-side fetch (SSRF).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Code follows project style (`./scripts/format.sh`)
- [x] Validation passes (`./scripts/validate.sh`)
- [x] Tests added (6 unit tests: buffered, streaming, data-URL decode, type-less entry, non-data-URL skipped, text-only negative)
- [x] Cookbook example added
- [x] Self-review completed

## Notes
- Verified live against the OpenRouter API (`google/gemini-2.5-flash-image`): buffered `agent.run()`, streaming, and AgentOS all return real images.
- Known limitation (pre-existing, not introduced here): `Message.image_output` holds a single image, so a multi-image response surfaces only the last on the non-streaming path. This is framework-wide (affects all image providers) and out of scope here.

## Related
Alternative to #4987.
