### PR TITLE
fix: Ollama crashes on a tool_call with empty-string or missing arguments

### DIFF
--- a/libs/agno/agno/models/ollama/chat.py
+++ b/libs/agno/agno/models/ollama/chat.py
@@ -175,14 +175,20 @@ class Ollama(Model):
             for tool_call in message.tool_calls:
                 if "function" in tool_call:
                     function_data = tool_call["function"]
+                    # arguments may be absent or an empty string (e.g. a no-arg tool call from
+                    # another provider replayed through Ollama); json.loads("") / a missing key
+                    # would otherwise crash.
+                    raw_arguments = function_data.get("arguments")
+                    if isinstance(raw_arguments, str):
+                        arguments = json.loads(raw_arguments) if raw_arguments.strip() else {}
+                    else:
+                        arguments = raw_arguments if raw_arguments is not None else {}
                     formatted_tool_call = {
                         "id": tool_call.get("id"),
                         "type": "function",
                         "function": {
                             "name": function_data["name"],
-                            "arguments": json.loads(function_data["arguments"])
-                            if isinstance(function_data["arguments"], str)
-                            else function_data["arguments"],
+                            "arguments": arguments,
                         },
                     }
                     formatted_tool_calls.append(formatted_tool_call)

--- a/libs/agno/tests/unit/models/ollama_model/test_ollama_tool_arguments.py
+++ b/libs/agno/tests/unit/models/ollama_model/test_ollama_tool_arguments.py
@@ -1,0 +1,27 @@
+"""Ollama._format_message must not crash on a tool_call whose arguments are an empty
+string or absent (a no-arg tool call from another provider replayed through Ollama)."""
+
+import pytest
+
+from agno.models.message import Message
+from agno.models.ollama.chat import Ollama
+
+
+def _arguments(tool_call_function):
+    model = Ollama(id="llama3")
+    message = Message(role="assistant", tool_calls=[{"id": "t1", "type": "function", "function": tool_call_function}])
+    formatted = model._format_message(message)
+    return formatted["tool_calls"][0]["function"]["arguments"]
+
+
+@pytest.mark.parametrize(
+    "function, expected",
+    [
+        ({"name": "w", "arguments": ""}, {}),  # empty string (was JSONDecodeError)
+        ({"name": "w"}, {}),  # missing key (was KeyError)
+        ({"name": "w", "arguments": '{"city": "Paris"}'}, {"city": "Paris"}),
+        ({"name": "w", "arguments": {"x": 1}}, {"x": 1}),
+    ],
+)
+def test_tool_call_arguments_are_robust(function, expected):
+    assert _arguments(function) == expected


### PR DESCRIPTION
## Summary

`Ollama._format_message` did `json.loads(function_data["arguments"])`. When `arguments` is an **empty string** (`json.loads("")` -> `JSONDecodeError`) or the key is **absent** (`KeyError`), the call crashed.

This is reachable via agno's cross-model interchange pattern: several providers persist a no-arg tool call as `arguments: ""` (`aws/bedrock.py`, `cerebras`, `azure/ai_foundry`, `google/gemini`), and replaying that history through an Ollama model hits this **before any network call**.

```python
# arguments=""  -> JSONDecodeError   (now {})
# arguments key absent -> KeyError    (now {})
# arguments='{"city":"Paris"}' -> {"city": "Paris"}   (unchanged)
# arguments={"x": 1} -> {"x": 1}   (unchanged)
```

## Fix

Read arguments defensively: empty/missing -> `{}`, a JSON string -> parsed, a dict -> used as-is.

## Type of change
- [x] Bug fix

## Checklist
- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check
- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New parametrized `test_ollama_tool_arguments.py`: empty-string and missing arguments no longer crash (-> {}), valid JSON and dict unchanged. The first two fail on `main` and pass with this fix; full `ollama_model` suite (10 tests) passes; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.