### PR TITLE
feat: add Smallest AI text-to-speech toolkit

### DIFF
--- a/cookbook/91_tools/smallest_tools.py
+++ b/cookbook/91_tools/smallest_tools.py
@@ -1,0 +1,81 @@
+"""
+Smallest AI text-to-speech tools.
+
+Requires the SMALLEST_API_KEY environment variable.
+Get an API key at https://app.smallest.ai/dashboard (Developer -> API Keys).
+
+Models:
+- lightning_v3.1 (default): 12 languages, supports cloned voices
+- lightning_v3.1_pro: premium voice pool, 29 languages
+
+Language defaults to "en". For other language codes, see the model cards:
+https://docs.smallest.ai/waves/model-cards/text-to-speech/lightning-v-3-1
+https://docs.smallest.ai/waves/model-cards/text-to-speech/lightning-v-3-1-pro
+"""
+
+import base64
+from textwrap import dedent
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.smallest import SmallestTools
+from agno.utils.media import save_base64_data
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+
+audio_agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[
+        SmallestTools(
+            voice_id="magnus",
+            model="lightning_v3.1",
+        )
+    ],
+    description="You are an AI agent that can generate audio using the Smallest AI API.",
+    instructions=[
+        dedent(
+            """
+            You have access to the Smallest AI toolkit:
+            - Use the `text_to_speech` tool to convert text into natural voice audio.
+            - Use the `get_voices` tool to list the available voices.
+            Keep the audio prompt as defined by the user.
+            """
+        ),
+    ],
+    markdown=True,
+)
+
+# Premium voices: use the Lightning v3.1 Pro pool with a Pro voice
+pro_audio_agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[
+        SmallestTools(
+            voice_id="meher",
+            model="lightning_v3.1_pro",
+        )
+    ],
+    description="You are an AI agent that can generate premium audio using the Smallest AI API.",
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    response = audio_agent.run(
+        "Generate a short audio welcoming listeners to a podcast about the history of aviation.",
+    )
+
+    if response.audio:
+        print("Agent response:", response.content)
+        base64_audio = base64.b64encode(response.audio[0].content).decode("utf-8")
+        save_base64_data(base64_audio, "tmp/podcast_welcome.wav")
+
+    # response2 = pro_audio_agent.run("Generate a short audio narrating a movie trailer.")
+    # if response2.audio:
+    #     print("Agent response:", response2.content)
+    #     base64_audio = base64.b64encode(response2.audio[0].content).decode("utf-8")
+    #     save_base64_data(base64_audio, "tmp/movie_trailer.wav")

--- a/libs/agno/agno/tools/smallest.py
+++ b/libs/agno/agno/tools/smallest.py
@@ -1,7 +1,7 @@
 import json
 from os import getenv, path
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union, get_args
 from uuid import uuid4
 
 import httpx
@@ -23,6 +23,7 @@ SmallestModel = Literal[
     "lightning_v3.1",  # 12 languages, supports cloned voices
     "lightning_v3.1_pro",  # premium voice pool, 29 languages
 ]
+SMALLEST_MODELS = get_args(SmallestModel)
 
 SmallestOutputFormat = Literal["wav", "mp3", "pcm", "ulaw", "alaw"]
 
@@ -55,6 +56,9 @@ class SmallestTools(Toolkit):
         self.api_key = api_key or getenv("SMALLEST_API_KEY")
         if not self.api_key:
             log_error("SMALLEST_API_KEY not set. Please set the SMALLEST_API_KEY environment variable.")
+
+        if model not in SMALLEST_MODELS:
+            raise ValueError(f"Invalid model '{model}'. Valid options are: {', '.join(SMALLEST_MODELS)}")
 
         self.voice_id = voice_id
         self.model = model
@@ -100,7 +104,12 @@ class SmallestTools(Toolkit):
 
             voices_data = response.json()
             if isinstance(voices_data, dict):
