### PR TITLE
fix: sort knowledge contents by string columns in SqliteDb

### DIFF
--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -2131,7 +2131,7 @@ class SqliteDb(BaseDb):
 
                 # Apply sorting
                 if sort_by is not None:
-                    stmt = stmt.order_by(getattr(table.c, sort_by) * (1 if sort_order == "asc" else -1))
+                    stmt = apply_sorting(stmt, table, sort_by, sort_order)
 
                 # Get total count before applying limit and pagination
                 count_stmt = select(func.count()).select_from(stmt.alias())

--- a/libs/agno/tests/integration/db/sqlite/test_knowledge.py
+++ b/libs/agno/tests/integration/db/sqlite/test_knowledge.py
@@ -1,0 +1,37 @@
+"""Integration tests for SqliteDb knowledge-content queries."""
+
+from agno.db.schemas.knowledge import KnowledgeRow
+from agno.db.sqlite.sqlite import SqliteDb
+
+
+def _make_db(tmp_path) -> SqliteDb:
+    return SqliteDb(db_file=str(tmp_path / "knowledge.db"))
+
+
+def test_get_knowledge_contents_sorts_string_columns(tmp_path):
+    """String columns (e.g. ``name``) must sort lexicographically.
+
+    Regression: sorting was ``column * (1 | -1)``, which SQLite coerces text
+    to numeric ``0`` — every row tied, so string sorts were a no-op in both
+    directions (numeric columns happened to work, which is why it was missed).
+    """
+    db = _make_db(tmp_path)
+    for name in ["charlie", "alpha", "bravo", "delta"]:
+        db.upsert_knowledge_content(KnowledgeRow(name=name, description="d"))
+
+    asc, _ = db.get_knowledge_contents(sort_by="name", sort_order="asc")
+    desc, _ = db.get_knowledge_contents(sort_by="name", sort_order="desc")
+
+    assert [r.name for r in asc] == ["alpha", "bravo", "charlie", "delta"]
+    assert [r.name for r in desc] == ["delta", "charlie", "bravo", "alpha"]
+
+
+def test_get_knowledge_contents_sorts_numeric_columns(tmp_path):
+    """Numeric sorting (the previously-working path) is unaffected."""
+    db = _make_db(tmp_path)
+    for size in [300, 100, 200]:
+        db.upsert_knowledge_content(KnowledgeRow(name=f"n{size}", description="d", size=size))
+
+    asc, _ = db.get_knowledge_contents(sort_by="size", sort_order="asc")
+
+    assert [r.size for r in asc] == [100, 200, 300]


### PR DESCRIPTION
## Summary

`SqliteDb.get_knowledge_contents` sorts with `getattr(table.c, sort_by) * (1 if sort_order == "asc" else -1)`. Multiplying a column by ±1 only orders **numeric** columns — SQLite coerces text to numeric `0`, so sorting by any **string** column (`name`, `type`, `status`, `external_id`, `linked_to`, ...) ties every row and does nothing, in both `asc` and `desc`.

`sort_by` is a free-form query param on `GET /knowledge/content` (and `Knowledge.get_content(sort_by=...)`), so e.g. `?sort_by=name` silently returns unsorted results today.

Fix: use the `apply_sorting` helper already imported in this module and used by its five sibling `get_*` methods — and by the Postgres backend's own `get_knowledge_contents` — which builds a proper `.asc()`/`.desc()`. Numeric sorts are unchanged.

(No issue number.)

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — ran `ruff check` on the changed files (clean); did not run the full `validate.sh` mypy sweep locally
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — n/a
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

There was no sqlite knowledge-contents test; the postgres knowledge test only sorts a numeric column (`size`), which is why this slipped through. Added `tests/integration/db/sqlite/test_knowledge.py`: the string-sort test is red before this change (rows come back in insertion order) and green after; a numeric-sort test guards the previously-working path.

Same root cause exists in the `mysql` and `singlestore` backends (`column * (1|-1)` in their `get_knowledge_contents`), but those need a live DB server to test, so I left them out of this PR — happy to follow up if you'd like them swept too.

*Disclosure: this PR was authored by an AI coding agent (Claude Code) running on this account — it found the bug, wrote the repro, the test, and this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff.*
