### PR TITLE
fix: match aliased moderation categories in OpenAIModerationGuardrail

### DIFF
--- a/libs/agno/agno/guardrails/openai.py
+++ b/libs/agno/agno/guardrails/openai.py
@@ -76,7 +76,7 @@ class OpenAIModerationGuardrail(BaseGuardrail):
 
         if result.flagged:
             moderation_result = {
-                "categories": result.categories.model_dump(),
+                "categories": result.categories.model_dump(by_alias=True),
                 "category_scores": result.category_scores.model_dump(),
             }
 
@@ -122,7 +122,7 @@ class OpenAIModerationGuardrail(BaseGuardrail):
 
         if result.flagged:
             moderation_result = {
-                "categories": result.categories.model_dump(),
+                "categories": result.categories.model_dump(by_alias=True),
                 "category_scores": result.category_scores.model_dump(),
             }
 

--- a/libs/agno/tests/unit/guardrails/test_openai_moderation.py
+++ b/libs/agno/tests/unit/guardrails/test_openai_moderation.py
@@ -1,0 +1,63 @@
+"""Unit tests for OpenAIModerationGuardrail category matching (mocked client)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from openai.types.moderation import Categories, CategoryScores
+
+from agno.exceptions import InputCheckError
+from agno.guardrails.openai import OpenAIModerationGuardrail
+from agno.run.agent import RunInput
+
+# Categories whose OpenAI names carry a "/" or "-" alias (distinct from the
+# underscore field name). raise_for_categories and OpenAI's docs use these.
+ALIASED_CATEGORIES = [
+    "sexual/minors",
+    "harassment/threatening",
+    "hate/threatening",
+    "illicit/violent",
+    "self-harm",
+    "self-harm/intent",
+    "self-harm/instructions",
+    "violence/graphic",
+]
+PLAIN_CATEGORIES = ["harassment", "hate", "illicit", "sexual", "violence"]
+
+
+def _flagged_response(flagged_category: str) -> MagicMock:
+    cat_aliases = [f.alias or n for n, f in Categories.model_fields.items()]
+    categories = Categories.model_validate({a: (a == flagged_category) for a in cat_aliases})
+    score_aliases = [f.alias or n for n, f in CategoryScores.model_fields.items()]
+    scores = CategoryScores.model_validate(
+        {a: (0.9 if a == flagged_category else 0.0) for a in score_aliases}
+    )
+    result = MagicMock()
+    result.flagged = True
+    result.categories = categories
+    result.category_scores = scores
+    response = MagicMock()
+    response.results = [result]
+    return response
+
+
+@pytest.mark.parametrize("category", ALIASED_CATEGORIES + PLAIN_CATEGORIES)
+def test_check_raises_for_flagged_category(category):
+    """A flagged category listed in raise_for_categories must raise InputCheckError.
+
+    Regression: the categories dict was built with ``model_dump()`` (underscore
+    keys) while ``raise_for_categories`` uses the slash/hyphen aliases, so the
+    lookup raised KeyError for the 8 aliased categories instead of blocking.
+    """
+    guardrail = OpenAIModerationGuardrail(raise_for_categories=[category], api_key="test")
+    with patch("openai.OpenAI") as mock_client:
+        mock_client.return_value.moderations.create.return_value = _flagged_response(category)
+        with pytest.raises(InputCheckError):
+            guardrail.check(RunInput(input_content="bad content"))
+
+
+def test_check_does_not_raise_for_unlisted_category():
+    """A category that is flagged but NOT in raise_for_categories does not trigger."""
+    guardrail = OpenAIModerationGuardrail(raise_for_categories=["violence"], api_key="test")
+    with patch("openai.OpenAI") as mock_client:
+        mock_client.return_value.moderations.create.return_value = _flagged_response("self-harm/intent")
+        guardrail.check(RunInput(input_content="content"))  # no raise


### PR DESCRIPTION
## Summary

`OpenAIModerationGuardrail.check` / `async_check` build the categories dict with `result.categories.model_dump()`, whose keys are the pydantic **field** names (`self_harm_intent`, `harassment_threatening`, ...). But `raise_for_categories` — and OpenAI's docs — use the **alias** names with `/` and `-` (`self-harm/intent`, `harassment/threatening`, ...). So `moderation_result["categories"][category]` raises `KeyError` for the **8 of 13** categories that have an alias; the guardrail crashes instead of blocking flagged content for those categories. The 5 alias-less categories (`harassment`, `hate`, `illicit`, `sexual`, `violence`) work, which is why it wasn't caught.

Fix: dump with `by_alias=True` so the dict keys are the public category names `raise_for_categories` uses. One token, in both `check` and `async_check`.

(No issue number.)

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — ran `ruff check` on the changed files (clean); did not run the full `validate.sh` mypy sweep locally
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — n/a
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Added `tests/unit/guardrails/test_openai_moderation.py` (mocked client, no network): parametrized over all 13 categories — the 8 aliased ones raise `KeyError` before this change and pass after; plus a test that a flagged-but-unlisted category does not trigger. The existing guardrail tests are integration tests that hit the real API and only ever passed alias-less categories (`["violence", "hate"]`), so they never exercised the failing lookup.

**Overlap with #6600 (open):** that PR refactors this method into `_check_moderation_result` but keeps `result.categories.model_dump()` (no `by_alias`), so it carries this bug forward rather than fixing it. Whichever lands first, the `by_alias=True` dump should be preserved — happy to rebase onto #6600 if you'd rather fold it in there.

Left `category_scores.model_dump()` unchanged: it's only stored in `additional_data` and never looked up, so it doesn't crash — didn't want to change that data shape as part of a correctness fix.

*Disclosure: this PR was authored by an AI coding agent (Claude Code) running on this account — it found the bug, wrote the repro, the tests, and this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff.*
