### PR TITLE
fix: handle None path args in skill tools and expose directory in list_files schema

### DIFF
--- a/libs/agno/agno/skills/agent_skills.py
+++ b/libs/agno/agno/skills/agent_skills.py
@@ -213,7 +213,7 @@ class Skills:
             }
         )
 
-    def _get_skill_reference(self, skill_name: str, reference_path: str) -> str:
+    def _get_skill_reference(self, skill_name: str, reference_path: Optional[str]) -> str:
         """Load a reference document from a skill.
 
         Args:
@@ -223,6 +223,9 @@ class Skills:
         Returns:
             A JSON string with the reference content.
         """
+        if not reference_path:
+            return json.dumps({"error": "reference_path is required"})
+
         skill = self.get_skill(skill_name)
         if skill is None:
             available = ", ".join(self.get_skill_names())
@@ -273,7 +276,7 @@ class Skills:
     def _get_skill_script(
         self,
         skill_name: str,
-        script_path: str,
+        script_path: Optional[str],
         execute: bool = False,
         args: Optional[List[str]] = None,
         timeout: int = 30,
@@ -290,6 +293,9 @@ class Skills:
         Returns:
             A JSON string with either the script content or execution results.
         """
+        if not script_path:
+            return json.dumps({"error": "script_path is required"})
+
         skill = self.get_skill(skill_name)
         if skill is None:
             available = ", ".join(self.get_skill_names())

--- a/libs/agno/agno/tools/file.py
+++ b/libs/agno/agno/tools/file.py
@@ -266,13 +266,13 @@ class FileTools(Toolkit):
             log_error(f"Error removing {file_name}: {str(e)}")
             return f"Error removing file: {e}"
 
-    def list_files(self, **kwargs) -> str:
+    def list_files(self, directory: Optional[str] = None) -> str:
         """Returns a list of files in directory
-        :param directory: (Optional) name of directory to list.
+        :param directory: (Optional) name of directory to list. Defaults to the base directory.
 
         :return: The contents of the file if successful, otherwise returns an error message.
         """
-        directory = kwargs.get("directory", ".")
+        directory = directory or "."
         try:
             log_debug(f"Reading files in : {self.base_dir}/{directory}")
             safe, d = self.check_escape(directory)

--- a/libs/agno/tests/unit/skills/test_agent_skills.py
+++ b/libs/agno/tests/unit/skills/test_agent_skills.py
@@ -301,6 +301,16 @@ def test_get_skill_instructions_not_found(mock_loader: MockSkillLoader) -> None:
 # --- Skill Reference Tool Tests ---
 
 
+def test_get_skill_reference_none_path_returns_error(mock_loader: MockSkillLoader) -> None:
+    """Passing None for reference_path must return a graceful error, not raise ValidationError."""
+    skills = Skills(loaders=[mock_loader])
+    result_json = skills._get_skill_reference("test-skill", None)  # type: ignore[arg-type]
+    result = json.loads(result_json)
+
+    assert "error" in result
+    assert "reference_path" in result["error"]
+
+
 def test_get_skill_reference_skill_not_found(mock_loader: MockSkillLoader) -> None:
     """Test reference retrieval for non-existent skill."""
     skills = Skills(loaders=[mock_loader])
@@ -337,6 +347,16 @@ def test_get_skill_reference_with_real_file(temp_skill_dir: Path) -> None:
 
 
 # --- Skill Script Tool Tests ---
+
+
+def test_get_skill_script_none_path_returns_error(mock_loader: MockSkillLoader) -> None:
+    """Passing None for script_path must return a graceful error, not raise ValidationError."""
+    skills = Skills(loaders=[mock_loader])
+    result_json = skills._get_skill_script("test-skill", None)  # type: ignore[arg-type]
+    result = json.loads(result_json)
+
+    assert "error" in result
+    assert "script_path" in result["error"]
 
 
 def test_skill_script_read_skill_not_found(mock_loader: MockSkillLoader) -> None:

--- a/libs/agno/tests/unit/tools/test_filetools.py
+++ b/libs/agno/tests/unit/tools/test_filetools.py
@@ -21,6 +21,56 @@ def test_save_and_read_file():
         assert read_content == content
 
 
+def test_list_files_directory_param_visible_in_schema():
+    """list_files must expose `directory` in its tool schema so the LLM can discover it.
+
+    Previously the signature was ``**kwargs``, which hid the parameter from the
+    schema generator entirely — the model had no way to know the parameter existed.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir)
+
+        # Find the list_files Function in the registered tools
+        list_files_func = next(t for t in file_tools.functions.values() if t.name == "list_files")
+        # process_entrypoint() is normally called by the agent before tool use; call it explicitly here.
+        list_files_func.process_entrypoint()
+        params = list_files_func.parameters or {}
+        properties = params.get("properties", {})
+        assert "directory" in properties, (
+            "directory parameter must appear in list_files tool schema so the LLM can use it"
+        )
+
+
+def test_list_files_with_none_directory():
+    """list_files(directory=None) must default to the base directory without error."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir)
+
+        (base_dir / "a.txt").write_text("a")
+        result = file_tools.list_files(directory=None)
+        files = json.loads(result)
+        assert "a.txt" in files
+
+
+def test_list_files_with_explicit_directory():
+    """list_files(directory=<subdir>) must list only that subdirectory."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir)
+
+        sub = base_dir / "sub"
+        sub.mkdir()
+        (base_dir / "root.txt").write_text("root")
+        (sub / "nested.txt").write_text("nested")
+
+        result = file_tools.list_files(directory="sub")
+        files = json.loads(result)
+        assert any("nested.txt" in f for f in files)
+        assert not any("root.txt" in f for f in files)
+
+
 def test_list_files_returns_relative_paths():
     """Test that list_files returns relative paths, not absolute paths."""
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

- **`_get_skill_reference` / `_get_skill_script`**: Both methods declared their path parameters (`reference_path`, `script_path`) as `str`. When an LLM passes `null` for these, Pydantic's `validate_call` (applied by `Function._wrap_callable`) raises `ValidationError` before the function body runs. Changed both to `Optional[str]` and added an early guard that returns a graceful JSON error instead of crashing the tool call.

- **`FileTools.list_files`**: The signature was `def list_files(self, **kwargs)` with `directory` pulled via `kwargs.get("directory", ".")`. Because `**kwargs` has no type annotation, the schema generator emits empty `properties: {}` -- the model never learns that `directory` exists and cannot use it. Changed to `def list_files(self, directory: Optional[str] = None)` so `directory` appears in the JSON Schema tool definition.

## Test plan

- [ ] `test_get_skill_reference_none_path_returns_error` -- passes `None`, expects graceful error JSON
- [ ] `test_get_skill_script_none_path_returns_error` -- passes `None`, expects graceful error JSON
- [ ] `test_list_files_directory_param_visible_in_schema` -- asserts `directory` appears in tool schema properties
- [ ] `test_list_files_with_none_directory` -- verifies `directory=None` defaults to base dir
- [ ] `test_list_files_with_explicit_directory` -- verifies subdirectory scoping still works

All 5 new tests pass. No regressions in either suite.

Generated with Claude Code