### PR TITLE
fix: OpenAIResponses drops assistant text when the message also has tool_calls

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -690,6 +690,11 @@ class OpenAIResponses(Model):
                 if self._using_reasoning_model() and previous_response_id is not None:
                     continue
 
+                # Preserve any assistant text that accompanies the tool call; otherwise the
+                # elif chain below (role == "assistant") is unreachable and the text is lost.
+                if message.content:
+                    formatted_messages.append({"role": self.role_map[message.role], "content": message.content})
+
                 for tool_call in message.tool_calls:
                     formatted_messages.append(
                         {

--- a/libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py
@@ -102,6 +102,48 @@ def test_format_messages_maps_tool_output_fc_to_call_id():
     assert out_items[0]["call_id"] == "call_def456"
 
 
+def test_format_messages_preserves_assistant_text_with_tool_call():
+    model = OpenAIResponses(id="gpt-4.1-mini")
+
+    # An assistant turn that carries both text and a tool call (reasoning/GPT models
+    # routinely emit this). The text used to be dropped by the elif chain.
+    assistant = Message(
+        role="assistant",
+        content="Let me look that up for you.",
+        tool_calls=[
+            {
+                "id": "fc_abc123",
+                "call_id": "call_def456",
+                "type": "function",
+                "function": {"name": "search", "arguments": "{}"},
+            }
+        ],
+    )
+
+    fm = model._format_messages(messages=[assistant])
+
+    text_items = [x for x in fm if isinstance(x, dict) and x.get("content") == "Let me look that up for you."]
+    fc_items = [x for x in fm if isinstance(x, dict) and x.get("type") == "function_call"]
+
+    assert len(text_items) == 1
+    assert len(fc_items) == 1
+
+
+def test_format_messages_tool_call_without_content_emits_no_text():
+    model = OpenAIResponses(id="gpt-4.1-mini")
+
+    assistant = Message(
+        role="assistant",
+        content=None,
+        tool_calls=[{"id": "fc_1", "call_id": "call_1", "type": "function", "function": {"name": "s", "arguments": "{}"}}],
+    )
+
+    fm = model._format_messages(messages=[assistant])
+
+    assert len(fm) == 1
+    assert fm[0]["type"] == "function_call"
+
+
 def test_parse_provider_response_maps_ids():
     model = OpenAIResponses(id="gpt-4.1-mini")
 


### PR DESCRIPTION
## Summary

In `OpenAIResponses._format_messages`, the `elif message.tool_calls is not None ...`
branch emits only `function_call` items. The assistant `content` is emitted only by the
later `elif message.role == "assistant"` branch, which is **unreachable** once tool_calls
are present (elif chain). So an assistant turn carrying **both** text and a tool call —
the shape `base.py` builds from a single provider response, and what reasoning/GPT models
routinely emit — loses its text on history replay.

```python
Message(role="assistant", content="Let me look that up for you.",
        tool_calls=[{... "search" ...}])
# before: [{"type": "function_call", ...}]                          (text gone)
# after:  [{"role": "assistant", "content": "Let me..."}, {"type": "function_call", ...}]
```

`chat.py` keeps both and `gemini.py` emits a text part plus function-call parts; Responses
was the outlier.

## Fix

Emit the assistant text before the `function_call` items (after the reasoning-model
skip). No empty item is added when there is no content.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Added two tests to `test_openai_responses_id_handling.py`: text is preserved alongside
the function_call, and no empty text item is added when content is None. The first fails
on `main` and passes with this fix; full file (6 tests) passes; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
