### PR TITLE
fix: RAG retrieval runs on the unresolved template query

### DIFF
--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -920,6 +920,17 @@ def get_user_message(
                 else:
                     raise Exception("message must be a string or a callable when add_references is True")
 
+            # Resolve template variables before knowledge retrieval so RAG runs on the resolved
+            # query (e.g. "Tell me about quantum physics") rather than the literal template
+            # ("Tell me about {topic}").
+            if agent.resolve_in_context:
+                user_msg_content = format_message_with_state_variables(
+                    agent,
+                    user_msg_content,
+                    run_context=run_context,
+                )
+
+            if agent.add_knowledge_to_context:
                 try:
                     retrieval_timer = Timer()
                     retrieval_timer.start()
@@ -940,13 +951,6 @@ def get_user_message(
                     log_debug(f"Time to get references: {retrieval_timer.elapsed:.4f}s")
                 except Exception as e:
                     log_warning(f"Failed to get references: {str(e)}")
-
-            if agent.resolve_in_context:
-                user_msg_content = format_message_with_state_variables(
-                    agent,
-                    user_msg_content,
-                    run_context=run_context,
-                )
 
             # Convert to string for concatenation operations
             user_msg_content_str = get_text_from_message(user_msg_content) if user_msg_content is not None else ""
@@ -1085,6 +1089,17 @@ async def aget_user_message(
                 else:
                     raise Exception("message must be a string or a callable when add_references is True")
 
+            # Resolve template variables before knowledge retrieval so RAG runs on the resolved
+            # query (e.g. "Tell me about quantum physics") rather than the literal template
+            # ("Tell me about {topic}").
+            if agent.resolve_in_context:
+                user_msg_content = format_message_with_state_variables(
+                    agent,
+                    user_msg_content,
+                    run_context=run_context,
+                )
+
+            if agent.add_knowledge_to_context:
                 try:
                     retrieval_timer = Timer()
                     retrieval_timer.start()
@@ -1105,13 +1120,6 @@ async def aget_user_message(
                     log_debug(f"Time to get references: {retrieval_timer.elapsed:.4f}s")
                 except Exception as e:
                     log_warning(f"Failed to get references: {str(e)}")
-
-            if agent.resolve_in_context:
-                user_msg_content = format_message_with_state_variables(
-                    agent,
-                    user_msg_content,
-                    run_context=run_context,
-                )
 
             # Convert to string for concatenation operations
             user_msg_content_str = get_text_from_message(user_msg_content) if user_msg_content is not None else ""

--- a/libs/agno/tests/unit/agent/test_rag_retrieval_resolves_template.py
+++ b/libs/agno/tests/unit/agent/test_rag_retrieval_resolves_template.py
@@ -1,0 +1,65 @@
+"""Knowledge retrieval must run on the resolved query, not the literal template. With
+resolve_in_context=True (the default), retrieval fired before template variables were
+substituted, so RAG searched for "Tell me about {topic}" instead of the resolved text."""
+
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+
+
+class MockModel(Model):
+    def __init__(self):
+        super().__init__(id="m", name="m", provider="t")
+        self._r = ModelResponse(content="ok", role="assistant", response_usage=MessageMetrics())
+
+    def invoke(self, *a, **k) -> ModelResponse:
+        return self._r
+
+    async def ainvoke(self, *a, **k) -> ModelResponse:
+        return self._r
+
+    def invoke_stream(self, *a, **k) -> Iterator[ModelResponse]:
+        yield self._r
+
+    async def ainvoke_stream(self, *a, **k) -> AsyncIterator[ModelResponse]:
+        yield self._r
+        return
+
+    def _parse_provider_response(self, response: Any, **k) -> ModelResponse:
+        return self._r
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._r
+
+
+def _agent_capturing_query(captured):
+    def retriever(agent=None, query=None, **kwargs):
+        captured["query"] = query
+        return [{"content": "doc", "meta_data": {}}]
+
+    return Agent(
+        model=MockModel(),
+        knowledge_retriever=retriever,
+        add_knowledge_to_context=True,
+        search_knowledge=False,
+        dependencies={"topic": "quantum physics"},
+        resolve_in_context=True,
+    )
+
+
+def test_retrieval_uses_resolved_query_sync():
+    captured = {}
+    _agent_capturing_query(captured).run("Tell me about {topic}")
+    assert captured["query"] == "Tell me about quantum physics"
+
+
+@pytest.mark.asyncio
+async def test_retrieval_uses_resolved_query_async():
+    captured = {}
+    await _agent_capturing_query(captured).arun("Tell me about {topic}")
+    assert captured["query"] == "Tell me about quantum physics"


### PR DESCRIPTION
## Summary

With `resolve_in_context=True` (**the default**), knowledge retrieval fired using
`user_msg_content` **before** `format_message_with_state_variables` substituted the
template variables. For input like `"Tell me about {topic}"` with
`dependencies={"topic": "quantum physics"}`, the vector/knowledge search therefore ran on
the **literal** string `"Tell me about {topic}"`, while the model saw the correctly
resolved `"Tell me about quantum physics"`. Silent — no warning, just degraded/irrelevant
RAG results.

```python
Agent(..., add_knowledge_to_context=True, dependencies={"topic": "quantum physics"}).run("Tell me about {topic}")
# retriever received: "Tell me about {topic}"          (before)
# retriever received: "Tell me about quantum physics"  (after)
```

## Fix

Resolve template variables **before** knowledge retrieval so RAG uses the resolved query.
References are appended to the message afterward, so the reordering is safe. Both the sync
(`get_user_message`) and async (`aget_user_message`) paths are fixed.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_rag_retrieval_resolves_template.py` drives an offline `MockModel` agent with a
capturing retriever and asserts the retriever receives the resolved query (sync + async).
Both fail on `main` and pass with this fix; `test_dependencies_merge.py` (10 tests) still
passes; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
