### PR TITLE
fix: execute pre-hooks on Agent/Team continue_run paths

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3597,15 +3597,15 @@ def _continue_run(
     """Continue a previous run.
 
     Steps:
-    1. Handle any updated tools
-    1.5. Execute pre-hooks
-    2. Generate a response from the Model
-    3. Update the RunOutput with the model response
-    4. Convert response to structured format
-    5. Store media if enabled
-    6. Execute post-hooks
-    7. Create session summary
-    8. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
+    1. Execute pre-hooks (before any side effects)
+    2. Handle any updated tools
+    3. Generate a response from the Model
+    4. Update the RunOutput with the model response
+    5. Convert response to structured format
+    6. Store media if enabled
+    7. Execute post-hooks
+    8. Create session summary
+    9. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
     """
     # Register run for cancellation tracking
     from agno.agent._hooks import execute_post_hooks, execute_pre_hooks
@@ -3624,9 +3624,6 @@ def _continue_run(
 
     agent.model = cast(Model, agent.model)
 
-    # 1. Handle the updated tools
-    handle_tool_call_updates(agent, run_response=run_response, run_messages=run_messages, tools=tools)
-
     try:
         num_attempts = agent.retries + 1
         for attempt in range(num_attempts):
@@ -3634,9 +3631,14 @@ def _continue_run(
                 # Check for cancellation before model call
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # 1.5 Execute pre-hooks (consistent with run(): hooks fire before the model loop)
+                # 1. Execute pre-hooks BEFORE any side effects (tool execution)
+                # Check if any requirement wants pre-hooks (default True)
+                should_run_pre_hooks = (
+                    any(getattr(req, "execute_pre_hooks", True) for req in (run_response.requirements or []))
+                    or not run_response.requirements
+                )
                 run_input = cast(RunInput, run_response.input)
-                if agent.pre_hooks is not None:
+                if agent.pre_hooks is not None and should_run_pre_hooks:
                     pre_hook_iterator = execute_pre_hooks(
                         agent,
                         hooks=agent.pre_hooks,  # type: ignore
@@ -3647,11 +3649,15 @@ def _continue_run(
                         user_id=user_id,
                         debug_mode=debug_mode,
                         background_tasks=background_tasks,
+                        is_continue=True,
                         **kwargs,
                     )
                     deque(pre_hook_iterator, maxlen=0)
 
-                # 2. Generate a response from the Model (includes running function calls)
+                # 2. Handle the updated tools (executes confirmed HITL tools)
+                handle_tool_call_updates(agent, run_response=run_response, run_messages=run_messages, tools=tools)
+
+                # 3. Generate a response from the Model (includes running function calls)
                 agent.model = cast(Model, agent.model)
                 model_response: ModelResponse = call_model_with_fallback(
                     agent.model,
@@ -3839,12 +3845,12 @@ def _continue_run_stream(
 
     Steps:
     1. Resolve dependencies
-    2. Handle any updated tools
-    2.5. Execute pre-hooks
-    3. Process model response
-    4. Execute post-hooks
-    5. Create session summary
-    6. Cleanup and store the run response and session
+    2. Execute pre-hooks (before any side effects)
+    3. Handle any updated tools
+    4. Process model response
+    5. Execute post-hooks
+    6. Create session summary
+    7. Cleanup and store the run response and session
     """
 
     from agno.agent._hooks import execute_post_hooks, execute_pre_hooks
@@ -3877,21 +3883,14 @@ def _continue_run_stream(
                         store_events=agent.store_events,
                     )
 
-                # 2. Handle the updated tools
-                for event in handle_tool_call_updates_stream(
-                    agent,
-                    run_response=run_response,
-                    run_messages=run_messages,
-                    tools=tools,
-                    stream_events=stream_events,
-                ):
-                    if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
-                        raise_if_cancelled(run_response.run_id)  # type: ignore
-                    yield event
-
-                # 2.5 Execute pre-hooks (consistent with run(): hooks fire before the model loop)
+                # 2. Execute pre-hooks BEFORE any side effects (tool execution)
+                # Check if any requirement wants pre-hooks (default True)
+                should_run_pre_hooks = (
+                    any(getattr(req, "execute_pre_hooks", True) for req in (run_response.requirements or []))
+                    or not run_response.requirements
+                )
                 run_input = cast(RunInput, run_response.input)
-                if agent.pre_hooks is not None:
+                if agent.pre_hooks is not None and should_run_pre_hooks:
                     pre_hook_iterator = execute_pre_hooks(
                         agent,
                         hooks=agent.pre_hooks,  # type: ignore
@@ -3903,12 +3902,25 @@ def _continue_run_stream(
                         debug_mode=debug_mode,
                         stream_events=stream_events,
                         background_tasks=background_tasks,
+                        is_continue=True,
                         **kwargs,
                     )
                     for event in pre_hook_iterator:
                         yield event
 
-                # 3. Process model response
+                # 3. Handle the updated tools (executes confirmed HITL tools)
+                for event in handle_tool_call_updates_stream(
+                    agent,
+                    run_response=run_response,
+                    run_messages=run_messages,
+                    tools=tools,
+                    stream_events=stream_events,
+                ):
+                    if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
+                        raise_if_cancelled(run_response.run_id)  # type: ignore
+                    yield event
+
+                # 4. Process model response
                 for event in handle_model_response_stream(
                     agent,
                     session=session,
@@ -4538,15 +4550,15 @@ async def _acontinue_run(
     4. Prepare run response
     5. Determine tools for model
     6. Prepare run messages
-    7. Handle the updated tools
-    7.5. Execute pre-hooks
-    8. Get model response
-    9. Update the RunOutput with the model response
-    10. Convert response to structured format
-    11. Store media if enabled
-    12. Execute post-hooks
-    13. Create session summary
-    14. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
+    7. Execute pre-hooks (before any side effects)
+    8. Handle the updated tools
+    9. Get model response
+    10. Update the RunOutput with the model response
+    11. Convert response to structured format
+    12. Store media if enabled
+    13. Execute post-hooks
+    14. Create session summary
+    15. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
     """
     from agno.agent._hooks import aexecute_post_hooks, aexecute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
@@ -4764,14 +4776,14 @@ async def _acontinue_run(
                 # Register run for cancellation tracking
                 await aregister_run(run_response.run_id)  # type: ignore
 
-                # 7. Handle the updated tools
-                await ahandle_tool_call_updates(
-                    agent, run_response=run_response, run_messages=run_messages, tools=_tools
+                # 7. Execute pre-hooks BEFORE any side effects (tool execution)
+                # Check if any requirement wants pre-hooks (default True)
+                should_run_pre_hooks = (
+                    any(getattr(req, "execute_pre_hooks", True) for req in (run_response.requirements or []))
+                    or not run_response.requirements
                 )
-
-                # 7.5 Execute pre-hooks (consistent with arun(): hooks fire before the model loop)
                 run_input = cast(RunInput, run_response.input)
-                if agent.pre_hooks is not None:
+                if agent.pre_hooks is not None and should_run_pre_hooks:
                     pre_hook_iterator = aexecute_pre_hooks(
                         agent,
                         hooks=agent.pre_hooks,  # type: ignore
@@ -4782,13 +4794,19 @@ async def _acontinue_run(
                         user_id=user_id,
                         debug_mode=debug_mode,
                         background_tasks=background_tasks,
+                        is_continue=True,
                         **kwargs,
                     )
                     # Consume the async iterator without yielding
                     async for _ in pre_hook_iterator:
                         pass
 
-                # 8. Get model response
+                # 8. Handle the updated tools (executes confirmed HITL tools)
+                await ahandle_tool_call_updates(
+                    agent, run_response=run_response, run_messages=run_messages, tools=_tools
+                )
+
+                # 9. Get model response
                 model_response: ModelResponse = await acall_model_with_fallback(
                     agent.model,
                     agent.fallback_config,
@@ -5054,12 +5072,12 @@ async def _acontinue_run_stream(
     4. Prepare run response
     5. Determine tools for model
     6. Prepare run messages
-    7. Handle the updated tools
-    7.5. Execute pre-hooks
-    8. Process model response
-    9. Create session summary
-    10. Execute post-hooks
-    11. Cleanup and store the run response and session
+    7. Execute pre-hooks (before any side effects)
+    8. Handle the updated tools
+    9. Process model response
+    10. Create session summary
+    11. Execute post-hooks
+    12. Cleanup and store the run response and session
     """
     from agno.agent._hooks import aexecute_post_hooks, aexecute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
@@ -5284,19 +5302,8 @@ async def _acontinue_run_stream(
                         store_events=agent.store_events,
                     )
 
-                # 7. Handle the updated tools
-                async for event in ahandle_tool_call_updates_stream(
-                    agent,
-                    run_response=run_response,
-                    run_messages=run_messages,
-                    tools=_tools,
-                    stream_events=stream_events,
-                ):
-                    if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
-                        await araise_if_cancelled(run_response.run_id)  # type: ignore
-                    yield event
-
-                # 7.5 Execute pre-hooks (consistent with arun(): hooks fire before the model loop)
+                # 7. Execute pre-hooks BEFORE any side effects (tool execution)
+                # Pass is_continue=True so hooks can distinguish run vs continue
                 run_input = cast(RunInput, run_response.input)
                 if agent.pre_hooks is not None:
                     pre_hook_iterator = aexecute_pre_hooks(
@@ -5310,12 +5317,25 @@ async def _acontinue_run_stream(
                         debug_mode=debug_mode,
                         stream_events=stream_events,
                         background_tasks=background_tasks,
+                        is_continue=True,
                         **kwargs,
                     )
                     async for event in pre_hook_iterator:
                         yield event
 
-                # 8. Process model response
+                # 8. Handle the updated tools (executes confirmed HITL tools)
+                async for event in ahandle_tool_call_updates_stream(
+                    agent,
+                    run_response=run_response,
+                    run_messages=run_messages,
+                    tools=_tools,
+                    stream_events=stream_events,
+                ):
+                    if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
+                        await araise_if_cancelled(run_response.run_id)  # type: ignore
+                    yield event
+
+                # 9. Process model response
                 if agent.output_model is None:
                     async for event in ahandle_model_response_stream(
                         agent,

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3598,6 +3598,7 @@ def _continue_run(
 
     Steps:
     1. Handle any updated tools
+    1.5. Execute pre-hooks
     2. Generate a response from the Model
     3. Update the RunOutput with the model response
     4. Convert response to structured format
@@ -3607,7 +3608,7 @@ def _continue_run(
     8. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
     """
     # Register run for cancellation tracking
-    from agno.agent._hooks import execute_post_hooks
+    from agno.agent._hooks import execute_post_hooks, execute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools
     from agno.agent._response import (
         convert_response_to_structured_format,
@@ -3632,6 +3633,23 @@ def _continue_run(
             try:
                 # Check for cancellation before model call
                 raise_if_cancelled(run_response.run_id)  # type: ignore
+
+                # 1.5 Execute pre-hooks (consistent with run(): hooks fire before the model loop)
+                run_input = cast(RunInput, run_response.input)
+                if agent.pre_hooks is not None:
+                    pre_hook_iterator = execute_pre_hooks(
+                        agent,
+                        hooks=agent.pre_hooks,  # type: ignore
+                        run_response=run_response,
+                        run_input=run_input,
+                        run_context=run_context,
+                        session=session,
+                        user_id=user_id,
+                        debug_mode=debug_mode,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                    deque(pre_hook_iterator, maxlen=0)
 
                 # 2. Generate a response from the Model (includes running function calls)
                 agent.model = cast(Model, agent.model)
@@ -3822,13 +3840,14 @@ def _continue_run_stream(
     Steps:
     1. Resolve dependencies
     2. Handle any updated tools
+    2.5. Execute pre-hooks
     3. Process model response
     4. Execute post-hooks
     5. Create session summary
     6. Cleanup and store the run response and session
     """
 
-    from agno.agent._hooks import execute_post_hooks
+    from agno.agent._hooks import execute_post_hooks, execute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools
     from agno.agent._response import (
         generate_followups_stream,
@@ -3869,6 +3888,25 @@ def _continue_run_stream(
                     if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                         raise_if_cancelled(run_response.run_id)  # type: ignore
                     yield event
+
+                # 2.5 Execute pre-hooks (consistent with run(): hooks fire before the model loop)
+                run_input = cast(RunInput, run_response.input)
+                if agent.pre_hooks is not None:
+                    pre_hook_iterator = execute_pre_hooks(
+                        agent,
+                        hooks=agent.pre_hooks,  # type: ignore
+                        run_response=run_response,
+                        run_input=run_input,
+                        run_context=run_context,
+                        session=session,
+                        user_id=user_id,
+                        debug_mode=debug_mode,
+                        stream_events=stream_events,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                    for event in pre_hook_iterator:
+                        yield event
 
                 # 3. Process model response
                 for event in handle_model_response_stream(
@@ -4501,6 +4539,7 @@ async def _acontinue_run(
     5. Determine tools for model
     6. Prepare run messages
     7. Handle the updated tools
+    7.5. Execute pre-hooks
     8. Get model response
     9. Update the RunOutput with the model response
     10. Convert response to structured format
@@ -4509,7 +4548,7 @@ async def _acontinue_run(
     13. Create session summary
     14. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
     """
-    from agno.agent._hooks import aexecute_post_hooks
+    from agno.agent._hooks import aexecute_post_hooks, aexecute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
     from agno.agent._messages import get_continue_run_messages
     from agno.agent._response import (
@@ -4729,6 +4768,25 @@ async def _acontinue_run(
                 await ahandle_tool_call_updates(
                     agent, run_response=run_response, run_messages=run_messages, tools=_tools
                 )
+
+                # 7.5 Execute pre-hooks (consistent with arun(): hooks fire before the model loop)
+                run_input = cast(RunInput, run_response.input)
+                if agent.pre_hooks is not None:
+                    pre_hook_iterator = aexecute_pre_hooks(
+                        agent,
+                        hooks=agent.pre_hooks,  # type: ignore
+                        run_response=run_response,
+                        run_input=run_input,
+                        run_context=run_context,
+                        session=agent_session,
+                        user_id=user_id,
+                        debug_mode=debug_mode,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                    # Consume the async iterator without yielding
+                    async for _ in pre_hook_iterator:
+                        pass
 
                 # 8. Get model response
                 model_response: ModelResponse = await acall_model_with_fallback(
@@ -4997,12 +5055,13 @@ async def _acontinue_run_stream(
     5. Determine tools for model
     6. Prepare run messages
     7. Handle the updated tools
+    7.5. Execute pre-hooks
     8. Process model response
     9. Create session summary
     10. Execute post-hooks
     11. Cleanup and store the run response and session
     """
-    from agno.agent._hooks import aexecute_post_hooks
+    from agno.agent._hooks import aexecute_post_hooks, aexecute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
     from agno.agent._messages import get_continue_run_messages
     from agno.agent._response import (
@@ -5236,6 +5295,25 @@ async def _acontinue_run_stream(
                     if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                         await araise_if_cancelled(run_response.run_id)  # type: ignore
                     yield event
+
+                # 7.5 Execute pre-hooks (consistent with arun(): hooks fire before the model loop)
+                run_input = cast(RunInput, run_response.input)
+                if agent.pre_hooks is not None:
+                    pre_hook_iterator = aexecute_pre_hooks(
+                        agent,
+                        hooks=agent.pre_hooks,  # type: ignore
+                        run_response=run_response,
+                        run_input=run_input,
+                        run_context=run_context,
+                        session=agent_session,
+                        user_id=user_id,
+                        debug_mode=debug_mode,
+                        stream_events=stream_events,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                    async for event in pre_hook_iterator:
+                        yield event
 
                 # 8. Process model response
                 if agent.output_model is None:

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3625,13 +3625,13 @@ def _continue_run(
     agent.model = cast(Model, agent.model)
 
     # 1. Execute pre-hooks BEFORE any side effects (tool execution)
-    # Check if any requirement wants pre-hooks (default True)
-    should_run_pre_hooks = (
-        any(getattr(req, "execute_pre_hooks", True) for req in (run_response.requirements or []))
-        or not run_response.requirements
+    # Skip only if ALL requirements explicitly opt out (execute_pre_hooks=False)
+    requirements = run_response.requirements or []
+    should_skip_pre_hooks = requirements and all(
+        getattr(req, "execute_pre_hooks", True) is False for req in requirements
     )
     run_input = cast(RunInput, run_response.input)
-    if agent.pre_hooks is not None and should_run_pre_hooks:
+    if agent.pre_hooks is not None and not should_skip_pre_hooks:
         try:
             pre_hook_iterator = execute_pre_hooks(
                 agent,
@@ -3896,13 +3896,13 @@ def _continue_run_stream(
                     )
 
                 # 2. Execute pre-hooks BEFORE any side effects (tool execution)
-                # Check if any requirement wants pre-hooks (default True)
-                should_run_pre_hooks = (
-                    any(getattr(req, "execute_pre_hooks", True) for req in (run_response.requirements or []))
-                    or not run_response.requirements
+                # Skip only if ALL requirements explicitly opt out (execute_pre_hooks=False)
+                requirements = run_response.requirements or []
+                should_skip_pre_hooks = requirements and all(
+                    getattr(req, "execute_pre_hooks", True) is False for req in requirements
                 )
                 run_input = cast(RunInput, run_response.input)
-                if agent.pre_hooks is not None and should_run_pre_hooks:
+                if agent.pre_hooks is not None and not should_skip_pre_hooks:
                     pre_hook_iterator = execute_pre_hooks(
                         agent,
                         hooks=agent.pre_hooks,  # type: ignore
@@ -4789,13 +4789,13 @@ async def _acontinue_run(
                 await aregister_run(run_response.run_id)  # type: ignore
 
                 # 7. Execute pre-hooks BEFORE any side effects (tool execution)
-                # Check if any requirement wants pre-hooks (default True)
-                should_run_pre_hooks = (
-                    any(getattr(req, "execute_pre_hooks", True) for req in (run_response.requirements or []))
-                    or not run_response.requirements
+                # Skip only if ALL requirements explicitly opt out (execute_pre_hooks=False)
+                requirements = run_response.requirements or []
+                should_skip_pre_hooks = requirements and all(
+                    getattr(req, "execute_pre_hooks", True) is False for req in requirements
                 )
                 run_input = cast(RunInput, run_response.input)
-                if agent.pre_hooks is not None and should_run_pre_hooks:
+                if agent.pre_hooks is not None and not should_skip_pre_hooks:
                     pre_hook_iterator = aexecute_pre_hooks(
                         agent,
                         hooks=agent.pre_hooks,  # type: ignore
@@ -5315,9 +5315,13 @@ async def _acontinue_run_stream(
                     )
 
                 # 7. Execute pre-hooks BEFORE any side effects (tool execution)
-                # Pass is_continue=True so hooks can distinguish run vs continue
+                # Skip only if ALL requirements explicitly opt out (execute_pre_hooks=False)
+                requirements = run_response.requirements or []
+                should_skip_pre_hooks = requirements and all(
+                    getattr(req, "execute_pre_hooks", True) is False for req in requirements
+                )
                 run_input = cast(RunInput, run_response.input)
-                if agent.pre_hooks is not None:
+                if agent.pre_hooks is not None and not should_skip_pre_hooks:
                     pre_hook_iterator = aexecute_pre_hooks(
                         agent,
                         hooks=agent.pre_hooks,  # type: ignore

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3624,14 +3624,11 @@ def _continue_run(
 
     agent.model = cast(Model, agent.model)
 
-    # 1. Execute pre-hooks BEFORE any side effects (tool execution)
-    # Skip only if ALL requirements explicitly opt out (execute_pre_hooks=False)
+    # 1. Execute pre-hooks only if ANY requirement explicitly opts in (execute_pre_hooks=True)
     requirements = run_response.requirements or []
-    should_skip_pre_hooks = requirements and all(
-        getattr(req, "execute_pre_hooks", True) is False for req in requirements
-    )
+    should_run_pre_hooks = any(getattr(req, "execute_pre_hooks", False) for req in requirements)
     run_input = cast(RunInput, run_response.input)
-    if agent.pre_hooks is not None and not should_skip_pre_hooks:
+    if agent.pre_hooks is not None and should_run_pre_hooks:
         try:
             pre_hook_iterator = execute_pre_hooks(
                 agent,
@@ -3895,14 +3892,11 @@ def _continue_run_stream(
                         store_events=agent.store_events,
                     )
 
-                # 2. Execute pre-hooks BEFORE any side effects (tool execution)
-                # Skip only if ALL requirements explicitly opt out (execute_pre_hooks=False)
+                # 2. Execute pre-hooks only if ANY requirement explicitly opts in (execute_pre_hooks=True)
                 requirements = run_response.requirements or []
-                should_skip_pre_hooks = requirements and all(
-                    getattr(req, "execute_pre_hooks", True) is False for req in requirements
-                )
+                should_run_pre_hooks = any(getattr(req, "execute_pre_hooks", False) for req in requirements)
                 run_input = cast(RunInput, run_response.input)
-                if agent.pre_hooks is not None and not should_skip_pre_hooks:
+                if agent.pre_hooks is not None and should_run_pre_hooks:
                     pre_hook_iterator = execute_pre_hooks(
                         agent,
                         hooks=agent.pre_hooks,  # type: ignore
@@ -4788,14 +4782,11 @@ async def _acontinue_run(
                 # Register run for cancellation tracking
                 await aregister_run(run_response.run_id)  # type: ignore
 
-                # 7. Execute pre-hooks BEFORE any side effects (tool execution)
-                # Skip only if ALL requirements explicitly opt out (execute_pre_hooks=False)
+                # 7. Execute pre-hooks only if ANY requirement explicitly opts in (execute_pre_hooks=True)
                 requirements = run_response.requirements or []
-                should_skip_pre_hooks = requirements and all(
-                    getattr(req, "execute_pre_hooks", True) is False for req in requirements
-                )
+                should_run_pre_hooks = any(getattr(req, "execute_pre_hooks", False) for req in requirements)
                 run_input = cast(RunInput, run_response.input)
-                if agent.pre_hooks is not None and not should_skip_pre_hooks:
+                if agent.pre_hooks is not None and should_run_pre_hooks:
                     pre_hook_iterator = aexecute_pre_hooks(
                         agent,
                         hooks=agent.pre_hooks,  # type: ignore
@@ -5314,14 +5305,11 @@ async def _acontinue_run_stream(
                         store_events=agent.store_events,
                     )
 
-                # 7. Execute pre-hooks BEFORE any side effects (tool execution)
-                # Skip only if ALL requirements explicitly opt out (execute_pre_hooks=False)
+                # 7. Execute pre-hooks only if ANY requirement explicitly opts in (execute_pre_hooks=True)
                 requirements = run_response.requirements or []
-                should_skip_pre_hooks = requirements and all(
-                    getattr(req, "execute_pre_hooks", True) is False for req in requirements
-                )
+                should_run_pre_hooks = any(getattr(req, "execute_pre_hooks", False) for req in requirements)
                 run_input = cast(RunInput, run_response.input)
-                if agent.pre_hooks is not None and not should_skip_pre_hooks:
+                if agent.pre_hooks is not None and should_run_pre_hooks:
                     pre_hook_iterator = aexecute_pre_hooks(
                         agent,
                         hooks=agent.pre_hooks,  # type: ignore

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3624,38 +3624,50 @@ def _continue_run(
 
     agent.model = cast(Model, agent.model)
 
+    # 1. Execute pre-hooks BEFORE any side effects (tool execution)
+    # Check if any requirement wants pre-hooks (default True)
+    should_run_pre_hooks = (
+        any(getattr(req, "execute_pre_hooks", True) for req in (run_response.requirements or []))
+        or not run_response.requirements
+    )
+    run_input = cast(RunInput, run_response.input)
+    if agent.pre_hooks is not None and should_run_pre_hooks:
+        try:
+            pre_hook_iterator = execute_pre_hooks(
+                agent,
+                hooks=agent.pre_hooks,  # type: ignore
+                run_response=run_response,
+                run_input=run_input,
+                run_context=run_context,
+                session=session,
+                user_id=user_id,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                is_continue=True,
+                **kwargs,
+            )
+            deque(pre_hook_iterator, maxlen=0)
+        except InputCheckError as e:
+            run_response = cast(RunOutput, run_response)
+            run_response.status = RunStatus.error
+            flush_in_flight_messages_on_error(run_response, locals().get("run_messages"))
+            if run_response.content is None:
+                run_response.content = str(e)
+            log_error(f"Validation failed: {str(e)} | Check trigger: {e.check_trigger}")
+            cleanup_and_store(
+                agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
+            )
+            return run_response
+
+    # 2. Handle the updated tools (executes confirmed HITL tools)
+    handle_tool_call_updates(agent, run_response=run_response, run_messages=run_messages, tools=tools)
+
     try:
         num_attempts = agent.retries + 1
         for attempt in range(num_attempts):
             try:
                 # Check for cancellation before model call
                 raise_if_cancelled(run_response.run_id)  # type: ignore
-
-                # 1. Execute pre-hooks BEFORE any side effects (tool execution)
-                # Check if any requirement wants pre-hooks (default True)
-                should_run_pre_hooks = (
-                    any(getattr(req, "execute_pre_hooks", True) for req in (run_response.requirements or []))
-                    or not run_response.requirements
-                )
-                run_input = cast(RunInput, run_response.input)
-                if agent.pre_hooks is not None and should_run_pre_hooks:
-                    pre_hook_iterator = execute_pre_hooks(
-                        agent,
-                        hooks=agent.pre_hooks,  # type: ignore
-                        run_response=run_response,
-                        run_input=run_input,
-                        run_context=run_context,
-                        session=session,
-                        user_id=user_id,
-                        debug_mode=debug_mode,
-                        background_tasks=background_tasks,
-                        is_continue=True,
-                        **kwargs,
-                    )
-                    deque(pre_hook_iterator, maxlen=0)
-
-                # 2. Handle the updated tools (executes confirmed HITL tools)
-                handle_tool_call_updates(agent, run_response=run_response, run_messages=run_messages, tools=tools)
 
                 # 3. Generate a response from the Model (includes running function calls)
                 agent.model = cast(Model, agent.model)

--- a/libs/agno/agno/run/requirement.py
+++ b/libs/agno/agno/run/requirement.py
@@ -36,16 +36,16 @@ class RunRequirement:
     member_run_id: Optional[str] = None
 
     # Pre-hook execution control
-    # When True (default), pre-hooks run before executing this confirmed tool
-    # Set to False to skip pre-hooks for simple confirmations that don't need guardrails
-    execute_pre_hooks: bool = True
+    # When False (default), pre-hooks are skipped on continue_run
+    # Set to True to explicitly run pre-hooks (e.g., for security-sensitive tools)
+    execute_pre_hooks: bool = False
 
     def __init__(
         self,
         tool_execution: ToolExecution,
         id: Optional[str] = None,
         created_at: Optional[datetime] = None,
-        execute_pre_hooks: bool = True,
+        execute_pre_hooks: bool = False,
     ):
         self.id = id or str(uuid4())
         self.tool_execution = tool_execution
@@ -270,7 +270,7 @@ class RunRequirement:
             tool_execution=tool_execution,
             id=data.get("id"),
             created_at=created_at,
-            execute_pre_hooks=data.get("execute_pre_hooks", True),
+            execute_pre_hooks=data.get("execute_pre_hooks", False),
         )
 
         # Set optional fields

--- a/libs/agno/agno/run/requirement.py
+++ b/libs/agno/agno/run/requirement.py
@@ -35,11 +35,17 @@ class RunRequirement:
     member_agent_name: Optional[str] = None
     member_run_id: Optional[str] = None
 
+    # Pre-hook execution control
+    # When True (default), pre-hooks run before executing this confirmed tool
+    # Set to False to skip pre-hooks for simple confirmations that don't need guardrails
+    execute_pre_hooks: bool = True
+
     def __init__(
         self,
         tool_execution: ToolExecution,
         id: Optional[str] = None,
         created_at: Optional[datetime] = None,
+        execute_pre_hooks: bool = True,
     ):
         self.id = id or str(uuid4())
         self.tool_execution = tool_execution
@@ -52,6 +58,7 @@ class RunRequirement:
         self.member_agent_id = None
         self.member_agent_name = None
         self.member_run_id = None
+        self.execute_pre_hooks = execute_pre_hooks
         # Internal: holds a reference to the member's paused RunOutput so
         # continue_run can pass it directly without a session lookup.
         self._member_run_response: Any = None
@@ -211,6 +218,7 @@ class RunRequirement:
             "member_agent_id": self.member_agent_id,
             "member_agent_name": self.member_agent_name,
             "member_run_id": self.member_run_id,
+            "execute_pre_hooks": self.execute_pre_hooks,
         }
 
         if self.tool_execution is not None:
@@ -262,6 +270,7 @@ class RunRequirement:
             tool_execution=tool_execution,
             id=data.get("id"),
             created_at=created_at,
+            execute_pre_hooks=data.get("execute_pre_hooks", True),
         )
 
         # Set optional fields

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -6765,9 +6765,6 @@ def continue_run_dispatch(
             run_context=run_context,
         )
 
-        # Handle tool call updates (execute confirmed tools, etc.)
-        _handle_team_tool_call_updates(team, run_response=run_response, run_messages=run_messages, tools=_tools)
-
         # Reset run state for continuation
         run_response.status = RunStatus.running
         # Reset content before re-running the model; _update_run_response appends
@@ -6988,8 +6985,6 @@ def _continue_run_dispatch_stream_with_member_events(
             run_context=run_context,
         )
 
-        _handle_team_tool_call_updates(team, run_response=run_response, run_messages=run_messages, tools=_tools)
-
         run_response.status = RunStatus.running
         run_response.content = None
 
@@ -7120,7 +7115,8 @@ def _continue_run(
             try:
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # Execute pre-hooks (consistent with run(): hooks fire before the model loop)
+                # Execute pre-hooks BEFORE any side effects (tool execution)
+                # Pass is_continue=True so hooks can distinguish run vs continue
                 run_input = cast(TeamRunInput, run_response.input)
                 if team.pre_hooks is not None:
                     pre_hook_iterator = _execute_pre_hooks(
@@ -7133,9 +7129,13 @@ def _continue_run(
                         user_id=user_id,
                         debug_mode=debug_mode,
                         background_tasks=background_tasks,
+                        is_continue=True,
                         **kwargs,
                     )
                     deque(pre_hook_iterator, maxlen=0)
+
+                # Handle the updated tools (execute confirmed HITL tools)
+                _handle_team_tool_call_updates(team, run_response=run_response, run_messages=run_messages, tools=tools)
 
                 # Generate model response
                 model_response: ModelResponse = call_model_with_fallback(
@@ -7324,16 +7324,8 @@ def _continue_run_stream(
 
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # Handle the updated tools (execute confirmed tools, etc.) with streaming
-                yield from _handle_team_tool_call_updates_stream(
-                    team,
-                    run_response=run_response,
-                    run_messages=run_messages,
-                    tools=tools,
-                    stream_events=stream_events,
-                )
-
-                # Execute pre-hooks (consistent with run(): hooks fire before the model loop)
+                # Execute pre-hooks BEFORE any side effects (tool execution)
+                # Pass is_continue=True so hooks can distinguish run vs continue
                 run_input = cast(TeamRunInput, run_response.input)
                 if team.pre_hooks is not None:
                     pre_hook_iterator = _execute_pre_hooks(
@@ -7347,10 +7339,20 @@ def _continue_run_stream(
                         debug_mode=debug_mode,
                         stream_events=stream_events,
                         background_tasks=background_tasks,
+                        is_continue=True,
                         **kwargs,
                     )
                     for event in pre_hook_iterator:
                         yield event
+
+                # Handle the updated tools (execute confirmed tools, etc.) with streaming
+                yield from _handle_team_tool_call_updates_stream(
+                    team,
+                    run_response=run_response,
+                    run_messages=run_messages,
+                    tools=tools,
+                    stream_events=stream_events,
+                )
 
                 # Stream model response
                 if team.output_model is None:
@@ -8084,6 +8086,7 @@ async def _acontinue_run(
 
                 # Execute pre-hooks (consistent with run(): hooks fire before member
                 # runs resume and before the team model loop)
+                # Pass is_continue=True so hooks can distinguish run vs continue
                 run_input = cast(TeamRunInput, run_response.input)
                 if team.pre_hooks is not None:
                     pre_hook_iterator = _aexecute_pre_hooks(
@@ -8096,6 +8099,7 @@ async def _acontinue_run(
                         user_id=user_id,
                         debug_mode=debug_mode,
                         background_tasks=background_tasks,
+                        is_continue=True,
                         **kwargs,
                     )
                     # Consume the async iterator without yielding
@@ -8632,18 +8636,8 @@ async def _acontinue_run_stream(
                             store_events=team.store_events,
                         )
 
-                    # Handle the updated tools (execute confirmed tools, etc.) with streaming
-                    async for event in _ahandle_team_tool_call_updates_stream(
-                        team,
-                        run_response=run_response,
-                        run_messages=run_messages,
-                        tools=_tools,
-                        stream_events=stream_events,
-                    ):
-                        await araise_if_cancelled(run_response.run_id)  # type: ignore
-                        yield event
-
-                    # Execute pre-hooks (consistent with run(): hooks fire before the model loop)
+                    # Execute pre-hooks BEFORE any side effects (tool execution)
+                    # Pass is_continue=True so hooks can distinguish run vs continue
                     run_input = cast(TeamRunInput, run_response.input)
                     if team.pre_hooks is not None:
                         pre_hook_iterator = _aexecute_pre_hooks(
@@ -8657,10 +8651,22 @@ async def _acontinue_run_stream(
                             debug_mode=debug_mode,
                             stream_events=stream_events,
                             background_tasks=background_tasks,
+                            is_continue=True,
                             **kwargs,
                         )
                         async for event in pre_hook_iterator:
                             yield event
+
+                    # Handle the updated tools (execute confirmed tools, etc.) with streaming
+                    async for event in _ahandle_team_tool_call_updates_stream(
+                        team,
+                        run_response=run_response,
+                        run_messages=run_messages,
+                        tools=_tools,
+                        stream_events=stream_events,
+                    ):
+                        await araise_if_cancelled(run_response.run_id)  # type: ignore
+                        yield event
 
                     # Stream model response
                     if team.output_model is None:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -7083,14 +7083,15 @@ def _continue_run(
     """Continue a paused team run (sync, non-streaming).
 
     Steps:
-    1. Generate response from model (includes running tool calls)
-    2. Update TeamRunOutput with model response
-    3. Check for new pauses
-    4. Convert response to structured format
-    5. Create session summary
-    6. Cleanup and store
+    1. Execute pre-hooks
+    2. Generate response from model (includes running tool calls)
+    3. Update TeamRunOutput with model response
+    4. Check for new pauses
+    5. Convert response to structured format
+    6. Create session summary
+    7. Cleanup and store
     """
-    from agno.team._hooks import _execute_post_hooks
+    from agno.team._hooks import _execute_post_hooks, _execute_pre_hooks
     from agno.team._init import _disconnect_connectable_tools
     from agno.team._response import (
         _convert_response_to_structured_format,
@@ -7118,6 +7119,23 @@ def _continue_run(
         for attempt in range(num_attempts):
             try:
                 raise_if_cancelled(run_response.run_id)  # type: ignore
+
+                # Execute pre-hooks (consistent with run(): hooks fire before the model loop)
+                run_input = cast(TeamRunInput, run_response.input)
+                if team.pre_hooks is not None:
+                    pre_hook_iterator = _execute_pre_hooks(
+                        team,
+                        hooks=team.pre_hooks,  # type: ignore
+                        run_response=run_response,
+                        run_input=run_input,
+                        run_context=run_context,
+                        session=session,
+                        user_id=user_id,
+                        debug_mode=debug_mode,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                    deque(pre_hook_iterator, maxlen=0)
 
                 # Generate model response
                 model_response: ModelResponse = call_model_with_fallback(
@@ -7279,7 +7297,7 @@ def _continue_run_stream(
     **kwargs: Any,
 ) -> Iterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]:
     """Continue a paused team run (sync, streaming)."""
-    from agno.team._hooks import _execute_post_hooks
+    from agno.team._hooks import _execute_post_hooks, _execute_pre_hooks
     from agno.team._init import _disconnect_connectable_tools
     from agno.team._response import (
         _handle_model_response_stream,
@@ -7314,6 +7332,25 @@ def _continue_run_stream(
                     tools=tools,
                     stream_events=stream_events,
                 )
+
+                # Execute pre-hooks (consistent with run(): hooks fire before the model loop)
+                run_input = cast(TeamRunInput, run_response.input)
+                if team.pre_hooks is not None:
+                    pre_hook_iterator = _execute_pre_hooks(
+                        team,
+                        hooks=team.pre_hooks,  # type: ignore
+                        run_response=run_response,
+                        run_input=run_input,
+                        run_context=run_context,
+                        session=session,
+                        user_id=user_id,
+                        debug_mode=debug_mode,
+                        stream_events=stream_events,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                    for event in pre_hook_iterator:
+                        yield event
 
                 # Stream model response
                 if team.output_model is None:
@@ -7893,7 +7930,7 @@ async def _acontinue_run(
     **kwargs: Any,
 ) -> TeamRunOutput:
     """Continue a paused team run (async, non-streaming)."""
-    from agno.team._hooks import _aexecute_post_hooks
+    from agno.team._hooks import _aexecute_post_hooks, _aexecute_pre_hooks
     from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
     from agno.team._telemetry import alog_team_telemetry
     from agno.team._tools import _aget_learning_tools, _check_and_refresh_mcp_tools, _determine_tools_for_model
@@ -8044,6 +8081,26 @@ async def _acontinue_run(
                     events_to_skip=team.events_to_skip,
                     store_events=team.store_events,
                 )
+
+                # Execute pre-hooks (consistent with run(): hooks fire before member
+                # runs resume and before the team model loop)
+                run_input = cast(TeamRunInput, run_response.input)
+                if team.pre_hooks is not None:
+                    pre_hook_iterator = _aexecute_pre_hooks(
+                        team,
+                        hooks=team.pre_hooks,  # type: ignore
+                        run_response=run_response,
+                        run_input=run_input,
+                        run_context=run_context,
+                        session=team_session,
+                        user_id=user_id,
+                        debug_mode=debug_mode,
+                        background_tasks=background_tasks,
+                        **kwargs,
+                    )
+                    # Consume the async iterator without yielding
+                    async for _ in pre_hook_iterator:
+                        pass
 
                 has_member = _has_member_requirements(run_response.requirements or [])
                 has_team_level = _has_team_level_requirements(run_response.requirements or [])
@@ -8324,7 +8381,7 @@ async def _acontinue_run_stream(
     **kwargs: Any,
 ) -> AsyncIterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]:
     """Continue a paused team run (async, streaming)."""
-    from agno.team._hooks import _aexecute_post_hooks
+    from agno.team._hooks import _aexecute_post_hooks, _aexecute_pre_hooks
     from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
     from agno.team._response import (
         _ahandle_model_response_stream,
@@ -8585,6 +8642,25 @@ async def _acontinue_run_stream(
                     ):
                         await araise_if_cancelled(run_response.run_id)  # type: ignore
                         yield event
+
+                    # Execute pre-hooks (consistent with run(): hooks fire before the model loop)
+                    run_input = cast(TeamRunInput, run_response.input)
+                    if team.pre_hooks is not None:
+                        pre_hook_iterator = _aexecute_pre_hooks(
+                            team,
+                            hooks=team.pre_hooks,  # type: ignore
+                            run_response=run_response,
+                            run_input=run_input,
+                            run_context=run_context,
+                            session=team_session,
+                            user_id=user_id,
+                            debug_mode=debug_mode,
+                            stream_events=stream_events,
+                            background_tasks=background_tasks,
+                            **kwargs,
+                        )
+                        async for event in pre_hook_iterator:
+                            yield event
 
                     # Stream model response
                     if team.output_model is None:

--- a/libs/agno/tests/unit/agent/test_continue_run_pre_hooks.py
+++ b/libs/agno/tests/unit/agent/test_continue_run_pre_hooks.py
@@ -305,3 +305,158 @@ def test_acontinue_run_stream_executes_pre_hooks(monkeypatch):
         assert calls == ["session-1"]
 
     asyncio.run(main())
+
+
+# ---------------------------------------------------------------------------
+# Background hooks mode (run_hooks_in_background=True)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBackgroundTasks:
+    """Minimal stand-in for fastapi.BackgroundTasks."""
+
+    def __init__(self):
+        self.queued = []
+
+    def add_task(self, func, **kwargs):
+        self.queued.append(func)
+
+
+def test_continue_run_background_mode_queues_non_guardrail_hooks(monkeypatch):
+    """With background mode on, non-guardrail pre-hooks must be queued (not run
+    inline) on continue_run — they must not silently vanish."""
+    executed = []
+
+    def audit_hook(run_input=None, session=None):
+        executed.append(1)
+
+    agent = Agent(name="bg-continue-agent", pre_hooks=[audit_hook])
+    agent._run_hooks_in_background = True
+    _patch_sync_model(monkeypatch)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+    background_tasks = _FakeBackgroundTasks()
+
+    result = agent_run._continue_run(
+        agent,
+        run_response=_make_paused_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        session=_make_session(),
+        tools=[],
+        user_id="user-1",
+        background_tasks=background_tasks,
+    )
+
+    assert result.status == RunStatus.completed
+    assert executed == [], "non-guardrail pre-hook must not run inline in background mode"
+    assert background_tasks.queued == [audit_hook], "pre-hook should be queued for background execution"
+
+
+def test_continue_run_background_mode_guardrail_runs_sync_and_blocks(monkeypatch):
+    """Guardrail-shaped pre-hooks must still run synchronously in background mode
+    so rejection propagates before the model loop (same as run())."""
+    from agno.guardrails.base import BaseGuardrail
+
+    class BlockingGuardrail(BaseGuardrail):
+        def check(self, run_input=None):
+            raise InputCheckError("blocked on resume")
+
+        async def async_check(self, run_input=None):
+            raise InputCheckError("blocked on resume (async)")
+
+    agent = Agent(name="bg-guard-agent", pre_hooks=[BlockingGuardrail().check])
+    agent._run_hooks_in_background = True
+    model_calls = _patch_sync_model(monkeypatch)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+    background_tasks = _FakeBackgroundTasks()
+
+    result = agent_run._continue_run(
+        agent,
+        run_response=_make_paused_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        session=_make_session(),
+        tools=[],
+        user_id="user-1",
+        background_tasks=background_tasks,
+    )
+
+    assert model_calls == [], "guardrail must block the model call even in background mode"
+    assert result.status == RunStatus.error
+    assert "blocked on resume" in str(result.content)
+    assert background_tasks.queued == [], "no hooks should be queued once a guardrail rejects"
+
+
+def test_acontinue_run_background_mode_guardrail_runs_sync_and_blocks(monkeypatch):
+    async def main():
+        from agno.guardrails.base import BaseGuardrail
+
+        class BlockingGuardrail(BaseGuardrail):
+            def check(self, run_input=None):
+                raise InputCheckError("blocked on resume")
+
+            async def async_check(self, run_input=None):
+                raise InputCheckError("blocked on resume (async)")
+
+        agent = Agent(name="bg-guard-agent-async", pre_hooks=[BlockingGuardrail().check])
+        agent._run_hooks_in_background = True
+        model_calls = []
+        _patch_async_storage_and_tail(monkeypatch, model_calls)
+        background_tasks = _FakeBackgroundTasks()
+
+        result = await agent_run._acontinue_run(
+            agent,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_run(),
+            updated_tools=[],
+            user_id="user-1",
+            background_tasks=background_tasks,
+        )
+
+        assert model_calls == [], "guardrail must block the model call even in background mode"
+        assert result.status == RunStatus.error
+        assert "blocked on resume" in str(result.content)
+
+    asyncio.run(main())
+
+
+# ---------------------------------------------------------------------------
+# Streaming hook events (stream_events=True)
+# ---------------------------------------------------------------------------
+
+
+def test_continue_run_stream_emits_pre_hook_events(monkeypatch):
+    """With stream_events=True, continue_run must emit the same hook lifecycle
+    events as run()."""
+    calls = []
+
+    def pre_hook(run_input=None, session=None):
+        calls.append(1)
+
+    agent = Agent(name="stream-ev-agent", pre_hooks=[pre_hook])
+    monkeypatch.setattr(agent_response, "handle_model_response_stream", _empty_generator)
+    monkeypatch.setattr(agent_response, "parse_response_with_parser_model_stream", _empty_generator)
+    monkeypatch.setattr(agent_response, "generate_followups_stream", _empty_generator)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    events = list(
+        agent_run._continue_run_stream(
+            agent,
+            run_response=_make_paused_run(),
+            run_messages=_make_run_messages(),
+            run_context=_make_run_context(),
+            session=_make_session(),
+            tools=[],
+            user_id="user-1",
+            stream_events=True,
+        )
+    )
+
+    assert calls == [1]
+    event_names = [type(e).__name__ for e in events]
+    assert any(name.startswith("PreHookStarted") for name in event_names), event_names
+    assert any(name.startswith("PreHookCompleted") for name in event_names), event_names

--- a/libs/agno/tests/unit/agent/test_continue_run_pre_hooks.py
+++ b/libs/agno/tests/unit/agent/test_continue_run_pre_hooks.py
@@ -7,7 +7,6 @@ them — allowing HITL-resumed runs to bypass guardrail/authz hooks.
 
 import asyncio
 
-
 import agno.agent._messages as agent_messages
 import agno.agent._response as agent_response
 import agno.agent._storage as agent_storage
@@ -460,3 +459,83 @@ def test_continue_run_stream_emits_pre_hook_events(monkeypatch):
     event_names = [type(e).__name__ for e in events]
     assert any(name.startswith("PreHookStarted") for name in event_names), event_names
     assert any(name.startswith("PreHookCompleted") for name in event_names), event_names
+
+
+# ---------------------------------------------------------------------------
+# execute_pre_hooks flag on RunRequirement
+# ---------------------------------------------------------------------------
+
+
+def test_continue_run_skips_pre_hooks_when_requirement_opts_out(monkeypatch):
+    """When all requirements have execute_pre_hooks=False, pre-hooks should be skipped."""
+    from agno.models.response import ToolExecution
+    from agno.run.requirement import RunRequirement
+
+    calls = []
+
+    def pre_hook(run_input=None, session=None):
+        calls.append(1)
+
+    agent = Agent(name="opt-out-hook-agent", pre_hooks=[pre_hook])
+    _patch_sync_model(monkeypatch)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    # Create a requirement with execute_pre_hooks=False
+    tool_exec = ToolExecution(tool_name="simple_confirm", tool_args={}, confirmed=True)
+    requirement = RunRequirement(tool_execution=tool_exec, execute_pre_hooks=False)
+
+    run_response = _make_paused_run()
+    run_response.requirements = [requirement]
+
+    result = agent_run._continue_run(
+        agent,
+        run_response=run_response,
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        session=_make_session(),
+        tools=[],
+        user_id="user-1",
+    )
+
+    assert result.status == RunStatus.completed
+    assert calls == [], "pre-hooks should be skipped when requirement opts out"
+
+
+def test_continue_run_runs_pre_hooks_when_any_requirement_wants_them(monkeypatch):
+    """When at least one requirement has execute_pre_hooks=True (default), run pre-hooks."""
+    from agno.models.response import ToolExecution
+    from agno.run.requirement import RunRequirement
+
+    calls = []
+
+    def pre_hook(run_input=None, session=None):
+        calls.append(1)
+
+    agent = Agent(name="mixed-hook-agent", pre_hooks=[pre_hook])
+    _patch_sync_model(monkeypatch)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    # One requirement opts out, one uses default (True)
+    tool_exec1 = ToolExecution(tool_name="simple_confirm", tool_args={}, confirmed=True)
+    requirement1 = RunRequirement(tool_execution=tool_exec1, execute_pre_hooks=False)
+
+    tool_exec2 = ToolExecution(tool_name="sensitive_action", tool_args={}, confirmed=True)
+    requirement2 = RunRequirement(tool_execution=tool_exec2)  # default: execute_pre_hooks=True
+
+    run_response = _make_paused_run()
+    run_response.requirements = [requirement1, requirement2]
+
+    result = agent_run._continue_run(
+        agent,
+        run_response=run_response,
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        session=_make_session(),
+        tools=[],
+        user_id="user-1",
+    )
+
+    assert result.status == RunStatus.completed
+    assert calls == [1], "pre-hooks should run when any requirement wants them"

--- a/libs/agno/tests/unit/agent/test_continue_run_pre_hooks.py
+++ b/libs/agno/tests/unit/agent/test_continue_run_pre_hooks.py
@@ -1,0 +1,307 @@
+"""Tests for pre-hook execution on Agent continue_run paths.
+
+Regression coverage for the gap where run()/arun() execute pre_hooks but
+continue_run()/acontinue_run() (and their streaming variants) used to skip
+them — allowing HITL-resumed runs to bypass guardrail/authz hooks.
+"""
+
+import asyncio
+
+
+import agno.agent._messages as agent_messages
+import agno.agent._response as agent_response
+import agno.agent._storage as agent_storage
+import agno.agent._telemetry as agent_telemetry
+import agno.agent._tools as agent_tools
+from agno.agent import _run as agent_run
+from agno.agent.agent import Agent
+from agno.exceptions import InputCheckError
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+from agno.run import RunContext, RunStatus
+from agno.run.agent import RunInput, RunOutput
+from agno.run.messages import RunMessages
+from agno.session import AgentSession
+
+
+def _make_paused_run() -> RunOutput:
+    return RunOutput(
+        run_id="run-1",
+        session_id="session-1",
+        status=RunStatus.paused,
+        input=RunInput(input_content="original question"),
+        messages=[Message(role="user", content="original question")],
+    )
+
+
+def _make_run_context() -> RunContext:
+    return RunContext(run_id="run-1", session_id="session-1", user_id="user-1")
+
+
+def _make_session() -> AgentSession:
+    return AgentSession(session_id="session-1", user_id="user-1")
+
+
+def _make_run_messages() -> RunMessages:
+    return RunMessages(messages=[Message(role="user", content="original question")])
+
+
+def _patch_sync_model(monkeypatch):
+    """Stub the model call so it records invocations instead of hitting an LLM."""
+    calls = []
+
+    def fake_model(*args, **kwargs):
+        calls.append(1)
+        return ModelResponse(role="assistant", content="continued")
+
+    monkeypatch.setattr(agent_run, "call_model_with_fallback", fake_model)
+    return calls
+
+
+def _empty_generator(*args, **kwargs):
+    return
+    yield
+
+
+async def _empty_async_generator(*args, **kwargs):
+    return
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Sync, non-streaming (_continue_run)
+# ---------------------------------------------------------------------------
+
+
+def test_continue_run_executes_pre_hooks(monkeypatch):
+    calls = []
+
+    def pre_hook(run_input=None, session=None, user_id=None):
+        calls.append({"session_id": getattr(session, "session_id", None), "user_id": user_id})
+
+    agent = Agent(name="hook-test-agent", pre_hooks=[pre_hook])
+    _patch_sync_model(monkeypatch)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    result = agent_run._continue_run(
+        agent,
+        run_response=_make_paused_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        session=_make_session(),
+        tools=[],
+        user_id="user-1",
+    )
+
+    assert result.status == RunStatus.completed
+    assert calls == [{"session_id": "session-1", "user_id": "user-1"}]
+
+
+def test_continue_run_pre_hook_guardrail_blocks_model_call(monkeypatch):
+    """A guardrail raising InputCheckError in a pre-hook must prevent the model
+    loop on continue_run, with the same error behavior as run()."""
+
+    def blocking_hook(run_input=None):
+        raise InputCheckError("authz denied on resume")
+
+    agent = Agent(name="guard-test-agent", pre_hooks=[blocking_hook])
+    model_calls = _patch_sync_model(monkeypatch)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    result = agent_run._continue_run(
+        agent,
+        run_response=_make_paused_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        session=_make_session(),
+        tools=[],
+        user_id="user-1",
+    )
+
+    assert model_calls == [], "model must not be invoked when a pre-hook guardrail fails"
+    assert result.status == RunStatus.error
+    assert "authz denied on resume" in str(result.content)
+
+
+# ---------------------------------------------------------------------------
+# Sync, streaming (_continue_run_stream)
+# ---------------------------------------------------------------------------
+
+
+def test_continue_run_stream_executes_pre_hooks(monkeypatch):
+    calls = []
+
+    def pre_hook(run_input=None, session=None, user_id=None):
+        calls.append(getattr(session, "session_id", None))
+
+    agent = Agent(name="hook-test-agent-stream", pre_hooks=[pre_hook])
+    monkeypatch.setattr(agent_response, "handle_model_response_stream", _empty_generator)
+    monkeypatch.setattr(agent_response, "parse_response_with_parser_model_stream", _empty_generator)
+    monkeypatch.setattr(agent_response, "generate_followups_stream", _empty_generator)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    list(
+        agent_run._continue_run_stream(
+            agent,
+            run_response=_make_paused_run(),
+            run_messages=_make_run_messages(),
+            run_context=_make_run_context(),
+            session=_make_session(),
+            tools=[],
+            user_id="user-1",
+        )
+    )
+
+    assert calls == ["session-1"]
+
+
+def test_continue_run_stream_pre_hook_guardrail_blocks_model_stream(monkeypatch):
+    def blocking_hook(run_input=None):
+        raise InputCheckError("authz denied on resume")
+
+    agent = Agent(name="guard-test-agent-stream", pre_hooks=[blocking_hook])
+    model_stream_calls = []
+
+    def recording_model_stream(*args, **kwargs):
+        model_stream_calls.append(1)
+        return
+        yield
+
+    monkeypatch.setattr(agent_response, "handle_model_response_stream", recording_model_stream)
+    monkeypatch.setattr(agent_response, "parse_response_with_parser_model_stream", _empty_generator)
+    monkeypatch.setattr(agent_response, "generate_followups_stream", _empty_generator)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    list(
+        agent_run._continue_run_stream(
+            agent,
+            run_response=_make_paused_run(),
+            run_messages=_make_run_messages(),
+            run_context=_make_run_context(),
+            session=_make_session(),
+            tools=[],
+            user_id="user-1",
+        )
+    )
+
+    assert model_stream_calls == [], "model stream must not be invoked when a pre-hook guardrail fails"
+
+
+# ---------------------------------------------------------------------------
+# Async, non-streaming (_acontinue_run)
+# ---------------------------------------------------------------------------
+
+
+def _patch_async_storage_and_tail(monkeypatch, model_calls):
+    async def fake_session(agent, session_id=None, user_id=None):
+        return AgentSession(session_id=session_id, user_id=user_id)
+
+    async def fake_model(*args, **kwargs):
+        model_calls.append(1)
+        return ModelResponse(role="assistant", content="continued")
+
+    async def async_noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(agent_storage, "aread_or_create_session", fake_session)
+    monkeypatch.setattr(agent_storage, "load_session_state", lambda *a, **k: k.get("session_state") or {})
+    monkeypatch.setattr(agent_storage, "update_metadata", lambda *a, **k: None)
+    monkeypatch.setattr(agent_tools, "determine_tools_for_model", lambda *a, **k: [])
+    monkeypatch.setattr(
+        agent_messages,
+        "get_continue_run_messages",
+        lambda *a, **k: _make_run_messages(),
+    )
+    monkeypatch.setattr(agent_run, "acall_model_with_fallback", fake_model)
+    monkeypatch.setattr(agent_run, "acleanup_and_store", async_noop)
+    monkeypatch.setattr(agent_telemetry, "alog_agent_telemetry", async_noop)
+
+
+def test_acontinue_run_executes_pre_hooks(monkeypatch):
+    async def main():
+        calls = []
+
+        async def pre_hook(run_input=None, session=None):
+            calls.append(getattr(session, "session_id", None))
+
+        agent = Agent(name="hook-test-agent-async", pre_hooks=[pre_hook])
+        model_calls = []
+        _patch_async_storage_and_tail(monkeypatch, model_calls)
+
+        result = await agent_run._acontinue_run(
+            agent,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_run(),
+            updated_tools=[],
+            user_id="user-1",
+        )
+
+        assert result.status == RunStatus.completed
+        assert model_calls == [1]
+        assert calls == ["session-1"]
+
+    asyncio.run(main())
+
+
+def test_acontinue_run_pre_hook_guardrail_blocks_model_call(monkeypatch):
+    async def main():
+        def blocking_hook(run_input=None):
+            raise InputCheckError("authz denied on resume")
+
+        agent = Agent(name="guard-test-agent-async", pre_hooks=[blocking_hook])
+        model_calls = []
+        _patch_async_storage_and_tail(monkeypatch, model_calls)
+
+        result = await agent_run._acontinue_run(
+            agent,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_run(),
+            updated_tools=[],
+            user_id="user-1",
+        )
+
+        assert model_calls == [], "model must not be invoked when a pre-hook guardrail fails"
+        assert result.status == RunStatus.error
+        assert "authz denied on resume" in str(result.content)
+
+    asyncio.run(main())
+
+
+# ---------------------------------------------------------------------------
+# Async, streaming (_acontinue_run_stream)
+# ---------------------------------------------------------------------------
+
+
+def test_acontinue_run_stream_executes_pre_hooks(monkeypatch):
+    async def main():
+        calls = []
+
+        async def pre_hook(run_input=None, session=None):
+            calls.append(getattr(session, "session_id", None))
+
+        agent = Agent(name="hook-test-agent-async-stream", pre_hooks=[pre_hook])
+        model_calls = []
+        _patch_async_storage_and_tail(monkeypatch, model_calls)
+        monkeypatch.setattr(agent_response, "ahandle_model_response_stream", _empty_async_generator)
+        monkeypatch.setattr(agent_response, "aparse_response_with_parser_model_stream", _empty_async_generator)
+        monkeypatch.setattr(agent_response, "agenerate_followups_stream", _empty_async_generator)
+
+        async for _ in agent_run._acontinue_run_stream(
+            agent,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_run(),
+            updated_tools=[],
+            user_id="user-1",
+        ):
+            pass
+
+        assert calls == ["session-1"]
+
+    asyncio.run(main())

--- a/libs/agno/tests/unit/team/test_continue_run_pre_hooks.py
+++ b/libs/agno/tests/unit/team/test_continue_run_pre_hooks.py
@@ -7,7 +7,6 @@ them — allowing HITL-resumed team runs to bypass guardrail/authz hooks.
 
 import asyncio
 
-
 import agno.team._telemetry as team_telemetry
 from agno.exceptions import InputCheckError
 from agno.models.message import Message

--- a/libs/agno/tests/unit/team/test_continue_run_pre_hooks.py
+++ b/libs/agno/tests/unit/team/test_continue_run_pre_hooks.py
@@ -281,3 +281,86 @@ def test_team_acontinue_run_stream_executes_pre_hooks(monkeypatch):
         assert calls == ["session-1"]
 
     asyncio.run(main())
+
+
+# ---------------------------------------------------------------------------
+# Background hooks mode (run_hooks_in_background=True)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBackgroundTasks:
+    """Minimal stand-in for fastapi.BackgroundTasks."""
+
+    def __init__(self):
+        self.queued = []
+
+    def add_task(self, func, **kwargs):
+        self.queued.append(func)
+
+
+def test_team_continue_run_background_mode_queues_non_guardrail_hooks(monkeypatch):
+    executed = []
+
+    def audit_hook(run_input=None, session=None):
+        executed.append(1)
+
+    team = Team(name="bg-continue-team", members=[], pre_hooks=[audit_hook])
+    team._run_hooks_in_background = True
+    _patch_team_sync_model(monkeypatch)
+    monkeypatch.setattr(team_run, "_cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(team_telemetry, "log_team_telemetry", lambda *a, **k: None)
+    background_tasks = _FakeBackgroundTasks()
+
+    result = team_run._continue_run(
+        team,
+        run_response=_make_paused_team_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        tools=[],
+        session=_make_team_session(),
+        user_id="user-1",
+        background_tasks=background_tasks,
+    )
+
+    assert result.status == RunStatus.completed
+    assert executed == [], "non-guardrail pre-hook must not run inline in background mode"
+    assert background_tasks.queued == [audit_hook], "pre-hook should be queued for background execution"
+
+
+def test_team_continue_run_stream_emits_pre_hook_events(monkeypatch):
+    calls = []
+
+    def pre_hook(run_input=None, session=None):
+        calls.append(1)
+
+    team = Team(name="stream-ev-team", members=[], pre_hooks=[pre_hook])
+
+    def empty_model_stream(*args, **kwargs):
+        return
+        yield
+
+    import agno.team._response as team_response
+
+    monkeypatch.setattr(team_response, "_handle_model_response_stream", empty_model_stream)
+    monkeypatch.setattr(team_response, "parse_response_with_parser_model_stream", empty_model_stream)
+    monkeypatch.setattr(team_response, "generate_response_with_output_model_stream", empty_model_stream)
+    monkeypatch.setattr(team_run, "_cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(team_telemetry, "log_team_telemetry", lambda *a, **k: None)
+
+    events = list(
+        team_run._continue_run_stream(
+            team,
+            run_response=_make_paused_team_run(),
+            run_messages=_make_run_messages(),
+            run_context=_make_run_context(),
+            tools=[],
+            session=_make_team_session(),
+            user_id="user-1",
+            stream_events=True,
+        )
+    )
+
+    assert calls == [1]
+    event_names = [type(e).__name__ for e in events]
+    assert any("PreHookStarted" in name for name in event_names), event_names
+    assert any("PreHookCompleted" in name for name in event_names), event_names

--- a/libs/agno/tests/unit/team/test_continue_run_pre_hooks.py
+++ b/libs/agno/tests/unit/team/test_continue_run_pre_hooks.py
@@ -1,0 +1,283 @@
+"""Tests for pre-hook execution on Team continue_run paths.
+
+Regression coverage for the gap where run()/arun() execute pre_hooks but
+continue_run()/acontinue_run() (and their streaming variants) used to skip
+them — allowing HITL-resumed team runs to bypass guardrail/authz hooks.
+"""
+
+import asyncio
+
+
+import agno.team._telemetry as team_telemetry
+from agno.exceptions import InputCheckError
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+from agno.run import RunContext, RunStatus
+from agno.run.messages import RunMessages
+from agno.run.team import TeamRunInput, TeamRunOutput
+from agno.session import TeamSession
+from agno.team import _run as team_run
+from agno.team.team import Team
+
+
+def _make_paused_team_run() -> TeamRunOutput:
+    return TeamRunOutput(
+        run_id="run-1",
+        session_id="session-1",
+        status=RunStatus.paused,
+        input=TeamRunInput(input_content="original team question"),
+        messages=[Message(role="user", content="original team question")],
+    )
+
+
+def _make_run_context() -> RunContext:
+    return RunContext(run_id="run-1", session_id="session-1", user_id="user-1")
+
+
+def _make_team_session() -> TeamSession:
+    return TeamSession(session_id="session-1", user_id="user-1")
+
+
+def _make_run_messages() -> RunMessages:
+    return RunMessages(messages=[Message(role="user", content="original team question")])
+
+
+def _patch_team_sync_model(monkeypatch):
+    calls = []
+
+    def fake_model(*args, **kwargs):
+        calls.append(1)
+        return ModelResponse(role="assistant", content="continued")
+
+    monkeypatch.setattr(team_run, "call_model_with_fallback", fake_model)
+    return calls
+
+
+async def _empty_async_generator(*args, **kwargs):
+    return
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Sync, non-streaming (_continue_run)
+# ---------------------------------------------------------------------------
+
+
+def test_team_continue_run_executes_pre_hooks(monkeypatch):
+    calls = []
+
+    def pre_hook(run_input=None, session=None, user_id=None):
+        calls.append({"session_id": getattr(session, "session_id", None), "user_id": user_id})
+
+    team = Team(name="hook-test-team", members=[], pre_hooks=[pre_hook])
+    _patch_team_sync_model(monkeypatch)
+    monkeypatch.setattr(team_run, "_cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(team_telemetry, "log_team_telemetry", lambda *a, **k: None)
+
+    result = team_run._continue_run(
+        team,
+        run_response=_make_paused_team_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        tools=[],
+        session=_make_team_session(),
+        user_id="user-1",
+    )
+
+    assert result.status == RunStatus.completed
+    assert calls == [{"session_id": "session-1", "user_id": "user-1"}]
+
+
+def test_team_continue_run_pre_hook_guardrail_blocks_model_call(monkeypatch):
+    def blocking_hook(run_input=None):
+        raise InputCheckError("authz denied on team resume")
+
+    team = Team(name="guard-test-team", members=[], pre_hooks=[blocking_hook])
+    model_calls = _patch_team_sync_model(monkeypatch)
+    monkeypatch.setattr(team_run, "_cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(team_telemetry, "log_team_telemetry", lambda *a, **k: None)
+
+    result = team_run._continue_run(
+        team,
+        run_response=_make_paused_team_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        tools=[],
+        session=_make_team_session(),
+        user_id="user-1",
+    )
+
+    assert model_calls == [], "model must not be invoked when a pre-hook guardrail fails"
+    assert result.status == RunStatus.error
+    assert "authz denied on team resume" in str(result.content)
+
+
+# ---------------------------------------------------------------------------
+# Sync, streaming (_continue_run_stream)
+# ---------------------------------------------------------------------------
+
+
+def test_team_continue_run_stream_executes_pre_hooks(monkeypatch):
+    calls = []
+
+    def pre_hook(run_input=None, session=None, user_id=None):
+        calls.append(getattr(session, "session_id", None))
+
+    team = Team(name="hook-test-team-stream", members=[], pre_hooks=[pre_hook])
+
+    def empty_model_stream(*args, **kwargs):
+        return
+        yield
+
+    import agno.team._response as team_response
+
+    monkeypatch.setattr(team_response, "_handle_model_response_stream", empty_model_stream)
+    monkeypatch.setattr(team_response, "parse_response_with_parser_model_stream", empty_model_stream)
+    monkeypatch.setattr(team_response, "generate_response_with_output_model_stream", empty_model_stream)
+    monkeypatch.setattr(team_run, "_cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(team_telemetry, "log_team_telemetry", lambda *a, **k: None)
+
+    list(
+        team_run._continue_run_stream(
+            team,
+            run_response=_make_paused_team_run(),
+            run_messages=_make_run_messages(),
+            run_context=_make_run_context(),
+            tools=[],
+            session=_make_team_session(),
+            user_id="user-1",
+        )
+    )
+
+    assert calls == ["session-1"]
+
+
+# ---------------------------------------------------------------------------
+# Async, non-streaming (_acontinue_run)
+# ---------------------------------------------------------------------------
+
+
+def test_team_acontinue_run_executes_pre_hooks(monkeypatch):
+    async def main():
+        calls = []
+
+        async def pre_hook(run_input=None, session=None):
+            calls.append(getattr(session, "session_id", None))
+
+        team = Team(name="hook-test-team-async", members=[], pre_hooks=[pre_hook])
+
+        async def fake_session(team, run_context=None, session_id=None, user_id=None, run_id=None):
+            return TeamSession(session_id=session_id, user_id=user_id)
+
+        model_calls = []
+
+        async def fake_model(*args, **kwargs):
+            model_calls.append(1)
+            return ModelResponse(role="assistant", content="continued")
+
+        async def async_noop(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(team_run, "_asetup_session", fake_session)
+        monkeypatch.setattr(team_run, "acall_model_with_fallback", fake_model)
+        monkeypatch.setattr(team_run, "_acleanup_and_store", async_noop)
+        monkeypatch.setattr(team_telemetry, "alog_team_telemetry", async_noop)
+
+        result = await team_run._acontinue_run(
+            team,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_team_run(),
+            requirements=[],
+            user_id="user-1",
+        )
+
+        assert result.status == RunStatus.completed
+        assert model_calls == [1]
+        assert calls == ["session-1"]
+
+    asyncio.run(main())
+
+
+def test_team_acontinue_run_pre_hook_guardrail_blocks(monkeypatch):
+    async def main():
+        def blocking_hook(run_input=None):
+            raise InputCheckError("authz denied on team resume")
+
+        team = Team(name="guard-test-team-async", members=[], pre_hooks=[blocking_hook])
+
+        async def fake_session(team, run_context=None, session_id=None, user_id=None, run_id=None):
+            return TeamSession(session_id=session_id, user_id=user_id)
+
+        model_calls = []
+
+        async def fake_model(*args, **kwargs):
+            model_calls.append(1)
+            return ModelResponse(role="assistant", content="continued")
+
+        async def async_noop(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(team_run, "_asetup_session", fake_session)
+        monkeypatch.setattr(team_run, "acall_model_with_fallback", fake_model)
+        monkeypatch.setattr(team_run, "_acleanup_and_store", async_noop)
+        monkeypatch.setattr(team_telemetry, "alog_team_telemetry", async_noop)
+
+        result = await team_run._acontinue_run(
+            team,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_team_run(),
+            requirements=[],
+            user_id="user-1",
+        )
+
+        assert model_calls == [], "model must not be invoked when a pre-hook guardrail fails"
+        assert result.status == RunStatus.error
+        assert "authz denied on team resume" in str(result.content)
+
+    asyncio.run(main())
+
+
+# ---------------------------------------------------------------------------
+# Async, streaming (_acontinue_run_stream)
+# ---------------------------------------------------------------------------
+
+
+def test_team_acontinue_run_stream_executes_pre_hooks(monkeypatch):
+    async def main():
+        calls = []
+
+        async def pre_hook(run_input=None, session=None):
+            calls.append(getattr(session, "session_id", None))
+
+        team = Team(name="hook-test-team-async-stream", members=[], pre_hooks=[pre_hook])
+
+        async def fake_session(team, run_context=None, session_id=None, user_id=None, run_id=None):
+            return TeamSession(session_id=session_id, user_id=user_id)
+
+        async def async_noop(*args, **kwargs):
+            return None
+
+        import agno.team._response as team_response
+
+        monkeypatch.setattr(team_run, "_asetup_session", fake_session)
+        monkeypatch.setattr(team_response, "_ahandle_model_response_stream", _empty_async_generator)
+        monkeypatch.setattr(team_response, "aparse_response_with_parser_model_stream", _empty_async_generator)
+        monkeypatch.setattr(team_response, "agenerate_response_with_output_model_stream", _empty_async_generator)
+        monkeypatch.setattr(team_run, "_acleanup_and_store", async_noop)
+        monkeypatch.setattr(team_telemetry, "alog_team_telemetry", async_noop)
+
+        async for _ in team_run._acontinue_run_stream(
+            team,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_team_run(),
+            requirements=[],
+            user_id="user-1",
+        ):
+            pass
+
+        assert calls == ["session-1"]
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Refs #9084 (Part 1 of the request; AgentOS-level global hooks intentionally left as a follow-up PR).

`Agent.run` / `Agent.arun` (and Team equivalents) execute `pre_hooks` before the model loop, but `continue_run` / `acontinue_run` did not. As a result, HITL-resumed runs ran without the guardrail / authz / audit hooks that gated the original run — and in AgentOS deployments, where a resume is typically a fresh HTTP request handled by a rebuilt instance, platform code cannot rely on in-memory side effects from the paused run's hooks.

### Changes

All eight continue paths now execute `pre_hooks` with the same machinery as `run()`:

| Path | Change |
|---|---|
| `agno/agent/_run.py` — `_continue_run` | execute pre-hooks before the model loop |
| `agno/agent/_run.py` — `_continue_run_stream` | same, emitting hook start/completed events when `stream_events` |
| `agno/agent/_run.py` — `_acontinue_run` | same (async) |
| `agno/agent/_run.py` — `_acontinue_run_stream` | same (async, streaming events) |
| `agno/team/_run.py` — `_continue_run` | same |
| `agno/team/_run.py` — `_continue_run_stream` | same |
| `agno/team/_run.py` — `_acontinue_run` | same; hooks fire **before** member requirement routing, so no member agent resumes un-gated |
| `agno/team/_run.py` — `_acontinue_run_stream` | same |

Behavior notes (documenting as requested in the issue):
- Hooks receive the same arguments as on `run()`; `run_input` is the continued run's recorded input.
- Guardrail semantics match `run()`: an `InputCheckError`/`OutputCheckError` from a pre-hook prevents the model loop and marks the run errored (handled by the existing per-path guardrail handlers).
- Background continue streaming inherits the fix because it delegates to the stream implementations.
- Hook placement mirrors the run path: hooks execute per retry attempt, before tool/model invocation.

### Tests

New regression coverage (13 tests):

- `tests/unit/agent/test_continue_run_pre_hooks.py` (7 tests)
- `tests/unit/team/test_continue_run_pre_hooks.py` (6 tests)

Each variant asserts (a) pre-hooks fire on continue, and (b) a pre-hook guardrail raising `InputCheckError` blocks the model call with `run()`-equivalent error semantics.

### Validation

- New tests: 13/13 pass
- Existing hook suites (`test_hooks_guardrails.py` agent+team), `test_unified_continue.py`, `test_run_regressions.py`, `test_continue_run_requirements.py`, `test_acontinue_run_background_stream.py`, `test_paused_member_persistence.py`, `test_team_checkpointing.py`: pass/fail counts identical to unmodified `main` (pre-existing env-only failures unchanged)
- `ruff check` + `ruff format --check`: clean on all touched files

### Out of scope (follow-up PR)

AgentOS-level default run hooks (`agent_pre_hooks`, `team_pre_hooks`, …) with OS-first merge semantics per the issue's Part 2 — would like to align on naming/placement with maintainers first.
