### PR TITLE
fix: isolate team history by team_id for sub-team delegation

### DIFF
--- a/libs/agno/agno/session/team.py
+++ b/libs/agno/agno/session/team.py
@@ -288,19 +288,24 @@ class TeamSession:
                                 return tool_calls
         return tool_calls
 
-    def get_team_history(self, num_runs: Optional[int] = None) -> List[Tuple[str, str]]:
+    def get_team_history(self, num_runs: Optional[int] = None, team_id: Optional[str] = None) -> List[Tuple[str, str]]:
         """Get team history as structured data (input, response pairs) -> This is the history of the team leader, not the members.
 
         Args:
             num_runs: Number of recent runs to include. If None, returns all available history.
+            team_id: If provided, filter runs by this team_id for sub-team isolation.
+                     If None, falls back to the legacy behavior (completed runs with no parent).
         """
         if not self.runs:
             return []
 
         from agno.run.base import RunStatus
 
-        # Get completed runs only (exclude current/pending run)
-        completed_runs = [run for run in self.runs if run.status == RunStatus.completed and run.parent_run_id is None]
+        # Get completed runs filtered by team_id when provided, otherwise fall back to top-level runs
+        if team_id is not None:
+            completed_runs = [run for run in self.runs if run.status == RunStatus.completed and getattr(run, 'team_id', None) == team_id]
+        else:
+            completed_runs = [run for run in self.runs if run.status == RunStatus.completed and run.parent_run_id is None]
 
         if num_runs is not None:
             if num_runs <= 0:
@@ -333,13 +338,14 @@ class TeamSession:
 
         return history_data
 
-    def get_team_history_context(self, num_runs: Optional[int] = None) -> Optional[str]:
+    def get_team_history_context(self, num_runs: Optional[int] = None, team_id: Optional[str] = None) -> Optional[str]:
         """Get formatted team history context for steps
 
         Args:
             num_runs: Number of recent runs to include. If None, returns all available history.
+            team_id: If provided, filter runs by this team_id for sub-team isolation.
         """
-        history_data = self.get_team_history(num_runs)
+        history_data = self.get_team_history(num_runs, team_id=team_id)
 
         if not history_data:
             return None

--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -510,7 +510,7 @@ def _get_delegate_task_function(
         # 5. Get the team history
         team_history_str = None
         if team.add_team_history_to_members and session:
-            team_history_str = session.get_team_history_context(num_runs=team.num_team_history_runs)
+            team_history_str = session.get_team_history_context(num_runs=team.num_team_history_runs, team_id=team.id)
 
         # 6. Create the member agent task or use the input directly
         if team.determine_input_for_members is False:

--- a/libs/agno/agno/team/_task_tools.py
+++ b/libs/agno/agno/team/_task_tools.py
@@ -325,7 +325,7 @@ def _get_task_management_tools(
         )
         team_history_str = None
         if team.add_team_history_to_members and session:
-            team_history_str = session.get_team_history_context(num_runs=team.num_team_history_runs)
+            team_history_str = session.get_team_history_context(num_runs=team.num_team_history_runs, team_id=team.id)
 
         member_agent_task: Any = task_description
         if team_history_str or team_member_interactions_str:


### PR DESCRIPTION
Fixes #8954

Sub-teams currently receive parent team history when calling `get_team_history()` because the query doesn't filter by `team_id`. This breaks history isolation in multi-agent team setups.

**Fix**: Add `team_id` filter to the team history query so each team (including sub-teams) only sees its own history.