### PR TITLE
chore: add helpers to view env task attempts

### DIFF
--- a/cookbook/environments/README.md
+++ b/cookbook/environments/README.md
@@ -21,6 +21,14 @@ first question.
 |------|---------------|
 | `_01_first_env.py` | The whole thing in twenty lines: `Env`, a typed `CodeScorer`, `run_rollouts`, the live grid, `summary()` |
 | `_02_export_sft.py` | The second job: `learning_zone()`, `to_sft_jsonl`, the export report, and the provenance sidecar |
+| `_03_tool_reliability.py` | `ToolCallScorer`: did the lookup tool actually EXECUTE, or did the agent answer from its head? Executions, not requests |
+| `_04_judge_rubric.py` | `JudgeScorer` with a graded rubric: a pass rate for quality you cannot check with code (tone, commitments, next steps) |
+| `_05_compare_models.py` | The cost-review question: same env, `model=` override, `save`/`load`/`diff` -- can the cheaper model ship? Tasks from JSONL |
+
+The three scorers cover the three kinds of pass criteria: a typed field you can compare
+in code (`_01`), a tool that must have done real work (`_03`), and quality only a judge
+can grade (`_04`). `_02` and `_05` are the two things you do with the artifact
+afterwards: export the runs that worked, and compare runs across time or models.
 
 ## Setup
 
@@ -28,11 +36,16 @@ first question.
 export OPENAI_API_KEY=***
 .venvs/demo/bin/python cookbook/environments/_01_first_env.py
 .venvs/demo/bin/python cookbook/environments/_02_export_sft.py
