### PR TITLE
fix: DeepSeek drops image/audio when message content is None

### DIFF
--- a/libs/agno/agno/models/deepseek/deepseek.py
+++ b/libs/agno/agno/models/deepseek/deepseek.py
@@ -166,10 +166,11 @@ class DeepSeek(OpenAILike):
         if (message.images is not None and len(message.images) > 0) or (
             message.audio is not None and len(message.audio) > 0
         ):
-            # Ignore non-string message content
-            # because we assume that the images/audio are already added to the message
-            if isinstance(message.content, str):
-                message_dict["content"] = [{"type": "text", "text": message.content}]
+            # Build the parts list when content is None (the default) or a str, so the
+            # media is appended; skip only when content is already a list of parts.
+            if message.content is None or isinstance(message.content, str):
+                text = message.content if isinstance(message.content, str) else ""
+                message_dict["content"] = [{"type": "text", "text": text}]
                 if message.images is not None:
                     message_dict["content"].extend(images_to_message(images=message.images))
 
@@ -197,7 +198,8 @@ class DeepSeek(OpenAILike):
                 if file_part:
                     message_dict["content"].insert(0, file_part)
 
-        # Manually add the content field even if it is None
-        if message.content is None:
+        # Manually add the content field even if it is None, unless media/files already
+        # built a content list above (which would otherwise be clobbered back to "").
+        if message.content is None and "content" not in message_dict:
             message_dict["content"] = ""
         return message_dict

--- a/libs/agno/tests/unit/models/deepseek/test_deepseek_media_none_content.py
+++ b/libs/agno/tests/unit/models/deepseek/test_deepseek_media_none_content.py
@@ -1,0 +1,25 @@
+"""DeepSeek._format_message must keep images/audio when content is None (the default).
+Same class as the openai/chat.py None-content media fix."""
+
+from agno.media import Image
+from agno.models.deepseek.deepseek import DeepSeek
+from agno.models.message import Message
+
+
+def _image_parts(content):
+    return [p for p in content if isinstance(p, dict) and p.get("type") == "image_url"]
+
+
+def test_none_content_with_image_keeps_the_image():
+    model = DeepSeek(id="deepseek-chat")
+    formatted = model._format_message(Message(role="user", content=None, images=[Image(url="https://example.com/x.png")]))
+
+    assert isinstance(formatted["content"], list)
+    assert len(_image_parts(formatted["content"])) == 1
+    assert {"type": "text", "text": ""} in formatted["content"]
+
+
+def test_none_content_without_media_is_empty_string():
+    model = DeepSeek(id="deepseek-chat")
+    formatted = model._format_message(Message(role="user", content=None))
+    assert formatted["content"] == ""


### PR DESCRIPTION
## Summary

`DeepSeek._format_message` guarded media assembly with `isinstance(message.content, str)`. `Message.content` defaults to `None`, so a user message carrying images/audio but no text skipped assembly, and the trailing `if message.content is None: message_dict["content"] = ""` then reset content to an empty string — **silently dropping the media**.

```python
Message(role="user", content=None, images=[Image(url=...)])
# before: {"role": "user", "content": ""}   (image gone)
# after:  content = [{"type": "text", "text": ""}, {"type": "image_url", ...}]
```

Same class as the `openai/chat.py` None-content media fix.

## Fix

Build the parts list when content is None or a str; don't reset content to `""` when media/files already built a content list.

## Type of change
- [x] Bug fix

## Checklist
- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check
- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_deepseek_media_none_content.py`: None-content + image keeps the image; None-content without media stays `""`. The first fails on `main` and passes with this fix. Full `tests/unit/models/deepseek/` (14 tests) passes; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.