### PR TITLE
fix: handle already-serialized dicts in TeamRunOutput.to_dict media fields and member_responses

### DIFF
--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -884,22 +884,27 @@ class TeamRunOutput:
             _dict["followups"] = self.followups
 
         if self.images is not None:
-            _dict["images"] = [img.to_dict() for img in self.images]
+            _dict["images"] = [img.to_dict() if isinstance(img, Image) else img for img in self.images]
 
         if self.videos is not None:
-            _dict["videos"] = [vid.to_dict() for vid in self.videos]
+            _dict["videos"] = [vid.to_dict() if isinstance(vid, Video) else vid for vid in self.videos]
 
         if self.audio is not None:
-            _dict["audio"] = [aud.to_dict() for aud in self.audio]
+            _dict["audio"] = [aud.to_dict() if isinstance(aud, Audio) else aud for aud in self.audio]
 
         if self.files is not None:
-            _dict["files"] = [file.to_dict() for file in self.files]
+            _dict["files"] = [file.to_dict() if isinstance(file, File) else file for file in self.files]
 
         if self.response_audio is not None:
-            _dict["response_audio"] = self.response_audio.to_dict()
+            if isinstance(self.response_audio, Audio):
+                _dict["response_audio"] = self.response_audio.to_dict()
+            else:
+                _dict["response_audio"] = self.response_audio
 
         if self.member_responses:
-            _dict["member_responses"] = [response.to_dict() for response in self.member_responses]
+            _dict["member_responses"] = [
+                response.to_dict() if hasattr(response, "to_dict") else response for response in self.member_responses
+            ]
 
         if self.citations is not None:
             if isinstance(self.citations, Citations):

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -249,6 +249,30 @@ def test_team_session_state_in_run_output():
     assert reconstructed.session_state == {"phase": "planning", "tasks": 3}
 
 
+def test_team_run_output_to_dict_accepts_serialized_media_dicts():
+    """Test that TeamRunOutput.to_dict() tolerates already-serialized dicts in media fields."""
+    from agno.run.team import TeamRunOutput
+
+    team_output = TeamRunOutput(
+        run_id="team_123",
+        images=[{"url": "https://example.com/image.png"}],
+        videos=[{"url": "https://example.com/video.mp4"}],
+        audio=[{"url": "https://example.com/audio.mp3"}],
+        files=[{"url": "https://example.com/report.pdf"}],
+        response_audio={"id": "audio_123", "content": "base64-audio"},
+        member_responses=[{"run_id": "member_123", "content": "done"}],
+    )
+
+    team_dict = team_output.to_dict()
+
+    assert team_dict["images"] == [{"url": "https://example.com/image.png"}]
+    assert team_dict["videos"] == [{"url": "https://example.com/video.mp4"}]
+    assert team_dict["audio"] == [{"url": "https://example.com/audio.mp3"}]
+    assert team_dict["files"] == [{"url": "https://example.com/report.pdf"}]
+    assert team_dict["response_audio"] == {"id": "audio_123", "content": "base64-audio"}
+    assert team_dict["member_responses"] == [{"run_id": "member_123", "content": "done"}]
+
+
 def test_team_session_state_in_completed_event():
     """Test that TeamRunCompletedEvent includes session_state field."""
     from agno.run.team import TeamRunOutput


### PR DESCRIPTION
## Summary

Fixes #8678

`TeamRunOutput.to_dict()` crashed with `AttributeError: 'dict' object has no attribute 'to_dict'` when its media fields (`images`, `videos`, `audio`, `files`, `response_audio`) or `member_responses` already contained serialized dicts — a state that is easy to hit after a run output has been persisted, passed through an API/JSON boundary, or reconstructed from a dict.

This was inconsistent with `RunOutput.to_dict()` (in `agno/run/agent.py`), which already tolerates this shape via `isinstance` checks before calling `.to_dict()` on each item.
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
