### PR TITLE
feat(agent): add versioned runtime tool registry

### DIFF
--- a/cookbook/02_agents/04_tools/05_runtime_tool_registry.py
+++ b/cookbook/02_agents/04_tools/05_runtime_tool_registry.py
@@ -1,0 +1,29 @@
+"""Register a tool during a run and expose it on the next model step."""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools import ToolRegistry
+
+registry = ToolRegistry()
+
+
+def follow_up_tool() -> str:
+    """A tool that becomes available after the unlock tool runs."""
+    return "Follow-up tool completed."
+
+
+def unlock_tools() -> str:
+    """Register the follow-up tool for the next model step."""
+    registry.register(follow_up_tool)
+    return "The follow-up tool is now available."
+
+
+registry.register(unlock_tools)
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o-mini"),
+    tools=registry,
+    instructions=["Call unlock_tools first, then call follow_up_tool."],
+)
+
+agent.print_response("Run the two-step tool flow.")

--- a/cookbook/02_agents/04_tools/README.md
+++ b/cookbook/02_agents/04_tools/README.md
@@ -7,6 +7,7 @@ Examples for callable tool factories, tool choice, and tool call limits.
 - `02_session_state_tools.py` - Use session_state directly as a parameter with caching disabled.
 - `03_team_callable_members.py` - Assemble team members dynamically.
 - `04_tools_with_literal_type_param.py` - Use typing.Literal for tool parameters with predefined values.
+- `05_runtime_tool_registry.py` - Register a tool during a run and expose it on the next model step.
 - `tool_call_limit.py` - Limit the number of tool calls per run.
 - `tool_choice.py` - Control which tool the agent selects.
 

--- a/cookbook/02_agents/04_tools/TEST_LOG.md
+++ b/cookbook/02_agents/04_tools/TEST_LOG.md
@@ -58,3 +58,11 @@
 **Result:** Timed out after 120s.
 
 ---
+
+### 05_runtime_tool_registry.py
+
+**Status:** NOT RUN
+**Description:** Requires an OpenAI API key and demonstrates versioned runtime tool registration after a completed tool batch.
+**Result:** Added as a cookbook example for the runtime tool registry feature.
+
+---