-                voices = voices_data.get("voices") or voices_data.get("data") or voices_data
+                if "voices" in voices_data:
+                    voices = voices_data["voices"]
+                elif "data" in voices_data:
+                    voices = voices_data["data"]
+                else:
+                    voices = voices_data
             else:
                 voices = voices_data
 
@@ -181,6 +190,8 @@ class SmallestTools(Toolkit):
                 id=str(uuid4()),
                 content=audio_data,
                 mime_type=mime_type,
+                format=self.output_format,
+                sample_rate=self.sample_rate,
             )
 
             return ToolResult(

--- a/libs/agno/agno/tools/smallest.py
+++ b/libs/agno/agno/tools/smallest.py
@@ -47,10 +47,11 @@ class SmallestTools(Toolkit):
         speed: float = 1.0,
         output_format: SmallestOutputFormat = "wav",
         target_directory: Optional[str] = None,
+        base_url: str = SMALLEST_TTS_URL,
         enable_get_voices: bool = True,
         enable_text_to_speech: bool = True,
         all: bool = False,
-        timeout: int = 30,
+        timeout: float = 30,
         **kwargs,
     ):
         self.api_key = api_key or getenv("SMALLEST_API_KEY")
@@ -67,6 +68,8 @@ class SmallestTools(Toolkit):
         self.speed = speed
         self.output_format = output_format
         self.target_directory = target_directory
+        self.base_url = base_url
+        self.timeout = timeout
 
         if self.target_directory:
             target_path = Path(self.target_directory)
@@ -78,7 +81,7 @@ class SmallestTools(Toolkit):
         if all or enable_text_to_speech:
             tools.append(self.text_to_speech)
 
