### PR TITLE
fix: env_fingerprint under-invalidated on prompt-shaping agent fields

### DIFF
--- a/libs/agno/agno/environments/environment.py
+++ b/libs/agno/agno/environments/environment.py
@@ -16,6 +16,19 @@ from agno.tools.toolkit import Toolkit
 
 _TASK_KEYS = {"input", "expected", "id", "metadata"}
 
+# Bumped whenever the env_fingerprint payload shape changes. The version is a prefix on
+# the returned fingerprint string, so a fingerprint written by an older format never
+# compares equal to a new one (env_matches refuses to compare across versions -- the safe
+# default) even in the vanishingly unlikely event the raw hashes collide. envfp2 adds the
+# prompt-shaping agent fields that envfp1 omitted (additional_context, expected_output,
+# role, additional_input, and the markdown/name/location/datetime/session-state flags).
+_ENV_FINGERPRINT_VERSION = "envfp2"
+
+# Per-instance Message fields that carry no prompt meaning but DO vary run to run: a fresh
+# id on every construction and a wall-clock created_at. Hashing them would make two agents
+# with the same additional_input hash differently, so they are stripped before hashing.
+_VOLATILE_MESSAGE_KEYS = frozenset({"id", "created_at"})
+
 
 @dataclass(frozen=True, eq=False)
 class Task:
@@ -195,9 +208,7 @@ def _sha256(payload: Any) -> str:
 def _scorer_digest(scorer: Scorer) -> str:
     digest = getattr(scorer, "digest", None)
     if digest is None or not callable(digest):
-        raise FingerprintError(
-            f"scorer {type(scorer).__name__} has no digest(); the env_fingerprint degrades to None"
-        )
+        raise FingerprintError(f"scorer {type(scorer).__name__} has no digest(); the env_fingerprint degrades to None")
     return digest()
 
 
@@ -247,16 +258,61 @@ def _prompt_component(value: Any, label: str) -> Any:
     raise FingerprintError(f"agent.{label} is {type(value).__name__}; only strings and lists fingerprint")
 
 
+def _additional_input_item(item: Any) -> Any:
+    """One additional_input element, normalized to a JSON-serializable, run-stable form.
+
+    additional_input is List[Union[str, Dict, BaseModel, Message]]; each element shapes the
+    rendered run input. Messages serialize via to_dict() with the volatile per-instance
+    fields stripped (see _VOLATILE_MESSAGE_KEYS), so identical inputs hash identically;
+    BaseModels fall back to model_dump(); strings and dicts pass through as-is (a caller's
+    literal dict is already stable, so its keys are kept verbatim)."""
+    if item is None or isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        return item
+    to_dict = getattr(item, "to_dict", None)
+    if callable(to_dict):
+        rendered = to_dict()
+        if isinstance(rendered, dict):
+            return {key: value for key, value in rendered.items() if key not in _VOLATILE_MESSAGE_KEYS}
+        return rendered
+    model_dump = getattr(item, "model_dump", None)
+    if callable(model_dump):
+        return model_dump()
+    raise FingerprintError(f"cannot fingerprint additional_input item of type {type(item).__name__}")
+
+
+def _additional_input_component(value: Any) -> Any:
+    """The declared additional_input, each element normalized. None stays None so an agent
+    without extra input hashes the same as before this field entered the payload."""
+    if value is None:
+        return None
+    if not isinstance(value, (list, tuple)):
+        raise FingerprintError(f"agent.additional_input is {type(value).__name__}; expected a list")
+    return [_additional_input_item(item) for item in value]
+
+
 def _env_fingerprint_of(env: "Environment", agent: Agent, model: Optional[Model] = None) -> str:
     """sha256 over the environment identity: tasks, scorer, declared tools, prompt
-    strings (agent-level and model-level), declared session_state, and termination
-    settings.
+    strings and flags (agent-level and model-level), declared session_state, and
+    termination settings. Returned string is prefixed with the payload version
+    (_ENV_FINGERPRINT_VERSION) so cross-version fingerprints never compare equal.
 
     Model-level system_prompt/instructions are prompt-shaped and therefore
     environment, not policy: they enter here and are excluded from the policy
     payload. `model` is the model whose prompt fields count -- the runner passes the
     EFFECTIVE model so a prompt-bearing override reads as an environment change;
     callers that omit it get the agent's declared model.
+
+    Prompt-shaping agent fields all count as environment: the static strings
+    (additional_context, expected_output, role) and extra input (additional_input)
+    are folded in by value; the context flags (markdown, add_name_to_context,
+    add_location_to_context, add_datetime_to_context, add_session_state_to_context)
+    are hashed as their FLAG value, never their rendered text -- add_datetime_to_context
+    injects wall-clock time, so hashing the rendered value would make the fingerprint
+    non-deterministic across runs. agent.name is folded in only when
+    add_name_to_context is set, the sole path by which it reaches the prompt; a
+    cosmetic rename with the flag off leaves the fingerprint unchanged.
 
     Every component failure surfaces as FingerprintError -- including exceptions
     raised while BUILDING the payload (a sourceless scorer, a schema builder choking
@@ -265,6 +321,7 @@ def _env_fingerprint_of(env: "Environment", agent: Agent, model: Optional[Model]
     """
     if model is None:
         model = getattr(agent, "model", None)
