### PR TITLE
fix: validate required args before calling entrypoint in FunctionCall

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -910,6 +910,37 @@ class FunctionCall(BaseModel):
                 log_warning(f"Error in post-hook callback: {str(e)}")
                 log_exception(e)
 
+    def _validate_required_args(self, entrypoint_args: Dict[str, Any]) -> Optional[str]:
+        """Validate that all required parameters are provided.
+
+        When the LLM sends a tool call with missing or empty arguments, this
+        checks whether every required (no default value) parameter of the
+        entrypoint is satisfied by the combined entrypoint_args + self.arguments.
+        Returns an error string if any required argument is missing, or None if
+        all required arguments are present.
+        """
+        if self.arguments is None or self.arguments == {}:
+            from inspect import Parameter, signature
+
+            sig = signature(self.function.entrypoint)  # type: ignore
+            provided_keys = set(entrypoint_args.keys())
+            missing: list = []
+            for param_name, param in sig.parameters.items():
+                if param_name in provided_keys:
+                    continue
+                if param.default is not Parameter.empty:
+                    continue
+                if param.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD):
+                    continue
+                missing.append(param_name)
+            if missing:
+                return (
+                    f"Missing required argument(s) for function '{self.function.name}': "
+                    f"{', '.join(missing)}. "
+                    f"Please provide the missing arguments and retry."
+                )
+        return None
+
     def _build_entrypoint_args(self) -> Dict[str, Any]:
         """Builds the arguments for the entrypoint."""
         from inspect import signature
@@ -1063,6 +1094,12 @@ class FunctionCall(BaseModel):
 
         entrypoint_args = self._build_entrypoint_args()
 
+        # Validate that all required arguments are provided
+        validation_error = self._validate_required_args(entrypoint_args)
+        if validation_error is not None:
+            self.error = validation_error
+            return FunctionExecutionResult(status="failure", error=validation_error)
+
         # Check cache if enabled and not a generator function
         if self.function.cache_results and not isgeneratorfunction(self.function.entrypoint):
             cache_key = self.function._get_cache_key(entrypoint_args, self.arguments)
@@ -1084,7 +1121,10 @@ class FunctionCall(BaseModel):
                 execution_chain = self._build_nested_execution_chain(entrypoint_args=entrypoint_args)
                 result = execution_chain(self.function.name, self.function.entrypoint, self.arguments or {})
             else:
-                result = self.function.entrypoint(**entrypoint_args, **self.arguments)  # type: ignore
+                if self.arguments is None or self.arguments == {}:
+                    result = self.function.entrypoint(**entrypoint_args)
+                else:
+                    result = self.function.entrypoint(**entrypoint_args, **self.arguments)
 
             # Handle generator case
             if isgenerator(result):
@@ -1279,6 +1319,12 @@ class FunctionCall(BaseModel):
             self._handle_pre_hook()
 
         entrypoint_args = self._build_entrypoint_args()