-        super().__init__(name="smallest_tools", tools=tools, timeout=timeout, **kwargs)
+        super().__init__(name="smallest_tools", tools=tools, **kwargs)
 
     def _headers(self) -> Dict[str, str]:
         return {
@@ -135,7 +138,7 @@ class SmallestTools(Toolkit):
             log_error(f"Failed to fetch voices: {str(e)}")
             return f"Error: {e}"
 
-    def _process_audio(self, audio_data: bytes) -> bytes:
+    def _save_audio(self, audio_data: bytes) -> bytes:
         # Save to disk if target_directory exists
         if self.target_directory:
             output_filename = f"{uuid4()}.{self.output_format}"
@@ -173,7 +176,7 @@ class SmallestTools(Toolkit):
             }
 
             response = httpx.post(
-                SMALLEST_TTS_URL,
+                self.base_url,
                 headers={
                     **self._headers(),
                     "Content-Type": "application/json",
@@ -184,7 +187,11 @@ class SmallestTools(Toolkit):
             )
             response.raise_for_status()
 
-            audio_data = self._process_audio(response.content)
+            content_type = response.headers.get("content-type", "")
+            if "audio" not in content_type and "octet-stream" not in content_type:
+                raise ValueError(f"Expected audio response but got content-type '{content_type}': {response.text}")
+
+            audio_data = self._save_audio(response.content)
 
             audio_artifact = Audio(
                 id=str(uuid4()),

--- a/libs/agno/agno/tools/smallest.py
+++ b/libs/agno/agno/tools/smallest.py
@@ -1,0 +1,193 @@
+import json
+from os import getenv, path
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional, Union
+from uuid import uuid4
+
+import httpx
+
+from agno.agent import Agent
+from agno.media import Audio
+from agno.team.team import Team
+from agno.tools import Toolkit
+from agno.tools.function import ToolResult
+from agno.utils.log import log_error, log_info
+
+SMALLEST_TTS_URL = "https://api.smallest.ai/waves/v1/tts"
+SMALLEST_VOICES_URLS = {
+    "lightning_v3.1": "https://api.smallest.ai/waves/v1/lightning-v3.1/get_voices",
+    "lightning_v3.1_pro": "https://api.smallest.ai/waves/v1/lightning-v3.1-pro/get_voices",
+}
+
+SmallestModel = Literal[
+    "lightning_v3.1",  # 12 languages, supports cloned voices
+    "lightning_v3.1_pro",  # premium voice pool, 29 languages
+]
+
+SmallestOutputFormat = Literal["wav", "mp3", "pcm", "ulaw", "alaw"]
+
+MIME_TYPES: Dict[str, str] = {
+    "wav": "audio/wav",
+    "mp3": "audio/mpeg",
+    "pcm": "audio/wav",
+    "ulaw": "audio/basic",
+    "alaw": "audio/x-alaw-basic",
+}
+
+
+class SmallestTools(Toolkit):
+    def __init__(
+        self,
+        voice_id: str = "magnus",
+        api_key: Optional[str] = None,
+        model: SmallestModel = "lightning_v3.1",
+        language: str = "en",
+        sample_rate: int = 24000,
+        speed: float = 1.0,
+        output_format: SmallestOutputFormat = "wav",
+        target_directory: Optional[str] = None,
+        enable_get_voices: bool = True,
+        enable_text_to_speech: bool = True,
+        all: bool = False,
+        timeout: int = 30,
+        **kwargs,
+    ):
+        self.api_key = api_key or getenv("SMALLEST_API_KEY")
+        if not self.api_key:
+            log_error("SMALLEST_API_KEY not set. Please set the SMALLEST_API_KEY environment variable.")
+
+        self.voice_id = voice_id
+        self.model = model
+        self.language = language
+        self.sample_rate = sample_rate
+        self.speed = speed
+        self.output_format = output_format
+        self.target_directory = target_directory
+
+        if self.target_directory:
+            target_path = Path(self.target_directory)
+            target_path.mkdir(parents=True, exist_ok=True)
+
+        tools: List[Any] = []
+        if all or enable_get_voices:
+            tools.append(self.get_voices)
+        if all or enable_text_to_speech:
+            tools.append(self.text_to_speech)
+
+        super().__init__(name="smallest_tools", tools=tools, timeout=timeout, **kwargs)
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "X-Source": "agno",
+        }
+
+    def get_voices(self) -> str:
+        """
+        Get all the voices available for the configured Smallest AI model. The standard
+        Lightning v3.1 and Lightning v3.1 Pro models have separate voice catalogs.
+
+        Returns:
+            result (str): JSON string containing a list of voices with their metadata.
+        """
+        try:
+            response = httpx.get(
+                SMALLEST_VOICES_URLS[self.model],
+                headers=self._headers(),
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+
+            voices_data = response.json()
+            if isinstance(voices_data, dict):
+                voices = voices_data.get("voices") or voices_data.get("data") or voices_data
+            else:
+                voices = voices_data
+
+            if isinstance(voices, list):
+                result = []
+                for voice in voices:
+                    if not isinstance(voice, dict):
+                        continue
+                    tags = voice.get("tags") or {}
+                    result.append(
+                        {
+                            "id": voice.get("voiceId") or voice.get("voice_id") or voice.get("id"),
+                            "name": voice.get("displayName") or voice.get("name"),
+                            "gender": tags.get("gender") or voice.get("gender"),
+                            "accent": tags.get("accent") or voice.get("accent"),
+                            "languages": tags.get("language") or voice.get("languages"),
+                        }
+                    )
+                return json.dumps(result)
+
+            return json.dumps(voices)
+        except Exception as e:
+            log_error(f"Failed to fetch voices: {str(e)}")
+            return f"Error: {e}"
+
+    def _process_audio(self, audio_data: bytes) -> bytes:
+        # Save to disk if target_directory exists
+        if self.target_directory:
+            output_filename = f"{uuid4()}.{self.output_format}"
+            output_path = path.join(self.target_directory, output_filename)
+
+            with open(output_path, "wb") as f:
+                f.write(audio_data)
+
+            log_info(f"Audio saved to: {output_path}")
+
+        return audio_data
+
+    def text_to_speech(self, agent: Union[Agent, Team], prompt: str, voice_id: Optional[str] = None) -> ToolResult:
+        """
+        Convert text to natural speech using Smallest AI Lightning models.
+
+        Args:
+            prompt (str): Text to generate audio from.
+            voice_id (optional): The ID of the voice to use. If None, uses the default voice
+                configured in the tool. The voice must belong to the configured model's pool.
+        Returns:
+            ToolResult: A ToolResult containing the generated audio or error message.
+        """
+        try:
+            mime_type = MIME_TYPES.get(self.output_format, "audio/wav")
+
+            payload: Dict[str, Any] = {
+                "text": prompt,
+                "voice_id": voice_id or self.voice_id,
+                "model": self.model,
+                "language": self.language,
+                "sample_rate": self.sample_rate,
+                "speed": self.speed,
+                "output_format": self.output_format,
+            }
+
+            response = httpx.post(
+                SMALLEST_TTS_URL,
+                headers={
+                    **self._headers(),
+                    "Content-Type": "application/json",
+                    "Accept": mime_type,
+                },
+                json=payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+
+            audio_data = self._process_audio(response.content)
+
+            audio_artifact = Audio(
+                id=str(uuid4()),
+                content=audio_data,
+                mime_type=mime_type,
+            )
+
+            return ToolResult(
+                content="Audio generated successfully",
+                audios=[audio_artifact],
+            )
+
+        except Exception as e:
+            log_error(f"Failed to generate audio: {str(e)}")
+            return ToolResult(content=f"Error: {e}")

--- a/libs/agno/tests/unit/tools/test_smallest.py
+++ b/libs/agno/tests/unit/tools/test_smallest.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from agno.agent import Agent
@@ -65,6 +66,12 @@ def test_init_override_defaults():
     assert tools.output_format == "mp3"
 
 
+def test_init_invalid_model_raises():
+    """Test that an invalid model name raises a clear error instead of failing later."""
+    with pytest.raises(ValueError, match="Invalid model"):
+        SmallestTools(api_key="test_key", model="lightning")
+
+
 def test_feature_registration(smallest_tools):
     """Test that the expected tools are registered."""
     assert "get_voices" in smallest_tools.functions
@@ -101,6 +108,7 @@ def test_text_to_speech_success(smallest_tools, mock_agent):
     assert kwargs["json"]["voice_id"] == "magnus"
     assert kwargs["json"]["model"] == "lightning_v3.1"
     assert kwargs["json"]["sample_rate"] == 24000
+    assert kwargs["json"]["speed"] == 1.0
     assert kwargs["json"]["output_format"] == "wav"
     assert kwargs["headers"]["Authorization"] == "Bearer test_key"
     assert kwargs["headers"]["X-Source"] == "agno"
@@ -168,9 +176,28 @@ def test_text_to_speech_saves_to_target_directory(mock_agent, tmp_path):
     assert saved_files[0].read_bytes() == b"audio data"
 
 
+def test_text_to_speech_saves_multiple_times_without_overwriting(mock_agent, tmp_path):
+    """Test that repeated saves get unique filenames instead of overwriting each other."""
+    target_dir = tmp_path / "audio"
+    tools = SmallestTools(api_key="test_key", target_directory=str(target_dir))
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.smallest.httpx.post", return_value=mock_response):
+        tools.text_to_speech(mock_agent, "Hello world")
+        tools.text_to_speech(mock_agent, "Hello again")
+
+    saved_files = list(target_dir.glob("*.wav"))
+    assert len(saved_files) == 2
+
+
 def test_text_to_speech_error(smallest_tools, mock_agent):
-    """Test text-to-speech error handling."""
-    with patch("agno.tools.smallest.httpx.post", side_effect=Exception("API error")):
+    """Test text-to-speech error handling against a real HTTP error response."""
+    request = httpx.Request("POST", SMALLEST_TTS_URL)
+    error_response = httpx.Response(401, json={"error": "unauthorized"}, request=request)
+
+    with patch("agno.tools.smallest.httpx.post", return_value=error_response):
         result = smallest_tools.text_to_speech(mock_agent, "Hello world")
 
     assert isinstance(result, ToolResult)
@@ -235,15 +262,19 @@ def test_get_voices_pro_model_uses_pro_catalog():
     mock_response.json.return_value = {"voices": []}
 
     with patch("agno.tools.smallest.httpx.get", return_value=mock_response) as mock_get:
-        tools.get_voices()
+        result = tools.get_voices()
 
     args, _ = mock_get.call_args
     assert args[0] == SMALLEST_VOICES_URLS["lightning_v3.1_pro"]
+    assert json.loads(result) == []
 
 
 def test_get_voices_error(smallest_tools):
-    """Test voice listing error handling."""
-    with patch("agno.tools.smallest.httpx.get", side_effect=Exception("API error")):
+    """Test voice listing error handling against a real HTTP error response."""
+    request = httpx.Request("GET", SMALLEST_VOICES_URLS["lightning_v3.1"])
+    error_response = httpx.Response(400, json={"error": "bad request"}, request=request)
+
+    with patch("agno.tools.smallest.httpx.get", return_value=error_response):
         result = smallest_tools.get_voices()
 
     assert result.startswith("Error")

--- a/libs/agno/tests/unit/tools/test_smallest.py
+++ b/libs/agno/tests/unit/tools/test_smallest.py
@@ -1,0 +1,249 @@
+"""Unit tests for Smallest AI tools."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.agent import Agent
+from agno.tools.function import ToolResult
+from agno.tools.smallest import SMALLEST_TTS_URL, SMALLEST_VOICES_URLS, SmallestTools
+
+
+@pytest.fixture
+def mock_agent():
+    agent = MagicMock(spec=Agent)
+    return agent
+
+
+@pytest.fixture
+def smallest_tools():
+    """Create SmallestTools instance with a test API key."""
+    with patch.dict("os.environ", {"SMALLEST_API_KEY": "test_key"}):
+        return SmallestTools()
+
+
+def test_init_with_api_key():
+    """Test initialization with API key."""
+    tools = SmallestTools(api_key="test_key")
+    assert tools.api_key == "test_key"
+    assert tools.model == "lightning_v3.1"
+    assert tools.voice_id == "magnus"
+    assert tools.sample_rate == 24000
+    assert tools.speed == 1.0
+    assert tools.output_format == "wav"
+
+
+def test_init_with_env_var():
+    """Test initialization with environment variable."""
+    with patch.dict("os.environ", {"SMALLEST_API_KEY": "env_key"}):
+        tools = SmallestTools()
+        assert tools.api_key == "env_key"
+
+
+def test_init_missing_api_key():
+    """Test initialization with missing API key logs an error but does not raise."""
+    with patch("agno.tools.smallest.getenv", return_value=None):
+        tools = SmallestTools()
+        assert tools.api_key is None
+
+
+def test_init_override_defaults():
+    """Test initialization overriding defaults with the Pro model."""
+    tools = SmallestTools(
+        api_key="test_key",
+        voice_id="meher",
+        model="lightning_v3.1_pro",
+        sample_rate=44100,
+        speed=1.2,
+        output_format="mp3",
+    )
+    assert tools.voice_id == "meher"
+    assert tools.model == "lightning_v3.1_pro"
+    assert tools.sample_rate == 44100
+    assert tools.speed == 1.2
+    assert tools.output_format == "mp3"
+
+
+def test_feature_registration(smallest_tools):
+    """Test that the expected tools are registered."""
+    assert "get_voices" in smallest_tools.functions
+    assert "text_to_speech" in smallest_tools.functions
+
+
+def test_feature_registration_disabled():
+    """Test disabling tools."""
+    tools = SmallestTools(api_key="test_key", enable_get_voices=False)
+    assert "get_voices" not in tools.functions
+    assert "text_to_speech" in tools.functions
+
+
+def test_text_to_speech_success(smallest_tools, mock_agent):
+    """Test successful text-to-speech generation."""
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.smallest.httpx.post", return_value=mock_response) as mock_post:
+        result = smallest_tools.text_to_speech(mock_agent, "Hello world")
+
+    assert isinstance(result, ToolResult)
+    assert result.content == "Audio generated successfully"
+    assert result.audios is not None
+    assert len(result.audios) == 1
+    assert result.audios[0].content == b"audio data"
+    assert result.audios[0].mime_type == "audio/wav"
+
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert args[0] == SMALLEST_TTS_URL
+    assert kwargs["json"]["text"] == "Hello world"
+    assert kwargs["json"]["voice_id"] == "magnus"
+    assert kwargs["json"]["model"] == "lightning_v3.1"
+    assert kwargs["json"]["sample_rate"] == 24000
+    assert kwargs["json"]["output_format"] == "wav"
+    assert kwargs["headers"]["Authorization"] == "Bearer test_key"
+    assert kwargs["headers"]["X-Source"] == "agno"
+
+
+def test_text_to_speech_voice_override(smallest_tools, mock_agent):
+    """Test text-to-speech with a per-call voice override."""
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.smallest.httpx.post", return_value=mock_response) as mock_post:
+        smallest_tools.text_to_speech(mock_agent, "Hello world", voice_id="custom_voice")
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["json"]["voice_id"] == "custom_voice"
+
+
+def test_text_to_speech_language_param(mock_agent):
+    """Test that language defaults to en and can be overridden."""
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.smallest.httpx.post", return_value=mock_response) as mock_post:
+        SmallestTools(api_key="test_key").text_to_speech(mock_agent, "Hello world")
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"]["language"] == "en"
+
+        SmallestTools(api_key="test_key", model="lightning_v3.1_pro", language="de").text_to_speech(
+            mock_agent, "Hallo Welt"
+        )
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"]["language"] == "de"
+
+
+def test_text_to_speech_mp3_mime_type(mock_agent):
+    """Test that mp3 output format sets the correct mime type."""
+    tools = SmallestTools(api_key="test_key", output_format="mp3")
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.smallest.httpx.post", return_value=mock_response) as mock_post:
+        result = tools.text_to_speech(mock_agent, "Hello world")
+
+    assert result.audios[0].mime_type == "audio/mpeg"
+    _, kwargs = mock_post.call_args
+    assert kwargs["headers"]["Accept"] == "audio/mpeg"
+
+
+def test_text_to_speech_saves_to_target_directory(mock_agent, tmp_path):
+    """Test that audio is saved to disk when target_directory is set."""
+    target_dir = tmp_path / "audio"
+    tools = SmallestTools(api_key="test_key", target_directory=str(target_dir))
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.smallest.httpx.post", return_value=mock_response):
+        tools.text_to_speech(mock_agent, "Hello world")
+
+    saved_files = list(target_dir.glob("*.wav"))
+    assert len(saved_files) == 1
+    assert saved_files[0].read_bytes() == b"audio data"
+
+
+def test_text_to_speech_error(smallest_tools, mock_agent):
+    """Test text-to-speech error handling."""
+    with patch("agno.tools.smallest.httpx.post", side_effect=Exception("API error")):
+        result = smallest_tools.text_to_speech(mock_agent, "Hello world")
+
+    assert isinstance(result, ToolResult)
+    assert "Error" in result.content
+    assert not result.audios
+
+
+def test_get_voices_success(smallest_tools):
+    """Test successful voice listing."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "voices": [
+            {
+                "voiceId": "magnus",
+                "displayName": "Magnus",
+                "tags": {"gender": "male", "accent": "american", "language": ["en"]},
+            },
+            {
+                "voiceId": "meher",
+                "displayName": "Meher",
+                "tags": {"gender": "female", "accent": "indian", "language": ["en", "hi"]},
+            },
+        ]
+    }
+
+    with patch("agno.tools.smallest.httpx.get", return_value=mock_response) as mock_get:
+        result = smallest_tools.get_voices()
+
+    args, kwargs = mock_get.call_args
+    assert args[0] == SMALLEST_VOICES_URLS["lightning_v3.1"]
+    assert kwargs["headers"]["Authorization"] == "Bearer test_key"
+    assert kwargs["headers"]["X-Source"] == "agno"
+
+    voices = json.loads(result)
+    assert len(voices) == 2
+    assert voices[0]["id"] == "magnus"
+    assert voices[1]["id"] == "meher"
+    assert voices[1]["languages"] == ["en", "hi"]
+
+
+def test_get_voices_list_response(smallest_tools):
+    """Test voice listing when the API returns a bare list."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = [{"id": "magnus", "name": "Magnus"}]
+
+    with patch("agno.tools.smallest.httpx.get", return_value=mock_response):
+        result = smallest_tools.get_voices()
+
+    voices = json.loads(result)
+    assert len(voices) == 1
+    assert voices[0]["id"] == "magnus"
+    assert voices[0]["name"] == "Magnus"
+
+
+def test_get_voices_pro_model_uses_pro_catalog():
+    """Test that the Pro model queries the Pro voice catalog endpoint."""
+    tools = SmallestTools(api_key="test_key", model="lightning_v3.1_pro", voice_id="meher")
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {"voices": []}
+
+    with patch("agno.tools.smallest.httpx.get", return_value=mock_response) as mock_get:
+        tools.get_voices()
+
+    args, _ = mock_get.call_args
+    assert args[0] == SMALLEST_VOICES_URLS["lightning_v3.1_pro"]
+
+
+def test_get_voices_error(smallest_tools):
+    """Test voice listing error handling."""
+    with patch("agno.tools.smallest.httpx.get", side_effect=Exception("API error")):
+        result = smallest_tools.get_voices()
+
+    assert result.startswith("Error")

--- a/libs/agno/tests/unit/tools/test_smallest.py
+++ b/libs/agno/tests/unit/tools/test_smallest.py
@@ -72,6 +72,30 @@ def test_init_invalid_model_raises():
         SmallestTools(api_key="test_key", model="lightning")
 
 
+def test_init_default_base_url():
+    """Test that base_url defaults to the standard Smallest AI TTS endpoint."""
+    tools = SmallestTools(api_key="test_key")
+    assert tools.base_url == SMALLEST_TTS_URL
+
+
+def test_init_custom_base_url(mock_agent):
+    """Test that a custom base_url is used for text-to-speech requests."""
+    custom_url = "https://self-hosted.example.com/tts"
+    tools = SmallestTools(api_key="test_key", base_url=custom_url)
+    assert tools.base_url == custom_url
+
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/wav"}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.smallest.httpx.post", return_value=mock_response) as mock_post:
+        tools.text_to_speech(mock_agent, "Hello world")
+
+    args, _ = mock_post.call_args
+    assert args[0] == custom_url
+
+
 def test_feature_registration(smallest_tools):
     """Test that the expected tools are registered."""
     assert "get_voices" in smallest_tools.functions
@@ -89,6 +113,7 @@ def test_text_to_speech_success(smallest_tools, mock_agent):
     """Test successful text-to-speech generation."""
     mock_response = MagicMock()
     mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/wav"}
     mock_response.raise_for_status.return_value = None
 
     with patch("agno.tools.smallest.httpx.post", return_value=mock_response) as mock_post:
@@ -118,6 +143,7 @@ def test_text_to_speech_voice_override(smallest_tools, mock_agent):
     """Test text-to-speech with a per-call voice override."""
     mock_response = MagicMock()
     mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/wav"}
     mock_response.raise_for_status.return_value = None
 
     with patch("agno.tools.smallest.httpx.post", return_value=mock_response) as mock_post:
@@ -131,6 +157,7 @@ def test_text_to_speech_language_param(mock_agent):
     """Test that language defaults to en and can be overridden."""
     mock_response = MagicMock()
     mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/wav"}
     mock_response.raise_for_status.return_value = None
 
     with patch("agno.tools.smallest.httpx.post", return_value=mock_response) as mock_post:
@@ -150,6 +177,7 @@ def test_text_to_speech_mp3_mime_type(mock_agent):
     tools = SmallestTools(api_key="test_key", output_format="mp3")
     mock_response = MagicMock()
     mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/mpeg"}
     mock_response.raise_for_status.return_value = None
 
     with patch("agno.tools.smallest.httpx.post", return_value=mock_response) as mock_post:
@@ -166,6 +194,7 @@ def test_text_to_speech_saves_to_target_directory(mock_agent, tmp_path):
     tools = SmallestTools(api_key="test_key", target_directory=str(target_dir))
     mock_response = MagicMock()
     mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/wav"}
     mock_response.raise_for_status.return_value = None
 
     with patch("agno.tools.smallest.httpx.post", return_value=mock_response):
@@ -182,6 +211,7 @@ def test_text_to_speech_saves_multiple_times_without_overwriting(mock_agent, tmp
     tools = SmallestTools(api_key="test_key", target_directory=str(target_dir))
     mock_response = MagicMock()
     mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/wav"}
     mock_response.raise_for_status.return_value = None
 
     with patch("agno.tools.smallest.httpx.post", return_value=mock_response):
@@ -198,6 +228,22 @@ def test_text_to_speech_error(smallest_tools, mock_agent):
     error_response = httpx.Response(401, json={"error": "unauthorized"}, request=request)
 
     with patch("agno.tools.smallest.httpx.post", return_value=error_response):
+        result = smallest_tools.text_to_speech(mock_agent, "Hello world")
+
+    assert isinstance(result, ToolResult)
+    assert "Error" in result.content
+    assert not result.audios
+
+
+def test_text_to_speech_unexpected_content_type(smallest_tools, mock_agent):
+    """Test that a non-audio 200 response (e.g. a JSON error body) is treated as an error."""
+    mock_response = MagicMock()
+    mock_response.content = b'{"error": "invalid voice_id"}'
+    mock_response.text = '{"error": "invalid voice_id"}'
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.smallest.httpx.post", return_value=mock_response):
         result = smallest_tools.text_to_speech(mock_agent, "Hello world")
 
     assert isinstance(result, ToolResult)


### PR DESCRIPTION
## Summary

Adds `SmallestTools`, a toolkit for [Smallest AI](https://smallest.ai) text-to-speech.

Closes #9017

- `text_to_speech` — synthesizes speech via Smallest AI's unified `/waves/v1/tts` endpoint and returns the audio as an `Audio` artifact in a `ToolResult`; optional `target_directory` to also save files to disk.
- `get_voices` — lists the voice catalog for the configured model (the standard and Pro models have separate catalogs, so the toolkit queries the matching endpoint).
- Supports both models: `lightning_v3.1` (12 languages, cloned voices) and `lightning_v3.1_pro` (premium voice pool, 29 languages). Configurable voice, language (defaults to `en`), sample rate, speed, and output format (`wav`/`mp3`/`pcm`/`ulaw`/`alaw`).
- Uses `httpx` (already a core dependency) — no new optional dependency or pyproject change required.
- Sends an `X-Source: agno` header for integration attribution.

Includes a cookbook example (`cookbook/91_tools/smallest_tools.py`) and unit tests (15 tests).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Draft while final review is completed.
- Live-tested against the Smallest AI API: both models (synthesis + voice listing), per-call voice overrides, mp3/wav output formats, custom sample rates and speed, Hindi text, long text, disk saving, and graceful 401/400 error handling. Also verified with a clean-environment install (`pip install` from this branch into a fresh venv).
- A companion integration guide is being added to [docs.smallest.ai](https://docs.smallest.ai) (Integrations → Agno).



