### PR TITLE
fix: FixedSizeChunking silently drops short documents when overlap >= content length

### DIFF
--- a/libs/agno/agno/knowledge/chunking/fixed.py
+++ b/libs/agno/agno/knowledge/chunking/fixed.py
@@ -49,8 +49,7 @@ class FixedSizeChunking(ChunkingStrategy):
                 )
             )
             chunk_number += 1
-            # This chunk already reached the end of the content -- stop, rather than
-            # looping again with an overlap-adjusted start that re-emits the same tail.
+            # Stop once a chunk reaches the end of the content
             if end >= content_length:
                 break
             # Ensure start always advances by at least 1 to prevent infinite loops

--- a/libs/agno/agno/knowledge/chunking/fixed.py
+++ b/libs/agno/agno/knowledge/chunking/fixed.py
@@ -23,7 +23,7 @@ class FixedSizeChunking(ChunkingStrategy):
         chunk_number = 1
         chunk_meta_data = document.meta_data
         start = 0
-        while start + self.overlap < content_length:
+        while start < content_length:
             end = min(start + self.chunk_size, content_length)
 
             # Ensure we're not splitting a word in half
@@ -49,6 +49,10 @@ class FixedSizeChunking(ChunkingStrategy):
                 )
             )
             chunk_number += 1
+            # This chunk already reached the end of the content -- stop, rather than
+            # looping again with an overlap-adjusted start that re-emits the same tail.
+            if end >= content_length:
+                break
             # Ensure start always advances by at least 1 to prevent infinite loops
             # when overlap is large relative to chunk_size
             new_start = max(start + 1, end - self.overlap)

--- a/libs/agno/tests/unit/knowledge/chunking/test_fixed_size_chunking.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_fixed_size_chunking.py
@@ -1,19 +1,11 @@
-"""Regression tests for FixedSizeChunking.
-
-The loop guard `while start + self.overlap < content_length` (rather than
-just `while start < content_length`) meant a document shorter than
-`self.overlap` characters never entered the loop body at all -- the entire
-document was silently dropped with zero chunks returned, no error or
-warning. `overlap` is only validated to be `< chunk_size` in the
-constructor, not `< len(content)`, so this was easy to hit with a large
-chunk_size/overlap pair applied to a short document.
-"""
+"""Tests for FixedSizeChunking with short documents and overlap."""
 
 from agno.knowledge.chunking.fixed import FixedSizeChunking
 from agno.knowledge.document.base import Document
 
 
 def test_short_document_with_large_overlap_is_not_silently_dropped():
+    """Test that a document shorter than the overlap is not dropped."""
     strategy = FixedSizeChunking(chunk_size=100, overlap=50)
     doc = Document(name="short", content="Hello world, this is short.")
 
@@ -24,6 +16,7 @@ def test_short_document_with_large_overlap_is_not_silently_dropped():
 
 
 def test_empty_document_still_returns_no_chunks():
+    """Test that an empty document returns no chunks."""
     strategy = FixedSizeChunking(chunk_size=100, overlap=50)
     doc = Document(name="empty", content="")
 
@@ -31,11 +24,7 @@ def test_empty_document_still_returns_no_chunks():
 
 
 def test_long_document_still_chunks_with_overlap_and_no_duplication():
-    """A naive fix that only widens the loop guard (without also stopping
-    once a chunk reaches the end of the content) causes `new_start` to
-    barely advance when overlap is large relative to the remaining
-    content, re-emitting near-duplicate chunks one character apart instead
-    of terminating cleanly at the end of the document."""
+    """Test that a long document chunks with overlap and no duplicate tail."""
     strategy = FixedSizeChunking(chunk_size=20, overlap=5)
     doc = Document(name="long", content="a" * 100)
 

--- a/libs/agno/tests/unit/knowledge/chunking/test_fixed_size_chunking.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_fixed_size_chunking.py
@@ -1,0 +1,45 @@
+"""Regression tests for FixedSizeChunking.
+
+The loop guard `while start + self.overlap < content_length` (rather than
+just `while start < content_length`) meant a document shorter than
+`self.overlap` characters never entered the loop body at all -- the entire
+document was silently dropped with zero chunks returned, no error or
+warning. `overlap` is only validated to be `< chunk_size` in the
+constructor, not `< len(content)`, so this was easy to hit with a large
+chunk_size/overlap pair applied to a short document.
+"""
+
+from agno.knowledge.chunking.fixed import FixedSizeChunking
+from agno.knowledge.document.base import Document
+
+
+def test_short_document_with_large_overlap_is_not_silently_dropped():
+    strategy = FixedSizeChunking(chunk_size=100, overlap=50)
+    doc = Document(name="short", content="Hello world, this is short.")
+
+    chunks = strategy.chunk(doc)
+
+    assert len(chunks) == 1
+    assert chunks[0].content == "Hello world, this is short."
+
+
+def test_empty_document_still_returns_no_chunks():
+    strategy = FixedSizeChunking(chunk_size=100, overlap=50)
+    doc = Document(name="empty", content="")
+
+    assert strategy.chunk(doc) == []
+
+
+def test_long_document_still_chunks_with_overlap_and_no_duplication():
+    """A naive fix that only widens the loop guard (without also stopping
+    once a chunk reaches the end of the content) causes `new_start` to
+    barely advance when overlap is large relative to the remaining
+    content, re-emitting near-duplicate chunks one character apart instead
+    of terminating cleanly at the end of the document."""
+    strategy = FixedSizeChunking(chunk_size=20, overlap=5)
+    doc = Document(name="long", content="a" * 100)
+
+    chunks = strategy.chunk(doc)
+
+    assert len(chunks) == 7
+    assert [len(c.content) for c in chunks] == [20, 20, 20, 20, 20, 20, 10]


### PR DESCRIPTION
## Problem

The loop guard `while start + self.overlap < content_length` never enters the loop body when a document is shorter than `overlap` characters, so the entire document is silently dropped with zero chunks and no error. The constructor only validates `overlap < chunk_size`, not `overlap < len(content)`, so this is easy to hit with a large `chunk_size`/`overlap` pair applied to a short document.

## Fix

Changed the loop guard to `while start < content_length`, and added an explicit `break` once a chunk reaches the end of the content — otherwise the overlap-adjusted `new_start` barely advances when overlap exceeds the remaining content, re-emitting near-duplicate chunks instead of terminating cleanly.

## Testing

- 3 new tests in `tests/unit/knowledge/chunking/test_fixed_size_chunking.py`: short-document case (asserts 1 chunk, was 0), empty-document case (still 0 chunks, no regression), and a longer-document case (asserts correct chunk count with no duplication from the overlap boundary).
- Confirmed red→green: reverting only `fixed.py` reproduces `0 == 1` (document dropped entirely); reapplying passes.
- Full `tests/unit/knowledge/chunking/` (excluding two files that fail to collect in this sandbox due to a missing optional `numpy` dependency, unrelated to this change): 35 passed, 8 skipped.
- `ruff check` — clean.
- xref: no open PR touches `chunking/fixed.py`.

## AI-Generated disclosure

Drafted with Claude Code (Opus 4.8) and personally reviewed/tested before submission.