### PR TITLE
fix: falsy-zero row_limit/tail returns everything in csv/shell/workspace tools

### DIFF
--- a/libs/agno/agno/tools/csv_toolkit.py
+++ b/libs/agno/agno/tools/csv_toolkit.py
@@ -78,7 +78,7 @@ class CsvTools(Toolkit):
 
             # Read the csv file
             csv_data = []
-            _row_limit = row_limit or self.row_limit
+            _row_limit = row_limit if row_limit is not None else self.row_limit
             with open(str(file_path), encoding="utf-8-sig", newline="") as csvfile:
                 reader = csv.DictReader(csvfile)
                 if _row_limit is not None:

--- a/libs/agno/agno/tools/shell.py
+++ b/libs/agno/agno/tools/shell.py
@@ -62,7 +62,7 @@ class ShellTools(Toolkit):
             log_debug(f"Return code: {result.returncode}")
             if result.returncode != 0:
                 return f"Error: {result.stderr}"
-            return "\n".join(result.stdout.split("\n")[-tail:])
+            return "\n".join(result.stdout.split("\n")[-tail:] if tail > 0 else [])
         except Exception as e:
             log_warning(f"Failed to run shell command: {str(e)}")
             return f"Error: {e}"

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -818,9 +818,9 @@ class Workspace(Toolkit):
                 timeout=timeout,
             )
             if result.returncode != 0:
-                err = "\n".join(_strip_ansi(result.stderr).splitlines()[-tail:])
+                err = "\n".join(_strip_ansi(result.stderr).splitlines()[-tail:] if tail > 0 else [])
                 return f"Error (exit {result.returncode}): {err}"
-            return "\n".join(_strip_ansi(result.stdout).splitlines()[-tail:])
+            return "\n".join(_strip_ansi(result.stdout).splitlines()[-tail:] if tail > 0 else [])
         except subprocess.TimeoutExpired:
             log_warning(f"run_command timed out after {timeout}s: {args}")
             return f"Error: command timed out after {timeout} seconds"
@@ -899,9 +899,9 @@ class Workspace(Toolkit):
             stdout = stdout_b.decode("utf-8", errors="replace") if stdout_b else ""
             stderr = stderr_b.decode("utf-8", errors="replace") if stderr_b else ""
             if proc.returncode != 0:
-                err = "\n".join(_strip_ansi(stderr).splitlines()[-tail:])
+                err = "\n".join(_strip_ansi(stderr).splitlines()[-tail:] if tail > 0 else [])
                 return f"Error (exit {proc.returncode}): {err}"
-            return "\n".join(_strip_ansi(stdout).splitlines()[-tail:])
+            return "\n".join(_strip_ansi(stdout).splitlines()[-tail:] if tail > 0 else [])
         except Exception as e:
             log_warning(f"arun_command failed: {e}")
             return f"Error running command: {e}"

--- a/libs/agno/tests/unit/tools/test_csv_toolkit.py
+++ b/libs/agno/tests/unit/tools/test_csv_toolkit.py
@@ -66,3 +66,14 @@ def test_query_csv_file_path_injection_is_neutralized(tmp_path):
 
     # The path is bound as a parameter, so the injected statement never runs
     assert connection.execute("SELECT COUNT(*) FROM inventory").fetchone()[0] == 1
+
+
+def test_read_csv_file_row_limit_zero_returns_no_rows(tmp_path):
+    # row_limit=0 is a legal non-negative int; `row_limit or self.row_limit` treated
+    # it as falsy and returned every row.
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("a,b\n1,2\n3,4\n", encoding="utf-8")
+    tools = CsvTools(csvs=[csv_path])
+
+    assert json.loads(tools.read_csv_file("data", row_limit=0)) == []
+    assert json.loads(tools.read_csv_file("data", row_limit=1)) == [{"a": "1", "b": "2"}]

--- a/libs/agno/tests/unit/tools/test_shell_tools.py
+++ b/libs/agno/tests/unit/tools/test_shell_tools.py
@@ -28,3 +28,9 @@ def test_requires_confirmation_tools_gates_run_shell_command():
     """The documented HITL pattern marks run_shell_command for confirmation."""
     tools = ShellTools(requires_confirmation_tools=["run_shell_command"])
     assert tools.functions["run_shell_command"].requires_confirmation is True
+
+
+def test_run_shell_command_tail_zero_returns_no_lines():
+    # tail=0 is a legal int; `[-tail:]` is `[-0:]` == the whole list, returning everything.
+    tools = ShellTools()
+    assert tools.run_shell_command(["printf", "a\nb\nc\n"], tail=0) == ""

--- a/libs/agno/tests/unit/tools/test_workspace.py
+++ b/libs/agno/tests/unit/tools/test_workspace.py
@@ -839,3 +839,10 @@ def test_empty_exclude_patterns_opts_out():
         result = json.loads(ws.list_files(pattern="**/*.py"))
         paths = [e["path"] for e in result["files"]]
         assert any(".venv" in p for p in paths)
+
+
+def test_run_command_tail_zero_returns_no_lines():
+    # tail=0 is a legal int; `splitlines()[-tail:]` is `[-0:]` == everything.
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        assert ws.run_command(["printf", "a\nb\nc\n"], tail=0) == ""


### PR DESCRIPTION
## Summary

A legal `0` limit was treated as "no limit" in three toolkits:

- `CsvTools.read_csv_file(row_limit=0)` did `row_limit or self.row_limit`, so `0` fell
  back to the default (`None` → all rows) and returned **every** row.
- `ShellTools.run_shell_command(tail=0)` and `Workspace.run_command(tail=0)` sliced with
  `[-tail:]`, which for `tail=0` is `[-0:]` == the whole list, returning **all** output.

All three take a documented non-negative int ("number of rows/lines to return"), so `0`
is legal input and should return nothing.

```python
CsvTools(...).read_csv_file("data", row_limit=0)      # before: all rows;  after: []
ShellTools().run_shell_command([...], tail=0)          # before: all output; after: ""
Workspace(root).run_command([...], tail=0)             # before: all output; after: ""
```

## Fix

Guard `0` explicitly: `row_limit if row_limit is not None else self.row_limit`, and
`[-tail:] if tail > 0 else []` (both `run_command`/`arun_command` sites in `Workspace`).
This mirrors the same zero/negative-guard fix applied to Workflow metrics in #8942.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Added a `row_limit=0` / `tail=0` test to each toolkit's existing test file; all three
fail on `main` and pass with this fix. Full `test_csv_toolkit.py` / `test_shell_tools.py`
/ `test_workspace.py` (79 tests) still pass; ruff + mypy clean (the pre-existing
`duckdb` import-stub note is unrelated).

Prepared with AI assistance (Claude Code) and reviewed before submission.
