### PR TITLE
fix: ClickUpTools._find_by_name crashes on a literal name that isn't valid regex

### DIFF
--- a/libs/agno/agno/tools/clickup.py
+++ b/libs/agno/agno/tools/clickup.py
@@ -70,13 +70,20 @@ class ClickUpTools(Toolkit):
         if not name:
             return items[0] if items else None
 
-        pattern = re.compile(name, re.IGNORECASE)
+        # Exact match first so a literal name that isn't valid regex still resolves.
+        name_lower = name.lower()
         for item in items:
-            # Try exact match first (case-insensitive)
-            if item["name"].lower() == name.lower():
+            if item.get("name", "").lower() == name_lower:
                 return item
-            # Then try regex pattern match
-            if pattern.search(item["name"]):
+
+        # Then fuzzy regex match; a name with unbalanced brackets/metachars is not a
+        # valid pattern, so degrade to "no match" instead of raising re.error.
+        try:
+            pattern = re.compile(name, re.IGNORECASE)
+        except re.error:
+            return None
+        for item in items:
+            if pattern.search(item.get("name", "")):
                 return item
         return None
 

--- a/libs/agno/tests/unit/tools/test_clickup.py
+++ b/libs/agno/tests/unit/tools/test_clickup.py
@@ -1,0 +1,26 @@
+"""ClickUpTools._find_by_name must not crash when a literal name contains regex
+metacharacters; the unconditional re.compile raised re.error and left the exact-match
+path unreachable."""
+
+from agno.tools.clickup import ClickUpTools
+
+_find_by_name = ClickUpTools._find_by_name
+
+
+def test_literal_name_with_regex_metacharacters_matches_exactly():
+    for name in ["*Sprint", "Design [v2", "Sales (West"]:
+        items = [{"name": name}, {"name": "Other"}]
+        assert _find_by_name(None, items, name) == {"name": name}
+
+
+def test_invalid_pattern_with_no_exact_match_returns_none():
+    assert _find_by_name(None, [{"name": "other"}], "Sales (West") is None
+
+
+def test_fuzzy_and_exact_matches_still_work():
+    assert _find_by_name(None, [{"name": "Sprint 1"}], "Spr") == {"name": "Sprint 1"}
+    assert _find_by_name(None, [{"name": "Backlog"}], "backlog") == {"name": "Backlog"}
+
+
+def test_item_without_name_key_does_not_crash():
+    assert _find_by_name(None, [{"id": 1}, {"name": "x"}], "x") == {"name": "x"}


### PR DESCRIPTION
## Summary

`ClickUpTools._find_by_name` compiles the name as a regex **unconditionally**:

```python
pattern = re.compile(name, re.IGNORECASE)   # runs before any matching
for item in items:
    if item["name"].lower() == name.lower():   # exact-match, unreachable if compile threw
        return item
    if pattern.search(item["name"]):
        return item
```

A ClickUp space/list name containing regex metacharacters (e.g. `*Sprint`, `Design [v2`,
`Sales (West`) raises an **uncaught** `re.error`. It's thrown out of the public
`list_tasks` / `create_task` tools (via `_get_space` / `_get_list`), which otherwise
return a JSON `{"error": ...}` string — so it breaks the toolkit's error contract. The
exact-match branch meant to handle literal names is also unreachable, so even a name that
*exactly* equals the query crashes.

## Fix

Do the exact-match pass first, and guard the regex compile so an invalid pattern degrades
to "no fuzzy match" instead of raising. Read item names with `.get` to avoid a latent
KeyError.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_clickup.py`: literal metacharacter names match exactly; an invalid pattern with
no exact match returns None; fuzzy/exact matching still work; a missing `name` key no
longer crashes. Three fail on `main` and pass with this fix; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
