### PR TITLE
[fix] Retry model streams that complete without usable output

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -91,6 +91,20 @@ def _log_messages(messages: List[Message]) -> None:
         m.log(metrics=False)
 
 
+def _has_usable_stream_output(response: ModelResponse) -> bool:
+    return bool(
+        response.content
+        or response.reasoning_content
+        or response.redacted_reasoning_content
+        or response.tool_calls
+        or response.audio
+        or response.images
+        or response.videos
+        or response.audios
+        or response.files
+    )
+
+
 def _handle_agent_exception(a_exc: AgentRunException, additional_input: Optional[List[Message]] = None) -> None:
     """Handle AgentRunException and collect additional messages."""
     if additional_input is None:
@@ -330,14 +344,26 @@ class Model(ABC):
         Invoke the model stream with retry logic for ModelProviderError.
 
         This method wraps the invoke_stream() call and retries on ModelProviderError
-        with optional exponential backoff. Note that retries restart the entire stream.
+        with optional exponential backoff. Empty completed streams also consume a retry when retries are enabled.
         """
         last_exception: Optional[ModelProviderError] = None
         retries_with_guidance_count = kwargs.pop("retries_with_guidance_count", 0)
 
         for attempt in range(self.retries + 1):
+            has_usable_output = False
             try:
-                yield from self.invoke_stream(**kwargs)
+                for response in self.invoke_stream(**kwargs):
+                    has_usable_output = has_usable_output or _has_usable_stream_output(response)
+                    yield response
+                if self.retries > 0 and not has_usable_output:
+                    log_warning(
+                        f"Model stream completed without usable output (attempt {attempt + 1}/{self.retries + 1})."
+                    )
+                    if attempt < self.retries:
+                        delay = self._get_retry_delay(attempt)
+                        log_warning(f"Retrying in {delay}s...")
+                        sleep(delay)
+                        continue
                 return  # Success, exit the retry loop
             except ModelProviderError as e:
                 last_exception = self.classify_error(e)
@@ -382,15 +408,26 @@ class Model(ABC):
         Asynchronously invoke the model stream with retry logic for ModelProviderError.
 
         This method wraps the ainvoke_stream() call and retries on ModelProviderError
-        with optional exponential backoff. Note that retries restart the entire stream.
+        with optional exponential backoff. Empty completed streams also consume a retry when retries are enabled.
         """
         last_exception: Optional[ModelProviderError] = None
         retries_with_guidance_count = kwargs.pop("retries_with_guidance_count", 0)
 
         for attempt in range(self.retries + 1):
+            has_usable_output = False
             try:
                 async for response in self.ainvoke_stream(**kwargs):
+                    has_usable_output = has_usable_output or _has_usable_stream_output(response)
                     yield response
+                if self.retries > 0 and not has_usable_output:
+                    log_warning(
+                        f"Model stream completed without usable output (attempt {attempt + 1}/{self.retries + 1})."
+                    )
+                    if attempt < self.retries:
+                        delay = self._get_retry_delay(attempt)
+                        log_warning(f"Retrying in {delay}s...")
+                        await asyncio.sleep(delay)
+                        continue
                 return  # Success, exit the retry loop
             except ModelProviderError as e:
                 last_exception = self.classify_error(e)

