### PR TITLE
fix: SessionSummary.from_dict mutates the caller's dict

### DIFF
--- a/libs/agno/agno/session/summary.py
+++ b/libs/agno/agno/session/summary.py
@@ -37,6 +37,7 @@ class SessionSummary:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionSummary":
+        data = dict(data)  # don't mutate the caller's dict
         updated_at = data.get("updated_at")
         if updated_at:
             data["updated_at"] = datetime.fromisoformat(updated_at)

--- a/libs/agno/tests/unit/session/test_session_summary_from_dict.py
+++ b/libs/agno/tests/unit/session/test_session_summary_from_dict.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from agno.session.summary import SessionSummary
+
+
+def test_from_dict_does_not_mutate_caller_dict():
+    data = {"summary": "hello", "topics": ["a"], "updated_at": "2026-01-01T00:00:00"}
+
+    summary = SessionSummary.from_dict(data)
+    assert isinstance(summary.updated_at, datetime)
+
+    # The caller's dict must be untouched (was rewritten str -> datetime in place).
+    assert data["updated_at"] == "2026-01-01T00:00:00"
+
+
+def test_from_dict_is_repeatable_on_same_dict():
+    data = {"summary": "hello", "topics": ["a"], "updated_at": "2026-01-01T00:00:00"}
+
+    # Deserializing the same stored dict twice used to raise
+    # "TypeError: fromisoformat: argument must be str" on the second call.
+    first = SessionSummary.from_dict(data)
+    second = SessionSummary.from_dict(data)
+    assert first.updated_at == second.updated_at


### PR DESCRIPTION
## Summary

`SessionSummary.from_dict` rewrote `data["updated_at"]` from an ISO string to a
`datetime` **in place**:

```python
def from_dict(cls, data):
    updated_at = data.get("updated_at")
    if updated_at:
        data["updated_at"] = datetime.fromisoformat(updated_at)  # mutates caller's dict
    return cls(**data)
```

Two consequences on legal input:
1. the caller's dict is silently corrupted (a DB row's `updated_at` is no longer a string);
2. deserializing the same dict a second time raises
   `TypeError: fromisoformat: argument must be str`.

`AgentSession.from_dict` / `TeamSession.from_dict` call this on their nested summary
dict, and the in-memory db layer already `deepcopy`s at every deserialization site to
work around exactly this hazard.

## Fix

Copy the dict before mutating (`data = dict(data)`), matching the existing
`UserMemory.from_dict` (`db/schemas/memory.py`).

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `tests/unit/session/test_session_summary_from_dict.py` asserts the caller's dict is
untouched and that a second `from_dict` on the same dict no longer raises; both fail on
`main` and pass with this fix. ruff + mypy clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
