### PR TITLE
fix: empty Parallel crashes in sync/stream paths (max_workers=0)

### DIFF
--- a/libs/agno/agno/workflow/parallel.py
+++ b/libs/agno/agno/workflow/parallel.py
@@ -365,7 +365,7 @@ class Parallel:
         # Use index to preserve order
         indexed_steps = list(enumerate(self.steps))
 
-        with ThreadPoolExecutor(max_workers=len(self.steps)) as executor:
+        with ThreadPoolExecutor(max_workers=max(1, len(self.steps))) as executor:
             # Submit all tasks with their original indices
             # Use copy_context().run to propagate context variables to child threads
             future_to_index = {
@@ -551,7 +551,7 @@ class Parallel:
         # Submit all parallel tasks
         indexed_steps = list(enumerate(self.steps))
 
-        with ThreadPoolExecutor(max_workers=len(self.steps)) as executor:
+        with ThreadPoolExecutor(max_workers=max(1, len(self.steps))) as executor:
             # Submit all tasks
             # Use copy_context().run to propagate context variables to child threads
             futures = [

--- a/libs/agno/tests/unit/workflow/test_parallel_empty.py
+++ b/libs/agno/tests/unit/workflow/test_parallel_empty.py
@@ -1,0 +1,28 @@
+"""An empty Parallel (built dynamically with no steps) must not crash.
+
+The async path already returns a "No parallel steps executed" StepOutput, but the
+sync execute()/execute_stream() paths built a ThreadPoolExecutor with
+max_workers=len(self.steps) == 0, raising ValueError.
+"""
+
+import asyncio
+
+from agno.workflow.parallel import Parallel
+from agno.workflow.types import StepInput
+
+
+def _step_input():
+    return StepInput(input="hi")
+
+
+def test_empty_parallel_sync_matches_async():
+    result = Parallel(name="empty").execute(_step_input())
+    assert result.content == "No parallel steps executed"
+
+    async_result = asyncio.run(Parallel(name="empty").aexecute(_step_input()))
+    assert async_result.content == result.content
+
+
+def test_empty_parallel_stream_does_not_crash():
+    events = list(Parallel(name="empty").execute_stream(_step_input()))
+    assert events  # produces its aggregated output without raising


### PR DESCRIPTION
## Summary

`Parallel.execute()` and `Parallel.execute_stream()` build the `ThreadPoolExecutor`
with `max_workers=len(self.steps)`. A `Parallel` constructed dynamically from an empty
step list therefore passes `max_workers=0`, raising
`ValueError: max_workers must be greater than 0`. The async paths already treat an empty
`Parallel` as legal — they skip the executor and return a
`"No parallel steps executed"` `StepOutput` from `_aggregate_results([])`.

```python
Parallel(name="e").aexecute(step_input)  # -> "No parallel steps executed"
Parallel(name="e").execute(step_input)   # before: ValueError; after: same as async
```

## Fix

`max_workers=max(1, len(self.steps))` at both call sites. With no steps the executor
submits nothing and control falls through to the same empty-aggregate result, so
sync/stream now match async.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_parallel_empty.py` asserts sync/stream match the async empty-Parallel result;
it fails on `main` and passes with this fix. `test_parallel_serialization.py` (20 tests)
still passes; ruff + mypy clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