+.venvs/demo/bin/python cookbook/environments/_03_tool_reliability.py
+.venvs/demo/bin/python cookbook/environments/_04_judge_rubric.py
+.venvs/demo/bin/python cookbook/environments/_05_compare_models.py
 ```
 
 No database or services needed: rollouts are hermetic (each attempt runs on a fresh
 copy with an in-memory db, fresh session and user ids, and the response cache off), so
-nothing touches your stores.
+nothing touches your stores. State owned by your own tools is the one thing the runner
+cannot isolate for you -- `_03` keeps its lookup table read-only for exactly that
+reason.
 
 ## Choosing a door
 
@@ -41,4 +54,6 @@ nothing touches your stores.
 - Measuring a distribution over K attempts, or exporting training data:
   `agno.environments` (`EnvTask`, `run_rollouts`).
 
-Exports land in `data/generated/`, which is gitignored.
+Task sets a team owns in git live in `tasks/` (checked in, strict-validated by
+`EnvTask.from_jsonl`). Exports and saved baselines land in `data/generated/`, which is
+gitignored.

--- a/cookbook/environments/TEST_LOG.md
+++ b/cookbook/environments/TEST_LOG.md
@@ -76,3 +76,51 @@ train.jsonl was written this run; the export path (including the new ato_sft_jso
 twin) is pinned by the unit suite.
 
 ---
+
+## 2026-07-19 — three new use-case cookbooks (_03/_04/_05), all executed live
+
+### _03_tool_reliability.py
+
+**Status:** PASS
+
+**Description:** ToolCallScorer over an order-support agent with a read-only lookup
+tool; three tasks including a tempting-assertion trap (customer asserts a status in
+the question) and an unknown-order id. Measures the fraction of attempts where the
+lookup actually EXECUTED.
+
+**Result:** 24 attempts in 26s, grounding rate 1.0 on every task — gpt-5.5 with
+explicit grounding instructions executes the lookup on all 8 attempts of all three
+tasks, including the trap and the not-found path.
+
+### _04_judge_rubric.py
+
+**Status:** PASS (after one documented calibration round)
+
+**Description:** JudgeScorer in numeric mode (threshold 8) with a five-point support
+rubric over a reply-rewriting agent. The file deliberately documents its own
+iteration loop: the first-draft instructions ("be professional and empathetic")
+measured 0/12 at threshold 8 with mean raw score ~5.2 (judge reasons: no
+acknowledgment of frustration, no apology, no concrete next step); instructions were
+tuned against the rubric and the run repeated.
+
+**Result:** Before: 0/12, mean value 0.46. After: 12/12 in 45s, mean value 0.96. Both
+endpoints recorded in the file's comments as the measured instructions-vs-rubric gap.
+
+### _05_compare_models.py
+
+**Status:** PASS (with one observed teardown artifact)
+
+**Description:** EnvTask.from_jsonl over tasks/support_triage.jsonl (5 triage tasks,
+one deliberately ambiguous), CodeScorer on a typed output_schema field, baseline run
+on gpt-5.5, candidate via the model= override on gpt-5-mini, save/load round-trip,
+and candidate.diff(baseline).
+
+**Result:** 80 attempts total (40 + 40), both models 8/8 on all five tasks including
+the ambiguous crash-then-charge row; baseline saved and reloaded; diff printed
+"(env identical, policy changed)" with +0.00 on every row — the cheap-model question
+answered "yes" for this task set. Observed: a RuntimeError("Event loop is closed")
+traceback from httpcore transport cleanup between the two runs (exit code still 0) —
+consistent with the known sync-door loop-shutdown residual and the unclosed
+per-attempt HTTP clients noted in review.
+
+---

--- a/cookbook/environments/_03_tool_reliability.py
+++ b/cookbook/environments/_03_tool_reliability.py
@@ -1,0 +1,108 @@
+"""
+Tool Reliability: Did the Agent Actually Use the Tool?
+======================================================
+A support agent that answers order questions from its own head instead of the
+lookup tool is hallucinating politely. One clean transcript proves nothing --
+the interesting question is: out of K attempts, how often did the lookup
+actually RUN?
+
+ToolCallScorer counts tool EXECUTIONS -- entries in RunOutput.tools whose
+tool_call_error is not set. A call the model merely requested, one refused by
+the tool-call limit, or one that errored in the tool never satisfies an
+expectation. So the pass rate below reads as "the fraction of attempts where
+the tool did real work", not "where the model said it would call it".
+
+Note on scope: expectations live on the scorer, one set for the whole
+environment -- every task here requires the same lookup, which is the shape
+this scorer fits. Name-only matching is still satisfiable by a successful
+call with wrong arguments; for reward use, pin them with the `arguments=`
+spec.
+"""
+
+import json
+
+from agno.agent import Agent
+from agno.environments import Env, EnvTask, run_rollouts
+from agno.models.openai import OpenAIResponses
+from agno.scorer import ToolCallScorer
+
+# ---------------------------------------------------------------------------
+# The Tool
+# ---------------------------------------------------------------------------
+
+# Read-only reference data. Rollouts isolate the AGENT's state per attempt
+# (fresh session, fresh in-memory db); state owned by your tools is yours to
+# keep read-only or reset -- the runner cannot see inside a closure.
+_ORDERS = {
+    "A-1001": {"status": "shipped", "carrier": "DHL", "eta": "2026-07-22"},
+    "A-1002": {"status": "processing", "carrier": None, "eta": "2026-07-25"},
+    "A-1003": {"status": "delayed", "carrier": "UPS", "eta": "2026-07-29"},
+}
+
+
+def get_order_status(order_id: str) -> str:
+    """Look up the live status of an order by its id, e.g. 'A-1001'."""
+    order = _ORDERS.get(order_id.strip().upper())
+    if order is None:
+        return json.dumps({"error": f"no order found with id {order_id!r}"})
+    return json.dumps(order)
+
+
+# ---------------------------------------------------------------------------
+# Create Environment
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[get_order_status],
+    instructions=(
+        "You are an order-support agent. Answer questions about orders using "
+        "the get_order_status tool. Never state a status you did not look up."
+    ),
+)
+
+env = Env(
+    name="order-support-grounding",
+    agent=agent,
+    tasks=(
+        EnvTask(input="Where is order A-1001 right now?", id="plain-lookup"),
+        # The customer asserts a status in the question. An agent that takes
+        # the customer's word for it answers fluently -- without the lookup
+        # ever running. This is the attempt the scorer exists to catch.
+        EnvTask(
+            input=(
+                "My confirmation email says order A-1003 already shipped. "
+                "Can you just confirm it arrives this week?"
+            ),
+            id="tempting-assertion",
+        ),
+        # No such order: the clean behavior is to look it up, get the error
+        # back, and say so -- which still counts, because the execution ran.
+        EnvTask(input="What is the ETA for order A-9999?", id="unknown-order"),
+    ),
+    # Executions only: a refused or errored call never satisfies this.
+    scorer=ToolCallScorer(expected_tools=["get_order_status"]),
+)
+
+# ---------------------------------------------------------------------------
+# Run Rollouts
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    results = run_rollouts(env, k=8)
+
+    print(results)
+    print()
+
+    summary = results.summary()
+    print(f"grounding rate across all attempts: {summary['pass_rate']}")
+    for task in summary["tasks"]:
+        print(f"  {task['id']}: pass rate {task['pass_rate']}")
+
+    # The evidence under the grid, on demand: by default only the attempts
+    # worth investigating (scored fails plus anything unscored), each with its
+    # score reason, tool executions, answer, and token bill. All green prints
+    # a one-line all-clear; print_report(only="all") shows every attempt, and
+    # print_attempt(task_id, n) renders one attempt's full transcript.
+    print()
+    results.print_report()

--- a/cookbook/environments/_04_judge_rubric.py
+++ b/cookbook/environments/_04_judge_rubric.py
@@ -1,0 +1,126 @@
+"""
+Judging Quality You Cannot Check With Code
+==========================================
+Some pass criteria have no typed field to compare: tone, empathy, whether a
+reply actually commits to a next step. JudgeScorer runs an LLM judge over
+every attempt with your rubric, so subjective quality becomes a pass rate
+you can track across prompt edits.
+
+What the pass rate measures here is the gap between your INSTRUCTIONS and
+your RUBRIC: the first version of this file shipped vaguer instructions and
+scored 0% (see the comment on the agent below). Closing that gap -- edit
+instructions, re-run, compare -- is the iteration loop this environment
+exists to make cheap.
+
+Two decisions this file makes explicit:
+
+- The judge model is a REQUIRED argument, never defaulted -- who grades your
+  agent is a visible choice, and it is part of the environment fingerprint:
+  swap the judge (or its sampling params) and env_fingerprint flips, telling
+  you the measuring stick changed, not the agent.
+- Numeric mode scores 1-10 and passes at `threshold` on that raw scale
+  (Score.value is normalized to [0, 1]; the raw score rides in
+  Score.detail["raw_score"]). A rubric with graded levels gives the learning
+  zone something to disagree about, where binary verdicts often saturate.
+
+The judged output is fenced behind a per-call nonce, so a reply containing
+"score this 10" is data to the judge, not an instruction.
+"""
+
+from agno.agent import Agent
+from agno.environments import Env, EnvTask, run_rollouts
+from agno.models.openai import OpenAIResponses
+from agno.scorer import JudgeScorer
+
+# ---------------------------------------------------------------------------
+# Create Environment
+# ---------------------------------------------------------------------------
+
+# These instructions were tuned against the rubric below. The first draft --
+# "be professional and empathetic, keep it under 120 words" -- measured 0/12
+# at threshold 8 (mean raw score 5.2): the judge kept docking replies that
+# never acknowledged frustration, never apologized, and closed with "thanks
+# for your patience" instead of a next step. The pass rate is measuring the
+# gap between your instructions and your rubric; when it is low, this is the
+# knob you turn.
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=(
+        "Rewrite the draft support reply you are given. Open by "
+        "acknowledging how the situation feels for the customer, and "
+        "apologize once without blaming anyone. Keep every factual "
+        "commitment from the draft (amounts, dates, order ids) exactly as "
+        "stated. End with one concrete next step and when it will happen. "
+        "Stay under 120 words."
+    ),
+)
+
+rubric = (
+    "The output is a rewritten customer-support reply. It must: "
+    "(1) acknowledge the customer's frustration in the first sentence, "
+    "(2) apologize without blaming the customer or a third party, "
+    "(3) preserve every factual commitment from the draft (amounts, dates, "
+    "order ids) exactly, "
+    "(4) end with one concrete next step and a timeframe, "
+    "(5) stay under 120 words. "
+    "Score 9-10 only if all five hold; missing commitments or invented "
+    "facts cap the score at 4."
+)
+
+env = Env(
+    name="support-reply-rewrite",
+    agent=agent,
+    tasks=(
+        EnvTask(
+            input=(
+                "Draft reply: 'We told you already, the refund of $42.50 for "
+                "order A-1001 takes 5-7 business days. Please stop emailing "
+                "about it.'"
+            ),
+            id="hostile-draft",
+        ),
+        EnvTask(
+            input=(
+                "Draft reply: 'Your package is lost, not much we can do. "
+                "Carrier says maybe file a claim? Order A-1003, worth $180.'"
+            ),
+            id="shrug-draft",
+        ),
+        EnvTask(
+            input=(
+                "Draft reply: 'The outage on 2026-07-14 wiped your report. "
+                "Engineering restored a backup from 2026-07-12 so two days "
+                "of edits are gone forever. A 20% credit was applied.'"
+            ),
+            id="bad-news-draft",
+        ),
+    ),
+    scorer=JudgeScorer(
+        model=OpenAIResponses(id="gpt-5.5"),
+        criteria=rubric,
+        mode="numeric",
+        threshold=8,
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Run Rollouts
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    # Every attempt costs two model calls here (the agent, then the judge);
+    # k=4 keeps the demo cheap. Raise k for tighter statistics.
+    results = run_rollouts(env, k=4)
+
+    print(results)
+    print()
+
+    summary = results.summary()
+    print(f"pass rate at threshold 8: {summary['pass_rate']}")
+    print(f"mean judge value (normalized): {summary['mean_value']}")
+
+    # The tasks the judge disagreed on across attempts are where a prompt
+    # edit is worth trying -- rerun after editing the instructions and
+    # compare summaries.
+    zone_ids = [task["id"] for task in summary["tasks"] if task["learning_zone"]]
+    print(f"learning zone tasks: {zone_ids}")

--- a/cookbook/environments/_05_compare_models.py
+++ b/cookbook/environments/_05_compare_models.py
@@ -1,0 +1,99 @@
+"""
+Can We Ship the Cheaper Model?
+==============================
+The question every cost review asks, answered with a distribution instead of
+a vibe: run the SAME environment on the current model and the candidate, and
+diff the two results task by task.
+
+Three pieces of the API meet here:
+
+- EnvTask.from_jsonl loads the task set from a file a team can own in git.
+  Validation is strict: an unknown key (say, a misspelled "expected_output"
+  column) raises with the line number instead of silently making every
+  expected None.
+- run_rollouts(env, model=...) swaps the policy for one run without touching
+  the env. The environment fingerprint stays identical -- the tasks, scorer,
+  and prompts did not move -- while the policy fingerprint tracks the model
+  that actually ran. That split is what makes the diff meaningful.
+- results.save() / EnvRunResult.load() / candidate.diff(baseline) close the
+  loop across time: save a baseline today, diff a candidate against it next
+  week. diff raises EnvMismatchError if the environment drifted in between,
+  so you cannot accidentally compare across different task sets. Note the
+  saved artifact contains full transcripts in plain text -- treat it like
+  any other file holding your production prompts.
+"""
+
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.environments import Env, EnvRunResult, EnvTask, run_rollouts
+from agno.models.openai import OpenAIResponses
+from agno.scorer import CodeScorer
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Create Environment
+# ---------------------------------------------------------------------------
+
+
+class Triage(BaseModel):
+    category: str  # one of: billing, bug, feature_request, account_access
+    reasoning: str
+
+
+def label_matches(run, expected):
+    return run.content.category.strip().lower() == expected
+
+
+_TASKS_PATH = Path(__file__).parent / "tasks" / "support_triage.jsonl"
+_OUTPUT_DIR = Path(__file__).parent / "data" / "generated"
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    output_schema=Triage,
+    instructions=(
+        "Triage the customer message into exactly one category: billing, "
+        "bug, feature_request, or account_access."
+    ),
+)
+
+env = Env(
+    name="support-triage",
+    agent=agent,
+    tasks=EnvTask.from_jsonl(_TASKS_PATH),
+    scorer=CodeScorer(label_matches),
+)
+
+# ---------------------------------------------------------------------------
+# Baseline, Candidate, Diff
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    _OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    baseline_path = _OUTPUT_DIR / "triage_baseline.json"
+
+    # Baseline: the model the agent ships with today.
+    baseline = run_rollouts(env, k=8)
+    print(baseline)
+    baseline.save(baseline_path)
+    print(f"baseline saved to {baseline_path}")
+    print()
+
+    # Candidate: same env, cheaper model. Only the policy changes; the
+    # stamped policy_fingerprint is computed from the model that actually
+    # ran, so the two runs are distinguishable forever.
+    candidate = run_rollouts(env, k=8, model=OpenAIResponses(id="gpt-5-mini"))
+    print(candidate)
+    print()
+
+    # Reload the baseline as a second session would, then diff.
+    baseline = EnvRunResult.load(baseline_path)
+    diff = candidate.diff(baseline)
+    print(diff)
+
+    # The decision, in two numbers.
+    baseline_rate = baseline.summary()["pass_rate"]
+    candidate_rate = candidate.summary()["pass_rate"]
+    print()
+    print(f"baseline pass rate:  {baseline_rate}")
+    print(f"candidate pass rate: {candidate_rate}")

--- a/cookbook/environments/_06_drilldown_demo.py
+++ b/cookbook/environments/_06_drilldown_demo.py
@@ -1,0 +1,131 @@
+"""
+Tool Reliability: Did the Agent Actually Use the Tool?
+======================================================
+A support agent that answers order questions from its own head instead of the
+lookup tool is hallucinating politely. One clean transcript proves nothing --
+the interesting question is: out of K attempts, how often did the lookup
+actually RUN?
+
+ToolCallScorer counts tool EXECUTIONS -- entries in RunOutput.tools whose
+tool_call_error is not set. A call the model merely requested, one refused by
+the tool-call limit, or one that errored in the tool never satisfies an
+expectation. So the pass rate below reads as "the fraction of attempts where
+the tool did real work", not "where the model said it would call it".
+
+Note on scope: expectations live on the scorer, one set for the whole
+environment -- every task here requires the same lookup, which is the shape
+this scorer fits. Name-only matching is still satisfiable by a successful
+call with wrong arguments; for reward use, pin them with the `arguments=`
+spec.
+"""
+
+import json
+
+from agno.agent import Agent
+from agno.environments import Env, EnvTask, run_rollouts
+from agno.models.openai import OpenAIResponses
+from agno.scorer import ToolCallScorer
+
+# ---------------------------------------------------------------------------
+# The Tool
+# ---------------------------------------------------------------------------
+
+# Read-only reference data. Rollouts isolate the AGENT's state per attempt
+# (fresh session, fresh in-memory db); state owned by your tools is yours to
+# keep read-only or reset -- the runner cannot see inside a closure.
+_ORDERS = {
+    "A-1001": {"status": "shipped", "carrier": "DHL", "eta": "2026-07-22"},
+    "A-1002": {"status": "processing", "carrier": None, "eta": "2026-07-25"},
+    "A-1003": {"status": "delayed", "carrier": "UPS", "eta": "2026-07-29"},
+}
+
+
+def get_order_status(order_id: str) -> str:
+    """Look up the live status of an order by its id, e.g. 'A-1001'."""
+    order = _ORDERS.get(order_id.strip().upper())
+    if order is None:
+        return json.dumps({"error": f"no order found with id {order_id!r}"})
+    return json.dumps(order)
+
+
+# ---------------------------------------------------------------------------
+# Create Environment
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[get_order_status],
+    instructions=(
+        "You are an order-support agent. Answer questions about orders using "
+        "the get_order_status tool. Never state a status you did not look up."
+    ),
+)
+
+env = Env(
+    name="order-support-grounding",
+    agent=agent,
+    tasks=(
+        EnvTask(input="Where is order A-1001 right now?", id="plain-lookup"),
+        # The customer asserts a status in the question. An agent that takes
+        # the customer's word for it answers fluently -- without the lookup
+        # ever running. This is the attempt the scorer exists to catch.
+        EnvTask(
+            input=(
+                "My confirmation email says order A-1003 already shipped. "
+                "Can you just confirm it arrives this week?"
+            ),
+            id="tempting-assertion",
+        ),
+        # No such order: the clean behavior is to look it up, get the error
+        # back, and say so -- which still counts, because the execution ran.
+        EnvTask(input="What is the ETA for order A-9999?", id="unknown-order"),
+    ),
+    # Executions only: a refused or errored call never satisfies this.
+    scorer=ToolCallScorer(expected_tools=["get_order_status"]),
+)
+
+# ---------------------------------------------------------------------------
+# Run Rollouts
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    results = run_rollouts(env, k=8)
+
+    print(results)
+    print()
+
+    summary = results.summary()
+    print(f"grounding rate across all attempts: {summary['pass_rate']}")
+    for task in summary["tasks"]:
+        print(f"  {task['id']}: pass rate {task['pass_rate']}")
+
+    # Attempts that errored (provider failures, timeouts) are excluded from
+    # the statistics, never counted as failures -- inspect them separately.
+    errors = results.errors()
+    if errors:
+        print(f"attempts with errors: {errors}")
+
+    # -----------------------------------------------------------------------
+    # Drill Down: everything the grid does not show
+    # -----------------------------------------------------------------------
+    # The default report shows only the attempts worth investigating: scored
+    # fails plus anything unscored (errors, timeouts, pauses). All green means
+    # a one-line all-clear.
+    print("=" * 72)
+    results.print_report()
+
+    # only="all" is the full evidence: verdict, score reason, every tool
+    # EXECUTION with its parsed args, the answer, and the token bill.
+    print("=" * 72)
+    results.print_report(only="all", attempts=2)
+
+    # One attempt in complete detail: the scorer's uncut reasoning, then the
+    # whole transcript rendered by pprint_run_response -- exactly the messages
+    # to_sft_jsonl would export.
+    print("=" * 72)
+    results.print_attempt("tempting-assertion", 1)
+
+    # All of this is presentation over retained data. The objects underneath --
+    # results.task_results[i].attempts[j].run / .score / .stop_reason -- stay
+    # available for anything custom, and results.save("rollouts.json") writes
+    # the whole artifact (transcripts, scores, fingerprints) as one JSON file.

--- a/libs/agno/agno/environments/_render.py
+++ b/libs/agno/agno/environments/_render.py
@@ -1,8 +1,11 @@
-"""The rollout grid. Private: `summary()` is the programmatic contract, this is not.
+"""The rollout grid and the per-attempt report. Private: `summary()` is the
+programmatic contract, none of this is.
 
 K attempts is K glyphs: a full block for a pass, a light shade for a scored fail, a
 triangle for an unscored attempt. Rendered live through rich during a TTY run, and
-statically by `EnvRunResult.__str__`.
+statically by `EnvRunResult.__str__`. `build_report` is the layer underneath the
+glyphs: one text block per attempt -- verdict, score reason, tool executions, the
+answer -- so a red glyph is explainable without walking the result objects by hand.
 """
 
 from typing import Any, Dict, List, Optional, Sequence
@@ -55,6 +58,97 @@ def build_grid(
     if first_error:
         lines.append(f"  first error: {first_error}")
     return "\n".join(lines)
+
+
+def _clip(text: Any, limit: int) -> str:
+    """One line, whitespace collapsed, hard-capped at `limit` characters."""
+    flat = " ".join(str(text).split())
+    if len(flat) <= limit:
+        return flat
+    return flat[: limit - 3] + "..."
+
+
+def _attempt_lines(attempt: Any, index: int) -> List[str]:
+    """The report block for one attempt. `index` is 1-based, matching glyph order."""
+    score = attempt.score
+    verdict = "unscored" if score is None else ("PASS" if score.passed else "FAIL")
+    value = f"{score.value:.2f}" if score is not None else "-"
+    head = (
+        f"  attempt {index}: {verdict}   value={value}   "
+        f"stop={attempt.stop_reason.value}   {attempt.duration_seconds:.1f}s"
+    )
+    if attempt.tool_call_limit_hit:
+        head += "   tool-call limit hit"
+    lines = [head]
+    if attempt.error:
+        lines.append(f"    error: {_clip(attempt.error, 200)}")
+    if score is not None and score.reason:
+        lines.append(f"    reason: {_clip(score.reason, 200)}")
+    run = attempt.run
+    if run is None:
+        lines.append("    (no run captured)")
+        return lines
+    for tool in getattr(run, "tools", None) or []:
+        status = "error" if tool.tool_call_error else "ok"
+        lines.append(f"    tool: {tool.tool_name}({tool.tool_args}) -> {status}")
+    if run.content is not None:
+        lines.append(f"    answer: {_clip(run.content, 110)}")
+    metrics = getattr(run, "metrics", None)
+    if metrics is not None:
+        tokens = f"    tokens: in={metrics.input_tokens} out={metrics.output_tokens}"
+        cost = getattr(metrics, "cost", None)
+        if cost is not None:
+            tokens += f" cost=${cost:.4f}"
+        lines.append(tokens)
+    return lines
+
+
+def _is_reportable_failure(attempt: Any) -> bool:
+    """A "red": scored-and-failed, or any attempt that did not complete cleanly."""
+    if attempt.score is not None:
+        return not attempt.score.passed
+    return True  # unscored: error, timeout, cancellation, pause, or scorer crash
+
+
+def build_report(
+    task_results: Sequence[Any],
+    *,
+    only: str = "failed",
+    attempts: Optional[int] = None,
+) -> str:
+    """The per-attempt report. Presentation only -- the format is not a contract and
+    may change without notice; parse `summary()` or `save()` output, never this.
+
+    `only="failed"` (default) keeps the attempts a person investigates: scored fails
+    plus everything unscored (errors, timeouts, pauses). `only="all"` shows every
+    attempt. `attempts` caps the rows shown per task after filtering.
+    """
+    if only not in ("failed", "all"):
+        raise ValueError(f"only must be 'failed' or 'all', got {only!r}")
+    sections: List[str] = []
+    n_total = 0
+    for task_result in task_results:
+        n_total += len(task_result.attempts)
+        selected = [
+            (index, attempt)
+            for index, attempt in enumerate(task_result.attempts, start=1)
+            if only == "all" or _is_reportable_failure(attempt)
+        ]
+        hidden = 0
+        if attempts is not None and len(selected) > attempts:
+            hidden = len(selected) - attempts
+            selected = selected[:attempts]
+        if not selected:
+            continue
+        lines = [f"task {task_result.task.id}: {_clip(task_result.task.input, 90)}"]
+        for index, attempt in selected:
+            lines.extend(_attempt_lines(attempt, index))
+        if hidden:
+            lines.append(f"  ... {hidden} more (raise attempts= to see them)")
+        sections.append("\n".join(lines))
+    if not sections:
+        return f'all {n_total} attempts passed; nothing to report. print_report(only="all") shows every attempt.'
+    return "\n\n".join(sections)
 
 
 class LiveGrid:

--- a/libs/agno/agno/environments/runner.py
+++ b/libs/agno/agno/environments/runner.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 from agno.agent import Agent
 from agno.db.in_memory import InMemoryDb
 from agno.environments._engine import AttemptResult, StopReason, arun_batch
-from agno.environments._render import LiveGrid, attempt_glyph, build_grid
+from agno.environments._render import LiveGrid, attempt_glyph, build_grid, build_report
 from agno.environments.env import (
     Env,
     EnvTask,
@@ -305,6 +305,63 @@ class EnvRunResult:
     async def aload(cls, path: Union[str, Path]) -> "EnvRunResult":
         """Async twin of load."""
         return await asyncio.to_thread(cls.load, path)
+
+    def print_report(
+        self,
+        *,
+        only: str = "failed",
+        attempts: Optional[int] = None,
+        console: Optional[Any] = None,
+    ) -> None:
+        """Print the per-attempt evidence underneath the grid: verdict, score reason,
+        tool executions, the answer, and the token bill for each attempt.
+
+        `only="failed"` (default) shows the attempts a person investigates -- scored
+        fails plus everything unscored (errors, timeouts, pauses); `only="all"` shows
+        every attempt. `attempts` caps rows per task. Presentation only: the format is
+        not a contract and may change; parse `summary()` or `save()` output instead.
+        """
+        text = build_report(self.task_results, only=only, attempts=attempts)
+        if console is not None:
+            console.print(text)
+        else:
+            print(text)
+
+    def print_attempt(self, task_id: str, attempt: int = 1, *, markdown: bool = False) -> None:
+        """Print one attempt in full: the score's complete reasoning, then the whole
+        run transcript via `pprint_run_response`. `attempt` is 1-based, matching the
+        grid's glyph order. Presentation only, like `print_report`."""
+        task_result = next((tr for tr in self.task_results if str(tr.task.id) == task_id), None)
+        if task_result is None:
+            known = ", ".join(str(tr.task.id) for tr in self.task_results)
+            raise KeyError(f"no task with id {task_id!r}; known ids: {known}")
+        if not 1 <= attempt <= len(task_result.attempts):
+            raise IndexError(f"attempt must be in 1..{len(task_result.attempts)} for task {task_id!r}, got {attempt}")
+        selected = task_result.attempts[attempt - 1]
+        print(f"task {task_id}, attempt {attempt} of {len(task_result.attempts)}")
+        print(f"  input: {task_result.task.input}")
+        if task_result.task.expected is not None:
+            print(f"  expected: {task_result.task.expected}")
+        score = selected.score
+        verdict = "unscored" if score is None else ("PASS" if score.passed else "FAIL")
+        print(
+            f"  {verdict}   stop={selected.stop_reason.value}   "
+            f"{selected.duration_seconds:.1f}s   limit_hit={selected.tool_call_limit_hit}"
+        )
+        if selected.error:
+            print(f"  error: {selected.error}")
+        if score is not None:
+            print(f"  score: value={score.value} passed={score.passed}")
+            if score.reason:
+                print(f"  reason: {score.reason}")
+            if score.detail:
+                print(f"  detail: {score.detail}")
+        if selected.run is None:
+            print("  (no run captured)")
+            return
+        from agno.utils.pprint import pprint_run_response
+
+        pprint_run_response(selected.run, markdown=markdown)
 
     def __str__(self) -> str:
         rows = []

--- a/libs/agno/tests/unit/environments/test_report.py
+++ b/libs/agno/tests/unit/environments/test_report.py
@@ -1,0 +1,140 @@
+"""Unit tests for the per-attempt report: build_report, print_report, print_attempt.
+
+The report is presentation, not contract -- these tests pin behavior (what is shown,
+hidden, and refused), not exact formatting.
+"""
+
+import pytest
+
+from agno.environments import EnvRunResult, EnvTask, StopReason, TaskResult
+from agno.environments._engine import AttemptResult
+from agno.environments._render import build_report
+from agno.models.response import ToolExecution
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.scorer import Score
+
+
+def _attempt(
+    *,
+    passed=None,
+    value=None,
+    stop_reason=StopReason.completed,
+    error=None,
+    content="the answer",
+    tools=None,
+    run_present=True,
+):
+    score = None
+    if passed is not None:
+        score = Score(value=(1.0 if passed else 0.0) if value is None else value, passed=passed)
+    run = None
+    if run_present:
+        run = RunOutput(content=content, tools=tools, status=RunStatus.completed)
+    return AttemptResult(
+        run=run,
+        score=score,
+        stop_reason=stop_reason,
+        duration_seconds=1.5,
+        error=error,
+    )
+
+
+def _task_result(task_id, attempts):
+    return TaskResult(task=EnvTask(input=f"input for {task_id}", id=task_id), attempts=tuple(attempts))
+
+
+def _result(task_results):
+    return EnvRunResult(
+        env_name="report-env",
+        k=max((len(tr.attempts) for tr in task_results), default=0),
+        env_fingerprint="e" * 8,
+        policy_fingerprint="p" * 8,
+        task_results=tuple(task_results),
+        duration_seconds=3.0,
+    )
+
+
+def test_report_failed_only_keeps_fails_and_unscored():
+    task = _task_result(
+        "t-mixed",
+        [
+            _attempt(passed=True),
+            _attempt(passed=False),
+            _attempt(stop_reason=StopReason.error, error="boom", run_present=False),
+        ],
+    )
+    text = build_report([task])
+    assert "attempt 2: FAIL" in text
+    assert "attempt 3: unscored" in text
+    assert "attempt 1" not in text
+    assert "boom" in text
+    assert "(no run captured)" in text
+
+
+def test_report_all_shows_every_attempt_with_evidence():
+    execution = ToolExecution(tool_name="lookup", tool_args={"q": 1}, result="ok", tool_call_error=False)
+    task = _task_result("t-all", [_attempt(passed=True, tools=[execution])])
+    text = build_report([task], only="all")
+    assert "attempt 1: PASS" in text
+    assert "lookup({'q': 1}) -> ok" in text
+    assert "the answer" in text
+
+
+def test_report_all_green_returns_all_clear_message():
+    task = _task_result("t-green", [_attempt(passed=True), _attempt(passed=True)])
+    text = build_report([task])
+    assert "all 2 attempts passed" in text
+    assert 'only="all"' in text
+
+
+def test_report_attempts_cap_names_hidden_count():
+    task = _task_result("t-cap", [_attempt(passed=False) for _ in range(5)])
+    text = build_report([task], attempts=2)
+    assert "attempt 1: FAIL" in text
+    assert "attempt 2: FAIL" in text
+    assert "attempt 3" not in text
+    assert "3 more" in text
+
+
+def test_report_rejects_unknown_only():
+    with pytest.raises(ValueError):
+        build_report([], only="everything")
+
+
+def test_print_report_prints_to_stdout(capsys):
+    result = _result([_task_result("t1", [_attempt(passed=False)])])
+    result.print_report()
+    out = capsys.readouterr().out
+    assert "t1" in out
+    assert "FAIL" in out
+
+
+def test_print_attempt_full_detail(capsys):
+    score = Score(value=0.0, passed=False, reason="wrong label", detail={"raw_score": 3})
+    attempt = AttemptResult(
+        run=RunOutput(content="nope", status=RunStatus.completed),
+        score=score,
+        stop_reason=StopReason.completed,
+        duration_seconds=2.0,
+    )
+    result = _result([_task_result("t1", [attempt])])
+    result.print_attempt("t1", 1)
+    out = capsys.readouterr().out
+    assert "wrong label" in out
+    assert "raw_score" in out
+    assert "FAIL" in out
+
+
+def test_print_attempt_unknown_task_names_known_ids():
+    result = _result([_task_result("t1", [_attempt(passed=True)])])
+    with pytest.raises(KeyError, match="t1"):
+        result.print_attempt("nope")
+
+
+def test_print_attempt_index_is_one_based_and_bounded():
+    result = _result([_task_result("t1", [_attempt(passed=True)])])
+    with pytest.raises(IndexError):
+        result.print_attempt("t1", 0)
+    with pytest.raises(IndexError):
+        result.print_attempt("t1", 2)


### PR DESCRIPTION
## Summary

Follow-up to #9052, addressing a DX gap surfaced in review (design finding D12): the
result object had exactly two renderings -- the glyph grid and the frozen `summary()`
dict -- and the first question anyone asks after a surprising number ("which attempt
failed, and why?") required hand-walking four dataclasses. The evidence was all
retained; there was no view onto it.

**Two presentation helpers on `EnvRunResult`** (implemented in `_render.py`, the same
private module as the grid):

- `print_report(only="failed", attempts=None, console=None)` -- the layer under the
  glyphs: one block per attempt with verdict, score value, stop reason, duration, the
  scorer's reason, every tool EXECUTION as `name(args) -> ok|error`, the truncated
  answer, and the token/cost bill. `only="failed"` (default) shows just the attempts a
  person investigates -- scored fails plus everything unscored (errors, timeouts,
  pauses); an all-green run prints a one-line all-clear pointing at `only="all"`.
  `attempts=` caps rows per task and names the hidden count.
- `print_attempt(task_id, attempt, markdown=False)` -- one attempt in full: the
  uncut score reasoning and `detail` payload, then the complete transcript delegated
  to the existing `pprint_run_response` (no second run renderer invented). 1-based
  index, matching the grid's glyph order.

Both are **presentation, not contract** -- docstrings say the format may change and
direct parsers to `summary()` / `save()`. This keeps the design's existing split
(frozen machine contract vs. free-form rendering) intact, and gives prose-y
diagnostics a home OUTSIDE data fields. Following the `ReliabilityResult.print_eval`
precedent, print helpers are sync-only (no async twin: no I/O beyond stdout).

**Three use-case cookbooks**, extending `cookbook/environments/` beyond the two
CodeScorer examples so each shipped scorer has a realistic home:

- `_03_tool_reliability.py` -- ToolCallScorer over an order-support agent with a
  lookup tool: "did the tool actually EXECUTE, or did the agent answer from its
  head?" Includes a tempting-assertion trap task and an unknown-order task; ends with
  `print_report()`.
- `_04_judge_rubric.py` -- JudgeScorer (numeric mode, threshold 8) with a five-point
  support rubric. The file documents its own measured iteration loop: the first-draft
  instructions scored 0/12 (mean raw 5.2, judge reasons quoted); the tuned
  instructions score 12/12. The pass rate is the instructions-vs-rubric gap.
- `_05_compare_models.py` -- the cost-review question: tasks from a checked-in JSONL
  (`tasks/support_triage.jsonl`, strict-validated by `EnvTask.from_jsonl`), baseline
  on gpt-5.5, candidate via the `model=` override, then `save`/`load`/`diff` --
  "(env identical, policy changed)" end to end.


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
