### PR TITLE
cookbook: refresh data_labeling for agno 2.7.x

### DIFF
--- a/cookbook/data_labeling/README.md
+++ b/cookbook/data_labeling/README.md
@@ -77,6 +77,7 @@ Each subfolder's `README.md` documents its inputs, the model it expects, and any
 | Variable | Used by |
 |---|---|
 | `GOOGLE_API_KEY` | Default for every cookbook (Gemini 3.5 Flash, natively multimodal) |
-| `ANTHROPIC_API_KEY` | `_18_quality_review/` only — Claude Opus 4.7 is the second labeler |
+| `ANTHROPIC_API_KEY` | `_18_quality_review/` (Claude is the second labeler) and `_05_text_pairwise_preference/dpo_jury.py` |
+| `OPENAI_API_KEY`, `GROQ_API_KEY`, `MISTRAL_API_KEY` | `_05_text_pairwise_preference/dpo_jury.py` only — the 5-model jury |
 
 The per-cookbook README calls out which model it uses and why.

--- a/cookbook/data_labeling/_01_text_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_01_text_classification/TEST_LOG.md
@@ -1,14 +1,14 @@
 # Test Log - _01_text_classification
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Sentiment classification (positive/negative/neutral) over three product reviews.
+**Description:** Sentiment classification (positive/negative/neutral) over three product reviews using an output_schema with a single Literal label field.
 
-**Result:** All three samples classified as expected.
+**Result:** All three samples classified as expected: "I love this product, fantastic quality and fast shipping." -> positive; "Broken on arrival, total waste of money." -> negative; "It works as described, nothing special." -> neutral.
 
 ---
 
@@ -16,9 +16,9 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Same task as basic.py with an extra `confidence` field on the output.
+**Description:** Same task as basic.py with an extra `confidence` field (high/medium/low) on the output, to support routing low-confidence labels to a human queue.
 
-**Result:** Classifications correct; confidence tracks ambiguity (e.g. "It's fine I guess." -> neutral, medium).
+**Result:** Confidence tracked ambiguity as intended: "Best purchase of my life, life-changing!" -> positive/high; "It's fine I guess." -> neutral/medium; "Yeah right, this thing is 'amazing'." (sarcasm) -> negative/low.
 
 ---
 
@@ -26,8 +26,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Same task with a free-text rationale alongside each label.
+**Description:** Same task with a free-text `rationale` field alongside each label; instructions ask the model to quote or paraphrase the deciding words.
 
-**Result:** Rationales correctly cite the deciding phrases in each input.
+**Result:** Both labels correct with rationales citing the deciding phrases: "Shipping was fast but the product itself fell apart in a week." -> negative ("...the product quickly fell apart within a week"); "Better than expected, will buy again." -> positive (quotes 'Better than expected' and 'will buy again').
 
 ---

--- a/cookbook/data_labeling/_01_text_classification/basic.py
+++ b/cookbook/data_labeling/_01_text_classification/basic.py
@@ -10,9 +10,9 @@ This example classifies short product reviews into sentiment classes.
 
 from typing import Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_01_text_classification/with_confidence.py
+++ b/cookbook/data_labeling/_01_text_classification/with_confidence.py
@@ -8,9 +8,9 @@ to route low-confidence labels to a human queue or to a stronger model.
 
 from typing import Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_01_text_classification/with_rationale.py
+++ b/cookbook/data_labeling/_01_text_classification/with_rationale.py
@@ -8,9 +8,9 @@ for training datasets where the reasoning trace is itself an artifact.
 
 from typing import Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_02_text_multilabel_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_02_text_multilabel_classification/TEST_LOG.md
@@ -1,14 +1,14 @@
 # Test Log - _02_text_multilabel_classification
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Tag restaurant reviews with any subset of {food, service, value, atmosphere, cleanliness}.
+**Description:** Tags three restaurant reviews with any subset of {food, service, value, atmosphere, cleanliness} using an output_schema with a List[Literal] field.
 
-**Result:** Tags match the aspects mentioned in each review.
+**Result:** All three runs returned valid Tagging objects. "Pasta was excellent and our server was attentive. A bit pricey but worth it." -> tags=['food', 'service', 'value']; "Place was filthy. Floors sticky, bathroom unusable." -> tags=['cleanliness']; "Came for the vibes, stayed for the cocktails. The space is gorgeous." -> tags=['food', 'atmosphere'] (cocktails counted under food).
 
 ---
 
@@ -16,9 +16,9 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Two-level (parent/child) tagging on news snippets.
+**Description:** Tags two news snippets with parent/child pairs from a two-level taxonomy (parent constrained to a Literal of 5 topics, child free-text subtopic).
 
-**Result:** Tags correctly nested (e.g. business -> markets, tech -> ai chips).
+**Result:** Fed/markets snippet -> [business/markets, tech/ai, tech/hardware]; Manchester United snippet -> [sports/football]. All parents valid Literal values, children are sensible subtopics.
 
 ---
 
@@ -26,8 +26,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Same task with per-tag confidence.
+**Description:** Same aspect-tagging task with a per-tag confidence field (high/medium/low Literal) on three reviews including one deliberately vague input.
 
-**Result:** Reasonable tag/confidence pairs; empty list returned when no aspects are addressed.
+**Result:** "Pasta was excellent and the server brought refills without asking." -> food/high, service/high; "Not sure I'd come back. Something was off." -> atmosphere/low, food/low, service/low (this run tagged the vague review with three low-confidence guesses rather than an empty list); "Cocktails were $22. The room is loud. Food was fine." -> food/high, atmosphere/high, value/high.
 
 ---

--- a/cookbook/data_labeling/_02_text_multilabel_classification/basic.py
+++ b/cookbook/data_labeling/_02_text_multilabel_classification/basic.py
@@ -11,9 +11,9 @@ on.
 
 from typing import List, Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 Aspect = Literal["food", "service", "value", "atmosphere", "cleanliness"]
 

--- a/cookbook/data_labeling/_02_text_multilabel_classification/hierarchical.py
+++ b/cookbook/data_labeling/_02_text_multilabel_classification/hierarchical.py
@@ -9,9 +9,9 @@ that category. Useful when the label space is large and naturally nested
 
 from typing import List, Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 ParentTopic = Literal["sports", "politics", "tech", "business", "health"]
 

--- a/cookbook/data_labeling/_02_text_multilabel_classification/with_confidence.py
+++ b/cookbook/data_labeling/_02_text_multilabel_classification/with_confidence.py
@@ -9,9 +9,9 @@ the training set.
 
 from typing import List, Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 Aspect = Literal["food", "service", "value", "atmosphere", "cleanliness"]
 

--- a/cookbook/data_labeling/_03_text_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_03_text_extraction/TEST_LOG.md
@@ -1,14 +1,14 @@
 # Test Log - _03_text_extraction
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Extract `Contact` (name, email, phone, company, title) from email-signature-style text.
+**Description:** Extracts a flat `Contact` (name, email, phone, company, title) from two email-signature-style samples using `output_schema`.
 
-**Result:** All fields extracted verbatim; missing fields left null.
+**Result:** Sample 1 extracted all fields verbatim: name='Sarah Johnson', email='sarah@acme.com', phone='+1-555-0102', company='Acme Corp.', title='VP of Marketing'. Sample 2 extracted name='Mike', email='engineering@startup.io' with phone, company, and title left None as instructed.
 
 ---
 
@@ -16,9 +16,9 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Extract a `Meeting` containing a list of nested `ActionItem`s from a meeting transcript.
+**Description:** Extracts a `Meeting` containing a list of nested `ActionItem` objects (owner, description, due_date) from a four-line meeting transcript; vague group asks are to be ignored.
 
-**Result:** Three action items extracted with correct owners and due dates.
+**Result:** Three action items extracted with correct owners: Mike ('Send out the updated roadmap'), Sarah ('Set up the kickoff with the design team'), Mike ('Draft the budget memo'). Jess's vague 'budget approval at some point' was correctly excluded. All due_date fields were None this run - the transcript only contains relative dates ('by Friday', 'end of next week'), which the model did not resolve to ISO dates.
 
 ---
 
@@ -26,8 +26,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Same task with `ConfidentField` wrapping each value.
+**Description:** Same contact-extraction task with each field wrapped in a `ConfidentField` (value plus Literal high/medium/low confidence) to support routing low-confidence fields to review.
 
-**Result:** Confidences are sensible: high for explicit fields, medium for inferred ones (e.g. "@mike" as a name).
+**Result:** Sample 1 (full signature) returned all five fields with confidence='high' and verbatim values. Sample 2 ('ping @mike on the eng team') returned name=('mike', high), title=('eng team', medium), and email/phone/company as (None, low). Confidence spread is sensible, though name='mike' at 'high' and 'eng team' as a title are looser calls this run.
 
 ---

--- a/cookbook/data_labeling/_03_text_extraction/basic.py
+++ b/cookbook/data_labeling/_03_text_extraction/basic.py
@@ -10,9 +10,9 @@ This example extracts contact info from an email signature.
 
 from typing import Optional
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_03_text_extraction/nested.py
+++ b/cookbook/data_labeling/_03_text_extraction/nested.py
@@ -10,9 +10,9 @@ This example extracts action items from a meeting transcript.
 
 from typing import List, Optional
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_03_text_extraction/with_confidence.py
+++ b/cookbook/data_labeling/_03_text_extraction/with_confidence.py
@@ -9,9 +9,9 @@ or a stronger model.
 
 from typing import Literal, Optional
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_04_text_span_labeling/TEST_LOG.md
+++ b/cookbook/data_labeling/_04_text_span_labeling/TEST_LOG.md
@@ -1,14 +1,14 @@
 # Test Log - _04_text_span_labeling
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** NER over a short sentence; agent returns exact substrings, Python computes offsets.
+**Description:** NER over a short sentence using an output_schema of (text, label) pairs with labels PERSON, ORG, LOCATION, DATE; character offsets are computed in Python via `text.find()` rather than by the model.
 
