### PR TITLE
fix: get_text_from_message crashes / drops text on a list of plain strings

### DIFF
--- a/libs/agno/agno/utils/message.py
+++ b/libs/agno/agno/utils/message.py
@@ -299,7 +299,11 @@ def get_text_from_message(message: Union[List, Dict, str, Message, BaseModel]) -
                     content_text = get_text_from_message(m.content)
                     if content_text:
                         text_messages.append(content_text)
-        elif "type" in message[0]:
+        elif isinstance(message[0], str):
+            for m in message:
+                if isinstance(m, str):
+                    text_messages.append(m)
+        elif isinstance(message[0], dict) and "type" in message[0]:
             for m in message:
                 m_type = m.get("type")
                 if m_type is not None and isinstance(m_type, str):
@@ -311,7 +315,7 @@ def get_text_from_message(message: Union[List, Dict, str, Message, BaseModel]) -
                         #     text_messages.append(f"Image: {m_value}")
                         # else:
                         #     text_messages.append(f"{m_type}: {m_value}")
-        elif "role" in message[0]:
+        elif isinstance(message[0], dict) and "role" in message[0]:
             for m in message:
                 m_role = m.get("role")
                 if m_role is not None and isinstance(m_role, str):

--- a/libs/agno/tests/unit/utils/test_get_text_from_message.py
+++ b/libs/agno/tests/unit/utils/test_get_text_from_message.py
@@ -1,0 +1,19 @@
+from agno.utils.message import get_text_from_message
+
+
+def test_list_of_plain_strings():
+    # A plain string was treated as a dict: `"type" in message[0]` is a substring
+    # test, so a string containing "type" crashed (str.get) and one without it was
+    # silently dropped.
+    assert get_text_from_message(["what data type is this?"]) == "what data type is this?"
+    assert get_text_from_message(["hello world"]) == "hello world"
+    assert get_text_from_message(["line one", "line two"]) == "line one\nline two"
+
+
+def test_list_of_content_dicts_still_works():
+    assert get_text_from_message([{"type": "text", "text": "hi"}]) == "hi"
+    assert get_text_from_message([{"role": "user", "content": "hey"}]) == "hey"
+
+
+def test_empty_list():
+    assert get_text_from_message([]) == ""


### PR DESCRIPTION
## Summary

`get_text_from_message` branches on `"type" in message[0]` and `"role" in message[0]`
as dict-key tests, but `message[0]` may be a plain `str`, turning those into
**substring** tests:

- a string containing "type"/"role" enters the branch and calls `.get()` on a `str`
  → `AttributeError: 'str' object has no attribute 'get'`;
- a list of plain strings without those substrings falls through every branch and
  returns `""` — silent data loss.

Reachable from `agent.print_response(input=[...])` / `team.print_response(input=[...])`
(`utils/print_response/*.py` call `get_text_from_message(input)` directly).

```python
get_text_from_message(["what data type is this?"])  # before: AttributeError
get_text_from_message(["hello world"])               # before: "" (dropped)
```

## Fix

Guard the dict branches with `isinstance(message[0], dict)` and add an explicit branch
that collects a list of strings.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_get_text_from_message.py` covers the plain-string list (crash + silent-loss),
the existing content-dict paths, and the empty list; it fails on `main` and passes with
this fix. ruff + mypy clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
