### PR TITLE
feat: improve agno create onboarding

### DIFF
--- a/libs/agnoctl/README.md
+++ b/libs/agnoctl/README.md
@@ -1,3 +1,19 @@
 # agnoctl
 
 The CLI for [AgentOS](https://docs.agno.com), built for humans and coding agents.
+
+Create a new AgentOS interactively:
+
+```bash
+uvx agno create
+```
+
+Choose a starter template and project name, or press Enter to use `agentos-docker`
+and `agentos`. The CLI clones the template and copies `example.env` to `.env`.
+Add your secrets to `agentos/.env`, then cd into `agentos` and run `agno up`.
+
+For automation, pass the project name and optional template explicitly:
+
+```bash
+uvx agno create my-agentos --template agentos-railway --json
+```

--- a/libs/agnoctl/README.md
+++ b/libs/agnoctl/README.md
@@ -8,7 +8,8 @@ Create a new AgentOS interactively:
 uvx agno create
 ```
 
-Choose a starter template and project name, or press Enter to use `agentos-docker`
+Choose from nine maintained starters—Docker, AWS, Azure, Fly, GCP, Helm, Modal,
+Railway, and Render—and name your project. Press Enter to use `agentos-docker`
 and `agentos`. The CLI clones the template and copies `example.env` to `.env`.
 Add your secrets to `agentos/.env`, then cd into `agentos` and run `agno up`.
 

--- a/libs/agnoctl/agnoctl/commands/create.py
+++ b/libs/agnoctl/agnoctl/commands/create.py
@@ -1,19 +1,23 @@
 """`agno create`: scaffold a new AgentOS project from a starter template.
 
 The mechanism is deliberately simple (inherited from `ag infra create`): shallow-clone
-the template repository, strip its git history, and copy example secrets into place.
-No registry file is kept — commands operate on the current directory.
+the template repository, strip its git history, and copy example.env to .env. No
+registry file is kept — commands operate on the current directory.
+
+Bare `agno create` is interactive: choose a starter template, then name the project.
+Explicit arguments keep the command deterministic for scripts and coding agents.
 """
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import typer
 
-from agnoctl.commands._common import handle_cli_error, validate_project_name
-from agnoctl.console import emit_json, print_info, print_success
+from agnoctl.commands._common import handle_cli_error, stdin_is_interactive, validate_project_name
+from agnoctl.console import emit_json, print_heading, print_info, print_success, print_warning
 from agnoctl.errors import CLIError
 
 TEMPLATES: Dict[str, str] = {
@@ -25,6 +29,8 @@ TEMPLATES: Dict[str, str] = {
 }
 
 DEFAULT_TEMPLATE = "agentos-docker"
+DEFAULT_PROJECT_NAME = "agentos"
+TEMPLATE_CHOICES: List[str] = list(TEMPLATES)
 
 GIT_TIMEOUT = 300.0
 
@@ -48,10 +54,117 @@ def _clone(repo_url: str, target: Path) -> None:
     shutil.rmtree(target / ".git", ignore_errors=True)
 
 
+def _copy_example_env(project_dir: Path) -> bool:
+    """Seed a private .env when the template provides example.env.
+
+    Custom templates may use a different environment layout, and a tracked .env must
+    never be overwritten.
+    """
+    example_env = project_dir / "example.env"
+    env_file = project_dir / ".env"
+    if example_env.is_symlink() or env_file.is_symlink():
+        raise CLIError("Refusing to create .env from a symlinked template file.")
+    if env_file.exists():
+        if not env_file.is_file():
+            raise CLIError(str(env_file) + " exists but is not a file.")
+        return True
+    if not example_env.is_file():
+        return False
+
+    no_follow = getattr(os, "O_NOFOLLOW", 0)
+    binary = getattr(os, "O_BINARY", 0)
+    source_flags = os.O_RDONLY | no_follow | binary
+    destination_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | no_follow | binary
+    created = False
+    try:
+        with os.fdopen(os.open(example_env, source_flags), "rb") as source:
+            destination_fd = os.open(env_file, destination_flags, 0o600)
+            created = True
+            with os.fdopen(destination_fd, "wb") as destination:
+                shutil.copyfileobj(source, destination)
+    except OSError as e:
+        if created:
+            try:
+                env_file.unlink()
+            except OSError:
+                pass
+        raise CLIError("Could not create " + str(env_file) + ": " + str(e))
+    return True
+
+
+def _prompt_template() -> str:
+    """Show a stable numbered menu; Enter chooses agentos-docker."""
+    print_info("Choose a template:")
+    for index, template_name in enumerate(TEMPLATE_CHOICES, start=1):
+        suffix = " (default)" if template_name == DEFAULT_TEMPLATE else ""
+        print_info("  " + str(index) + ". " + template_name + suffix)
+
+    while True:
+        answer = str(typer.prompt("Template", default="1")).strip()
+        if answer in TEMPLATES:
+            return answer
+        if answer.isdigit() and 1 <= int(answer) <= len(TEMPLATE_CHOICES):
+            return TEMPLATE_CHOICES[int(answer) - 1]
+        print_warning("Choose a template by name or enter a number from 1 to " + str(len(TEMPLATE_CHOICES)) + ".")
+
+
+def _prompt_project_name() -> str:
+    """Prompt until the project name is safe and available in the current directory."""
+    while True:
+        name = str(typer.prompt("Project name", default=DEFAULT_PROJECT_NAME)).strip()
+        try:
+            validate_project_name(name)
+        except CLIError as e:
+            print_warning(e.message)
+            if e.hint:
+                print_warning(e.hint)
+            continue
+
+        target = Path.cwd() / name
+        if target.exists():
+            print_warning("The directory " + str(target) + " already exists. Choose another name.")
+            continue
+        return name
+
+
+def _resolve_create_inputs(
+    name: Optional[str],
+    template: Optional[str],
+    template_url: Optional[str],
+    *,
+    json_output: bool,
+) -> Tuple[str, str]:
+    """Prompt only for missing interactive input and preserve explicit CLI behavior."""
+    interactive = not json_output and stdin_is_interactive()
+
+    if name is None:
+        if not interactive:
+            raise CLIError(
+                "A project name is required in non-interactive mode.",
+                hint="Pass a name, for example: agno create agentos",
+            )
+        print_info("")
+        print_heading("Create an AgentOS")
+        print_info("")
+        if template_url is None and template is None:
+            template = _prompt_template()
+            print_info("")
+        name = _prompt_project_name()
+
+    return name, template or DEFAULT_TEMPLATE
+
+
 def create(
-    name: str = typer.Argument(..., help="Directory name for the new AgentOS project."),
-    template: str = typer.Option(
-        DEFAULT_TEMPLATE, "--template", "-t", help="Starter template: " + ", ".join(sorted(TEMPLATES)) + "."
+    name: Optional[str] = typer.Argument(
+        None,
+        help="Directory name for the new AgentOS project. Prompt default: " + DEFAULT_PROJECT_NAME + ".",
+    ),
+    template: Optional[str] = typer.Option(
+        None,
+        "--template",
+        "-t",
+        help="Starter template: " + ", ".join(TEMPLATE_CHOICES) + ". Default when omitted: " + DEFAULT_TEMPLATE + ".",
+        show_default=False,
     ),
     template_url: Optional[str] = typer.Option(
         None, "--url", "-u", help="Clone from a custom template repository URL instead."
@@ -60,6 +173,12 @@ def create(
 ) -> None:
     """Create a new AgentOS project from a starter template."""
     try:
+        name, template = _resolve_create_inputs(
+            name,
+            template,
+            template_url,
+            json_output=json_output,
+        )
         payload = _create(name=name, template=template, template_url=template_url)
     except CLIError as e:
         raise handle_cli_error(e, json_output)
@@ -67,13 +186,16 @@ def create(
     if json_output:
         emit_json(payload)
         return
-    print_success("Created " + str(payload["path"]) + " from " + str(payload["template"]))
     print_info("")
-    print_info("Next steps:")
-    print_info("  cd " + name)
-    print_info("  cp example.env .env  # then fill in your secrets")
-    print_info("  agno up              # start it with docker compose")
-    print_info("  agno connect         # make it available in your coding agents")
+    print_success("Created " + name + " from " + str(payload["template"]) + ".")
+    print_info("")
+    env_file = Path(str(payload["path"])) / ".env"
+    if env_file.is_file():
+        print_info("Add your secrets to " + name + "/.env, then cd into " + name + " and run agno up.")
+    else:
+        print_info(
+            "No example.env found. Follow the template setup instructions, then cd into " + name + " and run agno up."
+        )
 
 
 def _create(name: str, template: str, template_url: Optional[str]) -> Dict[str, Any]:
@@ -98,4 +220,5 @@ def _create(name: str, template: str, template_url: Optional[str]) -> Dict[str, 
         template_label = template
 
     _clone(repo_url, target)
+    _copy_example_env(target)
     return {"path": str(target), "template": template_label}

--- a/libs/agnoctl/agnoctl/commands/create.py
+++ b/libs/agnoctl/agnoctl/commands/create.py
@@ -58,7 +58,7 @@ def _clone(repo_url: str, target: Path) -> None:
     shutil.rmtree(target / ".git", ignore_errors=True)
 
 
-def _copy_example_env(project_dir: Path) -> bool:
+def _copy_example_env(project_dir: Path) -> None:
     """Seed a private .env when the template provides example.env.
 
     Custom templates may use a different environment layout, and a tracked .env must
@@ -71,9 +71,9 @@ def _copy_example_env(project_dir: Path) -> bool:
     if env_file.exists():
         if not env_file.is_file():
             raise CLIError(str(env_file) + " exists but is not a file.")
-        return True
+        return
     if not example_env.is_file():
-        return False
+        return
 
     no_follow = getattr(os, "O_NOFOLLOW", 0)
     binary = getattr(os, "O_BINARY", 0)
@@ -93,7 +93,6 @@ def _copy_example_env(project_dir: Path) -> bool:
             except OSError:
                 pass
         raise CLIError("Could not create " + str(env_file) + ": " + str(e))
-    return True
 
 
 def _prompt_template() -> str:
@@ -104,7 +103,7 @@ def _prompt_template() -> str:
         print_info("  " + str(index) + ". " + template_name + suffix)
 
     while True:
-        answer = str(typer.prompt("Template", default="1")).strip()
+        answer = str(typer.prompt("Template", default=str(TEMPLATE_CHOICES.index(DEFAULT_TEMPLATE) + 1))).strip()
         if answer in TEMPLATES:
             return answer
         if answer.isdigit() and 1 <= int(answer) <= len(TEMPLATE_CHOICES):
@@ -131,6 +130,14 @@ def _prompt_project_name() -> str:
         return name
 
 
+def _validate_template(template: str) -> None:
+    if template not in TEMPLATES:
+        raise CLIError(
+            "Unknown template: " + template,
+            hint="Available templates: " + ", ".join(TEMPLATE_CHOICES) + ", or pass --url for a custom repo.",
+        )
+
+
 def _resolve_create_inputs(
     name: Optional[str],
     template: Optional[str],
@@ -147,6 +154,9 @@ def _resolve_create_inputs(
                 "A project name is required in non-interactive mode.",
                 hint="Pass a name, for example: agno create agentos",
             )
+        # A bad --template should fail here, before the user answers the name prompt.
+        if template is not None and template_url is None:
+            _validate_template(template)
         print_info("")
         print_heading("Create an AgentOS")
         print_info("")
@@ -155,7 +165,7 @@ def _resolve_create_inputs(
             print_info("")
         name = _prompt_project_name()
 
-    return name, template or DEFAULT_TEMPLATE
+    return name, DEFAULT_TEMPLATE if template is None else template
 
 
 def create(
@@ -215,14 +225,19 @@ def _create(name: str, template: str, template_url: Optional[str]) -> Dict[str, 
         repo_url = template_url
         template_label = template_url
     else:
-        repo_url = TEMPLATES.get(template, "")
-        if not repo_url:
-            raise CLIError(
-                "Unknown template: " + template,
-                hint="Available templates: " + ", ".join(sorted(TEMPLATES)) + ", or pass --url for a custom repo.",
-            )
+        _validate_template(template)
+        repo_url = TEMPLATES[template]
         template_label = template
 
     _clone(repo_url, target)
-    _copy_example_env(target)
+    try:
+        _copy_example_env(target)
+    except CLIError as e:
+        # A failed seed must not leave the half-created project behind; a retry
+        # would fail "directory already exists" and hide the real error.
+        try:
+            shutil.rmtree(target)
+        except OSError:
+            e.hint = "Remove the leftover directory " + str(target) + ", then re-run."
+        raise
     return {"path": str(target), "template": template_label}

--- a/libs/agnoctl/agnoctl/commands/create.py
+++ b/libs/agnoctl/agnoctl/commands/create.py
@@ -23,9 +23,13 @@ from agnoctl.errors import CLIError
 TEMPLATES: Dict[str, str] = {
     "agentos-docker": "https://github.com/agno-agi/agentos-docker",
     "agentos-aws": "https://github.com/agno-agi/agentos-aws",
+    "agentos-azure": "https://github.com/agno-agi/agentos-azure",
     "agentos-fly": "https://github.com/agno-agi/agentos-fly",
     "agentos-gcp": "https://github.com/agno-agi/agentos-gcp",
+    "agentos-helm": "https://github.com/agno-agi/agentos-helm",
+    "agentos-modal": "https://github.com/agno-agi/agentos-modal",
     "agentos-railway": "https://github.com/agno-agi/agentos-railway",
+    "agentos-render": "https://github.com/agno-agi/agentos-render",
 }
 
 DEFAULT_TEMPLATE = "agentos-docker"

--- a/libs/agnoctl/agnoctl/commands/lifecycle.py
+++ b/libs/agnoctl/agnoctl/commands/lifecycle.py
@@ -44,7 +44,7 @@ def find_compose_file(explicit: Optional[str] = None, cwd: Optional[Path] = None
                 return candidate
     raise CLIError(
         "No compose file found in " + str(base) + " or " + str(base / "infra") + ".",
-        hint="Run from an AgentOS project (agno create <name>) or pass --file.",
+        hint="Run inside an AgentOS project created with agno create, or pass --file.",
     )
 
 

--- a/libs/agnoctl/agnoctl/main.py
+++ b/libs/agnoctl/agnoctl/main.py
@@ -45,7 +45,7 @@ _GROUPS: List[Tuple[str, List[Tuple[str, str]]]] = [
     (
         "Get started",
         [
-            ("agno create <name>", "Create a new AgentOS"),
+            ("agno create", "Create a new AgentOS"),
             ("agno connect", "Connect your AI apps to your AgentOS using MCP"),
             ("agno disconnect", "Disconnect your AI apps from your AgentOS"),
         ],

--- a/libs/agnoctl/tests/test_create_lifecycle.py
+++ b/libs/agnoctl/tests/test_create_lifecycle.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from click import unstyle
 from typer.testing import CliRunner
 
 import agnoctl.commands.create as create_module
@@ -128,7 +129,8 @@ def test_create_interactive_reprompts_existing_default(fake_git, monkeypatch, tm
     result = runner.invoke(app, ["create"], input="\n\nfresh-os\n")
 
     assert result.exit_code == 0, result.output
-    assert "already exists. Choose another name." in result.output
+    warning = " ".join(unstyle(result.stderr).split())
+    assert "already exists. Choose another name." in warning
     assert (tmp_path / "fresh-os" / ".env").exists()
 
 

--- a/libs/agnoctl/tests/test_create_lifecycle.py
+++ b/libs/agnoctl/tests/test_create_lifecycle.py
@@ -2,12 +2,12 @@
 
 import json
 import os
+import re
 import stat
 import subprocess
 from pathlib import Path
 
 import pytest
-from click import unstyle
 from typer.testing import CliRunner
 
 import agnoctl.commands.create as create_module
@@ -129,7 +129,7 @@ def test_create_interactive_reprompts_existing_default(fake_git, monkeypatch, tm
     result = runner.invoke(app, ["create"], input="\n\nfresh-os\n")
 
     assert result.exit_code == 0, result.output
-    warning = " ".join(unstyle(result.stderr).split())
+    warning = " ".join(re.sub(r"\x1b\[[0-9;]*m", "", result.stderr).split())
     assert "already exists. Choose another name." in warning
     assert (tmp_path / "fresh-os" / ".env").exists()
 

--- a/libs/agnoctl/tests/test_create_lifecycle.py
+++ b/libs/agnoctl/tests/test_create_lifecycle.py
@@ -81,23 +81,41 @@ def test_create_interactive_uses_defaults(fake_git, monkeypatch, tmp_path):
     assert (tmp_path / "agentos" / ".env").read_text() == "KEY=value\n"
 
 
+def test_create_template_catalog_lists_all_supported_starters():
+    expected = {
+        "agentos-docker": "https://github.com/agno-agi/agentos-docker",
+        "agentos-aws": "https://github.com/agno-agi/agentos-aws",
+        "agentos-azure": "https://github.com/agno-agi/agentos-azure",
+        "agentos-fly": "https://github.com/agno-agi/agentos-fly",
+        "agentos-gcp": "https://github.com/agno-agi/agentos-gcp",
+        "agentos-helm": "https://github.com/agno-agi/agentos-helm",
+        "agentos-modal": "https://github.com/agno-agi/agentos-modal",
+        "agentos-railway": "https://github.com/agno-agi/agentos-railway",
+        "agentos-render": "https://github.com/agno-agi/agentos-render",
+    }
+    assert create_module.TEMPLATES == expected
+    assert create_module.TEMPLATE_CHOICES == list(expected)
+
+
 def test_create_interactive_selects_template_and_name(fake_git, monkeypatch, tmp_path):
     monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
 
-    result = runner.invoke(app, ["create"], input="5\nmy-os\n")
+    render_choice = create_module.TEMPLATE_CHOICES.index("agentos-render") + 1
+    result = runner.invoke(app, ["create"], input=str(render_choice) + "\nmy-os\n")
 
     assert result.exit_code == 0, result.output
-    assert create_module.TEMPLATES["agentos-railway"] in fake_git.calls[0]
+    assert create_module.TEMPLATES["agentos-render"] in fake_git.calls[0]
     assert (tmp_path / "my-os" / ".env").exists()
 
 
 def test_create_interactive_reprompts_invalid_choices(fake_git, monkeypatch, tmp_path):
     monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
 
-    result = runner.invoke(app, ["create"], input="9\n2\n../escape\nvalid-os\n")
+    invalid_choice = len(create_module.TEMPLATE_CHOICES) + 1
+    result = runner.invoke(app, ["create"], input=str(invalid_choice) + "\n2\n../escape\nvalid-os\n")
 
     assert result.exit_code == 0, result.output
-    assert "enter a number from 1 to 5" in result.output
+    assert "enter a number from 1 to " + str(len(create_module.TEMPLATE_CHOICES)) in result.output
     assert "Invalid project name" in result.output
     assert create_module.TEMPLATES["agentos-aws"] in fake_git.calls[0]
     assert (tmp_path / "valid-os").exists()

--- a/libs/agnoctl/tests/test_create_lifecycle.py
+++ b/libs/agnoctl/tests/test_create_lifecycle.py
@@ -1,6 +1,8 @@
 """`agno create` and `agno up/down/restart` behavior (git and docker are faked)."""
 
 import json
+import os
+import stat
 import subprocess
 from pathlib import Path
 
@@ -19,8 +21,10 @@ runner = CliRunner()
 class FakeGit:
     """Simulates `git clone` by scaffolding a template directory."""
 
-    def __init__(self, returncode: int = 0):
+    def __init__(self, returncode: int = 0, with_example_env: bool = True, existing_env=None):
         self.returncode = returncode
+        self.with_example_env = with_example_env
+        self.existing_env = existing_env
         self.calls = []
 
     def __call__(self, args, **kwargs):
@@ -29,7 +33,10 @@ class FakeGit:
             target = Path(args[-1])
             (target / ".git").mkdir(parents=True)
             (target / "docker-compose.yml").write_text("services: {}\n")
-            (target / "example.env").write_text("KEY=value\n")
+            if self.with_example_env:
+                (target / "example.env").write_text("KEY=value\n")
+            if self.existing_env is not None:
+                (target / ".env").write_text(self.existing_env)
         return subprocess.CompletedProcess(args, self.returncode, stdout="", stderr="boom" if self.returncode else "")
 
 
@@ -49,14 +56,194 @@ def test_create_scaffolds_project(fake_git, tmp_path):
 
     assert payload["template"] == "agentos-docker"
     project = tmp_path / "my-os"
+    assert payload == {"path": str(project), "template": "agentos-docker"}
     assert (project / "docker-compose.yml").exists()
     assert not (project / ".git").exists()
-    # create clones only: it ships example.env but never seeds .env itself.
     assert (project / "example.env").exists()
-    assert not (project / ".env").exists()
-    assert "secrets" not in payload
+    assert (project / ".env").read_text() == "KEY=value\n"
+    if os.name != "nt":
+        assert stat.S_IMODE((project / ".env").stat().st_mode) == 0o600
     clone_args = fake_git.calls[0]
     assert "https://github.com/agno-agi/agentos-docker" in clone_args
+
+
+def test_create_interactive_uses_defaults(fake_git, monkeypatch, tmp_path):
+    monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
+
+    result = runner.invoke(app, ["create"], input="\n\n")
+
+    assert result.exit_code == 0, result.output
+    assert "Create an AgentOS" in result.output
+    assert "1. agentos-docker (default)" in result.output
+    assert "Template [1]" in result.output
+    assert "Project name [agentos]" in result.output
+    assert create_module.TEMPLATES["agentos-docker"] in fake_git.calls[0]
+    assert (tmp_path / "agentos" / ".env").read_text() == "KEY=value\n"
+
+
+def test_create_interactive_selects_template_and_name(fake_git, monkeypatch, tmp_path):
+    monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
+
+    result = runner.invoke(app, ["create"], input="5\nmy-os\n")
+
+    assert result.exit_code == 0, result.output
+    assert create_module.TEMPLATES["agentos-railway"] in fake_git.calls[0]
+    assert (tmp_path / "my-os" / ".env").exists()
+
+
+def test_create_interactive_reprompts_invalid_choices(fake_git, monkeypatch, tmp_path):
+    monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
+
+    result = runner.invoke(app, ["create"], input="9\n2\n../escape\nvalid-os\n")
+
+    assert result.exit_code == 0, result.output
+    assert "enter a number from 1 to 5" in result.output
+    assert "Invalid project name" in result.output
+    assert create_module.TEMPLATES["agentos-aws"] in fake_git.calls[0]
+    assert (tmp_path / "valid-os").exists()
+
+
+def test_create_interactive_reprompts_existing_default(fake_git, monkeypatch, tmp_path):
+    (tmp_path / "agentos").mkdir()
+    monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
+
+    result = runner.invoke(app, ["create"], input="\n\nfresh-os\n")
+
+    assert result.exit_code == 0, result.output
+    assert "already exists. Choose another name." in result.output
+    assert (tmp_path / "fresh-os" / ".env").exists()
+
+
+def test_create_explicit_name_keeps_default_without_prompt(fake_git, monkeypatch, tmp_path):
+    def fail_prompt(*args, **kwargs):
+        pytest.fail("explicit create must not prompt")
+
+    monkeypatch.setattr(create_module.typer, "prompt", fail_prompt)
+    monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
+
+    result = runner.invoke(app, ["create", "my-os"])
+
+    assert result.exit_code == 0, result.output
+    assert create_module.TEMPLATES["agentos-docker"] in fake_git.calls[0]
+    assert (tmp_path / "my-os").exists()
+
+
+def test_create_explicit_template_prompts_only_for_name(fake_git, monkeypatch, tmp_path):
+    monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
+
+    result = runner.invoke(app, ["create", "-t", "agentos-fly"], input="fly-os\n")
+
+    assert result.exit_code == 0, result.output
+    assert "Choose a template" not in result.output
+    assert "Project name [agentos]" in result.output
+    assert create_module.TEMPLATES["agentos-fly"] in fake_git.calls[0]
+    assert (tmp_path / "fly-os").exists()
+
+
+def test_create_bare_json_requires_name_without_prompt(fake_git, monkeypatch):
+    def fail_prompt(*args, **kwargs):
+        pytest.fail("JSON create must not prompt")
+
+    monkeypatch.setattr(create_module.typer, "prompt", fail_prompt)
+    monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
+
+    result = runner.invoke(app, ["create", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "project name is required" in payload["error"].lower()
+    assert fake_git.calls == []
+
+
+def test_create_bare_noninteractive_requires_name(fake_git, monkeypatch):
+    monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: False)
+
+    result = runner.invoke(app, ["create"])
+
+    assert result.exit_code == 1
+    assert "project name is required" in result.output.lower()
+    assert fake_git.calls == []
+
+
+def test_create_human_output_is_concise(fake_git):
+    result = runner.invoke(app, ["create", "my-os"])
+
+    assert result.exit_code == 0, result.output
+    assert "Created my-os from agentos-docker." in result.output
+    assert "Add your secrets to my-os/.env, then cd into my-os and run agno up." in result.output
+    assert "Next steps" not in result.output
+    assert "cp example.env" not in result.output
+    assert "agno connect" not in result.output
+
+
+def test_create_does_not_overwrite_existing_env(monkeypatch, tmp_path):
+    fake = FakeGit(existing_env="KEEP_ME=true\n")
+    monkeypatch.setattr(create_module.subprocess, "run", fake)
+    monkeypatch.setattr(create_module.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["create", "my-os", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "my-os" / ".env").read_text() == "KEEP_ME=true\n"
+
+
+def test_create_custom_url_without_example_env(monkeypatch, tmp_path):
+    fake = FakeGit(with_example_env=False)
+    monkeypatch.setattr(create_module.subprocess, "run", fake)
+    monkeypatch.setattr(create_module.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["create", "my-os", "--url", "https://example.com/custom.git", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert not (tmp_path / "my-os" / ".env").exists()
+
+
+def test_create_custom_url_without_example_env_has_truthful_handoff(monkeypatch, tmp_path):
+    fake = FakeGit(with_example_env=False)
+    monkeypatch.setattr(create_module.subprocess, "run", fake)
+    monkeypatch.setattr(create_module.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["create", "my-os", "--url", "https://example.com/custom.git"])
+
+    assert result.exit_code == 0, result.output
+    assert "No example.env found." in result.output
+    assert "Follow the template setup instructions" in result.output
+    assert "cd into my-os" in result.output
+    assert "run agno up." in result.output
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
+def test_copy_example_env_rejects_symlinked_source(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside.env"
+    outside.write_text("SECRET=outside\n")
+    (project / "example.env").symlink_to(outside)
+
+    with pytest.raises(CLIError, match="symlinked"):
+        create_module._copy_example_env(project)
+
+    assert not (project / ".env").exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
+def test_copy_example_env_rejects_dangling_destination_symlink(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "example.env").write_text("KEY=value\n")
+    outside = tmp_path / "outside.env"
+    (project / ".env").symlink_to(outside)
+
+    with pytest.raises(CLIError, match="symlinked"):
+        create_module._copy_example_env(project)
+
+    assert not outside.exists()
 
 
 @pytest.mark.parametrize("name", ["../escape", "a/b", "/tmp/abs", ".."])

--- a/libs/agnoctl/tests/test_create_lifecycle.py
+++ b/libs/agnoctl/tests/test_create_lifecycle.py
@@ -15,6 +15,7 @@ import agnoctl.commands.lifecycle as lifecycle_module
 from agnoctl.commands.lifecycle import find_compose_file
 from agnoctl.errors import CLIError
 from agnoctl.main import app
+from tests.conftest import all_output as _all_output
 
 runner = CliRunner()
 
@@ -22,10 +23,17 @@ runner = CliRunner()
 class FakeGit:
     """Simulates `git clone` by scaffolding a template directory."""
 
-    def __init__(self, returncode: int = 0, with_example_env: bool = True, existing_env=None):
+    def __init__(
+        self,
+        returncode: int = 0,
+        with_example_env: bool = True,
+        existing_env=None,
+        symlink_example_env: bool = False,
+    ):
         self.returncode = returncode
         self.with_example_env = with_example_env
         self.existing_env = existing_env
+        self.symlink_example_env = symlink_example_env
         self.calls = []
 
     def __call__(self, args, **kwargs):
@@ -34,7 +42,9 @@ class FakeGit:
             target = Path(args[-1])
             (target / ".git").mkdir(parents=True)
             (target / "docker-compose.yml").write_text("services: {}\n")
-            if self.with_example_env:
+            if self.symlink_example_env:
+                (target / "example.env").symlink_to(target.parent / "outside.env")
+            elif self.with_example_env:
                 (target / "example.env").write_text("KEY=value\n")
             if self.existing_env is not None:
                 (target / ".env").write_text(self.existing_env)
@@ -264,6 +274,74 @@ def test_copy_example_env_rejects_dangling_destination_symlink(tmp_path):
         create_module._copy_example_env(project)
 
     assert not outside.exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
+def test_create_symlinked_example_env_fails_cleanly_via_cli(monkeypatch, tmp_path):
+    fake = FakeGit(symlink_example_env=True)
+    monkeypatch.setattr(create_module.subprocess, "run", fake)
+    monkeypatch.setattr(create_module.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["create", "my-os"])
+
+    assert result.exit_code == 1
+    assert "symlinked" in _all_output(result)
+    assert not (tmp_path / "my-os").exists()
+
+    # The retry must hit the same refusal, not "directory already exists".
+    second = runner.invoke(app, ["create", "my-os", "--json"])
+    assert second.exit_code == 1
+    assert "symlinked" in json.loads(second.output)["error"]
+    assert not (tmp_path / "my-os").exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
+def test_create_reports_leftover_dir_when_cleanup_fails(monkeypatch, tmp_path):
+    fake = FakeGit(symlink_example_env=True)
+    monkeypatch.setattr(create_module.subprocess, "run", fake)
+    monkeypatch.setattr(create_module.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "my-os"
+
+    real_rmtree = create_module.shutil.rmtree
+
+    def locked_rmtree(path, *args, **kwargs):
+        if Path(path) == target:
+            raise OSError("locked")
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(create_module.shutil, "rmtree", locked_rmtree)
+
+    result = runner.invoke(app, ["create", "my-os", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "symlinked" in payload["error"]
+    assert str(target) in payload["hint"]
+    assert target.exists()
+
+
+def test_create_empty_template_is_rejected(fake_git):
+    result = runner.invoke(app, ["create", "my-os", "-t", "", "--json"])
+
+    assert result.exit_code == 1
+    assert "Unknown template" in json.loads(result.output)["error"]
+    assert fake_git.calls == []
+
+
+def test_create_unknown_template_rejected_before_name_prompt(fake_git, monkeypatch):
+    def fail_prompt(*args, **kwargs):
+        pytest.fail("a bad --template must fail before any prompt")
+
+    monkeypatch.setattr(create_module.typer, "prompt", fail_prompt)
+    monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
+
+    result = runner.invoke(app, ["create", "-t", "bogus"])
+
+    assert result.exit_code == 1
+    assert "Unknown template" in _all_output(result)
+    assert fake_git.calls == []
 
 
 @pytest.mark.parametrize("name", ["../escape", "a/b", "/tmp/abs", ".."])

--- a/libs/agnoctl/tests/test_main.py
+++ b/libs/agnoctl/tests/test_main.py
@@ -1,5 +1,6 @@
 """Root `agno` app: branded home screen, version flag, and command routing."""
 
+from click import unstyle
 from typer.testing import CliRunner
 
 from agnoctl import __version__
@@ -36,6 +37,6 @@ def test_commands_are_registered():
 def test_create_help_shows_interactive_defaults():
     result = runner.invoke(app, ["create", "--help"])
     assert result.exit_code == 0
-    output = " ".join(result.output.lower().replace("│", " ").split())
+    output = " ".join(unstyle(result.output).lower().replace("│", " ").split())
     assert "default: agentos." in output
     assert "when omitted: agentos-docker." in output

--- a/libs/agnoctl/tests/test_main.py
+++ b/libs/agnoctl/tests/test_main.py
@@ -1,4 +1,4 @@
-"""Root `agno` app: branded home screen, version flag, and command routing."""
+"""Root `agno` app: branded home screen, version flag, command routing, and create-help defaults."""
 
 import re
 
@@ -18,7 +18,7 @@ def test_bare_invocation_shows_home_screen():
     for heading in ("Get started", "Operate", "Tokens"):
         assert heading in result.output
     assert "agno create" in result.output
-    assert "agno create <name>" not in result.output
+    assert "agno create <name>" not in result.output  # the pre-interactive home screen advertised a required <name>
     assert __version__ in result.output
 
 

--- a/libs/agnoctl/tests/test_main.py
+++ b/libs/agnoctl/tests/test_main.py
@@ -15,6 +15,8 @@ def test_bare_invocation_shows_home_screen():
     assert "The CLI for AgentOS" in result.output
     for heading in ("Get started", "Operate", "Tokens"):
         assert heading in result.output
+    assert "agno create" in result.output
+    assert "agno create <name>" not in result.output
     assert __version__ in result.output
 
 
@@ -29,3 +31,11 @@ def test_commands_are_registered():
     assert result.exit_code == 0
     for command in ("connect", "create", "status", "tokens", "up", "down", "restart"):
         assert command in result.output
+
+
+def test_create_help_shows_interactive_defaults():
+    result = runner.invoke(app, ["create", "--help"])
+    assert result.exit_code == 0
+    output = result.output.lower()
+    assert "default: agentos." in output
+    assert "when omitted: agentos-docker." in output

--- a/libs/agnoctl/tests/test_main.py
+++ b/libs/agnoctl/tests/test_main.py
@@ -36,6 +36,6 @@ def test_commands_are_registered():
 def test_create_help_shows_interactive_defaults():
     result = runner.invoke(app, ["create", "--help"])
     assert result.exit_code == 0
-    output = result.output.lower()
+    output = " ".join(result.output.lower().replace("│", " ").split())
     assert "default: agentos." in output
     assert "when omitted: agentos-docker." in output

--- a/libs/agnoctl/tests/test_main.py
+++ b/libs/agnoctl/tests/test_main.py
@@ -1,6 +1,7 @@
 """Root `agno` app: branded home screen, version flag, and command routing."""
 
-from click import unstyle
+import re
+
 from typer.testing import CliRunner
 
 from agnoctl import __version__
@@ -37,6 +38,7 @@ def test_commands_are_registered():
 def test_create_help_shows_interactive_defaults():
     result = runner.invoke(app, ["create", "--help"])
     assert result.exit_code == 0
-    output = " ".join(unstyle(result.output).lower().replace("│", " ").split())
+    output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    output = " ".join(output.lower().replace("│", " ").split())
     assert "default: agentos." in output
     assert "when omitted: agentos-docker." in output


### PR DESCRIPTION
## Summary

- Make bare `agno create` prompt for a starter template and project name, with `agentos-docker` and `agentos` as the defaults.
- Expand the official starter catalog from five to nine: Docker, AWS, Azure, Fly, GCP, Helm, Modal, Railway, and Render.
- Copy `example.env` to a private `.env` automatically, without overwriting existing files and without following template symlinks.
- Replace the noisy multi-command handoff with one concise instruction to add secrets, enter the project, and run `agno up`.
- Keep explicit names, template flags, custom URLs, non-TTY use, and `--json` deterministic and prompt-free.
- Update the CLI home screen, help text, lifecycle hint, README, and regression coverage.

Motivation: make the first AgentOS setup path fast, clear, and safe while preserving automation compatibility.

(If applicable, issue number: N/A)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: not applicable; this is a CLI-only onboarding change
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I searched existing open pull requests and found #8863.
- [x] This PR supersedes #8863: it retains the interactive create flow, adds automatic and symlink-safe `.env` seeding, uses the requested `agentos` name default, preserves the existing non-prompting `agno create NAME` behavior, and replaces the old next-steps block with the reviewed onboarding handoff.
- [x] This PR was created with Codex under human direction and review.

---

## Additional Notes

Persistent automatic `cd` is not possible from a standalone child process such as `uvx`; changing directories would affect only the short-lived CLI process. The handoff therefore says to cd into the generated project before running `agno up`.

For the provider-specific starters, `agno up` launches the local Docker Compose stack. Production deployment still follows the selected template's Azure, Helm, Modal, or Render workflow. Render deployment also requires initializing and pushing the generated project to a Git repository.

Validation:

- `PYTHONPATH=libs/agnoctl /Users/ab/code/agno/.venv/bin/python -m pytest libs/agnoctl/tests -q` — 314 passed
- `./scripts/validate.sh` — Ruff, mypy, and cookbook pattern checks passed
- Live CLI clones of Azure, Helm, Modal, and Render — each created `.env` with mode `0600`, retained `compose.yaml`, and removed `.git`
- The four new starters' Compose configurations and `agno up --dry-run` paths passed
- `git diff --check` — passed