-**Result:** Five entities found (DATE, PERSON, ORG, LOCATION, ORG) with correct offsets.
+**Result:** Five entities returned with correct offsets: DATE 'March 3rd' (3-12), PERSON 'Sarah Johnson' (14-27), ORG 'Acme Corp' (33-42), LOCATION 'Berlin' (70-76), ORG 'Lumen Labs' (84-94). Run took about 2.9s.
 
 ---
 
@@ -16,8 +16,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Detect PII spans (name, phone, email, credit card) and produce a redacted string.
+**Description:** PII span detection (email, phone, ssn, credit_card, person_name) followed by a Python find-and-replace redaction step that substitutes each span with a [TYPE] token.
 
-**Result:** All four PII items detected; redacted text replaces each span with its tag.
+**Result:** All four PII items detected: person_name 'Jane Doe', phone '415-555-0199', email 'jane.doe@example.com', credit_card '4242 4242 4242 4242'. Redacted output: "Customer [PERSON_NAME] called from [PHONE] about her order. She asked us to email [EMAIL] with the receipt. Card on file ends [CREDIT_CARD]." Run took about 2.9s.
 
 ---

--- a/cookbook/data_labeling/_04_text_span_labeling/basic.py
+++ b/cookbook/data_labeling/_04_text_span_labeling/basic.py
@@ -11,9 +11,9 @@ substring and locating it in Python is the robust pattern.
 
 from typing import List, Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_04_text_span_labeling/pii_redaction.py
+++ b/cookbook/data_labeling/_04_text_span_labeling/pii_redaction.py
@@ -9,9 +9,9 @@ and its PII type; Python does the find-and-replace.
 
 from typing import List, Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_05_text_pairwise_preference/TEST_LOG.md
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/TEST_LOG.md
@@ -1,34 +1,14 @@
 # Test Log - _05_text_pairwise_preference
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Pick winner between two responses to the same prompt; output A/B/tie.
+**Description:** Pick the winner between two responses to the same prompt; typed A/B/tie output via output_schema.
 
-**Result:** Picks the more informative response (A) over the trivial one (B).
-
----
-
-### with_rationale.py
-
-**Status:** PASS
-
-**Description:** Same task with a free-text rationale for the choice.
-
-**Result:** Winner and rationale agree; rationale cites the discriminating quality.
-
----
-
-### with_rubric.py
-
-**Status:** PASS
-
-**Description:** Same task driven by an explicit rubric in the instructions.
-
-**Result:** Picks the more accurate/complete response per the rubric.
+**Result:** Returned `Preference(winner='A')`, preferring the substantive scattering explanation over "Because of physics."
 
 ---
 
@@ -36,8 +16,28 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Tested 2026-07-18 with `.venvs/demo` (agno 2.7.0a1) and against agno 2.7.3. A jury of 5 model families (gpt-5.5, claude-sonnet-5, gemini-3.5-flash, qwen/qwen3.6-27b via Groq, mistral-large-latest) labels 3 raw pairs and 3 gold pairs, scoring each pair in both orderings.
+**Description:** A jury of 5 model families (gpt-5.5, claude-sonnet-5, gemini-3.5-flash, qwen/qwen3.6-27b via Groq, mistral-large-latest) labels 3 raw pairs and 3 gold pairs, scoring each pair in both orderings with position debiasing, self-preference recusal, gold calibration, and a 0.75 agreement gate.
 
-**Result:** 2 pairs accepted as DPO records (fib 5/5; git-reset 4/4 after the anthropic juror recused), is_even routed to human review (winner=tie, agreement 0.60), gold calibration 3/3. Occasional schema breaks from JSON-mode jurors and Mistral 429s on back-to-back runs are absorbed by the backoff retry in `ask`.
+**Result:** 2 DPO records emitted: fib (agreement 1.0, confidence 0.99, 5/5 votes for a) and git reset (agreement 1.0, confidence 0.99, 4/4 votes for a after the anthropic juror recused from the pair it authored). is_even routed to human review (winner=tie, agreement 0.60, confidence 0.83). Gold calibration 3/3. One juror emitted malformed JSON once ("Failed to convert response to output_schema" warning); the backoff retry in `ask` absorbed it.
+
+---
+
+### with_rationale.py
+
+**Status:** PASS
+
+**Description:** Same pairwise task with a one-sentence free-text rationale alongside the winner.
+
+**Result:** Returned winner='A' ('Drift') with rationale: "Response A provides a realistic, evocative, and high-quality name suggestion with helpful context, whereas Response B is overly long and reads like a joke."
+
+---
+
+### with_rubric.py
+
+**Status:** PASS
+
+**Description:** Same pairwise task graded against an explicit 4-point ordered rubric (correctness, completeness, clarity, concision) in the instructions.
+
+**Result:** Returned `Preference(winner='A')`, preferring the concrete Settings > Subscription cancellation steps over the vague "dig around in the app" response.
 
 ---

--- a/cookbook/data_labeling/_05_text_pairwise_preference/basic.py
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/basic.py
@@ -8,9 +8,9 @@ data shape used to train reward models (RLHF) or do DPO fine-tuning.
 
 from typing import Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_05_text_pairwise_preference/with_rationale.py
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/with_rationale.py
@@ -9,9 +9,9 @@ own preferences to a human reviewer.
 
 from typing import Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_05_text_pairwise_preference/with_rubric.py
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/with_rubric.py
@@ -9,9 +9,9 @@ across many graders or many runs.
 
 from typing import Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_06_image_classification/README.md
