### PR TITLE
fix: OpenAIChat drops image/audio when message content is None

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -337,10 +337,11 @@ class OpenAIChat(Model):
         if (message.images is not None and len(message.images) > 0) or (
             message.audio is not None and len(message.audio) > 0
         ):
-            # Ignore non-string message content
-            # because we assume that the images/audio are already added to the message
-            if isinstance(message.content, str):
-                message_dict["content"] = [{"type": "text", "text": message.content}]
+            # Skip only when content is already a pre-built list of parts; a str or None
+            # (the default) still needs its media appended.
+            if message.content is None or isinstance(message.content, str):
+                text = message.content if isinstance(message.content, str) else ""
+                message_dict["content"] = [{"type": "text", "text": text}]
                 if message.images is not None:
                     message_dict["content"].extend(images_to_message(images=message.images))
 
@@ -372,8 +373,9 @@ class OpenAIChat(Model):
                 if file_part:
                     message_dict["content"].insert(0, file_part)
 
-        # Manually add the content field even if it is None
-        if message.content is None:
+        # Manually add the content field even if it is None, unless media/files already
+        # built a content list above (which would otherwise be clobbered back to "").
+        if message.content is None and "content" not in message_dict:
             message_dict["content"] = ""
         return message_dict
 

--- a/libs/agno/tests/unit/models/openai/test_openai_chat_media_none_content.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_chat_media_none_content.py
@@ -1,0 +1,39 @@
+"""A user Message with images/audio but content=None (the default) must still carry
+the media. The str-only guard skipped media assembly, and the trailing None-handler
+reset content to "", silently dropping the image."""
+
+from agno.media import Image
+from agno.models.message import Message
+from agno.models.openai.chat import OpenAIChat
+
+
+def _image_parts(content):
+    return [p for p in content if isinstance(p, dict) and p.get("type") == "image_url"]
+
+
+def test_none_content_with_image_keeps_the_image():
+    model = OpenAIChat(id="gpt-4o")
+    message = Message(role="user", content=None, images=[Image(url="https://example.com/x.png")])
+
+    formatted = model._format_message(message)
+
+    assert isinstance(formatted["content"], list)
+    assert len(_image_parts(formatted["content"])) == 1
+    # A text part is present with empty text (content was None).
+    assert {"type": "text", "text": ""} in formatted["content"]
+
+
+def test_str_content_with_image_unchanged():
+    model = OpenAIChat(id="gpt-4o")
+    message = Message(role="user", content="describe", images=[Image(url="https://example.com/x.png")])
+
+    formatted = model._format_message(message)
+
+    assert {"type": "text", "text": "describe"} in formatted["content"]
+    assert len(_image_parts(formatted["content"])) == 1
+
+
+def test_none_content_without_media_is_empty_string():
+    model = OpenAIChat(id="gpt-4o")
+    formatted = model._format_message(Message(role="user", content=None))
+    assert formatted["content"] == ""


### PR DESCRIPTION
## Summary

`OpenAIChat._format_message`'s multipart-assembly block was guarded by
`isinstance(message.content, str)`. `Message.content` defaults to `None`, so a user
message that carries images/audio but no text skipped media assembly entirely, and the
trailing `if message.content is None: message_dict["content"] = ""` then reset content to
an empty string — **silently dropping the image/audio** from the request.

```python
Message(role="user", content=None, images=[Image(url=...)])
# before: {"role": "user", "content": ""}                 (image gone)
# after:  {"role": "user", "content": [{"type": "text", "text": ""},
#                                       {"type": "image_url", ...}]}
```

Reachable via `agent.run(Message(role="user", images=[...]))` — a directly-passed
Message is used unchanged, so it reaches the formatter with `content=None`.

## Fix

- Build the parts list when content is `None` **or** a `str` (empty text part for None),
  so media is appended; keep skipping only when content is already a pre-built list.
- Don't reset content to `""` when media/files already built a content list.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_openai_chat_media_none_content.py`: None-content + image keeps the image;
str-content + image unchanged; None-content without media stays `""`. The first fails on
`main` and passes with this fix. Full `tests/unit/models/openai/` (77 tests) passes;
ruff clean. (The same pattern in `openai/responses.py` is left for a separate change.)

Prepared with AI assistance (Claude Code) and reviewed before submission.
