### PR TITLE
fix: agentic memory search discards the native structured-output result

### DIFF
--- a/libs/agno/agno/memory/manager.py
+++ b/libs/agno/agno/memory/manager.py
@@ -715,8 +715,10 @@ class MemoryManager:
         ):
             memory_search = response.parsed
 
-        # Otherwise convert the response to the structured format
-        if isinstance(response.content, str):
+        # Otherwise convert the response to the structured format. Only do this when the native
+        # parse above didn't already produce a result, else a native-structured provider that
+        # returns valid `parsed` plus natural-language `content` has its good result clobbered.
+        if memory_search is None and isinstance(response.content, str):
             try:
                 memory_search = parse_response_model_str(response.content, MemorySearchResponse)  # type: ignore
 

--- a/libs/agno/tests/unit/memory/test_agentic_search_native_parsed.py
+++ b/libs/agno/tests/unit/memory/test_agentic_search_native_parsed.py
@@ -1,0 +1,60 @@
+"""Agentic memory search must keep a native structured-output result. The unconditional
+content re-parse clobbered it: a native provider returning a valid `parsed` plus
+natural-language `content` had its good result overwritten (and dropped to [])."""
+
+from typing import Any
+
+from agno.db.in_memory.in_memory_db import InMemoryDb
+from agno.memory.manager import MemoryManager, MemorySearchResponse, UserMemory
+from agno.models.base import Model
+from agno.models.response import ModelResponse
+
+
+def _model(parsed, content, native=True):
+    class _M(Model):
+        def __init__(self):
+            super().__init__(id="m", name="m", provider="t")
+            self.supports_native_structured_outputs = native
+
+        def response(self, messages=None, response_format=None, **kwargs):
+            r = ModelResponse(role="assistant")
+            r.parsed = parsed
+            r.content = content
+            return r
+
+        def invoke(self, *a, **k):
+            return None
+
+        async def ainvoke(self, *a, **k):
+            return None
+
+        def invoke_stream(self, *a, **k):
+            yield None
+
+        async def ainvoke_stream(self, *a, **k):
+            yield None
+            return
+
+        def _parse_provider_response(self, response: Any, **k) -> ModelResponse:
+            return ModelResponse(role="assistant")
+
+        def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+            return ModelResponse(role="assistant")
+
+    return _M()
+
+
+def _search(model):
+    manager = MemoryManager(model=model, db=InMemoryDb())
+    manager.read_from_db = lambda user_id=None: {"u1": [UserMemory(memory_id="m1", memory="A", user_id="u1")]}
+    return [m.memory_id for m in manager._search_user_memories_agentic(user_id="u1", query="q")]
+
+
+def test_native_parsed_with_natural_language_content_is_kept():
+    result = _search(_model(MemorySearchResponse(memory_ids=["m1"]), "I found it for you."))
+    assert result == ["m1"]
+
+
+def test_native_parsed_with_empty_content_is_kept():
+    result = _search(_model(MemorySearchResponse(memory_ids=["m1"]), ""))
+    assert result == ["m1"]


### PR DESCRIPTION
## Summary

`_search_user_memories_agentic` sets `memory_search` from `response.parsed` when the
model natively supports structured outputs:

```python
if model.supports_native_structured_outputs and response.parsed is not None and isinstance(response.parsed, MemorySearchResponse):
    memory_search = response.parsed

# Otherwise convert the response to the structured format
if isinstance(response.content, str):          # <-- runs unconditionally
    memory_search = parse_response_model_str(response.content, MemorySearchResponse)
    if memory_search is None:
        return []                              # <-- clobbers the good native result
```

The second block runs **unconditionally**, so a native-structured provider that returns a
valid `parsed` object **plus** natural-language (or empty) `content` has its good result
overwritten by a failed re-parse — and the search returns `[]`.

## Fix

Only re-parse `content` when the native parse didn't already produce a result
(`if memory_search is None and isinstance(response.content, str):`).

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_agentic_search_native_parsed.py`: a native parsed result is kept when content is
natural-language or empty. Both fail on `main` and pass with this fix; full
`test_memory_manager_crud.py` (43 tests) passes; ruff clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
