### PR TITLE
fix: retry model when stream completes without usable output

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -325,26 +325,103 @@ class Model(ABC):
         # If we've exhausted all retries, raise the last exception
         raise last_exception  # type: ignore
 
+    @staticmethod
+    def _response_has_usable_output(response: ModelResponse) -> bool:
+        """Check whether a ModelResponse chunk contributes usable output.
+
+        Usable output includes non-empty content, reasoning or redacted reasoning,
+        tool calls, or any generated media (audio, images, videos, files).
+        Whitespace-only content is considered usable per the existing contract.
+        """
+        if response.content is not None and response.content != "":
+            return True
+        if response.reasoning_content is not None and response.reasoning_content != "":
+            return True
+        if response.redacted_reasoning_content is not None and response.redacted_reasoning_content != "":
+            return True
+        if response.tool_calls:
+            return True
+        if response.audio is not None:
+            return True
+        if response.images:
+            return True
+        if response.videos:
+            return True
+        if response.audios:
+            return True
+        if response.files:
+            return True
+        return False
+
     def _invoke_stream_with_retry(self, **kwargs) -> Iterator[ModelResponse]:
         """
         Invoke the model stream with retry logic for ModelProviderError.
 
         This method wraps the invoke_stream() call and retries on ModelProviderError
         with optional exponential backoff. Note that retries restart the entire stream.
+
+        When retries are enabled, a stream that completes without producing any
+        usable output (non-empty content, reasoning, tool calls, or media) is
+        treated as a retryable failure.
         """
         last_exception: Optional[ModelProviderError] = None
         retries_with_guidance_count = kwargs.pop("retries_with_guidance_count", 0)
+        has_yielded_usable = False
 
         for attempt in range(self.retries + 1):
             try:
-                yield from self.invoke_stream(**kwargs)
-                return  # Success, exit the retry loop
+                if self.retries > 0 and not has_yielded_usable:
+                    # Buffer chunks until we see usable output, then flush and
+                    # stream directly. If the stream ends without usable output,
+                    # consume a retry attempt.
+                    buffer: List[ModelResponse] = []
+                    has_usable_output = False
+                    stream_iter = self.invoke_stream(**kwargs)
+                    for response in stream_iter:
+                        if not has_usable_output:
+                            buffer.append(response)
+                            if self._response_has_usable_output(response):
+                                has_usable_output = True
+                                has_yielded_usable = True
+                                # Flush the buffer immediately
+                                yield from buffer
+                                buffer = []
+                        else:
+                            # Already found usable output — stream directly
+                            yield response
+
+                    if not has_usable_output:
+                        if attempt < self.retries:
+                            delay = self._get_retry_delay(attempt)
+                            log_warning(
+                                f"Stream completed without usable output "
+                                f"(attempt {attempt + 1}/{self.retries + 1}). "
+                                f"Retrying in {delay}s..."
+                            )
+                            sleep(delay)
+                            continue
+                        else:
+                            log_error(f"Stream completed without usable output after {self.retries + 1} attempts")
+                            last_exception = ModelProviderError(
+                                message=f"Stream completed without usable output "
+                                f"after {self.retries + 1} attempts",
+                                model_name=self.name,
+                                model_id=self.id,
+                            )
+                            break
+                    return  # Success, exit the retry loop
+                else:
+                    yield from self.invoke_stream(**kwargs)
+                    return  # Success, exit the retry loop
             except ModelProviderError as e:
                 last_exception = self.classify_error(e)
                 # Check if error is non-retryable (e.g., context window exceeded, auth errors)
                 if not self._is_retryable_error(last_exception):
                     log_error(f"Non-retryable model provider error: {str(e)}")
                     raise last_exception from e
