### PR TITLE
fix: LiteLLM drops image/audio when message content is None

### DIFF
--- a/libs/agno/agno/models/litellm/chat.py
+++ b/libs/agno/agno/models/litellm/chat.py
@@ -145,8 +145,11 @@ class LiteLLM(Model):
 
             # Handle media
             if (m.images is not None and len(m.images) > 0) or (m.audio is not None and len(m.audio) > 0):
-                if isinstance(m.content, str):
-                    content_list = [{"type": "text", "text": m.content}]
+                # Build the parts list when content is None (the default) or a str, so the
+                # media is appended; skip only when content is already a list of parts.
+                if m.content is None or isinstance(m.content, str):
+                    text = m.content if isinstance(m.content, str) else ""
+                    content_list = [{"type": "text", "text": text}]
                     if m.images is not None:
                         content_list.extend(images_to_message(images=m.images))
                     if m.audio is not None:

--- a/libs/agno/tests/unit/models/litellm/test_litellm_media_none_content.py
+++ b/libs/agno/tests/unit/models/litellm/test_litellm_media_none_content.py
@@ -1,0 +1,25 @@
+"""LiteLLM._format_messages must keep images/audio when content is None (the default).
+Same class as the openai/chat.py None-content media fix."""
+
+from agno.media import Image
+from agno.models.litellm.chat import LiteLLM
+from agno.models.message import Message
+
+
+def _image_parts(content):
+    return [p for p in content if isinstance(p, dict) and p.get("type") == "image_url"]
+
+
+def test_none_content_with_image_keeps_the_image():
+    model = LiteLLM(id="gpt-4o")
+    formatted = model._format_messages([Message(role="user", content=None, images=[Image(url="https://example.com/x.png")])])[0]
+
+    assert isinstance(formatted["content"], list)
+    assert len(_image_parts(formatted["content"])) == 1
+    assert {"type": "text", "text": ""} in formatted["content"]
+
+
+def test_none_content_without_media_is_empty_string():
+    model = LiteLLM(id="gpt-4o")
+    formatted = model._format_messages([Message(role="user", content=None)])[0]
+    assert formatted["content"] == ""


### PR DESCRIPTION
## Summary

`LiteLLM._format_messages` guarded media assembly with `isinstance(m.content, str)`. `content` defaults to `None` (coerced to `""` for the base message dict), so a user message carrying images/audio but no text skipped assembly and was sent with empty content — **silently dropping the media**.

```python
Message(role="user", content=None, images=[Image(url=...)])
# before: {"role": "user", "content": ""}   (image gone)
# after:  content = [{"type": "text", "text": ""}, {"type": "image_url", ...}]
```

Same class as the `openai/chat.py` None-content media fix.

## Fix

Build the parts list when content is None or a str.

## Type of change
- [x] Bug fix

## Checklist
- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check
- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_litellm_media_none_content.py`: None-content + image keeps the image; None-content without media stays `""`. The first fails on `main` and passes with this fix; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.