### PR TITLE
cookbook: add The Context Company observability example

### DIFF
--- a/cookbook/observability/README.md
+++ b/cookbook/observability/README.md
@@ -20,6 +20,7 @@ Observability examples for tracing and monitoring Agno agents, teams, and workfl
 - `mlflow_via_openinference.py`
 - `maxim_ops.py`
 - `opik_via_openinference.py`
+- `the_context_company.py`
 - `trace_to_database.py`
 - `traceloop_op.py`
 - `weave_op.py`

--- a/cookbook/observability/the_context_company.py
+++ b/cookbook/observability/the_context_company.py
@@ -21,9 +21,9 @@ from contextcompany.agno import instrument_agno
 # Initialize instrumentation before importing Agno.
 instrument_agno()
 
-from agno.agent import Agent
-from agno.models.openai import OpenAIChat
-from agno.tools.yfinance import YFinanceTools
+from agno.agent import Agent  # noqa: E402
+from agno.models.openai import OpenAIChat  # noqa: E402
+from agno.tools.yfinance import YFinanceTools  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Create Agent

--- a/cookbook/observability/the_context_company.py
+++ b/cookbook/observability/the_context_company.py
@@ -1,0 +1,41 @@
+"""
+The Context Company
+===================
+
+Demonstrates instrumenting an Agno agent with The Context Company.
+
+Setup:
+    pip install "contextcompany[agno]" agno openai yfinance
+
+Set TCC_API_KEY and OPENAI_API_KEY before running this example.
+See https://docs.thecontextcompany.com/frameworks/agno for the complete setup guide.
+"""
+
+import asyncio
+
+from contextcompany.agno import instrument_agno
+
+# Initialize instrumentation before importing Agno.
+instrument_agno()
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.yfinance import YFinanceTools
+
+agent = Agent(
+    name="Stock Price Agent",
+    model=OpenAIChat(id="gpt-5.2"),
+    tools=[YFinanceTools()],
+    instructions="You are a stock price agent. Answer questions in the style of a stock analyst.",
+)
+
+
+async def main() -> None:
+    await agent.aprint_response(
+        "What is the current price of Tesla? Then find the current price of NVIDIA.",
+        stream=True,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/observability/the_context_company.py
+++ b/cookbook/observability/the_context_company.py
@@ -5,7 +5,7 @@ The Context Company
 Demonstrates instrumenting an Agno agent with The Context Company.
 
 Setup:
-    pip install "contextcompany[agno]" agno openai yfinance
+    pip install "contextcompany[agno]>=1.9.1" agno openai yfinance
 
 Set TCC_API_KEY and OPENAI_API_KEY before running this example.
 See https://docs.thecontextcompany.com/frameworks/agno for the complete setup guide.

--- a/cookbook/observability/the_context_company.py
+++ b/cookbook/observability/the_context_company.py
@@ -15,6 +15,9 @@ import asyncio
 
 from contextcompany.agno import instrument_agno
 
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
 # Initialize instrumentation before importing Agno.
 instrument_agno()
 
@@ -22,6 +25,9 @@ from agno.agent import Agent
 from agno.models.openai import OpenAIChat
 from agno.tools.yfinance import YFinanceTools
 
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
 agent = Agent(
     name="Stock Price Agent",
     model=OpenAIChat(id="gpt-5.2"),
@@ -30,6 +36,9 @@ agent = Agent(
 )
 
 
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
 async def main() -> None:
     await agent.aprint_response(
         "What is the current price of Tesla? Then find the current price of NVIDIA.",


### PR DESCRIPTION
## Summary

- Adds a runnable The Context Company observability example for Agno agents
- Lists the example in the observability cookbook index
- Links the complete Agno integration guide

Closes #8978

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Tested the exact cookbook in a clean environment with `contextcompany==1.9.1`, OpenTelemetry 1.43.0, and Agno 2.7.3. Both YFinance tool calls completed and the five-span trace exported successfully. I did not run the repository-wide validation scripts.