### PR TITLE
fix: RunOutput/TeamRunOutput.to_json unicode escaping and non-JSON value crash

### DIFF
--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -835,6 +835,8 @@ class RunOutput:
     def to_json(self, separators=(", ", ": "), indent: Optional[int] = 2) -> str:
         import json
 
+        from agno.utils.serialize import json_serializer
+
         try:
             _dict = self.to_dict()
         except Exception as e:
@@ -842,9 +844,9 @@ class RunOutput:
             raise
 
         if indent is None:
-            return json.dumps(_dict, separators=separators)
+            return json.dumps(_dict, separators=separators, default=json_serializer, ensure_ascii=False)
         else:
-            return json.dumps(_dict, indent=indent, separators=separators)
+            return json.dumps(_dict, indent=indent, separators=separators, default=json_serializer, ensure_ascii=False)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "RunOutput":

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -934,6 +934,8 @@ class TeamRunOutput:
     def to_json(self, separators=(", ", ": "), indent: Optional[int] = 2) -> str:
         import json
 
+        from agno.utils.serialize import json_serializer
+
         try:
             _dict = self.to_dict()
         except Exception as e:
@@ -941,9 +943,9 @@ class TeamRunOutput:
             raise
 
         if indent is None:
-            return json.dumps(_dict, separators=separators)
+            return json.dumps(_dict, separators=separators, default=json_serializer, ensure_ascii=False)
         else:
-            return json.dumps(_dict, indent=indent, separators=separators)
+            return json.dumps(_dict, indent=indent, separators=separators, default=json_serializer, ensure_ascii=False)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "TeamRunOutput":

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -523,3 +523,20 @@ def test_requirements_in_run_paused_event():
     assert reconstructed.requirements[0].tool_execution.tool_name == "get_the_weather"
     assert reconstructed.requirements[0].tool_execution.requires_confirmation is True
     assert reconstructed.requirements[0].needs_confirmation is True
+
+
+def test_run_output_to_json_preserves_unicode_and_serializes_datetime():
+    """RunOutput/TeamRunOutput.to_json must match the base event: keep non-ASCII
+    unraveled and serialize non-JSON-native values (e.g. datetime) instead of crashing."""
+    from agno.run.agent import RunOutput
+    from agno.run.team import TeamRunOutput
+
+    for cls in (RunOutput, TeamRunOutput):
+        # Non-ASCII content is not escaped to \uXXXX
+        result = cls(run_id="r1", content="héllo 中文").to_json(indent=None)
+        assert "中文" in result
+        assert "\\u" not in result
+
+        # A datetime in metadata serializes rather than raising TypeError
+        result = cls(run_id="r1", content="x", metadata={"ts": datetime(2020, 1, 1)}).to_json(indent=None)
+        assert "2020" in json.loads(result)["metadata"]["ts"]


### PR DESCRIPTION
## Summary

`RunOutput.to_json` (`run/agent.py`) and `TeamRunOutput.to_json` (`run/team.py`) call
`json.dumps` **without** `default=json_serializer` or `ensure_ascii=False`, unlike the
sibling `BaseRunOutputEvent.to_json` (`run/base.py`) which passes both. Two consequences:

1. Non-ASCII content is escaped to `\uXXXX` — directly contradicting #7041, which added
   `ensure_ascii=False` elsewhere to stop exactly this.
2. A non-JSON-native value (e.g. a `datetime` in `metadata` / `session_state` / `content`)
   raises `TypeError: Object of type datetime is not JSON serializable`, which the event
   base class tolerates.

```python
RunOutput(run_id="r1", content="héllo 中文").to_json(indent=None)
# before: ...éllo 中文...   after: ...héllo 中文...
RunOutput(run_id="r1", content="x", metadata={"ts": datetime(2020, 1, 1)}).to_json()
# before: TypeError   after: serialized
```

## Fix

Mirror `BaseRunOutputEvent.to_json`: pass `default=json_serializer, ensure_ascii=False`
in both branches of both methods.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Added `test_run_output_to_json_preserves_unicode_and_serializes_datetime` (covers both
`RunOutput` and `TeamRunOutput`); it fails on `main` and passes with this fix. Full
`test_run_events.py` (17 tests) green; ruff + mypy clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
