### PR TITLE
[feat] Add optional Adanos market sentiment tools

### DIFF
--- a/cookbook/91_tools/adanos_tools.py
+++ b/cookbook/91_tools/adanos_tools.py
@@ -1,0 +1,34 @@
+"""
+Adanos Market Sentiment Tools
+=============================
+
+Demonstrates cross-platform stock and crypto sentiment research with Adanos.
+
+Requirements:
+- An Adanos API key from https://adanos.org/register
+
+Set the following environment variable (or pass the key to AdanosTools):
+
+    export ADANOS_API_KEY="your_api_key"
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.adanos import AdanosTools
+
+agent = Agent(
+    name="Market Sentiment Research Agent",
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[AdanosTools()],
+    instructions=[
+        "Compare sentiment across available sources before drawing conclusions.",
+        "Treat sentiment as research context, not as trading advice.",
+    ],
+    markdown=True,
+)
+
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Compare AAPL sentiment on Reddit, X, financial news, and Polymarket over the last seven UTC days."
+    )

--- a/libs/agno/agno/tools/adanos.py
+++ b/libs/agno/agno/tools/adanos.py
@@ -1,0 +1,253 @@
+from os import getenv
+from typing import Any, Dict, List, Literal, Optional
+from urllib.parse import quote
+
+import httpx
+
+from agno.tools import Toolkit
+from agno.utils.log import log_error
+
+StockSource = Literal["reddit", "x", "news", "polymarket"]
+AssetType = Literal["stocks", "crypto"]
+
+
+class AdanosTools(Toolkit):
+    """Tools for retrieving stock and crypto market sentiment from Adanos."""
+
+    _STOCK_PATHS: Dict[str, str] = {
+        "reddit": "reddit/stocks/v1",
+        "x": "x/stocks/v1",
+        "news": "news/stocks/v1",
+        "polymarket": "polymarket/stocks/v1",
+    }
+    _CRYPTO_PATH = "reddit/crypto/v1"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.adanos.org",
+        timeout: float = 20.0,
+        enable_stock_sentiment: bool = True,
+        enable_crypto_sentiment: bool = True,
+        enable_trending: bool = True,
+        enable_market_sentiment: bool = True,
+        all: bool = False,
+        **kwargs,
+    ):
+        """Initialize the Adanos market sentiment toolkit.
+
+        Args:
+            api_key: Adanos API key. Uses ``ADANOS_API_KEY`` when omitted.
+            base_url: Adanos API base URL.
+            timeout: Per-request timeout in seconds.
+            enable_stock_sentiment: Register the stock sentiment tool.
+            enable_crypto_sentiment: Register the crypto sentiment tool.
+            enable_trending: Register the trending assets tool.
+            enable_market_sentiment: Register the aggregate market sentiment tool.
+            all: Register all tools regardless of individual flags.
+        """
+        self.api_key = api_key or getenv("ADANOS_API_KEY")
+        self.base_url = base_url.rstrip("/")
+        self.timeout = httpx.Timeout(timeout)
+
+        if not self.api_key:
+            log_error("ADANOS_API_KEY not set. Please set the ADANOS_API_KEY environment variable.")
+
+        tools: List[Any] = []
+        async_tools: List[tuple] = []
+        if all or enable_stock_sentiment:
+            tools.append(self.get_stock_sentiment)
+            async_tools.append((self.aget_stock_sentiment, "get_stock_sentiment"))
+        if all or enable_crypto_sentiment:
+            tools.append(self.get_crypto_sentiment)
+            async_tools.append((self.aget_crypto_sentiment, "get_crypto_sentiment"))
+        if all or enable_trending:
+            tools.append(self.get_trending)
+            async_tools.append((self.aget_trending, "get_trending"))
+        if all or enable_market_sentiment:
+            tools.append(self.get_market_sentiment)
+            async_tools.append((self.aget_market_sentiment, "get_market_sentiment"))
+
+        name = kwargs.pop("name", "adanos_tools")
+        super().__init__(name=name, tools=tools, async_tools=async_tools, **kwargs)
+
+    def _headers(self) -> Dict[str, str]:
+        if not self.api_key:
+            raise ValueError("Adanos API key is required. Set ADANOS_API_KEY or pass api_key.")
+        return {"X-API-Key": self.api_key}
+
+    @staticmethod
+    def _params(start_date: Optional[str] = None, end_date: Optional[str] = None, **kwargs: Any) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"from": start_date, "to": end_date, **kwargs}
+        return {key: value for key, value in params.items() if value is not None}
+
+    @staticmethod
+    def _error(response: httpx.Response) -> Dict[str, Any]:
+        try:
+            detail = response.json().get("detail", response.text)
+        except ValueError:
+            detail = response.text
+        return {"error": "Adanos API request failed", "status_code": response.status_code, "detail": detail}
+
+    def _request(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        try:
+            with httpx.Client(timeout=self.timeout) as client:
+                response = client.get(f"{self.base_url}/{path}", headers=self._headers(), params=params)
+                response.raise_for_status()
+                return response.json()
+        except ValueError as error:
+            return {"error": str(error)}
+        except httpx.HTTPStatusError as error:
+            return self._error(error.response)
+        except httpx.RequestError as error:
+            return {"error": "Adanos API request failed", "detail": str(error)}
+
+    async def _arequest(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(f"{self.base_url}/{path}", headers=self._headers(), params=params)
+                response.raise_for_status()
+                return response.json()
+        except ValueError as error:
+            return {"error": str(error)}
+        except httpx.HTTPStatusError as error:
+            return self._error(error.response)
+        except httpx.RequestError as error:
+            return {"error": "Adanos API request failed", "detail": str(error)}
+
+    def get_stock_sentiment(
+        self,
+        ticker: str,
+        source: StockSource = "reddit",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get sentiment for a stock from one Adanos data source.
+
+        Args:
+            ticker: Stock ticker, for example ``AAPL`` or ``TSLA``.
+            source: Sentiment source: reddit, x, news, or polymarket.
+            start_date: Inclusive UTC start date in YYYY-MM-DD format.
+            end_date: Inclusive UTC end date in YYYY-MM-DD format.
+        """
+        path = self._STOCK_PATHS.get(source)
+        if path is None:
+            return {"error": "source must be one of: reddit, x, news, polymarket"}
+        symbol = quote(ticker.strip().lstrip("$").upper(), safe=".-")
+        return self._request(f"{path}/stock/{symbol}", self._params(start_date, end_date))
+
+    async def aget_stock_sentiment(
+        self,
+        ticker: str,
+        source: StockSource = "reddit",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Asynchronously get sentiment for a stock from one Adanos data source."""
+        path = self._STOCK_PATHS.get(source)
+        if path is None:
+            return {"error": "source must be one of: reddit, x, news, polymarket"}
+        symbol = quote(ticker.strip().lstrip("$").upper(), safe=".-")
+        return await self._arequest(f"{path}/stock/{symbol}", self._params(start_date, end_date))
+
+    def get_crypto_sentiment(
+        self, symbol: str, start_date: Optional[str] = None, end_date: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Get Reddit sentiment for a cryptocurrency.
+
+        Args:
+            symbol: Cryptocurrency symbol, for example ``BTC`` or ``ETH``.
+            start_date: Inclusive UTC start date in YYYY-MM-DD format.
+            end_date: Inclusive UTC end date in YYYY-MM-DD format.
+        """
+        normalized_symbol = quote(symbol.strip().upper(), safe=".-")
+        return self._request(f"{self._CRYPTO_PATH}/token/{normalized_symbol}", self._params(start_date, end_date))
+
+    async def aget_crypto_sentiment(
+        self, symbol: str, start_date: Optional[str] = None, end_date: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Asynchronously get Reddit sentiment for a cryptocurrency."""
+        normalized_symbol = quote(symbol.strip().upper(), safe=".-")
+        return await self._arequest(
+            f"{self._CRYPTO_PATH}/token/{normalized_symbol}", self._params(start_date, end_date)
+        )
+
+    def get_trending(
+        self,
+        asset_type: AssetType = "stocks",
+        source: StockSource = "reddit",
+        limit: int = 10,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get trending stocks or cryptocurrencies ranked by attention and sentiment.
+
+        Args:
+            asset_type: Asset universe: stocks or crypto.
+            source: For stocks, reddit, x, news, or polymarket. Crypto uses reddit.
+            limit: Maximum number of results, from 1 to 100.
+            start_date: Inclusive UTC start date in YYYY-MM-DD format.
+            end_date: Inclusive UTC end date in YYYY-MM-DD format.
+        """
+        path = self._asset_path(asset_type, source)
+        if isinstance(path, dict):
+            return path
+        params = self._params(start_date, end_date, limit=max(1, min(limit, 100)))
+        return self._request(f"{path}/trending", params)
+
+    async def aget_trending(
+        self,
+        asset_type: AssetType = "stocks",
+        source: StockSource = "reddit",
+        limit: int = 10,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Asynchronously get trending stocks or cryptocurrencies."""
+        path = self._asset_path(asset_type, source)
+        if isinstance(path, dict):
+            return path
+        params = self._params(start_date, end_date, limit=max(1, min(limit, 100)))
+        return await self._arequest(f"{path}/trending", params)
+
+    def get_market_sentiment(
+        self,
+        asset_type: AssetType = "stocks",
+        source: StockSource = "reddit",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get aggregate market sentiment for stocks or cryptocurrencies.
+
+        Args:
+            asset_type: Asset universe: stocks or crypto.
+            source: For stocks, reddit, x, news, or polymarket. Crypto uses reddit.
+            start_date: Inclusive UTC start date in YYYY-MM-DD format.
+            end_date: Inclusive UTC end date in YYYY-MM-DD format.
+        """
+        path = self._asset_path(asset_type, source)
+        if isinstance(path, dict):
+            return path
+        return self._request(f"{path}/market-sentiment", self._params(start_date, end_date))
+
+    async def aget_market_sentiment(
+        self,
+        asset_type: AssetType = "stocks",
+        source: StockSource = "reddit",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Asynchronously get aggregate market sentiment for stocks or cryptocurrencies."""
+        path = self._asset_path(asset_type, source)
+        if isinstance(path, dict):
+            return path
+        return await self._arequest(f"{path}/market-sentiment", self._params(start_date, end_date))
+
+    def _asset_path(self, asset_type: str, source: str) -> Any:
+        if asset_type == "crypto":
+            if source != "reddit":
+                return {"error": "crypto sentiment is currently available from reddit only"}
+            return self._CRYPTO_PATH
+        if asset_type != "stocks":
+            return {"error": "asset_type must be one of: stocks, crypto"}
+        return self._STOCK_PATHS.get(source) or {"error": "source must be one of: reddit, x, news, polymarket"}

--- a/libs/agno/tests/unit/tools/test_adanos.py
+++ b/libs/agno/tests/unit/tools/test_adanos.py
@@ -1,0 +1,143 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from agno.tools.adanos import AdanosTools
+
+
+def test_initialization_registers_sync_and_async_tools():
+    tools = AdanosTools(api_key="test-key")
+
+    assert tools.name == "adanos_tools"
+    assert set(tools.functions) == {
+        "get_stock_sentiment",
+        "get_crypto_sentiment",
+        "get_trending",
+        "get_market_sentiment",
+    }
+    assert set(tools.async_functions) == set(tools.functions)
+
+
+def test_initialization_reads_api_key_from_environment():
+    with patch.dict("os.environ", {"ADANOS_API_KEY": "env-key"}):
+        tools = AdanosTools()
+
+    assert tools.api_key == "env-key"
+
+
+def test_disabled_tool_is_not_registered():
+    tools = AdanosTools(api_key="test-key", enable_crypto_sentiment=False)
+
+    assert "get_crypto_sentiment" not in tools.functions
+    assert "get_stock_sentiment" in tools.functions
+
+
+@patch("agno.tools.adanos.httpx.Client")
+def test_get_stock_sentiment_maps_source_dates_and_auth(mock_client_class):
+    response = MagicMock()
+    response.json.return_value = {"ticker": "AAPL", "found": True}
+    response.raise_for_status.return_value = None
+    client = mock_client_class.return_value.__enter__.return_value
+    client.get.return_value = response
+    tools = AdanosTools(api_key="test-key", base_url="https://example.test/")
+
+    result = tools.get_stock_sentiment("$aapl", source="news", start_date="2026-07-01", end_date="2026-07-07")
+
+    assert result == {"ticker": "AAPL", "found": True}
+    client.get.assert_called_once_with(
+        "https://example.test/news/stocks/v1/stock/AAPL",
+        headers={"X-API-Key": "test-key"},
+        params={"from": "2026-07-01", "to": "2026-07-07"},
+    )
+
+
+@patch("agno.tools.adanos.httpx.Client")
+def test_get_crypto_sentiment_uses_reddit_crypto_endpoint(mock_client_class):
+    response = MagicMock()
+    response.json.return_value = {"symbol": "BTC", "found": True}
+    response.raise_for_status.return_value = None
+    client = mock_client_class.return_value.__enter__.return_value
+    client.get.return_value = response
+    tools = AdanosTools(api_key="test-key")
+
+    result = tools.get_crypto_sentiment("btc")
+
+    assert result["symbol"] == "BTC"
+    assert client.get.call_args.args[0] == "https://api.adanos.org/reddit/crypto/v1/token/BTC"
+
+
+@patch("agno.tools.adanos.httpx.Client")
+def test_get_trending_clamps_limit_to_api_maximum(mock_client_class):
+    response = MagicMock()
+    response.json.return_value = {"results": []}
+    response.raise_for_status.return_value = None
+    client = mock_client_class.return_value.__enter__.return_value
+    client.get.return_value = response
+    tools = AdanosTools(api_key="test-key")
+
+    tools.get_trending(source="x", limit=500)
+
+    assert client.get.call_args.kwargs["params"] == {"limit": 100}
+    assert client.get.call_args.args[0] == "https://api.adanos.org/x/stocks/v1/trending"
+
+
+@patch("agno.tools.adanos.httpx.Client")
+def test_crypto_rejects_non_reddit_source_without_request(mock_client_class):
+    tools = AdanosTools(api_key="test-key")
+
+    result = tools.get_market_sentiment(asset_type="crypto", source="news")
+
+    assert result == {"error": "crypto sentiment is currently available from reddit only"}
+    mock_client_class.assert_not_called()
+
+
+@patch("agno.tools.adanos.httpx.Client")
+def test_missing_api_key_returns_actionable_error(mock_client_class):
+    with patch.dict("os.environ", {}, clear=True):
+        tools = AdanosTools()
+
+    result = tools.get_stock_sentiment("AAPL")
+
+    assert result == {"error": "Adanos API key is required. Set ADANOS_API_KEY or pass api_key."}
+    mock_client_class.return_value.__enter__.return_value.get.assert_not_called()
+
+
+@patch("agno.tools.adanos.httpx.Client")
+def test_http_error_preserves_status_and_api_detail(mock_client_class):
+    request = httpx.Request("GET", "https://api.adanos.org/reddit/stocks/v1/stock/AAPL")
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 429
+    response.json.return_value = {"detail": {"error": "Rate limit exceeded"}}
+    client = mock_client_class.return_value.__enter__.return_value
+    client.get.return_value = response
+    response.raise_for_status.side_effect = httpx.HTTPStatusError("rate limited", request=request, response=response)
+    tools = AdanosTools(api_key="test-key")
+
+    result = tools.get_stock_sentiment("AAPL")
+
+    assert result == {
+        "error": "Adanos API request failed",
+        "status_code": 429,
+        "detail": {"error": "Rate limit exceeded"},
+    }
+
+
+@pytest.mark.asyncio
+@patch("agno.tools.adanos.httpx.AsyncClient")
+async def test_async_tool_uses_same_endpoint_contract(mock_client_class):
+    response = MagicMock()
+    response.json.return_value = {"market_sentiment": "bullish"}
+    response.raise_for_status.return_value = None
+    client = mock_client_class.return_value.__aenter__.return_value
+    client.get = AsyncMock(return_value=response)
+    tools = AdanosTools(api_key="test-key")
+
+    result = await tools.aget_market_sentiment(source="polymarket")
+
+    assert result == {"market_sentiment": "bullish"}
+    client.get.assert_awaited_once_with(
+        "https://api.adanos.org/polymarket/stocks/v1/market-sentiment",
+        headers={"X-API-Key": "test-key"},
+        params={},
+    )


### PR DESCRIPTION
## Summary

Adds a native, read-only `AdanosTools` toolkit for market sentiment research:

- stock sentiment from Reddit, X / FinTwit, financial news, or Polymarket
- Reddit crypto sentiment
- trending stocks or cryptocurrencies
- aggregate market sentiment
- explicit or `ADANOS_API_KEY` authentication
- sync and async execution using Agno's toolkit mapping
- `from` / `to` UTC date windows and structured API errors

The integration is optional, uses Agno's existing `httpx` dependency, and does not modify trading or portfolio behavior. A cookbook example demonstrates cross-source equity research.

Closes #9058

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] This PR was prepared with AI assistance and reviewed against the current Adanos OpenAPI contract and Agno contribution guidelines

---

## Verification

- `.venv/bin/python -m pytest libs/agno/tests/unit/tools/test_adanos.py -q` — 10 passed
- `./scripts/format.sh` — passed
- `./scripts/validate.sh` — passed, including Mypy over 922 Agno source files
- `git diff --check` — passed

All HTTP behavior is covered with mocked requests; no live API credentials are required by the test suite.

## Additional Notes

I maintain Adanos. API documentation is available at https://api.adanos.org/docs and the machine-readable contract at https://api.adanos.org/openapi.json.