### PR TITLE
fix: OpenAIResponses drops images when message content is None

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -644,12 +644,12 @@ class OpenAIResponses(Model):
                 # Ignore non-string message content
                 # because we assume that the images/audio are already added to the message
                 if message.images is not None and len(message.images) > 0:
-                    # Ignore non-string message content
-                    # because we assume that the images/audio are already added to the message
-                    if isinstance(message.content, str):
-                        message_dict["content"] = [{"type": "input_text", "text": message.content}]
-                        if message.images is not None:
-                            message_dict["content"].extend(images_to_message(images=message.images))
+                    # Build the parts list when content is None (the default) or a str, so the
+                    # images are appended; skip only when content is already a list of parts.
+                    if message.content is None or isinstance(message.content, str):
+                        text = message.content if isinstance(message.content, str) else ""
+                        message_dict["content"] = [{"type": "input_text", "text": text}]
+                        message_dict["content"].extend(images_to_message(images=message.images))
 
                 if message.audio is not None and len(message.audio) > 0:
                     log_warning("Audio input is currently unsupported.")

--- a/libs/agno/tests/unit/models/openai/test_openai_responses_media_none_content.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_responses_media_none_content.py
@@ -1,0 +1,35 @@
+"""A user Message with images but content=None (the default) must still carry the
+image through the Responses formatter. The str-only guard dropped it, leaving a
+content-less message."""
+
+from agno.media import Image
+from agno.models.message import Message
+from agno.models.openai.responses import OpenAIResponses
+
+
+def _image_parts(items):
+    for item in items:
+        content = item.get("content") if isinstance(item, dict) else None
+        if isinstance(content, list):
+            return [p for p in content if isinstance(p, dict) and p.get("type") == "input_image"]
+    return []
+
+
+def test_none_content_with_image_keeps_the_image():
+    model = OpenAIResponses(id="gpt-4o")
+    message = Message(role="user", content=None, images=[Image(url="https://example.com/x.png")])
+
+    formatted = model._format_messages([message])
+
+    assert len(_image_parts(formatted)) == 1
+    assert formatted[0]["content"][0] == {"type": "input_text", "text": ""}
+
+
+def test_str_content_with_image_unchanged():
+    model = OpenAIResponses(id="gpt-4o")
+    message = Message(role="user", content="describe", images=[Image(url="https://example.com/x.png")])
+
+    formatted = model._format_messages([message])
+
+    assert len(_image_parts(formatted)) == 1
+    assert formatted[0]["content"][0] == {"type": "input_text", "text": "describe"}


### PR DESCRIPTION
## Summary

`OpenAIResponses._format_messages`' image-assembly block was guarded by
`isinstance(message.content, str)`. `Message.content` defaults to `None`, so a user
message carrying images but no text skipped assembly entirely and was emitted as a
content-less `{"role": "user"}` — the image was **silently dropped**.

```python
Message(role="user", content=None, images=[Image(url=...)])
# before: {"role": "user"}                     (image gone, no content)
# after:  {"role": "user", "content": [{"type": "input_text", "text": ""},
#                                       {"type": "input_image", ...}]}
```

This is the same class as the `openai/chat.py` None-content media fix.

## Fix

Build the parts list when content is `None` or a `str` (empty `input_text` for None),
skipping only when content is already a list of parts.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_openai_responses_media_none_content.py`: None-content + image keeps the image;
str-content + image unchanged. The first fails on `main` and passes with this fix. Full
`tests/unit/models/openai/` (74 tests) passes; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
