### PR TITLE
fix: resolve agno create onboarding review findings

### DIFF
--- a/libs/agnoctl/agnoctl/commands/create.py
+++ b/libs/agnoctl/agnoctl/commands/create.py
@@ -232,9 +232,12 @@ def _create(name: str, template: str, template_url: Optional[str]) -> Dict[str, 
     _clone(repo_url, target)
     try:
         _copy_example_env(target)
-    except CLIError:
+    except CLIError as e:
         # A failed seed must not leave the half-created project behind; a retry
         # would fail "directory already exists" and hide the real error.
-        shutil.rmtree(target, ignore_errors=True)
+        try:
+            shutil.rmtree(target)
+        except OSError:
+            e.hint = "Remove the leftover directory " + str(target) + ", then re-run."
         raise
     return {"path": str(target), "template": template_label}

--- a/libs/agnoctl/agnoctl/commands/create.py
+++ b/libs/agnoctl/agnoctl/commands/create.py
@@ -58,7 +58,7 @@ def _clone(repo_url: str, target: Path) -> None:
     shutil.rmtree(target / ".git", ignore_errors=True)
 
 
-def _copy_example_env(project_dir: Path) -> bool:
+def _copy_example_env(project_dir: Path) -> None:
     """Seed a private .env when the template provides example.env.
 
     Custom templates may use a different environment layout, and a tracked .env must
@@ -71,9 +71,9 @@ def _copy_example_env(project_dir: Path) -> bool:
     if env_file.exists():
         if not env_file.is_file():
             raise CLIError(str(env_file) + " exists but is not a file.")
-        return True
+        return
     if not example_env.is_file():
-        return False
+        return
 
     no_follow = getattr(os, "O_NOFOLLOW", 0)
     binary = getattr(os, "O_BINARY", 0)
@@ -93,7 +93,6 @@ def _copy_example_env(project_dir: Path) -> bool:
             except OSError:
                 pass
         raise CLIError("Could not create " + str(env_file) + ": " + str(e))
-    return True
 
 
 def _prompt_template() -> str:
@@ -104,7 +103,7 @@ def _prompt_template() -> str:
         print_info("  " + str(index) + ". " + template_name + suffix)
 
     while True:
-        answer = str(typer.prompt("Template", default="1")).strip()
+        answer = str(typer.prompt("Template", default=str(TEMPLATE_CHOICES.index(DEFAULT_TEMPLATE) + 1))).strip()
         if answer in TEMPLATES:
             return answer
         if answer.isdigit() and 1 <= int(answer) <= len(TEMPLATE_CHOICES):
@@ -131,6 +130,14 @@ def _prompt_project_name() -> str:
         return name
 
 
+def _validate_template(template: str) -> None:
+    if template not in TEMPLATES:
+        raise CLIError(
+            "Unknown template: " + template,
+            hint="Available templates: " + ", ".join(TEMPLATE_CHOICES) + ", or pass --url for a custom repo.",
+        )
+
+
 def _resolve_create_inputs(
     name: Optional[str],
     template: Optional[str],
@@ -147,6 +154,9 @@ def _resolve_create_inputs(
                 "A project name is required in non-interactive mode.",
                 hint="Pass a name, for example: agno create agentos",
             )
+        # A bad --template should fail here, before the user answers the name prompt.
+        if template is not None and template_url is None:
+            _validate_template(template)
         print_info("")
         print_heading("Create an AgentOS")
         print_info("")
@@ -155,7 +165,7 @@ def _resolve_create_inputs(
             print_info("")
         name = _prompt_project_name()
 
-    return name, template or DEFAULT_TEMPLATE
+    return name, DEFAULT_TEMPLATE if template is None else template
 
 
 def create(
@@ -215,14 +225,16 @@ def _create(name: str, template: str, template_url: Optional[str]) -> Dict[str, 
         repo_url = template_url
         template_label = template_url
     else:
-        repo_url = TEMPLATES.get(template, "")
-        if not repo_url:
-            raise CLIError(
-                "Unknown template: " + template,
-                hint="Available templates: " + ", ".join(sorted(TEMPLATES)) + ", or pass --url for a custom repo.",
-            )
+        _validate_template(template)
+        repo_url = TEMPLATES[template]
         template_label = template
 
     _clone(repo_url, target)
-    _copy_example_env(target)
+    try:
+        _copy_example_env(target)
+    except CLIError:
+        # A failed seed must not leave the half-created project behind; a retry
+        # would fail "directory already exists" and hide the real error.
+        shutil.rmtree(target, ignore_errors=True)
+        raise
     return {"path": str(target), "template": template_label}

--- a/libs/agnoctl/tests/test_create_lifecycle.py
+++ b/libs/agnoctl/tests/test_create_lifecycle.py
@@ -296,6 +296,32 @@ def test_create_symlinked_example_env_fails_cleanly_via_cli(monkeypatch, tmp_pat
     assert not (tmp_path / "my-os").exists()
 
 
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
+def test_create_reports_leftover_dir_when_cleanup_fails(monkeypatch, tmp_path):
+    fake = FakeGit(symlink_example_env=True)
+    monkeypatch.setattr(create_module.subprocess, "run", fake)
+    monkeypatch.setattr(create_module.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "my-os"
+
+    real_rmtree = create_module.shutil.rmtree
+
+    def locked_rmtree(path, *args, **kwargs):
+        if Path(path) == target:
+            raise OSError("locked")
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(create_module.shutil, "rmtree", locked_rmtree)
+
+    result = runner.invoke(app, ["create", "my-os", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "symlinked" in payload["error"]
+    assert str(target) in payload["hint"]
+    assert target.exists()
+
+
 def test_create_empty_template_is_rejected(fake_git):
     result = runner.invoke(app, ["create", "my-os", "-t", "", "--json"])
 

--- a/libs/agnoctl/tests/test_create_lifecycle.py
+++ b/libs/agnoctl/tests/test_create_lifecycle.py
@@ -15,6 +15,7 @@ import agnoctl.commands.lifecycle as lifecycle_module
 from agnoctl.commands.lifecycle import find_compose_file
 from agnoctl.errors import CLIError
 from agnoctl.main import app
+from tests.conftest import all_output as _all_output
 
 runner = CliRunner()
 
@@ -22,10 +23,17 @@ runner = CliRunner()
 class FakeGit:
     """Simulates `git clone` by scaffolding a template directory."""
 
-    def __init__(self, returncode: int = 0, with_example_env: bool = True, existing_env=None):
+    def __init__(
+        self,
+        returncode: int = 0,
+        with_example_env: bool = True,
+        existing_env=None,
+        symlink_example_env: bool = False,
+    ):
         self.returncode = returncode
         self.with_example_env = with_example_env
         self.existing_env = existing_env
+        self.symlink_example_env = symlink_example_env
         self.calls = []
 
     def __call__(self, args, **kwargs):
@@ -34,7 +42,9 @@ class FakeGit:
             target = Path(args[-1])
             (target / ".git").mkdir(parents=True)
             (target / "docker-compose.yml").write_text("services: {}\n")
-            if self.with_example_env:
+            if self.symlink_example_env:
+                (target / "example.env").symlink_to(target.parent / "outside.env")
+            elif self.with_example_env:
                 (target / "example.env").write_text("KEY=value\n")
             if self.existing_env is not None:
                 (target / ".env").write_text(self.existing_env)
@@ -264,6 +274,48 @@ def test_copy_example_env_rejects_dangling_destination_symlink(tmp_path):
         create_module._copy_example_env(project)
 
     assert not outside.exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
+def test_create_symlinked_example_env_fails_cleanly_via_cli(monkeypatch, tmp_path):
+    fake = FakeGit(symlink_example_env=True)
+    monkeypatch.setattr(create_module.subprocess, "run", fake)
+    monkeypatch.setattr(create_module.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["create", "my-os"])
+
+    assert result.exit_code == 1
+    assert "symlinked" in _all_output(result)
+    assert not (tmp_path / "my-os").exists()
+
+    # The retry must hit the same refusal, not "directory already exists".
+    second = runner.invoke(app, ["create", "my-os", "--json"])
+    assert second.exit_code == 1
+    assert "symlinked" in json.loads(second.output)["error"]
+    assert not (tmp_path / "my-os").exists()
+
+
+def test_create_empty_template_is_rejected(fake_git):
+    result = runner.invoke(app, ["create", "my-os", "-t", "", "--json"])
+
+    assert result.exit_code == 1
+    assert "Unknown template" in json.loads(result.output)["error"]
+    assert fake_git.calls == []
+
+
+def test_create_unknown_template_rejected_before_name_prompt(fake_git, monkeypatch):
+    def fail_prompt(*args, **kwargs):
+        pytest.fail("a bad --template must fail before any prompt")
+
+    monkeypatch.setattr(create_module.typer, "prompt", fail_prompt)
+    monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
+
+    result = runner.invoke(app, ["create", "-t", "bogus"])
+
+    assert result.exit_code == 1
+    assert "Unknown template" in _all_output(result)
+    assert fake_git.calls == []
 
 
 @pytest.mark.parametrize("name", ["../escape", "a/b", "/tmp/abs", ".."])

--- a/libs/agnoctl/tests/test_main.py
+++ b/libs/agnoctl/tests/test_main.py
@@ -1,4 +1,4 @@
-"""Root `agno` app: branded home screen, version flag, and command routing."""
+"""Root `agno` app: branded home screen, version flag, command routing, and create-help defaults."""
 
 import re
 
@@ -18,7 +18,7 @@ def test_bare_invocation_shows_home_screen():
     for heading in ("Get started", "Operate", "Tokens"):
         assert heading in result.output
     assert "agno create" in result.output
-    assert "agno create <name>" not in result.output
+    assert "agno create <name>" not in result.output  # the pre-interactive home screen advertised a required <name>
     assert __version__ in result.output
 
 


### PR DESCRIPTION
## Summary

Addresses the review findings on #8959, stacked on its head so the diff shows only the fixes:

- Reject an explicitly empty `--template` instead of silently cloning the default (`""` is no longer conflated with omitted).
- Validate a provided `--template` against the catalog before the interactive name prompt, so `agno create -t bogus` fails immediately instead of after the user answers the name prompt (requested by Kaustubh during review).
- Remove the cloned directory when `.env` seeding fails, so a retry reports the real error instead of "directory already exists" — and if that cleanup itself fails, keep the original error primary and add a hint naming the leftover path.
- Derive the template menu's Enter default from `DEFAULT_TEMPLATE` instead of hardcoding position 1.
- List the unknown-template hint in catalog order, matching the menu and `--template` help.
- Drop `_copy_example_env`'s unused bool return.
- New end-to-end tests: empty template, symlinked `example.env` through the CLI (including the no-leftover retry and the cleanup-failure hint), and bad-template-before-prompt.
- Test prose: explain the home-screen scrub assertion and extend the file docstring.

## Type of change

- [x] Bug fix
- [x] Improvement

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tests added/updated — 314 -> 318 passed (`pytest libs/agnoctl/tests`)
- [x] Tested in clean environment

## Additional Notes

Base branch is `codex/create-onboarding` (#8959's head) so this stacks on that PR; retarget to `main` if #8959 merges first. Every behavior change here maps to an inline review comment on #8959 plus one teammate-requested UX fix (early template validation), all verified by execution: the symlinked-template create leaves no directory behind and retries with the same error, `--template ""` exits 1 with "Unknown template", and interactive `create -t bogus` never reaches the name prompt.
