### PR TITLE
fix(team): retain nested team history

### DIFF
--- a/libs/agno/agno/session/team.py
+++ b/libs/agno/agno/session/team.py
@@ -151,8 +151,8 @@ class TeamSession:
                 return True
             return False
 
-        if member_ids is not None and skip_member_messages:
-            log_debug("Member IDs to filter by were provided. The skip_member_messages flag will be ignored.")
+        if (team_id is not None or member_ids is not None) and skip_member_messages:
+            log_debug("Team or member IDs to filter by were provided. The skip_member_messages flag will be ignored.")
             skip_member_messages = False
 
         if not self.runs:

--- a/libs/agno/tests/unit/team/test_get_messages_dedup.py
+++ b/libs/agno/tests/unit/team/test_get_messages_dedup.py
@@ -234,6 +234,31 @@ class TestGetMessagesMemberDedup:
         assert len(messages) == 4
 
 
+class TestGetMessagesTeamFilter:
+    """Tests for filtering nested team runs by team ID."""
+
+    def test_team_id_includes_nested_team_runs(self):
+        nested_run = TeamRunOutput(
+            run_id="nested-run",
+            team_id="nested-team",
+            parent_run_id="parent-run",
+            status=RunStatus.completed,
+            messages=[Message(role="assistant", content="Nested team response")],
+        )
+        top_level_run = TeamRunOutput(
+            run_id="top-level-run",
+            team_id="top-level-team",
+            status=RunStatus.completed,
+            messages=[Message(role="assistant", content="Top-level team response")],
+        )
+        session = TeamSession(session_id="test-session", runs=[nested_run, top_level_run])
+
+        messages = session.get_messages(team_id="nested-team")
+
+        assert [message.content for message in messages] == ["Nested team response"]
+        assert [message.content for message in session.get_messages()] == ["Top-level team response"]
+
+
 class TestGetTeamHistoryZeroCount:
     """get_team_history() zero/negative num_runs must return empty, not the whole history."""
 


### PR DESCRIPTION
## Summary

Fix nested Team history lookup by treating an explicit `team_id` as a member-history filter. This prevents delegated sub-team runs with a `parent_run_id` from being removed after matching the requested team, while preserving the default top-level filtering behavior.

Fixes #8951.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation:
- `PYTHONPATH=libs/agno python -m pytest libs/agno/tests/unit/team/test_get_messages_dedup.py -q` (12 passed)
- `python -m ruff check libs/agno/agno/session/team.py libs/agno/tests/unit/team/test_get_messages_dedup.py`
- `python -m ruff format --check libs/agno/agno/session/team.py libs/agno/tests/unit/team/test_get_messages_dedup.py`