### PR TITLE
cookbook: add dpo_jury pairwise preference example

### DIFF
--- a/cookbook/data_labeling/_05_text_pairwise_preference/README.md
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/README.md
@@ -9,6 +9,10 @@ the data shape used for RLHF/DPO preference datasets.
 - `with_rubric.py` — pick based on an explicit rubric supplied in the
   instructions.
 - `with_rationale.py` — winner plus a one-sentence explanation.
+- `dpo_jury.py` — a jury of 5 model families emits trainer-ready DPO records:
+  typed verdicts, both-orderings position debiasing, self-preference recusal,
+  gold-pair calibration, and an agreement gate that routes contested pairs to
+  human review.
 
 ## When to use
 
@@ -25,6 +29,8 @@ comparison, use [`_17_llm_as_judge/`](../_17_llm_as_judge/).
 python cookbook/data_labeling/_05_text_pairwise_preference/basic.py
 python cookbook/data_labeling/_05_text_pairwise_preference/with_rubric.py
 python cookbook/data_labeling/_05_text_pairwise_preference/with_rationale.py
+python cookbook/data_labeling/_05_text_pairwise_preference/dpo_jury.py
 ```
 
-Requires `GOOGLE_API_KEY`.
+Requires `GOOGLE_API_KEY`. `dpo_jury.py` additionally requires `OPENAI_API_KEY`,
+`ANTHROPIC_API_KEY`, `GROQ_API_KEY`, and `MISTRAL_API_KEY`.

--- a/cookbook/data_labeling/_05_text_pairwise_preference/TEST_LOG.md
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/TEST_LOG.md
@@ -31,3 +31,13 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 **Result:** Picks the more accurate/complete response per the rubric.
 
 ---
+
+### dpo_jury.py
+
+**Status:** PASS
+
+**Description:** Tested 2026-07-18 with `.venvs/demo` (agno 2.7.0a1) and against agno 2.7.3. A jury of 5 model families (gpt-5.5, claude-sonnet-5, gemini-3.5-flash, qwen/qwen3.6-27b via Groq, mistral-large-latest) labels 3 raw pairs and 3 gold pairs, scoring each pair in both orderings.
+
+**Result:** 2 pairs accepted as DPO records (fib 5/5; git-reset 4/4 after the anthropic juror recused), is_even routed to human review (winner=tie, agreement 0.60), gold calibration 3/3. Occasional schema breaks from JSON-mode jurors and Mistral 429s on back-to-back runs are absorbed by the backoff retry in `ask`.
+
+---

--- a/cookbook/data_labeling/_05_text_pairwise_preference/dpo_jury.py
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/dpo_jury.py
@@ -1,0 +1,155 @@
+"""A jury of 5 models turns raw response pairs into trainer-ready DPO data."""
+
+import asyncio
+import json
+from collections import Counter
+from typing import Literal
+
+from agno.agent import Agent
+from agno.models.anthropic import Claude
+from agno.models.google import Gemini
+from agno.models.groq import Groq
+from agno.models.mistral import MistralChat
+from agno.models.openai import OpenAIResponses
+from pydantic import BaseModel, Field
+
+
+class Verdict(BaseModel):
+    winner: Literal["a", "b", "tie"]
+    confidence: float = Field(ge=0, le=1)
+
+
+RUBRIC = "Pick the more correct, more helpful answer; ties are allowed. Never reward length or a confident tone."
+
+
+def juror(model) -> Agent:
+    return Agent(model=model, instructions=RUBRIC, output_schema=Verdict)
+
+
+JURY: dict[str, Agent] = {  # one juror per model family
+    "openai": juror(OpenAIResponses(id="gpt-5.5")),
+    "anthropic": juror(Claude(id="claude-sonnet-5")),
+    "google": juror(Gemini(id="gemini-3.5-flash", temperature=0)),
+    "qwen": juror(Groq(id="qwen/qwen3.6-27b", temperature=0)),
+    "mistral": juror(MistralChat(id="mistral-large-latest", temperature=0)),
+}
+# gold pairs calibrate the jury; the rest are raw DPO candidates
+EXAMPLES: list[dict] = [
+    dict(
+        id="fib",
+        source_family="xai",
+        gold=None,
+        prompt="Write an iterative Python fib(n), with fib(0) = 0.",
+        a="def fib(n):\n    a, b = 0, 1\n    for _ in range(n):\n        a, b = b, a + b\n    return a",
+        b="def fib(n):\n    a, b = 0, 1\n    for _ in range(n - 1):\n        a, b = b, a + b\n    return b",
+    ),
+    dict(
+        id="is_even",
+        source_family="deepseek",
+        gold=None,
+        prompt="Write is_even(n) for Python integers.",
+        a="def is_even(n):\n    return n % 2 == 0",
+        b="def is_even(n):\n    return not n & 1",
+    ),
+    dict(
+        id="reset",
+        source_family="anthropic",
+        gold=None,
+        prompt="What does git reset --soft HEAD~1 do?",
+        a="Moves the branch back one commit; the undone commit's changes remain staged; working tree untouched.",
+        b="Moves the branch back one commit and unstages those changes, leaving them as edits in your working tree.",
+    ),
+    dict(
+        id="g-incl",
+        source_family="meta",
+        gold="a",
+        prompt="How many integers from 1 to 1000 are divisible by 3 or 5?",
+        a="467: floor(1000/3)=333, floor(1000/5)=200, subtract floor(1000/15)=66 counted twice: 333+200-66=467.",
+        b="533: there are 333 multiples of 3 and 200 multiples of 5, giving 533 integers divisible by 3 or 5.",
+    ),
+    dict(
+        id="g-round",
+        source_family="xai",
+        gold="a",
+        prompt="In Python 3, what is round(2.5) and why?",
+        a="2. Python 3 uses banker's rounding: halves go to the nearest even integer, so 2.5 rounds down to 2.",
+        b="3. Python rounds .5 up, as in standard arithmetic, so round(2.5) is 3.",
+    ),
+    dict(
+        id="g-tcp",
+        source_family="deepseek",
+        gold="a",
+        prompt="Does TCP preserve message boundaries across send()/recv()?",
+        a="No. TCP is a byte stream: one send may arrive across several recvs, so applications must frame messages.",
+        b="Yes. Each send() maps to one recv() on the peer, so boundaries survive while the connection stays open.",
+    ),
+]
+SWAP = {"a": "b", "b": "a", "tie": "tie"}
+SEM = asyncio.Semaphore(8)  # stay under provider rate limits
+
+
+async def ask(agent: Agent, prompt: str, first: str, second: str) -> Verdict:
+    for attempt in range(4):  # retry schema breaks and rate limits, never coerce
+        async with SEM:
+            run = await agent.arun(
+                f"PROMPT:\n{prompt}\n\nANSWER a:\n{first}\n\nANSWER b:\n{second}"
+            )
+        if isinstance(run.content, Verdict):
+            return run.content
+        await asyncio.sleep(2**attempt)
+    raise RuntimeError(f"juror {agent.model.id} would not produce a valid Verdict")
+
+
+async def judge(family: str, ex: dict) -> dict | None:
+    if family == ex["source_family"]:
+        print(f"recusal: {family} sits out '{ex['id']}' - it wrote these responses")
+        return None
+    fwd = await ask(JURY[family], ex["prompt"], ex["a"], ex["b"])
+    rev = await ask(JURY[family], ex["prompt"], ex["b"], ex["a"])  # same pair, swapped
+    winner = (
+        fwd.winner if fwd.winner == SWAP[rev.winner] else "tie"
+    )  # order-sensitive verdicts become ties
+    return {
+        "family": family,
+        "winner": winner,
+        "confidence": (fwd.confidence + rev.confidence) / 2,
+    }
+
+
+async def main() -> None:
+    results = await asyncio.gather(
+        *[asyncio.gather(*[judge(f, ex) for f in JURY]) for ex in EXAMPLES]
+    )
+    gold_right, gold_total, dpo, review = 0, 0, [], []
+    for ex, jury_votes in zip(EXAMPLES, results):
+        votes = [v for v in jury_votes if v is not None]
+        winner, count = Counter(v["winner"] for v in votes).most_common(1)[0]
+        agreement = count / len(votes)
+        confidence = sum(v["confidence"] for v in votes) / len(votes)
+        if ex["gold"]:
+            gold_right, gold_total = gold_right + (winner == ex["gold"]), gold_total + 1
+        elif winner != "tie" and agreement >= 0.75:
+            dpo.append(
+                {
+                    "prompt": ex["prompt"],
+                    "chosen": ex[winner],
+                    "rejected": ex[SWAP[winner]],
+                    "agreement": agreement,
+                    "confidence": round(confidence, 2),
+                    "votes": {v["family"]: v["winner"] for v in votes},
+                }
+            )
+        else:
+            review.append(
+                f"{ex['id']}: winner={winner}, agreement={agreement:.2f}, confidence={confidence:.2f}"
+            )
+    print("\n-- dpo records --")
+    for record in dpo:
+        print(json.dumps(record))
+    print("\n-- needs a human --")
+    for item in review:
+        print(item)
+    print(f"\njury calibration: {gold_right}/{gold_total} gold pairs labeled correctly")
+
+
+asyncio.run(main())


### PR DESCRIPTION
## Summary

Adds `dpo_jury.py` to the `_05_text_pairwise_preference` data-labeling cookbook: a jury of 5 model families (OpenAI, Anthropic, Google, Qwen via Groq, Mistral) that turns raw response pairs into trainer-ready DPO records.

What the example demonstrates:

- **Typed verdicts** — every juror is an `Agent` with `output_schema=Verdict` (`winner` + `confidence`), retried with backoff on schema breaks rather than coerced.
- **Position debiasing** — each pair is scored in both orderings; order-sensitive verdicts collapse to `tie`.
- **Self-preference recusal** — a juror from the same model family as the responses sits out.
- **Gold-pair calibration** — 3 pairs with known winners score the jury itself.
- **Agreement gate** — majority winner with agreement >= 0.75 becomes a DPO record; contested pairs are routed to human review.

Also updates the folder README (file listing, run command, API-key requirements) and TEST_LOG.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [x] Other: cookbook example

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Tested 2026-07-18 with `.venvs/demo` and against agno 2.7.3 (full run details in the folder's `TEST_LOG.md`): 2 raw pairs accepted as DPO records (fib 5/5; git-reset 4/4 after the anthropic juror recused), `is_even` routed to human review (agreement 0.60), gold calibration 3/3.

Running this example requires `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`, and `MISTRAL_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
