### PR TITLE
fix: clean_text() no longer erases newlines it just normalized

### DIFF
--- a/libs/agno/agno/knowledge/chunking/strategy.py
+++ b/libs/agno/agno/knowledge/chunking/strategy.py
@@ -42,7 +42,9 @@ class ChunkingStrategy(ABC):
         # Replace multiple newlines with a single newline
         cleaned_text = re.sub(r"\n+", "\n", text)
         # Replace multiple spaces with a single space
-        cleaned_text = re.sub(r"\s+", " ", cleaned_text)
+        # Note: uses " +" (not "\s+"), since "\s" also matches "\n" and would
+        # collapse the newlines just normalized above into plain spaces.
+        cleaned_text = re.sub(r" +", " ", cleaned_text)
         # Replace multiple tabs with a single tab
         cleaned_text = re.sub(r"\t+", "\t", cleaned_text)
         # Replace multiple carriage returns with a single carriage return

--- a/libs/agno/tests/unit/knowledge/chunking/test_clean_text.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_clean_text.py
@@ -1,0 +1,41 @@
+"""Tests for ChunkingStrategy.clean_text() newline-preservation behavior."""
+
+from agno.knowledge.chunking.fixed import FixedSizeChunking
+from agno.knowledge.document.base import Document
+
+
+class TestCleanTextPreservesNewlines:
+    """clean_text() collapses multiple newlines to one but must not erase them entirely."""
+
+    def test_multiple_newlines_collapse_to_single_newline(self):
+        strategy = FixedSizeChunking()
+        text = "First paragraph.\n\n\nSecond paragraph.\n\nThird paragraph."
+
+        cleaned = strategy.clean_text(text)
+
+        assert "\n" in cleaned
+        assert cleaned == "First paragraph.\nSecond paragraph.\nThird paragraph."
+
+    def test_single_newline_is_preserved(self):
+        strategy = FixedSizeChunking()
+        text = "AAAAAAAAAA\nBBBBBBBBBB"
+
+        cleaned = strategy.clean_text(text)
+
+        assert cleaned == "AAAAAAAAAA\nBBBBBBBBBB"
+
+
+class TestFixedSizeChunkingSplitsAtNewlines:
+    """FixedSizeChunking checks for '\\n' as a word-boundary split point (fixed.py),
+    which requires clean_text() to actually preserve newlines in its output."""
+
+    def test_splits_at_newline_boundary_not_mid_word(self):
+        text = "AAAAAAAAAA\nBBBBBBBBBB"
+
+        doc = Document(id="test", name="test", content=text)
+        chunker = FixedSizeChunking(chunk_size=15, overlap=0)
+        chunks = chunker.chunk(doc)
+
+        assert len(chunks) == 2
+        assert chunks[0].content == "AAAAAAAAAA"
+        assert chunks[1].content == "\nBBBBBBBBBB"

--- a/libs/agno/tests/unit/reader/test_firecrawl_reader.py
+++ b/libs/agno/tests/unit/reader/test_firecrawl_reader.py
@@ -52,8 +52,7 @@ def test_scrape_basic(mock_scrape_response):
         assert len(documents) == 1
         assert documents[0].name == "https://example.com"
         assert documents[0].id == "https://example.com_1"
-        # Content is joined with spaces instead of newlines
-        expected_content = "# Test Website This is test content from a scraped website."
+        expected_content = "# Test Website\nThis is test content from a scraped website."
         assert documents[0].content == expected_content
 
         # Verify FirecrawlApp was called correctly
@@ -186,9 +185,8 @@ def test_crawl_basic(mock_crawl_response):
         assert len(documents) == 2
         # Base URL is used for name
         assert documents[0].name == "https://example.com"
-        # Content joined with spaces
-        assert documents[0].content == "# Page 1 This is content from page 1."
-        assert documents[1].content == "# Page 2 This is content from page 2."
+        assert documents[0].content == "# Page 1\nThis is content from page 1."
+        assert documents[1].content == "# Page 2\nThis is content from page 2."
 
         # Verify FirecrawlApp was called correctly
         MockFirecrawlApp.assert_called_once_with(api_key=None)
@@ -261,7 +259,7 @@ def test_read_scrape_mode(mock_scrape_response):
         documents = reader.read("https://example.com")
 
         assert len(documents) == 1
-        expected_content = "# Test Website This is test content from a scraped website."
+        expected_content = "# Test Website\nThis is test content from a scraped website."
         assert documents[0].content == expected_content
 
         mock_app.scrape_url.assert_called_once()

