### PR TITLE
fix: scope external tool results to the latest matching call

### DIFF
--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -529,11 +529,23 @@ def handle_external_execution_update(agent: Agent, run_messages: RunMessages, to
     agent.model = cast(Model, agent.model)
 
     if tool.result is not None:
-        for msg in run_messages.messages:
-            # Skip if the message is already in the run_messages
-            if msg.tool_call_id == tool.tool_call_id:
-                break
-        else:
+        # Tool call IDs can recur in history, so only deduplicate within the latest matching call.
+        latest_call_index = None
+        for index, msg in enumerate(run_messages.messages):
+            if any(tool_call.get("id") == tool.tool_call_id for tool_call in msg.tool_calls or []):
+                latest_call_index = index
+
+        search_start = latest_call_index + 1 if latest_call_index is not None else 0
+        existing_message = next(
+            (
+                msg
+                for msg in reversed(run_messages.messages[search_start:])
+                if msg.role == agent.model.tool_message_role and msg.tool_call_id == tool.tool_call_id
+            ),
+            None,
+        )
+
+        if existing_message is None:
             run_messages.messages.append(
                 Message(
                     role=agent.model.tool_message_role,
@@ -545,6 +557,12 @@ def handle_external_execution_update(agent: Agent, run_messages: RunMessages, to
                     stop_after_tool_call=tool.stop_after_tool_call,
                 )
             )
+        else:
+            existing_message.content = tool.result
+            existing_message.tool_name = tool.tool_name
+            existing_message.tool_args = tool.tool_args
+            existing_message.tool_call_error = tool.tool_call_error
+            existing_message.stop_after_tool_call = tool.stop_after_tool_call
         tool.external_execution_required = False
     else:
         raise ValueError(f"Tool {tool.tool_name} requires external execution, cannot continue run")

--- a/libs/agno/tests/unit/agent/test_external_execution_message_update.py
+++ b/libs/agno/tests/unit/agent/test_external_execution_message_update.py
@@ -1,0 +1,164 @@
+from typing import Any, AsyncIterator, Iterator
+
+from agno.agent import Agent
+from agno.agent._tools import handle_external_execution_update
+from agno.db.in_memory import InMemoryDb
+from agno.models.base import Model
+from agno.models.message import Message, MessageMetrics
+from agno.models.response import ModelResponse, ToolExecution
+from agno.run.messages import RunMessages
+from agno.tools.decorator import tool
+
+
+class SequenceModel(Model):
+    def __init__(self, responses: list[ModelResponse]):
+        super().__init__(id="sequence", name="sequence", provider="test")
+        self.responses = responses
+        self.requests: list[list[Message]] = []
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, messages: list[Message], *args, **kwargs) -> ModelResponse:
+        self.requests.append(list(messages))
+        return self.responses.pop(0)
+
+    async def ainvoke(self, messages: list[Message], *args, **kwargs) -> ModelResponse:
+        return self.invoke(messages, *args, **kwargs)
+
+    def invoke_stream(self, messages: list[Message], *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self.invoke(messages, *args, **kwargs)
+
+    async def ainvoke_stream(self, messages: list[Message], *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self.invoke(messages, *args, **kwargs)
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+
+def _response(content=None, tool_calls=None):
+    return ModelResponse(
+        content=content,
+        role="assistant",
+        tool_calls=tool_calls or [],
+        response_usage=MessageMetrics(),
+    )
+
+
+def _tool_call(call_id: str, name: str):
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": "{}"},
+    }
+
+
+def test_native_continue_scopes_tool_result_to_latest_matching_call():
+    @tool
+    def backend_tool() -> str:
+        return "historical result"
+
+    @tool(external_execution=True)
+    def client_tool() -> str:
+        raise AssertionError("external tool must not execute in the agent")
+
+    model = SequenceModel(
+        [
+            _response(tool_calls=[_tool_call("reused-id", "backend_tool")]),
+            _response(content="first run complete"),
+            _response(tool_calls=[_tool_call("reused-id", "client_tool")]),
+            _response(content="second run complete"),
+        ]
+    )
+    agent = Agent(
+        id="external-message-repro",
+        model=model,
+        tools=[backend_tool, client_tool],
+        db=InMemoryDb(),
+        add_history_to_context=True,
+        num_history_runs=5,
+        telemetry=False,
+    )
+    session_id = "external-message-repro-session"
+
+    first = agent.run("run the backend tool", session_id=session_id)
+    assert first.content == "first run complete"
+
+    paused = agent.run("run the client tool", session_id=session_id)
+    assert paused.is_paused
+    paused.active_requirements[0].set_external_execution_result("current result")
+
+    completed = agent.continue_run(
+        run_id=paused.run_id,
+        session_id=session_id,
+        requirements=paused.requirements,
+    )
+    assert not completed.is_paused
+
+    continuation_request = model.requests[-1]
+    current_assistant_index = max(
+        i
+        for i, message in enumerate(continuation_request)
+        if any(call.get("id") == "reused-id" for call in (message.tool_calls or []))
+    )
+    current_results = [
+        message
+        for message in continuation_request[current_assistant_index + 1 :]
+        if message.role == "tool" and message.tool_call_id == "reused-id"
+    ]
+    assert [message.content for message in current_results] == ["current result"]
+
+
+def test_existing_result_for_current_call_is_updated_without_duplication():
+    model = SequenceModel([])
+    agent = Agent(model=model, telemetry=False)
+    run_messages = RunMessages(
+        messages=[
+            Message(
+                role="assistant",
+                tool_calls=[_tool_call("call-1", "client_tool")],
+            ),
+            Message(
+                role="tool",
+                content="stale result",
+                tool_call_id="call-1",
+                tool_name="client_tool",
+                tool_args={"value": "old"},
+                tool_call_error=True,
+            ),
+        ]
+    )
+    updated_tool = ToolExecution(
+        tool_call_id="call-1",
+        tool_name="client_tool",
+        tool_args={"value": "new"},
+        result="fresh result",
+        tool_call_error=False,
+        external_execution_required=True,
+        stop_after_tool_call=True,
+    )
+
+    handle_external_execution_update(agent, run_messages, updated_tool)
+
+    result_messages = [message for message in run_messages.messages if message.role == "tool"]
+    assert len(result_messages) == 1
+    assert result_messages[0].content == "fresh result"
+    assert result_messages[0].tool_args == {"value": "new"}
+    assert result_messages[0].tool_call_error is False
+    assert result_messages[0].stop_after_tool_call is True
+    assert updated_tool.external_execution_required is False


### PR DESCRIPTION
## Summary

Fixes #8949.

External execution continuation previously deduplicated tool results against the entire assembled history. When a provider reused a `tool_call_id`, a historical result could shadow the current result and leave the latest assistant tool call unanswered.

The shared handler now:

- finds the latest assistant tool call with the matching ID
- searches only following messages for an existing result
- refreshes an existing current-call result's content and tool metadata
- appends a result when the current call does not have one

This preserves duplicate prevention while ensuring results are associated with the current call. Team-level HITL paths benefit because they use the same handler.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other

## Relationship to prior fixes

- #5191 prevented duplicate AG-UI tool result messages, but did not scope matching to the latest assistant call or refresh stale current-call content.
- #8229 and #8565 fixed AG-UI transcript and resume routing; the shared Agent/Team result handler remained unchanged.

## Regression proof

A deterministic two-run test reuses the same tool call ID:

- run 1 produces a historical backend tool result
- run 2 pauses for external execution using the same ID
- before the fix, the supplied current result is absent after the latest assistant call
- after the fix, exactly one current result follows that call

A second test verifies that an existing result for the current call is updated without duplication.

## Verification

- targeted Agent continue, AG-UI resume, and Team HITL tests: 144 passed
- `ruff check`: passed
- `ruff format --check`: passed
- `mypy`: passed for 920 source files
- `git diff --check`: passed

Not tested: live provider API integration.

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Tests added
- [x] Existing open issues and PRs searched for duplicates
- [x] Tested on current `upstream/main`
- [x] AI assistance disclosed

## AI assistance

This patch was prepared with Codex under human direction. I reviewed the two-file diff, message-boundary logic, focused regressions, and repository validation output.