### PR TITLE
fix: StepInput.get_last_step_content drops all Parallel branches but the last

### DIFF
--- a/libs/agno/agno/workflow/types.py
+++ b/libs/agno/agno/workflow/types.py
@@ -408,6 +408,17 @@ class StepInput:
         """Helper method to recursively extract deepest content from nested steps"""
         # If this step has nested steps, go deeper
         if step_output.steps and len(step_output.steps) > 0:
+            # For Parallel steps, aggregate content from ALL inner branches, not just the last
+            # one (otherwise every branch except the last is silently dropped).
+            if step_output.step_type == StepType.PARALLEL:
+                aggregated_parts = []
+                for i, inner_step in enumerate(step_output.steps):
+                    inner_content = self._get_deepest_step_content(inner_step)
+                    if inner_content:
+                        step_name = inner_step.step_name or f"Step {i + 1}"
+                        aggregated_parts.append(f"=== {step_name} ===\n{inner_content}")
+                return "\n\n".join(aggregated_parts) if aggregated_parts else step_output.content  # type: ignore[return-value]
+
             return self._get_deepest_step_content(step_output.steps[-1])
 
         # Return the content of this step

--- a/libs/agno/tests/unit/workflow/test_step_input_last_content.py
+++ b/libs/agno/tests/unit/workflow/test_step_input_last_content.py
@@ -1,0 +1,35 @@
+"""StepInput.get_last_step_content must aggregate ALL Parallel branches, not just the
+last one — otherwise a step placed after a Parallel (the fan-out -> synthesize pattern)
+silently loses every branch except the last."""
+
+from agno.workflow.types import StepInput, StepOutput, StepType
+
+
+def test_parallel_content_aggregates_all_branches():
+    branch_a = StepOutput(step_name="branch_a", content="AAA")
+    branch_b = StepOutput(step_name="branch_b", content="BBB")
+    parallel = StepOutput(step_name="par", step_type=StepType.PARALLEL, content="agg", steps=[branch_a, branch_b])
+    step_input = StepInput(input="x", previous_step_outputs={"par": parallel})
+
+    content = step_input.get_last_step_content()
+
+    assert "AAA" in content
+    assert "BBB" in content
+
+
+def test_non_parallel_nested_uses_last_step():
+    inner = StepOutput(step_name="inner", content="INNER")
+    nested = StepOutput(
+        step_name="seq",
+        step_type=StepType.STEPS,
+        content="c",
+        steps=[StepOutput(content="first"), inner],
+    )
+    step_input = StepInput(input="x", previous_step_outputs={"seq": nested})
+
+    assert step_input.get_last_step_content() == "INNER"
+
+
+def test_plain_step_content_unchanged():
+    step_input = StepInput(input="x", previous_step_outputs={"s": StepOutput(step_name="s", content="plain")})
+    assert step_input.get_last_step_content() == "plain"


### PR DESCRIPTION
## Summary

`StepInput._get_deepest_step_content` (`workflow/types.py`) recursed blindly into
`step_output.steps[-1]`. For a **Parallel** step output that means it returned only the
**last** branch's content — every other branch was silently dropped:

```python
StepInput(previous_step_outputs={"par": parallel_output})
# get_step_content("par")        -> {"branch_a": "AAA", "branch_b": "BBB"}   (correct)
# get_last_step_content()        -> "BBB"                                    (branch_a lost)
```

A step placed **after** a Parallel — the common fan-out → synthesize pattern, e.g. a
custom function step reading `previous_step_content` — therefore saw only one branch's
result. (Agent/team steps escape it because they render through the Parallel-aware
`_prepare_message`; the function-step path is the victim. Sync and async both affected.)

The method's two siblings — `get_step_content` and `Step._get_deepest_content_from_step_output`
— both already special-case Parallel; this one was missed.

## Fix

Aggregate content from all inner branches for Parallel steps (mirroring
`Step._get_deepest_content_from_step_output`). Non-Parallel nested steps still resolve to
their last step; plain steps are unchanged.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_step_input_last_content.py` asserts Parallel aggregates all branches, non-Parallel
nested resolves to its last step, and plain steps are unchanged. The Parallel test fails on
`main` and passes with this fix; ruff + mypy clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