--- a/libs/agno/tests/unit/reader/test_tavily_reader.py
+++ b/libs/agno/tests/unit/reader/test_tavily_reader.py
@@ -53,8 +53,7 @@ def test_extract_basic(mock_extract_response):
         assert len(documents) == 1
         assert documents[0].name == "https://example.com"
         assert documents[0].id == "https://example.com_1"
-        # Content is joined with spaces instead of newlines
-        expected_content = "# Test Website This is test content from an extracted website."
+        expected_content = "# Test Website\nThis is test content from an extracted website."
         assert documents[0].content == expected_content
 
         # Verify TavilyClient was called correctly
@@ -242,7 +241,7 @@ def test_read_method(mock_extract_response):
         documents = reader.read("https://example.com")
 
         assert len(documents) == 1
-        expected_content = "# Test Website This is test content from an extracted website."
+        expected_content = "# Test Website\nThis is test content from an extracted website."
         assert documents[0].content == expected_content
 
         mock_client.extract.assert_called_once()


### PR DESCRIPTION
## Summary

`ChunkingStrategy.clean_text()` (`libs/agno/agno/knowledge/chunking/strategy.py`) is supposed to preserve newline structure while tidying up other whitespace — that's the whole point of its first substitution, which collapses multiple newlines down to one (`\n+` -> `\n`). But the very next line collapses "multiple spaces" using `re.sub(r"\s+", " ", ...)`. `\s` also matches `\n`, `\t`, `\r`, `\f`, `\v`, so this second substitution immediately flattens every newline the first line just normalized into a plain space — along with every tab, CR, FF, and VT. The per-character-type collapse steps further down in the function (for tabs, CR, FF, VT) were themselves dead code as a result, since `\s+` had already erased all of those characters before those lines could ever match anything.

```python
>>> from agno.knowledge.chunking.fixed import FixedSizeChunking
>>> FixedSizeChunking().clean_text("AAAAAAAAAA\nBBBBBBBBBB")
'AAAAAAAAAA BBBBBBBBBB'   # newline silently turned into a space
```

This has a concrete downstream effect: `FixedSizeChunking.chunk()` explicitly checks for `\n`/`\r`/`\t` as valid word-boundary split points (`fixed.py`, the `content[end] not in [" ", "\n", "\r", "\t"]` loop), but since `clean_text()` never lets those characters survive, those branches are unreachable — only space-separated boundaries ever exist. Every chunking strategy that calls `clean_text()` (`FixedSizeChunking`, `RecursiveChunking`, `SemanticChunking`, `DocumentChunking`, `MarkdownChunking`, `AgenticChunking`) is affected the same way: paragraph/line structure is silently destroyed before it ever reaches split-point logic.

**Fix:** change the space-collapsing regex from `\s+` to `" +"` so it only touches literal repeated spaces and leaves the newline (already normalized by the line above) and other whitespace types (collapsed by the lines below) intact. This is the minimal change — it also makes the existing tab/CR/FF/VT collapse lines functional again instead of dead code, matching what the surrounding code was clearly trying to do.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — n/a, no public API/docstring change
- [x] Examples and guides — n/a, internal bug fix, no user-facing behavior change beyond correctness
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**AI-generated contribution disclosure:** I used an AI coding assistant (Claude) to help identify this bug and draft the fix. I independently verified the regex behavior and the split-point logic in `fixed.py` myself, wrote/verified new regression tests in both red and green states, and ran the full local test suite plus the repo's required format/validate scripts before opening this PR.

## Testing

Added `libs/agno/tests/unit/knowledge/chunking/test_clean_text.py`:
- `clean_text()` collapses `\n\n\n` to a single `\n` and does not erase it
- a single `\n` survives `clean_text()` unchanged
- `FixedSizeChunking` now actually splits at a newline boundary instead of treating the whole string as one space-joined blob

All three fail against pre-fix code (asserting the newline becomes a space) and pass after the fix.

Ran the full `libs/agno/tests/unit/knowledge/chunking/` directory (38 passed, 8 skipped — the 2 skipped modules require optional deps `unstructured`/`chonkie`/`numpy` not installed in this environment, unrelated to this change) and the broader `libs/agno/tests/unit/knowledge/` directory (419 passed, 8 skipped) — no regressions. `./scripts/format.sh` and `./scripts/validate.sh` both pass clean on the changed files.