--- a/libs/agno/agno/agent/_init.py
+++ b/libs/agno/agno/agent/_init.py
@@ -17,6 +17,7 @@ from typing import (
 
 if TYPE_CHECKING:
     from agno.agent.agent import Agent
+    from agno.tools.tool_registry import ToolRegistry
 
 from agno.compression.manager import CompressionManager
 from agno.culture.manager import CultureManager
@@ -288,6 +289,11 @@ def initialize_agent(agent: Agent, debug_mode: Optional[bool] = None) -> None:
 
 def add_tool(agent: Agent, tool: Union[Toolkit, Callable, Function, Dict]) -> None:
     from agno.utils.callables import is_callable_factory
+    from agno.tools.tool_registry import ToolRegistry
+
+    if isinstance(agent.tools, ToolRegistry):
+        agent.tools.register(tool)
+        return
 
     if is_callable_factory(agent.tools, excluded_types=(Toolkit, Function)):
         raise RuntimeError(
@@ -298,8 +304,17 @@ def add_tool(agent: Agent, tool: Union[Toolkit, Callable, Function, Dict]) -> No
     agent.tools.append(tool)  # type: ignore[union-attr]
 
 
-def set_tools(agent: Agent, tools: Union[Sequence[Union[Toolkit, Callable, Function, Dict]], Callable]) -> None:
+def set_tools(
+    agent: Agent,
+    tools: Union[Sequence[Union[Toolkit, Callable, Function, Dict]], Callable, "ToolRegistry"],
+) -> None:
     from agno.utils.callables import is_callable_factory
+    from agno.tools.tool_registry import ToolRegistry
+
+    if isinstance(tools, ToolRegistry):
+        agent.tools = tools
+        agent._callable_tools_cache.clear()
+        return
 
     if is_callable_factory(tools, excluded_types=(Toolkit, Function)):
         agent.tools = tools  # type: ignore[assignment]
@@ -310,8 +325,11 @@ def set_tools(agent: Agent, tools: Union[Sequence[Union[Toolkit, Callable, Funct
 
 async def connect_mcp_tools(agent: Agent) -> None:
     """Connect the MCP tools to the agent."""
-    if agent.tools and isinstance(agent.tools, list):
-        for tool in agent.tools:
+    from agno.tools.tool_registry import ToolRegistry
+
+    tools = agent.tools.snapshot().tools if isinstance(agent.tools, ToolRegistry) else agent.tools
+    if tools and isinstance(tools, (list, tuple)):
+        for tool in tools:
             # Alternate method of using isinstance(tool, (MCPTools, MultiMCPTools)) to avoid imports
             if (
                 hasattr(type(tool), "__mro__")
@@ -338,8 +356,11 @@ async def disconnect_mcp_tools(agent: Agent) -> None:
 
 def connect_connectable_tools(agent: Agent) -> None:
     """Connect tools that require connection management (e.g., database connections)."""
-    if agent.tools and isinstance(agent.tools, list):
-        for tool in agent.tools:
+    from agno.tools.tool_registry import ToolRegistry
+
+    tools = agent.tools.snapshot().tools if isinstance(agent.tools, ToolRegistry) else agent.tools
+    if tools and isinstance(tools, (list, tuple)):
+        for tool in tools:
             if (
                 hasattr(tool, "requires_connect")
                 and tool.requires_connect  # type: ignore

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -7,6 +7,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
+    Callable,
     Dict,
     Iterator,
     List,
@@ -1055,6 +1056,7 @@ def handle_model_response_stream(
     stream_events: bool = False,
     session_state: Optional[Dict[str, Any]] = None,
     run_context: Optional[RunContext] = None,
+    tools_resolver: Optional[Callable[[], Optional[List[Union[Function, dict]]]]] = None,
 ) -> Iterator[RunOutputEvent]:
     agent.model = cast(Model, agent.model)
 
@@ -1094,6 +1096,7 @@ def handle_model_response_stream(
             run_messages=run_messages,
             run_context=run_context,
         ),
+        tools_resolver=tools_resolver,
     ):
         # Handle LLM request events and compression events from ModelResponse
         if isinstance(model_response_event, ModelResponse):
@@ -1215,6 +1218,7 @@ async def ahandle_model_response_stream(
     stream_events: bool = False,
     session_state: Optional[Dict[str, Any]] = None,
     run_context: Optional[RunContext] = None,
+    tools_resolver: Optional[Callable[[], Any]] = None,
 ) -> AsyncIterator[RunOutputEvent]:
     agent.model = cast(Model, agent.model)
 
@@ -1254,6 +1258,7 @@ async def ahandle_model_response_stream(
             run_messages=run_messages,
             run_context=run_context,
         ),
+        tools_resolver=tools_resolver,
     )  # type: ignore
 
     async for model_response_event in model_response_stream:  # type: ignore

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -75,6 +75,7 @@ from agno.run.cancel import (
 from agno.run.messages import RunMessages
 from agno.run.requirement import RunRequirement
 from agno.session import AgentSession
+from agno.tools import ToolRegistry
 from agno.tools.function import Function
 from agno.utils.agent import (
     await_for_open_threads,
@@ -546,6 +547,13 @@ def _run(
                         run_messages=run_messages,
                         run_context=run_context,
                     ),
+                    **model_tool_registry_kwargs(
+                        agent,
+                        run_response=run_response,
+                        session=agent_session,
+                        run_context=run_context,
+                        user_id=user_id,
+                    ),
                 )
 
                 # Check for cancellation after model call
@@ -962,6 +970,13 @@ def _run_stream(
                         stream_events=stream_events,
                         session_state=run_context.session_state,
                         run_context=run_context,
+                        **model_tool_registry_kwargs(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        ),
                     ):
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             raise_if_cancelled(run_response.run_id)  # type: ignore
@@ -982,6 +997,13 @@ def _run_stream(
                         stream_events=stream_events,
                         session_state=run_context.session_state,
                         run_context=run_context,
+                        **model_tool_registry_kwargs(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        ),
                     ):
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             raise_if_cancelled(run_response.run_id)  # type: ignore
@@ -1685,6 +1707,13 @@ async def _arun(
                         run_messages=run_messages,
                         run_context=run_context,
                     ),
+                    **amodel_tool_registry_kwargs(
+                        agent,
+                        run_response=run_response,
+                        session=agent_session,
+                        run_context=run_context,
+                        user_id=user_id,
+                    ),
                 )
 
                 # Check for cancellation after model call
@@ -2363,6 +2392,13 @@ async def _arun_stream(
                         stream_events=stream_events,
                         session_state=run_context.session_state,
                         run_context=run_context,
+                        **amodel_tool_registry_kwargs(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        ),
                     ):
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             await araise_if_cancelled(run_response.run_id)  # type: ignore
@@ -2383,6 +2419,13 @@ async def _arun_stream(
                         stream_events=stream_events,
                         session_state=run_context.session_state,
                         run_context=run_context,
+                        **amodel_tool_registry_kwargs(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        ),
                     ):
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             await araise_if_cancelled(run_response.run_id)  # type: ignore
@@ -3652,6 +3695,13 @@ def _continue_run(
                         run_messages=run_messages,
                         run_context=run_context,
                     ),
+                    **model_tool_registry_kwargs(
+                        agent,
+                        run_response=run_response,
+                        session=session,
+                        run_context=run_context,
+                        user_id=user_id,
+                    ),
                 )
 
                 # Check for cancellation after model processing
@@ -3880,6 +3930,13 @@ def _continue_run_stream(
                     stream_events=stream_events,
                     session_state=run_context.session_state,
                     run_context=run_context,
+                    **model_tool_registry_kwargs(
+                        agent,
+                        run_response=run_response,
+                        session=session,
+                        run_context=run_context,
+                        user_id=user_id,
+                    ),
                 ):
                     if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                         raise_if_cancelled(run_response.run_id)  # type: ignore
@@ -4748,6 +4805,13 @@ async def _acontinue_run(
                         run_messages=run_messages,
                         run_context=run_context,
                     ),
+                    **amodel_tool_registry_kwargs(
+                        agent,
+                        run_response=run_response,
+                        session=agent_session,
+                        run_context=run_context,
+                        user_id=user_id,
+                    ),
                 )
                 # Check for cancellation after model call
                 await araise_if_cancelled(run_response.run_id)  # type: ignore
@@ -5247,6 +5311,13 @@ async def _acontinue_run_stream(
                         response_format=response_format,
                         stream_events=stream_events,
                         run_context=run_context,
+                        **amodel_tool_registry_kwargs(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        ),
                     ):
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             await araise_if_cancelled(run_response.run_id)  # type: ignore
@@ -5266,6 +5337,13 @@ async def _acontinue_run_stream(
                         response_format=response_format,
                         stream_events=stream_events,
                         run_context=run_context,
+                        **amodel_tool_registry_kwargs(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        ),
                     ):
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             await araise_if_cancelled(run_response.run_id)  # type: ignore
@@ -6049,6 +6127,134 @@ def build_after_tool_results_callback(
         checkpoint_run(agent, run_response, session, run_context)
 
     return _callback
+
+
+def agent_tool_registry(agent: Agent) -> Optional[ToolRegistry]:
+    """Return the Agent's runtime registry, if one is configured."""
+    return agent.tools if isinstance(agent.tools, ToolRegistry) else None
+
+
+def model_tool_registry_kwargs(
+    agent: Agent,
+    *,
+    run_response: RunOutput,
+    session: AgentSession,
+    run_context: RunContext,
+    user_id: Optional[str] = None,
+) -> dict:
+    """Kwargs for model calls that support versioned runtime tool snapshots."""
+    return {
+        "tools_resolver": build_tool_registry_resolver(
+            agent,
+            run_response=run_response,
+            session=session,
+            run_context=run_context,
+            user_id=user_id,
+        ),
+    }
+
+
+def amodel_tool_registry_kwargs(
+    agent: Agent,
+    *,
+    run_response: RunOutput,
+    session: AgentSession,
+    run_context: RunContext,
+    user_id: Optional[str] = None,
+) -> dict:
+    """Async runs — same surface as :func:`model_tool_registry_kwargs`."""
+    return {
+        "tools_resolver": abuild_tool_registry_resolver(
+            agent,
+            run_response=run_response,
+            session=session,
+            run_context=run_context,
+            user_id=user_id,
+        ),
+    }
+
+
+def build_tool_registry_resolver(
+    agent: Agent,
+    run_response: RunOutput,
+    session: AgentSession,
+    run_context: RunContext,
+    user_id: Optional[str] = None,
+) -> Optional[Any]:
+    """Build a resolver that refreshes only after a registry version changes."""
+    registry = agent_tool_registry(agent)
+    if registry is None:
+        return None
+
+    from agno.agent._tools import determine_tools_for_model
+
+    last_version = registry.version
+
+    def _resolver() -> Optional[List[Union[Function, dict]]]:
+        nonlocal last_version
+        current_version = registry.version
+        if current_version == last_version:
+            return None
+        processed_tools = agent.get_tools(
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            user_id=user_id,
+        )
+        resolved_tools = determine_tools_for_model(
+            agent,
+            model=cast(Model, agent.model),
+            processed_tools=processed_tools,
+            run_response=run_response,
+            session=session,
+            run_context=run_context,
+        )
+        last_version = current_version
+        return resolved_tools
+
+    return _resolver
+
+
+def abuild_tool_registry_resolver(
+    agent: Agent,
+    run_response: RunOutput,
+    session: AgentSession,
+    run_context: RunContext,
+    user_id: Optional[str] = None,
+) -> Optional[Any]:
+    """Async variant of :func:`build_tool_registry_resolver`."""
+    registry = agent_tool_registry(agent)
+    if registry is None:
+        return None
+
+    from agno.agent._tools import determine_tools_for_model
+
+    last_version = registry.version
+
+    async def _resolver() -> Optional[List[Union[Function, dict]]]:
+        nonlocal last_version
+        current_version = registry.version
+        if current_version == last_version:
+            return None
+        processed_tools = await agent.aget_tools(
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            user_id=user_id,
+        )
+        resolved_tools = determine_tools_for_model(
+            agent,
+            model=cast(Model, agent.model),
+            processed_tools=processed_tools,
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            async_mode=True,
+        )
+        last_version = current_version
+        return resolved_tools
+
+    return _resolver
 
 
 def abuild_after_tool_results_callback(

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -59,7 +59,7 @@ from agno.run.requirement import RunRequirement
 from agno.session import AgentSession, SessionSummaryManager, TeamSession, WorkflowSession
 from agno.session.summary import SessionSummary
 from agno.skills import Skills
-from agno.tools import Toolkit
+from agno.tools import ToolRegistry, Toolkit
 from agno.tools.function import Function
 from agno.utils.log import log_warning
 from agno.utils.safe_formatter import SafeFormatter
@@ -170,8 +170,8 @@ class Agent:
     # --- Agent Tools ---
     # A list of tools provided to the Model.
     # Tools are functions the model may generate JSON inputs for.
-    # Can also be a callable factory that returns a list of tools at runtime.
-    tools: Optional[Union[List[Union[Toolkit, Callable, Function, Dict]], Callable[..., List]]] = None
+    # Can also be a callable factory or ToolRegistry for runtime tool lifecycles.
+    tools: Optional[Union[List[Union[Toolkit, Callable, Function, Dict]], Callable[..., List], ToolRegistry]] = None
 
     # Maximum number of tool calls allowed.
     tool_call_limit: Optional[int] = None
@@ -431,7 +431,9 @@ class Agent:
         references_format: Literal["json", "yaml"] = "json",
         skills: Optional[Skills] = None,
         metadata: Optional[Dict[str, Any]] = None,
-        tools: Optional[Union[Sequence[Union[Toolkit, Callable, Function, Dict]], Callable[..., List]]] = None,
+        tools: Optional[
+            Union[Sequence[Union[Toolkit, Callable, Function, Dict]], Callable[..., List], ToolRegistry]
+        ] = None,
         tool_call_limit: Optional[int] = None,
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         tool_hooks: Optional[List[Callable]] = None,
@@ -597,6 +599,8 @@ class Agent:
 
         if tools is None:
             self.tools = []
+        elif isinstance(tools, ToolRegistry):
+            self.tools = tools
         elif is_callable_factory(tools, excluded_types=(Toolkit, Function)):
             self.tools = tools  # type: ignore[assignment]
         else:

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -59,6 +59,10 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.timer import Timer
 from agno.utils.tools import get_function_call_for_tool_call, get_function_call_for_tool_execution
 
+ModelTools = List[Union[Function, dict]]
+ToolsResolver = Callable[[], Optional[ModelTools]]
+AsyncToolsResolver = Callable[[], Awaitable[Optional[ModelTools]]]
+
 
 @dataclass
 class MessageData:
@@ -612,6 +616,41 @@ class Model(ABC):
         _tool_dicts.sort(key=self._tool_name)
         return _tool_dicts
 
+    def _resolve_tools_for_model_step(
+        self,
+        tools: Optional[ModelTools],
+        tools_resolver: Optional[ToolsResolver] = None,
+    ) -> Tuple[Optional[ModelTools], List[dict], Dict[str, Function]]:
+        """Return the tool snapshot and provider-specific representations for one model call.
+
+        ``tools_resolver`` is evaluated only when a caller explicitly asks for a new
+        snapshot. Keeping this operation in the model loop lets Agent refresh tools
+        after a completed tool batch without changing the default run-level snapshot.
+        """
+        if tools_resolver is not None:
+            resolved_tools = tools_resolver()
+            if resolved_tools is not None:
+                tools = resolved_tools
+
+        tool_dicts = self._format_tools(tools) if tools is not None else []
+        functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+        return tools, tool_dicts, functions
+
+    async def _aresolve_tools_for_model_step(
+        self,
+        tools: Optional[ModelTools],
+        tools_resolver: Optional[AsyncToolsResolver] = None,
+    ) -> Tuple[Optional[ModelTools], List[dict], Dict[str, Function]]:
+        """Async counterpart to :meth:`_resolve_tools_for_model_step`."""
+        if tools_resolver is not None:
+            resolved_tools = await tools_resolver()
+            if resolved_tools is not None:
+                tools = resolved_tools
+
+        tool_dicts = self._format_tools(tools) if tools is not None else []
+        functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+        return tools, tool_dicts, functions
+
     def _ensure_message_metrics_initialized(self, assistant_message: Message) -> None:
         """
         Ensure message metrics are initialized and timer is started.
@@ -658,6 +697,7 @@ class Model(ABC):
         send_media_to_model: bool = True,
         compression_manager: Optional["CompressionManager"] = None,
         after_tool_results: Optional[Callable[["ModelResponse"], None]] = None,
+        tools_resolver: Optional[ToolsResolver] = None,
     ) -> ModelResponse:
         """
         Generate a response from the model.
@@ -676,9 +716,14 @@ class Model(ABC):
                 as its single argument. Used by Agent-level checkpointing
                 (``checkpoint="tool-batch"``) to persist mid-run state. Exceptions are caught and
                 logged — a failed callback must not kill the run.
+            tools_resolver: Optional callback that returns the tool snapshot for the next model
+                call. It is evaluated after a completed tool batch and is intended for Agent
+                tool factories whose available tools can change during a run. Response caching
+                is disabled while this callback is active because the tool snapshot is dynamic.
         """
         # Check cache if enabled
-        if self.cache_response:
+        cache_enabled = self.cache_response and tools_resolver is None
+        if cache_enabled:
             cache_key = self._get_model_cache_key(messages, stream=False, response_format=response_format, tools=tools)
             cached_data = self._get_cached_model_response(cache_key)
 
@@ -694,13 +739,17 @@ class Model(ABC):
 
         function_call_count = 0
 
-        _tool_dicts = self._format_tools(tools) if tools is not None else []
-        _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+        tools, _tool_dicts, _functions = self._resolve_tools_for_model_step(tools)
 
         _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
         _compression_manager = compression_manager if _compress_tool_results else None
 
+        refresh_tools_next_step = False
         while True:
+            if refresh_tools_next_step:
+                tools, _tool_dicts, _functions = self._resolve_tools_for_model_step(tools, tools_resolver)
+                refresh_tools_next_step = False
+
             # Compress tool results if compression is enabled and threshold is met
             if _compression_manager is not None and _compression_manager.should_compress(
                 messages, tools, model=self, response_format=response_format
@@ -845,6 +894,9 @@ class Model(ABC):
                     except Exception as e:
                         log_error(f"after_tool_results callback failed: {e}")
 
+                if tools_resolver is not None:
+                    refresh_tools_next_step = True
+
                 # If we have any tool calls that require confirmation, break the loop
                 if any(tc.requires_confirmation for tc in model_response.tool_executions or []):
                     break
@@ -873,7 +925,7 @@ class Model(ABC):
         log_debug(f"{self.get_provider()} Response End", center=True, symbol="-")
 
         # Save to cache if enabled
-        if self.cache_response:
+        if cache_enabled:
             self._save_model_response_to_cache(cache_key, model_response, is_streaming=False)
 
         return model_response
@@ -889,6 +941,7 @@ class Model(ABC):
         send_media_to_model: bool = True,
         compression_manager: Optional["CompressionManager"] = None,
         after_tool_results: Optional[Callable[["ModelResponse"], Awaitable[None]]] = None,
+        tools_resolver: Optional[AsyncToolsResolver] = None,
     ) -> ModelResponse:
         """
         Generate an asynchronous response from the model.
@@ -901,7 +954,8 @@ class Model(ABC):
         """
 
         # Check cache if enabled
-        if self.cache_response:
+        cache_enabled = self.cache_response and tools_resolver is None
+        if cache_enabled:
             cache_key = self._get_model_cache_key(messages, stream=False, response_format=response_format, tools=tools)
             cached_data = self._get_cached_model_response(cache_key)
 
@@ -914,15 +968,19 @@ class Model(ABC):
         _log_messages(messages)
         model_response = ModelResponse()
 
-        _tool_dicts = self._format_tools(tools) if tools is not None else []
-        _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+        tools, _tool_dicts, _functions = await self._aresolve_tools_for_model_step(tools)
 
         _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
         _compression_manager = compression_manager if _compress_tool_results else None
 
         function_call_count = 0
 
+        refresh_tools_next_step = False
         while True:
+            if refresh_tools_next_step:
+                tools, _tool_dicts, _functions = await self._aresolve_tools_for_model_step(tools, tools_resolver)
+                refresh_tools_next_step = False
+
             # Compress existing tool results BEFORE making API call to avoid context overflow
             if _compression_manager is not None and await _compression_manager.ashould_compress(
                 messages, tools, model=self, response_format=response_format
@@ -1066,6 +1124,9 @@ class Model(ABC):
                     except Exception as e:
                         log_error(f"after_tool_results callback failed: {e}")
 
+                if tools_resolver is not None:
+                    refresh_tools_next_step = True
+
                 # If we have any tool calls that require confirmation, break the loop
                 if any(tc.requires_confirmation for tc in model_response.tool_executions or []):
                     break
@@ -1094,7 +1155,7 @@ class Model(ABC):
         log_debug(f"{self.get_provider()} Async Response End", center=True, symbol="-")
 
         # Save to cache if enabled
-        if self.cache_response:
+        if cache_enabled:
             self._save_model_response_to_cache(cache_key, model_response, is_streaming=False)
 
         return model_response
@@ -1371,6 +1432,7 @@ class Model(ABC):
         send_media_to_model: bool = True,
         compression_manager: Optional["CompressionManager"] = None,
         after_tool_results: Optional[Callable[["ModelResponse"], None]] = None,
+        tools_resolver: Optional[ToolsResolver] = None,
     ) -> Iterator[Union[ModelResponse, RunOutputEvent, TeamRunOutputEvent]]:
         """
         Generate a streaming response from the model.
@@ -1383,7 +1445,8 @@ class Model(ABC):
         """
         # Check cache if enabled - capture key BEFORE streaming to avoid mismatch
         cache_key = None
-        if self.cache_response:
+        cache_enabled = self.cache_response and tools_resolver is None
+        if cache_enabled:
             cache_key = self._get_model_cache_key(messages, stream=True, response_format=response_format, tools=tools)
             cached_data = self._get_cached_model_response(cache_key)
 
@@ -1403,15 +1466,19 @@ class Model(ABC):
         log_debug(f"Model: {self.id}", center=True, symbol="-")
         _log_messages(messages)
 
-        _tool_dicts = self._format_tools(tools) if tools is not None else []
-        _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+        tools, _tool_dicts, _functions = self._resolve_tools_for_model_step(tools)
 
         _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
         _compression_manager = compression_manager if _compress_tool_results else None
 
         function_call_count = 0
 
+        refresh_tools_next_step = False
         while True:
+            if refresh_tools_next_step:
+                tools, _tool_dicts, _functions = self._resolve_tools_for_model_step(tools, tools_resolver)
+                refresh_tools_next_step = False
+
             # Compress existing tool results BEFORE invoke
             if _compression_manager is not None and _compression_manager.should_compress(
                 messages, tools, model=self, response_format=response_format
@@ -1572,6 +1639,9 @@ class Model(ABC):
                     except Exception as e:
                         log_error(f"after_tool_results callback failed: {e}")
 
+                if tools_resolver is not None:
+                    refresh_tools_next_step = True
+
                 # If we have any tool calls that require confirmation, break the loop
                 if any(fc.function.requires_confirmation for fc in function_calls_to_run):
                     break
@@ -1600,7 +1670,7 @@ class Model(ABC):
         log_debug(f"{self.get_provider()} Response Stream End", center=True, symbol="-")
 
         # Save streaming responses to cache if enabled
-        if self.cache_response and cache_key and streaming_responses:
+        if cache_enabled and cache_key and streaming_responses:
             self._save_streaming_responses_to_cache(cache_key, streaming_responses)
 
     async def aprocess_response_stream(
@@ -1650,6 +1720,7 @@ class Model(ABC):
         send_media_to_model: bool = True,
         compression_manager: Optional["CompressionManager"] = None,
         after_tool_results: Optional[Callable[["ModelResponse"], Awaitable[None]]] = None,
+        tools_resolver: Optional[AsyncToolsResolver] = None,
     ) -> AsyncIterator[Union[ModelResponse, RunOutputEvent, TeamRunOutputEvent]]:
         """
         Generate an asynchronous streaming response from the model.
@@ -1662,7 +1733,8 @@ class Model(ABC):
         """
         # Check cache if enabled - capture key BEFORE streaming to avoid mismatch
         cache_key = None
-        if self.cache_response:
+        cache_enabled = self.cache_response and tools_resolver is None
+        if cache_enabled:
             cache_key = self._get_model_cache_key(messages, stream=True, response_format=response_format, tools=tools)
             cached_data = self._get_cached_model_response(cache_key)
 
@@ -1682,15 +1754,19 @@ class Model(ABC):
         log_debug(f"Model: {self.id}", center=True, symbol="-")
         _log_messages(messages)
 
-        _tool_dicts = self._format_tools(tools) if tools is not None else []
-        _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+        tools, _tool_dicts, _functions = await self._aresolve_tools_for_model_step(tools)
 
         _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
         _compression_manager = compression_manager if _compress_tool_results else None
 
         function_call_count = 0
 
+        refresh_tools_next_step = False
         while True:
+            if refresh_tools_next_step:
+                tools, _tool_dicts, _functions = await self._aresolve_tools_for_model_step(tools, tools_resolver)
+                refresh_tools_next_step = False
+
             # Compress existing tool results BEFORE making API call to avoid context overflow
             if _compression_manager is not None and await _compression_manager.ashould_compress(
                 messages, tools, model=self, response_format=response_format
@@ -1851,6 +1927,9 @@ class Model(ABC):
                     except Exception as e:
                         log_error(f"after_tool_results callback failed: {e}")
 
+                if tools_resolver is not None:
+                    refresh_tools_next_step = True
+
                 # If we have any tool calls that require confirmation, break the loop
                 if any(fc.function.requires_confirmation for fc in function_calls_to_run):
                     break
@@ -1879,7 +1958,7 @@ class Model(ABC):
         log_debug(f"{self.get_provider()} Async Response Stream End", center=True, symbol="-")
 
         # Save streaming responses to cache if enabled
-        if self.cache_response and cache_key and streaming_responses:
+        if cache_enabled and cache_key and streaming_responses:
             self._save_streaming_responses_to_cache(cache_key, streaming_responses)
 
     def _populate_assistant_message_from_stream_data(

--- a/libs/agno/agno/tools/__init__.py
+++ b/libs/agno/agno/tools/__init__.py
@@ -1,10 +1,13 @@
 from agno.tools.decorator import tool
 from agno.tools.function import Function, FunctionCall
+from agno.tools.tool_registry import ToolRegistry, ToolSnapshot
 from agno.tools.toolkit import Toolkit
 
 __all__ = [
     "tool",
     "Function",
     "FunctionCall",
+    "ToolRegistry",
+    "ToolSnapshot",
     "Toolkit",
 ]

--- a/libs/agno/agno/tools/tool_registry.py
+++ b/libs/agno/agno/tools/tool_registry.py
@@ -1,1 +1,79 @@
-from agno.tools.toolkit import Toolkit as ToolRegistry  # type: ignore  # noqa: F401
+"""Runtime tool registration and immutable tool snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import RLock
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+from agno.tools.function import Function
+from agno.tools.toolkit import Toolkit
+
+Tool = Union[Toolkit, Callable, Function, Dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class ToolSnapshot:
+    """An immutable view of the tools visible to the next model request."""
+
+    tools: Tuple[Tool, ...]
+    version: int
+
+
+class ToolRegistry:
+    """Thread-safe runtime registry for tools that can change during an Agent run.
+
+    A registry is intentionally separate from the Agent's normal static ``tools``
+    list. Tool executions can call :meth:`register`, :meth:`unregister`, or
+    :meth:`replace`, and the Agent refreshes its model-visible tool snapshot only
+    when the registry version changes.
+    """
+
+    def __init__(self, tools: Optional[List[Tool]] = None) -> None:
+        self._lock = RLock()
+        self._tools: List[Tool] = list(tools or [])
+        self._version = 0
+
+    @property
+    def version(self) -> int:
+        """Return the monotonically increasing registry version."""
+        with self._lock:
+            return self._version
+
+    def snapshot(self) -> ToolSnapshot:
+        """Return a stable view of the current tools and version."""
+        with self._lock:
+            return ToolSnapshot(tools=tuple(self._tools), version=self._version)
+
+    def register(self, tool: Tool) -> int:
+        """Register a tool and return the new registry version."""
+        with self._lock:
+            self._tools.append(tool)
+            self._version += 1
+            return self._version
+
+    def unregister(self, name: str) -> bool:
+        """Remove tools matching ``name`` and return whether anything changed."""
+        with self._lock:
+            remaining = [tool for tool in self._tools if _tool_name(tool) != name]
+            if len(remaining) == len(self._tools):
+                return False
+            self._tools = remaining
+            self._version += 1
+            return True
+
+    def replace(self, tools: List[Tool]) -> int:
+        """Replace the registry contents and return the new registry version."""
+        with self._lock:
+            self._tools = list(tools)
+            self._version += 1
+            return self._version
+
+
+def _tool_name(tool: Tool) -> str:
+    if isinstance(tool, dict):
+        function = tool.get("function")
+        if isinstance(function, dict):
+            return str(function.get("name", ""))
+        return str(tool.get("name", ""))
+    return str(getattr(tool, "name", getattr(tool, "__name__", "")))

--- a/libs/agno/agno/utils/callables.py
+++ b/libs/agno/agno/utils/callables.py
@@ -593,10 +593,14 @@ def get_resolved_knowledge(entity: Any, run_context: Optional["RunContext"] = No
 
 
 def get_resolved_tools(entity: Any, run_context: Optional["RunContext"] = None) -> Optional[list]:
-    """Get the resolved tools: run_context.tools > entity.tools (if list)."""
+    """Get resolved tools from the run context, Agent list, or ToolRegistry."""
+    from agno.tools.tool_registry import ToolRegistry
+
     if run_context is not None and run_context.tools is not None:
         return run_context.tools
     tools = getattr(entity, "tools", None)
+    if isinstance(tools, ToolRegistry):
+        return list(tools.snapshot().tools)
     if tools is not None and isinstance(tools, list):
         return tools
     return None

--- a/libs/agno/tests/unit/agent/test_callable_resources.py
+++ b/libs/agno/tests/unit/agent/test_callable_resources.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+import asyncio
+from typing import Any, AsyncIterator, Dict, Iterator, Optional
 from unittest.mock import MagicMock
 
 import pytest
 
 from agno.agent.agent import Agent
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
 from agno.run.base import RunContext
 from agno.tools import Toolkit
 from agno.tools.function import Function
+from agno.tools.tool_registry import ToolRegistry
 from agno.utils.callables import (
     aclear_callable_cache,
     ainvoke_callable_factory,
@@ -69,9 +74,93 @@ def _another_tool(x: str) -> str:
     return f"other: {x}"
 
 
-# ---------------------------------------------------------------------------
-# is_callable_factory
-# ---------------------------------------------------------------------------
+class _StepToolRefreshModel(Model):
+    """Offline model that requests a tool once, then verifies refreshed tools."""
+
+    def __init__(self):
+        super().__init__(id="step-refresh-test", name="step-refresh-test", provider="test")
+        self.tool_names_by_step = []
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return ModelResponse(content="unused", role="assistant", response_usage=MessageMetrics())
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self.invoke(*args, **kwargs)
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self.invoke(*args, **kwargs)
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self.invoke(*args, **kwargs)
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+    @staticmethod
+    def _tool_names(tools):
+        names = []
+        for tool in tools or []:
+            if isinstance(tool, dict):
+                function = tool.get("function") or {}
+                names.append(function.get("name") or tool.get("name"))
+            else:
+                names.append(getattr(tool, "name", None))
+        return [name for name in names if name]
+
+    def _process_model_response(
+        self,
+        *,
+        messages,
+        assistant_message,
+        model_response,
+        response_format=None,
+        tools=None,
+        tool_choice=None,
+        run_response=None,
+        compress_tool_results=False,
+    ):
+        tool_names = self._tool_names(tools)
+        self.tool_names_by_step.append(tool_names)
+        model_response.response_usage = MessageMetrics()
+
+        if len(self.tool_names_by_step) == 1:
+            assert "unlock_tool" in tool_names
+            assert "second_tool" not in tool_names
+            assistant_message.content = None
+            assistant_message.tool_calls = [
+                {
+                    "id": "call_unlock",
+                    "type": "function",
+                    "function": {"name": "unlock_tool", "arguments": "{}"},
+                }
+            ]
+            return
+
+        assert "second_tool" in tool_names
+        assistant_message.content = "refreshed"
+        assistant_message.tool_calls = None
+        model_response.content = "refreshed"
+
+    async def _aprocess_model_response(self, **kwargs):
+        self._process_model_response(**kwargs)
 
 
 class TestIsCallableFactory:
@@ -251,6 +340,62 @@ class TestAgentCallableToolsStorage:
         assert hasattr(agent, "_callable_knowledge_cache")
         assert isinstance(agent._callable_tools_cache, dict)
         assert isinstance(agent._callable_knowledge_cache, dict)
+
+
+class TestAgentToolRegistry:
+    @staticmethod
+    def _make_registry():
+        registry = ToolRegistry()
+
+        def unlock_tool() -> str:
+            registry.register(second_tool)
+            return "unlocked"
+
+        def second_tool() -> str:
+            return "available"
+
+        registry.register(unlock_tool)
+        return registry
+
+    def test_registry_refreshes_after_tool_batch(self):
+        registry = self._make_registry()
+        model = _StepToolRefreshModel()
+        agent = Agent(model=model, tools=registry)
+
+        response = agent.run("refresh tools")
+
+        assert response.content == "refreshed"
+        assert model.tool_names_by_step[0] == ["unlock_tool"]
+        assert set(model.tool_names_by_step[1]) == {"unlock_tool", "second_tool"}
+
+    def test_registry_refreshes_in_async_runs(self):
+        registry = self._make_registry()
+        model = _StepToolRefreshModel()
+        agent = Agent(model=model, tools=registry)
+
+        response = asyncio.run(agent.arun("refresh tools asynchronously"))
+
+        assert response.content == "refreshed"
+        assert model.tool_names_by_step[0] == ["unlock_tool"]
+        assert set(model.tool_names_by_step[1]) == {"unlock_tool", "second_tool"}
+
+    def test_registry_versions_and_unregister(self):
+        registry = ToolRegistry([_dummy_tool])
+        assert registry.snapshot().version == 0
+        assert registry.unregister("missing") is False
+        assert registry.register(_another_tool) == 1
+        assert registry.unregister("_dummy_tool") is True
+        snapshot = registry.snapshot()
+        assert snapshot.version == 2
+        assert [tool.__name__ for tool in snapshot.tools] == ["_another_tool"]
+
+    def test_agent_add_tool_updates_registry(self):
+        registry = ToolRegistry([_dummy_tool])
+        agent = Agent(tools=registry)
+
+        agent.add_tool(_another_tool)
+
+        assert [tool.__name__ for tool in registry.snapshot().tools] == ["_dummy_tool", "_another_tool"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a versioned runtime `ToolRegistry` for Agent runs. This addresses [#8688](https://github.com/agno-agi/agno/issues/8688): a tool can discover or register another tool during the current run, and the next model step can see the new tool without waiting for a new user run.

This supersedes the boolean refresh approach in #8718. The registry makes the lifecycle explicit and refreshes only when its version changes.

## Changes

**ToolRegistry:**
- Add `ToolRegistry` and immutable `ToolSnapshot` to `agno.tools.tool_registry`.
- Provide thread-safe `register()`, `unregister()`, `replace()`, `snapshot()`, and monotonically increasing `version`.
- Keep registry state runtime-only; existing Agent serialization remains unchanged.

**Agent:**
- Accept a `ToolRegistry` anywhere a static `tools` collection is accepted.
- Make `Agent.add_tool()` and `Agent.set_tools()` work with a registry.
- Support registry-backed connectable and MCP tools.
- Preserve the existing list and callable-factory behavior.

**Run/model lifecycle:**
- Resolve the normal Agent tool pipeline at run start.
- After a completed tool batch, check the registry version.
- Rebuild model-visible tools only when the version changed, before the next model request.
- Wire the behavior through sync, async, streaming, and continue paths.
- Keep the default behavior unchanged for Agents that do not use a registry.

## Example

```python
from agno.agent import Agent
from agno.tools import ToolRegistry

registry = ToolRegistry()

def follow_up_tool() -> str:
    return "follow-up complete"

def unlock_tools() -> str:
    registry.register(follow_up_tool)
    return "follow-up tool registered"

registry.register(unlock_tools)

agent = Agent(tools=registry)
```

After `unlock_tools` completes, `follow_up_tool` is included in the next model request in the same run. If the registry is unchanged, no tool re-resolution occurs.

## Testing

- Callable-resource and registry tests: 70 passed.
- Checkpoint compatibility tests: 29 passed.
- Full targeted suite: 99 passed.
- Ruff format/check passed for the full `libs/agno` tree.
- Added cookbook: `cookbook/02_agents/04_tools/05_runtime_tool_registry.py`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Refactoring

## Checklist

- [x] Code formatted with Ruff
- [x] Existing sync/async behavior covered
- [x] Tests added/updated
- [x] Cookbook example added
- [x] Backward compatibility preserved for static tools and callable factories

## Additional notes

The model layer receives an internal resolver callback, but the public lifecycle is owned by `ToolRegistry`. This avoids exposing an Agent-level “refresh every step” policy and avoids rerunning the full tool pipeline when no registry mutation occurred.
