### PR TITLE
[fix] Isolate nested session state for delegated team members

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 import asyncio
 import contextlib
 import json
-from copy import copy
+from copy import deepcopy
 from typing import (
     Any,
     AsyncIterator,
@@ -615,7 +615,7 @@ def _get_delegate_task_function(
         # Make sure for the member agent, we are using the agent logger
         use_agent_logger()
 
-        member_session_state_copy = copy(run_context.session_state)
+        member_session_state_copy = deepcopy(run_context.session_state)
 
         member_agent_run_response = None
         try:
@@ -802,7 +802,7 @@ def _get_delegate_task_function(
         # Make sure for the member agent, we are using the agent logger
         use_agent_logger()
 
-        member_session_state_copy = copy(run_context.session_state)
+        member_session_state_copy = deepcopy(run_context.session_state)
 
         member_agent_run_response = None
         try:
@@ -973,7 +973,7 @@ def _get_delegate_task_function(
         for _, member_agent in enumerate(resolved_members):
             member_agent_task, history = _setup_delegate_task_to_member(member_agent=member_agent, task=task)
 
-            member_session_state_copy = copy(run_context.session_state)
+            member_session_state_copy = deepcopy(run_context.session_state)
             member_agent_run_response = None
             try:
                 if stream:
@@ -1150,7 +1150,7 @@ def _get_delegate_task_function(
 
             async def stream_member(agent: Union[Agent, "Team"]) -> None:
                 member_agent_task, history = _setup_delegate_task_to_member(member_agent=agent, task=task)  # type: ignore
-                member_session_state_copy = copy(run_context.session_state)
+                member_session_state_copy = deepcopy(run_context.session_state)
 
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
@@ -1283,7 +1283,7 @@ def _get_delegate_task_function(
                     history=history,
                     member_agent_index=member_agent_index,
                 ) -> tuple[str, Optional[Union[Agent, "Team"]], Optional[Union[RunOutput, TeamRunOutput]]]:
-                    member_session_state_copy = copy(run_context.session_state)
+                    member_session_state_copy = deepcopy(run_context.session_state)
 
                     try:
                         member_run_id = str(uuid4())

--- a/libs/agno/tests/unit/team/test_delegated_session_state_isolation.py
+++ b/libs/agno/tests/unit/team/test_delegated_session_state_isolation.py
@@ -1,0 +1,87 @@
+import asyncio
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from agno.agent import Agent
+from agno.run import RunContext
+from agno.run.agent import RunOutput
+from agno.run.team import TeamRunOutput
+from agno.session.team import TeamSession
+from agno.team import Team
+
+
+def test_delegated_member_merges_nested_session_state_after_run(monkeypatch: pytest.MonkeyPatch):
+    parent_state = {"nested": {"values": {}}}
+    run_context = RunContext(run_id="team-run", session_id="session", session_state=parent_state)
+    parent_state_during_member_run: dict[str, Any] = {}
+    member = Agent(id="member", name="member")
+
+    def fake_run(*args: Any, session_state: dict[str, Any], **kwargs: Any) -> RunOutput:
+        session_state["nested"]["values"]["member"] = True
+        parent_state_during_member_run.update(deepcopy(parent_state))
+        return RunOutput(run_id="member-run", agent_id="member", content="done")
+
+    monkeypatch.setattr(member, "run", fake_run)
+    team = Team(name="test-team", members=[member])
+    delegate = team._get_delegate_task_function(
+        session=TeamSession(session_id="session"),
+        run_response=TeamRunOutput(run_id="team-run", session_id="session"),
+        run_context=run_context,
+        team_run_context={},
+    )
+
+    responses = list(delegate.entrypoint(member_id="member", task="work"))
+
+    assert responses == ["done"]
+    assert parent_state_during_member_run == {"nested": {"values": {}}}
+    assert parent_state == {"nested": {"values": {"member": True}}}
+
+
+@pytest.mark.asyncio
+async def test_parallel_delegated_members_do_not_share_nested_session_state(monkeypatch: pytest.MonkeyPatch):
+    parent_state = {"nested": {"values": {}}}
+    run_context = RunContext(run_id="team-run", session_id="session", session_state=parent_state)
+    member_states: dict[str, dict[str, Any]] = {}
+    parent_snapshots: list[dict[str, Any]] = []
+    members_ready = asyncio.Event()
+    mutations_recorded = asyncio.Event()
+
+    def make_member(member_id: str) -> Agent:
+        member = Agent(id=member_id, name=member_id)
+
+        async def fake_arun(*args: Any, session_state: dict[str, Any], **kwargs: Any) -> RunOutput:
+            member_states[member_id] = session_state
+            if len(member_states) == 2:
+                members_ready.set()
+            await members_ready.wait()
+
+            session_state["nested"]["values"][member_id] = True
+            parent_snapshots.append(deepcopy(parent_state))
+            if len(parent_snapshots) == 2:
+                mutations_recorded.set()
+            await mutations_recorded.wait()
+            return RunOutput(run_id=f"{member_id}-run", agent_id=member_id, content="done")
+
+        monkeypatch.setattr(member, "arun", fake_arun)
+        return member
+
+    members = [make_member("member-1"), make_member("member-2")]
+    team = Team(name="test-team", members=members, delegate_to_all_members=True)
+    delegate = team._get_delegate_task_function(
+        session=TeamSession(session_id="session"),
+        run_response=TeamRunOutput(run_id="team-run", session_id="session"),
+        run_context=run_context,
+        team_run_context={},
+        async_mode=True,
+    )
+
+    responses = [response async for response in delegate.entrypoint(task="work")]
+
+    assert len(responses) == 2
+    assert member_states["member-1"]["nested"] is not member_states["member-2"]["nested"]
+    assert member_states["member-1"] == {"nested": {"values": {"member-1": True}}}
+    assert member_states["member-2"] == {"nested": {"values": {"member-2": True}}}
+    assert parent_snapshots == [{"nested": {"values": {}}}, {"nested": {"values": {}}}]
+    assert parent_state == {"nested": {"values": {"member-1": True, "member-2": True}}}


### PR DESCRIPTION
## Summary

Fixes #8947.

Default Team delegation used shallow session-state copies, allowing nested objects to remain shared by the parent Team and concurrent members before post-run merging.

This change:

- uses `deepcopy` in sync, async, streaming, and broadcast delegation paths
- preserves the existing recursive post-run merge behavior
- adds deterministic sync and concurrent async regression tests
- aligns default delegation with task-mode member-state isolation

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other

## Regression proof

Before the production change:

- a member mutation was visible on the parent state before the member returned
- concurrently delegated members received different outer dictionaries but shared the same nested object

After the change:

- the parent remains unchanged until post-processing merges completed member state
- each concurrent member receives an independent nested snapshot
- non-conflicting nested updates from both members are preserved by the existing recursive merge

## Verification

- focused Team regression and adjacent delegation tests: 9 passed, 1 skipped
- broader focused Team tests: 58 passed
- `ruff check`: passed
- `ruff format --check`: passed
- `git diff --check`: passed

The full Team unit directory currently stops during collection because the available environment does not include `sqlalchemy`; the focused affected tests do not require it.

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Tests added
- [x] Existing open issues and PRs searched for duplicates
- [x] Tested on current `upstream/main`
- [x] AI assistance disclosed

## AI assistance

This patch was prepared with Codex under human direction. I reviewed the final two-file diff and reran the focused regression and adjacent delegation tests.