### PR TITLE
fix: Anthropic format_messages mutates the caller's list-shaped user content

### DIFF
--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -487,6 +487,11 @@ def format_messages(
         elif message.role == "user":
             if isinstance(content, str):
                 content = [{"type": "text", "text": content}]
+            else:
+                # Copy so the image/file appends below don't mutate the caller's Message
+                # (format_messages runs several times per request — e.g. count_tokens then
+                # invoke — which would otherwise duplicate blocks unboundedly).
+                content = list(content)
 
             if message.images is not None:
                 for image in message.images:

--- a/libs/agno/tests/unit/utils/test_claude.py
+++ b/libs/agno/tests/unit/utils/test_claude.py
@@ -154,3 +154,24 @@ class TestFormatFileForMessage:
 
         assert result["source"]["type"] == "url"
         assert "citations" not in result
+
+
+class TestFormatMessagesDoesNotMutate:
+    def test_list_content_not_mutated_across_calls(self):
+        from agno.models.message import Message
+        from agno.utils.models.claude import format_messages
+
+        message = Message(
+            role="user",
+            content=[{"type": "text", "text": "hi"}],
+            files=[File(content=b"name,age\nAlice,30", mime_type="text/csv")],
+        )
+
+        # format_messages runs several times per request lifecycle; the caller's list-shaped
+        # content must not accumulate the appended file/image blocks.
+        first, _ = format_messages([message])
+        assert len(message.content) == 1
+        assert len(first[0]["content"]) == 2  # text + document in the output copy
+
+        format_messages([message])
+        assert len(message.content) == 1


### PR DESCRIPTION
## Summary

In `format_messages` (Anthropic), the user branch did `content = message.content or ""`.
When `message.content` is already a **list** of parts (pre-formatted multimodal content),
`content` aliases the caller's list, and the subsequent image/file appends mutate the
original `Message` in place:

```python
content = message.content or ""
...
if isinstance(content, str):
    content = [{"type": "text", "text": content}]   # str: fresh list, safe
if message.images: for ...: content.append(...)     # list: mutates caller
if message.files:  for ...: content.append(...)     # list: mutates caller
```

`format_messages` runs several times per request lifecycle (e.g. `count_tokens` then
`invoke`), so the caller's `Message.content` grows unboundedly and **duplicate**
document/image blocks are sent. Affects the Anthropic direct path and `AnthropicBedrock`
(both call this helper).

```
caller content BEFORE:        1 item
caller content AFTER 1 call:  2 items   (text + document)
caller content AFTER 2 calls: 3 items   (duplicate document)
```

## Fix

Copy the list before appending (`content = list(content)` for the non-str case).

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `TestFormatMessagesDoesNotMutate` asserts the caller's list content stays at one item
across repeated calls while the output copy carries the file block. It fails on `main` and
passes with this fix; full `test_claude.py` (22 tests) passes; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
