### PR TITLE
fix: preserve custom base_app routes across AgentOS.resync()

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -434,6 +434,15 @@ class AgentOS:
         # the caller's app in place, so preparing twice would double routes/lifespans).
         self._base_app_prepared: bool = False
 
+        # id() of every route object AgentOS itself has added to the app via
+        # _add_router (populated on both the initial get_app() and every resync()).
+        # Route/APIRoute define value equality and are unhashable, so identity is
+        # tracked by id() rather than by keeping the objects themselves in a set.
+        # _reprovision_routers() uses this to remove only what AgentOS put there,
+        # leaving FastAPI's own routes (/docs, /mcp mount, ...) and anything the
+        # caller defined on their base_app untouched.
+        self._agentos_route_ids: set = set()
+
         self._initialize_agents()
         self._initialize_teams()
         self._initialize_workflows()
@@ -606,16 +615,13 @@ class AgentOS:
         else:
             updated_routers.append(_get_disabled_feature_router("/registry", "Registry", "registry"))
 
-        # Clear all previously existing routes
-        app.router.routes = [
-            route
-            for route in app.router.routes
-            if hasattr(route, "path")
-            and (
-                route.path in ["/docs", "/redoc", "/openapi.json", "/docs/oauth2-redirect"]
-                or route.path.startswith("/mcp")
-            )
-        ]
+        # Drop only the routes AgentOS itself previously added (tracked in
+        # self._agentos_route_ids by _add_router). Everything else -- FastAPI's own
+        # /docs & co, the /mcp mount (added outside _add_router, see
+        # _mount_mcp_app), and any route the caller defined on their base_app -- is
+        # left in place instead of being destroyed and never restored.
+        app.router.routes = [route for route in app.router.routes if id(route) not in self._agentos_route_ids]
+        self._agentos_route_ids.clear()
 
         # Add the built-in routes
         self._add_built_in_routes(app=app)
@@ -1492,6 +1498,10 @@ class AgentOS:
         Args:
             router: The APIRouter to add
         """
+        # Snapshot by identity so routes actually added below -- as opposed to ones
+        # skipped by the "preserve_base_app" conflict policy just below -- are the
+        # only ones recorded as AgentOS-owned (see self._agentos_route_ids).
+        route_ids_before = {id(route) for route in fastapi_app.router.routes}
 
         conflicts = find_conflicting_routes(fastapi_app, router)
         conflicting_routes = [conflict["route"] for conflict in conflicts]
@@ -1541,6 +1551,10 @@ class AgentOS:
         else:
             # No conflicts, add router normally
             fastapi_app.include_router(router)
+
+        self._agentos_route_ids.update(
+            id(route) for route in fastapi_app.router.routes if id(route) not in route_ids_before
+        )
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """Get the telemetry data for the OS"""

--- a/libs/agno/tests/integration/os/test_custom_fastapi_app.py
+++ b/libs/agno/tests/integration/os/test_custom_fastapi_app.py
@@ -217,6 +217,39 @@ def test_custom_app_endpoints_preserved(test_agent: Agent):
     assert "AgentOS API" in data["name"]
 
 
+def test_custom_app_endpoints_preserved_after_resync(test_agent: Agent):
+    """Test that resync() preserves base_app routes, including ones that only
+    survived an initial conflict via on_route_conflict='preserve_base_app'."""
+    custom_app = FastAPI(title="Custom App")
+
+    @custom_app.get("/status")
+    async def status_check():
+        return {"status": "healthy"}
+
+    @custom_app.get("/health")
+    async def custom_health():
+        return {"status": "custom_ok"}
+
+    agent_os = AgentOS(
+        agents=[test_agent],
+        base_app=custom_app,
+        on_route_conflict="preserve_base_app",
+    )
+
+    app = agent_os.get_app()
+    client = TestClient(app)
+
+    assert client.get("/status").json() == {"status": "healthy"}
+    assert client.get("/health").json()["status"] == "custom_ok"
+
+    agent_os.agents.append(Agent(name="second-agent", db=InMemoryDb()))
+    agent_os.resync(app)
+
+    assert client.get("/status").json() == {"status": "healthy"}
+    assert client.get("/health").json()["status"] == "custom_ok"
+    assert len(client.get("/agents").json()) == 2
+
+
 def test_custom_lifespan_integration(test_agent: Agent):
     """Test custom lifespan context manager integration."""
     startup_called = False


### PR DESCRIPTION
## Summary

Fixes #5860

When using AgentOS with a custom FastAPI `base_app`, `resync()` called `_reprovision_routers()`, which wiped all routes except docs/mcp paths. That deleted caller-defined routes (e.g. `GET /status` → 404 after resync).

This tracks the concrete route objects AgentOS itself adds (by identity via `id()`), and on resync only removes those — leaving FastAPI docs, the `/mcp` mount, and any `base_app` routes in place.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

Prior attempt [#6269](https://github.com/agno-agi/agno/pull/6269) (closed) tracked managed routes by path allowlist. This PR tracks by route object identity so conflict-skipped routes are not recorded as AgentOS-owned, and `/mcp` (mounted outside `_add_router`) is preserved without a hardcoded path list.

## AI disclosure

Prepared with Claude Code assistance (Opus orchestrator / Sonnet implementation). I reviewed the change, understand the route-ownership model, and verified `pytest libs/agno/tests/integration/os/test_custom_fastapi_app.py` — 20 passed including the new `test_custom_app_endpoints_preserved_after_resync`.

## Additional Notes

Verified: `pytest libs/agno/tests/integration/os/test_custom_fastapi_app.py` — 20 passed.

Made with [Cursor](https://cursor.com)