+                # If we already yielded usable output, don't retry
+                if has_yielded_usable:
+                    raise
                 if attempt < self.retries:
                     delay = self._get_retry_delay(attempt)
                     log_warning(
@@ -357,6 +434,8 @@ class Model(ABC):
                     if self.retries > 0:
                         log_error(f"Model provider error after {self.retries + 1} attempts: {str(e)}")
             except RetryableModelProviderError as e:
+                if has_yielded_usable:
+                    raise
                 current_count = retries_with_guidance_count
                 if current_count >= self.retry_with_guidance_limit:
                     raise ModelProviderError(
@@ -383,21 +462,71 @@ class Model(ABC):
 
         This method wraps the ainvoke_stream() call and retries on ModelProviderError
         with optional exponential backoff. Note that retries restart the entire stream.
+
+        When retries are enabled, a stream that completes without producing any
+        usable output (non-empty content, reasoning, tool calls, or media) is
+        treated as a retryable failure.
         """
         last_exception: Optional[ModelProviderError] = None
         retries_with_guidance_count = kwargs.pop("retries_with_guidance_count", 0)
+        has_yielded_usable = False
 
         for attempt in range(self.retries + 1):
             try:
-                async for response in self.ainvoke_stream(**kwargs):
-                    yield response
-                return  # Success, exit the retry loop
+                if self.retries > 0 and not has_yielded_usable:
+                    # Buffer chunks until we see usable output, then flush and
+                    # stream directly. If the stream ends without usable output,
+                    # consume a retry attempt.
+                    buffer: List[ModelResponse] = []
+                    has_usable_output = False
+                    stream_iter = self.ainvoke_stream(**kwargs)
+                    async for response in stream_iter:
+                        if not has_usable_output:
+                            buffer.append(response)
+                            if self._response_has_usable_output(response):
+                                has_usable_output = True
+                                has_yielded_usable = True
+                                # Flush the buffer immediately
+                                for buffered in buffer:
+                                    yield buffered
+                                buffer = []
+                        else:
+                            # Already found usable output — stream directly
+                            yield response
+
+                    if not has_usable_output:
+                        if attempt < self.retries:
+                            delay = self._get_retry_delay(attempt)
+                            log_warning(
+                                f"Stream completed without usable output "
+                                f"(attempt {attempt + 1}/{self.retries + 1}). "
+                                f"Retrying in {delay}s..."
+                            )
+                            await asyncio.sleep(delay)
+                            continue
+                        else:
+                            log_error(f"Stream completed without usable output after {self.retries + 1} attempts")
+                            last_exception = ModelProviderError(
+                                message=f"Stream completed without usable output "
+                                f"after {self.retries + 1} attempts",
+                                model_name=self.name,
+                                model_id=self.id,
+                            )
+                            break
+                    return  # Success, exit the retry loop
+                else:
+                    async for response in self.ainvoke_stream(**kwargs):
+                        yield response
+                    return  # Success, exit the retry loop
             except ModelProviderError as e:
                 last_exception = self.classify_error(e)
                 # Check if error is non-retryable
                 if not self._is_retryable_error(last_exception):
                     log_error(f"Non-retryable model provider error: {str(e)}")
                     raise last_exception from e
+                # If we already yielded usable output, don't retry
+                if has_yielded_usable:
+                    raise
                 if attempt < self.retries:
                     delay = self._get_retry_delay(attempt)
                     log_warning(
@@ -410,6 +539,8 @@ class Model(ABC):
                     if self.retries > 0:
                         log_error(f"Model provider error after {self.retries + 1} attempts: {str(e)}")
             except RetryableModelProviderError as e:
+                if has_yielded_usable:
+                    raise
                 current_count = retries_with_guidance_count
                 if current_count >= self.retry_with_guidance_limit:
                     raise ModelProviderError(

--- a/libs/agno/tests/unit/models/test_stream_empty_output_retry.py
+++ b/libs/agno/tests/unit/models/test_stream_empty_output_retry.py
@@ -1,0 +1,313 @@
+"""Tests for retrying streams that complete without usable output.
+
+A provider can return HTTP success and close a stream after emitting only
+empty content or metadata. When retries are enabled, such a stream should
+consume a retry attempt instead of being treated as successful.
+
+See https://github.com/agno-agi/agno/issues/8952
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+# Set test API key to avoid env var lookup errors
+os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
+
+from agno.exceptions import ModelProviderError
+from agno.models.openai.chat import OpenAIChat
+from agno.models.response import ModelResponse
+
+
+@pytest.fixture
+def model_with_one_retry():
+    """Create a model instance with 1 retry and no delay."""
+    return OpenAIChat(id="gpt-4o-mini", retries=1, delay_between_retries=0)
+
+
+@pytest.fixture
+def model_without_retries():
+    """Create a model instance with retries disabled."""
+    return OpenAIChat(id="gpt-4o-mini", retries=0)
+
+
+def _empty_attempt():
+    """Chunks for a stream that completes without usable output."""
+    return [
+        ModelResponse(content=""),
+        ModelResponse(response_usage={"input_tokens": 1}),  # type: ignore
+    ]
+
+
+def _recovered_attempt():
+    """Chunks for a stream that produces usable output."""
+    return [ModelResponse(content="recovered")]
+
+
+# =============================================================================
+# Tests for _response_has_usable_output helper
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "response,expected",
+    [
+        (ModelResponse(content="hello"), True),
+        (ModelResponse(content="  "), True),  # whitespace remains valid content
+        (ModelResponse(content=""), False),
+        (ModelResponse(content=None), False),
+        (ModelResponse(reasoning_content="thinking"), True),
+        (ModelResponse(redacted_reasoning_content="redacted"), True),
+        (ModelResponse(tool_calls=[{"id": "1", "function": {"name": "f"}}]), True),
+        (ModelResponse(response_usage={"input_tokens": 1}), False),  # type: ignore
+        (ModelResponse(), False),
+    ],
+    ids=[
+        "content",
+        "whitespace_content",
+        "empty_content",
+        "no_content",
+        "reasoning",
+        "redacted_reasoning",
+        "tool_calls",
+        "usage_only",
+        "empty_chunk",
+    ],
+)
+def test_response_has_usable_output(model_with_one_retry, response, expected):
+    assert model_with_one_retry._response_has_usable_output(response) is expected
+
+
+# =============================================================================
+# Sync streaming
+# =============================================================================
+
+
+def test_sync_stream_empty_output_is_retried(model_with_one_retry):
+    """A stream completing without usable output should consume a retry attempt."""
+    call_count = 0
+
+    def mock_invoke_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        attempt = _empty_attempt() if call_count == 1 else _recovered_attempt()
+        yield from attempt
+
+    with patch.object(model_with_one_retry, "invoke_stream", side_effect=mock_invoke_stream):
+        responses = list(model_with_one_retry._invoke_stream_with_retry(messages=[]))
+
+    assert call_count == 2, "Empty stream should have triggered a retry"
+    assert [r.content for r in responses] == ["recovered"]
+    # Metadata-only chunks from the discarded attempt must not be emitted downstream
+    assert all(r.response_usage is None for r in responses)
+
+
+def test_sync_stream_metadata_flushed_when_usable_output_arrives(model_with_one_retry):
+    """Metadata received before the first usable chunk is flushed in order."""
+
+    def mock_invoke_stream(**kwargs):
+        yield ModelResponse(response_usage={"input_tokens": 1})  # type: ignore
+        yield ModelResponse(content="hello")
+        yield ModelResponse(content=" world")
+
+    with patch.object(model_with_one_retry, "invoke_stream", side_effect=mock_invoke_stream):
+        responses = list(model_with_one_retry._invoke_stream_with_retry(messages=[]))
+
+    assert len(responses) == 3
+    assert responses[0].response_usage is not None
+    assert [r.content for r in responses] == [None, "hello", " world"]
+
+
+def test_sync_stream_all_empty_attempts_raise(model_with_one_retry):
+    """If every attempt completes without usable output, raise ModelProviderError."""
+    call_count = 0
+
+    def mock_invoke_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        yield from _empty_attempt()
+
+    with patch.object(model_with_one_retry, "invoke_stream", side_effect=mock_invoke_stream):
+        with pytest.raises(ModelProviderError):
+            list(model_with_one_retry._invoke_stream_with_retry(messages=[]))
+
+    assert call_count == 2, "All retry attempts should have been consumed"
+
+
+def test_sync_stream_empty_output_not_retried_when_retries_disabled(model_without_retries):
+    """With retries=0 the previous behavior is unchanged: the stream passes through."""
+    call_count = 0
+
+    def mock_invoke_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        yield from _empty_attempt()
+
+    with patch.object(model_without_retries, "invoke_stream", side_effect=mock_invoke_stream):
+        responses = list(model_without_retries._invoke_stream_with_retry(messages=[]))
+
+    assert call_count == 1
+    assert len(responses) == 2
+
+
+def test_sync_stream_error_after_usable_output_is_not_retried(model_with_one_retry):
+    """Once usable output has been emitted, an error must not restart the stream."""
+    call_count = 0
+
+    def mock_invoke_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        yield ModelResponse(content="partial")
+        raise ModelProviderError("Server error", status_code=500)
+
+    received = []
+    with patch.object(model_with_one_retry, "invoke_stream", side_effect=mock_invoke_stream):
+        with pytest.raises(ModelProviderError):
+            for response in model_with_one_retry._invoke_stream_with_retry(messages=[]):
+                received.append(response)
+
+    assert call_count == 1, "Stream must not restart after delivering usable output"
+    assert [r.content for r in received] == ["partial"]
+
+
+def test_sync_stream_error_before_usable_output_is_still_retried(model_with_one_retry):
+    """Provider errors before any usable output keep the existing retry behavior."""
+    call_count = 0
+
+    def mock_invoke_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ModelProviderError("Server error", status_code=500)
+        yield from _recovered_attempt()
+
+    with patch.object(model_with_one_retry, "invoke_stream", side_effect=mock_invoke_stream):
+        responses = list(model_with_one_retry._invoke_stream_with_retry(messages=[]))
+
+    assert call_count == 2
+    assert [r.content for r in responses] == ["recovered"]
+
+
+@pytest.mark.parametrize(
+    "usable_chunk",
+    [
+        ModelResponse(content="  "),
+        ModelResponse(tool_calls=[{"id": "1", "function": {"name": "f"}}]),
+        ModelResponse(reasoning_content="thinking"),
+    ],
+    ids=["whitespace_content", "tool_calls", "reasoning"],
+)
+def test_sync_stream_usable_chunk_variants_prevent_retry(model_with_one_retry, usable_chunk):
+    """Whitespace content, tool calls, and reasoning all count as usable output."""
+    call_count = 0
+
+    def mock_invoke_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        yield usable_chunk
+
+    with patch.object(model_with_one_retry, "invoke_stream", side_effect=mock_invoke_stream):
+        responses = list(model_with_one_retry._invoke_stream_with_retry(messages=[]))
+
+    assert call_count == 1, "Usable output should not trigger a retry"
+    assert len(responses) == 1
+
+
+# =============================================================================
+# Async streaming
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_async_stream_empty_output_is_retried(model_with_one_retry):
+    """An async stream completing without usable output should consume a retry attempt."""
+    call_count = 0
+
+    async def mock_ainvoke_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        attempt = _empty_attempt() if call_count == 1 else _recovered_attempt()
+        for chunk in attempt:
+            yield chunk
+
+    with patch.object(model_with_one_retry, "ainvoke_stream", side_effect=mock_ainvoke_stream):
+        responses = [r async for r in model_with_one_retry._ainvoke_stream_with_retry(messages=[])]
+
+    assert call_count == 2, "Empty async stream should have triggered a retry"
+    assert [r.content for r in responses] == ["recovered"]
+    assert all(r.response_usage is None for r in responses)
+
+
+@pytest.mark.asyncio
+async def test_async_stream_metadata_flushed_when_usable_output_arrives(model_with_one_retry):
+    """Metadata received before the first usable chunk is flushed in order."""
+
+    async def mock_ainvoke_stream(**kwargs):
+        yield ModelResponse(response_usage={"input_tokens": 1})  # type: ignore
+        yield ModelResponse(content="hello")
+
+    with patch.object(model_with_one_retry, "ainvoke_stream", side_effect=mock_ainvoke_stream):
+        responses = [r async for r in model_with_one_retry._ainvoke_stream_with_retry(messages=[])]
+
+    assert len(responses) == 2
+    assert responses[0].response_usage is not None
+    assert responses[1].content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_async_stream_all_empty_attempts_raise(model_with_one_retry):
+    """If every async attempt completes without usable output, raise ModelProviderError."""
+    call_count = 0
+
+    async def mock_ainvoke_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        for chunk in _empty_attempt():
+            yield chunk
+
+    with patch.object(model_with_one_retry, "ainvoke_stream", side_effect=mock_ainvoke_stream):
+        with pytest.raises(ModelProviderError):
+            async for _ in model_with_one_retry._ainvoke_stream_with_retry(messages=[]):
+                pass
+
+    assert call_count == 2, "All retry attempts should have been consumed"
+
+
+@pytest.mark.asyncio
+async def test_async_stream_empty_output_not_retried_when_retries_disabled(model_without_retries):
+    """With retries=0 the previous behavior is unchanged: the stream passes through."""
+    call_count = 0
+
+    async def mock_ainvoke_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        for chunk in _empty_attempt():
+            yield chunk
+
+    with patch.object(model_without_retries, "ainvoke_stream", side_effect=mock_ainvoke_stream):
+        responses = [r async for r in model_without_retries._ainvoke_stream_with_retry(messages=[])]
+
+    assert call_count == 1
+    assert len(responses) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_stream_error_after_usable_output_is_not_retried(model_with_one_retry):
+    """Once usable output has been emitted, an async error must not restart the stream."""
+    call_count = 0
+
+    async def mock_ainvoke_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        yield ModelResponse(content="partial")
+        raise ModelProviderError("Server error", status_code=500)
+
+    received = []
+    with patch.object(model_with_one_retry, "ainvoke_stream", side_effect=mock_ainvoke_stream):
+        with pytest.raises(ModelProviderError):
+            async for response in model_with_one_retry._ainvoke_stream_with_retry(messages=[]):
+                received.append(response)
+
+    assert call_count == 1, "Async stream must not restart after delivering usable output"
+    assert [r.content for r in received] == ["partial"]


### PR DESCRIPTION
Fixes #8952

## Problem

A provider can return HTTP success and close a stream after emitting only empty content or metadata. The retry wrappers (`_invoke_stream_with_retry` / `_ainvoke_stream_with_retry`) treated any normally completed iterator as successful because no provider exception was raised, so `Model(retries > 0)` never retried and the Agent could finish with a blank response.

A related problem: a provider error raised after partial output restarted the stream and replayed already-delivered chunks.

## Fix

Track usable output per attempt in both sync and async stream retry wrappers:

- New helper `Model._response_has_usable_output()` detects chunks that carry usable output: non-empty content, reasoning or redacted reasoning, tool calls, or generated media. Whitespace-only content remains valid content, per the issue's contract; no provider-specific heuristics are applied.
- When retries are enabled, chunks are buffered only until the first usable chunk arrives. The buffer is then flushed immediately (preserving order, including preceding metadata chunks) and the stream continues directly with no further buffering.
- If the stream completes without any usable output, the attempt's metadata-only buffer is discarded and a retry attempt is consumed (with the existing delay/backoff handling).
- If all attempts complete without usable output, `ModelProviderError` is raised.
- Once usable output has been emitted, provider errors propagate without restarting the attempt, so delivered chunks are never replayed.
- `retries=0` (the default) keeps the exact previous pass-through behavior — no buffering, no new failure mode.

No new configuration surface: this reuses the existing `retries` opt-in.

## Tests

Added `libs/agno/tests/unit/models/test_stream_empty_output_retry.py` (deterministic, mock-based, sync and async), covering:

- empty stream consumes a retry and the recovered attempt's content is delivered
- metadata-only chunks from a discarded attempt are not emitted downstream
- metadata received before the first usable chunk is flushed in order
- all-empty attempts raise `ModelProviderError` after consuming every attempt
- `retries=0` passes an empty stream through unchanged
- errors after usable output propagate without restarting (no chunk replay)
- errors before usable output keep the existing retry behavior
- whitespace content, tool calls, and reasoning all count as usable output
