### PR TITLE
[fix] Clarify Adanos trending ranking

### DIFF
--- a/libs/agno/agno/tools/adanos.py
+++ b/libs/agno/agno/tools/adanos.py
@@ -180,7 +180,7 @@ class AdanosTools(Toolkit):
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Get trending stocks or cryptocurrencies ranked by attention and sentiment.
+        """Get trending stocks or cryptocurrencies ranked by buzz score with sentiment data.
 
         Args:
             asset_type: Asset universe: stocks or crypto.
@@ -203,7 +203,7 @@ class AdanosTools(Toolkit):
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Asynchronously get trending stocks or cryptocurrencies."""
+        """Asynchronously get trending stocks or cryptocurrencies ranked by buzz score with sentiment data."""
         path = self._asset_path(asset_type, source)
         if isinstance(path, dict):
             return path


### PR DESCRIPTION
## Summary

Clarifies the `AdanosTools.get_trending` sync and async descriptions added in #9060.

Adanos trending results are ranked by `buzz_score`; sentiment is included as additional result data. Runtime behavior is unchanged.

Companion documentation: agno-agi/docs#736

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement

## Verification

- `.venv/bin/python -m pytest libs/agno/tests/unit/tools/test_adanos.py -q` (`10 passed`)
- `.venv/bin/python -m py_compile libs/agno/agno/tools/adanos.py`
- `git diff --check`
- structured autoreview: clean, no actionable findings
