### PR TITLE
fix: run session summary generation in the background on streaming runs

### DIFF
--- a/libs/agno/agno/agent/_managers.py
+++ b/libs/agno/agno/agent/_managers.py
@@ -18,7 +18,7 @@ from agno.db.base import UserMemory
 from agno.db.schemas.culture import CulturalKnowledge
 from agno.models.message import Message
 from agno.run.messages import RunMessages
-from agno.session import AgentSession
+from agno.session import AgentSession, TeamSession
 from agno.utils.log import log_debug, log_warning
 
 # ---------------------------------------------------------------------------
@@ -524,5 +524,141 @@ def start_learning_future(
             session=session,
             user_id=user_id,
         )
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Session summary
+# ---------------------------------------------------------------------------
+
+
+def make_session_summary(
+    agent: Agent,
+    session: AgentSession,
+) -> Optional[RunMetrics]:
+    """Create the session summary and persist it (runs in background thread).
+
+    Persists the summary itself because it runs after the run's session save:
+    the stored session is re-read and only its summary is updated, so runs
+    stored while the summary was generating are not overwritten. If a newer run
+    was stored meanwhile, this stale result is discarded — that run's own
+    summary supersedes it. A store landing between the re-read and this save
+    can still win the race — the same last-writer-wins exposure as every
+    session save.
+    """
+    from agno.agent import _session
+    from agno.metrics import RunMetrics
+
+    collector = RunMetrics()
+    if agent.session_summary_manager is None:
+        return collector
+    try:
+        latest_run_id = session.runs[-1].run_id if session.runs else None
+        summary = agent.session_summary_manager.create_session_summary(session=session, run_metrics=collector)
+        if summary is not None:
+            latest = _session.get_session(agent, session_id=session.session_id) or session
+            if isinstance(latest, (AgentSession, TeamSession)):
+                if latest.runs and latest.runs[-1].run_id != latest_run_id:
+                    log_debug("Skipping stale session summary: a newer run was stored meanwhile.")
+                    return collector
+                latest.summary = summary
+                _session.save_session(agent, session=latest)
+    except Exception as e:
+        log_warning(f"Error in session summary creation: {str(e)}")
+    return collector
+
+
+async def amake_session_summary(
+    agent: Agent,
+    session: AgentSession,
+) -> Optional[RunMetrics]:
+    """Create the session summary and persist it (runs in background task).
+
+    Persists the summary itself because it runs after the run's session save:
+    the stored session is re-read and only its summary is updated, so runs
+    stored while the summary was generating are not overwritten. If a newer run
+    was stored meanwhile, this stale result is discarded — that run's own
+    summary supersedes it. A store landing between the re-read and this save
+    can still win the race — the same last-writer-wins exposure as every
+    session save.
+    """
+    from agno.agent import _session
+    from agno.metrics import RunMetrics
+
+    collector = RunMetrics()
+    if agent.session_summary_manager is None:
+        return collector
+    try:
+        latest_run_id = session.runs[-1].run_id if session.runs else None
+        summary = await agent.session_summary_manager.acreate_session_summary(session=session, run_metrics=collector)
+        if summary is not None:
+            latest = await _session.aget_session(agent, session_id=session.session_id) or session
+            if isinstance(latest, (AgentSession, TeamSession)):
+                if latest.runs and latest.runs[-1].run_id != latest_run_id:
+                    log_debug("Skipping stale session summary: a newer run was stored meanwhile.")
+                    return collector
+                latest.summary = summary
+                await _session.asave_session(agent, session=latest)
+    except Exception as e:
+        log_warning(f"Error in session summary creation: {str(e)}")
+    return collector
+
+
+async def astart_session_summary_task(
+    agent: Agent,
+    session: AgentSession,
+    existing_task: Optional[Task] = None,
+) -> Optional[Task]:
+    """Cancel any existing session summary task and start a new one if conditions are met.
+
+    Args:
+        agent: The Agent instance.
+        session: The agent session to summarize.
+        existing_task: An existing session summary task to cancel before starting a new one.
+
+    Returns:
+        A new session summary task if conditions are met, None otherwise.
+    """
+    # Cancel any existing task from a previous retry attempt
+    if existing_task is not None and not existing_task.done():
+        existing_task.cancel()
+        try:
+            await existing_task
+        except CancelledError:
+            pass
+
+    # Create new task if conditions are met
+    if agent.session_summary_manager is not None and agent.enable_session_summaries:
+        log_debug("Starting session summary creation in background task.")
+        return create_task(amake_session_summary(agent, session=session))
+
+    return None
+
+
+def start_session_summary_future(
+    agent: Agent,
+    session: AgentSession,
+    existing_future: Optional[Future] = None,
+) -> Optional[Future]:
+    """Cancel any existing session summary future and start a new one if conditions are met.
+
+    Args:
+        agent: The Agent instance.
+        session: The agent session to summarize.
+        existing_future: An existing session summary future to cancel before starting a new one.
+
+    Returns:
+        A new session summary future if conditions are met, None otherwise.
+    """
+    # Cancel any existing future from a previous retry attempt
+    # Note: cancel() only works if the future hasn't started yet
+    if existing_future is not None and not existing_future.done():
+        existing_future.cancel()
+
+    # Create new future if conditions are met
+    if agent.session_summary_manager is not None and agent.enable_session_summaries:
+        log_debug("Starting session summary creation in background thread.")
+        return agent.background_executor.submit(make_session_summary, agent, session=session)
 
     return None

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -99,8 +99,6 @@ from agno.utils.events import (
     create_run_error_event,
     create_run_paused_event,
     create_run_started_event,
-    create_session_summary_completed_event,
-    create_session_summary_started_event,
     error_type_of,
     handle_event,
 )
