### PR TITLE
fix: JSONReader crashes / corrupts on a top-level JSON scalar

### DIFF
--- a/libs/agno/agno/knowledge/reader/json_reader.py
+++ b/libs/agno/agno/knowledge/reader/json_reader.py
@@ -53,7 +53,10 @@ class JSONReader(Reader):
             else:
                 raise ValueError("Unsupported file type. Must be Path or file-like object.")
 
-            if isinstance(json_contents, dict):
+            # Wrap any non-list top-level value (dict or a bare scalar) in a single-element
+            # list; otherwise enumerate() would iterate a string char-by-char or crash on
+            # a number/bool.
+            if not isinstance(json_contents, list):
                 json_contents = [json_contents]
 
             documents = [

--- a/libs/agno/tests/unit/reader/test_json_reader.py
+++ b/libs/agno/tests/unit/reader/test_json_reader.py
@@ -51,6 +51,20 @@ def test_read_json_list():
     assert [json.loads(doc.content) for doc in documents] == test_data
 
 
+@pytest.mark.parametrize("value", ["hello world", 42, True])
+def test_read_json_top_level_scalar(value):
+    # A bare top-level scalar (valid JSON) used to iterate char-by-char (str) or crash
+    # (int/bool); it must produce a single document.
+    json_bytes = BytesIO(json.dumps(value).encode())
+    json_bytes.name = "test.json"
+
+    reader = JSONReader(chunk=False)
+    documents = reader.read(json_bytes)
+
+    assert len(documents) == 1
+    assert json.loads(documents[0].content) == value
+
+
 def test_chunking():
     # Test document chunking functionality
     test_data = {"key": "value"}


### PR DESCRIPTION
## Summary

`JSONReader.read` only wrapped a top-level **dict** into a list; any other non-list
top-level value fell straight into `enumerate(json_contents, ...)`. All are valid JSON
(RFC 8259):

- a top-level **string** was iterated character-by-character → one `Document` per
  character (silent corruption);
- a top-level **number / bool** → `TypeError: 'int'/'bool' object is not iterable`.

```python
JSONReader(chunk=False).read(BytesIO(b'"hello world"'))  # before: 11 docs; after: 1
JSONReader(chunk=False).read(BytesIO(b'42'))             # before: TypeError; after: 1 doc
```

## Fix

Wrap any non-list top-level value (`if not isinstance(json_contents, list)`), leaving
the existing dict and list-of-items behavior unchanged.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Added a parametrized `test_read_json_top_level_scalar` (string / int / bool); all fail on
`main` and pass with this fix. Full `test_json_reader.py` (27 tests) passes; ruff clean.
(The two pre-existing `read`/`async_read` signature-override mypy notes are unrelated to
this change.)

Prepared with AI assistance (Claude Code) and reviewed before submission.
