### PR TITLE
fix: run event from_dict does not reconstruct citations

### DIFF
--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -260,6 +260,10 @@ class BaseRunOutputEvent:
         if references is not None:
             data["references"] = [MessageReferences.model_validate(reference) for reference in references]
 
+        citations = data.pop("citations", None)
+        if citations is not None:
+            data["citations"] = Citations.model_validate(citations)
+
         metrics = data.pop("metrics", None)
         if metrics:
             data["metrics"] = RunMetrics.from_dict(metrics)

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -523,3 +523,17 @@ def test_requirements_in_run_paused_event():
     assert reconstructed.requirements[0].tool_execution.tool_name == "get_the_weather"
     assert reconstructed.requirements[0].tool_execution.requires_confirmation is True
     assert reconstructed.requirements[0].needs_confirmation is True
+
+
+def test_run_event_from_dict_reconstructs_citations():
+    from agno.models.message import UrlCitation
+    from agno.models.response import Citations
+    from agno.run.agent import RunContentEvent
+
+    event = RunContentEvent(content="x", citations=Citations(urls=[UrlCitation(url="http://e.com", title="T")]))
+
+    restored = RunContentEvent.from_dict(event.to_dict())
+
+    # Was left as a raw dict (only to_dict emitted citations; from_dict never rebuilt it).
+    assert isinstance(restored.citations, Citations)
+    assert restored.citations.urls[0].url == "http://e.com"


### PR DESCRIPTION
## Summary

`BaseRunOutputEvent.to_dict` emits `citations` (via `Citations.model_dump`), but
`from_dict` never rebuilt them — unlike the sibling complex fields `references` and
`reasoning_steps`, which are reconstructed via `model_validate`. A
`to_dict()` → `from_dict()` round-trip therefore left `citations` as a **raw dict**
instead of a `Citations` object, breaking any consumer that persists/replays run events
(e.g. Anthropic/Perplexity web citations) and expects the typed object.

```python
event = RunContentEvent(content="x", citations=Citations(urls=[UrlCitation(...)]))
RunContentEvent.from_dict(event.to_dict()).citations
# before: dict     after: Citations
```

## Fix

Reconstruct `citations` in `from_dict`, mirroring the `references` handling.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_run_event_from_dict_reconstructs_citations` asserts the round-trip yields a
`Citations` object with its urls preserved. It fails on `main` and passes with this fix;
full `test_run_events.py` (17 tests) passes; ruff + mypy clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
