### PR TITLE
fix: preserve CustomEvent dynamic fields during serialization

### DIFF
--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -10,7 +10,13 @@ from agno.models.message import Citations, Message
 from agno.models.metrics import RunMetrics
 from agno.models.response import ToolExecution
 from agno.reasoning.step import ReasoningStep
-from agno.run.base import BaseRunOutputEvent, MessageReferences, RunStatus
+from agno.run.base import (
+    BaseRunOutputEvent,
+    MessageReferences,
+    RunStatus,
+    get_dynamic_fields,
+    init_event_with_dynamic_fields,
+)
 from agno.run.requirement import RunRequirement
 from agno.utils.log import log_error
 from agno.utils.media import (
@@ -517,8 +523,12 @@ class CustomEvent(BaseAgentRunEvent):
 
     def __init__(self, **kwargs):
         # Store arbitrary attributes directly on the instance
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+        init_event_with_dynamic_fields(self, kwargs)
+
+    def to_dict(self) -> Dict[str, Any]:
+        _dict = super().to_dict()
+        _dict.update({k: v for k, v in get_dynamic_fields(self).items() if v is not None})
+        return _dict
 
 
 RunOutputEvent = Union[

--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -1,4 +1,4 @@
-from dataclasses import asdict, dataclass
+from dataclasses import MISSING, asdict, dataclass, fields
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type, Union
 
@@ -41,6 +41,30 @@ class RunContext:
     # Per-run additive tools from the client (e.g., AG-UI frontend tools)
     # Merged AFTER agent.tools during tool resolution
     client_tools: Optional[List[Any]] = None
+
+
+def init_event_with_dynamic_fields(event: Any, kwargs: Dict[str, Any]) -> None:
+    """Initialize a CustomEvent that accepts arbitrary user-supplied fields.
+
+    Declared dataclass fields are populated from kwargs or their defaults, so the instance
+    stays a valid dataclass for asdict(); anything left over is set as a dynamic attribute.
+    """
+    remaining = dict(kwargs)
+    for f in fields(event):
+        if f.name in remaining:
+            setattr(event, f.name, remaining.pop(f.name))
+        elif f.default is not MISSING:
+            setattr(event, f.name, f.default)
+        elif f.default_factory is not MISSING:
+            setattr(event, f.name, f.default_factory())
+    for key, value in remaining.items():
+        setattr(event, key, value)
+
+
+def get_dynamic_fields(event: Any) -> Dict[str, Any]:
+    """Return the attributes of a CustomEvent that are not declared dataclass fields."""
+    declared = {f.name for f in fields(event)}
+    return {k: v for k, v in event.__dict__.items() if k not in declared}
 
 
 @dataclass

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -11,7 +11,13 @@ from agno.models.metrics import RunMetrics
 from agno.models.response import ToolExecution
 from agno.reasoning.step import ReasoningStep
 from agno.run.agent import RunEvent, RunOutput, RunOutputEvent, run_output_event_from_dict
-from agno.run.base import BaseRunOutputEvent, MessageReferences, RunStatus
+from agno.run.base import (
+    BaseRunOutputEvent,
+    MessageReferences,
+    RunStatus,
+    get_dynamic_fields,
+    init_event_with_dynamic_fields,
+)
 from agno.run.requirement import RunRequirement
 from agno.utils.log import log_error
 from agno.utils.media import (
@@ -633,8 +639,12 @@ class CustomEvent(BaseTeamRunEvent):
 
     def __init__(self, **kwargs):
         # Store arbitrary attributes directly on the instance
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+        init_event_with_dynamic_fields(self, kwargs)
+
+    def to_dict(self) -> Dict[str, Any]:
+        _dict = super().to_dict()
+        _dict.update({k: v for k, v in get_dynamic_fields(self).items() if v is not None})
+        return _dict
 
 
 TeamRunOutputEvent = Union[

--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -7,7 +7,12 @@ from pydantic import BaseModel
 
 from agno.media import Audio, File, Image, Video
 from agno.run.agent import RunEvent, RunOutput, run_output_event_from_dict
-from agno.run.base import BaseRunOutputEvent, RunStatus
+from agno.run.base import (
+    BaseRunOutputEvent,
+    RunStatus,
+    get_dynamic_fields,
+    init_event_with_dynamic_fields,
+)
 from agno.run.team import TeamRunEvent, TeamRunOutput, team_run_output_event_from_dict
 from agno.utils.log import log_warning
 from agno.utils.media import (
@@ -606,8 +611,12 @@ class CustomEvent(BaseWorkflowRunOutputEvent):
 
     def __init__(self, **kwargs):
         # Store arbitrary attributes directly on the instance
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+        init_event_with_dynamic_fields(self, kwargs)
+
+    def to_dict(self) -> Dict[str, Any]:
+        _dict = super().to_dict()
+        _dict.update({k: v for k, v in get_dynamic_fields(self).items() if v is not None})
+        return _dict
 
 
 # Union type for all workflow run response events

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -405,6 +405,55 @@ def test_custom_event_subclass_serialization():
     assert restored_run_evt.data["title"] == "Test Chart"
 
 
+def test_custom_event_dynamic_fields_survive_serialization():
+    """Regression test for #7075: fields passed to CustomEvent's dynamic __init__ must
+    survive to_dict().
+
+    CustomEvent.__init__ only setattr'd the supplied kwargs, so declared dataclass fields
+    (created_at, agent_id, ...) were never initialized and asdict() raised AttributeError;
+    dynamic fields were invisible to asdict() regardless, since it only walks declared
+    fields. The subclass path is covered above and was unaffected because @dataclass
+    generates an __init__ for subclasses that declare their fields.
+    """
+    from agno.run.agent import CustomEvent
+
+    event = CustomEvent(event="CustomEvent", my_field="hello", my_data={"key": "value"})
+
+    assert event.my_field == "hello"
+    assert event.my_data == {"key": "value"}
+
+    event_dict = event.to_dict()
+
+    assert event_dict["my_field"] == "hello"
+    assert event_dict["my_data"] == {"key": "value"}
+    assert event_dict["event"] == "CustomEvent"
+    # declared fields must be initialized from their defaults, not left unset
+    assert "created_at" in event_dict
+
+
+def test_custom_event_dynamic_fields_round_trip():
+    """Dynamic fields must survive to_dict() -> from_dict(); from_dict already passed all
+    keys through for CustomEvent, so the loss was one-directional."""
+    from agno.run.agent import CustomEvent
+
+    restored = CustomEvent.from_dict(CustomEvent(event="CustomEvent", chart_type="bar", data={"x": 1}).to_dict())
+
+    assert restored.chart_type == "bar"
+    assert restored.data == {"x": 1}
+
+
+def test_custom_event_dynamic_fields_on_team_and_workflow():
+    """The team and workflow CustomEvent classes carry the same dynamic __init__ and were
+    confirmed to drop fields identically."""
+    from agno.run.team import CustomEvent as TeamCustomEvent
+    from agno.run.workflow import CustomEvent as WorkflowCustomEvent
+
+    for event_cls in (TeamCustomEvent, WorkflowCustomEvent):
+        event_dict = event_cls(event="CustomEvent", my_field="hello").to_dict()
+        assert event_dict["my_field"] == "hello", f"{event_cls.__module__} dropped my_field"
+        assert "created_at" in event_dict
+
+
 def test_team_custom_event_subclass_serialization():
     """Test that Team CustomEvent subclass properties are preserved during serialization."""
     from typing import Any, Dict


### PR DESCRIPTION
## Summary

`CustomEvent` fields passed to its dynamic `__init__` were lost when the event was serialized, so custom fields yielded during streaming never survived a session reload.

(Issue number: #7075)

The reported symptom was that `to_dict()` returned only `{'event': 'CustomEvent'}`. On current `main` (and released 2.7.3) it is worse: `to_dict()` raises outright.

```
>>> CustomEvent(event="CustomEvent", my_field="hello").to_dict()
AttributeError: 'CustomEvent' object has no attribute 'created_at'
```

Both come from the same defect. `CustomEvent.__init__` only `setattr`'d the kwargs it was handed:

```python
def __init__(self, **kwargs):
    for key, value in kwargs.items():
        setattr(self, key, value)
```

Declared dataclass fields (`created_at`, `agent_id`, `event`, ...) were therefore never initialized, so `asdict()` in `BaseRunOutputEvent.to_dict()` blew up on the first one it could not `getattr`. Separately, `asdict()` only walks declared fields, so the dynamic attributes in `self.__dict__` were invisible to it even when it did not raise.

The fix initializes declared fields from kwargs or their defaults, keeping the instance a valid dataclass, then merges the remaining dynamic attributes into `to_dict()`. `from_dict()` already passed all keys through for `CustomEvent`, so the loss was one-directional and round-tripping now works end to end.

The same `__init__` is duplicated on the agent, team and workflow `CustomEvent` classes. I confirmed all three fail identically before extending the fix to them, rather than assuming:

```
agent     to_dict() RAISES -> AttributeError: 'CustomEvent' object has no attribute 'created_at'
team      to_dict() RAISES -> AttributeError: 'CustomEvent' object has no attribute 'created_at'
workflow  to_dict() RAISES -> AttributeError: 'CustomEvent' object has no attribute 'created_at'
```

The shared helpers therefore live in `run/base.py` instead of being pasted three times.

Why this went unnoticed: `test_custom_event_subclass_serialization` covers a `CustomEvent` subclass that declares its fields, and `@dataclass` generates a proper `__init__` for such a subclass, so it never reaches the broken one. The dynamic-kwargs path that the docs recommend had no coverage.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

On the validation scripts: I ran `ruff check` and `ruff format` (what those scripts wrap) against the five changed files and both pass. I could not run the scripts themselves, since they expect the `./scripts/dev_setup.sh` virtualenv which I did not provision.

On the test suite: `libs/agno/tests/unit/run/` reports 16 failed / 75 passed with this branch. The same 16 fail identically on unmodified `main` (16 failed / 72 passed there); they are pre-existing and unrelated, and the delta is the 3 tests added here.

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

I scanned the 400 open PRs for ones touching `CustomEvent`, `asdict`, or `run/base.py`. Eight matched, none address this defect: #8772 excludes `CustomEvent` yields from tool results, #8069 emits followup suggestions as a `CustomEvent`, #8133 coerces `RunOutput.status` in `from_dict`. Flagging the AI-generated box honestly: the code, tests and analysis here were produced with Claude Code, then reviewed. Every claim above was verified by running it rather than inferred.

---

## Additional Notes

Tests added to `libs/agno/tests/unit/run/test_run_events.py`, alongside the existing subclass test:

- `test_custom_event_dynamic_fields_survive_serialization` — the reporter's exact repro
- `test_custom_event_dynamic_fields_round_trip` — `to_dict()` -> `from_dict()`
- `test_custom_event_dynamic_fields_on_team_and_workflow` — the two sibling classes

All three fail on unpatched `main` with the `AttributeError` above and pass with this change, so the regression is pinned rather than merely covered.

Credit to @weiguangli-io, whose comment on #7075 identified `asdict()` in `BaseRunOutputEvent.to_dict()` as the root cause and noted that `from_dict()` already handles `CustomEvent` correctly. Their suggested fix was to override `to_dict()`; that alone would not have been enough here, since `asdict()` raises before it can merge anything, so `__init__` needed fixing too.

No cookbook change seemed warranted since this restores documented behavior rather than adding a pattern; happy to add one if you would like.