--- a/libs/agno/tests/unit/models/test_empty_stream_retry.py
+++ b/libs/agno/tests/unit/models/test_empty_stream_retry.py
@@ -1,0 +1,194 @@
+import asyncio
+from typing import Any, AsyncIterator, Iterator
+from unittest.mock import patch
+
+import pytest
+
+from agno.media import Audio, File, Image, Video
+from agno.metrics import MessageMetrics
+from agno.models.base import Model, _has_usable_stream_output
+from agno.models.response import ModelResponse
+
+
+class StubModel(Model):
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return ModelResponse()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return ModelResponse()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield ModelResponse()
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        yield ModelResponse()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return ModelResponse()
+
+
+@pytest.fixture
+def model() -> StubModel:
+    return StubModel(id="test-model", retries=2, delay_between_retries=0)
+
+
+def test_sync_empty_stream_is_retried_and_chunks_are_preserved(model: StubModel):
+    call_count = 0
+
+    def mock_invoke_stream(**kwargs: Any) -> Iterator[ModelResponse]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            yield ModelResponse(
+                content="",
+                provider_data={"attempt": 1},
+                response_usage=MessageMetrics(input_tokens=1),
+            )
+            return
+        yield ModelResponse(provider_data={"attempt": 2}, response_usage=MessageMetrics(input_tokens=2))
+        yield ModelResponse(content="recovered")
+
+    with patch.object(model, "invoke_stream", side_effect=mock_invoke_stream):
+        responses = list(model._invoke_stream_with_retry(messages=[]))
+
+    assert call_count == 2
+    assert [response.provider_data for response in responses if response.provider_data] == [
+        {"attempt": 1},
+        {"attempt": 2},
+    ]
+    assert [response.response_usage.input_tokens for response in responses if response.response_usage] == [1, 2]
+    assert responses[-1].content == "recovered"
+
+
+def test_sync_all_empty_attempts_return_blank_response(model: StubModel):
+    call_count = 0
+
+    def mock_invoke_stream(**kwargs: Any) -> Iterator[ModelResponse]:
+        nonlocal call_count
+        call_count += 1
+        yield ModelResponse(
+            provider_data={"attempt": call_count},
+            response_usage=MessageMetrics(input_tokens=call_count),
+        )
+        yield ModelResponse(content="")
+
+    with patch.object(model, "invoke_stream", side_effect=mock_invoke_stream):
+        responses = list(model._invoke_stream_with_retry(messages=[]))
+
+    assert call_count == 3
+    assert len(responses) == 6
+    assert [response.provider_data for response in responses if response.provider_data] == [
+        {"attempt": 1},
+        {"attempt": 2},
+        {"attempt": 3},
+    ]
+    assert responses[-1].content == ""
+
+
+def test_sync_empty_stream_is_unchanged_without_retries(model: StubModel):
+    model.retries = 0
+    call_count = 0
+
+    def mock_invoke_stream(**kwargs: Any) -> Iterator[ModelResponse]:
+        nonlocal call_count
+        call_count += 1
+        yield ModelResponse(provider_data={"attempt": 1}, response_usage=MessageMetrics(input_tokens=1))
+        yield ModelResponse(content="")
+
+    with patch.object(model, "invoke_stream", side_effect=mock_invoke_stream):
+        responses = list(model._invoke_stream_with_retry(messages=[]))
+
+    assert call_count == 1
+    assert len(responses) == 2
+    assert responses[0].provider_data == {"attempt": 1}
+    assert responses[1].content == ""
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        ModelResponse(content=" "),
+        ModelResponse(reasoning_content="thinking"),
+        ModelResponse(redacted_reasoning_content="redacted"),
+        ModelResponse(tool_calls=[{"id": "call-1"}]),
+        ModelResponse(audio=Audio(content=b"audio")),
+        ModelResponse(images=[Image(content=b"image")]),
+        ModelResponse(videos=[Video(content=b"video")]),
+        ModelResponse(audios=[Audio(content=b"audio")]),
+        ModelResponse(files=[File(content=b"file")]),
+    ],
+    ids=["content", "reasoning", "redacted_reasoning", "tool_call", "audio", "image", "video", "audios", "file"],
+)
+def test_usable_stream_output_signals(response: ModelResponse):
+    assert _has_usable_stream_output(response) is True
+
+
+@pytest.mark.parametrize(
+    "response",
+    [ModelResponse(), ModelResponse(content=""), ModelResponse(provider_data={"request_id": "metadata-only"})],
+    ids=["empty", "empty_content", "metadata_only"],
+)
+def test_empty_stream_output_signals(response: ModelResponse):
+    assert _has_usable_stream_output(response) is False
+
+
+def test_async_empty_stream_is_retried_and_chunks_are_preserved(model: StubModel):
+    call_count = 0
+
+    async def mock_ainvoke_stream(**kwargs: Any) -> AsyncIterator[ModelResponse]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            yield ModelResponse(
+                content="",
+                provider_data={"attempt": 1},
+                response_usage=MessageMetrics(input_tokens=1),
+            )
+            return
+        yield ModelResponse(provider_data={"attempt": 2}, response_usage=MessageMetrics(input_tokens=2))
+        yield ModelResponse(reasoning_content="recovered")
+
+    async def collect_responses() -> list[ModelResponse]:
+        return [response async for response in model._ainvoke_stream_with_retry(messages=[])]
+
+    with patch.object(model, "ainvoke_stream", side_effect=mock_ainvoke_stream):
+        responses = asyncio.run(collect_responses())
+
+    assert call_count == 2
+    assert [response.provider_data for response in responses if response.provider_data] == [
+        {"attempt": 1},
+        {"attempt": 2},
+    ]
+    assert [response.response_usage.input_tokens for response in responses if response.response_usage] == [1, 2]
+    assert responses[-1].reasoning_content == "recovered"
+
+
+def test_async_all_empty_attempts_return_blank_response(model: StubModel):
+    call_count = 0
+
+    async def mock_ainvoke_stream(**kwargs: Any) -> AsyncIterator[ModelResponse]:
+        nonlocal call_count
+        call_count += 1
+        yield ModelResponse(
+            provider_data={"attempt": call_count},
+            response_usage=MessageMetrics(input_tokens=call_count),
+        )
+        yield ModelResponse(content="")
+
+    async def collect_responses() -> list[ModelResponse]:
+        return [response async for response in model._ainvoke_stream_with_retry(messages=[])]
+
+    with patch.object(model, "ainvoke_stream", side_effect=mock_ainvoke_stream):
+        responses = asyncio.run(collect_responses())
+
+    assert call_count == 3
+    assert len(responses) == 6
+    assert [response.provider_data for response in responses if response.provider_data] == [
+        {"attempt": 1},
+        {"attempt": 2},
+        {"attempt": 3},
+    ]
+    assert responses[-1].content == ""


