### PR TITLE
fix: don't substitute literal `$var` text in state-variable formatting

### DIFF
--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -62,7 +62,6 @@ def format_message_with_state_variables(
     import re
     import string
     from collections import ChainMap
-    from copy import deepcopy
 
     if not isinstance(message, str):
         return message
@@ -81,7 +80,9 @@ def format_message_with_state_variables(
         {"user_id": user_id} if user_id is not None else {},
     )
 
-    converted_msg = deepcopy(message)
+    # Escape literal `$` so Template only substitutes the `${var}` forms created below,
+    # not pre-existing `$word` text the user wrote (e.g. shell/env vars).
+    converted_msg = message.replace("$", "$$")
     for var_name in format_variables.keys():
         # Only convert standalone {var_name} patterns, not nested ones
         pattern = r"\{" + re.escape(var_name) + r"\}"

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -1494,7 +1494,9 @@ def _format_message_with_state_variables(
         metadata or {},
         {"user_id": user_id} if user_id is not None else {},
     )
-    converted_msg = message
+    # Escape literal `$` so Template only substitutes the `${var}` forms created below,
+    # not pre-existing `$word` text the user wrote (e.g. shell/env vars).
+    converted_msg = message.replace("$", "$$")
     for var_name in format_variables.keys():
         # Only convert standalone {var_name} patterns, not nested ones
         pattern = r"\{" + re.escape(var_name) + r"\}"

--- a/libs/agno/tests/unit/agent/test_state_variable_dollar_escape.py
+++ b/libs/agno/tests/unit/agent/test_state_variable_dollar_escape.py
@@ -1,0 +1,32 @@
+"""State-variable substitution must not touch literal ``$word`` text.
+
+The documented template syntax is ``{var}``. The substitution machinery converts
+``{var}`` to ``${var}`` and then runs ``string.Template.safe_substitute``, which
+also matches any pre-existing ``$word`` the user wrote. A prompt containing e.g.
+``$name`` (shell/env text) used to be silently rewritten whenever ``name`` was a
+session-state key.
+"""
+
+import pytest
+
+from agno.agent._messages import format_message_with_state_variables
+from agno.run.base import RunContext
+from agno.team._messages import _format_message_with_state_variables
+
+
+@pytest.fixture
+def run_context():
+    return RunContext(run_id="r", session_id="s", session_state={"name": "Alice", "path": "/tmp"})
+
+
+@pytest.mark.parametrize("fn", [format_message_with_state_variables, _format_message_with_state_variables])
+def test_literal_dollar_var_is_not_substituted(fn, run_context):
+    assert fn(None, "echo $name to shell", run_context) == "echo $name to shell"
+    assert fn(None, "export PATH=$path:/x", run_context) == "export PATH=$path:/x"
+
+
+@pytest.mark.parametrize("fn", [format_message_with_state_variables, _format_message_with_state_variables])
+def test_documented_brace_syntax_still_substitutes(fn, run_context):
+    assert fn(None, "Hi {name}", run_context) == "Hi Alice"
+    # Brace form is substituted; the literal $name in the same string is preserved.
+    assert fn(None, "{name} owes $name", run_context) == "Alice owes $name"


### PR DESCRIPTION
## Summary

State-variable formatting (`format_message_with_state_variables` in `agent/_messages.py`
and `_format_message_with_state_variables` in `team/_messages.py`) converts the
documented `{var}` placeholders to `${var}` and then calls
`string.Template.safe_substitute`. `safe_substitute` also matches any **pre-existing**
`$word` in the message. So a prompt that legitimately contains `$name`, `$path`, etc.
(shell commands, env vars, prices, regex, LaTeX) is silently rewritten whenever that
word collides with a `session_state` / `dependencies` / `metadata` key — even though
the documented template syntax is only `{var}` ("Only convert standalone {var_name}
patterns").

```python
rc = RunContext(..., session_state={"name": "Alice", "path": "/tmp"})
format_message_with_state_variables(agent, "echo $name to shell", rc)
# before: "echo Alice to shell"   after: "echo $name to shell"
format_message_with_state_variables(agent, "Hi {name}", rc)
# "Hi Alice" (documented syntax) — unchanged by this fix
```

## Fix

Escape literal `$` (`message.replace("$", "$$")`) before generating the `${var}` forms,
so `Template` only substitutes the placeholders we deliberately create. Applied to both
the agent and team formatters. Removed a now-unused `deepcopy` import in the agent path
(`message` is already guaranteed to be a `str`).

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New parametrized test `test_state_variable_dollar_escape.py` covers both the agent and
team formatters (literal `$var` preserved; documented `{var}` still substituted). It
fails on `main` and passes with this fix; existing `test_dependencies_merge.py` (10
tests) still passes. ruff + mypy clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
