### PR TITLE
fix: replace retired qwen/qwen3-32b with openai/gpt-oss-20b on Groq

### DIFF
--- a/cookbook/10_reasoning/models/groq/9_11_or_9_9.py
+++ b/cookbook/10_reasoning/models/groq/9_11_or_9_9.py
@@ -15,7 +15,7 @@ from agno.models.groq import Groq
 def run_example() -> None:
     agent = Agent(
         model=Groq(
-            id="qwen/qwen3-32b",
+            id="openai/gpt-oss-20b",
             temperature=0.6,
             max_tokens=1024,
             top_p=0.95,

--- a/cookbook/10_reasoning/models/groq/TEST_LOG.md
+++ b/cookbook/10_reasoning/models/groq/TEST_LOG.md
@@ -9,3 +9,23 @@
 **Result:** Files in this directory pass structure checks and compile successfully.
 
 ---
+
+### 9_11_or_9_9.py
+
+**Status:** PASS
+
+**Description:** Live run after swapping the retired qwen/qwen3-32b for openai/gpt-oss-20b (Groq no longer serves the qwen model; confirmed against the models API).
+
+**Result:** Reasoning streamed and the agent answered 9.9 > 9.11 correctly.
+
+---
+
+### deepseek_plus_claude.py
+
+**Status:** PASS
+
+**Description:** Live run with the same model swap; Groq gpt-oss-20b reasons, Claude responds.
+
+**Result:** Clean run, correct answer.
+
+---

--- a/cookbook/10_reasoning/models/groq/deepseek_plus_claude.py
+++ b/cookbook/10_reasoning/models/groq/deepseek_plus_claude.py
@@ -1,8 +1,8 @@
 """
-Deepseek Plus Claude
-====================
+Groq Reasoning Plus Claude
+==========================
 
-Demonstrates this reasoning cookbook example.
+A Groq-hosted reasoning model thinks; Claude writes the answer.
 """
 
 from agno.agent import Agent
@@ -17,7 +17,7 @@ def run_example() -> None:
     deepseek_plus_claude = Agent(
         model=Claude(id="claude-3-7-sonnet-20250219"),
         reasoning_model=Groq(
-            id="qwen/qwen3-32b",
+            id="openai/gpt-oss-20b",
             temperature=0.6,
             max_tokens=1024,
             top_p=0.95,

--- a/libs/agno/tests/integration/models/groq/test_reasoning_streaming.py
+++ b/libs/agno/tests/integration/models/groq/test_reasoning_streaming.py
@@ -22,8 +22,8 @@ def groq_model():
 
 @pytest.fixture(scope="module")
 def groq_reasoning_model():
-    """Fixture that provides a Groq DeepSeek reasoning model."""
-    return Groq(id="qwen/qwen3-32b", request_params={"include_reasoning": True})
+    """Fixture that provides a Groq reasoning model (gpt-oss emits reasoning on Groq)."""
+    return Groq(id="openai/gpt-oss-20b", request_params={"include_reasoning": True})
 
 
 def _get_reasoning_streaming_agent(main_model, reasoning_model, **kwargs):


### PR DESCRIPTION
## Summary

Groq retired `qwen/qwen3-32b` (confirmed against the live `/v1/models` API), which has kept the `test-groq (3.12)` job red on main's Main Validation runs: the three reasoning-streaming integration tests fail with `The model 'qwen/qwen3-32b' does not exist or you do not have access to it`.

This swaps the stale id for `openai/gpt-oss-20b` in the test fixture and the two cookbook files that used it. `gpt-oss-20b` is live on Groq, emits streamed reasoning, and is already in `is_groq_reasoning_model`'s detection list — so the fix needs no production-code change. The old `qwen/qwen3-32b` entry stays in the detection list (a harmless id match; removing it would only affect anyone still routing that id through a custom endpoint).

Verified live:
- All 3 tests in `tests/integration/models/groq/test_reasoning_streaming.py` pass against real Groq (reasoning deltas stream incrementally).
- Both cookbooks (`9_11_or_9_9.py`, `deepseek_plus_claude.py`) run clean end to end; runs logged in the folder `TEST_LOG.md`.
- `./scripts/format.sh` and `./scripts/validate.sh` green.

## Type of change

- [x] Bug fix
- [x] Model update

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Unrelated to the 2.7.5 environments stack (#9049-#9053) — this red job pre-dates it on main's scheduled runs. `deepseek_plus_claude.py` keeps its filename to avoid breaking links, but its docstring title now says what it does; a rename can ride a future cookbook cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