+++ b/cookbook/data_labeling/_06_image_classification/README.md
@@ -24,5 +24,6 @@ python cookbook/data_labeling/_06_image_classification/basic.py
 python cookbook/data_labeling/_06_image_classification/multilabel.py
 ```
 
-Requires `GOOGLE_API_KEY`. The samples use stable Wikimedia URLs - swap
-your own image URLs or local paths in the `Image(...)` call.
+Requires `GOOGLE_API_KEY`. The samples use stable public image URLs
+(Google sample assets and the agno public S3 bucket) - swap in your own
+image URLs or local paths in the `Image(...)` call.

--- a/cookbook/data_labeling/_06_image_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_06_image_classification/TEST_LOG.md
@@ -1,16 +1,14 @@
 # Test Log - _06_image_classification
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Single-label scene-type classification (wildlife / landscape / sports / architecture / other) over four photos.
+**Description:** Single-label scene-type classification with a Literal output schema (wildlife / landscape / sports / architecture / other) over four image URLs: a Google generative-AI wildlife sample, two gstatic webp gallery photos, and the agno-public Krakow basilica photo.
 
-**Result:** All four classified into the expected scene type.
-
-**Note:** Test inputs moved off Wikimedia (Gemini can't fetch those URLs) to agno-public S3, gstatic gallery, and a Google generative-AI sample. Label set switched from animal types to scene types so the available images classify cleanly.
+**Result:** All four images classified as expected: elephants/giraffes/zebras sunset -> `wildlife`, gstatic gallery/1.jpg -> `landscape`, gstatic gallery/2.jpg -> `sports`, krakow_mariacki.jpg -> `architecture`. Each run returned a validated `Classification` object; per-image latency 1.2-3.2s.
 
 ---
 
@@ -18,8 +16,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Multi-label tagging of scene attributes (outdoor, daytime, people, nature, architecture, etc.) over a Krakow basilica photo and a Google generative-AI wildlife sample.
+**Description:** Multi-label scene tagging with a List[Literal] output schema over eight possible tags (outdoor, indoor, daytime, nighttime, people, vehicle, nature, architecture) on the Krakow basilica photo and the Google generative-AI wildlife sample.
 
-**Result:** Tag sets are coherent with each image's content.
+**Result:** krakow_mariacki.jpg -> `['outdoor', 'nighttime', 'architecture']`; elephants/giraffes/zebras sunset -> `['outdoor', 'daytime', 'nature']`. Both tag sets coherent with image content; each run returned a validated `Tagging` object; per-image latency 2.8-5.6s.
 
 ---

--- a/cookbook/data_labeling/_06_image_classification/basic.py
+++ b/cookbook/data_labeling/_06_image_classification/basic.py
@@ -8,10 +8,10 @@ classification with image input.
 
 from typing import Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Image
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_06_image_classification/multilabel.py
+++ b/cookbook/data_labeling/_06_image_classification/multilabel.py
@@ -8,10 +8,10 @@ content categorization.
 
 from typing import List, Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Image
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 SceneTag = Literal[
     "outdoor",

--- a/cookbook/data_labeling/_07_image_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_07_image_extraction/TEST_LOG.md
@@ -1,16 +1,14 @@
 # Test Log - _07_image_extraction
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Extract a `Scene` (subject, setting, time of day, colors, objects) from a photo of Krakow's St. Mary's Basilica.
+**Description:** Extracts a typed `Scene` (subject, setting, time_of_day, dominant_colors, notable_objects) from a photo of Krakow's St. Mary's Basilica via `output_schema` on a Gemini agent.
 
-**Result:** All fields populated correctly.
-
-**Note:** Test image switched from a Wikimedia URL (Gemini can't fetch those) to `agno-public.s3.amazonaws.com/images/krakow_mariacki.jpg`.
+**Result:** Returned `Scene(subject="St. Mary's Basilica viewed through the arches of the Cloth Hall in Kraków", setting='outdoor', time_of_day='dawn_or_dusk', dominant_colors=['blue', 'yellow', 'beige'])` with five notable_objects including "Sukiennice (Cloth Hall) arches" and "Adam Mickiewicz Monument". Run took 6.9s, 1249 total tokens.
 
 ---
 
@@ -18,11 +16,9 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** OCR a text-heavy image into typed fields (primary text, secondary text, color scheme).
+**Description:** OCRs a text-heavy image (the Agno intro graphic) into a typed `SignReading` with primary_text, secondary_text list, and color_scheme.
 
-**Result:** Reads the Agno wordmark and body copy from the intro image into the typed schema.
-
-**Note:** Input switched from a Wikimedia "Welcome to Las Vegas" sign (Gemini can't fetch those URLs) to `agno-public.s3.us-east-1.amazonaws.com/images/agno-intro.png`. The schema is still about extracting text from an image — content changed from a sign to a marketing graphic.
+**Result:** Returned `primary_text='What is Agno'`, eight secondary_text entries in reading order (from 'Introduction' through 'Level 5: Agentic Workflows with state and determinism.'), and `color_scheme='Black, White, Red'`. Run took 2.4s, 1246 total tokens.
 
 ---
 
@@ -30,8 +26,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Same task with `ConfidentStr` / `ConfidentList` wrapping each output (fjord landscape from the gstatic gallery).
+**Description:** Same scene-extraction task with per-field `ConfidentStr` / `ConfidentList` wrappers, using a fjord landscape photo from the gstatic gallery.
 
-**Result:** All fields populated with `high` confidence; nested confidence wrappers serialize correctly.
+**Result:** All five fields populated with `confidence='high'`; subject value 'A deep fjord valley with a river flowing between steep, green mountains', dominant_colors ['blue', 'green', 'grey', 'brown'], notable_objects ['fjord', 'mountains', 'rocky peak', 'valley', 'river']. Nested wrappers deserialized into the Pydantic models correctly. Run took 3.3s, 1332 total tokens.
 
 ---

--- a/cookbook/data_labeling/_07_image_extraction/basic.py
+++ b/cookbook/data_labeling/_07_image_extraction/basic.py
@@ -8,10 +8,10 @@ object whose schema you control.
 
 from typing import List, Literal, Optional
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Image
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_07_image_extraction/ocr_fields.py
+++ b/cookbook/data_labeling/_07_image_extraction/ocr_fields.py
@@ -9,10 +9,10 @@ schema.
 
 from typing import List, Optional
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Image
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_07_image_extraction/with_confidence.py
+++ b/cookbook/data_labeling/_07_image_extraction/with_confidence.py
@@ -9,10 +9,10 @@ need to flag uncertain fields for review.
 
 from typing import List, Literal, Optional
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Image
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 Confidence = Literal["high", "medium", "low"]
 

--- a/cookbook/data_labeling/_08_image_bounding_boxes/TEST_LOG.md
+++ b/cookbook/data_labeling/_08_image_bounding_boxes/TEST_LOG.md
@@ -1,16 +1,14 @@
 # Test Log - _08_image_bounding_boxes
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Detect the main subject in a kayaker-in-whitewater photo, return one normalized bounding box.
+**Description:** Detects the main subject in a kayaker-in-whitewater photo (`www.gstatic.com/webp/gallery/2.jpg`) and returns one normalized bounding box via `output_schema=BoundingBox`. Exercises single-object detection with `[0, 1]` coordinates.
 
-**Result:** Sensible tight box around the kayaker.
-
-**Note:** Test image switched from a Wikimedia cat photo (Gemini can't fetch those URLs) to `www.gstatic.com/webp/gallery/2.jpg`.
+**Result:** Schema-valid box returned: `label='the main subject'`, `x=0.356`, `y=0.115`, `width=0.324`, `height=0.514` — a sensible tight box over the kayaker region. Note: the model echoes the prompt phrase as the label instead of a semantic label like "kayaker"; consistent across two runs. Coordinates vary slightly run to run (second run: `x=0.25`, `width=0.44`).
 
 ---
 
@@ -18,11 +16,9 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Detect multiple objects in an image, return a list of bounding boxes. Input is a savanna scene with elephants, giraffes, zebras, and a crocodile.
+**Description:** Detects multiple objects of multiple classes in a savanna scene (elephants, giraffes, zebras, crocodile) and returns a `Detection` with a list of labeled normalized boxes.
 
-**Result:** Multiple boxes returned with reasonable coordinates and per-animal labels.
-
-**Note:** Test image switched from a Wikimedia "Collage of Nine Dogs" (Gemini can't fetch those URLs) to a Google generative-AI sample at `storage.googleapis.com/generativeai-downloads/images/generated_elephants_giraffes_zebras_sunset.jpg`.
+**Result:** 11 boxes returned: 6 `elephant`, 2 `giraffe`, 2 `zebra`, 1 `crocodile`. Coordinates are plausible and all in `[0, 1]` (e.g. crocodile at `x=0.606`, `y=0.848`, `width=0.321`, `height=0.081` along the bottom of the frame). Labels here are semantic, unlike the single-object files.
 
 ---
 
@@ -30,10 +26,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Same task with a `confidence` field added to the schema (kayaker-in-whitewater photo).
+**Description:** Same kayaker photo as basic.py with a `confidence: Literal["high", "medium", "low"]` field added to the schema, so downstream consumers can threshold or route low-confidence boxes to review.
 
-**Result:** Sensible bounding box around the kayaker with `high` confidence.
-
-**Note:** Per-field `description` on `x`, `y`, `width`, `height` is load-bearing — without it, and without the `[0, 1]` coordinate convention spelled out in instructions, models tend to return degenerate boxes (all-zero or whole-image).
+**Result:** Box returned with `confidence='high'`: `label='the main subject'`, `x=0.354`, `y=0.115`, `width=0.332`, `height=0.521` — nearly identical to the basic.py box, with the same prompt-echo label quirk.
 
 ---

--- a/cookbook/data_labeling/_08_image_bounding_boxes/basic.py
+++ b/cookbook/data_labeling/_08_image_bounding_boxes/basic.py
@@ -6,10 +6,10 @@ Detect a single object in an image and return its bounding box. The model
 emits normalized coordinates so the result is resolution-independent.
 """
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Image
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_08_image_bounding_boxes/multi_object.py
+++ b/cookbook/data_labeling/_08_image_bounding_boxes/multi_object.py
@@ -8,10 +8,10 @@ list of boxes, each with a label and normalized coordinates.
 
 from typing import List
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Image
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_08_image_bounding_boxes/with_confidence.py
+++ b/cookbook/data_labeling/_08_image_bounding_boxes/with_confidence.py
@@ -8,10 +8,10 @@ low-confidence boxes to a human reviewer.
 
 from typing import Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Image
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_09_image_extraction_to_vectordb/README.md
+++ b/cookbook/data_labeling/_09_image_extraction_to_vectordb/README.md
@@ -21,7 +21,9 @@ No variants. The value here is the full pipeline.
 ## When to use
 
 - Searching a stock photo library by natural-language query.
-- Deduplicating a product catalog by visual + descriptive similarity.
+- Deduplicating a product catalog by description similarity. Note the
+  search operates on the extracted text descriptions, not on image
+  embeddings - two images match when their descriptions match.
 - Building "find more like this" features on user-uploaded media.
 
 ## Run
@@ -29,7 +31,7 @@ No variants. The value here is the full pipeline.
 Install the extra dependency for LanceDb first:
 
 ```bash
-pip install lancedb tantivy
+pip install lancedb
 python cookbook/data_labeling/_09_image_extraction_to_vectordb/basic.py
 ```
 

--- a/cookbook/data_labeling/_09_image_extraction_to_vectordb/TEST_LOG.md
+++ b/cookbook/data_labeling/_09_image_extraction_to_vectordb/TEST_LOG.md
@@ -1,15 +1,13 @@
 # Test Log - _09_image_extraction_to_vectordb
 
-Tested 2026-05-22 against `gemini-3.5-flash` + `gemini-embedding-001` (embedder), agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash` + `gemini-embedding-001` (embedder), agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Describe three images (Krakow basilica, fjord, savanna wildlife), embed the descriptions with `GeminiEmbedder`, store in LanceDb, then run two semantic queries.
+**Description:** End-to-end labeling pipeline run from a clean slate (tmp/lancedb/ deleted before the run). An agent extracts a structured `ImageDescription` (subject, setting, mood, key_objects) from three image URLs (Krakow basilica, fjord, savanna wildlife), the descriptions are flattened to searchable strings, embedded with `GeminiEmbedder`, inserted into a fresh LanceDb table (`data_labeling_images`, `SearchType.vector`), and two natural-language queries are run against the index. Exercised without `tantivy` installed - vector search does not need it.
 
-**Result:** "a historic city at night" returns the Krakow basilica as top hit; "wildlife on the savanna" returns the elephants/giraffes/zebras scene.
-
-**Note:** Requires `lancedb` (not in the `agno[demo]` extras). Install with `uv pip install lancedb` into `.venvs/demo`. Test inputs were also swapped off Wikimedia URLs since Gemini can't fetch those.
+**Result:** All three extractions succeeded with well-formed structured output (e.g. Krakow: subject "St. Mary's Basilica framed by the arches of the Cloth Hall", mood "Magical and serene"; savanna: subject "A diverse group of African wildlife, including elephants, giraffes, zebras, and a crocodile, gathered at a watering hole"). 3 documents inserted. Query "a historic city at night" returned the Krakow basilica as top hit; "wildlife on the savanna" returned the elephants/giraffes/zebras scene as top hit. Each extraction took roughly 2.7-4.8s.
 
 ---

--- a/cookbook/data_labeling/_09_image_extraction_to_vectordb/basic.py
+++ b/cookbook/data_labeling/_09_image_extraction_to_vectordb/basic.py
@@ -21,7 +21,7 @@ from agno.knowledge.embedder.google import GeminiEmbedder
 from agno.media import Image
 from agno.vectordb.lancedb import LanceDb, SearchType
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_10_audio_classification/README.md
+++ b/cookbook/data_labeling/_10_audio_classification/README.md
@@ -16,8 +16,8 @@ with audio input.
 
 ## Models
 
-Uses Gemini for native audio input. Replace the `Gemini(...)` line with an
-audio-capable model from another provider if needed.
+Uses Gemini for native audio input. Swap the `model="google:gemini-3.5-flash"`
+string for an audio-capable model from another provider if needed.
 
 ## Run
 

