### PR TITLE
fix: Cohere drops images when message content is None

### DIFF
--- a/libs/agno/agno/utils/models/cohere.py
+++ b/libs/agno/agno/utils/models/cohere.py
@@ -11,8 +11,8 @@ def _format_images_for_message(message: Message, images: Sequence[Image]) -> Lis
     Format an image into the format expected by WatsonX.
     """
 
-    # Create a default message content with text
-    message_content_with_image: List[Dict[str, Any]] = [{"type": "text", "text": message.content}]
+    # Create a default message content with text (content may be None when only images are sent)
+    message_content_with_image: List[Dict[str, Any]] = [{"type": "text", "text": message.content or ""}]
 
     # Add images to the message content
     for image in images:
@@ -79,8 +79,9 @@ def format_messages(messages: List[Message], compress_tool_results: bool = False
         }
 
         if message.images is not None and len(message.images) > 0:
-            # Ignore non-string message content
-            if isinstance(message.content, str):
+            # Build the parts list when content is None (the default) or a str; skip only
+            # when content is already a list of parts.
+            if message.content is None or isinstance(message.content, str):
                 message_content_with_image = _format_images_for_message(message=message, images=message.images)
                 if len(message_content_with_image) > 1:
                     message_dict["content"] = message_content_with_image

--- a/libs/agno/tests/unit/utils/test_cohere_media_none_content.py
+++ b/libs/agno/tests/unit/utils/test_cohere_media_none_content.py
@@ -1,0 +1,28 @@
+"""Cohere format_messages must keep images when content is None (the default), and must
+not emit a null text block. Same class as the openai/chat.py None-content media fix."""
+
+from agno.media import Image
+from agno.models.message import Message
+from agno.utils.models.cohere import format_messages
+
+# Bytes content avoids the helper's URL fetch (offline-safe).
+_IMAGE = Image(content=b"\x89PNG_fake_bytes")
+
+
+def _content(message):
+    return format_messages([message])[0]["content"]
+
+
+def test_none_content_with_image_keeps_image_and_empty_text():
+    content = _content(Message(role="user", content=None, images=[_IMAGE]))
+
+    assert isinstance(content, list)
+    assert content[0] == {"type": "text", "text": ""}  # empty text, not None
+    assert any(p.get("type") == "image_url" for p in content)
+
+
+def test_str_content_with_image_unchanged():
+    content = _content(Message(role="user", content="describe", images=[_IMAGE]))
+
+    assert content[0] == {"type": "text", "text": "describe"}
+    assert any(p.get("type") == "image_url" for p in content)


### PR DESCRIPTION
## Summary

Cohere `format_messages` guarded the image block with `isinstance(message.content, str)`. `content` defaults to `None`, so a user message carrying images but no text skipped assembly — the image was **silently dropped**. The `_format_images_for_message` helper also built its text part from raw `message.content`, which is None in that case (a null text block).

```python
Message(role="user", content=None, images=[Image(...)])
# before: content = None                              (image gone)
# after:  content = [{"type": "text", "text": ""}, {"type": "image_url", ...}]
```

Same class as the `openai/chat.py` None-content media fix.

## Fix

Build the parts list when content is None or a str, and use `message.content or ""` for the text part so it is never null.

## Type of change
- [x] Bug fix

## Checklist
- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check
- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_cohere_media_none_content.py` (bytes image, offline-safe): None-content keeps the image with an empty text block; str-content unchanged. The first fails on `main` and passes with this fix; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.