### PR TITLE
fix: Mistral drops tool_calls on an assistant message that also has reasoning_content

### DIFF
--- a/libs/agno/agno/utils/models/mistral.py
+++ b/libs/agno/agno/utils/models/mistral.py
@@ -74,12 +74,15 @@ def format_messages(messages: List[Message], compress_tool_results: bool = False
             else:
                 mistral_message = UserMessage(role="user", content=message.content)
         elif message.role == "assistant":
-            if message.reasoning_content is not None:
-                mistral_message = UserMessage(role="user", content=message.content)
-            elif message.tool_calls is not None:
+            # tool_calls must win: an assistant turn that both reasoned and called a tool
+            # would otherwise be flattened to a UserMessage, dropping the tool_calls and
+            # orphaning the following tool result.
+            if message.tool_calls is not None:
                 mistral_message = AssistantMessage(
                     role="assistant", content=message.content, tool_calls=message.tool_calls
                 )
+            elif message.reasoning_content is not None:
+                mistral_message = UserMessage(role="user", content=message.content)
             else:
                 mistral_message = AssistantMessage(role=message.role, content=message.content)
         elif message.role == "system":

--- a/libs/agno/tests/unit/models/test_mistral_format_messages.py
+++ b/libs/agno/tests/unit/models/test_mistral_format_messages.py
@@ -1,0 +1,30 @@
+"""Mistral format_messages must keep tool_calls on an assistant turn that also has
+reasoning_content; the reasoning branch used to win and flatten it to a UserMessage,
+dropping the tool_calls and orphaning the following tool result."""
+
+from agno.models.message import Message
+from agno.utils.models._mistral_compat import AssistantMessage, UserMessage
+from agno.utils.models.mistral import format_messages
+
+
+def test_reasoning_with_tool_calls_keeps_tool_calls():
+    assistant = Message(
+        role="assistant",
+        content="Let me check the weather.",
+        reasoning_content="considering get_weather",
+        tool_calls=[{"id": "abc123", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}],
+    )
+
+    formatted = format_messages([assistant])[0]
+
+    assert isinstance(formatted, AssistantMessage)
+    assert formatted.role == "assistant"
+    assert formatted.tool_calls is not None and len(formatted.tool_calls) == 1
+
+
+def test_reasoning_without_tool_calls_still_maps_to_user():
+    assistant = Message(role="assistant", content="hmm", reasoning_content="thinking")
+
+    formatted = format_messages([assistant])[0]
+
+    assert isinstance(formatted, UserMessage)


### PR DESCRIPTION
## Summary

`format_messages` (Mistral) tested `reasoning_content` before `tool_calls` in the
assistant branch:

```python
elif message.role == "assistant":
    if message.reasoning_content is not None:
        mistral_message = UserMessage(role="user", content=message.content)  # tool_calls lost
    elif message.tool_calls is not None:
        mistral_message = AssistantMessage(..., tool_calls=message.tool_calls)
    ...
```

An assistant turn that both reasoned and called a tool (reasoning models / agno's
`reasoning=True` handoff / the cross-model interchange pattern) was flattened to a
`UserMessage` — dropping the `tool_calls` and flipping the role. The following `tool`
result is then orphaned (its `tool_call_id` matches no assistant tool_call), so Mistral
rejects the sequence (422) or loses the tool context.

## Fix

Check `tool_calls` first so it is always preserved; fall back to the reasoning-content
`UserMessage` mapping only when there are no tool_calls.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_mistral_format_messages.py`: reasoning + tool_calls keeps the tool_calls
(AssistantMessage); reasoning without tool_calls still maps to UserMessage. The first
fails on `main` and passes with this fix. ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