--- a/cookbook/data_labeling/_10_audio_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_10_audio_classification/TEST_LOG.md
@@ -1,14 +1,14 @@
 # Test Log - _10_audio_classification
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Classify audio clip language from a closed set.
+**Description:** Downloads an mp3 clip (QA-01.mp3 from the agno-public S3 bucket) and asks a Gemini agent with an `output_schema` to assign a single language label from a closed Literal set (english, spanish, french, german, mandarin, hindi, other).
 
-**Result:** Identified as `english`.
+**Result:** Returned `Classification(language='english')`. Single model call, 1921 input / 6 output tokens, 2.36s.
 
 ---
 
@@ -16,8 +16,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Same task with a `confidence` field.
+**Description:** Same language-identification task on the same clip, with the schema extended by a `confidence` Literal field (high, medium, low) and instructions defining each confidence tier for downstream routing.
 
-**Result:** `english`, confidence `high`.
+**Result:** Returned `Classification(language='english', confidence='high')`. Single model call, 1965 input / 12 output tokens, 1.67s.
 
 ---

--- a/cookbook/data_labeling/_10_audio_classification/basic.py
+++ b/cookbook/data_labeling/_10_audio_classification/basic.py
@@ -10,10 +10,10 @@ audio classification (genre, emotion, speaker, intent).
 from typing import Literal
 
 import requests
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Audio
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_10_audio_classification/with_confidence.py
+++ b/cookbook/data_labeling/_10_audio_classification/with_confidence.py
@@ -9,10 +9,10 @@ differently (escalate to a stronger model, queue for human review).
 from typing import Literal
 
 import requests
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Audio
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_11_audio_transcription/TEST_LOG.md
+++ b/cookbook/data_labeling/_11_audio_transcription/TEST_LOG.md
@@ -1,14 +1,14 @@
 # Test Log - _11_audio_transcription
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Verbatim transcript from `QA-01.mp3` (English Q&A).
+**Description:** Verbatim transcript of `QA-01.mp3` (English family Q&A clip) into a flat `Transcript` schema with a single `text` field.
 
-**Result:** Clean transcript of the full clip.
+**Result:** Full clean transcript returned, starting "How many people are there in your family? There are five people in my family..." and ending "...My mom always prepares delicious meals for us." Tokens: input=1949, output=1488; duration 8.23s.
 
 ---
 
@@ -16,9 +16,9 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Transcript split into speaker turns over `sample_conversation.wav`.
+**Description:** Transcript of `sample_conversation.wav` split into speaker turns via the `DiarizedTranscript` schema, with generic speaker identifiers.
 
-**Result:** Two speakers identified with five turns; speaker labels are consistent across turns.
+**Result:** Five turns returned alternating between exactly two speakers, labeled consistently as "Speaker A" and "Speaker B" (A opens with "Hello, Liam, hey..." and closes with "...Thanks for the encouragement."). No invented names. Duration 3.38s.
 
 ---
 
@@ -26,8 +26,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Transcript with `[start, end]` second timestamps per segment.
+**Description:** Transcript of `QA-01.mp3` split into sentence-level segments with start/end times in seconds via the `TimedTranscript` schema.
 
-**Result:** Segments returned with monotonically increasing timestamps.
+**Result:** 25 segments returned from 0.0 to 116.0 with monotonically non-decreasing times, e.g. [0.0, 2.1] "How many people are there in your family?". Known model quirk observed: past the one-minute mark the model flattens mm:ss into decimal (59.3 jumps to 103.3, i.e. 1:03.3 read as 103.3 seconds), so absolute values after 60s are inflated while ordering stays correct.
 
 ---

