### PR TITLE
fix: RecursiveChunking emits duplicate tail chunks when overlap > 0

### DIFF
--- a/libs/agno/agno/knowledge/chunking/recursive.py
+++ b/libs/agno/agno/knowledge/chunking/recursive.py
@@ -51,6 +51,11 @@ class RecursiveChunking(ChunkingStrategy):
             meta_data["chunk_size"] = len(chunk)
             chunks.append(Document(id=chunk_id, name=document.name, meta_data=meta_data, content=chunk))
 
+            # Reached the end of the content; the overlap rewind below would only re-emit
+            # a tail already contained in this chunk.
+            if end == len(content):
+                break
+
             new_start = end - self.overlap
             if new_start <= start:  # Prevent infinite loop
                 new_start = min(

--- a/libs/agno/tests/unit/knowledge/chunking/test_recursive_chunking_overlap.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_recursive_chunking_overlap.py
@@ -1,0 +1,28 @@
+"""RecursiveChunking with overlap must not re-emit the tail as duplicate chunks."""
+
+from agno.knowledge.chunking.recursive import RecursiveChunking
+from agno.knowledge.document.base import Document
+
+
+def _chunk(content, chunk_size=200, overlap=20):
+    document = Document(content=content, name="x", meta_data={})
+    return RecursiveChunking(chunk_size=chunk_size, overlap=overlap).chunk(document)
+
+
+def test_overlap_does_not_emit_duplicate_tail_chunks():
+    content = "This is a sentence about vectors. It has some words here. Another clause follows now. " * 6
+    chunks = _chunk(content)
+
+    # No chunk's content may be fully contained in an earlier chunk.
+    for i in range(1, len(chunks)):
+        for j in range(i):
+            assert not (chunks[i].content and chunks[i].content in chunks[j].content), (
+                f"chunk {i} duplicates content already in chunk {j}"
+            )
+
+    # The end of the content is still covered.
+    assert content.rstrip()[-10:] in "".join(c.content for c in chunks)
+
+
+def test_short_document_is_a_single_chunk():
+    assert len(_chunk("short text")) == 1


### PR DESCRIPTION
## Summary

Once a `RecursiveChunking` chunk reached the end of the content, the loop did not stop.
The overlap rewind (`new_start = end - self.overlap`) sent `start` back behind the final
position while `start < len(content)` was still true, so the algorithm re-emitted one or
more trailing chunks whose content is **entirely contained** in a previous chunk. Those
duplicates get embedded and indexed into the vector store — wasting storage and biasing
retrieval (identical text returned multiple times / skewed scores).

```python
RecursiveChunking(chunk_size=200, overlap=20).chunk(doc)   # overlap = 10% of size
# before: 4 chunks, sizes [171, 192, 193, 20]  (chunk 3 duplicates the tail of 0/1/2)
# after:  3 chunks, sizes [171, 192, 193]      (tail still fully covered)
```

`overlap=20` here is within the library's own recommended range, so no warning fires.

## Fix

Break once a chunk has reached the end of the content (the overlap rewind would only
re-emit a tail already contained in that chunk).

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_recursive_chunking_overlap.py`: no chunk is fully contained in an earlier one
and the content tail is still covered; a short document stays a single chunk. The first
fails on `main` and passes with this fix; ruff clean. (Kept in a separate file so it
isn't gated by the `unstructured` import-skip in `test_chunking_split.py`.)

Prepared with AI assistance (Claude Code) and reviewed before submission.