@@ -781,8 +779,8 @@ def _run_stream(
     9. Process model response
     10. Parse response with parser model if provided
     11. Wait for background memory creation and cultural knowledge creation
-    12. Create session summary
-    13. Cleanup and store the run response and session
+    12. Cleanup and store the run response and session
+    13. Create the session summary in a background thread
     """
     from agno.agent._hooks import execute_post_hooks, execute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools
@@ -804,6 +802,7 @@ def _run_stream(
     memory_future = None
     learning_future = None
     cultural_knowledge_future = None
+    summary_future = None
     agent_session: Optional[AgentSession] = None
 
     try:
@@ -1100,34 +1099,6 @@ def _run_stream(
                     collect_background_metrics(memory_future, cultural_knowledge_future, learning_future),
                 )
 
-                # 9. Create session summary
-                if agent.session_summary_manager is not None and agent.enable_session_summaries:
-                    # Upsert the RunOutput to Agent Session before creating the session summary
-                    agent_session.upsert_run(run=run_response)
-
-                    if stream_events:
-                        yield handle_event(  # type: ignore
-                            create_session_summary_started_event(from_run_response=run_response),
-                            run_response,
-                            events_to_skip=agent.events_to_skip,  # type: ignore
-                            store_events=agent.store_events,
-                        )
-                    try:
-                        agent.session_summary_manager.create_session_summary(
-                            session=agent_session, run_metrics=run_response.metrics
-                        )
-                    except Exception as e:
-                        log_warning(f"Error in session summary creation: {str(e)}")
-                    if stream_events:
-                        yield handle_event(  # type: ignore
-                            create_session_summary_completed_event(
-                                from_run_response=run_response, session_summary=agent_session.summary
-                            ),
-                            run_response,
-                            events_to_skip=agent.events_to_skip,  # type: ignore
-                            store_events=agent.store_events,
-                        )
-
                 # Update run_response.session_state before creating RunCompletedEvent
                 # This ensures the event has the final state after all tool modifications
                 if agent_session.session_data is not None and "session_state" in agent_session.session_data:
@@ -1144,10 +1115,18 @@ def _run_stream(
                 # Set the run status to completed
                 run_response.status = RunStatus.completed
 
-                # 10. Cleanup and store the run response and session
+                # 9. Cleanup and store the run response and session
                 cleanup_and_store(
                     agent, run_response=run_response, session=agent_session, run_context=run_context, user_id=user_id
                 )
+
+                # 10. Create the session summary in a background thread so RunCompleted
+                # is not delayed by the summary model call. The thread persists the
+                # summary itself once generated.
+                if agent.session_summary_manager is not None and agent.enable_session_summaries:
+                    summary_future = _managers.start_session_summary_future(
+                        agent, session=agent_session, existing_future=summary_future
+                    )
 
                 if stream_events:
                     yield completed_event  # type: ignore
@@ -1274,6 +1253,14 @@ def _run_stream(
                     )
 
                 yield run_error
+
+        # All events are delivered; block until the background summary (if any) is
+        # generated and persisted, so callers that exhaust the stream can rely on it.
+        # The merged summary metrics are in-memory only — the run row was stored
+        # before the summary ran.
+        if summary_future is not None:
+            summary_future.result()
+            merge_background_metrics(run_response.metrics, collect_background_metrics(summary_future))
     finally:
         # Cancel background futures on error (wait_for_thread_tasks_stream handles waiting on success)
         for future in (memory_future, cultural_knowledge_future, learning_future):
@@ -2176,8 +2163,8 @@ async def _arun_stream(
     9. Generate a response from the Model (includes running function calls)
     10. Parse response with parser model if provided
     11. Wait for background memory creation
-    12. Create session summary
-    13. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
+    12. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
+    13. Create the session summary in a background task
     """
     from agno.agent._hooks import aexecute_post_hooks, aexecute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
@@ -2199,6 +2186,7 @@ async def _arun_stream(
     memory_task = None
     cultural_knowledge_task = None
     learning_task = None
+    summary_task = None
     agent_session: Optional[AgentSession] = None
 
     # Set up retry logic
@@ -2503,34 +2491,6 @@ async def _arun_stream(
                     collect_background_metrics(memory_task, cultural_knowledge_task, learning_task),
                 )
 
-                # 12. Create session summary
-                if agent.session_summary_manager is not None and agent.enable_session_summaries:
-                    # Upsert the RunOutput to Agent Session before creating the session summary
-                    agent_session.upsert_run(run=run_response)
-
-                    if stream_events:
-                        yield handle_event(  # type: ignore
-                            create_session_summary_started_event(from_run_response=run_response),
-                            run_response,
-                            events_to_skip=agent.events_to_skip,  # type: ignore
-                            store_events=agent.store_events,
-                        )
-                    try:
-                        await agent.session_summary_manager.acreate_session_summary(
-                            session=agent_session, run_metrics=run_response.metrics
-                        )
-                    except Exception as e:
-                        log_warning(f"Error in session summary creation: {str(e)}")
-                    if stream_events:
-                        yield handle_event(  # type: ignore
-                            create_session_summary_completed_event(
-                                from_run_response=run_response, session_summary=agent_session.summary
-                            ),
-                            run_response,
-                            events_to_skip=agent.events_to_skip,  # type: ignore
-                            store_events=agent.store_events,
-                        )
-
                 # Update run_response.session_state before creating RunCompletedEvent
                 # This ensures the event has the final state after all tool modifications
                 if agent_session.session_data is not None and "session_state" in agent_session.session_data:
@@ -2547,7 +2507,7 @@ async def _arun_stream(
                 # Set the run status to completed
                 run_response.status = RunStatus.completed
 
-                # 13. Cleanup and store the run response and session
+                # 12. Cleanup and store the run response and session
                 await acleanup_and_store(
                     agent,
                     run_response=run_response,
@@ -2555,6 +2515,19 @@ async def _arun_stream(
                     run_context=run_context,
                     user_id=user_id,
                 )
+
+                # 13. Create the session summary in a background task so RunCompleted
+                # is not delayed by the summary model call. The task persists the
+                # summary itself once generated.
+                if agent.session_summary_manager is not None and agent.enable_session_summaries:
+                    summary_task = await _managers.astart_session_summary_task(
+                        agent, session=agent_session, existing_task=summary_task
+                    )
+                    if summary_task is not None:
+                        # Strong reference: if the generator is closed on client disconnect,
+                        # the task keeps running detached and persists the summary.
+                        _background_tasks.add(summary_task)
+                        summary_task.add_done_callback(_background_tasks.discard)
 
                 if stream_events:
                     yield completed_event  # type: ignore
@@ -2704,6 +2677,16 @@ async def _arun_stream(
 
                 # Yield the error event
                 yield run_error
+
+        # All events are delivered; wait for the background summary (if any) so
+        # callers that exhaust the stream can rely on the persisted summary.
+        # Shielded: a client disconnect cancels this await, not the task — it
+        # finishes detached (kept alive by _background_tasks) and persists the
+        # summary itself. The merged summary metrics are in-memory only — the
+        # run row was stored before the summary ran.
+        if summary_task is not None:
+            await asyncio.shield(summary_task)
+            merge_background_metrics(run_response.metrics, collect_background_metrics(summary_task))
     finally:
         # Always disconnect connectable tools
         disconnect_connectable_tools(agent)
@@ -3824,10 +3807,11 @@ def _continue_run_stream(
     2. Handle any updated tools
     3. Process model response
     4. Execute post-hooks
-    5. Create session summary
-    6. Cleanup and store the run response and session
+    5. Cleanup and store the run response and session
+    6. Create the session summary in a background thread
     """
 
+    from agno.agent import _managers
     from agno.agent._hooks import execute_post_hooks
     from agno.agent._init import disconnect_connectable_tools
     from agno.agent._response import (
@@ -3839,6 +3823,8 @@ def _continue_run_stream(
     from agno.agent._tools import handle_tool_call_updates_stream
 
     register_run(run_response.run_id)  # type: ignore
+
+    summary_future = None
 
     # Set up retry logic
     num_attempts = agent.retries + 1
@@ -3947,35 +3933,6 @@ def _continue_run_stream(
                 # Check for cancellation before model call
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # 4. Create session summary
-                if agent.session_summary_manager is not None and agent.enable_session_summaries:
-                    # Upsert the RunOutput to Agent Session before creating the session summary
-                    session.upsert_run(run=run_response)
-
-                    if stream_events:
-                        yield handle_event(  # type: ignore
-                            create_session_summary_started_event(from_run_response=run_response),
-                            run_response,
-                            events_to_skip=agent.events_to_skip,  # type: ignore
-                            store_events=agent.store_events,
-                        )
-                    try:
-                        agent.session_summary_manager.create_session_summary(
-                            session=session, run_metrics=run_response.metrics
-                        )
-                    except Exception as e:
-                        log_warning(f"Error in session summary creation: {str(e)}")
-
-                    if stream_events:
-                        yield handle_event(  # type: ignore
-                            create_session_summary_completed_event(
-                                from_run_response=run_response, session_summary=session.summary
-                            ),
-                            run_response,
-                            events_to_skip=agent.events_to_skip,  # type: ignore
-                            store_events=agent.store_events,
-                        )
-
                 # Update run_response.session_state before creating RunCompletedEvent
                 # This ensures the event has the final state after all tool modifications
                 if session.session_data is not None and "session_state" in session.session_data:
@@ -3992,10 +3949,18 @@ def _continue_run_stream(
                 # Set the run status to completed
                 run_response.status = RunStatus.completed
 
-                # 5. Cleanup and store the run response and session
+                # 4. Cleanup and store the run response and session
                 cleanup_and_store(
                     agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
                 )
+
+                # 5. Create the session summary in a background thread so RunCompleted
+                # is not delayed by the summary model call. The thread persists the
+                # summary itself once generated.
+                if agent.session_summary_manager is not None and agent.enable_session_summaries:
+                    summary_future = _managers.start_session_summary_future(
+                        agent, session=session, existing_future=summary_future
+                    )
 
                 if stream_events:
                     yield completed_event  # type: ignore
@@ -4105,6 +4070,14 @@ def _continue_run_stream(
                 )
 
                 yield run_error
+
+        # All events are delivered; block until the background summary (if any) is
+        # generated and persisted, so callers that exhaust the stream can rely on it.
+        # The merged summary metrics are in-memory only — the run row was stored
+        # before the summary ran.
+        if summary_future is not None:
+            summary_future.result()
+            merge_background_metrics(run_response.metrics, collect_background_metrics(summary_future))
     finally:
         # Always disconnect connectable tools
         disconnect_connectable_tools(agent)
@@ -4998,10 +4971,11 @@ async def _acontinue_run_stream(
     6. Prepare run messages
     7. Handle the updated tools
     8. Process model response
-    9. Create session summary
-    10. Execute post-hooks
-    11. Cleanup and store the run response and session
+    9. Execute post-hooks
+    10. Cleanup and store the run response and session
+    11. Create the session summary in a background task
     """
+    from agno.agent import _managers
     from agno.agent._hooks import aexecute_post_hooks
     from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
     from agno.agent._messages import get_continue_run_messages
@@ -5018,6 +4992,7 @@ async def _acontinue_run_stream(
     log_debug(f"Agent Run Continue: {run_response.run_id if run_response else run_id}", center=True)  # type: ignore
 
     agent_session: Optional[AgentSession] = None
+    summary_task = None
 
     # Resolve retry parameters
     try:
@@ -5357,34 +5332,6 @@ async def _acontinue_run_stream(
                 # Check for cancellation before model call
                 await araise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # 9. Create session summary
-                if agent.session_summary_manager is not None and agent.enable_session_summaries:
-                    # Upsert the RunOutput to Agent Session before creating the session summary
-                    agent_session.upsert_run(run=run_response)
-
-                    if stream_events:
-                        yield handle_event(  # type: ignore
-                            create_session_summary_started_event(from_run_response=run_response),
-                            run_response,
-                            events_to_skip=agent.events_to_skip,  # type: ignore
-                            store_events=agent.store_events,
-                        )
-                    try:
-                        await agent.session_summary_manager.acreate_session_summary(
-                            session=agent_session, run_metrics=run_response.metrics
-                        )
-                    except Exception as e:
-                        log_warning(f"Error in session summary creation: {str(e)}")
-                    if stream_events:
-                        yield handle_event(  # type: ignore
-                            create_session_summary_completed_event(
-                                from_run_response=run_response, session_summary=agent_session.summary
-                            ),
-                            run_response,
-                            events_to_skip=agent.events_to_skip,  # type: ignore
-                            store_events=agent.store_events,
-                        )
-
                 # Update run_response.session_state before creating RunCompletedEvent
                 # This ensures the event has the final state after all tool modifications
                 if agent_session.session_data is not None and "session_state" in agent_session.session_data:
@@ -5401,10 +5348,23 @@ async def _acontinue_run_stream(
                 # Set the run status to completed
                 run_response.status = RunStatus.completed
 
-                # 10. Cleanup and store the run response and session
+                # 9. Cleanup and store the run response and session
                 await acleanup_and_store(
                     agent, run_response=run_response, session=agent_session, run_context=run_context, user_id=user_id
                 )
+
+                # 10. Create the session summary in a background task so RunCompleted
+                # is not delayed by the summary model call. The task persists the
+                # summary itself once generated.
+                if agent.session_summary_manager is not None and agent.enable_session_summaries:
+                    summary_task = await _managers.astart_session_summary_task(
+                        agent, session=agent_session, existing_task=summary_task
+                    )
+                    if summary_task is not None:
+                        # Strong reference: if the generator is closed on client disconnect,
+                        # the task keeps running detached and persists the summary.
+                        _background_tasks.add(summary_task)
+                        summary_task.add_done_callback(_background_tasks.discard)
 
                 if stream_events:
                     yield completed_event  # type: ignore
@@ -5565,6 +5525,16 @@ async def _acontinue_run_stream(
 
                 # Yield the error event
                 yield run_error
+
+        # All events are delivered; wait for the background summary (if any) so
+        # callers that exhaust the stream can rely on the persisted summary.
+        # Shielded: a client disconnect cancels this await, not the task — it
+        # finishes detached (kept alive by _background_tasks) and persists the
+        # summary itself. The merged summary metrics are in-memory only — the
+        # run row was stored before the summary ran.
+        if summary_task is not None:
+            await asyncio.shield(summary_task)
+            merge_background_metrics(run_response.metrics, collect_background_metrics(summary_task))  # type: ignore
     finally:
         # Always disconnect connectable tools
         disconnect_connectable_tools(agent)

--- a/libs/agno/tests/integration/agent/test_event_streaming.py
+++ b/libs/agno/tests/integration/agent/test_event_streaming.py
@@ -611,7 +611,7 @@ def test_intermediate_steps_with_memory(shared_db):
 
 
 def test_intermediate_steps_with_session_summary(shared_db):
-    """Test that the agent streams events."""
+    """Summary generation is backgrounded: no summary events, but the summary is stored."""
     agent = Agent(
         model=OpenAIChat(id="gpt-4o-mini"),
         db=shared_db,
@@ -627,6 +627,8 @@ def test_intermediate_steps_with_session_summary(shared_db):
             events[run_response_delta.event] = []
         events[run_response_delta.event].append(run_response_delta)
 
+    # The session summary runs in a background thread after the run is stored,
+    # so no SessionSummaryStarted/Completed events are emitted
     assert events.keys() == {
         RunEvent.run_started,
         RunEvent.model_request_started,
@@ -634,8 +636,6 @@ def test_intermediate_steps_with_session_summary(shared_db):
         RunEvent.run_content,
         RunEvent.run_content_completed,
         RunEvent.run_completed,
-        RunEvent.session_summary_started,
-        RunEvent.session_summary_completed,
     }
 
     assert len(events[RunEvent.run_started]) == 1
@@ -644,8 +644,10 @@ def test_intermediate_steps_with_session_summary(shared_db):
     assert len(events[RunEvent.run_content]) > 1
     assert len(events[RunEvent.run_content_completed]) == 1
     assert len(events[RunEvent.run_completed]) == 1
-    assert len(events[RunEvent.session_summary_started]) == 1
-    assert len(events[RunEvent.session_summary_completed]) == 1
+
+    # The summary is generated and persisted by the time the stream is exhausted
+    session_id = events[RunEvent.run_completed][0].session_id
+    assert agent.get_session_summary(session_id=session_id) is not None
 
 
 def test_pre_hook_events_are_emitted(shared_db):

--- a/libs/agno/tests/unit/agent/test_session_summary_background.py
+++ b/libs/agno/tests/unit/agent/test_session_summary_background.py
@@ -1,0 +1,299 @@
+"""Session summary generation must not block streaming runs.
+
+Verifies fix for https://github.com/agno-agi/agno/issues/8746: the summary is
+generated in a background task/thread after the session store, so RunCompleted
+is emitted without waiting on it — but the summary must still be persisted by
+the time the stream is exhausted.
+"""
+
+import asyncio
+import time
+from typing import Any, AsyncIterator, Iterator
+
+from agno.agent.agent import Agent
+from agno.db.base import SessionType
+from agno.db.in_memory import InMemoryDb
+from agno.media import Image
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run.agent import RunCompletedEvent
+from agno.session.summary import SessionSummary, SessionSummaryManager
+
+SUMMARY_DELAY = 0.3
+
+
+class MockModel(Model):
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.instructions = None
+        self._mock_response = ModelResponse(
+            content="Hello there",
+            role="assistant",
+            response_usage=MessageMetrics(),
+        )
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._mock_response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._mock_response
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._mock_response
+
+
+class MockModelWithImage(MockModel):
+    def __init__(self):
+        super().__init__()
+        self._mock_response = ModelResponse(
+            content="Here is your generated image",
+            role="assistant",
+            images=[Image(url="https://example.com/generated.png", id="img-1")],
+            response_usage=MessageMetrics(),
+        )
+
+
+class SlowSummaryManager(SessionSummaryManager):
+    """Stub manager whose summary generation sleeps, to expose blocking."""
+
+    finished = False
+
+    def create_session_summary(self, session, run_metrics=None):
+        time.sleep(SUMMARY_DELAY)
+        summary = SessionSummary(summary="stub summary")
+        session.summary = summary
+        self.finished = True
+        return summary
+
+    async def acreate_session_summary(self, session, run_metrics=None):
+        await asyncio.sleep(SUMMARY_DELAY)
+        summary = SessionSummary(summary="stub summary")
+        session.summary = summary
+        self.finished = True
+        return summary
+
+
+def _make_agent(db: InMemoryDb) -> Agent:
+    return Agent(
+        model=MockModel(),
+        db=db,
+        session_summary_manager=SlowSummaryManager(),
+        telemetry=False,
+    )
+
+
+def _stored_summary(db: InMemoryDb, session_id: str):
+    stored = db.get_session(session_id=session_id, session_type=SessionType.AGENT)
+    assert stored is not None
+    return stored.summary
+
+
+def test_sync_stream_run_completed_not_blocked_by_summary():
+    db = InMemoryDb()
+    agent = _make_agent(db)
+
+    summary_finished_at_completed = None
+    for event in agent.run("hello", stream=True, stream_events=True, session_id="s-sync", user_id="u1"):
+        if isinstance(event, RunCompletedEvent):
+            summary_finished_at_completed = agent.session_summary_manager.finished
+
+    # RunCompleted was emitted before the summary finished...
+    assert summary_finished_at_completed is False
+    # ...but by stream exhaustion the summary is generated and persisted
+    assert agent.session_summary_manager.finished is True
+    summary = _stored_summary(db, "s-sync")
+    assert summary is not None
+    assert summary.summary == "stub summary"
+
+
+async def test_async_stream_run_completed_not_blocked_by_summary():
+    db = InMemoryDb()
+    agent = _make_agent(db)
+
+    summary_finished_at_completed = None
+    async for event in agent.arun("hello", stream=True, stream_events=True, session_id="s-async", user_id="u1"):
+        if isinstance(event, RunCompletedEvent):
+            summary_finished_at_completed = agent.session_summary_manager.finished
+
+    assert summary_finished_at_completed is False
+    assert agent.session_summary_manager.finished is True
+    summary = _stored_summary(db, "s-async")
+    assert summary is not None
+    assert summary.summary == "stub summary"
+
+
+async def test_second_streaming_run_keeps_all_runs_and_summary():
+    # The background summary save must not clobber runs stored by a later run
+    # on the same session, so drive the same session twice.
+    db = InMemoryDb()
+    agent = _make_agent(db)
+
+    for _ in range(2):
+        async for _event in agent.arun("hello", stream=True, stream_events=True, session_id="s-twice", user_id="u1"):
+            pass
+
+    stored = db.get_session(session_id="s-twice", session_type=SessionType.AGENT)
+    assert stored is not None
+    assert stored.runs is not None
+    assert len(stored.runs) == 2
+    assert stored.summary is not None
+    assert stored.summary.summary == "stub summary"
+
+
+async def test_consumer_task_cancelled_after_run_completed_keeps_summary():
+    # The AgentOS/SSE disconnect pattern: the server consumes the stream in a
+    # task and has already advanced past RunCompleted into the generator's
+    # final summary wait when the client disconnect cancels it. Cancelling
+    # that await must not cancel the summary task itself — it finishes
+    # detached and persists the summary.
+    db = InMemoryDb()
+    agent = _make_agent(db)
+    got_completed = asyncio.Event()
+
+    async def consume():
+        async for event in agent.arun("hello", stream=True, stream_events=True, session_id="s-cancel", user_id="u1"):
+            if isinstance(event, RunCompletedEvent):
+                got_completed.set()
+
+    consumer = asyncio.create_task(consume())
+    await got_completed.wait()
+    # One tick is enough to land the consumer in the shielded summary wait because
+    # nothing between RunCompleted and that wait suspends; if a suspending await is
+    # ever added there, the cancel lands earlier and this test stops exercising
+    # the shield.
+    await asyncio.sleep(0)
+    consumer.cancel()
+    try:
+        await consumer
+    except asyncio.CancelledError:
+        pass
+
+    # The event loop stays alive (AgentOS server case): the detached task finishes
+    await asyncio.sleep(SUMMARY_DELAY + 0.2)
+    summary = _stored_summary(db, "s-cancel")
+    assert summary is not None
+    assert summary.summary == "stub summary"
+
+
+async def test_abandoned_stream_summary_does_not_clobber_next_run():
+    # The detached case the re-read protects: run 1's stream is abandoned at
+    # RunCompleted while its summary is still generating, run 2 stores on the
+    # same session before that summary lands. The delayed summary save must
+    # re-read the stored session and keep run 2.
+    db = InMemoryDb()
+    gate = asyncio.Event()
+
+    class GatedSummaryManager(SessionSummaryManager):
+        calls = 0
+
+        async def acreate_session_summary(self, session, run_metrics=None):
+            GatedSummaryManager.calls += 1
+            call = GatedSummaryManager.calls
+            if call == 1:
+                await gate.wait()
+            summary = SessionSummary(summary=f"summary-{call}")
+            session.summary = summary
+            return summary
+
+    agent = Agent(
+        model=MockModel(),
+        db=db,
+        session_summary_manager=GatedSummaryManager(),
+        telemetry=False,
+    )
+
+    # Run 1: abandon the stream at RunCompleted; its summary task stays gated
+    gen = agent.arun("one", stream=True, stream_events=True, session_id="s-overlap", user_id="u1")
+    async for event in gen:
+        if isinstance(event, RunCompletedEvent):
+            break
+    await gen.aclose()
+    await asyncio.sleep(0.05)  # let the abandonment persistence settle
+
+    # Run 2 on the same session completes fully (its summary is ungated)
+    async for _event in agent.arun("two", stream=True, stream_events=True, session_id="s-overlap", user_id="u1"):
+        pass
+
+    # Release run 1's summary; its save must not erase run 2 from the session,
+    # and its stale result must not overwrite run 2's newer summary
+    gate.set()
+    await asyncio.sleep(0.3)
+
+    stored = db.get_session(session_id="s-overlap", session_type=SessionType.AGENT)
+    assert stored is not None
+    assert stored.runs is not None
+    assert len(stored.runs) == 2
+    assert stored.summary is not None
+    assert stored.summary.summary == "summary-2"
+
+
+def test_background_summary_does_not_leak_scrubbed_media_cached_session():
+    # With cache_session=True the summary task re-reads the cached session
+    # object; it must not save unscrubbed run data (store_media=False) with it.
+    db = InMemoryDb()
+    agent = Agent(
+        model=MockModelWithImage(),
+        db=db,
+        session_summary_manager=SlowSummaryManager(),
+        cache_session=True,
+        store_media=False,
+        telemetry=False,
+    )
+
+    for _event in agent.run("make an image", stream=True, stream_events=True, session_id="s-scrub", user_id="u1"):
+        pass
+
+    stored = db.get_session(session_id="s-scrub", session_type=SessionType.AGENT)
+    assert stored is not None
+    assert stored.runs is not None
+    assert not stored.runs[-1].images
+    assert stored.summary is not None
+
+
+async def test_background_summary_does_not_leak_scrubbed_media_cached_session_async():
+    db = InMemoryDb()
+    agent = Agent(
+        model=MockModelWithImage(),
+        db=db,
+        session_summary_manager=SlowSummaryManager(),
+        cache_session=True,
+        store_media=False,
+        telemetry=False,
+    )
+
+    async for _event in agent.arun(
+        "make an image", stream=True, stream_events=True, session_id="s-scrub-a", user_id="u1"
+    ):
+        pass
+
+    stored = db.get_session(session_id="s-scrub-a", session_type=SessionType.AGENT)
+    assert stored is not None
+    assert stored.runs is not None
+    assert not stored.runs[-1].images
+    assert stored.summary is not None


### PR DESCRIPTION
## Summary

Fixes #8746 — Session summary generation blocks streaming runs

With `enable_session_summaries=True`, the summary is produced by a **full LLM call that ran inline between the last content chunk and `RunCompleted`**. Every streaming turn stalled for the duration of that call (typically 3–15s) before the terminal event arrived; behind buffering SSE gateways this surfaces as the tail of the answer freezing and then arriving in one late burst — on every turn.

This PR moves summary generation off the streaming path on all four streaming code paths, following the existing background pattern used for memory/learning in `agent/_managers.py`, while keeping the summary reliably generated and persisted.

## Architecture: Streaming Path Before vs After

```
                     STREAMING RUN TAIL
                     ==================

    BEFORE (main)                        AFTER (this PR)
    ─────────────                        ───────────────
    model streams content                model streams content
          │                                    │
          ▼                                    ▼
    wait for memory task                 wait for memory task
          │                                    │
          ▼                                    ▼
    ┌───────────────────┐                build RunCompleted event
    │ summary LLM call  │                      │
    │     (INLINE)      │                      ▼
    │   3–15s STALL ✗   │                cleanup_and_store()
    └─────────┬─────────┘                (run + session persisted)
          │                                    │
          ▼                                    ▼
    build RunCompleted                   ┌────────────────────┐
          │                              │ start summary task │────┐
          ▼                              │   (background)     │    │
    cleanup_and_store()                  └─────────┬──────────┘    │ runs in
          │                                        ▼               │ parallel
          ▼                              yield RunCompleted ✓      │
    yield RunCompleted                   (immediately)             ▼
    (only after the stall)                         │        ┌──────────────────┐
                                                   ▼        │  summary task:   │
                                         shielded wait for  │  generate summary│
                                         the summary task   │  re-read session │
                                         (stream stays open │  staleness check │
                                          a few seconds; no │  save summary    │
                                          events pending)   └──────────────────┘
```

The background task persists the summary **itself**, safely against concurrent runs:

```
                BACKGROUND TASK PERSISTENCE PROTOCOL
                ====================================

    snapshot: last run_id of the session          ┐
          │                                       │ captured BEFORE the
          ▼                                       │ slow LLM call
    generate summary (the LLM call, 3–15s)        ┘
          │
          ▼
    re-read the STORED session from db     ← never trusts its own stale copy
          │
          ▼
    last run_id changed? ──── yes ──► DISCARD (stale — a newer run was stored;
          │                            that run's own summary supersedes this one)
          no
          ▼
    set .summary on the fresh row, save    ← summary-only delta

    On SSE client disconnect: the stream's wait is cancelled, the TASK is not
    (asyncio.shield + a strong reference in _background_tasks) — it finishes
    detached and still persists the summary.
```

## Bug Scenario: What Users Experienced

```
    TIMELINE: one streaming turn (measured, gpt-5-mini + real summary model)
    ========================================================================

    BEFORE (main)                          AFTER (this PR)
    ─────────────                          ───────────────
    t=0.0s   RunContent streaming...       t=0.0s   RunContent streaming...
    t=5.9s   last content chunk            t=5.9s   last content chunk
    t=5.9s   ── stream freezes ──          t=6.1s   RunCompleted ✓ (gap 0.2s)
             (summary LLM call             t=11.5s  stream closes; summary
              runs inline)                          generated in background
    t=11.5s  RunCompleted finally                   and persisted ✓
             arrives (gap 5.6s)
```

## The Fix

```python
# BEFORE (main) — agent/_run.py, all four streaming paths
if agent.session_summary_manager is not None and agent.enable_session_summaries:
    agent_session.upsert_run(run=run_response)
    yield SessionSummaryStartedEvent(...)
    await agent.session_summary_manager.acreate_session_summary(
        session=agent_session, run_metrics=run_response.metrics
    )                                     # ← full LLM call, blocks the stream
    yield SessionSummaryCompletedEvent(...)
# ... then build RunCompleted, store, yield RunCompleted

# AFTER (this PR)
await acleanup_and_store(...)             # run + session persisted first

if agent.session_summary_manager is not None and agent.enable_session_summaries:
    summary_task = await _managers.astart_session_summary_task(
        agent, session=agent_session, existing_task=summary_task
    )
    if summary_task is not None:
        _background_tasks.add(summary_task)          # survives client disconnect
        summary_task.add_done_callback(_background_tasks.discard)

yield completed_event                     # ← RunCompleted, immediately

# after the retry loop — consumers that exhaust the stream get
# deterministic persistence; a disconnect cancels the wait, not the task
if summary_task is not None:
    await asyncio.shield(summary_task)
    merge_background_metrics(run_response.metrics, collect_background_metrics(summary_task))
```

The new `_managers.py` helpers mirror the existing memory pattern exactly: `make_session_summary` / `amake_session_summary` (generate + self-persist with the staleness guard) started via `start_session_summary_future` / `astart_session_summary_task` (thread for sync, task for async).

## Code Paths Summary

| Code path | Function (`agent/_run.py`) | Treatment |
|---|---|---|
| Sync stream | `_run_stream` | Background thread (executor future), joined after the stream |
| Async stream | `_arun_stream` | Background task + `asyncio.shield` + `_background_tasks` keepalive |
| Continue-run sync stream | `_continue_run_stream` | Same as sync stream |
| Continue-run async stream | `_acontinue_run_stream` | Same as async stream |
| Non-streaming (all 4 paths) | `_run` / `_arun` / `_continue_run` / `_acontinue_run` | **Unchanged** — inline await; they emit no events mid-flight and callers rely on the summary being stored when `run()` returns |

## Behavior Changes (please review deliberately)

1. **Protocol change — agent streaming no longer emits `SessionSummaryStarted` / `SessionSummaryCompleted`.** Once the summary is backgrounded these events cannot straddle `RunCompleted` (the option proposed by the issue author in #8746). The event classes, enum values, and creators remain public API, and team paths still emit their `Team*` variants. `cookbook/90_models/openai/chat/access_memories_in_memory_completed_event.py` still branches on the removed events — happy to update it here or in a follow-up, and to add a deprecation note for the two agent events if you want this documented as a protocol change.
2. **Stored run metrics no longer include the summary model call.** The run row is stored before the summary runs; summary-model tokens are merged into the in-memory `RunOutput.metrics` only (and not at all if the client disconnected). Persisting them afterwards would need a post-hoc run-row update — happy to do that as a follow-up if wanted.
3. **Residual write race (pre-existing class).** The staleness check and the save are not atomic: a run committing in that microsecond window can be overwritten by the full-row save. This is the same last-writer-wins exposure every session save in the framework has today (two concurrent runs on one session already overwrite each other on `main`, no summaries involved). Closing it fully needs an atomic summary-only conditional update in the DB layer — proposing that as a follow-up issue rather than expanding this PR across all backends.

## Changes

| File | Change |
|---|---|
| `libs/agno/agno/agent/_managers.py` | +~130 lines — new Session summary section: `make_session_summary` / `amake_session_summary` (generate, re-read, staleness guard, persist) and `start_session_summary_future` / `astart_session_summary_task`, mirroring the memory/learning starters |
| `libs/agno/agno/agent/_run.py` | All 4 streaming paths: summary moved after `cleanup_and_store` into a background task/thread; shielded post-loop wait; summary events no longer emitted; net −8 lines |
| `libs/agno/tests/unit/agent/test_session_summary_background.py` | New — 7 tests (see Test Plan) |
| `libs/agno/tests/integration/agent/test_event_streaming.py` | Updated: summary events removed from the expected event set; added assertion that the summary is persisted by stream exhaustion |

## Test Plan

- [x] 7 new unit tests: sync + async streams emit `RunCompleted` before the summary finishes yet persist it by stream end; consumer-task cancellation mid-wait (the AgentOS/SSE disconnect pattern) still persists; overlapping runs keep all runs **and** the freshest summary; `cache_session=True` + `store_media=False` leaks nothing (sync + async)
- [x] All 524 existing agent unit tests pass
- [x] `./scripts/format.sh` and `./scripts/validate.sh` clean
- [x] Manual: offline repro — `RunCompleted` at ~2ms vs ~1s (1s summary stub) on all four streaming paths
- [x] Manual: live streaming run (gpt-5-mini) — gap after last content dropped from ~5.6s to ~0.2s, summaries persisted and correct across turns
- [x] Manual: AgentOS over SSE (FastAPI, the environment reported in #8746) — `RunCompleted` in ~0.05s, multi-turn, summary persisted after a client disconnect mid-generation

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: one cookbook consumes the removed events — see Behavior Changes; awaiting maintainer preference
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests — #8762 targets the same issue but patches only `team/_managers.py`; the reported bug lives in the agent run paths, which that PR does not touch. This PR supersedes it.
- [x] If a similar PR exists, I have explained above why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)