--- a/cookbook/data_labeling/_11_audio_transcription/basic.py
+++ b/cookbook/data_labeling/_11_audio_transcription/basic.py
@@ -6,10 +6,10 @@ Speech-to-text on an audio clip. The output is a flat transcript string.
 """
 
 import requests
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Audio
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_11_audio_transcription/with_diarization.py
+++ b/cookbook/data_labeling/_11_audio_transcription/with_diarization.py
@@ -10,10 +10,10 @@ consistently across the clip but does not know real names.
 from typing import List
 
 import requests
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Audio
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_11_audio_transcription/with_timestamps.py
+++ b/cookbook/data_labeling/_11_audio_transcription/with_timestamps.py
@@ -10,10 +10,10 @@ chunked playback.
 from typing import List
 
 import requests
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Audio
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_12_audio_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_12_audio_extraction/TEST_LOG.md
@@ -1,14 +1,14 @@
 # Test Log - _12_audio_extraction
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Extract a generic `CallSummary` (caller intent, key topics, next action) from a conversation clip.
+**Description:** Downloads `sample_conversation.wav` and extracts a generic `CallSummary` (caller_intent, key_topics, next_action) via `output_schema` on a Gemini agent.
 
-**Result:** Caller intent and next action captured; key topics list is coherent.
+**Result:** Returned `CallSummary(caller_intent='Discuss taking on a new project lead role', key_topics=['project lead role', 'career transition'], next_action='The caller will update Liam on their decision or progress with the role')`. 1092 input / 43 output tokens, 4.8s.
 
 ---
 
@@ -16,9 +16,9 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Extract a domain-shaped `SupportCall` (issue, resolution status, sentiment, follow-up).
+**Description:** Extracts a support-desk-shaped `SupportCall` (issue, resolution_status, customer_sentiment, follow_up_required, notes) with Literal-constrained fields from the same conversation clip.
 
-**Result:** All fields populated with sensible values.
+**Result:** Returned `issue='Discussing the possibility of applying for a new project lead role'`, `resolution_status='unclear'`, `customer_sentiment='neutral'`, `follow_up_required=False`. The model's notes field correctly observed the clip is a conversation between colleagues, not a customer support interaction. 1107 input / 74 output tokens, 4.4s.
 
 ---
 
@@ -26,8 +26,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Extract `MeetingNotes` (attendees, topics, action items) from a conversation clip.
+**Description:** Extracts `MeetingNotes` (attendees, topics, nested `ActionItem` list) from the conversation clip; instructions require attendees identifiable from the audio and explicitly assigned action items only.
 
-**Result:** Attendees and topics extracted; action_items empty since none were stated in this clip.
+**Result:** Returned `attendees=['Liam']`, `topics=['New project lead role opportunity']`, `action_items=[]` (none explicitly assigned in the clip, consistent with the instructions). 1101 input / 24 output tokens, 3.5s.
 
 ---

--- a/cookbook/data_labeling/_12_audio_extraction/basic.py
+++ b/cookbook/data_labeling/_12_audio_extraction/basic.py
@@ -9,10 +9,10 @@ generic call summary; swap in domain-specific shapes for production use.
 from typing import List, Optional
 
 import requests
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Audio
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_12_audio_extraction/call_summary.py
+++ b/cookbook/data_labeling/_12_audio_extraction/call_summary.py
@@ -9,10 +9,10 @@ Common shape for populating ticketing systems from voice channels.
 from typing import Literal, Optional
 
 import requests
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Audio
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_12_audio_extraction/meeting_notes.py
+++ b/cookbook/data_labeling/_12_audio_extraction/meeting_notes.py
@@ -9,10 +9,10 @@ shape used by note-taking integrations.
 from typing import List, Optional
 
 import requests
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Audio
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_13_video_classification/README.md
+++ b/cookbook/data_labeling/_13_video_classification/README.md
@@ -26,3 +26,7 @@ python cookbook/data_labeling/_13_video_classification/with_confidence.py
 ```
 
 Requires `GOOGLE_API_KEY`. Uses Gemini for native video input.
+
+Note on the sample asset: `sample_seaview.mp4` is misnamed - the clip is
+a short lab scene (a scientist examining a sample through a microscope),
+not a sea view. Expect labels like `indoor` or `people`.

--- a/cookbook/data_labeling/_13_video_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_13_video_classification/TEST_LOG.md
@@ -1,14 +1,14 @@
 # Test Log - _13_video_classification
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Single-label classification of the clip's scene type.
+**Description:** Downloads `sample_seaview.mp4` from agno-public S3 and runs single-label closed-set classification (`scene_type` Literal with 7 options) via `output_schema` on Gemini with native video input.
 
-**Result:** Classified as `indoor` (consistent with the actual lab scene).
+**Result:** Returned `Classification(scene_type='indoor')`. Run took 9.8s (677 input / 10 output tokens, 313 reasoning). Note: despite the filename, the clip shows a scientist at a microscope in a lab, so `indoor` is correct.
 
 ---
 
@@ -16,8 +16,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Same task with a `confidence` field.
+**Description:** Same clip and label set, with an added `confidence` Literal field (`high`/`medium`/`low`) and instructions defining each confidence tier.
 
-**Result:** Classified as `people` with `high` confidence (model picks a different valid label than basic.py — both are reasonable for a person in a lab).
+**Result:** Returned `Classification(scene_type='people', confidence='high')`. Run took 9.0s (724 input / 15 output tokens, 304 reasoning). Model picks a different valid label than basic.py — both `indoor` and `people` fit a person working in a lab.
 
 ---

--- a/cookbook/data_labeling/_13_video_classification/basic.py
+++ b/cookbook/data_labeling/_13_video_classification/basic.py
@@ -9,10 +9,10 @@ the clip end-to-end and emits one label for the whole thing.
 from typing import Literal
 
 import httpx
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Video
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_13_video_classification/with_confidence.py
+++ b/cookbook/data_labeling/_13_video_classification/with_confidence.py
@@ -9,10 +9,10 @@ human review or a stronger model.
 from typing import Literal
 
 import httpx
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Video
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_14_video_extraction/README.md
+++ b/cookbook/data_labeling/_14_video_extraction/README.md
@@ -28,3 +28,7 @@ python cookbook/data_labeling/_14_video_extraction/action_timestamps.py
 ```
 
 Requires `GOOGLE_API_KEY`.
+
+Note on the sample asset: `sample_seaview.mp4` is misnamed - the clip is
+a short lab scene (a scientist examining a sample through a microscope),
+not a sea view. The extracted events and scenes describe the lab scene.

--- a/cookbook/data_labeling/_14_video_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_14_video_extraction/TEST_LOG.md
@@ -1,14 +1,14 @@
 # Test Log - _14_video_extraction
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### action_timestamps.py
 
 **Status:** PASS
 
-**Description:** Extract a list of `Event`s with action descriptions and `[start, end]` second timestamps.
+**Description:** Extracts an `Events` list from sample_seaview.mp4, each `Event` with an action name and start/end times in seconds. Exercises structured output (`output_schema`) over raw video bytes with Gemini.
 
-**Result:** Three events returned with monotonically increasing timestamps.
+**Result:** One event returned: `action='A scientist looking into a microscope'`, `start_seconds=0.0`, `end_seconds=9.0`. Timestamps monotonic and within the clip. Model call took ~6.8s (726 input / 54 output tokens).
 
 ---
 
@@ -16,9 +16,9 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Extract a `VideoSummary` (overall summary, dominant subject, scenes list).
+**Description:** Extracts a `VideoSummary` (overall summary, dominant subject, ordered scene phrases) from sample_seaview.mp4. Exercises clip-level summarization with a typed schema.
 
-**Result:** Two-sentence summary plus three scene phrases; matches what's on screen.
+**Result:** `dominant_subject='Female scientist'`; two-sentence summary of a scientist in protective gear examining a sample through a microscope under blue and warm lighting; 3 scene phrases returned (side view at microscope, close-up adjusting focus, continued observation). Model call took ~7.6s (733 input / 117 output tokens).
 
 ---
 
@@ -26,8 +26,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Extract a list of `Scene` objects with name, description, and visible objects.
+**Description:** Extracts a `ScenesDocument` from sample_seaview.mp4, one `Scene` per detected scene with name, description, and up to five visible objects. Exercises per-scene structured indexing output.
 
-**Result:** One scene returned with detailed description and visible objects list.
+**Result:** One scene returned: `name='Scientific Microscope Examination'` with a detailed description and 5 visible objects (`microscope`, `scientist`, `protective suit`, `safety glasses`, `gloves`). Model call took ~7.5s (726 input / 102 output tokens).
 
 ---

--- a/cookbook/data_labeling/_14_video_extraction/action_timestamps.py
+++ b/cookbook/data_labeling/_14_video_extraction/action_timestamps.py
@@ -10,10 +10,10 @@ data for temporal action detection.
 from typing import List
 
 import httpx
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Video
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_14_video_extraction/basic.py
+++ b/cookbook/data_labeling/_14_video_extraction/basic.py
@@ -10,10 +10,10 @@ metadata.
 from typing import List, Optional
 
 import httpx
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Video
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_14_video_extraction/scene_descriptions.py
+++ b/cookbook/data_labeling/_14_video_extraction/scene_descriptions.py
@@ -10,10 +10,10 @@ video indexing and search.
 from typing import List
 
 import httpx
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import Video
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_15_document_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_15_document_classification/TEST_LOG.md
@@ -1,14 +1,14 @@
 # Test Log - _15_document_classification
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Classify a PDF into one of {invoice, receipt, contract, spec_sheet, report, recipe, other}.
+**Description:** Classifies a PDF (ThaiRecipes.pdf from agno-public S3) into one of {invoice, receipt, contract, spec_sheet, report, recipe, other} using a Literal-constrained Pydantic output_schema. Exercises File(url=...) PDF input and structured output on `google:gemini-3.5-flash`.
 
-**Result:** Correctly classified as `recipe`.
+**Result:** Returned `Classification(label='recipe')` - correct label for the recipe PDF. This run: input=7449 tokens, output=6, duration 4.58s.
 
 ---
 
@@ -16,8 +16,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Same task with a `confidence` field.
+**Description:** Same classification task with an added `confidence` field (Literal high/medium/low) so downstream routing can escalate low-confidence documents. Exercises multi-field structured output over a PDF file input.
 
-**Result:** Classified as `recipe` with `high` confidence.
+**Result:** Returned `Classification(label='recipe', confidence='high')` - correct label with high confidence. This run: input=7468 tokens, output=19, duration 3.03s.
 
 ---

--- a/cookbook/data_labeling/_15_document_classification/basic.py
+++ b/cookbook/data_labeling/_15_document_classification/basic.py
@@ -8,10 +8,10 @@ step before a more specific extraction pipeline runs.
 
 from typing import Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import File
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_15_document_classification/with_confidence.py
+++ b/cookbook/data_labeling/_15_document_classification/with_confidence.py
@@ -8,10 +8,10 @@ differently (escalate, retry, or send to human review).
 
 from typing import Literal
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import File
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_16_document_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_16_document_extraction/TEST_LOG.md
@@ -1,14 +1,14 @@
 # Test Log - _16_document_extraction
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Extract document-level metadata (title, cuisine, language, recipe_count) into a `RecipeBook`.
+**Description:** Extracts document-level metadata (title, cuisine, language, recipe_count) from the public ThaiRecipes.pdf into a typed `RecipeBook` via `output_schema`. Exercises PDF file input by URL plus structured output on a Gemini model.
 
-**Result:** Title "Thai SELECT Cookbook", cuisine "Thai cuisine", language "English", recipe_count 10.
+**Result:** Returned `RecipeBook(title='Thai SELECT Cookbook', cuisine='Thai', language='English', recipe_count=10)`. Single model call, 7449 total tokens, ~3.9s.
 
 ---
 
@@ -16,11 +16,9 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Same task with `ConfidentField` wrapping each value.
+**Description:** Same metadata extraction with each field wrapped in a `ConfidentField` (value plus Literal high/medium/low confidence), exercising nested models and Literal enums inside the structured-output schema.
 
-**Result:** All four fields populated with sensible confidences.
-
-**Note:** Originally failed with `Invalid schema for response_format 'RecipeBook': $ref cannot have keywords {'description'}` — OpenAI's strict structured-output mode rejects a `description` on a field whose type is itself a referenced model. Fix: removed the `Field(..., description=...)` annotation on `recipe_count` (kept the explanatory text as a code comment).
+**Result:** All four fields populated with confidence "high": title 'Thai SELECT Cookbook', cuisine 'Thai', language 'English', recipe_count '10'. ~6.0s model call.
 
 ---
 
@@ -28,8 +26,8 @@ Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 **Status:** PASS
 
-**Description:** Extract a `RecipeBook` with a nested list of `Recipe` line items (name, course, prep time).
+**Description:** Extracts book metadata plus a nested `List[Recipe]` (name, course, prep_time_minutes), the line-item extraction shape, from the same PDF.
 
-**Result:** Multiple recipes extracted with full nested structure.
+**Result:** Returned title 'Thai SELECT COOKBOOK', cuisine 'Thai', and 10 recipes including 'Pad Thai Goong Sod' (prep 15), 'Tom Kha Gai' (prep 10), and 'Gluai Buat Chi' (prep 10); all `course` fields null, consistent with the document not labeling courses. ~9.4s model call.
 
 ---

--- a/cookbook/data_labeling/_16_document_extraction/basic.py
+++ b/cookbook/data_labeling/_16_document_extraction/basic.py
@@ -9,10 +9,10 @@ LabReport, etc. for your domain.
 
 from typing import Optional
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import File
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_16_document_extraction/with_confidence.py
+++ b/cookbook/data_labeling/_16_document_extraction/with_confidence.py
@@ -9,10 +9,10 @@ human review.
 
 from typing import Literal, Optional
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import File
 from pydantic import BaseModel
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 Confidence = Literal["high", "medium", "low"]
 

--- a/cookbook/data_labeling/_16_document_extraction/with_line_items.py
+++ b/cookbook/data_labeling/_16_document_extraction/with_line_items.py
@@ -9,10 +9,10 @@ common production extraction pattern.
 
 from typing import List, Optional
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from agno.media import File
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_17_llm_as_judge/TEST_LOG.md
+++ b/cookbook/data_labeling/_17_llm_as_judge/TEST_LOG.md
@@ -1,16 +1,14 @@
 # Test Log - _17_llm_as_judge
 
-Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
-
-Score schemas switched from `Literal[1, 2, 3, 4, 5]` to `int` with `ge=1, le=5`. Gemini's structured-output enforcement requires string-valued enums, not integer enums; bounded `int` keeps the same 1-5 scale and the discrete-output guarantee without the Literal incompatibility.
+Tested 2026-07-18 against `gemini-3.5-flash`, agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Score response quality on a 1-5 scale against the prompt.
+**Description:** Scores a (prompt, response) pair on overall quality 1-5 via `output_schema=Score` (bounded int, ge=1 le=5). Runs two samples against the same prompt: a correct one-sentence Rayleigh-scattering explanation and the non-answer "It just is."
 
-**Result:** Detailed answer scored 5, "It just is." scored 1.
+**Result:** Detailed scattering answer scored `Score(overall=5)`; "It just is." scored `Score(overall=1)`. Both runs returned valid structured output on the first attempt.
 
 ---
 
@@ -18,9 +16,9 @@ Score schemas switched from `Literal[1, 2, 3, 4, 5]` to `int` with `ge=1, le=5`.
 
 **Status:** PASS
 
-**Description:** Score against an explicit rubric (correctness, completeness, clarity, concision, overall).
+**Description:** Scores a subscription-cancellation support answer against an explicit five-field rubric (correctness, completeness, clarity, concision, overall), each a bounded 1-5 int in `RubricScore`.
 
-**Result:** All rubric dimensions scored independently with a separate overall.
+**Result:** Returned `RubricScore(correctness=5, completeness=5, clarity=5, concision=5, overall=5)` for the clear, complete cancellation instructions. All five fields populated independently in one structured response.
 
 ---
 
@@ -28,8 +26,8 @@ Score schemas switched from `Literal[1, 2, 3, 4, 5]` to `int` with `ge=1, le=5`.
 
 **Status:** PASS
 
-**Description:** Same task with a free-text rationale for the score.
+**Description:** Scores a project-name suggestion 1-5 and requires a one-sentence free-text rationale alongside the score, with instructions to quote a phrase from the response.
 
-**Result:** Score 4 with a rationale that calls out both the positives and a specific weakness.
+**Result:** Returned `overall=5` with rationale: "The suggested name 'Drift' is highly relevant and evocative for a sleep project, and the response provides helpful context regarding its domain availability." The rationale references the specific name 'Drift' as instructed.
 
 ---

--- a/cookbook/data_labeling/_17_llm_as_judge/basic.py
+++ b/cookbook/data_labeling/_17_llm_as_judge/basic.py
@@ -7,9 +7,9 @@ eval primitive - and identical machinery to single-label text
 classification, just applied to (prompt, response) pairs.
 """
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_17_llm_as_judge/single_rubric.py
+++ b/cookbook/data_labeling/_17_llm_as_judge/single_rubric.py
@@ -7,9 +7,9 @@ score, plus an overall. Use this for eval consistency across runs and
 graders.
 """
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_17_llm_as_judge/with_rationale.py
+++ b/cookbook/data_labeling/_17_llm_as_judge/with_rationale.py
@@ -7,9 +7,9 @@ check the model's reasoning and is itself useful as training data for a
 reward model.
 """
 
