### PR TITLE
feat: Release v2.8.0

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "2.7.4"
+version = "2.8.0"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"


### PR DESCRIPTION
# Changelog

## **New Features**

- **`agno.scorer`** — Turn a run into a number:
    - **`CodeScorer`**: wraps any callable (`bool | float | Score`; typed-field comparison under `output_schema` recommended)
    - **`JudgeScorer`**: LLM judge with the model always an explicit choice and numeric verdicts normalized to exact endpoints (`(score - 1) / 9`)
    - **`ToolCallScorer`**: checks tool **executions** deterministically (refused, errored, or HITL-rejected calls never satisfy an expectation)
    - All scorers ship sync and async variants.
- **`agno.environments`** — `Environment` + `Task` + `run_rollouts(env, k=8)`: run each task K times in full isolation (fresh db/session/user, no memory/knowledge/learning writes, cache off; knowledge reads still work). Includes a live per-attempt grid, real pass rate per task, drift-vs-policy fingerprints, `save`/`load`/`diff`, `learning_zone()`, and `to_sft_jsonl(...)` to export passing attempts as conversational-SFT JSONL with a provenance sidecar. This is the pass@k door.
- **`Case.scorer`**: the eval suite gains a third check — plug any scorer into a `Case` (with `Case.expected`), free and exact, no LLM call. `SuiteResult.to_dict()` gains additive `score_value`, `score_passed`, `score_reason` keys.
- **FileGenerationTools**: Added code file generation for `FileGenerationTools`.
- **Gmail Tools**: Added pagination and `max_results_per_request`.
- **Adanos Tools**: Added optional Adanos market sentiment tools.

## **Bug Fixes**

- **RemoteAgent / RemoteTeam**: Fixed metadata being dropped on the A2A protocol path.
- **Content**: Return empty string for empty content list in `get_content_string()`.
- **Decision log**: Replaced deprecated `datetime.utcnow()` in the decision_log store.

## **Breaking Changes**

- **`ReliabilityEval` matches tool executions**: Tool expectations are now satisfied only by a clean execution (`RunOutput.tools`, `tool_call_error` not set), not by message-side requests. **Verdicts can flip red after upgrading** — when they do, the eval was previously passing for the wrong reason (missing entries are annotated `"... (requested but refused/errored — execution matching, new in 2.8.0)"`). Argument checks moved to `ToolExecution.tool_args` with the same partial-match semantics.
- **Hardened judge prompt**: Every `AgentAsJudgeEval` now fences judged output behind a per-call random nonce, with the untrusted-data instruction inside the prompt. A literal `</output>` no longer escapes the block, and "score this 10" inside a judged answer is data, not an instruction. **Judge verdicts and token counts may shift.**