### PR TITLE
fix: SafeFormatter.get_value ignores positional arguments

### DIFF
--- a/libs/agno/agno/utils/safe_formatter.py
+++ b/libs/agno/agno/utils/safe_formatter.py
@@ -4,6 +4,8 @@ import string
 class SafeFormatter(string.Formatter):
     def get_value(self, key, args, kwargs):
         """Handle missing keys by returning '{key}'."""
+        if isinstance(key, int):
+            return args[key]
         if key not in kwargs:
             return f"{key}"
         return kwargs[key]

--- a/libs/agno/tests/unit/utils/test_safe_formatter.py
+++ b/libs/agno/tests/unit/utils/test_safe_formatter.py
@@ -1,0 +1,14 @@
+"""Tests for SafeFormatter."""
+
+from agno.utils.safe_formatter import SafeFormatter
+
+
+def test_positional_fields_use_positional_arguments():
+    formatter = SafeFormatter()
+
+    assert formatter.format("{0} {name}", "hello", name="world") == "hello world"
+    assert formatter.format("{} {name}", "hello", name="world") == "hello world"
+
+
+def test_missing_named_fields_keep_existing_fallback():
+    assert SafeFormatter().format("{missing}") == "missing"


### PR DESCRIPTION
## Summary

`SafeFormatter.get_value()` (`libs/agno/agno/utils/safe_formatter.py`) only checks `kwargs` for a field's value:

```python
class SafeFormatter(string.Formatter):
    def get_value(self, key, args, kwargs):
        """Handle missing keys by returning '{key}'."""
        if key not in kwargs:
            return f"{key}"
        return kwargs[key]
```

`string.Formatter.get_value` is called with an `int` `key` for positional placeholders (`{0}`, `{}`) and a `str` key for named placeholders (`{name}`). Since this override never inspects `args` at all, any positional field falls into the `key not in kwargs` branch — `0 not in kwargs` is always `True` for an integer key — and the literal placeholder index string is returned instead of the actual positional argument:

```python
>>> SafeFormatter().format("{0} {name}", "foo", name="bar")
'0 bar'   # expected 'foo bar'
```

## Fix

Check for an integer key first and return the corresponding positional argument, mirroring how `string.Formatter`'s own default implementation dispatches on key type — only the "missing key falls back to `{key}`" behavior for named fields is custom here, so it stays untouched:

```python
def get_value(self, key, args, kwargs):
    """Handle missing keys by returning '{key}'."""
    if isinstance(key, int):
        return args[key]
    if key not in kwargs:
        return f"{key}"
    return kwargs[key]
```

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff check` + `ruff format --check` + `mypy`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — n/a, no public API/docstring change
- [x] Examples and guides — n/a, internal bug fix, no user-facing behavior change beyond correctness
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Testing

Added `libs/agno/tests/unit/utils/test_safe_formatter.py`: confirmed red against unfixed code (`'{0} {name}'.format('hello', name='world')` returned `'0 world'`, not `'hello world'`), green after the fix, plus a companion test confirming the existing missing-named-field fallback (`{missing}` → `"missing"`) is unaffected. Ran the full `libs/agno/tests/unit/utils/` directory: 405 passed, 1 skipped (unrelated). `ruff check`, `ruff format --check`, `mypy`: clean.

## Additional Notes

**AI-generated contribution disclosure:** I used an AI coding assistant (Claude) to help identify this bug and draft the fix and tests. I independently traced `string.Formatter`'s calling convention for positional vs. named keys, verified the fix red→green, and ran the full local test suite plus lint/type-check before submitting.