### PR TITLE
fix: Groq json_object directive dropped from payload and mutates the Message

### DIFF
--- a/libs/agno/agno/models/groq/groq.py
+++ b/libs/agno/agno/models/groq/groq.py
@@ -252,8 +252,10 @@ class Groq(Model):
             and isinstance(response_format, dict)
             and response_format.get("type") == "json_object"
         ):
-            # This is required by Groq to ensure the model outputs in the correct format
-            message.content += "\n\nYour output should be in JSON format."
+            # This is required by Groq to ensure the model outputs in the correct format.
+            # Write it to the payload rather than mutating the shared Message (which both
+            # dropped it from this request and duplicated it on every reuse).
+            message_dict["content"] = message.content + "\n\nYour output should be in JSON format."
 
         if message.images is not None and len(message.images) > 0:
             # Ignore non-string message content

--- a/libs/agno/tests/unit/models/groq/test_groq_format_message.py
+++ b/libs/agno/tests/unit/models/groq/test_groq_format_message.py
@@ -1,0 +1,28 @@
+"""Groq.format_message must write the json_object directive to the request payload,
+not mutate the shared Message (which dropped it from the request and duplicated it on
+every reuse)."""
+
+from agno.models.groq.groq import Groq
+from agno.models.message import Message
+
+JSON_FORMAT = {"type": "json_object"}
+
+
+def test_json_object_directive_reaches_payload():
+    model = Groq(id="test")
+    message = Message(role="system", content="You are a helpful assistant.")
+
+    payload = model.format_message(message, response_format=JSON_FORMAT)
+
+    assert "Your output should be in JSON format." in payload["content"]
+
+
+def test_json_object_directive_does_not_mutate_message():
+    model = Groq(id="test")
+    message = Message(role="system", content="You are a helpful assistant.")
+
+    model.format_message(message, response_format=JSON_FORMAT)
+    # The shared Message is untouched, so a reuse doesn't accumulate duplicate directives.
+    assert message.content == "You are a helpful assistant."
+    second = model.format_message(message, response_format=JSON_FORMAT)
+    assert second["content"].count("Your output should be in JSON format.") == 1


### PR DESCRIPTION
## Summary

For a system message with `response_format={"type": "json_object"}`,
`Groq.format_message` appended the required JSON directive via
`message.content += "..."`. That rebinds the `Message.content` attribute, but the
request dict's `"content"` was already captured from the *old* value a few lines
earlier. Two consequences:

1. the "required by Groq" JSON directive **never reaches the request payload** (silent
   loss — the model isn't told to emit JSON);
2. the shared `Message` is **mutated**, so on any reuse (retry, multi-turn) the system
   prompt accumulates a duplicated directive.

```python
model.format_message(msg, response_format={"type": "json_object"})
# before: payload content == "You are a helpful assistant."  (directive missing)
#         msg.content mutated, grows on each call
# after:  payload carries the directive; msg.content untouched
```

## Fix

Write the directive to `message_dict["content"]` instead of mutating `message.content`.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `tests/unit/models/groq/test_groq_format_message.py` asserts the directive reaches
the payload and the Message is not mutated (no duplicate on reuse); both fail on `main`
and pass with this fix. ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