### PR DESCRIPTION
## Summary

Fixes #8952.

When model retries are enabled, a normally completed stream with no content, reasoning, tool calls, or media now logs a warning and consumes a retry attempt.

The sync and async retry wrappers:

- yield every chunk unchanged, preserving usage, metrics, and provider metadata
- track whether each attempt produced usable output
- retry only when an attempt completes normally with zero usable output
- honor the existing retry delay
- preserve `retries=0` behavior
- preserve the existing blank final response when every attempt is empty

This PR does not change exception handling after a stream has already emitted usable output.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other

## Usable output

An attempt is considered usable when a `ModelResponse` contains:

- non-empty `content`
- reasoning or redacted reasoning
- one or more tool calls
- audio, images, videos, audios, or files

Whitespace content remains valid. Single punctuation and other application-specific quality rules are intentionally out of scope.

## Regression coverage

Deterministic sync and async tests cover:

- empty and metadata-only attempts retrying successfully
- chunks, provider metadata, and usage from every attempt remaining visible
- all-empty attempts exhausting configured retries and returning a blank stream without raising
- `retries=0` preserving existing behavior
- content, reasoning, tool-call, and media usability signals

## Verification

- focused empty-stream tests: 17 passed
- related fallback and model-helper tests: 116 passed
- `ruff format`: passed
- `ruff check`: passed
- `mypy`: passed for 920 Agno source files
- `git diff --check`: passed

The complete provider-specific model test directory cannot be collected without optional packages such as `anthropic`, `boto3`, `google-genai`, `litellm`, and `ollama`. No live provider integration was run.

## Review updates

Applied maintainer feedback in `5c8e5e8bb`:

- removed pre-output buffering
- removed the new all-empty exception
- restored existing retry behavior for errors after partial output
- updated sync and async tests to assert chunk and usage preservation

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Tests added
- [x] Existing open issues and PRs searched for duplicates
- [x] Tested on current `upstream/main`
- [x] AI assistance disclosed

## AI assistance

This patch was prepared with Codex under human direction. I reviewed the revised retry semantics against the maintainer feedback, the final two-file diff, and validation output.