### PR TITLE
fix: AwsBedrock drops assistant text when the message also has tool_calls

### DIFF
--- a/libs/agno/agno/models/aws/bedrock.py
+++ b/libs/agno/agno/models/aws/bedrock.py
@@ -321,6 +321,10 @@ class AwsBedrock(Model):
                 if isinstance(message.content, list):
                     formatted_message["content"].extend(message.content)
                 elif message.tool_calls:
+                    # Preserve any narration text that accompanies the tool call; otherwise this
+                    # branch emits only toolUse blocks and the assistant text is dropped on replay.
+                    if isinstance(message.content, str) and message.content:
+                        formatted_message["content"].append({"text": message.content})
                     tool_use_content = []
                     for tool_call in message.tool_calls:
                         try:

--- a/libs/agno/tests/unit/models/aws/test_bedrock_format_messages.py
+++ b/libs/agno/tests/unit/models/aws/test_bedrock_format_messages.py
@@ -1,0 +1,39 @@
+"""AwsBedrock._format_messages must keep assistant narration text that accompanies a
+tool call. The if/elif branch emitted only toolUse blocks, dropping the text on replay."""
+
+from agno.models.aws import AwsBedrock
+from agno.models.message import Message
+
+MODEL_ID = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+
+
+def _content_blocks(message):
+    model = AwsBedrock(id=MODEL_ID)
+    formatted, _ = model._format_messages([message])
+    return formatted[0]["content"]
+
+
+def test_assistant_text_with_tool_call_is_preserved():
+    message = Message(
+        role="assistant",
+        content="Let me check the weather for you.",
+        tool_calls=[{"id": "t1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}],
+    )
+
+    blocks = _content_blocks(message)
+
+    assert {"text": "Let me check the weather for you."} in blocks
+    assert any("toolUse" in b for b in blocks)
+
+
+def test_tool_call_without_text_adds_no_text_block():
+    message = Message(
+        role="assistant",
+        content=None,
+        tool_calls=[{"id": "t1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}],
+    )
+
+    blocks = _content_blocks(message)
+
+    assert all("text" not in b for b in blocks)
+    assert any("toolUse" in b for b in blocks)


### PR DESCRIPTION
## Summary

`AwsBedrock._format_messages`' assistant branch is an if/elif:

```python
if isinstance(message.content, list):
    ...extend
elif message.tool_calls:
    ...emit only toolUse blocks
else:
    ...append {"text": message.content}
```

An assistant turn that narrates and then calls a tool — the normal Claude-on-Bedrock
shape — has both str `content` and `tool_calls`, so it takes the `elif` branch and emits
**only** toolUse blocks. The narration text is silently dropped when that turn is replayed
in a multi-turn conversation. (The direct Anthropic path keeps both a text and a tool_use
block.)

```python
Message(role="assistant", content="Let me check the weather for you.",
        tool_calls=[{... "get_weather" ...}])
# before: content = [{"toolUse": ...}]                      (text gone)
# after:  content = [{"text": "Let me..."}, {"toolUse": ...}]
```

## Fix

Emit the narration text before the toolUse blocks when `content` is a non-empty str.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_bedrock_format_messages.py`: text is preserved alongside toolUse, and no empty
text block is added when there's no content. The first fails on `main` and passes with
this fix. Full `tests/unit/models/aws/` (32 tests) passes; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
