### PR TITLE
[fix] align AIMLAPI and LlamaOpenAI _format_message signature

### DIFF
--- a/libs/agno/agno/models/aimlapi/aimlapi.py
+++ b/libs/agno/agno/models/aimlapi/aimlapi.py
@@ -45,17 +45,18 @@ class AIMLAPI(OpenAILike):
                 )
         return super()._get_client_params()
 
-    def _format_message(self, message: Message) -> Dict[str, Any]:
+    def _format_message(self, message: Message, compress_tool_results: bool = False) -> Dict[str, Any]:
         """
         Minimal additional formatter that only replaces None with empty string.
 
         Args:
             message (Message): The message to format.
+            compress_tool_results (bool): Whether to compress tool results.
 
         Returns:
             Dict[str, Any]: The formatted message, where 'content = None' is replaced with the empty string.
         """
-        formatted: dict = super()._format_message(message)
+        formatted: dict = super()._format_message(message, compress_tool_results=compress_tool_results)
 
         formatted["content"] = "" if formatted.get("content") is None else formatted["content"]
 

--- a/libs/agno/agno/models/meta/llama_openai.py
+++ b/libs/agno/agno/models/meta/llama_openai.py
@@ -66,14 +66,15 @@ class LlamaOpenAI(OpenAILike):
                 )
         return super()._get_client_params()
 
-    def _format_message(self, message: Message) -> Dict[str, Any]:
+    def _format_message(self, message: Message, compress_tool_results: bool = False) -> Dict[str, Any]:
         """
         Format a message into the format expected by Llama API.
 
         Args:
             message (Message): The message to format.
+            compress_tool_results (bool): Whether to compress tool results.
 
         Returns:
             Dict[str, Any]: The formatted message.
         """
-        return format_message(message, openai_like=True)
+        return format_message(message, openai_like=True, compress_tool_results=compress_tool_results)

--- a/libs/agno/tests/unit/models/aimlapi/test_aimlapi.py
+++ b/libs/agno/tests/unit/models/aimlapi/test_aimlapi.py
@@ -1,0 +1,15 @@
+from agno.models.aimlapi import AIMLAPI
+from agno.models.message import Message
+
+
+def test_aimlapi_format_message_signature():
+    """Test that AIMLAPI._format_message correctly handles the compress_tool_results argument."""
+    model = AIMLAPI(id="gpt-4o-mini", api_key="test-api-key")
+    message = Message(role="user", content="Hello")
+
+    # This should not raise a TypeError
+    formatted = model._format_message(message, compress_tool_results=True)
+
+    assert isinstance(formatted, dict)
+    assert formatted["role"] == "user"
+    assert formatted["content"] == "Hello"

--- a/libs/agno/tests/unit/models/meta/test_llama_openai.py
+++ b/libs/agno/tests/unit/models/meta/test_llama_openai.py
@@ -1,0 +1,23 @@
+import pytest
+
+try:
+    from agno.models.meta import LlamaOpenAI
+    from agno.models.message import Message
+
+    HAS_LLAMA_API = True
+except ImportError:
+    HAS_LLAMA_API = False
+
+
+@pytest.mark.skipif(not HAS_LLAMA_API, reason="llama-api-client is not installed")
+def test_llama_openai_format_message_signature():
+    """Test that LlamaOpenAI._format_message correctly handles the compress_tool_results argument."""
+    model = LlamaOpenAI(id="llama-3.2", api_key="test-api-key")
+    message = Message(role="user", content="Hello")
+
+    # This should not raise a TypeError
+    formatted = model._format_message(message, compress_tool_results=True)
+
+    assert isinstance(formatted, dict)
+    assert formatted["role"] == "user"
+    assert formatted["content"] == "Hello"


### PR DESCRIPTION
## Summary

Fixes the signature mismatch in `_format_message` for `AIMLAPI` and `LlamaOpenAI` models. Both models were missing the `compress_tool_results` parameter, which caused a TypeError (`_format_message() takes 2 positional arguments but 3 were given`) when called by the framework.

Fixes issue: #9034

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The `_format_message` method in both `AIMLAPI` and `LlamaOpenAI` has been updated to accept `compress_tool_results: bool = False` and correctly passes it along (to `super()._format_message` and `format_message` respectively), ensuring compatibility with the parent class and preventing the positional argument error.