-from agno.agent import Agent, RunOutput  # noqa
+from agno.agent import Agent, RunOutput
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
+from rich.pretty import pprint
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/data_labeling/_18_quality_review/README.md
+++ b/cookbook/data_labeling/_18_quality_review/README.md
@@ -7,10 +7,18 @@ input. Use this when label quality matters more than throughput.
 
 ## Files
 
-- `basic.py` — labeler → reviewer → adjudicator applied to text
-  extraction (the `_03_text_extraction/basic.py` Contact schema). The same
-  pattern composes on top of any image / audio / document extraction
+- `basic.py` — labeler → reviewer → adjudicator expressed as an agno
+  Workflow: the two labelers run inside `Parallel(...)`, the reviewer
+  diffs their outputs field by field, and a `Condition` step runs the
+  adjudicator only when the reviewer flags disagreement. Applied to text
+  extraction (the `_03_text_extraction/basic.py` Contact schema); the
+  same shape composes on top of any image / audio / document extraction
   cookbook in this directory.
+
+The demo runs two inputs — a clean one where the labelers agree and the
+adjudication step is skipped, and one with deliberately conflicting
+details where the adjudicator resolves the disagreement — and prints the
+full step trail for both.
 
 ## When to use
 
@@ -24,10 +32,11 @@ see [`_17_llm_as_judge/`](../_17_llm_as_judge/).
 
 ## Composition
 
-`basic.py` is a flat imperative pipeline (three sequential agent calls).
-For production traceability and parallelism, wrap the same agents in
-`Workflow(Parallel(labeler_a, labeler_b), reviewer, Condition(adjudicator))` -
-see `cookbook/04_workflows/04_parallel_execution/parallel_with_condition.py`.
+The workflow is `Parallel(labeler_a, labeler_b)` → reviewer →
+`Condition(adjudicator)`, with every run persisted to SQLite
+(`tmp/labeling.db`) for traceability. Swap the labeler agents and the
+schema to apply the same quality gate to any other primitive in this
+directory.
 
 ## Run
 

--- a/cookbook/data_labeling/_18_quality_review/TEST_LOG.md
+++ b/cookbook/data_labeling/_18_quality_review/TEST_LOG.md
@@ -1,13 +1,13 @@
 # Test Log - _18_quality_review
 
-Tested 2026-05-22 against `gemini-3.5-flash` for labeler A and `claude-opus-4-7` for labeler B / reviewer / adjudicator, agno 2.6.9.
+Tested 2026-07-18 against `gemini-3.5-flash` (labeler A) and `claude-opus-4-7` (labeler B, reviewer, adjudicator), agno 2.7.4.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** End-to-end labeler / reviewer / adjudicator pipeline on a Contact extraction task. Two labelers (different providers) extract, a reviewer diffs them, an adjudicator runs only if there's disagreement.
+**Description:** Labeler / reviewer / adjudicator pipeline expressed as an agno Workflow (Parallel labelers, reviewer, Condition-gated adjudicator) on a Contact extraction task. The demo runs two inputs - a clean one and one with deliberately conflicting details - and prints the full step trail for both, exercising both the skip path and the adjudication path.
 
-**Result:** Labelers agreed; reviewer returned `needs_adjudication=False`; final label returned with `notes='Labelers agreed.'` (adjudicator path not exercised on this input — covered by the original invoice cookbook in git history).
+**Result:** Clean input: both labelers returned identical Contact objects (name='Liam Ortega', email='liam@meadow.io', company='Meadow', title='Support Engineer'), the reviewer returned needs_adjudication=False, and the trail shows the Condition skip ('Condition Adjudicate not met - skipped 1 steps'). Conflicting input: the labelers disagreed on name ('Dr. Sarah Chen-Watanabe' vs 'Sarah Chen') and title ('Principal Scientist and acting Head of Platform' vs 'Principal Scientist'); the reviewer flagged both fields with per-field reasons; the adjudicator ran and emitted FinalLabel(contact=Contact(name='Sarah Chen', email='s.chen@nova-labs.io', phone='+1-415-555-0177', company='NovaLabs', title='Principal Scientist and acting Head of Platform')). Which fields disagree can vary run to run; the conflicting input is constructed so that at least one field reliably does.
 
 ---

--- a/cookbook/data_labeling/_18_quality_review/basic.py
+++ b/cookbook/data_labeling/_18_quality_review/basic.py
@@ -7,6 +7,11 @@ Workflow. Two labelers (different providers) run concurrently, a reviewer
 diffs them field by field, and an adjudicator runs only when the reviewer
 flags disagreement. Every run is persisted to SQLite for traceability.
 