+    add_name_to_context = bool(getattr(agent, "add_name_to_context", False))
     try:
         payload = {
             "tasks": [
@@ -275,6 +332,18 @@ def _env_fingerprint_of(env: "Environment", agent: Agent, model: Optional[Model]
             "instructions": _prompt_component(getattr(agent, "instructions", None), "instructions"),
             "description": _prompt_component(getattr(agent, "description", None), "description"),
             "system_message": _prompt_component(getattr(agent, "system_message", None), "system_message"),
+            "additional_context": _prompt_component(getattr(agent, "additional_context", None), "additional_context"),
+            "expected_output": _prompt_component(getattr(agent, "expected_output", None), "expected_output"),
+            "role": _prompt_component(getattr(agent, "role", None), "role"),
+            "additional_input": _additional_input_component(getattr(agent, "additional_input", None)),
+            "name": getattr(agent, "name", None) if add_name_to_context else None,
+            "prompt_flags": {
+                "markdown": bool(getattr(agent, "markdown", False)),
+                "add_name_to_context": add_name_to_context,
+                "add_location_to_context": bool(getattr(agent, "add_location_to_context", False)),
+                "add_datetime_to_context": bool(getattr(agent, "add_datetime_to_context", False)),
+                "add_session_state_to_context": bool(getattr(agent, "add_session_state_to_context", False)),
+            },
             "model_prompt": model_prompt_payload(model),
             "session_state": getattr(agent, "session_state", None),
             "termination": {
@@ -286,7 +355,7 @@ def _env_fingerprint_of(env: "Environment", agent: Agent, model: Optional[Model]
         raise
     except Exception as exc:
         raise FingerprintError(f"fingerprint component failed: {type(exc).__name__}: {exc}") from exc
-    return _sha256(payload)
+    return f"{_ENV_FINGERPRINT_VERSION}:{_sha256(payload)}"
 
 
 def _policy_fingerprint_of(model: Model) -> str:

--- a/libs/agno/tests/unit/environments/test_env.py
+++ b/libs/agno/tests/unit/environments/test_env.py
@@ -8,7 +8,9 @@ import pytest
 
 from agno.agent import Agent
 from agno.environments import Environment, FingerprintError, Task
+from agno.environments.environment import _ENV_FINGERPRINT_VERSION
 from agno.environments.environment import _policy_fingerprint_of as policy_fingerprint_of
+from agno.models.message import Message
 from agno.models.openai import OpenAIChat
 from agno.scorer import CodeScorer, JudgeScorer
 
@@ -213,6 +215,129 @@ def test_policy_fingerprint_reads_the_live_model():
     fingerprint = policy_fingerprint_of(OpenAIChat(id="gpt-5-mini", temperature=0.7))
     assert fingerprint != policy_fingerprint_of(OpenAIChat(id="gpt-5-mini", temperature=0.8))
     assert fingerprint == policy_fingerprint_of(OpenAIChat(id="gpt-5-mini", temperature=0.7))
+
+
+# ---------------------------------------------------------------------------
+# Prompt-shaping agent fields (envfp2): each changes the rendered system prompt or
+# run input, so each must flip env_fingerprint while leaving policy_fingerprint alone.
+# Before envfp2 every pair below hashed IDENTICALLY -- the under-invalidation this fixes.
+# ---------------------------------------------------------------------------
+
+
+def _prompt_agent(**overrides) -> Agent:
+    return Agent(model=OpenAIChat(id="gpt-5-mini"), **overrides)
+
+
+# (label, base kwargs, edited kwargs) -- the two agents differ in exactly one field.
+_PROMPT_FIELD_EDITS = [
+    ("additional_context", {"additional_context": "Cite sources."}, {"additional_context": "Be terse."}),
+    ("expected_output", {"expected_output": "a number"}, {"expected_output": "a sentence"}),
+    ("role", {"role": "teacher"}, {"role": "examiner"}),
+    ("markdown", {"markdown": False}, {"markdown": True}),
+    ("add_datetime_to_context", {"add_datetime_to_context": False}, {"add_datetime_to_context": True}),
+    ("add_location_to_context", {"add_location_to_context": False}, {"add_location_to_context": True}),
+    (
+        "add_session_state_to_context",
+        {"add_session_state_to_context": False},
+        {"add_session_state_to_context": True},
+    ),
+    (
+        "add_name_to_context",
+        {"name": "Bot", "add_name_to_context": False},
+        {"name": "Bot", "add_name_to_context": True},
+    ),
+    (
+        "name (with add_name_to_context on)",
+        {"name": "Alice", "add_name_to_context": True},
+        {"name": "Bob", "add_name_to_context": True},
+    ),
+    (
+        "additional_input (dict)",
+        {"additional_input": [{"role": "user", "content": "one"}]},
+        {"additional_input": [{"role": "user", "content": "two"}]},
+    ),
+    (
+        "additional_input (Message)",
+        {"additional_input": [Message(role="user", content="one")]},
+        {"additional_input": [Message(role="user", content="two")]},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "label, base_kwargs, edited_kwargs", _PROMPT_FIELD_EDITS, ids=[e[0] for e in _PROMPT_FIELD_EDITS]
+)
+def test_prompt_shaping_field_flips_env_fingerprint(label, base_kwargs, edited_kwargs):
+    base = _env(agent=_prompt_agent(**base_kwargs))
+    edited = _env(agent=_prompt_agent(**edited_kwargs))
+    # The environment changed (prompt/input differs), so the env fingerprint must too.
+    assert edited.env_fingerprint() != base.env_fingerprint()
+    # ...but the model is untouched, so it is an environment change, not a policy one.
+    assert edited.policy_fingerprint() == base.policy_fingerprint()
+
+
+def test_add_name_to_context_gates_the_name():
+    # With the flag off, agent.name never reaches the prompt, so a rename must NOT
+    # invalidate: hashing name unconditionally would spuriously flag cosmetic renames.
+    flag_off = _env(agent=_prompt_agent(name="Alice"))
+    renamed_off = _env(agent=_prompt_agent(name="Bob"))
+    assert flag_off.env_fingerprint() == renamed_off.env_fingerprint()
+
+    # With the flag on, the name is in the prompt, so a rename must invalidate.
+    flag_on = _env(agent=_prompt_agent(name="Alice", add_name_to_context=True))
+    renamed_on = _env(agent=_prompt_agent(name="Bob", add_name_to_context=True))
+    assert flag_on.env_fingerprint() != renamed_on.env_fingerprint()
+
+
+def test_add_datetime_to_context_is_reproducible():
+    # add_datetime_to_context injects wall-clock time into the prompt. The fingerprint
+    # hashes the FLAG, not the rendered time, so repeated calls on the same agent are
+    # stable -- the timestamp must not leak into the hash.
+    import time
+
+    env = _env(agent=_prompt_agent(add_datetime_to_context=True))
+    first = env.env_fingerprint()
+    time.sleep(1.1)  # cross a whole-second boundary; a leaked timestamp would change here
+    assert env.env_fingerprint() == first
+
+
+def test_additional_input_message_hashes_stably():
+    # Two agents with semantically identical Message input must hash the same. A raw
+    # Message carries a fresh id and a wall-clock created_at on every construction;
+    # those volatile fields are stripped before hashing.
+    one = _env(agent=_prompt_agent(additional_input=[Message(role="user", content="hello")]))
+    two = _env(agent=_prompt_agent(additional_input=[Message(role="user", content="hello")]))
+    assert one.env_fingerprint() == two.env_fingerprint()
+
+
+class _OldFormatResult:
+    """Stand-in for a result whose env_fingerprint was written by the pre-version format
+    (a bare sha256, no 'envfp2:' prefix)."""
+
+    def __init__(self, fingerprint):
+        self._fingerprint = fingerprint
+
+    def env_fingerprint(self):
+        return self._fingerprint
+
+
+def test_env_fingerprint_carries_version_prefix():
+    fingerprint = _env().env_fingerprint()
+    assert fingerprint.startswith(f"{_ENV_FINGERPRINT_VERSION}:")
+
+
+def test_cross_version_fingerprints_do_not_match():
+    # A version bump must make old fingerprints refuse to compare, even if the raw hash
+    # underneath is byte-identical: the prefix is what env_matches sees, so a bare
+    # (pre-version) hash never equals the prefixed one. Refusing to compare is the safe
+    # behavior -- a false "same environment" is exactly what the fingerprint exists to
+    # prevent.
+    env = _env()
+    new_fingerprint = env.env_fingerprint()
+    bare_hash = new_fingerprint.split(":", 1)[1]  # simulate the old format: hash without prefix
+    assert env.env_matches(_OldFormatResult(bare_hash)) is False
+    # Same version and hash still matches -- the prefix does not break normal equality.
+    assert env.env_matches(_OldFormatResult(new_fingerprint)) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes an **under-invalidation** bug in `agno.environments`' `env_fingerprint`. `_env_fingerprint_of` ([environment.py](libs/agno/agno/environments/environment.py)) hashed a fixed payload — tasks, scorer digest, tool schemas, `instructions`, `description`, `system_message`, `model_prompt`, `session_state`, `termination`. Several prompt-shaping `Agent` fields that **do** change the rendered system prompt / run input were absent, so two agents differing only in one of them produced an **identical** `env_fingerprint`. Since the fingerprint's whole job is "did the environment change," a baseline comparison would silently report *same environment* when the prompt actually differed.

Follow-up to the 2.8.0 environments work (2.8.1-class); reviewed and merged separately.

## Type of change

- [x] Bug fix

---

## What was missing (each verified by driving the code, not trusted from a list)

For every field I built two agents differing **only** in that field, rendered the system message via `agno.agent._messages.get_system_message` (or the run input via `get_run_messages`), and confirmed **before** the fix that the prompt differed while the `env_fingerprint` was identical — then that the fix flips it.

| Field | Prompt differs? | `env_fingerprint` before | after | How added |
|---|---|---|---|---|
| `additional_context` | yes | identical (bug) | differs | static string via `_prompt_component` |
| `expected_output` | yes | identical (bug) | differs | static string via `_prompt_component` |
| `role` | yes | identical (bug) | differs | static string via `_prompt_component` |
| `additional_input` | yes (dict/Message elems) | identical (bug) | differs | new `_additional_input_component` normalizer |
| `add_datetime_to_context` | yes | identical (bug) | differs | **flag** hashed (not rendered — see determinism) |
| `markdown` | yes | identical (bug) | differs | flag hashed |
| `add_name_to_context` | yes | identical (bug) | differs | flag hashed |
| `add_location_to_context` | yes | identical (bug) | differs | flag hashed |
| `add_session_state_to_context` | yes | identical (bug) | differs | flag hashed |
| `name` (discovered) | yes, when `add_name_to_context=True` | identical (bug) | differs | folded in **only** when the flag is set |

### `name` — discovered during verification (not in the original candidate list)

`add_name_to_context` gates injecting `f"Your name is: {agent.name}."`. Hashing the flag alone is an **incomplete** fix: two agents with `add_name_to_context=True` and names `"Alice"` vs `"Bob"` render different prompts but (flag equal) would still hash identically. So `name` is folded in — but **only when `add_name_to_context` is set**, the sole path by which it reaches the prompt. With the flag off (the default), a cosmetic rename leaves the fingerprint unchanged — no false "environment changed". Flagged here for reviewer visibility since it extends the provided list.

### `goal` — could NOT reproduce; not added

`goal` is **not an `Agent` field** (`inspect.signature(Agent.__init__)` has no `goal`; `hasattr(Agent(), "goal")` is `False`; it appears only inside culture/team prompt text). There is no agent-level `goal` to under-invalidate, so it was left out.

## Determinism (`add_datetime_to_context`)

`add_datetime_to_context` injects wall-clock time into the prompt. Hashing the *rendered* value would make the fingerprint non-deterministic across runs (the same agent would hash differently second-to-second). All context flags therefore hash the **boolean**, not the rendered output: the same agent hashes consistently, while two agents differing in the flag hash differently. Covered by `test_add_datetime_to_context_is_reproducible` (stable across a >1s sleep).

`additional_input` has a related trap: a raw `Message` carries a fresh `id` and a wall-clock `created_at` on every construction. `_additional_input_component` strips `{"id", "created_at"}` (`_VOLATILE_MESSAGE_KEYS`) before hashing, so two agents with semantically identical `Message` input hash identically (`test_additional_input_message_hashes_stably`). Unserializable elements raise `FingerprintError`, which the runner already catches and degrades to `None` — a fingerprint can never crash a run.

## Version prefix bump

The payload did **not** previously carry a version prefix (the task's premise was slightly off — confirmed no `envfp`/version marker existed). Introduced `_ENV_FINGERPRINT_VERSION = "envfp2"` and prefixed it onto the returned string (`envfp2:<sha256>`). Because `env_matches` / `EnvironmentDiff.diff` compare fingerprint **strings** and refuse to compare when they differ, an old-format bare hash never compares equal to a new prefixed one — even if the underlying hash is byte-identical. Refusing to compare across versions is the safe behavior (a false "same environment" is exactly what the fingerprint exists to prevent). `test_cross_version_fingerprints_do_not_match` asserts this with an identical underlying hash.

## Out of scope (left untouched, per the brief)

Model-side `model_identity_payload` / `policy_fingerprint` (sampling params already flip it), role-remap plumbing and output-neutral bookkeeping (store/user/metadata), the `JudgeScorer` digest, `_isolate_attempt`, the runner, the engine, the `Scorer` protocol, and exporters.

Note: there are further prompt-shaping fields beyond this brief's list (e.g. `build_context`, `use_instruction_tags`, `datetime_format`/`timezone_identifier`, `skills`) that also aren't hashed. They're intentionally **not** in this focused follow-up; can be a separate pass if wanted.

---

## Tests

Added to [`libs/agno/tests/unit/environments/test_env.py`](libs/agno/tests/unit/environments/test_env.py):

- `test_prompt_shaping_field_flips_env_fingerprint` — parametrized over all 11 field edits; each flips `env_fingerprint` and leaves `policy_fingerprint` unchanged (confirming env-not-policy).
- `test_add_name_to_context_gates_the_name` — rename with flag off does **not** invalidate; with flag on it does.
- `test_add_datetime_to_context_is_reproducible` — stable fingerprint across a whole-second boundary.
- `test_additional_input_message_hashes_stably` — identical `Message` input hashes the same.
- `test_env_fingerprint_carries_version_prefix` + `test_cross_version_fingerprints_do_not_match` — version prefix present; cross-version fingerprints refuse to compare.

```
python -m pytest libs/agno/tests/unit/environments libs/agno/tests/unit/scorer libs/agno/tests/unit/eval -q
# 342 passed, 1 skipped
```

`./scripts/format.sh` and `./scripts/validate.sh` both clean (ruff + mypy).

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: cookbook updated (n/a — internal fingerprint behavior, no user-facing surface change)
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed no other PR already addresses this
- [x] Check if this PR was entirely AI-generated — yes, authored with Claude Code, human-reviewed

---

## Additional Notes

Draft — leaving for review, do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
