### PR TITLE
fix: base CustomEvent crashes in to_dict() (missing created_at)

### DIFF
--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -516,7 +516,11 @@ class CustomEvent(BaseAgentRunEvent):
     tool_call_id: Optional[str] = None
 
     def __init__(self, **kwargs):
-        # Store arbitrary attributes directly on the instance
+        # Store arbitrary attributes directly on the instance. created_at uses a
+        # field default_factory (no class attribute), so this custom __init__ must set
+        # it explicitly or to_dict()/asdict() raises AttributeError.
+        if "created_at" not in kwargs:
+            self.created_at = int(time())
         for key, value in kwargs.items():
             setattr(self, key, value)
 

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -632,7 +632,11 @@ class CustomEvent(BaseTeamRunEvent):
     event: str = TeamRunEvent.custom_event.value
 
     def __init__(self, **kwargs):
-        # Store arbitrary attributes directly on the instance
+        # Store arbitrary attributes directly on the instance. created_at uses a
+        # field default_factory (no class attribute), so this custom __init__ must set
+        # it explicitly or to_dict()/asdict() raises AttributeError.
+        if "created_at" not in kwargs:
+            self.created_at = int(time())
         for key, value in kwargs.items():
             setattr(self, key, value)
 

--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -605,7 +605,11 @@ class CustomEvent(BaseWorkflowRunOutputEvent):
     event: str = WorkflowRunEvent.custom_event.value
 
     def __init__(self, **kwargs):
-        # Store arbitrary attributes directly on the instance
+        # Store arbitrary attributes directly on the instance. created_at uses a
+        # field default_factory (no class attribute), so this custom __init__ must set
+        # it explicitly or to_dict()/asdict() raises AttributeError.
+        if "created_at" not in kwargs:
+            self.created_at = int(time())
         for key, value in kwargs.items():
             setattr(self, key, value)
 

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -523,3 +523,19 @@ def test_requirements_in_run_paused_event():
     assert reconstructed.requirements[0].tool_execution.tool_name == "get_the_weather"
     assert reconstructed.requirements[0].tool_execution.requires_confirmation is True
     assert reconstructed.requirements[0].needs_confirmation is True
+
+
+def test_base_custom_event_to_dict_has_created_at():
+    """The base CustomEvent (public, **kwargs init) must be serializable directly;
+    its custom __init__ bypasses the dataclass created_at default_factory."""
+    from agno.run.agent import CustomEvent as AgentCustomEvent
+    from agno.run.team import CustomEvent as TeamCustomEvent
+    from agno.run.workflow import CustomEvent as WorkflowCustomEvent
+
+    for cls in (AgentCustomEvent, TeamCustomEvent, WorkflowCustomEvent):
+        event = cls(name="x", value="y")
+        result = event.to_dict()  # used to raise AttributeError: no attribute 'created_at'
+        assert isinstance(result["created_at"], int)
+
+        # An explicitly-provided created_at is respected.
+        assert cls(created_at=123).created_at == 123


### PR DESCRIPTION
## Summary

`CustomEvent` (in `run/agent.py`, `run/team.py`, `run/workflow.py`) overrides `__init__` with `**kwargs` that only `setattr`s the passed keys. All base fields have class-level defaults **except** `created_at`, which uses `field(default_factory=...)` — so there is no class attribute for it. An instance built via this `__init__` without an explicit `created_at` therefore has no such attribute, and the inherited `to_dict()` / `asdict()` raises `AttributeError: 'CustomEvent' object has no attribute 'created_at'`.

```python
from agno.run.agent import CustomEvent
CustomEvent(name="x", value="y").to_dict()   # AttributeError
```

The class is public with a `**kwargs` init, so direct instantiation is a supported path. (A `@dataclass` subclass regenerates a proper `__init__` and already works — this only bit the exported base class.)

## Fix

Default `created_at` to `int(time())` in each `__init__` when not provided.

## Type of change
- [x] Bug fix

## Checklist
- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check
- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_base_custom_event_to_dict_has_created_at` covers all three CustomEvent classes (to_dict no longer raises; an explicit created_at is respected). It fails on `main` and passes with this fix; full `test_run_events.py` (17 tests) passes; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.