+The demo runs two inputs: a clean one where the labelers agree and the
+adjudication step is skipped, and one with genuinely conflicting details
+where the adjudicator resolves the disagreement. The full step trail is
+printed for both.
+
 The same shape composes on top of any extraction primitive in this
 directory (text, image, audio, document).
 """
@@ -168,10 +173,37 @@ workflow = Workflow(
 # ---------------------------------------------------------------------------
 # Run
 # ---------------------------------------------------------------------------
+def print_step_outputs(step_results) -> None:
+    """Walk the step trail, descending into Parallel / Condition children."""
+    for step in step_results:
+        if step.steps:
+            print_step_outputs(step.steps)
+        elif step.content is not None:
+            pprint({"step": step.step_name, "output": step.content})
+
+
 if __name__ == "__main__":
-    text = (
-        "Sarah Johnson, VP Marketing at Acme Corp. "
-        "Reach me at sarah@acme.com or +1-555-0102."
+    clean = (
+        "Liam Ortega is a Support Engineer at Meadow and can be reached "
+        "at liam@meadow.io."
     )
-    response = workflow.run(input=text)
-    pprint(response.content)
+    # Conflicting details by construction - two phone numbers, a rebranded
+    # company, a compound title, a preferred short name - so independent
+    # labelers serialize at least one field differently and the
+    # adjudication path runs.
+    conflicting = (
+        "Forwarded note: you can reach Dr. Sarah Chen-Watanabe (she goes "
+        "by Sarah Chen) about the platform work. Sarah is Principal "
+        "Scientist and acting Head of Platform at NovaLabs, which recently "
+        "rebranded from Nova Biotech. Email s.chen@nova-labs.io. The "
+        "555-0123 number on the website is stale; her direct line is "
+        "+1-415-555-0177."
+    )
+
+    print("=== clean input: labelers expected to agree ===")
+    response = workflow.run(input=clean)
+    print_step_outputs(response.step_results)
+
+    print("\n=== conflicting input: adjudicator expected to run ===")
+    response = workflow.run(input=conflicting)
+    print_step_outputs(response.step_results)

--- a/cookbook/data_labeling/image_search/TEST_LOG.md
+++ b/cookbook/data_labeling/image_search/TEST_LOG.md
@@ -1,251 +1,33 @@
-# TEST_LOG — image_search
+# Test Log - image_search
 
-## Run env
+Tested 2026-07-18 against gemini-3.5-flash + gemini-embedding-001 (embedder), agno 2.7.4.
 
-- Tested 2026-05-21 against `gemini-3.5-flash` (vision + structured output)
-  and `gemini-embedding-001` (embeddings), agno 2.6.8.
-- Vector DB: ChromaDb local (`persistent_client=True`, `data/chroma/`).
-- Contents DB: SqliteDb (single file, shared by Knowledge + Workflow).
-- Run command: `fastapi dev cookbook/data_labeling/image_search/run.py --port 7777`.
-
----
-
-### Knowledge plumbing roundtrip
+### run.py (server + endpoints)
 
 **Status:** PASS
 
-**Description:** 3 hand-typed `ImageDescription` fixtures roundtripped
-through `Knowledge.insert(text_content=..., metadata=...)`, `get_content()`,
-`search()`, and re-insert with `skip_if_exists=True`.
+**Description:** Starts the AgentOS server app (run.py, wiring db.py, schemas.py, settings.py, workflows/ingest.py) against the local pgvector on port 5532 and exercises the HTTP surface: the explicit /ui route, the native /knowledge/content gallery endpoint, and the native workflow-run endpoints. Note: the demo venv does not ship the `fastapi` CLI (`fastapi[standard]`), so the server was started with the equivalent `python -m uvicorn run:app --app-dir cookbook/data_labeling/image_search --port 7777`.
 
-**Result:**
-
-- `insert(text_content=..., metadata=...)` round-trips through both
-  contents_db and vector_db on the same call. Synchronous — search hits
-  return immediately, status=COMPLETED on return.
-- No chunking for ~150-char descriptions — 1 chunk per fixture.
-- Idempotent: re-insert with `skip_if_exists=True` leaves the count alone.
-- ChromaDb persistent_client survives process restarts.
+**Result:** Server started cleanly ("Application startup complete", port 7777). GET /ui returned 200 with the index.html document (doctype + Tailwind/Alpine CDN head visible). GET /knowledge/content returned the paginated envelope `{data, meta}` with `meta.total_count: 0` on the empty index before ingest and `meta.total_count: 38` after ingest. POST /workflows/image-ingest/runs requires the form field `message` (422 "Field required" without it) and defaults to `stream=true`, so a background run that should return 202 metadata immediately needs `background=true&stream=false`; with those it returned `{"run_id": "78ac80c2-...", "session_id": "8d1d5ddf-...", "status": "PENDING"}` at once.
 
 ---
 
-### AgentOS endpoints
+### run.py (ingest workflow)
 
 **Status:** PASS
 
-- `GET /ui` → 200 with index.html.
-  - Note: `StaticFiles(html=True)` mounted at `/ui` redirect-loops because
-    AgentOS's `TrailingSlashMiddleware` strips the slash StaticFiles uses
-    for index-resolution. Resolved by registering an explicit
-    `@base_app.get("/ui")` returning `FileResponse`.
-- `GET /knowledge/content` → paginated list with `metadata` per item.
-- `POST /knowledge/search` → vector hits with `meta_data` carrying the
-  full ImageDescription.
-- `POST /workflows/image-ingest/runs` (form-encoded, background=true) →
-  run_id + session_id.
-- `GET /workflows/image-ingest/runs/{id}?session_id=...` → status
-  progression + the final indexed/skipped/failed/total summary.
+**Description:** Triggers the image-ingest workflow (full wipe + re-ingest of the 38 built-in Picsum URLs at INGEST_CONCURRENCY=3: httpx fetch, gemini-3.5-flash structured ImageDescription extraction, gemini-embedding-001 embed, PgVector upsert) via POST /workflows/image-ingest/runs with background=true and stream=false, then polls GET /workflows/image-ingest/runs/{run_id}?session_id={session_id} until terminal status.
 
-**Port gotcha:** `fastapi dev` defaults to port 8000. Docker Desktop's
-webview also binds 8000 with a wildcard listener that silently returns
-stale JSON to local curl. We run on 7777 to dodge that. README documents
-the flag.
+**Result:** Run completed with status COMPLETED and final summary content `{'total': 38, 'failed': 0, 'indexed': 38}` in well under a minute. Server log showed 38 "Upserted batch of 1 documents" lines for the run (76 cumulative across the two runs performed today, confirming the wipe + full re-ingest behavior), and /knowledge/content reported `total_count: 38` afterward. Per-image Gemini extraction calls ran at roughly 4s each (e.g. one logged call: input=1401 tokens, output=240, duration 3.88s). No failed URLs, no "agent returned str" structured-output corruption.
 
 ---
 
-### End-to-end parallel ingest
-
-**Status:** PASS (after two fixes)
-
-**Description:** Triggered the ingest workflow against the 38 Picsum URLs
-with `INGEST_CONCURRENCY=8` (the shipped default has since been lowered to
-3 to stay clear of transient 5xx bursts — see settings.py).
-
-**Result:** all 38 indexed in ~10s.
-
-**Fix 1 — image fetch:** initial impl passed `Image(url=picsum_url)` to
-the agent. Picsum redirects via 302 to signed Fastly URLs and Gemini's URL
-fetcher handles redirects inconsistently — most URLs returned `400
-INVALID_ARGUMENT`. Solved by fetching bytes locally with `httpx` and
-passing `Image(content=...)`. Works for any public URL, including the
-future S3 path.
-
-**Fix 2 — agent thread-safety:** initial impl shared one `Agent` instance
-across the ThreadPoolExecutor. Under concurrency=8, ~63% of calls
-returned a string instead of an `ImageDescription` — the agent's
-structured-output parsing has per-run state that isn't thread-safe.
-Solved by constructing a fresh `Agent` inside `_ingest_one` for each
-worker. Object construction is cheap; the underlying Gemini client is
-shared via the model. After fix: 38/38 clean.
-
----
-
-### Search quality with the search-tuned schema
+### run.py (search quality)
 
 **Status:** PASS
 
-Spot-checked against the live index:
+**Description:** Exercises POST /knowledge/search (hybrid PgVector search: cosine similarity over GeminiEmbedder vectors fused with Postgres FTS, prefix_match=True) against the freshly built 38-image index using four probe queries: animal, mountain, coffee, and the nonsense token asdf. Scores read from `meta_data.similarity_score` on each hit.
 
-| Query                  | Top hit                                                              |
-|------------------------|----------------------------------------------------------------------|
-| `mountains and lakes`  | "A dense green evergreen forest overlooking a wide blue lake..."     |
-| `cozy indoor scene`    | "A steaming teacup and an open book..."                              |
-| `abstract patterns`    | "Wavy sandstone formations of a slot canyon..."                      |
-| `wildlife on savanna`  | (no result — no wildlife in the 38-image Picsum set)                 |
-
-The five-field schema (caption + subjects + scene + visual_style + tags)
-gives noticeably stronger signal than the previous four (subject /
-setting / mood / key_objects). The caption alone tends to dominate, but
-the tag list catches near-misses (e.g. "outdoors" / "wilderness" surfacing
-nature shots that don't match the literal query).
+**Result:** All four queries behaved as designed. "animal" top hits: tiger cub 0.602, English Bulldog 0.600, leopard on savanna road 0.594. "mountain" top hits: mountain valley under overcast sky 0.695, mountain lake at sunset 0.690, Mount Everest peaks 0.683. "coffee": roasted coffee beans macro 0.710 as a clear bullseye, with the laptop-in-cafe image second at 0.523 and the tea cup demoted to 0.276. "asdf" returned only vector noise, all scores 0.217-0.227 - below the UI's 0.30 score floor, so it would correctly land in the below-threshold tray. Full ImageDescription metadata (caption, subjects, scene, visual_style, tags) round-tripped on every hit as native JSON.
 
 ---
-
-### UI
-
-**Status:** PASS
-
-Static preview renders. Live API wiring verified via curl path-equivalence
-(`fetch()` from index.html issues identical requests). Cards render
-caption, subjects line, scene, visual style, and up to 6 tag chips.
-
-Open <http://localhost:7777/ui>. First load is empty — click Reindex,
-counter ticks up live, gallery and search populate on completion.
-
----
-
-### UI rewrite — Alpine + Lucide + PhotoSwipe (post-test addendum)
-
-**Status:** Static rendering verified; interactive smoke pending.
-
-The UI was rewritten after the section above to swap the imperative
-vanilla JS for Alpine.js (declarative state via `x-data`), add Lucide
-icons to the Reindex (spinning when active) and Search buttons, and wire
-PhotoSwipe lightboxes to both `#search-grid` and `#gallery-grid`. All CDN,
-no build step.
-
-Fetch URLs and field mappings are unchanged, so the curl-equivalence
-verification above still applies. Interactive features (lightbox click,
-reindex polling, tab switching) should be re-smoked against a live server
-before relying on them.
-
----
-
-### PgVector swap (2026-05-22)
-
-**Status:** PASS
-
-The cookbook was migrated from `ChromaDb` + `SqliteDb` to `PgVector` +
-`PostgresDb` against `agnohq/pgvector:18` (the image
-`cookbook/scripts/run_pgvector.sh` brings up on port 5532). The swap
-deletes two client-side workarounds that were papering over storage-layer
-weirdness in the previous stack:
-
-- `asArray()` in [`public/index.html`](public/index.html): pgvector
-  preserves JSONB arrays as native arrays in both
-  `/knowledge/content.metadata` and `/knowledge/search.meta_data`. No
-  more string ↔ array reconciliation.
-- The frontend "trust real keyword hits, not substring noise" heuristic
-  is no longer needed. PgVector's keyword branch runs
-  `to_tsvector(english, content)` + `websearch_to_tsquery(english,
-  query)`, so `car` no longer false-matches `carnivore` or `streetcar` —
-  the English Snowball stemmer lemmatizes both query and document into
-  lexemes (`car`, `cars` → `car`; `carnivore` → `carnivor`).
-
-**Reindex:** 38/38 indexed in ~10s. No "agent returned str" issues
-recurred (the per-worker Agent construction from Fix 2 still applies).
-
-**Query battery** — `MIN_SCORE_RATIO=0.5`, `SCORE_FLOOR=0.30`. PgVector's
-hybrid score = `0.5 * cosine_similarity + 0.5 * ts_rank`. A pure vector
-match tops out at ~0.5; anything above that is FTS-boosted.
-
-| Query        | Best   | Shown | Below | Verdict                                              |
-|--------------|--------|-------|-------|------------------------------------------------------|
-| `animal`     | 0.525  | 5     | 7     | bulldog, leopard, bear, coyote, highland cow         |
-| `anim`       | 0.488  | 6     | 6     | same set as `animal`, stemmer makes them equivalent  |
-| `anima`      | 0.243  | 0     | 12    | tsquery `anima` ≠ lexeme `anim` — tucked under tray  |
-| `wildlife`   | 0.532  | 5     | 7     | coyote, bear, leopard, tiger cub, pelican            |
-| `mountain`   | 0.696  | 8     | 4     | valleys, peaks, lakes — all mountain scenes          |
-| `coffee`     | 0.710  | 1     | 11    | just the macro beans — laptop-in-cafe correctly demoted to 0.27 |
-| `car`        | 0.240  | 0     | 12    | no FTS hits — leopard `carnivore` is gone (stemmer)  |
-| `night city` | 0.259  | 0     | 12    | vector-only candidates (Milan dusk, NYC) shown via tray |
-| `asdf`       | 0.223  | 0     | 12    | correctly tucked under tray                          |
-
-**Observations:**
-
-- `SCORE_FLOOR = 0.30` cleanly separates "real FTS match" (scores >0.45)
-  from "vector noise" (scores 0.20–0.27). The relative cutoff
-  (`best * MIN_SCORE_RATIO`) only kicks in inside the strong-match tier,
-  so `coffee` correctly returns one bullseye instead of dragging in the
-  laptop-in-cafe image.
-- Search-as-you-type has a quirk: `anim` matches because the lexeme is
-  `anim`, but `anima` doesn't because the stemmer treats it as a
-  different word. The 250ms debounce + AbortController + tray-fallback
-  UX (`Show 12 below threshold`) gives an honest "no high-confidence
-  match" experience instead of pretending.
-- `prefix_match=True` was tried and reverted: it appends `*` to query
-  terms, but agno passes the query through `websearch_to_tsquery`, which
-  doesn't honor `:*` / `*` operators — it's a silent no-op. (Fixed
-  upstream in #8048 and re-enabled below.)
-
-**Endpoints:** unchanged surface — `/knowledge/content`,
-`/knowledge/search`, `/workflows/image-ingest/runs` all behave the same
-shape-wise. Just the underlying storage moved.
-
----
-
-### prefix_match=True (2026-05-21)
-
-**Status:** PASS
-
-Now that #8048 routes `prefix_match=True` through `to_tsquery('tok:*')`
-instead of letting `websearch_to_tsquery` strip the `*`, the cookbook
-enables it in [`db.py`](db.py). The win is partial-typed queries: "ani"
-now matches docs containing "animal" (the stemmer reduces "animal" to
-the lexeme `anim`, which `ani:*` covers as a prefix), and "mount"
-matches "mountain". Both flip from the "no exact match · showing
-closest" tray into first-class primary results.
-
-**Query battery** — same `MIN_SCORE_RATIO=0.5`, `SCORE_FLOOR=0.30` as
-the prior run, against the same 38-image index. The two columns show
-the *primary tier* count (results that clear the floor + ratio) before
-vs. after the flip.
-
-| Query        | Before | After | Verdict                                                |
-|--------------|--------|-------|--------------------------------------------------------|
-| `animal`     | 6      | 6     | exact lexeme match, unchanged                          |
-| `anim`       | 6      | 6     | stemmer already collapsed this, unchanged              |
-| `ani`        | **0**  | **6** | `ani:*` now matches `anim` — primary results restored  |
-| `anima`      | 0      | 0     | quirk — lexeme is `anim`, `anima:*` requires lexemes starting with `anima` (none exist) |
-| `wildlife`   | 5      | 5     | exact match, unchanged                                 |
-| `wildlif`    | 5      | 5     | stemmer-equivalent, unchanged                          |
-| `mountain`   | 8      | 8     | exact match, unchanged                                 |
-| `mount`      | **1**  | **8** | `mount:*` now matches `mountain`/`mountains` lexemes   |
-| `coffee`     | 1      | 1     | only one doc has coffee content, unchanged             |
-| `car`        | **0**  | **1** | `car:*` now matches `carnivor` (stemmed "carnivore") — surfaces the leopard |
-| `night city` | 0      | 0     | no doc has lexemes starting with `night`, unchanged    |
-| `asdf`       | 0      | 0     | nonsense token, still tucked under tray                |
-
-**Observations:**
-
-- The two headline wins are `ani` (0.233 → 0.478 top score, 0 → 6 primary
-  results) and `mount` (0.585 → 0.669, 1 → 8). Partial-typed words now
-  behave the way a user would expect: more characters typed = more
-  matches, not a sudden drop to zero.
-- `anima` is an instructive non-win: the document side stores the
-  stemmed lexeme `anim`, and `to_tsquery('anima:*')` only matches
-  lexemes that *start with* `anima` — `anim` doesn't qualify. This is
-  inherent to FTS stemming, not an agno limitation. The tray fallback
-  catches it cleanly.
-- `car` now surfaces the leopard image because the doc's "carnivore"
-  stems to `carnivor`, which `car:*` matches. This is the tradeoff for
-  prefix matching — accepting some false-positive prefix collisions in
-  exchange for partial-word ergonomics. For this 38-image demo it's a
-  good trade; on a larger corpus we'd consider re-ranking the FTS hits
-  by exact-term overlap.
-- `SCORE_FLOOR = 0.30` still cleanly separates the new prefix-matched
-  FTS hits (0.45+) from the vector-only tail (0.20-0.27). No change
-  needed to the threshold.
-- The `index.html` comment that called out "car" as the canonical
-  example of a no-FTS-match query was updated to use "night city" and
-  "asdf" instead, since "car" now has a (prefix-collided) FTS hit.

--- a/cookbook/data_labeling/image_search/workflows/ingest.py
+++ b/cookbook/data_labeling/image_search/workflows/ingest.py
@@ -148,9 +148,9 @@ ingest_workflow = Workflow(
     id="image-ingest",
     name="Image Ingest",
     description=(
-        "Index images for natural-language search. For each image: download "
-        "the bytes, describe it with search-tuned metadata, embed, and store. "
-        "Idempotent — items already indexed are skipped."
+        "Index images for natural-language search. Clears the index, then "
+        "for each image: download the bytes, describe it with search-tuned "
+        "metadata, embed, and store. Each run is a full rebuild."
     ),
     db=get_db(),  # required for background runs (the Reindex button)
     steps=[Step(name="Ingest", executor=ingest)],

--- a/libs/agno/tests/unit/tools/test_telegram.py
+++ b/libs/agno/tests/unit/tools/test_telegram.py
@@ -515,9 +515,7 @@ def test_pin_message_api_error(monkeypatch):
     from agno.tools.telegram import TelegramTools
 
     tools = TelegramTools(chat_id="12345", enable_pin_message=True)
-    tools.bot.pin_chat_message = MagicMock(
-        side_effect=_FakeApiTelegramException("pinChatMessage", "Bad Request", 400)
-    )
+    tools.bot.pin_chat_message = MagicMock(side_effect=_FakeApiTelegramException("pinChatMessage", "Bad Request", 400))
 
     result = tools.pin_message(message_id=42)
     parsed = json.loads(result)
@@ -593,9 +591,7 @@ def test_get_file_save_downloads_to_disk(monkeypatch, tmp_path):
     monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
     from agno.tools.telegram import TelegramTools
 
-    tools = TelegramTools(
-        chat_id="12345", enable_get_file=True, save_downloads=True, output_directory=str(tmp_path)
-    )
+    tools = TelegramTools(chat_id="12345", enable_get_file=True, save_downloads=True, output_directory=str(tmp_path))
     mock_file = MagicMock()
     mock_file.file_id = "ABC123"
     mock_file.file_path = "photos/file_0.jpg"


### PR DESCRIPTION
## Summary

Full audit and refresh of `cookbook/data_labeling/` (19 folders, 52 runnable examples) against agno 2.7.4.

- **Re-ran every example** with the demo venv on `gemini-3.5-flash` and rewrote all 19 `TEST_LOG.md` files from today's observed output. Previous logs dated 2026-05-22 against agno 2.6.9. All 52 files PASS with zero code fixes needed - no API drift between 2.6.9 and 2.7.4 for these cookbooks.
- **`_18_quality_review` rewrite:** the README described `basic.py` as a "flat imperative pipeline" while the code is a Workflow (`Parallel` labelers -> reviewer -> `Condition`-gated adjudicator), and the old demo input only exercised the skip path while the TEST_LOG claimed a `FinalLabel` output that path cannot produce. The demo now runs two inputs - a clean one showing the Condition skip and a deliberately conflicting one that reliably triggers real adjudication - and prints the full step trail. README and TEST_LOG now match actual behavior (verified run: reviewer flagged `name` and `title`, adjudicator emitted the resolved `FinalLabel`).
- **Stale README fixes:** `_06` claimed Wikimedia sample URLs (actual: Google sample assets + agno S3); `_09` said `pip install lancedb tantivy` (tantivy is FTS-only; the example uses `SearchType.vector` - verified passing without tantivy installed) and implied visual similarity (search is over extracted text descriptions); `_10` said "replace the `Gemini(...)` line" (code uses model-string shorthand since #8080); `_13`/`_14` now note that `sample_seaview.mp4` is misnamed - the clip is a lab scene (scientist at a microscope), confirmed by model output across independent runs.
- **`image_search`:** ingest `Workflow(description=...)` claimed idempotent skip-if-indexed; the executor does a full rebuild (verified: 76 cumulative upserts across 2 runs, count stays 38). Description corrected. TEST_LOG rewritten from a live server run (38/38 indexed, search battery logged).
- **Dead `# noqa` sweep:** removed ~100 `# noqa` comments on import lines across the folder; `ruff check` passes without any of them.
- **Top-level README:** env-var table now documents the five provider keys `_05/dpo_jury.py` needs.
- Drive-by: `libs/agno/tests/unit/tools/test_telegram.py` picked up a 2-hunk `ruff format` reflow - `./scripts/format.sh` produces it on current main; included so the format script leaves a clean tree.

Notes from testing worth knowing (logged in the TEST_LOGs): `dpo_jury.py` (frozen) re-run today - 2 DPO records, is_even routed to review, gold 3/3; `_08` returns the literal label "the main subject" (echo of the prompt phrase) - stable across runs, schema-valid; `_11` timestamps flatten mm:ss to decimal past 60s.

## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`python3 cookbook/scripts/check_cookbook_pattern.py --base-dir cookbook/data_labeling` passes (0 violations). Recursive mode flags only `image_search/` app modules (server app, not single-file examples) and the deliberately template-relaxed `dpo_jury.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