+
+        # Validate that all required arguments are provided
+        validation_error = self._validate_required_args(entrypoint_args)
+        if validation_error is not None:
+            self.error = validation_error
+            return FunctionExecutionResult(status="failure", error=validation_error)
 
         # Check cache if enabled and not a generator function
         if self.function.cache_results and not (

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1147,6 +1147,115 @@ def test_post_hook_receives_messages_via_run_context():
     assert captured_messages == run_context.messages
 
 
+def test_function_call_with_missing_required_args():
+    """Test that executing a function call with empty arguments returns a
+    descriptive error instead of crashing with a pydantic ValidationError.
+
+    Regression test: when the LLM sends a tool call without arguments,
+    the framework should return a failure result with a clear error message
+    so the LLM can retry, rather than raising an unhandled exception.
+    """
+
+    def search_learnings(query: str, limit: int = 5) -> str:
+        """Search for relevant insights."""
+        return f"results for {query}"
+
+    func = Function.from_callable(search_learnings, strict=True)
+    func.process_entrypoint()
+
+    call = FunctionCall(function=func, arguments=None)
+
+    result = call.execute()
+    assert result.status == "failure"
+    assert "query" in result.error
+    assert "search_learnings" in result.error
+    assert "Missing required argument" in result.error
+
+
+def test_function_call_with_empty_dict_args():
+    """Test that executing with an empty dict also validates missing required args."""
+
+    def my_tool(query: str) -> str:
+        return f"result for {query}"
+
+    func = Function(name="my_tool", entrypoint=my_tool)
+    func.process_entrypoint()
+
+    call = FunctionCall(function=func, arguments={})
+
+    result = call.execute()
+    assert result.status == "failure"
+    assert "query" in result.error
+
+
+def test_function_call_with_all_defaults_no_args():
+    """Test that a function with only default params succeeds with empty args."""
+
+    def my_tool(query: str = "default", limit: int = 5) -> str:
+        return f"result for {query}"
+
+    func = Function(name="my_tool", entrypoint=my_tool)
+    func.process_entrypoint()
+
+    call = FunctionCall(function=func, arguments=None)
+
+    result = call.execute()
+    assert result.status == "success"
+    assert result.result == "result for default"
+
+
+def test_function_call_with_no_params_no_args():
+    """Test that a function with no params succeeds with empty args."""
+
+    def my_tool() -> str:
+        return "hello"
+
+    func = Function(name="my_tool", entrypoint=my_tool)
+    func.process_entrypoint()
+
+    call = FunctionCall(function=func, arguments=None)
+
+    result = call.execute()
+    assert result.status == "success"
+    assert result.result == "hello"
+
+
+@pytest.mark.asyncio
+async def test_async_function_call_with_missing_required_args():
+    """Test that async execution also validates missing required args."""
+
+    async def search_learnings(query: str, limit: int = 5) -> str:
+        """Search for relevant insights."""
+        return f"results for {query}"
+
+    func = Function.from_callable(search_learnings, strict=True)
+    func.process_entrypoint()
+
+    call = FunctionCall(function=func, arguments=None)
+
+    result = await call.aexecute()
+    assert result.status == "failure"
+    assert "query" in result.error
+    assert "search_learnings" in result.error
+
+
+def test_function_call_with_provided_args_succeeds():
+    """Test that providing the required args works normally."""
+
+    def search_learnings(query: str, limit: int = 5) -> str:
+        """Search for relevant insights."""
+        return f"results for {query}"
+
+    func = Function.from_callable(search_learnings, strict=True)
+    func.process_entrypoint()
+
+    call = FunctionCall(function=func, arguments={"query": "test", "limit": 3})
+
+    result = call.execute()
+    assert result.status == "success"
+    assert result.result == "results for test"
+
+
 def test_tool_hook_receives_messages_via_run_context():
     """Test that tool hooks can access current run message history via run_context.messages."""
     captured_messages: Optional[List[Message]] = None


### PR DESCRIPTION
## Problem

When the LLM generates a tool call with empty or missing arguments (e.g., `search_learnings()` without `query`), `FunctionCall.execute`/`aexecute` attempts to call the entrypoint with only framework-injected params (`agent`/`team`/`run_context`). For functions with required user-facing parameters, this causes a `pydantic ValidationError` that crashes the agent run instead of returning a recoverable error.

This commonly affects learning store tools (`search_learnings`, `save_learning`, etc.) created with `Function.from_callable(tool, strict=True)` in:
- `learned_knowledge.py`
- `session_context.py`
- `entity_memory.py`
- `user_memory.py`
- `user_profile.py`

## Root Cause

In `FunctionCall.aexecute` (line 1305-1308), when `self.arguments is None or {}`, only `entrypoint_args` (framework-injected params) are passed to the entrypoint. If the function has required parameters not in the injection set, the call fails with a validation error.

The sync `execute` had an additional bug: it did `**self.arguments` without a `None` check, causing `TypeError: argument after ** must be a mapping, not NoneType`.

## Fix

1. **Added `_validate_required_args()`** to `FunctionCall`: checks whether all required (no default) entrypoint parameters are satisfied by `entrypoint_args + self.arguments`. When arguments are empty and required params are missing, returns a descriptive error message instead of crashing.

2. **Added validation calls** in both `execute()` and `aexecute()` before the entrypoint invocation.

3. **Fixed sync `execute()`** to handle `self.arguments is None` the same way `aexecute()` does (using the `if None or {}` pattern).

## Test Results

6 new tests added, all 58 tests pass:

- `test_function_call_with_missing_required_args` — sync path returns failure with descriptive error
- `test_function_call_with_empty_dict_args` — empty dict also validated
- `test_function_call_with_all_defaults_no_args` — functions with only defaults succeed
- `test_function_call_with_no_params_no_args` — no-param functions succeed
- `test_async_function_call_with_missing_required_args` — async path also validated
- `test_function_call_with_provided_args_succeeds` — normal execution still works