### PR TITLE
fix: FunctionCall.execute crashes when arguments is None

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1084,7 +1084,8 @@ class FunctionCall(BaseModel):
                 execution_chain = self._build_nested_execution_chain(entrypoint_args=entrypoint_args)
                 result = execution_chain(self.function.name, self.function.entrypoint, self.arguments or {})
             else:
-                result = self.function.entrypoint(**entrypoint_args, **self.arguments)  # type: ignore
+                # Guard None/empty arguments like aexecute() does; `**None` raises TypeError.
+                result = self.function.entrypoint(**entrypoint_args, **(self.arguments or {}))
 
             # Handle generator case
             if isgenerator(result):

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -492,6 +492,21 @@ def test_function_call_execution_with_error():
     assert "Test error" in result.error
 
 
+def test_function_call_execute_with_none_arguments():
+    """execute() must handle arguments=None like aexecute() (not `**None`)."""
+
+    def test_func() -> str:
+        return "ok"
+
+    func = Function(name="test_func", entrypoint=test_func)
+
+    call = FunctionCall(function=func, arguments=None)
+    result = call.execute()
+
+    assert result.status == "success"
+    assert result.result == "ok"
+
+
 def test_function_call_with_hooks():
     """Test function call execution with pre and post hooks."""
     pre_hook_called = False


### PR DESCRIPTION
## Summary

The sync `FunctionCall.execute()` non-hooks path did:

```python
result = self.function.entrypoint(**entrypoint_args, **self.arguments)
```

`self.arguments` is `Optional[Dict]` defaulting to `None`, so `**None` raises `TypeError: argument after ** must be a mapping, not NoneType`. The async `aexecute()` already guards this (special-cases `None`/`{}`), and the sync **hooks** path uses `self.arguments or {}` — the non-hooks path was the only one missing the guard, so `FunctionCall(function=f, arguments=None).execute()` silently returned `status=failure` while `aexecute()` succeeded.

## Fix

Use `**(self.arguments or {})` to match `aexecute()`.

## Type of change
- [x] Bug fix

## Checklist
- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check
- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_function_call_execute_with_none_arguments`: sync execute with `arguments=None` now succeeds (matching aexecute). Fails on `main`, passes with this fix; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.