### PR TITLE
fix: cancelled streaming run persists content it never streamed

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -963,9 +963,13 @@ def _run_stream(
                         session_state=run_context.session_state,
                         run_context=run_context,
                     ):
+                        # Deliver the event before checking for cancellation: the model stream
+                        # has already committed this delta's content to run_response.content, so
+                        # cancelling before the yield would drop its RunContent event and leave the
+                        # streamed events diverging from the persisted/returned content.
+                        yield event
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             raise_if_cancelled(run_response.run_id)  # type: ignore
-                        yield event
                 else:
                     from agno.run.agent import (
                         IntermediateRunContentEvent,
@@ -2364,9 +2368,13 @@ async def _arun_stream(
                         session_state=run_context.session_state,
                         run_context=run_context,
                     ):
+                        # Deliver the event before checking for cancellation: the model stream
+                        # has already committed this delta's content to run_response.content, so
+                        # cancelling before the yield would drop its RunContent event and leave the
+                        # streamed events diverging from the persisted/returned content.
+                        yield event
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             await araise_if_cancelled(run_response.run_id)  # type: ignore
-                        yield event
                 else:
                     from agno.run.agent import (
                         IntermediateRunContentEvent,

--- a/libs/agno/tests/unit/agent/test_stream_cancel_content_consistency.py
+++ b/libs/agno/tests/unit/agent/test_stream_cancel_content_consistency.py
@@ -1,0 +1,60 @@
+"""A streaming run cancelled mid-stream must not persist content it never streamed. The
+model stream commits each delta to run_response.content before the cancel check yielded
+it, so cancelling before the yield dropped that delta's RunContent event while keeping its
+content -> the reconstructed stream diverged from the final RunOutput.content."""
+
+from typing import Any, AsyncIterator, Iterator
+
+
+from agno.agent import Agent
+from agno.models.base import Model
+from agno.models.response import ModelResponse
+from agno.run.agent import RunOutput
+
+
+class _ScriptedModel(Model):
+    def __init__(self, deltas):
+        super().__init__(id="m", name="m", provider="test")
+        self._deltas = deltas
+
+    def invoke(self, *a, **k):
+        raise NotImplementedError
+
+    async def ainvoke(self, *a, **k):
+        raise NotImplementedError
+
+    def invoke_stream(self, *a, **k) -> Iterator[ModelResponse]:
+        yield from self._deltas
+
+    async def ainvoke_stream(self, *a, **k) -> AsyncIterator[ModelResponse]:
+        for d in self._deltas:
+            yield d
+        return
+
+    def _parse_provider_response(self, response: Any, **k) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+
+def _deltas():
+    return [ModelResponse(content=w + " ", role="assistant") for w in ["one", "two", "three", "four", "five"]]
+
+
+def test_stream_cancel_content_matches_delivered_events():
+    agent = Agent(model=_ScriptedModel(_deltas()), telemetry=False)
+
+    seen = []
+    run_output = None
+    for event in agent.run("go", stream=True, stream_events=True, yield_run_output=True):
+        if isinstance(event, RunOutput):
+            run_output = event
+            continue
+        if event.event == "RunContent":
+            seen.append(event.content)
+            if len(seen) == 2:
+                agent.cancel_run(event.run_id)
+
+    # The persisted content must equal what was actually streamed (no un-emitted trailing delta).
+    assert "".join(seen) == run_output.content


### PR DESCRIPTION
## Summary

The model-response-stream loop commits each delta's content to `run_response.content`
(inside `handle_model_response_stream`) **before** the per-event cancel check runs. Because
`raise_if_cancelled(...)` fired **before** `yield event`, a mid-stream cancel dropped the
last delta's `RunContent` event while its content was already persisted — so the streamed
events diverge from the final/persisted `RunOutput.content`:

```
RunContent deltas DELIVERED : ['one ', 'two ']
Reconstructed from events   : 'one two '
Final RunOutput.content      : 'one two three '   <- 'three ' was committed but never streamed
```

A UI reconstructing the answer from `RunContent` deltas ends one delta short of what the
run reports and persists.

## Fix

Yield the event **before** checking for cancellation, so any delta whose content was
already committed to state is also delivered before the run cancels. Applied to the sync
(`_run_stream`) and async (`_arun_stream`) `run()` streaming paths.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

New `test_stream_cancel_content_consistency.py` cancels a streaming run after two deltas
and asserts the reconstructed stream equals the final `RunOutput.content`. It fails on
`main` and passes with this fix. Existing agent cancel/stream/continue tests (108) still
pass; ruff + mypy clean.

Prepared with AI assistance (Claude Code) and reviewed before submission.
