### PR TITLE
[fix] Preserve component versions when resuming paused runs

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -90,6 +90,7 @@ from agno.utils.agent import (
     wait_for_open_threads,
     wait_for_thread_tasks_stream,
 )
+from agno.utils.component_versioning import pin_component_version_metadata
 from agno.utils.events import (
     add_error_event,
     create_run_cancelled_event,
@@ -1413,6 +1414,13 @@ def run_dispatch(
     response_format = get_response_format(agent, run_context=run_context) if agent.parser_model is None else None
 
     # Create a new run_response for this attempt
+    run_context.metadata = pin_component_version_metadata(
+        run_context.metadata,
+        component_type="agent",
+        component_id=agent.id,
+        version=getattr(agent, "_version", None),
+    )
+
     run_response = RunOutput(
         run_id=run_id,
         session_id=session_id,
@@ -2864,6 +2872,13 @@ def arun_dispatch(  # type: ignore
     response_format = get_response_format(agent, run_context=run_context) if agent.parser_model is None else None
 
     # Create a new run_response for this attempt
+    run_context.metadata = pin_component_version_metadata(
+        run_context.metadata,
+        component_type="agent",
+        component_id=agent.id,
+        version=getattr(agent, "_version", None),
+    )
+
     run_response = RunOutput(
         run_id=run_id,
         session_id=session_id,

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -1082,6 +1082,8 @@ def load(
 
     agent = cls.from_dict(config, registry=registry)
     agent.id = id
+    agent._version = data.get("version") if isinstance(data.get("version"), int) else version
+    agent._stage = data.get("stage")
     # Only fall back to the caller-provided db if the config didn't
     # reconstruct one. Otherwise we'd clobber any custom table names
     # (session_table, memory_table, ...) that were serialized with the agent.

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -1769,6 +1769,8 @@ def get_agent_by_id(
 
         agent = Agent.from_dict(cfg, registry=registry)
         agent.id = id
+        agent._version = row.get("version") if isinstance(row.get("version"), int) else version
+        agent._stage = row.get("stage")
 
         return agent
 

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -64,6 +64,7 @@ from agno.os.utils import (
 from agno.registry import Registry
 from agno.run.agent import RunErrorEvent, RunOutput
 from agno.run.base import RunStatus
+from agno.utils.component_versioning import get_pinned_component_version
 from agno.utils.log import log_debug, log_error, log_warning
 from agno.utils.serialize import json_serializer
 
@@ -1059,6 +1060,32 @@ def get_agent_router(
                 component_type="agents",
                 component_id=agent_id,
             )
+
+        if not isinstance(agent, RemoteAgent):
+            get_run_output = getattr(agent, "aget_run_output", None)
+            existing_run = (
+                await get_run_output(run_id=run_id, session_id=session_id, user_id=scoped_user_id or user_id)
+                if callable(get_run_output)
+                else None
+            )
+            if existing_run is not None:
+                pinned_version = get_pinned_component_version(
+                    existing_run.metadata,
+                    component_type="agent",
+                    component_id=agent_id,
+                )
+                if pinned_version is not None and pinned_version != getattr(agent, "_version", None):
+                    agent = await resolve_agent(
+                        agent_id,
+                        os.agents,
+                        factory.db if factory else os.db,
+                        os.registry,
+                        version=pinned_version,
+                        request=request,
+                        user_id=user_id,
+                        session_id=session_id,
+                    )
+                    _require_capability(agent, "acontinue_run", "continue_run")
 
         # Convert tools dict to ToolExecution objects if provided
         updated_tools = None

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -65,6 +65,7 @@ from agno.run.team import TeamRunOutput
 from agno.team.factory import TeamFactory
 from agno.team.remote import RemoteTeam
 from agno.team.team import Team
+from agno.utils.component_versioning import get_pinned_component_version
 from agno.utils.log import log_debug, log_warning, logger
 from agno.utils.serialize import json_serializer
 
@@ -1067,6 +1068,30 @@ def get_team_router(
                 component_type="teams",
                 component_id=team_id,
             )
+
+        if not isinstance(team, RemoteTeam):
+            existing_run = await team.aget_run_output(
+                run_id=run_id, session_id=session_id, user_id=scoped_user_id or user_id
+            )
+            if existing_run is not None:
+                pinned_version = get_pinned_component_version(
+                    existing_run.metadata,
+                    component_type="team",
+                    component_id=team_id,
+                )
+                if pinned_version is not None and pinned_version != getattr(team, "_version", None):
+                    team = await resolve_team(
+                        team_id,
+                        os.teams,
+                        factory.db if factory else os.db,
+                        registry,
+                        version=pinned_version,
+                        request=request,
+                        user_id=user_id,
+                        session_id=session_id,
+                    )
+                    if not isinstance(team, RemoteTeam):
+                        team.store_member_responses = True
 
         # Convert requirements dict to RunRequirement objects if provided
         updated_requirements = None

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -56,6 +56,7 @@ from agno.os.utils import (
 )
 from agno.run.base import RunStatus
 from agno.run.workflow import WorkflowErrorEvent
+from agno.utils.component_versioning import get_pinned_component_version
 from agno.utils.log import log_debug, log_warning, logger
 from agno.utils.serialize import json_serializer
 from agno.workflow.factory import WorkflowFactory
@@ -1398,6 +1399,27 @@ def get_workflow_router(
         )
         if existing_run is None:
             raise HTTPException(status_code=404, detail="Run not found")
+
+        pinned_version = get_pinned_component_version(
+            existing_run.metadata,
+            component_type="workflow",
+            component_id=workflow_id,
+        )
+        if pinned_version is not None and pinned_version != getattr(workflow, "_version", None):
+            workflow = await resolve_workflow(
+                workflow_id,
+                os.workflows,
+                os.db,
+                os.registry,
+                version=pinned_version,
+                request=request,
+                user_id=user_id,
+                session_id=session_id,
+                factory_input=factory_input,
+            )
+
+            if isinstance(workflow, RemoteWorkflow):
+                raise HTTPException(status_code=400, detail="Continue is not supported for remote workflows")
 
         if not getattr(existing_run, "is_paused", False):
             status = getattr(existing_run, "status", None)

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -2026,6 +2026,7 @@ async def resolve_team(
 ) -> Union[Team, RemoteTeam]:
     """Resolve a team by ID with proper error handling for both factory and non-factory paths."""
     is_factory = teams and any(isinstance(t, TeamFactory) and t.id == team_id for t in teams)
+    is_registered = bool(teams and any(t.id == team_id for t in teams))
     if is_factory:
         if request is None:
             raise HTTPException(status_code=400, detail="Request context is required for factory teams")
@@ -2046,7 +2047,12 @@ async def resolve_team(
             raise HTTPException(status_code=500, detail=f"Error in team factory: {e}")
     else:
         try:
-            team = get_team_by_id(team_id, teams, db=db, version=version, registry=registry, create_fresh=True)
+            if version is not None and isinstance(db, BaseDb) and not is_registered:
+                # Versioned DB-backed teams must load their component graph so member
+                # agents and nested teams use the versions linked to that team version.
+                team = Team.load(id=team_id, db=db, version=version, registry=registry)
+            else:
+                team = get_team_by_id(team_id, teams, db=db, version=version, registry=registry, create_fresh=True)
         except Exception as e:
             logger.error(f"Error resolving team '{team_id}': {e}")
             raise HTTPException(status_code=500, detail=f"Error resolving team: {e}")

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -96,6 +96,7 @@ from agno.utils.agent import (
     wait_for_open_threads,
     wait_for_thread_tasks_stream,
 )
+from agno.utils.component_versioning import pin_component_version_metadata
 from agno.utils.events import (
     add_team_error_event,
     create_team_run_cancelled_event,
@@ -1999,6 +2000,13 @@ def run_dispatch(
         )
 
         # Create a new run_response for this attempt
+        run_context.metadata = pin_component_version_metadata(
+            run_context.metadata,
+            component_type="team",
+            component_id=team.id,
+            version=getattr(team, "_version", None),
+        )
+
         run_response = TeamRunOutput(
             run_id=run_id,
             session_id=session_id,
@@ -4213,6 +4221,13 @@ def arun_dispatch(  # type: ignore
     )
 
     # Create a new run_response for this attempt
+    run_context.metadata = pin_component_version_metadata(
+        run_context.metadata,
+        component_type="team",
+        component_id=team.id,
+        version=getattr(team, "_version", None),
+    )
+
     run_response = TeamRunOutput(
         run_id=run_id,
         user_id=user_id,

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -1103,6 +1103,8 @@ def _hydrate_from_graph(
 
     team = cls.from_dict(config, db=db, registry=registry)
     team.id = graph["component"]["component_id"]
+    team._version = graph["config"].get("version")
+    team._stage = graph["config"].get("stage")
     # Only fall back to the caller-provided db if the config didn't
     # reconstruct one. Otherwise we'd clobber any custom table names
     # (session_table, memory_table, ...) that were serialized with the team.
@@ -1124,8 +1126,10 @@ def _hydrate_from_graph(
         member_type = link_meta.get("type")
 
         if member_type == "agent":
-            agent = Agent.from_dict(child_config)
+            agent = Agent.from_dict(child_config, registry=registry)
             agent.id = child_graph["component"]["component_id"]
+            agent._version = child_graph["config"].get("version")
+            agent._stage = child_graph["config"].get("stage")
             if agent.db is None:
                 agent.db = db
             team.members.append(agent)
@@ -1158,8 +1162,17 @@ def load(
     Returns:
         The team loaded from the database with hydrated members, or None if not found.
     """
-    # Use graph to load team + all members in a single DB call
-    graph = db.load_component_graph(id, version=version, label=label)
+    # Use graph to load team + all members in a single DB call.
+    # Resolve labels via get_config first because some DB implementations
+    # do not yet accept ``label=...`` on load_component_graph().
+    resolved_version = version
+    if resolved_version is None and label is not None:
+        data = db.get_config(component_id=id, label=label)
+        if data is None:
+            return None
+        resolved_version = data.get("version")
+
+    graph = db.load_component_graph(id, version=resolved_version)
     if graph is None:
         return None
 

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -1802,6 +1802,11 @@ def get_team_by_id(
         Team instance or None.
     """
     try:
+        if version is not None or label is not None:
+            # A versioned team must be loaded with its component graph so member
+            # agents and nested teams retain the versions linked to that config.
+            return Team.load(id=id, db=db, version=version, label=label, registry=registry)
+
         row = db.get_config(component_id=id, version=version, label=label)
         if row is None:
             return None
@@ -1813,6 +1818,8 @@ def get_team_by_id(
         team = Team.from_dict(cfg, db=db, registry=registry)
         # Ensure team.id is set to the component_id
         team.id = id
+        team._version = row.get("version") if isinstance(row.get("version"), int) else version
+        team._stage = row.get("stage")
 
         return team
 

--- a/libs/agno/agno/utils/component_versioning.py
+++ b/libs/agno/agno/utils/component_versioning.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional
+
+RUN_COMPONENT_PIN_KEY = "__agno_component_pin__"
+
+
+def pin_component_version_metadata(
+    metadata: Optional[Mapping[str, Any]],
+    *,
+    component_type: str,
+    component_id: Optional[str],
+    version: Optional[int],
+) -> Optional[Dict[str, Any]]:
+    """Return metadata with a pinned component snapshot for later resume/reload."""
+
+    metadata_dict: Dict[str, Any] = dict(metadata) if metadata is not None else {}
+
+    if component_id is not None and version is not None:
+        metadata_dict[RUN_COMPONENT_PIN_KEY] = {
+            "component_type": component_type,
+            "component_id": component_id,
+            "version": version,
+        }
+
+    return metadata_dict or None
+
+
+def get_pinned_component_version(
+    metadata: Optional[Mapping[str, Any]], *, component_type: str, component_id: Optional[str]
+) -> Optional[int]:
+    """Extract a pinned component version from run metadata when it matches the component."""
+
+    if metadata is None:
+        return None
+
+    pin = metadata.get(RUN_COMPONENT_PIN_KEY)
+    if not isinstance(pin, Mapping):
+        return None
+
+    if pin.get("component_type") != component_type:
+        return None
+    if component_id is not None and pin.get("component_id") != component_id:
+        return None
+
+    version = pin.get("version")
+    return version if isinstance(version, int) else None

--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -68,6 +68,24 @@ from agno.workflow.types import (
     UserInputField,
 )
 
+
+def _get_linked_child_version(
+    links: Optional[List[Dict[str, Any]]], *, link_kind: str, link_key: Optional[str], child_component_id: Optional[str]
+) -> Optional[int]:
+    if not links or link_key is None or child_component_id is None:
+        return None
+
+    for link in links:
+        if (
+            link.get("link_kind") == link_kind
+            and link.get("link_key") == link_key
+            and link.get("child_component_id") == child_component_id
+        ):
+            child_version = link.get("child_version")
+            return child_version if isinstance(child_version, int) else None
+    return None
+
+
 if TYPE_CHECKING:
     from agno.workflow.workflow import Workflow
 
@@ -320,6 +338,7 @@ class Step:
             Step: Reconstructed step instance
         """
         config = data.copy()
+        link_key = config.get("step_id") or config.get("name")
 
         agent = None
         team = None
@@ -329,9 +348,14 @@ class Step:
         # --- Handle Agent reconstruction ---
         if "agent_id" in config and config["agent_id"]:
             agent_id = config.get("agent_id")
+            agent_version = _get_linked_child_version(
+                links, link_kind="step_agent", link_key=link_key, child_component_id=agent_id
+            )
 
-            # First try registry (code-defined agents)
-            if registry and agent_id:
+            # Registry lookup is only valid when the workflow link does not pin
+            # a database version; otherwise it could silently drift to a newer
+            # code-defined component.
+            if agent_version is None and registry and agent_id:
                 registry_agent = registry.get_agent(agent_id)
                 if registry_agent is not None:
                     try:
@@ -344,11 +368,11 @@ class Step:
 
                         agent = registry_agent
 
-            # Fall back to database
+            # Resolve from the database, preserving any linked child version.
             if agent is None and db is not None and agent_id is not None:
                 from agno.agent.agent import get_agent_by_id
 
-                agent = get_agent_by_id(db=db, id=agent_id, registry=registry)
+                agent = get_agent_by_id(db=db, id=agent_id, version=agent_version, registry=registry)
 
             if agent is None and agent_id:
                 log_warning(
@@ -358,9 +382,19 @@ class Step:
         # --- Handle Team reconstruction ---
         if "team_id" in config and config["team_id"]:
             team_id = config.get("team_id")
+            team_version = _get_linked_child_version(
+                links, link_kind="step_team", link_key=link_key, child_component_id=team_id
+            )
 
-            # First try registry (code-defined teams)
-            if registry and team_id:
+            if team_version is not None and db is not None and team_id is not None:
+                from agno.team.team import Team
+
+                team = Team.load(id=team_id, db=db, version=team_version, registry=registry)
+
+            # Registry lookup is only valid when the workflow link does not pin
+            # a database version; otherwise it could silently drift to a newer
+            # code-defined component.
+            if team is None and team_version is None and registry and team_id:
                 registry_team = registry.get_team(team_id)
                 if registry_team is not None:
                     try:
@@ -373,11 +407,11 @@ class Step:
 
                         team = registry_team
 
-            # Fall back to database
+            # Resolve from the database, preserving any linked child version.
             if team is None and db is not None and team_id is not None:
-                from agno.team.team import get_team_by_id
+                from agno.team.team import Team
 
-                team = get_team_by_id(db=db, id=team_id, registry=registry)
+                team = Team.load(id=team_id, db=db, version=team_version, registry=registry)
 
             if team is None and team_id:
                 log_warning(

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -97,6 +97,7 @@ from agno.run.workflow import (
 from agno.session.workflow import WorkflowChatInteraction, WorkflowSession
 from agno.team.team import Team
 from agno.utils.agent import validate_input
+from agno.utils.component_versioning import pin_component_version_metadata
 from agno.utils.log import (
     log_debug,
     log_error,
@@ -1140,9 +1141,14 @@ class Workflow:
         if config is None:
             return None
 
-        workflow = cls.from_dict(config, db=db, registry=registry)
+        resolved_version = data.get("version") if isinstance(data.get("version"), int) else version
+        links = db.get_links(component_id=id, version=resolved_version) if resolved_version is not None else []
+
+        workflow = cls.from_dict(config, db=db, links=links, registry=registry)
 
         workflow.id = id
+        workflow._version = resolved_version
+        workflow._stage = data.get("stage")
         # Only fall back to the caller-provided db if the config didn't
         # reconstruct one. Otherwise we'd clobber any custom table names
         # (session_table, memory_table, ...) that were serialized with the
@@ -4149,6 +4155,12 @@ class Workflow:
             dependencies=resolved["dependencies"],
             metadata=resolved["metadata"],
         )
+        run_context.metadata = pin_component_version_metadata(
+            run_context.metadata,
+            component_type="workflow",
+            component_id=self.id,
+            version=getattr(self, "_version", None),
+        )
 
         # Register the run for cancellation tracking before spawning the detached task
         await aregister_run(run_context.run_id)
@@ -4163,6 +4175,7 @@ class Workflow:
             user_id=user_id,
             workflow_id=self.id,
             workflow_name=self.name,
+            metadata=run_context.metadata,
             created_at=int(datetime.now().timestamp()),
             status=RunStatus.pending,
         )
@@ -4292,6 +4305,12 @@ class Workflow:
             dependencies=resolved["dependencies"],
             metadata=resolved["metadata"],
         )
+        run_context.metadata = pin_component_version_metadata(
+            run_context.metadata,
+            component_type="workflow",
+            component_id=self.id,
+            version=getattr(self, "_version", None),
+        )
 
         # Register the run for cancellation tracking before spawning the detached task
         await aregister_run(run_context.run_id)
@@ -4306,6 +4325,7 @@ class Workflow:
             user_id=user_id,
             workflow_id=self.id,
             workflow_name=self.name,
+            metadata=run_context.metadata,
             created_at=int(datetime.now().timestamp()),
             status=RunStatus.pending,
         )
@@ -4475,6 +4495,12 @@ class Workflow:
             session_state=session_state,
             dependencies=dependencies,
         )
+        run_context.metadata = pin_component_version_metadata(
+            run_context.metadata,
+            component_type="workflow",
+            component_id=self.id,
+            version=getattr(self, "_version", None),
+        )
 
         # Register the run for cancellation tracking before spawning the detached task
         await aregister_run(run_context.run_id)
@@ -4489,6 +4515,7 @@ class Workflow:
             user_id=user_id,
             workflow_id=self.id,
             workflow_name=self.name,
+            metadata=run_context.metadata,
             created_at=int(datetime.now().timestamp()),
             status=RunStatus.running,
         )
@@ -5012,6 +5039,7 @@ class Workflow:
                 user_id=session.user_id,
                 workflow_id=self.id,
                 workflow_name=self.name,
+                metadata=run_context.metadata,
                 created_at=int(datetime.now().timestamp()),
                 content=agent_response.content,
                 status=RunStatus.completed,
@@ -5417,6 +5445,7 @@ class Workflow:
                 user_id=session.user_id,
                 workflow_id=self.id,
                 workflow_name=self.name,
+                metadata=run_context.metadata,
                 created_at=int(datetime.now().timestamp()),
                 content=agent_response.content,
                 status=RunStatus.completed,
@@ -9534,6 +9563,12 @@ class Workflow:
             dependencies=resolved["dependencies"],
             metadata=resolved["metadata"],
         )
+        run_context.metadata = pin_component_version_metadata(
+            run_context.metadata,
+            component_type="workflow",
+            component_id=self.id,
+            version=getattr(self, "_version", None),
+        )
 
         # Execute workflow agent if configured
         if self.agent is not None:
@@ -9555,6 +9590,7 @@ class Workflow:
             user_id=user_id,
             workflow_id=self.id,
             workflow_name=self.name,
+            metadata=run_context.metadata,
             created_at=int(datetime.now().timestamp()),
         )
 
@@ -9771,6 +9807,12 @@ class Workflow:
             dependencies=resolved["dependencies"],
             metadata=resolved["metadata"],
         )
+        run_context.metadata = pin_component_version_metadata(
+            run_context.metadata,
+            component_type="workflow",
+            component_id=self.id,
+            version=getattr(self, "_version", None),
+        )
 
         log_debug(f"Async Workflow Run Start: {self.name}", center=True)
 
@@ -9819,6 +9861,7 @@ class Workflow:
             user_id=user_id,
             workflow_id=self.id,
             workflow_name=self.name,
+            metadata=run_context.metadata,
             created_at=int(datetime.now().timestamp()),
         )
 
@@ -10783,6 +10826,8 @@ def get_workflow_by_id(
 
         # Ensure workflow.id is set to the component_id
         workflow.id = id
+        workflow._version = resolved_version if isinstance(resolved_version, int) else version
+        workflow._stage = row.get("stage")
 
         return workflow
 

--- a/libs/agno/tests/integration/os/test_component_version_pinning.py
+++ b/libs/agno/tests/integration/os/test_component_version_pinning.py
@@ -1,0 +1,258 @@
+import asyncio
+import json
+
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.os import AgentOS
+from agno.os.utils import resolve_team
+from agno.registry import Registry
+from agno.team import Team
+from agno.utils.component_versioning import get_pinned_component_version
+from agno.workflow import Workflow
+from agno.workflow.step import Step
+from agno.workflow.types import StepInput, StepOutput
+from agno.workflow.workflow import get_workflow_by_id
+
+
+def _approval_gate(step_input: StepInput) -> StepOutput:
+    return StepOutput(content="approved")
+
+
+def _finish_v1(step_input: StepInput) -> StepOutput:
+    return StepOutput(content="finished-v1")
+
+
+def _finish_v2(step_input: StepInput) -> StepOutput:
+    return StepOutput(content="finished-v2")
+
+
+def _build_versioned_hitl_workflow(db: SqliteDb, finish_executor):
+    return Workflow(
+        name="Versioned HITL Workflow",
+        id="versioned-hitl-workflow",
+        db=db,
+        telemetry=False,
+        steps=[
+            Step(
+                name="gate",
+                executor=_approval_gate,
+                requires_confirmation=True,
+                confirmation_message="Approve execution?",
+            ),
+            Step(name="finish", executor=finish_executor),
+        ],
+    )
+
+
+def test_continue_workflow_uses_pinned_version_after_new_version_saved(temp_storage_db_file):
+    db = SqliteDb(db_file=temp_storage_db_file)
+    registry = Registry(functions=[_approval_gate, _finish_v1, _finish_v2])
+
+    version_1 = _build_versioned_hitl_workflow(db, _finish_v1).save(db=db)
+    client = TestClient(AgentOS(db=db, registry=registry).get_app())
+
+    start_response = client.post(
+        "/workflows/versioned-hitl-workflow/runs",
+        data={"message": "go", "stream": "false"},
+    )
+    assert start_response.status_code == 200
+    start_data = start_response.json()
+    assert start_data["status"] == "PAUSED"
+
+    persisted_v1 = Workflow.load(id="versioned-hitl-workflow", db=db, registry=registry, version=version_1)
+    assert persisted_v1 is not None
+    paused_run = persisted_v1.get_run_output(run_id=start_data["run_id"], session_id=start_data["session_id"])
+    assert paused_run is not None
+    assert (
+        get_pinned_component_version(
+            paused_run.metadata,
+            component_type="workflow",
+            component_id="versioned-hitl-workflow",
+        )
+        == version_1
+    )
+
+    version_2 = _build_versioned_hitl_workflow(db, _finish_v2).save(db=db)
+    assert version_2 > version_1
+    latest_workflow = get_workflow_by_id(db=db, id="versioned-hitl-workflow", registry=registry)
+    assert latest_workflow is not None
+    assert latest_workflow._version == version_2
+
+    requirements = start_data["step_requirements"]
+    requirements[-1]["confirmed"] = True
+    continue_response = client.post(
+        f"/workflows/versioned-hitl-workflow/runs/{start_data['run_id']}/continue",
+        data={
+            "stream": "false",
+            "session_id": start_data["session_id"],
+            "step_requirements": json.dumps(requirements),
+        },
+    )
+
+    assert continue_response.status_code == 200
+    continue_data = continue_response.json()
+    assert continue_data["status"] == "COMPLETED"
+    assert "finished-v1" in (continue_data.get("content") or "")
+    assert "finished-v2" not in (continue_data.get("content") or "")
+
+
+def test_team_load_specific_version_preserves_saved_member_version(temp_storage_db_file):
+    db = SqliteDb(db_file=temp_storage_db_file)
+
+    version_1 = Team(
+        name="Versioned Team V1",
+        id="versioned-team",
+        db=db,
+        telemetry=False,
+        members=[Agent(name="Shared Member V1", id="shared-member", telemetry=False)],
+    ).save(db=db)
+    version_2 = Team(
+        name="Versioned Team V2",
+        id="versioned-team",
+        db=db,
+        telemetry=False,
+        members=[Agent(name="Shared Member V2", id="shared-member", telemetry=False)],
+    ).save(db=db)
+
+    loaded_v1 = Team.load(id="versioned-team", db=db, version=version_1)
+    loaded_latest = Team.load(id="versioned-team", db=db)
+
+    assert version_2 > version_1
+    assert loaded_v1 is not None
+    assert loaded_latest is not None
+    assert loaded_v1.name == "Versioned Team V1"
+    assert loaded_v1.members[0].name == "Shared Member V1"
+    assert loaded_latest.name == "Versioned Team V2"
+    assert loaded_latest.members[0].name == "Shared Member V2"
+
+
+def test_versioned_team_resolution_preserves_saved_member_version(temp_storage_db_file):
+    db = SqliteDb(db_file=temp_storage_db_file)
+
+    version_1 = Team(
+        name="Resolver Team V1",
+        id="resolver-team",
+        db=db,
+        telemetry=False,
+        members=[Agent(name="Resolver Member V1", id="resolver-member", telemetry=False)],
+    ).save(db=db)
+    Team(
+        name="Resolver Team V2",
+        id="resolver-team",
+        db=db,
+        telemetry=False,
+        members=[Agent(name="Resolver Member V2", id="resolver-member", telemetry=False)],
+    ).save(db=db)
+
+    resolved = asyncio.run(resolve_team("resolver-team", teams=None, db=db, version=version_1))
+
+    assert resolved is not None
+    assert resolved.name == "Resolver Team V1"
+    assert resolved.members[0].name == "Resolver Member V1"
+
+
+def test_get_workflow_by_id_specific_version_preserves_step_agent_version(temp_storage_db_file):
+    db = SqliteDb(db_file=temp_storage_db_file)
+
+    version_1 = Workflow(
+        name="Workflow Agent V1",
+        id="workflow-step-agent",
+        db=db,
+        telemetry=False,
+        steps=[Step(name="agent-step", agent=Agent(name="Step Agent V1", id="step-agent", telemetry=False))],
+    ).save(db=db)
+    Workflow(
+        name="Workflow Agent V2",
+        id="workflow-step-agent",
+        db=db,
+        telemetry=False,
+        steps=[Step(name="agent-step", agent=Agent(name="Step Agent V2", id="step-agent", telemetry=False))],
+    ).save(db=db)
+
+    workflow_v1 = get_workflow_by_id(db=db, id="workflow-step-agent", version=version_1)
+    workflow_latest = get_workflow_by_id(db=db, id="workflow-step-agent")
+
+    assert workflow_v1 is not None
+    assert workflow_latest is not None
+    assert workflow_v1.steps[0].agent is not None
+    assert workflow_latest.steps[0].agent is not None
+    assert workflow_v1.steps[0].agent.name == "Step Agent V1"
+    assert workflow_latest.steps[0].agent.name == "Step Agent V2"
+
+
+def test_workflow_class_load_specific_version_preserves_step_agent_version(temp_storage_db_file):
+    db = SqliteDb(db_file=temp_storage_db_file)
+
+    version_1 = Workflow(
+        name="Workflow Load Agent V1",
+        id="workflow-load-agent",
+        db=db,
+        telemetry=False,
+        steps=[Step(name="agent-step", agent=Agent(name="Load Agent V1", id="load-agent", telemetry=False))],
+    ).save(db=db)
+    Workflow(
+        name="Workflow Load Agent V2",
+        id="workflow-load-agent",
+        db=db,
+        telemetry=False,
+        steps=[Step(name="agent-step", agent=Agent(name="Load Agent V2", id="load-agent", telemetry=False))],
+    ).save(db=db)
+
+    workflow_v1 = Workflow.load(id="workflow-load-agent", db=db, version=version_1)
+
+    assert workflow_v1 is not None
+    assert workflow_v1.steps[0].agent is not None
+    assert workflow_v1.steps[0].agent.name == "Load Agent V1"
+
+
+def test_workflow_load_specific_version_preserves_step_team_version(temp_storage_db_file):
+    db = SqliteDb(db_file=temp_storage_db_file)
+
+    version_1 = Workflow(
+        name="Workflow Team V1",
+        id="workflow-step-team",
+        db=db,
+        telemetry=False,
+        steps=[
+            Step(
+                name="team-step",
+                team=Team(
+                    name="Step Team V1",
+                    id="step-team",
+                    telemetry=False,
+                    members=[Agent(name="Team Member V1", id="team-member", telemetry=False)],
+                ),
+            )
+        ],
+    ).save(db=db)
+    Workflow(
+        name="Workflow Team V2",
+        id="workflow-step-team",
+        db=db,
+        telemetry=False,
+        steps=[
+            Step(
+                name="team-step",
+                team=Team(
+                    name="Step Team V2",
+                    id="step-team",
+                    telemetry=False,
+                    members=[Agent(name="Team Member V2", id="team-member", telemetry=False)],
+                ),
+            )
+        ],
+    ).save(db=db)
+
+    workflow_v1 = get_workflow_by_id(db=db, id="workflow-step-team", version=version_1)
+    workflow_latest = get_workflow_by_id(db=db, id="workflow-step-team")
+
+    assert workflow_v1 is not None
+    assert workflow_latest is not None
+    assert workflow_v1.steps[0].team is not None
+    assert workflow_latest.steps[0].team is not None
+    assert workflow_v1.steps[0].team.name == "Step Team V1"
+    assert workflow_v1.steps[0].team.members[0].name == "Team Member V1"
+    assert workflow_latest.steps[0].team.name == "Step Team V2"
+    assert workflow_latest.steps[0].team.members[0].name == "Team Member V2"

--- a/libs/agno/tests/unit/agent/test_agent_config.py
+++ b/libs/agno/tests/unit/agent/test_agent_config.py
@@ -615,6 +615,20 @@ class TestAgentLoad:
         assert agent is not None
         assert agent.db == mock_db
 
+    def test_load_sets_component_metadata(self, mock_db):
+        """Test load preserves component version metadata for resume pinning."""
+        mock_db.get_config.return_value = {
+            "config": {"id": "meta-agent", "name": "Meta Agent"},
+            "version": 2,
+            "stage": "published",
+        }
+
+        agent = Agent.load(id="meta-agent", db=mock_db)
+
+        assert agent is not None
+        assert agent._version == 2
+        assert agent._stage == "published"
+
     def test_save_load_preserves_store_history_messages(self, mock_db):
         """Test that store_history_messages=True survives save/load round-trip."""
         agent = Agent(id="persist-agent", name="Persist Agent", store_history_messages=True, db=mock_db)
@@ -763,6 +777,20 @@ class TestGetAgentById:
 
         assert agent is not None
         assert agent.db == mock_db
+
+    def test_get_agent_by_id_sets_component_metadata(self, mock_db):
+        """Test get_agent_by_id preserves component version metadata."""
+        mock_db.get_config.return_value = {
+            "config": {"id": "meta-agent", "name": "Meta Agent"},
+            "version": 3,
+            "stage": "published",
+        }
+
+        agent = get_agent_by_id(db=mock_db, id="meta-agent")
+
+        assert agent is not None
+        assert agent._version == 3
+        assert agent._stage == "published"
 
     def test_get_agent_by_id_handles_error(self, mock_db):
         """Test get_agent_by_id returns None on error."""

--- a/libs/agno/tests/unit/os/routers/test_continue_version_pinning.py
+++ b/libs/agno/tests/unit/os/routers/test_continue_version_pinning.py
@@ -1,0 +1,154 @@
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.os import AgentOS
+from agno.run import RunStatus
+from agno.run.agent import RunOutput
+from agno.run.team import TeamRunOutput
+from agno.run.workflow import WorkflowRunOutput
+from agno.team import Team
+from agno.utils.component_versioning import pin_component_version_metadata
+from agno.workflow import Workflow
+
+
+class _FakeEntity:
+    def __init__(self, entity_id: str, version: int, paused_run):
+        self.id = entity_id
+        self.name = entity_id
+        self._version = version
+        self._paused_run = paused_run
+        self.store_member_responses = False
+        self.continued = False
+
+    async def aget_run_output(self, **kwargs):
+        return self._paused_run
+
+    async def acontinue_run(self, **kwargs):
+        self.continued = True
+        payload = {
+            "run_id": kwargs["run_id"],
+            "session_id": kwargs.get("session_id"),
+            "status": RunStatus.completed,
+            "metadata": self._paused_run.metadata,
+        }
+        for field in ("agent_id", "team_id", "workflow_id"):
+            value = getattr(self._paused_run, field, None)
+            if value is not None:
+                payload[field] = value
+        return self._paused_run.__class__(**payload)
+
+
+def test_agent_continue_reloads_pinned_version(monkeypatch):
+    from agno.os.routers.agents import router as agent_router
+
+    paused = RunOutput(
+        run_id="run-1",
+        session_id="sess-1",
+        status=RunStatus.paused,
+        agent_id="agent-1",
+        metadata=pin_component_version_metadata(None, component_type="agent", component_id="agent-1", version=1),
+    )
+    current = _FakeEntity("agent-1", 2, paused)
+    pinned = _FakeEntity("agent-1", 1, paused)
+    resolved_versions = []
+
+    monkeypatch.setattr(agent_router, "get_agent_by_id", lambda **kwargs: current)
+
+    async def _resolve_agent(*args, version=None, **kwargs):
+        resolved_versions.append(version)
+        return pinned
+
+    monkeypatch.setattr(agent_router, "resolve_agent", _resolve_agent)
+
+    response = TestClient(AgentOS(agents=[Agent(id="placeholder-agent")]).get_app()).post(
+        "/agents/agent-1/runs/run-1/continue", data={"session_id": "sess-1", "stream": "false"}
+    )
+
+    assert response.status_code == 200
+    assert resolved_versions == [1]
+    assert pinned.continued is True
+
+
+def test_team_continue_reloads_pinned_version(monkeypatch):
+    from agno.os.routers.teams import router as team_router
+
+    paused = TeamRunOutput(
+        run_id="run-1",
+        session_id="sess-1",
+        status=RunStatus.paused,
+        team_id="team-1",
+        metadata=pin_component_version_metadata(None, component_type="team", component_id="team-1", version=1),
+    )
+    current = _FakeEntity("team-1", 2, paused)
+    pinned = _FakeEntity("team-1", 1, paused)
+    resolved_versions = []
+
+    monkeypatch.setattr(team_router, "get_team_by_id", lambda **kwargs: current)
+
+    async def _resolve_team(*args, version=None, **kwargs):
+        resolved_versions.append(version)
+        return pinned
+
+    monkeypatch.setattr(team_router, "resolve_team", _resolve_team)
+
+    response = TestClient(AgentOS(teams=[Team(id="placeholder-team", members=[])]).get_app()).post(
+        "/teams/team-1/runs/run-1/continue", data={"session_id": "sess-1", "stream": "false"}
+    )
+
+    assert response.status_code == 200
+    assert resolved_versions == [1]
+    assert pinned.continued is True
+
+
+def test_agent_continue_allows_missing_persisted_run_for_backward_compat(monkeypatch):
+    from agno.os.routers.agents import router as agent_router
+
+    paused = RunOutput(
+        run_id="run-1",
+        session_id="sess-1",
+        status=RunStatus.paused,
+        agent_id="agent-1",
+        metadata=pin_component_version_metadata(None, component_type="agent", component_id="agent-1", version=1),
+    )
+    current = _FakeEntity("agent-1", 2, paused)
+    current.aget_run_output = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(agent_router, "get_agent_by_id", lambda **kwargs: current)
+
+    response = TestClient(AgentOS(agents=[Agent(id="placeholder-agent")]).get_app()).post(
+        "/agents/agent-1/runs/run-1/continue", data={"session_id": "sess-1", "stream": "false"}
+    )
+
+    assert response.status_code == 200
+    assert current.continued is True
+
+
+def test_workflow_continue_reloads_pinned_version(monkeypatch):
+    from agno.os.routers.workflows import router as workflow_router
+
+    paused = WorkflowRunOutput(
+        run_id="run-1",
+        session_id="sess-1",
+        status=RunStatus.paused,
+        workflow_id="workflow-1",
+        metadata=pin_component_version_metadata(None, component_type="workflow", component_id="workflow-1", version=1),
+    )
+    current = _FakeEntity("workflow-1", 2, paused)
+    pinned = _FakeEntity("workflow-1", 1, paused)
+    resolved_versions = []
+
+    async def _resolve_workflow(*args, version=None, **kwargs):
+        resolved_versions.append(version)
+        return current if version is None else pinned
+
+    monkeypatch.setattr(workflow_router, "resolve_workflow", _resolve_workflow)
+
+    response = TestClient(AgentOS(workflows=[Workflow(id="placeholder-workflow")]).get_app()).post(
+        "/workflows/workflow-1/runs/run-1/continue", data={"session_id": "sess-1", "stream": "false"}
+    )
+
+    assert response.status_code == 200
+    assert resolved_versions == [None, 1]
+    assert pinned.continued is True

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -626,10 +626,11 @@ class TestTeamLoad:
 
         Team.load(id="versioned-team", db=mock_db, version=2)
 
-        mock_db.load_component_graph.assert_called_once_with("versioned-team", version=2, label=None)
+        mock_db.load_component_graph.assert_called_once_with("versioned-team", version=2)
 
     def test_load_with_label(self, mock_db):
         """Test load retrieves labeled version."""
+        mock_db.get_config.return_value = {"version": 3}
         mock_db.load_component_graph.return_value = {
             "component": {"component_id": "labeled-team"},
             "config": {"config": {"id": "labeled-team", "name": "Production Team"}},
@@ -638,7 +639,8 @@ class TestTeamLoad:
 
         Team.load(id="labeled-team", db=mock_db, label="production")
 
-        mock_db.load_component_graph.assert_called_once_with("labeled-team", version=None, label="production")
+        mock_db.get_config.assert_called_once_with(component_id="labeled-team", label="production")
+        mock_db.load_component_graph.assert_called_once_with("labeled-team", version=3)
 
     def test_load_hydrates_member_agents(self, mock_db):
         """Test load hydrates member agents from graph."""
@@ -694,6 +696,34 @@ class TestTeamLoad:
 
         assert team is not None
         assert team.db == mock_db
+
+    def test_load_sets_component_metadata_on_root_and_members(self, mock_db):
+        """Test load preserves version metadata for the saved team graph."""
+        mock_db.load_component_graph.return_value = {
+            "component": {"component_id": "meta-team"},
+            "config": {"config": {"id": "meta-team", "name": "Meta Team"}, "version": 2, "stage": "published"},
+            "children": [
+                {
+                    "link": {"meta": {"type": "agent"}},
+                    "graph": {
+                        "component": {"component_id": "agent-v1"},
+                        "config": {
+                            "config": {"id": "agent-v1", "name": "Agent V1"},
+                            "version": 1,
+                            "stage": "published",
+                        },
+                    },
+                }
+            ],
+        }
+
+        team = Team.load(id="meta-team", db=mock_db)
+
+        assert team is not None
+        assert team._version == 2
+        assert team._stage == "published"
+        assert team.members[0]._version == 1
+        assert team.members[0]._stage == "published"
 
 
 # =============================================================================
@@ -782,19 +812,31 @@ class TestGetTeamById:
 
     def test_get_team_by_id_with_version(self, mock_db):
         """Test get_team_by_id retrieves specific version."""
-        mock_db.get_config.return_value = {"config": {"id": "versioned", "name": "V3"}}
+        mock_db.load_component_graph.return_value = {
+            "component": {"component_id": "versioned"},
+            "config": {"config": {"id": "versioned", "name": "V3"}, "version": 3},
+            "children": [],
+        }
 
-        get_team_by_id(db=mock_db, id="versioned", version=3)
+        team = get_team_by_id(db=mock_db, id="versioned", version=3)
 
-        mock_db.get_config.assert_called_once_with(component_id="versioned", version=3, label=None)
+        assert team is not None
+        mock_db.load_component_graph.assert_called_once_with("versioned", version=3)
 
     def test_get_team_by_id_with_label(self, mock_db):
         """Test get_team_by_id retrieves labeled version."""
-        mock_db.get_config.return_value = {"config": {"id": "labeled", "name": "Staging"}}
+        mock_db.get_config.return_value = {"version": 4}
+        mock_db.load_component_graph.return_value = {
+            "component": {"component_id": "labeled"},
+            "config": {"config": {"id": "labeled", "name": "Staging"}, "version": 4},
+            "children": [],
+        }
 
-        get_team_by_id(db=mock_db, id="labeled", label="staging")
+        team = get_team_by_id(db=mock_db, id="labeled", label="staging")
 
-        mock_db.get_config.assert_called_once_with(component_id="labeled", version=None, label="staging")
+        assert team is not None
+        mock_db.get_config.assert_called_once_with(component_id="labeled", label="staging")
+        mock_db.load_component_graph.assert_called_once_with("labeled", version=4)
 
     def test_get_team_by_id_with_registry(self, mock_db):
         """Test get_team_by_id passes registry."""
@@ -834,6 +876,20 @@ class TestGetTeamById:
 
         assert team is not None
         assert team.db == mock_db
+
+    def test_get_team_by_id_sets_component_metadata(self, mock_db):
+        """Test get_team_by_id preserves component version metadata."""
+        mock_db.get_config.return_value = {
+            "config": {"id": "meta-team", "name": "Meta Team"},
+            "version": 4,
+            "stage": "published",
+        }
+
+        team = get_team_by_id(db=mock_db, id="meta-team")
+
+        assert team is not None
+        assert team._version == 4
+        assert team._stage == "published"
 
     def test_get_team_by_id_handles_error(self, mock_db):
         """Test get_team_by_id returns None on error."""

--- a/libs/agno/tests/unit/workflow/test_step_serialization.py
+++ b/libs/agno/tests/unit/workflow/test_step_serialization.py
@@ -235,8 +235,68 @@ class TestStepFromDict:
             mock_db = MagicMock()
             step = Step.from_dict(data, registry=registry, db=mock_db)
 
-            mock_get_agent.assert_called_once_with(db=mock_db, id="db-agent", registry=registry)
+            mock_get_agent.assert_called_once_with(db=mock_db, id="db-agent", version=None, registry=registry)
             assert step.agent is mock_db_agent
+
+    def test_from_dict_agent_uses_linked_child_version(self):
+        """Test from_dict honors pinned child agent versions from workflow links."""
+        mock_agent = MagicMock()
+        mock_agent.id = "db-agent"
+        data = {"type": "Step", "name": "db-step", "agent_id": "db-agent"}
+        links = [
+            {"link_kind": "step_agent", "link_key": "db-step", "child_component_id": "db-agent", "child_version": 7}
+        ]
+
+        with patch("agno.agent.agent.get_agent_by_id") as mock_get_agent:
+            mock_get_agent.return_value = mock_agent
+            step = Step.from_dict(data, db=MagicMock(), links=links)
+
+            mock_get_agent.assert_called_once()
+            assert mock_get_agent.call_args.kwargs["version"] == 7
+            assert step.agent is mock_agent
+
+    def test_from_dict_pinned_agent_does_not_fallback_to_registry(self):
+        """Test a missing pinned agent version cannot silently drift to registry state."""
+        data = {"type": "Step", "name": "db-step", "agent_id": "db-agent"}
+        links = [
+            {"link_kind": "step_agent", "link_key": "db-step", "child_component_id": "db-agent", "child_version": 7}
+        ]
+        registry = MagicMock()
+        registry.get_agent.return_value = MagicMock()
+
+        with patch("agno.agent.agent.get_agent_by_id", return_value=None), pytest.raises(ValueError):
+            Step.from_dict(data, db=MagicMock(), links=links, registry=registry)
+
+        registry.get_agent.assert_not_called()
+
+    def test_from_dict_team_uses_linked_child_version(self):
+        """Test from_dict honors pinned child team versions from workflow links."""
+        mock_team = MagicMock()
+        mock_team.id = "db-team"
+        data = {"type": "Step", "name": "team-step", "team_id": "db-team"}
+        links = [
+            {"link_kind": "step_team", "link_key": "team-step", "child_component_id": "db-team", "child_version": 5}
+        ]
+
+        with patch("agno.team.team.Team.load") as mock_load_team:
+            mock_load_team.return_value = mock_team
+            step = Step.from_dict(data, db=MagicMock(), links=links)
+
+            mock_load_team.assert_called_once()
+            assert mock_load_team.call_args.kwargs["version"] == 5
+            assert step.team is mock_team
+
+    def test_from_dict_pinned_team_does_not_fallback_to_registry(self):
+        """Test a missing pinned team version cannot silently drift to registry state."""
+        data = {"type": "Step", "name": "db-step", "team_id": "db-team"}
+        links = [{"link_kind": "step_team", "link_key": "db-step", "child_component_id": "db-team", "child_version": 5}]
+        registry = MagicMock()
+        registry.get_team.return_value = MagicMock()
+
+        with patch("agno.team.team.Team.load", return_value=None), pytest.raises(ValueError):
+            Step.from_dict(data, db=MagicMock(), links=links, registry=registry)
+
+        registry.get_team.assert_not_called()
 
     def test_from_dict_team_resolved_from_registry(self):
         """Test from_dict resolves team from registry before DB."""

--- a/libs/agno/tests/unit/workflow/test_workflow_config.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_config.py
@@ -430,6 +430,20 @@ class TestWorkflowLoad:
 
         mock_db.get_config.assert_called_once_with(component_id="labeled-workflow", label="production", version=None)
 
+    def test_load_sets_component_metadata(self, mock_db):
+        """Test load preserves component version metadata."""
+        mock_db.get_config.return_value = {
+            "config": {"id": "meta-workflow", "name": "Meta Workflow"},
+            "version": 2,
+            "stage": "published",
+        }
+
+        workflow = Workflow.load(id="meta-workflow", db=mock_db)
+
+        assert workflow is not None
+        assert workflow._version == 2
+        assert workflow._stage == "published"
+
     def test_load_returns_none_when_not_found(self, mock_db):
         """Test load returns None when workflow not found."""
         mock_db.get_config.return_value = None
@@ -529,6 +543,22 @@ class TestGetWorkflowById:
         assert workflow is not None
         assert workflow.id == "found-workflow"
         assert workflow.name == "Found Workflow"
+        assert workflow._version == 1
+
+    def test_get_workflow_by_id_sets_component_metadata(self, mock_db):
+        """Test get_workflow_by_id preserves component version metadata."""
+        mock_db.get_config.return_value = {
+            "config": {"id": "meta-workflow", "name": "Meta Workflow"},
+            "version": 3,
+            "stage": "published",
+        }
+        mock_db.get_links.return_value = []
+
+        workflow = get_workflow_by_id(db=mock_db, id="meta-workflow")
+
+        assert workflow is not None
+        assert workflow._version == 3
+        assert workflow._stage == "published"
 
     def test_get_workflow_by_id_with_version(self, mock_db):
         """Test get_workflow_by_id retrieves specific version."""


### PR DESCRIPTION
## Summary

Addresses the paused-run version-pinning portion of #8979.

DB-backed AgentOS runs now record the Agent, Team, or Workflow component version used when the run starts. When a paused run is continued, AgentOS resolves that saved version instead of silently switching to a newer current version.

This change also preserves linked component versions while rehydrating versioned Team graphs and Workflow step Agents/Teams, preventing nested components from drifting during the same resume path. Runs created before this metadata existed retain the previous fallback behavior.

Issue #8979 describes three independent persistence gaps. This PR intentionally covers only paused-run component-version drift. Callable Workspace tools persistence and Skills persistence remain separate follow-up changes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (no public API or documentation change required)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (not applicable; regression coverage exercises the AgentOS API flow)
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] No similar PR exists that requires an approach comparison
- [x] This PR was AI-assisted. I reviewed and understand the implementation, manually verified the behavior, and ran the repository checks and focused regression suite.

---

## Additional Notes

Validation performed:

- `./scripts/format.sh`
- `./scripts/validate.sh`
- Focused Agent/Team/Workflow configuration, continuation-router, and integration coverage: **206 passed**
- Manual SQLite-backed AgentOS workflow: start v1, pause, save v2, continue the paused run, and confirm it completes with the v1 executor

No external model or API credentials are required for the regression flow.
