### PR TITLE
fix: CalculatorTools.exponentiate leaks OverflowError/ValueError on legal floats

### DIFF
--- a/libs/agno/agno/tools/calculator.py
+++ b/libs/agno/agno/tools/calculator.py
@@ -97,7 +97,10 @@ class CalculatorTools(Toolkit):
         Returns:
             str: JSON string of the result.
         """
-        result = math.pow(a, b)
+        try:
+            result = math.pow(a, b)
+        except (OverflowError, ValueError) as e:
+            return json.dumps({"operation": "exponentiation", "error": str(e), "result": "Error"})
         log_debug(f"Raising {a} to the power of {b} to get {result}")
         return json.dumps({"operation": "exponentiation", "result": result})
 

--- a/libs/agno/tests/unit/tools/test_calculator.py
+++ b/libs/agno/tests/unit/tools/test_calculator.py
@@ -149,6 +149,14 @@ def test_exponentiate_operation(calculator_tools):
     result_data = json.loads(result)
     assert result_data["result"] == 6.25
 
+    # Overflow returns a JSON error instead of raising (like the sibling operations)
+    result_data = json.loads(calculator_tools.exponentiate(2.0, 10000.0))
+    assert "error" in result_data
+
+    # Math domain error (0 ** -1) is handled the same way
+    result_data = json.loads(calculator_tools.exponentiate(0.0, -1.0))
+    assert "error" in result_data
+
 
 def test_factorial_operation(calculator_tools):
     """Test factorial operation."""


### PR DESCRIPTION
## Summary

Unlike the sibling operations (`divide`, `factorial`, `square_root`), which return a JSON error string, `exponentiate` called `math.pow` unguarded:

```python
CalculatorTools().exponentiate(2.0, 10000.0)  # OverflowError: math range error
CalculatorTools().exponentiate(0.0, -1.0)     # ValueError: math domain error
```

Both are uncaught, breaking the toolkit's JSON-result contract (every other operation returns `{"operation": ..., "error": ...}`).

## Fix

Wrap `math.pow` in try/except returning the same JSON error shape as the siblings.

## Type of change
- [x] Bug fix

## Checklist
- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check
- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Extended `test_exponentiate_operation`: overflow and math-domain errors return a JSON error instead of raising. It fails on `main` and passes with this fix; full `test_calculator.py` (14 tests) passes; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.