### PR TITLE
fix: connect MCP tools in sync team delegation

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -68,6 +68,7 @@ from agno.run.team import (
     TeamRunOutputEvent,
 )
 from agno.session import TeamSession
+from agno.team._member_execution import run_member_sync, stream_member_sync
 from agno.tools.function import Function
 from agno.utils.knowledge import get_agentic_or_user_search_filters
 from agno.utils.log import (
@@ -623,7 +624,8 @@ def _get_delegate_task_function(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     register_member_run(run_response.run_id, member_run_id)
-                member_agent_run_response_stream = member_agent.run(
+                member_agent_run_response_stream = stream_member_sync(
+                    member_agent,
                     input=member_agent_task if not history else history,
                     user_id=user_id,
                     # All members have the same session_id
@@ -684,7 +686,8 @@ def _get_delegate_task_function(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     register_member_run(run_response.run_id, member_run_id)
-                member_agent_run_response = member_agent.run(  # type: ignore
+                member_agent_run_response = run_member_sync(  # type: ignore
+                    member_agent,
                     input=member_agent_task if not history else history,  # type: ignore
                     user_id=user_id,
                     # All members have the same session_id
@@ -980,7 +983,8 @@ def _get_delegate_task_function(
                     member_run_id = str(uuid4())
                     if run_response.run_id is not None:
                         register_member_run(run_response.run_id, member_run_id)
-                    member_agent_run_response_stream = member_agent.run(
+                    member_agent_run_response_stream = stream_member_sync(
+                        member_agent,
                         input=member_agent_task if not history else history,
                         user_id=user_id,
                         # All members have the same session_id
@@ -1044,7 +1048,8 @@ def _get_delegate_task_function(
                     member_run_id = str(uuid4())
                     if run_response.run_id is not None:
                         register_member_run(run_response.run_id, member_run_id)
-                    member_agent_run_response = member_agent.run(  # type: ignore
+                    member_agent_run_response = run_member_sync(  # type: ignore
+                        member_agent,
                         input=member_agent_task if not history else history,
                         user_id=user_id,
                         # All members have the same session_id

--- a/libs/agno/agno/team/_member_execution.py
+++ b/libs/agno/agno/team/_member_execution.py
@@ -1,0 +1,141 @@
+"""Helpers for synchronous team member execution.
+
+These helpers detect MCP-backed members and route only those members through the
+async ``arun()`` path on a dedicated event loop, so connection and tool
+invocation happen on the same loop. Non-MCP members keep the fast sync
+``run()`` path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from queue import Queue
+from threading import Thread
+from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Coroutine, Iterator, TypeVar, Union
+
+from agno.agent import Agent
+
+if TYPE_CHECKING:
+    from agno.team.team import Team
+
+_T = TypeVar("_T")
+
+# Sentinel marking the end of a bridged async stream.
+_STREAM_END = object()
+
+# MCP toolkit class names, matched via MRO to avoid importing the MCP extras.
+_MCP_TOOLKIT_CLASS_NAMES = {"MCPTools", "MultiMCPTools"}
+
+
+class _AsyncStreamError:
+    """Wraps an exception raised inside the async stream worker thread."""
+
+    def __init__(self, error: BaseException) -> None:
+        self.error = error
+
+
+def _tools_contain_mcp(tools: Any) -> bool:
+    """Return True if a concrete tools list contains an MCP toolkit."""
+    if not isinstance(tools, list):
+        return False
+    for tool in tools:
+        tool_type = type(tool)
+        if hasattr(tool_type, "__mro__") and any(
+            base.__name__ in _MCP_TOOLKIT_CLASS_NAMES for base in tool_type.__mro__
+        ):
+            return True
+    return False
+
+
+def member_has_mcp_tools(member: Union[Agent, "Team"]) -> bool:
+    """Return True if the member (or, for a member Team, any of its members) uses MCP tools.
+
+    Callable tool/member factories are treated as non-MCP here: they are resolved
+    later inside the run, and the async ``arun()`` path handles MCP connection for
+    them anyway. We only need this fast check to decide whether to bridge the
+    top-level sync delegation call to ``arun()``.
+    """
+    if _tools_contain_mcp(getattr(member, "tools", None)):
+        return True
+
+    # For member Teams, MCP tools may live on nested members.
+    members = getattr(member, "members", None)
+    if isinstance(members, list):
+        return any(member_has_mcp_tools(sub_member) for sub_member in members)
+
+    return False
+
+
+def _run_coro_in_thread(factory: Callable[[], Coroutine[Any, Any, _T]]) -> _T:
+    """Run a coroutine to completion on a fresh event loop in a worker thread.
+
+    A dedicated thread + loop avoids clashing with any event loop already running
+    on the calling thread and guarantees the MCP session is connected and used on
+    the same loop.
+    """
+    result: dict[str, _T] = {}
+    error: dict[str, BaseException] = {}
+
+    def worker() -> None:
+        try:
+            result["value"] = asyncio.run(factory())
+        except BaseException as exc:  # noqa: BLE001 - re-raised on the calling thread
+            error["value"] = exc
+
+    thread = Thread(target=worker, daemon=True)
+    thread.start()
+    thread.join()
+
+    if "value" in error:
+        raise error["value"]
+    return result["value"]
+
+
+def _stream_coro_in_thread(factory: Callable[[], AsyncIterator[Any]]) -> Iterator[Any]:
+    """Consume an async iterator on a worker-thread loop and yield items synchronously."""
+    queue: "Queue[object]" = Queue()
+
+    def worker() -> None:
+        async def consume() -> None:
+            async for item in factory():
+                queue.put(item)
+
+        try:
+            asyncio.run(consume())
+        except BaseException as exc:  # noqa: BLE001 - surfaced to the consumer below
+            queue.put(_AsyncStreamError(exc))
+        finally:
+            queue.put(_STREAM_END)
+
+    thread = Thread(target=worker, daemon=True)
+    thread.start()
+    try:
+        while True:
+            item = queue.get()
+            if item is _STREAM_END:
+                break
+            if isinstance(item, _AsyncStreamError):
+                raise item.error
+            yield item
+    finally:
+        thread.join()
+
+
+def run_member_sync(member: Union[Agent, "Team"], **kwargs: Any) -> Any:
+    """Run a member synchronously, bridging MCP-backed members to ``arun()``.
+
+    Non-MCP members use the plain sync ``run()`` path.
+    """
+    if member_has_mcp_tools(member):
+        return _run_coro_in_thread(lambda: member.arun(**kwargs))  # type: ignore[arg-type]
+    return member.run(**kwargs)
+
+
+def stream_member_sync(member: Union[Agent, "Team"], **kwargs: Any) -> Iterator[Any]:
+    """Stream a member synchronously, bridging MCP-backed members to ``arun()``.
+
+    Non-MCP members use the plain sync streaming ``run()`` path.
+    """
+    if member_has_mcp_tools(member):
+        return _stream_coro_in_thread(lambda: member.arun(**kwargs))  # type: ignore[arg-type]
+    return member.run(**kwargs)

--- a/libs/agno/agno/team/_task_tools.py
+++ b/libs/agno/agno/team/_task_tools.py
@@ -59,6 +59,7 @@ from agno.team._default_tools import (
     _acascading_cancel_run,
     _cascading_cancel_run,
 )
+from agno.team._member_execution import run_member_sync, stream_member_sync
 from agno.team.task import TaskList, TaskStatus, save_task_list
 from agno.tools.function import Function
 from agno.utils.events import (
@@ -446,7 +447,8 @@ def _get_task_management_tools(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     register_member_run(run_response.run_id, member_run_id)
-                member_stream = member_agent.run(
+                member_stream = stream_member_sync(
+                    member_agent,
                     input=member_agent_task if not history else history,
                     user_id=user_id,
                     session_id=session.session_id,
@@ -498,7 +500,8 @@ def _get_task_management_tools(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     register_member_run(run_response.run_id, member_run_id)
-                member_run_response = member_agent.run(
+                member_run_response = run_member_sync(
+                    member_agent,
                     input=member_agent_task if not history else history,
                     user_id=user_id,
                     session_id=session.session_id,
@@ -814,7 +817,8 @@ def _get_task_management_tools(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     register_member_run(run_response.run_id, member_run_id)
-                member_run_response = member_agent.run(
+                member_run_response = run_member_sync(
+                    member_agent,
                     input=member_agent_task if not history else history,
                     user_id=user_id,
                     session_id=session.session_id,

--- a/libs/agno/tests/unit/team/test_mcp_sync_delegation.py
+++ b/libs/agno/tests/unit/team/test_mcp_sync_delegation.py
@@ -1,0 +1,208 @@
+"""Unit tests for sync team delegation routing MCP-backed members through arun()"""
+
+import asyncio
+
+import pytest
+
+from agno.team import _member_execution as me
+
+# Detection matches classes named exactly "MCPTools"/"MultiMCPTools"
+class MCPTools:
+    """Stand-in whose class name matches the MRO-based MCP detection."""
+
+
+class MCPToolsSubclass(MCPTools):
+    """Subclass to confirm detection walks the full MRO, not just the leaf class."""
+
+
+class MultiMCPTools:
+    """Stand-in for the multi-server MCP toolkit, matched by class name."""
+
+
+class PlainToolkit:
+    """A non-MCP toolkit that must never trigger the async bridge."""
+
+
+class RecordingMember:
+    """Minimal Agent-like member that records whether run() or arun() was used."""
+
+    def __init__(self, tools=None, members=None, result="sync-result", astream_items=None):
+        self.tools = tools
+        # ``members`` is only read for Team-like members; harmless on an Agent stand-in.
+        if members is not None:
+            self.members = members
+        self._result = result
+        self._astream_items = astream_items or []
+        self.run_called = False
+        self.arun_called = False
+
+    def run(self, **kwargs):
+        self.run_called = True
+        return self._result
+
+    async def arun(self, **kwargs):
+        self.arun_called = True
+        # Confirm we are on a live event loop (the bridge's whole point).
+        await asyncio.sleep(0)
+        return f"async-{self._result}"
+
+
+class RecordingStreamMember(RecordingMember):
+    """Member whose arun() returns an async iterator, mirroring stream=True."""
+
+    def run(self, **kwargs):
+        self.run_called = True
+
+        def _gen():
+            yield from self._astream_items
+
+        return _gen()
+
+    def arun(self, **kwargs):
+        self.arun_called = True
+
+        async def _agen():
+            for item in self._astream_items:
+                await asyncio.sleep(0)
+                yield item
+
+        return _agen()
+
+
+# --- Detection -------------------------------------------------------------
+
+
+def test_detects_direct_mcp_tools():
+    member = RecordingMember(tools=[PlainToolkit(), MCPTools()])
+    assert me.member_has_mcp_tools(member) is True
+
+
+def test_detects_mcp_tools_subclass_via_mro():
+    member = RecordingMember(tools=[MCPToolsSubclass()])
+    assert me.member_has_mcp_tools(member) is True
+
+
+def test_detects_multi_mcp_tools():
+    member = RecordingMember(tools=[MultiMCPTools()])
+    assert me.member_has_mcp_tools(member) is True
+
+
+def test_no_mcp_tools_is_false():
+    member = RecordingMember(tools=[PlainToolkit()])
+    assert me.member_has_mcp_tools(member) is False
+
+
+def test_none_tools_is_false():
+    assert me.member_has_mcp_tools(RecordingMember(tools=None)) is False
+
+
+def test_callable_tools_factory_treated_as_non_mcp():
+    # Callable factories are resolved later by arun(); the fast check must not
+    # try to introspect them (and must not raise).
+    member = RecordingMember(tools=lambda: [MCPTools()])
+    assert me.member_has_mcp_tools(member) is False
+
+
+def test_detects_mcp_in_nested_team_member():
+    inner_agent = RecordingMember(tools=[MCPTools()])
+    team_member = RecordingMember(tools=[PlainToolkit()], members=[inner_agent])
+    assert me.member_has_mcp_tools(team_member) is True
+
+
+def test_nested_team_without_mcp_is_false():
+    inner_agent = RecordingMember(tools=[PlainToolkit()])
+    team_member = RecordingMember(tools=None, members=[inner_agent])
+    assert me.member_has_mcp_tools(team_member) is False
+
+
+# --- run_member_sync routing ----------------------------------------------
+
+
+def test_non_mcp_member_uses_sync_run():
+    member = RecordingMember(tools=[PlainToolkit()], result="value")
+    result = me.run_member_sync(member, input="hi")
+    assert result == "value"
+    assert member.run_called is True
+    assert member.arun_called is False
+
+
+def test_mcp_member_bridges_to_arun():
+    member = RecordingMember(tools=[MCPTools()], result="value")
+    result = me.run_member_sync(member, input="hi")
+    assert result == "async-value"
+    assert member.arun_called is True
+    assert member.run_called is False
+
+
+def test_run_member_sync_forwards_kwargs_to_run():
+    seen = {}
+
+    class KwargMember(RecordingMember):
+        def run(self, **kwargs):
+            seen.update(kwargs)
+            return "ok"
+
+    member = KwargMember(tools=[PlainToolkit()])
+    me.run_member_sync(member, input="task", session_id="abc", stream=False)
+    assert seen == {"input": "task", "session_id": "abc", "stream": False}
+
+
+def test_run_member_sync_propagates_exception_from_arun():
+    class FailingMember(RecordingMember):
+        async def arun(self, **kwargs):
+            await asyncio.sleep(0)
+            raise ValueError("mcp boom")
+
+    member = FailingMember(tools=[MCPTools()])
+    with pytest.raises(ValueError, match="mcp boom"):
+        me.run_member_sync(member, input="hi")
+
+
+# --- stream_member_sync routing -------------------------------------------
+
+
+def test_non_mcp_stream_uses_sync_run():
+    member = RecordingStreamMember(tools=[PlainToolkit()], astream_items=["a", "b", "c"])
+    items = list(me.stream_member_sync(member, input="hi", stream=True))
+    assert items == ["a", "b", "c"]
+    assert member.run_called is True
+    assert member.arun_called is False
+
+
+def test_mcp_stream_bridges_to_arun_preserving_order():
+    member = RecordingStreamMember(tools=[MCPTools()], astream_items=[1, 2, 3, 4])
+    items = list(me.stream_member_sync(member, input="hi", stream=True))
+    assert items == [1, 2, 3, 4]
+    assert member.arun_called is True
+    assert member.run_called is False
+
+
+def test_mcp_stream_propagates_exception():
+    class FailingStreamMember(RecordingStreamMember):
+        def arun(self, **kwargs):
+            self.arun_called = True
+
+            async def _agen():
+                await asyncio.sleep(0)
+                yield "first"
+                raise RuntimeError("stream boom")
+
+            return _agen()
+
+    member = FailingStreamMember(tools=[MCPTools()])
+    collected = []
+    with pytest.raises(RuntimeError, match="stream boom"):
+        for item in me.stream_member_sync(member, input="hi", stream=True):
+            collected.append(item)
+    # The item emitted before the error should still have been delivered.
+    assert collected == ["first"]
+
+
+def test_bridge_runs_on_a_real_event_loop_even_when_caller_has_none():
+    # There must be no running loop on the calling thread; the bridge creates its
+    # own. asyncio.get_running_loop() would raise here if we were inside a loop.
+    with pytest.raises(RuntimeError):
+        asyncio.get_running_loop()
+
+    member = RecordingMember(tools=[MCPTools()], result="v")
+    assert me.run_member_sync(member, input="hi") == "async-v"


### PR DESCRIPTION
## Summary

MCP tools timeout when a team delegates to a member using the sync path, even though the same member works fine when run directly with `arun()`.                                                                                                                                                                                                                 

The underlying issue is that the MCP sessions are only connected on the async `aget_tools()` path and MCP tool entrypoints are async coroutines bound to the event loop they were connected on. Team delegation runs members through the sync `member_agent.run()` path, which never connects MCP tools, so `self.session` stays `None` and every MCP tool call hangs until it times out. 

Closes #7032 

## Changes

This PR adds `agno/team/_member_execution.py` with `run_member_sync()` and `stream_member_sync()`. These detect MCP backed members and route only those through the async `arun()` path on a dedicated event loop in a worker thread. Non MCP members keep the existing fast sync `run()` path unchanged.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
