### PR TITLE
fix: session_data=None crashes calculate_date_metrics in 7 db backends

### DIFF
--- a/libs/agno/agno/db/dynamo/utils.py
+++ b/libs/agno/agno/db/dynamo/utils.py
@@ -345,7 +345,7 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                         model_counts[f"{model_id}:{model_provider}"] = (
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_metrics = (session.get("session_data") or {}).get("session_metrics", {})
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
     model_metrics = []

--- a/libs/agno/agno/db/gcs_json/utils.py
+++ b/libs/agno/agno/db/gcs_json/utils.py
@@ -105,7 +105,7 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
 
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_metrics = (session.get("session_data") or {}).get("session_metrics", {})
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/agno/db/in_memory/utils.py
+++ b/libs/agno/agno/db/in_memory/utils.py
@@ -105,7 +105,7 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
 
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_metrics = (session.get("session_data") or {}).get("session_metrics", {})
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/agno/db/json/utils.py
+++ b/libs/agno/agno/db/json/utils.py
@@ -105,7 +105,7 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
 
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_metrics = (session.get("session_data") or {}).get("session_metrics", {})
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/agno/db/mysql/utils.py
+++ b/libs/agno/agno/db/mysql/utils.py
@@ -284,7 +284,7 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
 
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_metrics = (session.get("session_data") or {}).get("session_metrics", {})
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/agno/db/redis/utils.py
+++ b/libs/agno/agno/db/redis/utils.py
@@ -231,7 +231,7 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
 
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_metrics = (session.get("session_data") or {}).get("session_metrics", {})
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/agno/db/singlestore/utils.py
+++ b/libs/agno/agno/db/singlestore/utils.py
@@ -259,7 +259,7 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
 
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_metrics = (session.get("session_data") or {}).get("session_metrics", {})
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/tests/unit/db/test_calculate_date_metrics_session_data_none.py
+++ b/libs/agno/tests/unit/db/test_calculate_date_metrics_session_data_none.py
@@ -1,0 +1,45 @@
+"""`session_data` defaults to None on agent/team/workflow sessions.
+
+`calculate_date_metrics` chained `session.get("session_data", {}).get(...)`, which
+crashes when the key is present with a None value (`.get(key, default)` returns None,
+not the default). postgres/valkey already guard this with `or {}`; the other backends
+did not. These use the dependency-free in_memory/json backends, which share the same
+fixed line.
+"""
+
+from datetime import date
+
+import pytest
+
+from agno.db.in_memory.utils import calculate_date_metrics as in_memory_metrics
+from agno.db.json.utils import calculate_date_metrics as json_metrics
+
+
+@pytest.mark.parametrize("calculate_date_metrics", [in_memory_metrics, json_metrics])
+def test_session_data_none_does_not_crash(calculate_date_metrics):
+    sessions_data = {
+        "agent": [{"user_id": "u1", "session_data": None, "runs": []}],
+        "team": [],
+        "workflow": [],
+    }
+    result = calculate_date_metrics(date(2024, 1, 1), sessions_data)
+    assert result["agent_sessions_count"] == 1
+    assert result["token_metrics"]["total_tokens"] == 0
+
+
+@pytest.mark.parametrize("calculate_date_metrics", [in_memory_metrics, json_metrics])
+def test_session_data_present_still_aggregates(calculate_date_metrics):
+    sessions_data = {
+        "agent": [
+            {
+                "user_id": "u1",
+                "session_data": {"session_metrics": {"input_tokens": 5, "total_tokens": 8}},
+                "runs": [],
+            }
+        ],
+        "team": [],
+        "workflow": [],
+    }
+    result = calculate_date_metrics(date(2024, 1, 1), sessions_data)
+    assert result["token_metrics"]["input_tokens"] == 5
+    assert result["token_metrics"]["total_tokens"] == 8


### PR DESCRIPTION
## Summary

`session_data` defaults to `None` on agent/team/workflow sessions
(`session_data: Optional[Dict[str, Any]] = None`). `calculate_date_metrics` read it
with:

```python
session_metrics = session.get("session_data", {}).get("session_metrics", {})
```

`dict.get(key, default)` returns the stored `None` (not the default) when the key is
present, so the chained `.get` raised
`AttributeError: 'NoneType' object has no attribute 'get'`. Because the whole metrics
pass is wrapped in a re-raising `try/except`, a single default-constructed session that
recorded no metrics breaks the public `calculate_metrics()` for that backend.

`postgres` (#5851) and `valkey` already guard this with `or {}`, but the fix was never
propagated to the other seven backends: **redis, in_memory, json, mysql, singlestore,
gcs_json, dynamo**.

```python
# before: session.get("session_data", {}).get(...)   -> crash when session_data is None
# after:  (session.get("session_data") or {}).get(...)
```

## Fix

Apply the same `(session.get("session_data") or {}).get("session_metrics", {})` guard —
matching valkey/postgres — to all seven affected backends.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `tests/unit/db/test_calculate_date_metrics_session_data_none.py` uses the
dependency-free `in_memory` and `json` backends (which share the identical fixed line):
the `session_data=None` case fails on `main` and passes with this fix, and the
metrics-present case still aggregates. ruff + mypy clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
