### PR TITLE
cookbook: image_search README - ingest is a full rebuild, not idempotent

### DIFF
--- a/cookbook/data_labeling/image_search/README.md
+++ b/cookbook/data_labeling/image_search/README.md
@@ -64,7 +64,7 @@ All four routes come from a single `AgentOS(knowledge=..., workflows=..., base_a
 
 ## How it works
 
-1. **Ingest** — the `image-ingest` workflow fetches each URL (httpx, redirects on), passes the bytes to a Gemini agent with `output_schema=ImageDescription`, and inserts the structured result into one shared `Knowledge` instance. The flattened description (caption + subjects + scene + style + tags) becomes the embedded text; the full `ImageDescription` plus the source URL becomes the metadata. URLs are processed concurrently with a `ThreadPoolExecutor`. The workflow is idempotent — items already present in `contents_db` are skipped.
+1. **Ingest** — the `image-ingest` workflow fetches each URL (httpx, redirects on), passes the bytes to a Gemini agent with `output_schema=ImageDescription`, and inserts the structured result into one shared `Knowledge` instance. The flattened description (caption + subjects + scene + style + tags) becomes the embedded text; the full `ImageDescription` plus the source URL becomes the metadata. URLs are processed concurrently with a `ThreadPoolExecutor`. A reindex is a full rebuild — the workflow clears `contents_db` and re-ingests everything, so runs are repeatable but not incremental.
 
 2. **Gallery** — the UI hits `GET /knowledge/content`. Items render as cards with the image, caption, subjects, scene, visual style, and tag chips.
 


### PR DESCRIPTION
## Summary

One-line docs fix: `image_search/README.md:67` claimed the ingest workflow is idempotent (skip-if-indexed), but the executor does a full `remove_all_content()` rebuild — as its own module docstring states. The README now matches the code. Last survivor from the data_labeling audit; no code changes.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)