### PR TITLE
fix: get_messages(limit=N) leaves an orphan tool message after the system message

### DIFF
--- a/libs/agno/agno/session/agent.py
+++ b/libs/agno/agno/session/agent.py
@@ -210,9 +210,12 @@ class AgentSession:
                 else:
                     messages_from_history = messages_from_history[-limit:]
 
-            # Remove tool result messages that don't have an associated assistant message with tool calls
-            while len(messages_from_history) > 0 and messages_from_history[0].role == "tool":
-                messages_from_history.pop(0)
+            # Remove tool result messages that don't have an associated assistant message with tool
+            # calls. Skip past a leading system message (prepended above) so an orphan tool at index 1
+            # is still stripped instead of left as [system, tool, ...] (a hard provider API error).
+            start = 1 if messages_from_history and messages_from_history[0].role == "system" else 0
+            while len(messages_from_history) > start and messages_from_history[start].role == "tool":
+                messages_from_history.pop(start)
 
         # If limit is not set, return all messages
         else:

--- a/libs/agno/agno/session/team.py
+++ b/libs/agno/agno/session/team.py
@@ -233,9 +233,12 @@ class TeamSession:
                 else:
                     messages_from_history = messages_from_history[-limit:]
 
-            # Remove tool result messages that don't have an associated assistant message with tool calls
-            while len(messages_from_history) > 0 and messages_from_history[0].role == "tool":
-                messages_from_history.pop(0)
+            # Remove tool result messages that don't have an associated assistant message with tool
+            # calls. Skip past a leading system message (prepended above) so an orphan tool at index 1
+            # is still stripped instead of left as [system, tool, ...] (a hard provider API error).
+            start = 1 if messages_from_history and messages_from_history[0].role == "system" else 0
+            while len(messages_from_history) > start and messages_from_history[start].role == "tool":
+                messages_from_history.pop(start)
         else:
             for run_response in session_runs:
                 if not (run_response and run_response.messages):

--- a/libs/agno/agno/session/workflow.py
+++ b/libs/agno/agno/session/workflow.py
@@ -293,9 +293,12 @@ class WorkflowSession:
                 else:
                     messages_from_history = messages_from_history[-limit:]
 
-            # Remove tool result messages that don't have an associated assistant message with tool calls
-            while len(messages_from_history) > 0 and messages_from_history[0].role == "tool":
-                messages_from_history.pop(0)
+            # Remove tool result messages that don't have an associated assistant message with tool
+            # calls. Skip past a leading system message (prepended above) so an orphan tool at index 1
+            # is still stripped instead of left as [system, tool, ...] (a hard provider API error).
+            start = 1 if messages_from_history and messages_from_history[0].role == "system" else 0
+            while len(messages_from_history) > start and messages_from_history[start].role == "tool":
+                messages_from_history.pop(start)
 
         # If limit is not set, return all messages
         else:
@@ -407,9 +410,12 @@ class WorkflowSession:
                 else:
                     messages_from_history = messages_from_history[-limit:]
 
-            # Remove tool result messages that don't have an associated assistant message with tool calls
-            while len(messages_from_history) > 0 and messages_from_history[0].role == "tool":
-                messages_from_history.pop(0)
+            # Remove tool result messages that don't have an associated assistant message with tool
+            # calls. Skip past a leading system message (prepended above) so an orphan tool at index 1
+            # is still stripped instead of left as [system, tool, ...] (a hard provider API error).
+            start = 1 if messages_from_history and messages_from_history[0].role == "system" else 0
+            while len(messages_from_history) > start and messages_from_history[start].role == "tool":
+                messages_from_history.pop(start)
         else:
             for run_response in session_runs:
                 if not (run_response and run_response.messages):

--- a/libs/agno/tests/unit/session/test_get_messages_orphan_tool.py
+++ b/libs/agno/tests/unit/session/test_get_messages_orphan_tool.py
@@ -1,0 +1,34 @@
+"""get_messages(limit=N) must not return a leading orphan tool message when a system
+message is present: the strip ran after the system message was prepended, leaving
+[system, tool, ...] — a tool result with no preceding assistant tool_calls, which is a
+hard provider API error."""
+
+from agno.models.message import Message
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.session.agent import AgentSession
+
+
+def _session():
+    messages = [
+        Message(role="system", content="You are helpful"),
+        Message(role="user", content="Q1"),
+        Message(role="assistant", content="", tool_calls=[{"id": "c1", "type": "function", "function": {"name": "w", "arguments": "{}"}}]),
+        Message(role="tool", tool_call_id="c1", content="result1"),
+        Message(role="assistant", content="answer1"),
+    ]
+    run = RunOutput(run_id="r1", messages=messages, status=RunStatus.completed)
+    run.parent_run_id = None
+    return AgentSession(session_id="s1", runs=[run])
+
+
+def test_limit_does_not_leave_orphan_tool_after_system():
+    roles = [m.role for m in _session().get_messages(limit=3)]
+    # Was ["system", "tool", "assistant"] before the fix (a leading orphan tool result).
+    assert roles == ["system", "assistant"]
+
+
+def test_limit_keeps_valid_tool_cycle():
+    # limit=4 keeps the assistant-with-tool_calls before the tool, so the tool is valid.
+    roles = [m.role for m in _session().get_messages(limit=4)]
+    assert roles == ["system", "assistant", "tool", "assistant"]


### PR DESCRIPTION
## Summary

In `get_messages(limit=N)`, the leading-orphan-tool strip ran **after** the system
message was prepended to the limited window:

```python
if system_message:
    messages_from_history = [system_message] + messages_from_history[-(limit - 1):]
...
while messages_from_history and messages_from_history[0].role == "tool":   # [0] is now the system message
    messages_from_history.pop(0)
```

So `messages_from_history[0]` is the system message, the `while` never fires, and the
result is `[system, tool, ...]` — a tool result with no preceding assistant `tool_calls`,
which is a hard provider API error (e.g. OpenAI 400).

```python
# run messages: [system, user, assistant(tool_call), tool, assistant]
session.get_messages(limit=3)
# before: [system, tool, assistant]   (orphan tool)
# after:  [system, assistant]
```

Reachable via the public `Agent.get_session_messages(limit=N)` (`skip_roles=None` keeps
the system message; the default `run()` path passes `skip_roles=["system"]` and escapes
it via the else-branch's identical guard).

## Fix

Skip past a leading system message when stripping orphan tool messages. Applied to the
agent, team, and workflow session variants (all four share the pattern). Valid tool
cycles (assistant-with-tool_calls still in the window) are preserved.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_get_messages_orphan_tool.py`: `limit=3` no longer leaves a leading orphan tool
after the system message, and a valid tool cycle (`limit=4`) is preserved. The orphan
test fails on `main` and passes with this fix. Existing team/workflow session tests
(23) still pass; ruff + mypy clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
