### PR TITLE
fix: resolve dataclass tool params under `from __future__ import annotations`

### DIFF
--- a/libs/agno/agno/utils/json_schema.py
+++ b/libs/agno/agno/utils/json_schema.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, Literal, Optional, Union, get_args, get_origin
+from typing import Any, Dict, Literal, Optional, Union, get_args, get_origin, get_type_hints
 
 from pydantic import BaseModel
 
@@ -174,8 +174,15 @@ def get_json_schema_for_arg(type_hint: Any) -> Optional[Dict[str, Any]]:
         properties = {}
         required = []
 
+        # Resolve annotations so string forms (from `from __future__ import annotations`)
+        # become real types instead of falling through to `str.__name__` below.
+        try:
+            resolved_hints = get_type_hints(type_hint)
+        except Exception:
+            resolved_hints = {}
+
         for field_name, field in type_hint.__dataclass_fields__.items():
-            field_type = field.type
+            field_type = resolved_hints.get(field_name, field.type)
             field_schema = get_json_schema_for_arg(field_type)
 
             if (

--- a/libs/agno/tests/unit/utils/test_json_schema_future_annotations.py
+++ b/libs/agno/tests/unit/utils/test_json_schema_future_annotations.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from agno.utils.json_schema import get_json_schema, get_json_schema_for_arg
+
+
+# With `from __future__ import annotations` active for this module, every field's
+# `.type` is stored as a string ("int") rather than a type object, which used to
+# crash json_schema's dataclass branch on `str.__name__`.
+@dataclass
+class Point:
+    x: int
+    y: Optional[str]
+    tags: List[int]
+
+
+def test_dataclass_arg_under_future_annotations():
+    schema = get_json_schema_for_arg(Point)
+
+    assert schema["type"] == "object"
+    assert schema["properties"]["x"] == {"type": "integer"}
+    assert schema["properties"]["y"]["type"] == "string"
+    assert schema["properties"]["tags"] == {"type": "array", "items": {"type": "integer"}}
+    # x and tags are required; the Optional field is not.
+    assert set(schema["required"]) == {"x", "tags"}
+
+
+def test_dataclass_tool_param_schema_not_silently_dropped():
+    # The realistic failure was silent: the crash was swallowed per-arg and the
+    # parameter vanished from `properties` while staying in `required`.
+    schema = get_json_schema({"target": Point})
+
+    target = schema["properties"]["target"]
+    assert target["type"] == "object"
+    assert set(target["properties"]) == {"x", "y", "tags"}


### PR DESCRIPTION
## Summary

`get_json_schema_for_arg`'s dataclass branch read each field's raw
`field.type`. Under `from __future__ import annotations` (PEP 563 — increasingly
the default in modern code), `dataclasses` stores that annotation as a **string**
(`"int"`) rather than a type object. The recursive call then falls through to:

```python
json_schema = {"type": get_json_type_for_py_type(type_hint.__name__)}
```

and raises `AttributeError: 'str' object has no attribute '__name__'`.

Through the tool-registration path (`Function.from_callable` → `get_json_schema`)
the crash is swallowed by the per-argument `except`, so the failure is **silent**:
the dataclass parameter is dropped from `properties` while remaining in
`required`, producing an invalid schema that strict-mode providers reject.

```python
from __future__ import annotations
from dataclasses import dataclass

@dataclass
class Point:
    x: int
    y: int

def move(target: Point) -> str: ...
# before: get_json_schema({"target": Point}) -> {'type': 'object', 'properties': {}}
# after:  target is fully described with x/y sub-properties
```

## Fix

Resolve field annotations with `typing.get_type_hints(...)` (falling back to the
raw `.type` if resolution fails) so string annotations become real types before
recursion. Behaviour for non-`__future__` dataclasses is unchanged.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New test module `libs/agno/tests/unit/utils/test_json_schema_future_annotations.py`
carries `from __future__ import annotations` so its dataclass reproduces the
string-annotation path; it fails (AttributeError) on `main` and passes with this
fix. Full `test_json_schema.py` suite (22 tests) green; ruff + mypy clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
