### PR TITLE
fix: execute pre-hooks before tool handling on continue_run paths

### DIFF
--- a/cookbook/02_agents/09_hooks/README.md
+++ b/cookbook/02_agents/09_hooks/README.md
@@ -5,6 +5,7 @@ Examples for pre-hooks, post-hooks, tool hooks, and stream lifecycle hooks.
 ## Files
 - `post_hook_output.py` - Run a hook after the agent responds.
 - `pre_hook_input.py` - Run a hook before the agent processes input.
+- `pre_hook_on_continue.py` - Pre-hooks with @hook(run_on_continue=True) for HITL flows.
 - `session_state_hooks.py` - Hooks that read and modify session state.
 - `stream_hook.py` - Hook into the streaming lifecycle.
 - `tool_hooks.py` - Middleware hooks that wrap every tool call.

--- a/cookbook/02_agents/09_hooks/pre_hook_on_continue.py
+++ b/cookbook/02_agents/09_hooks/pre_hook_on_continue.py
@@ -1,0 +1,69 @@
+"""
+Pre-hooks on continue_run
+=========================
+
+Demonstrates @hook(run_on_continue=True) for HITL (Human-in-the-Loop) flows.
+
+- Regular pre-hooks only run on initial run()
+- Hooks with @hook(run_on_continue=True) run on BOTH run() and continue_run()
+
+Use this for security checks or audit logging that must run on every execution.
+"""
+
+from agno.agent import Agent
+from agno.hooks import hook
+from agno.models.openai import OpenAIResponses
+from agno.run.agent import RunInput, RunRequirement
+from agno.tools import tool
+
+
+# Regular pre-hook - only runs on initial run()
+def log_request(run_input: RunInput) -> None:
+    """Logs initial request. Skipped on continue_run."""
+    print(f"[log_request] Input: {run_input.input_content[:50]}...")
+
+
+# Pre-hook with @hook(run_on_continue=True) - runs on BOTH
+@hook(run_on_continue=True)
+def security_check(run_input: RunInput, user_id: str = None) -> None:
+    """Security check that runs on every execution."""
+    print(f"[security_check] User: {user_id}")
+
+
+@tool(requires_confirmation=True)
+def transfer_funds(amount: float, to_account: str) -> str:
+    """Transfer funds to another account."""
+    return f"Transferred ${amount:.2f} to account {to_account}"
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    name="Banking Agent",
+    model=OpenAIResponses(id="gpt-5-mini"),
+    tools=[transfer_funds],
+    pre_hooks=[log_request, security_check],
+    instructions=["You help users with banking operations."],
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # Initial run - both hooks execute, then pauses for confirmation
+    run = agent.run(
+        input="Transfer $100 to account 12345",
+        user_id="user-123",
+    )
+    print(f"Status: {run.status}")
+
+    # Continue after approval - only security_check runs (has @hook decorator)
+    if run.requirements:
+        for req in run.requirements:
+            if isinstance(req, RunRequirement):
+                req.confirm()
+
+        run = agent.continue_run(run_response=run, user_id="user-123")
+        print(f"Status: {run.status}")
+        print(run.content)

--- a/cookbook/05_agent_os/17_slack/hitl_incident_commander.py
+++ b/cookbook/05_agent_os/17_slack/hitl_incident_commander.py
@@ -6,6 +6,11 @@ Combine user feedback, external execution, confirmation, and required user
 input in one persisted incident run. tool_choice="required" keeps each turn
 auditable; conclude_incident provides the explicit terminal tool.
 
+Demonstrates @hook(run_on_continue=True) for:
+- Announcing when an approved action begins executing
+- Validating maintenance windows before destructive operations
+- Audit logging of approval-to-execution timing
+
 Prerequisites: SLACK_TOKEN, SLACK_SIGNING_SECRET, OPENAI_API_KEY
 Run: .venvs/demo/bin/python cookbook/05_agent_os/17_slack/hitl_incident_commander.py
 Try in Slack: Ask "Production api-gateway returns 500s in eu-west; help me triage."
@@ -13,17 +18,70 @@ Slack scopes: app_mentions:read, assistant:write, chat:write, im:history
 """
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Literal
 from uuid import uuid4
 
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
+from agno.exceptions import InputCheckError
+from agno.hooks import hook
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
 from agno.os.interfaces.slack import Slack
+from agno.run.agent import RunInput
 from agno.tools import tool
 from agno.tools.user_feedback import UserFeedbackTools
 from agno.tools.websearch import WebSearchTools
+
+# ---------------------------------------------------------------------------
+# Pre-hooks for continue_run (run after HITL approval, before tool execution)
+# ---------------------------------------------------------------------------
+
+
+@hook(run_on_continue=True)
+def announce_execution_start(run_input: RunInput) -> None:
+    """
+    Announce when an approved action begins executing.
+
+    This hook runs on continue_run() after the operator clicks Approve in Slack.
+    In production, this would post to a #deployments channel or incident thread.
+    """
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{now}] Approved action now executing...")
+    if run_input:
+        print(
+            f"  Input: {run_input.input_content[:50] if run_input.input_content else 'N/A'}..."
+        )
+
+
+@hook(run_on_continue=True)
+def validate_maintenance_window(run_input: RunInput) -> None:
+    """
+    Block execution if outside the maintenance window.
+
+    Approval may have been granted hours or days ago. Re-validate that
+    we're still in an allowed window before executing destructive operations.
+
+    In production, this would check against a calendar API or config service.
+    For demo purposes, this always passes but logs the check.
+    """
+    current_hour = datetime.now().hour
+
+    # Demo: maintenance window is 6 AM - 10 PM local time
+    # In production: fetch from PagerDuty, Opsgenie, or config service
+    maintenance_start = 6
+    maintenance_end = 22
+
+    if not (maintenance_start <= current_hour < maintenance_end):
+        raise InputCheckError(
+            f"Outside maintenance window ({maintenance_start}:00-{maintenance_end}:00). "
+            f"Current hour: {current_hour}:00. Please re-approve during allowed hours."
+        )
+
+    print(
+        f"[Maintenance Window] Current hour {current_hour}:00 is within allowed window"
+    )
 
 
 @dataclass
@@ -125,6 +183,8 @@ incident_commander = Agent(
         conclude_incident,
         WebSearchTools(),
     ],
+    # Pre-hooks with run_on_continue=True run after HITL approval
+    pre_hooks=[announce_execution_start, validate_maintenance_window],
     instructions=[
         "Drive the incident through five phases:",
         "1. Triage: call ask_user for severity and affected systems.",
@@ -145,7 +205,7 @@ agent_os = AgentOS(
     description="AgentOS rendering all four run pause types through Slack.",
     db=db,
     agents=[incident_commander],
-    interfaces=[Slack(agent=incident_commander)],
+    interfaces=[Slack(agent=incident_commander, prefix="/slack/agent")],
 )
 app = agent_os.get_app()
 

--- a/cookbook/05_agent_os/17_slack/hitl_multi_container.py
+++ b/cookbook/05_agent_os/17_slack/hitl_multi_container.py
@@ -1,0 +1,178 @@
+"""
+Multi-Container HITL with Pre-hook Re-authentication
+=====================================================
+
+Demonstrates @hook(run_on_continue=True) for stateless deployments where
+each HTTP request may hit a different container/process.
+
+Problem:
+- User sends Slack message -> Container A handles run(), authenticates
+- Run pauses for confirmation (requires_confirmation=True)
+- User clicks Approve button -> Container B handles continue_run()
+- Container B has no auth state - must re-authenticate before tool execution
+
+Solution:
+- Mark authentication hooks with @hook(run_on_continue=True)
+- The hook runs on BOTH run() and continue_run()
+- Each container re-authenticates before executing, regardless of state
+
+This pattern is essential for:
+- Kubernetes deployments with multiple replicas
+- Serverless functions (Lambda, Cloud Functions)
+- Load-balanced web servers
+- Any stateless architecture
+
+Prerequisites:
+- SLACK_TOKEN or SLACK_AGENT_BOT_TOKEN
+- SLACK_SIGNING_SECRET or SLACK_AGENT_SIGNING_SECRET
+- OPENAI_API_KEY
+
+Run:
+    .venvs/demo/bin/python cookbook/05_agent_os/17_slack/hitl_multi_container.py
+
+Expose with ngrok:
+    ngrok http 7777 --domain=slack-agent.ngrok.app
+
+Try in Slack:
+    @bot Perform a database cleanup for user 123
+"""
+
+from os import getenv
+from typing import Optional
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.hooks import hook
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.slack import Slack
+from agno.run.agent import RunInput
+from agno.tools import tool
+
+
+# ---------------------------------------------------------------------------
+# External Service Client (simulates per-container auth)
+# ---------------------------------------------------------------------------
+class ServiceClient:
+    """
+    Per-process service authentication state.
+
+    In production each container/Lambda has its own instance.
+    Auth tokens are fetched from environment on each request.
+    """
+
+    _authenticated: bool = False
+    _api_key: Optional[str] = None
+
+    @classmethod
+    def authenticate(cls, api_key: str) -> None:
+        print(f"[ServiceClient] Authenticating with key: {api_key[:8]}...")
+        cls._api_key = api_key
+        cls._authenticated = True
+
+    @classmethod
+    def is_authenticated(cls) -> bool:
+        return cls._authenticated
+
+    @classmethod
+    def reset(cls) -> None:
+        """Simulate container restart - auth is lost."""
+        cls._authenticated = False
+        cls._api_key = None
+
+    @classmethod
+    def execute(cls, operation: str, user_id: str) -> str:
+        if not cls._authenticated:
+            raise RuntimeError("ServiceClient not authenticated")
+        return f"Executed '{operation}' for user {user_id}"
+
+
+# ---------------------------------------------------------------------------
+# Pre-hook: Authenticate Service (runs on continue_run too)
+# ---------------------------------------------------------------------------
+@hook(run_on_continue=True)
+def authenticate_service(run_input: RunInput) -> None:
+    """
+    Re-authenticate service client before tool execution.
+
+    @hook(run_on_continue=True) ensures this runs on:
+    - Initial run() call
+    - continue_run() after HITL approval
+
+    Without this decorator, continue_run() would skip authentication
+    and fail when trying to execute the tool from a fresh container.
+    """
+    if ServiceClient.is_authenticated():
+        print("[Hook] Already authenticated, skipping")
+        return
+
+    api_key = getenv("SERVICE_API_KEY", "demo-api-key-12345")
+    print(f"[Hook] Authenticating service with key: {api_key[:8]}...")
+    ServiceClient.authenticate(api_key)
+
+
+# ---------------------------------------------------------------------------
+# Tool: Database Cleanup (requires confirmation)
+# ---------------------------------------------------------------------------
+@tool(requires_confirmation=True)
+def database_cleanup(user_id: str, operation: str = "archive") -> str:
+    """
+    Perform a database cleanup operation for a user.
+
+    Requires approval because it modifies production data.
+
+    Args:
+        user_id: The user ID to clean up
+        operation: Type of cleanup (archive, delete, reset)
+
+    Returns:
+        Result of the cleanup operation
+    """
+    return ServiceClient.execute(operation, user_id)
+
+
+# ---------------------------------------------------------------------------
+# Agent and AgentOS
+# ---------------------------------------------------------------------------
+db = SqliteDb(
+    id="slack-hitl-multi-container-db",
+    db_file="tmp/slack_hitl_multi_container.db",
+)
+
+slack_agent = Agent(
+    id="slack-multi-container-agent",
+    name="Slack Multi-Container Agent",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+    tools=[database_cleanup],
+    pre_hooks=[authenticate_service],
+    instructions=[
+        "You help users perform database operations.",
+        "When a user requests a cleanup, call database_cleanup immediately with the provided user_id and operation.",
+        "Do NOT ask for confirmation in text - the tool has requires_confirmation=True which shows an Approve/Deny card.",
+        "Default operation is 'archive' if not specified.",
+    ],
+    markdown=True,
+)
+
+agent_os = AgentOS(
+    id="slack-hitl-multi-container-os",
+    description="Demonstrates pre-hook re-auth on continue_run().",
+    db=db,
+    agents=[slack_agent],
+    interfaces=[Slack(agent=slack_agent, prefix="/slack/agent")],
+)
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    print("Starting Slack HITL Multi-Container demo...")
+    print("Expose with: ngrok http 7777 --domain=slack-agent.ngrok.app")
+    print("")
+    print("The @hook(run_on_continue=True) decorator ensures authentication")
+    print("runs on both run() and continue_run(), handling container restarts.")
+    print("")
+    agent_os.serve(app=app)

--- a/libs/agno/agno/agent/_hooks.py
+++ b/libs/agno/agno/agent/_hooks.py
@@ -33,6 +33,7 @@ from agno.utils.hooks import (
     get_hook_name,
     is_guardrail_hook,
     should_run_hook_in_background,
+    should_run_on_continue,
 )
 from agno.utils.log import (
     log_exception,
@@ -51,6 +52,7 @@ def execute_pre_hooks(
     debug_mode: Optional[bool] = None,
     stream_events: bool = False,
     background_tasks: Optional[Any] = None,
+    is_continue: bool = False,
     **kwargs: Any,
 ) -> Iterator[RunOutputEvent]:
     """Execute multiple pre-hook functions in succession."""
@@ -58,6 +60,15 @@ def execute_pre_hooks(
 
     if hooks is None:
         return
+
+    # On continue_run, filter to only:
+    # 1. Hooks decorated with @hook(run_on_continue=True)
+    # 2. Guardrails (security-critical, always run)
+    if is_continue:
+        hooks = [hook for hook in hooks if should_run_on_continue(hook) or is_guardrail_hook(hook)]
+        if not hooks:
+            return
+
     # Prepare arguments for this hook
     all_args = {
         "run_input": run_input,
@@ -162,6 +173,7 @@ async def aexecute_pre_hooks(
     debug_mode: Optional[bool] = None,
     stream_events: bool = False,
     background_tasks: Optional[Any] = None,
+    is_continue: bool = False,
     **kwargs: Any,
 ) -> AsyncIterator[RunOutputEvent]:
     """Execute multiple pre-hook functions in succession (async version)."""
@@ -169,6 +181,15 @@ async def aexecute_pre_hooks(
 
     if hooks is None:
         return
+
+    # On continue_run, filter to only:
+    # 1. Hooks decorated with @hook(run_on_continue=True)
+    # 2. Guardrails (security-critical, always run)
+    if is_continue:
+        hooks = [hook for hook in hooks if should_run_on_continue(hook) or is_guardrail_hook(hook)]
+        if not hooks:
+            return
+
     # Prepare arguments for this hook
     all_args = {
         "run_input": run_input,

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -444,7 +444,7 @@ def _run(
                 # 4. Execute pre-hooks
                 run_input = cast(RunInput, run_response.input)
                 agent.model = cast(Model, agent.model)
-                if agent.pre_hooks is not None:
+                if attempt == 0 and agent.pre_hooks is not None:
                     # Can modify the run input
                     pre_hook_iterator = execute_pre_hooks(
                         agent,
@@ -847,7 +847,7 @@ def _run_stream(
                 # 4. Execute pre-hooks
                 run_input = cast(RunInput, run_response.input)
                 agent.model = cast(Model, agent.model)
-                if agent.pre_hooks is not None:
+                if attempt == 0 and agent.pre_hooks is not None:
                     # Can modify the run input
                     pre_hook_iterator = execute_pre_hooks(
                         agent,
@@ -1567,7 +1567,7 @@ async def _arun(
                 # 4. Execute pre-hooks
                 run_input = cast(RunInput, run_response.input)
                 agent.model = cast(Model, agent.model)
-                if agent.pre_hooks is not None:
+                if attempt == 0 and agent.pre_hooks is not None:
                     # Can modify the run input
                     pre_hook_iterator = aexecute_pre_hooks(
                         agent,
@@ -2324,7 +2324,7 @@ async def _arun_stream(
                 # 4. Execute pre-hooks
                 run_input = cast(RunInput, run_response.input)
                 agent.model = cast(Model, agent.model)
-                if agent.pre_hooks is not None:
+                if attempt == 0 and agent.pre_hooks is not None:
                     pre_hook_iterator = aexecute_pre_hooks(
                         agent,
                         hooks=agent.pre_hooks,  # type: ignore
@@ -3420,6 +3420,15 @@ def continue_run_dispatch(
     # Initialize the Agent
     agent.initialize_agent(debug_mode=debug_mode)
 
+    # Normalise hooks & guardrails (required for multi-container deployments where
+    # continue_run() may be the first call in a fresh process)
+    if not agent._hooks_normalised:
+        if agent.pre_hooks:
+            agent.pre_hooks = normalize_pre_hooks(agent.pre_hooks)  # type: ignore
+        if agent.post_hooks:
+            agent.post_hooks = normalize_post_hooks(agent.post_hooks)  # type: ignore
+        agent._hooks_normalised = True
+
     # Read existing session from storage
     agent_session = read_or_create_session(agent, session_id=session_id, user_id=user_id)
     update_metadata(agent, session=agent_session)
@@ -3706,7 +3715,7 @@ def _continue_run(
     8. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
     """
     # Register run for cancellation tracking
-    from agno.agent._hooks import execute_post_hooks
+    from agno.agent._hooks import execute_post_hooks, execute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools
     from agno.agent._response import (
         convert_response_to_structured_format,
@@ -3722,7 +3731,36 @@ def _continue_run(
 
     agent.model = cast(Model, agent.model)
 
-    # 1. Handle the updated tools
+    # 1. Execute pre-hooks
+    run_input = cast(RunInput, run_response.input)
+    if agent.pre_hooks is not None:
+        try:
+            pre_hook_iterator = execute_pre_hooks(
+                agent,
+                hooks=agent.pre_hooks,  # type: ignore
+                run_response=run_response,
+                run_input=run_input,
+                run_context=run_context,
+                session=session,
+                user_id=user_id,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                is_continue=True,
+                **kwargs,
+            )
+            deque(pre_hook_iterator, maxlen=0)
+        except (InputCheckError, OutputCheckError) as e:
+            run_response.status = RunStatus.error
+            flush_in_flight_messages_on_error(run_response, run_messages)
+            if run_response.content is None:
+                run_response.content = str(e)
+            log_error(f"Validation failed: {str(e)} | Check trigger: {e.check_trigger}")
+            cleanup_and_store(
+                agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
+            )
+            return run_response
+
+    # 2. Handle the updated tools
     handle_tool_call_updates(agent, run_response=run_response, run_messages=run_messages, tools=tools)
 
     try:
@@ -3928,7 +3966,7 @@ def _continue_run_stream(
     6. Cleanup and store the run response and session
     """
 
-    from agno.agent._hooks import execute_post_hooks
+    from agno.agent._hooks import execute_post_hooks, execute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools
     from agno.agent._response import (
         generate_followups_stream,
@@ -3940,12 +3978,45 @@ def _continue_run_stream(
 
     register_run(run_response.run_id)  # type: ignore
 
+    # 1. Execute pre-hooks
+    run_input = cast(RunInput, run_response.input)
+    if agent.pre_hooks is not None:
+        try:
+            pre_hook_iterator = execute_pre_hooks(
+                agent,
+                hooks=agent.pre_hooks,  # type: ignore
+                run_response=run_response,
+                run_input=run_input,
+                run_context=run_context,
+                session=session,
+                user_id=user_id,
+                debug_mode=debug_mode,
+                stream_events=stream_events,
+                background_tasks=background_tasks,
+                is_continue=True,
+                **kwargs,
+            )
+            for event in pre_hook_iterator:
+                yield event
+        except (InputCheckError, OutputCheckError) as e:
+            run_response.status = RunStatus.error
+            flush_in_flight_messages_on_error(run_response, run_messages)
+            if run_response.content is None:
+                run_response.content = str(e)
+            log_error(f"Validation failed: {str(e)} | Check trigger: {e.check_trigger}")
+            cleanup_and_store(
+                agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
+            )
+            if yield_run_output:
+                yield run_response
+            return
+
     # Set up retry logic
     num_attempts = agent.retries + 1
     try:
         for attempt in range(num_attempts):
             try:
-                # 1. Resolve dependencies
+                # 2. Resolve dependencies
                 if run_context.dependencies is not None:
                     resolve_run_dependencies(agent, run_context=run_context)
 
@@ -4288,6 +4359,15 @@ def acontinue_run_dispatch(  # type: ignore
 
     # Initialize the Agent
     agent.initialize_agent(debug_mode=debug_mode)
+
+    # Normalise hooks & guardrails (required for multi-container deployments where
+    # continue_run() may be the first call in a fresh process)
+    if not agent._hooks_normalised:
+        if agent.pre_hooks:
+            agent.pre_hooks = normalize_pre_hooks(agent.pre_hooks, async_mode=True)  # type: ignore
+        if agent.post_hooks:
+            agent.post_hooks = normalize_post_hooks(agent.post_hooks, async_mode=True)  # type: ignore
+        agent._hooks_normalised = True
 
     # Read existing session and update metadata BEFORE resolving run options,
     # so that session-stored metadata is visible to resolve_run_options.
@@ -4716,7 +4796,7 @@ async def _acontinue_run(
     13. Create session summary
     14. Cleanup and store (scrub, stop timer, save to file, add to session, calculate metrics, save session)
     """
-    from agno.agent._hooks import aexecute_post_hooks
+    from agno.agent._hooks import aexecute_post_hooks, aexecute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
     from agno.agent._messages import aget_continue_run_messages
     from agno.agent._response import (
@@ -4936,12 +5016,46 @@ async def _acontinue_run(
                 # Register run for cancellation tracking
                 await aregister_run(run_response.run_id)  # type: ignore
 
-                # 7. Handle the updated tools
+                # 7. Execute pre-hooks (only on first attempt)
+                run_input = cast(RunInput, run_response.input)
+                if attempt == 0 and agent.pre_hooks is not None:
+                    try:
+                        pre_hook_iterator = aexecute_pre_hooks(
+                            agent,
+                            hooks=agent.pre_hooks,  # type: ignore
+                            run_response=run_response,
+                            run_input=run_input,
+                            run_context=run_context,
+                            session=agent_session,
+                            user_id=user_id,
+                            debug_mode=debug_mode,
+                            background_tasks=background_tasks,
+                            is_continue=True,
+                            **kwargs,
+                        )
+                        async for _ in pre_hook_iterator:
+                            pass
+                    except (InputCheckError, OutputCheckError) as e:
+                        run_response.status = RunStatus.error
+                        flush_in_flight_messages_on_error(run_response, run_messages)
+                        if run_response.content is None:
+                            run_response.content = str(e)
+                        log_error(f"Validation failed: {str(e)} | Check trigger: {e.check_trigger}")
+                        await acleanup_and_store(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        )
+                        return run_response
+
+                # 8. Handle the updated tools
                 await ahandle_tool_call_updates(
                     agent, run_response=run_response, run_messages=run_messages, tools=_tools
                 )
 
-                # 8. Get model response
+                # 9. Get model response
                 model_response: ModelResponse = await acall_model_with_fallback(
                     agent.model,
                     agent.fallback_config,
@@ -5218,7 +5332,7 @@ async def _acontinue_run_stream(
     10. Execute post-hooks
     11. Cleanup and store the run response and session
     """
-    from agno.agent._hooks import aexecute_post_hooks
+    from agno.agent._hooks import aexecute_post_hooks, aexecute_pre_hooks
     from agno.agent._init import disconnect_connectable_tools, disconnect_mcp_tools
     from agno.agent._messages import aget_continue_run_messages
     from agno.agent._response import (
@@ -5445,7 +5559,44 @@ async def _acontinue_run_stream(
                         store_events=agent.store_events,
                     )
 
-                # 7. Handle the updated tools
+                # 7. Execute pre-hooks (only on first attempt)
+                run_input = cast(RunInput, run_response.input)
+                if attempt == 0 and agent.pre_hooks is not None:
+                    try:
+                        pre_hook_iterator = aexecute_pre_hooks(
+                            agent,
+                            hooks=agent.pre_hooks,  # type: ignore
+                            run_response=run_response,
+                            run_input=run_input,
+                            run_context=run_context,
+                            session=agent_session,
+                            user_id=user_id,
+                            debug_mode=debug_mode,
+                            stream_events=stream_events,
+                            background_tasks=background_tasks,
+                            is_continue=True,
+                            **kwargs,
+                        )
+                        async for event in pre_hook_iterator:
+                            yield event
+                    except (InputCheckError, OutputCheckError) as e:
+                        run_response.status = RunStatus.error
+                        flush_in_flight_messages_on_error(run_response, run_messages)
+                        if run_response.content is None:
+                            run_response.content = str(e)
+                        log_error(f"Validation failed: {str(e)} | Check trigger: {e.check_trigger}")
+                        await acleanup_and_store(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        )
+                        if yield_run_output:
+                            yield run_response
+                        return
+
+                # 8. Handle the updated tools
                 async for event in ahandle_tool_call_updates_stream(
                     agent,
                     run_response=run_response,

--- a/libs/agno/agno/hooks/__init__.py
+++ b/libs/agno/agno/hooks/__init__.py
@@ -1,3 +1,3 @@
-from agno.hooks.decorator import hook, should_run_in_background
+from agno.hooks.decorator import hook, should_run_in_background, should_run_on_continue
 
-__all__ = ["hook", "should_run_in_background"]
+__all__ = ["hook", "should_run_in_background", "should_run_on_continue"]

--- a/libs/agno/agno/hooks/decorator.py
+++ b/libs/agno/agno/hooks/decorator.py
@@ -6,6 +6,8 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 # Attribute name used to mark hooks for background execution
 HOOK_RUN_IN_BACKGROUND_ATTR = "_agno_run_in_background"
+# Attribute name used to mark hooks that should run on continue_run
+HOOK_RUN_ON_CONTINUE_ATTR = "_agno_run_on_continue"
 
 
 def _is_async_function(func: Callable) -> bool:
@@ -46,6 +48,7 @@ def hook() -> Callable[[F], F]: ...
 def hook(
     *,
     run_in_background: bool = False,
+    run_on_continue: bool = False,
 ) -> Callable[[F], F]: ...
 
 
@@ -60,7 +63,12 @@ def hook(*args, **kwargs) -> Union[F, Callable[[F], F]]:
         run_in_background: If True, this hook will be scheduled as a FastAPI background task
                           when background_tasks is available, regardless of the agent/team's
                           run_hooks_in_background setting. This allows per-hook control over
-                          background execution.  This is only use-able when running with AgentOS.
+                          background execution. This is only usable when running with AgentOS.
+        run_on_continue: If True, this hook will also run on continue_run() calls.
+                        By default (False), hooks only run on initial run() calls and are
+                        skipped on continue_run() since the input was already validated.
+                        Set to True for security-critical hooks that must run on every
+                        execution boundary.
 
     Returns:
         Union[F, Callable[[F], F]]: Decorated function or decorator
@@ -86,13 +94,18 @@ def hook(*args, **kwargs) -> Union[F, Callable[[F], F]]:
             # Async hooks also supported
             await send_async_notification(run_output.content)
 
+        @hook(run_on_continue=True)
+        def security_hook(run_input, agent):
+            # This hook runs on BOTH run() and continue_run()
+            validate_permissions(run_input)
+
         agent = Agent(
             model=OpenAIChat(id="gpt-5.5"),
             post_hooks=[my_hook, my_background_hook],
         )
     """
     # Valid kwargs for the hook decorator
-    VALID_KWARGS = frozenset({"run_in_background"})
+    VALID_KWARGS = frozenset({"run_in_background", "run_on_continue"})
 
     # Validate kwargs
     invalid_kwargs = set(kwargs.keys()) - VALID_KWARGS
@@ -103,11 +116,14 @@ def hook(*args, **kwargs) -> Union[F, Callable[[F], F]]:
 
     def decorator(func: F) -> F:
         run_in_background = kwargs.get("run_in_background", False)
+        run_on_continue = kwargs.get("run_on_continue", False)
 
         # Preserve existing hook attributes from previously applied decorators
         # Use OR logic: if any decorator sets run_in_background=True, it stays True
         existing_run_in_background = should_run_in_background(func)
+        existing_run_on_continue = should_run_on_continue(func)
         final_run_in_background = run_in_background or existing_run_in_background
+        final_run_on_continue = run_on_continue or existing_run_on_continue
 
         @wraps(func)
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -123,8 +139,9 @@ def hook(*args, **kwargs) -> Union[F, Callable[[F], F]]:
         else:
             wrapper = sync_wrapper
 
-        # Set the background execution attribute (combined from all decorators)
+        # Set the hook attributes (combined from all decorators)
         setattr(wrapper, HOOK_RUN_IN_BACKGROUND_ATTR, final_run_in_background)
+        setattr(wrapper, HOOK_RUN_ON_CONTINUE_ATTR, final_run_on_continue)
 
         return wrapper  # type: ignore
 
@@ -135,20 +152,21 @@ def hook(*args, **kwargs) -> Union[F, Callable[[F], F]]:
     return decorator
 
 
-def should_run_in_background(hook_func: Callable) -> bool:
+def _get_hook_attr(hook_func: Callable, attr_name: str, default: bool = False) -> bool:
     """
-    Check if a hook function is marked to run in background.
-    Traverses the wrapper chain to find the attribute when multiple decorators are stacked.
+    Get a hook attribute, traversing the wrapper chain if needed.
 
     Args:
         hook_func: The hook function to check
+        attr_name: The attribute name to look for
+        default: Default value if attribute not found
 
     Returns:
-        True if the hook is decorated with @hook(run_in_background=True)
+        The attribute value, or default if not found
     """
     # Check the function directly first
-    if hasattr(hook_func, HOOK_RUN_IN_BACKGROUND_ATTR):
-        return getattr(hook_func, HOOK_RUN_IN_BACKGROUND_ATTR)
+    if hasattr(hook_func, attr_name):
+        return getattr(hook_func, attr_name)
 
     # Traverse the wrapper chain to find the attribute
     current = hook_func
@@ -158,7 +176,33 @@ def should_run_in_background(hook_func: Callable) -> bool:
             break
         seen.add(id(current))
         current = current.__wrapped__
-        if hasattr(current, HOOK_RUN_IN_BACKGROUND_ATTR):
-            return getattr(current, HOOK_RUN_IN_BACKGROUND_ATTR)
+        if hasattr(current, attr_name):
+            return getattr(current, attr_name)
 
-    return False
+    return default
+
+
+def should_run_in_background(hook_func: Callable) -> bool:
+    """
+    Check if a hook function is marked to run in background.
+
+    Args:
+        hook_func: The hook function to check
+
+    Returns:
+        True if the hook is decorated with @hook(run_in_background=True)
+    """
+    return _get_hook_attr(hook_func, HOOK_RUN_IN_BACKGROUND_ATTR, False)
+
+
+def should_run_on_continue(hook_func: Callable) -> bool:
+    """
+    Check if a hook function should run on continue_run().
+
+    Args:
+        hook_func: The hook function to check
+
+    Returns:
+        True if the hook is decorated with @hook(run_on_continue=True)
+    """
+    return _get_hook_attr(hook_func, HOOK_RUN_ON_CONTINUE_ATTR, False)

--- a/libs/agno/agno/team/_hooks.py
+++ b/libs/agno/agno/team/_hooks.py
@@ -40,6 +40,7 @@ from agno.utils.hooks import (
     get_hook_name,
     is_guardrail_hook,
     should_run_hook_in_background,
+    should_run_on_continue,
 )
 from agno.utils.log import (
     log_debug,
@@ -248,6 +249,7 @@ def _execute_pre_hooks(
     debug_mode: Optional[bool] = None,
     stream_events: bool = False,
     background_tasks: Optional[Any] = None,
+    is_continue: bool = False,
     **kwargs: Any,
 ) -> Iterator[TeamRunOutputEvent]:
     """Execute multiple pre-hook functions in succession."""
@@ -255,6 +257,14 @@ def _execute_pre_hooks(
 
     if hooks is None:
         return
+
+    # On continue_run, filter to only:
+    # 1. Hooks decorated with @hook(run_on_continue=True)
+    # 2. Guardrails (security-critical, always run)
+    if is_continue:
+        hooks = [hook for hook in hooks if should_run_on_continue(hook) or is_guardrail_hook(hook)]
+        if not hooks:
+            return
 
     # Prepare arguments for hooks
     effective_debug_mode = debug_mode if debug_mode is not None else team.debug_mode
@@ -346,6 +356,7 @@ async def _aexecute_pre_hooks(
     debug_mode: Optional[bool] = None,
     stream_events: bool = False,
     background_tasks: Optional[Any] = None,
+    is_continue: bool = False,
     **kwargs: Any,
 ) -> AsyncIterator[TeamRunOutputEvent]:
     """Execute multiple pre-hook functions in succession (async version)."""
@@ -353,6 +364,14 @@ async def _aexecute_pre_hooks(
 
     if hooks is None:
         return
+
+    # On continue_run, filter to only:
+    # 1. Hooks decorated with @hook(run_on_continue=True)
+    # 2. Guardrails (security-critical, always run)
+    if is_continue:
+        hooks = [hook for hook in hooks if should_run_on_continue(hook) or is_guardrail_hook(hook)]
+        if not hooks:
+            return
 
     # Prepare arguments for hooks
     effective_debug_mode = debug_mode if debug_mode is not None else team.debug_mode

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -763,7 +763,7 @@ def _run_tasks_stream(
             run_messages.messages = accumulated_messages
 
             if team.output_model is None:
-                for event in _handle_model_response_stream(
+                for event in _handle_model_response_stream(  # type: ignore[assignment]
                     team,
                     session=session,
                     run_response=run_response,
@@ -778,7 +778,7 @@ def _run_tasks_stream(
                         raise_if_cancelled(run_response.run_id)  # type: ignore
                     yield event
             else:
-                for event in _handle_model_response_stream(
+                for event in _handle_model_response_stream(  # type: ignore[assignment]
                     team,
                     session=session,
                     run_response=run_response,
@@ -1160,7 +1160,7 @@ def _run(
                 # 1. Execute pre-hooks
                 run_input = cast(TeamRunInput, run_response.input)
                 team.model = cast(Model, team.model)
-                if team.pre_hooks is not None:
+                if attempt == 0 and team.pre_hooks is not None:
                     # Can modify the run input
                     pre_hook_iterator = _execute_pre_hooks(
                         team,
@@ -1522,7 +1522,7 @@ def _run_stream(
                 # 1. Execute pre-hooks
                 run_input = cast(TeamRunInput, run_response.input)
                 team.model = cast(Model, team.model)
-                if team.pre_hooks is not None:
+                if attempt == 0 and team.pre_hooks is not None:
                     # Can modify the run input
                     pre_hook_iterator = _execute_pre_hooks(
                         team,
@@ -1629,7 +1629,7 @@ def _run_stream(
 
                 # 6. Get a response from the model
                 if team.output_model is None:
-                    for event in _handle_model_response_stream(
+                    for event in _handle_model_response_stream(  # type: ignore[assignment]
                         team,
                         session=session,
                         run_response=run_response,
@@ -1644,7 +1644,7 @@ def _run_stream(
                             raise_if_cancelled(run_response.run_id)  # type: ignore
                         yield event
                 else:
-                    for event in _handle_model_response_stream(
+                    for event in _handle_model_response_stream(  # type: ignore[assignment]
                         team,
                         session=session,
                         run_response=run_response,
@@ -2689,7 +2689,7 @@ async def _arun_tasks_stream(
             run_messages.messages = accumulated_messages
 
             if team.output_model is None:
-                async for event in _ahandle_model_response_stream(
+                async for event in _ahandle_model_response_stream(  # type: ignore[assignment]
                     team,
                     session=team_session,
                     run_response=run_response,
@@ -2704,7 +2704,7 @@ async def _arun_tasks_stream(
                         await araise_if_cancelled(run_response.run_id)  # type: ignore
                     yield event
             else:
-                async for event in _ahandle_model_response_stream(
+                async for event in _ahandle_model_response_stream(  # type: ignore[assignment]
                     team,
                     session=team_session,
                     run_response=run_response,
@@ -3132,7 +3132,7 @@ async def _arun(
                 run_input = cast(TeamRunInput, run_response.input)
 
                 # 1. Execute pre-hooks after session is loaded but before processing starts
-                if team.pre_hooks is not None:
+                if attempt == 0 and team.pre_hooks is not None:
                     pre_hook_iterator = _aexecute_pre_hooks(
                         team,
                         hooks=team.pre_hooks,  # type: ignore
@@ -3849,7 +3849,7 @@ async def _arun_stream(
                 # 1. Execute pre-hooks
                 run_input = cast(TeamRunInput, run_response.input)
                 team.model = cast(Model, team.model)
-                if team.pre_hooks is not None:
+                if attempt == 0 and team.pre_hooks is not None:
                     pre_hook_iterator = _aexecute_pre_hooks(
                         team,
                         hooks=team.pre_hooks,  # type: ignore
@@ -3961,7 +3961,7 @@ async def _arun_stream(
 
                 # 6. Get a response from the model
                 if team.output_model is None:
-                    async for event in _ahandle_model_response_stream(
+                    async for event in _ahandle_model_response_stream(  # type: ignore[assignment]
                         team,
                         session=team_session,
                         run_response=run_response,
@@ -3976,7 +3976,7 @@ async def _arun_stream(
                             await araise_if_cancelled(run_response.run_id)  # type: ignore
                         yield event
                 else:
-                    async for event in _ahandle_model_response_stream(
+                    async for event in _ahandle_model_response_stream(  # type: ignore[assignment]
                         team,
                         session=team_session,
                         run_response=run_response,
@@ -7557,6 +7557,15 @@ def continue_run_dispatch(
     # Initialize the Team
     team.initialize_team(debug_mode=debug_mode)
 
+    # Normalise hooks & guardrails (required for multi-container deployments where
+    # continue_run() may be the first call in a fresh process)
+    if not team._hooks_normalised:
+        if team.pre_hooks:
+            team.pre_hooks = normalize_pre_hooks(team.pre_hooks)  # type: ignore
+        if team.post_hooks:
+            team.post_hooks = normalize_post_hooks(team.post_hooks)  # type: ignore
+        team._hooks_normalised = True
+
     # Read existing session from storage
     team_session = _read_or_create_session(team, session_id=session_id, user_id=user_id)
     _update_metadata(team, session=team_session)
@@ -8293,7 +8302,7 @@ def _continue_run(
     5. Create session summary
     6. Cleanup and store
     """
-    from agno.team._hooks import _execute_post_hooks
+    from agno.team._hooks import _execute_post_hooks, _execute_pre_hooks
     from agno.team._init import _disconnect_connectable_tools
     from agno.team._response import (
         _convert_response_to_structured_format,
@@ -8321,6 +8330,35 @@ def _continue_run(
         for attempt in range(num_attempts):
             try:
                 raise_if_cancelled(run_response.run_id)  # type: ignore
+
+                # Execute pre-hooks (only on first attempt)
+                run_input = cast(TeamRunInput, run_response.input)
+                if attempt == 0 and team.pre_hooks is not None:
+                    try:
+                        pre_hook_iterator = _execute_pre_hooks(
+                            team,
+                            hooks=team.pre_hooks,  # type: ignore
+                            run_response=run_response,
+                            run_input=run_input,
+                            run_context=run_context,
+                            session=session,
+                            user_id=user_id,
+                            debug_mode=debug_mode,
+                            background_tasks=background_tasks,
+                            is_continue=True,
+                            **kwargs,
+                        )
+                        deque(pre_hook_iterator, maxlen=0)
+                    except (InputCheckError, OutputCheckError) as e:
+                        run_response.status = RunStatus.error
+                        flush_in_flight_messages_on_error_team(run_response, run_messages)
+                        if run_response.content is None:
+                            run_response.content = str(e)
+                        log_error(f"Validation failed: {str(e)} | Check trigger: {e.check_trigger}")
+                        _cleanup_and_store(
+                            team, run_response=run_response, session=session, run_context=run_context
+                        )
+                        return run_response
 
                 # Generate model response
                 model_response: ModelResponse = call_model_with_fallback(
@@ -8483,7 +8521,7 @@ def _continue_run_stream(
     **kwargs: Any,
 ) -> Iterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]:
     """Continue a paused team run (sync, streaming)."""
-    from agno.team._hooks import _execute_post_hooks
+    from agno.team._hooks import _execute_post_hooks, _execute_pre_hooks
     from agno.team._init import _disconnect_connectable_tools
     from agno.team._response import (
         _handle_model_response_stream,
@@ -8510,6 +8548,39 @@ def _continue_run_stream(
 
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
+                # Execute pre-hooks (only on first attempt)
+                run_input = cast(TeamRunInput, run_response.input)
+                if attempt == 0 and team.pre_hooks is not None:
+                    try:
+                        pre_hook_iterator = _execute_pre_hooks(
+                            team,
+                            hooks=team.pre_hooks,  # type: ignore
+                            run_response=run_response,
+                            run_input=run_input,
+                            run_context=run_context,
+                            session=session,
+                            user_id=user_id,
+                            debug_mode=debug_mode,
+                            stream_events=stream_events,
+                            background_tasks=background_tasks,
+                            is_continue=True,
+                            **kwargs,
+                        )
+                        for event in pre_hook_iterator:
+                            yield event
+                    except (InputCheckError, OutputCheckError) as e:
+                        run_response.status = RunStatus.error
+                        flush_in_flight_messages_on_error_team(run_response, run_messages)
+                        if run_response.content is None:
+                            run_response.content = str(e)
+                        log_error(f"Validation failed: {str(e)} | Check trigger: {e.check_trigger}")
+                        _cleanup_and_store(
+                            team, run_response=run_response, session=session, run_context=run_context
+                        )
+                        if yield_run_output:
+                            yield run_response
+                        return
+
                 # Handle the updated tools (execute confirmed tools, etc.) with streaming
                 yield from _handle_team_tool_call_updates_stream(
                     team,
@@ -8521,7 +8592,7 @@ def _continue_run_stream(
 
                 # Stream model response
                 if team.output_model is None:
-                    for event in _handle_model_response_stream(
+                    for event in _handle_model_response_stream(  # type: ignore[assignment]
                         team,
                         session=session,
                         run_response=run_response,
@@ -8538,7 +8609,7 @@ def _continue_run_stream(
                 else:
                     from agno.run.team import IntermediateRunContentEvent, RunContentEvent
 
-                    for event in _handle_model_response_stream(
+                    for event in _handle_model_response_stream(  # type: ignore[assignment]
                         team,
                         session=session,
                         run_response=run_response,
@@ -9289,6 +9360,15 @@ def acontinue_run_dispatch(  # type: ignore
     # Initialize the Team
     team.initialize_team(debug_mode=debug_mode)
 
+    # Normalise hooks & guardrails (required for multi-container deployments where
+    # continue_run() may be the first call in a fresh process)
+    if not team._hooks_normalised:
+        if team.pre_hooks:
+            team.pre_hooks = normalize_pre_hooks(team.pre_hooks, async_mode=True)  # type: ignore
+        if team.post_hooks:
+            team.post_hooks = normalize_post_hooks(team.post_hooks, async_mode=True)  # type: ignore
+        team._hooks_normalised = True
+
     # Resolve run options
     opts = resolve_run_options(
         team,
@@ -9423,7 +9503,7 @@ async def _acontinue_run(
     **kwargs: Any,
 ) -> TeamRunOutput:
     """Continue a paused team run (async, non-streaming)."""
-    from agno.team._hooks import _aexecute_post_hooks
+    from agno.team._hooks import _aexecute_post_hooks, _aexecute_pre_hooks
     from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
     from agno.team._telemetry import alog_team_telemetry
     from agno.team._tools import _aget_learning_tools, _check_and_refresh_mcp_tools, _determine_tools_for_model
@@ -9580,6 +9660,39 @@ async def _acontinue_run(
                     _did_snapshot_dispatch = True
 
                 await aregister_run(run_response.run_id)  # type: ignore
+
+                # Execute pre-hooks (only on first attempt)
+                run_input = cast(TeamRunInput, run_response.input)
+                if attempt == 0 and team.pre_hooks is not None:
+                    try:
+                        pre_hook_iterator = _aexecute_pre_hooks(
+                            team,
+                            hooks=team.pre_hooks,  # type: ignore
+                            run_response=run_response,
+                            run_input=run_input,
+                            run_context=run_context,
+                            session=team_session,
+                            user_id=user_id,
+                            debug_mode=debug_mode,
+                            background_tasks=background_tasks,
+                            is_continue=True,
+                            **kwargs,
+                        )
+                        async for _ in pre_hook_iterator:
+                            pass
+                    except (InputCheckError, OutputCheckError) as e:
+                        run_response.status = RunStatus.error
+                        flush_in_flight_messages_on_error_team(run_response, None)
+                        if run_response.content is None:
+                            run_response.content = str(e)
+                        log_error(f"Validation failed: {str(e)} | Check trigger: {e.check_trigger}")
+                        await _acleanup_and_store(
+                            team,
+                            run_response=run_response,
+                            session=team_session,
+                            run_context=run_context,
+                        )
+                        return run_response
 
                 # Emit RunContinued event (matching streaming variant behaviour)
                 from agno.utils.events import create_team_run_continued_event
@@ -9903,7 +10016,7 @@ async def _acontinue_run_stream(
     **kwargs: Any,
 ) -> AsyncIterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]:
     """Continue a paused team run (async, streaming)."""
-    from agno.team._hooks import _aexecute_post_hooks
+    from agno.team._hooks import _aexecute_post_hooks, _aexecute_pre_hooks
     from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
     from agno.team._response import (
         _ahandle_model_response_stream,
@@ -10062,6 +10175,42 @@ async def _acontinue_run_stream(
 
                 await aregister_run(run_response.run_id)  # type: ignore
 
+                # Execute pre-hooks (only on first attempt)
+                run_input = cast(TeamRunInput, run_response.input)
+                if attempt == 0 and team.pre_hooks is not None:
+                    try:
+                        pre_hook_iterator = _aexecute_pre_hooks(
+                            team,
+                            hooks=team.pre_hooks,  # type: ignore
+                            run_response=run_response,
+                            run_input=run_input,
+                            run_context=run_context,
+                            session=team_session,
+                            user_id=user_id,
+                            debug_mode=debug_mode,
+                            stream_events=stream_events,
+                            background_tasks=background_tasks,
+                            is_continue=True,
+                            **kwargs,
+                        )
+                        async for event in pre_hook_iterator:
+                            yield event
+                    except (InputCheckError, OutputCheckError) as e:
+                        run_response.status = RunStatus.error
+                        flush_in_flight_messages_on_error_team(run_response, None)
+                        if run_response.content is None:
+                            run_response.content = str(e)
+                        log_error(f"Validation failed: {str(e)} | Check trigger: {e.check_trigger}")
+                        await _acleanup_and_store(
+                            team,
+                            run_response=run_response,
+                            session=team_session,
+                            run_context=run_context,
+                        )
+                        if yield_run_output:
+                            yield run_response
+                        return
+
                 run_response.requirements = _reclaim_own_requirements(
                     team, run_response.requirements, run_response.run_id
                 )
@@ -10105,7 +10254,7 @@ async def _acontinue_run_stream(
                     run_response.requirements = member_reqs
                     try:
                         # Streaming: use the async generator variant that yields member events
-                        async for event in _aroute_requirements_to_members_stream(
+                        async for event in _aroute_requirements_to_members_stream(  # type: ignore[assignment]
                             team,
                             run_response=run_response,
                             session=team_session,
@@ -10201,7 +10350,7 @@ async def _acontinue_run_stream(
                         )
 
                     # Handle the updated tools (execute confirmed tools, etc.) with streaming
-                    async for event in _ahandle_team_tool_call_updates_stream(
+                    async for event in _ahandle_team_tool_call_updates_stream(  # type: ignore[assignment]
                         team,
                         run_response=run_response,
                         run_messages=run_messages,
@@ -10213,7 +10362,7 @@ async def _acontinue_run_stream(
 
                     # Stream model response
                     if team.output_model is None:
-                        async for event in _ahandle_model_response_stream(
+                        async for event in _ahandle_model_response_stream(  # type: ignore[assignment]
                             team,
                             session=team_session,
                             run_response=run_response,
@@ -10230,7 +10379,7 @@ async def _acontinue_run_stream(
                     else:
                         from agno.run.team import IntermediateRunContentEvent, RunContentEvent
 
-                        async for event in _ahandle_model_response_stream(
+                        async for event in _ahandle_model_response_stream(  # type: ignore[assignment]
                             team,
                             session=team_session,
                             run_response=run_response,
@@ -10332,7 +10481,7 @@ async def _acontinue_run_stream(
 
                     # Stream model response
                     if team.output_model is None:
-                        async for event in _ahandle_model_response_stream(
+                        async for event in _ahandle_model_response_stream(  # type: ignore[assignment]
                             team,
                             session=team_session,
                             run_response=run_response,
@@ -10349,7 +10498,7 @@ async def _acontinue_run_stream(
                     else:
                         from agno.run.team import IntermediateRunContentEvent, RunContentEvent
 
-                        async for event in _ahandle_model_response_stream(
+                        async for event in _ahandle_model_response_stream(  # type: ignore[assignment]
                             team,
                             session=team_session,
                             run_response=run_response,

--- a/libs/agno/agno/utils/hooks.py
+++ b/libs/agno/agno/utils/hooks.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 from agno.eval.base import BaseEval
 from agno.guardrails.base import BaseGuardrail
-from agno.hooks.decorator import HOOK_RUN_IN_BACKGROUND_ATTR
+from agno.hooks.decorator import HOOK_RUN_IN_BACKGROUND_ATTR, HOOK_RUN_ON_CONTINUE_ATTR
 from agno.utils.log import log_warning
 
 # Keys that should be deep copied for background hooks to prevent race conditions
@@ -58,6 +58,21 @@ def should_run_hook_in_background(hook: Callable[..., Any]) -> bool:
         True if the hook is decorated with @hook(run_in_background=True)
     """
     return getattr(hook, HOOK_RUN_IN_BACKGROUND_ATTR, False)
+
+
+def should_run_on_continue(hook: Callable[..., Any]) -> bool:
+    """
+    Check if a hook function should run on continue_run().
+
+    This checks for the _agno_run_on_continue attribute set by the @hook decorator.
+
+    Args:
+        hook: The hook function to check
+
+    Returns:
+        True if the hook is decorated with @hook(run_on_continue=True)
+    """
+    return getattr(hook, HOOK_RUN_ON_CONTINUE_ATTR, False)
 
 
 def is_guardrail_hook(hook: Callable[..., Any]) -> bool:

--- a/libs/agno/tests/unit/agent/test_continue_run_pre_hooks.py
+++ b/libs/agno/tests/unit/agent/test_continue_run_pre_hooks.py
@@ -1,0 +1,581 @@
+"""Tests for pre-hook execution on Agent continue_run paths.
+
+Pre-hooks are opt-in on continue_run — by default they skip since the input was
+already validated on the initial run(). Hooks that need to run on continue_run
+must be decorated with @hook(run_on_continue=True).
+"""
+
+import asyncio
+
+import agno.agent._messages as agent_messages
+import agno.agent._response as agent_response
+import agno.agent._storage as agent_storage
+import agno.agent._telemetry as agent_telemetry
+import agno.agent._tools as agent_tools
+from agno.agent import _run as agent_run
+from agno.agent.agent import Agent
+from agno.exceptions import InputCheckError
+from agno.hooks import hook
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+from agno.run import RunContext, RunStatus
+from agno.run.agent import RunInput, RunOutput
+from agno.run.messages import RunMessages
+from agno.session import AgentSession
+
+
+def _make_paused_run() -> RunOutput:
+    return RunOutput(
+        run_id="run-1",
+        session_id="session-1",
+        status=RunStatus.paused,
+        input=RunInput(input_content="original question"),
+        messages=[Message(role="user", content="original question")],
+    )
+
+
+def _make_run_context() -> RunContext:
+    return RunContext(run_id="run-1", session_id="session-1", user_id="user-1")
+
+
+def _make_session() -> AgentSession:
+    return AgentSession(session_id="session-1", user_id="user-1")
+
+
+def _make_run_messages() -> RunMessages:
+    return RunMessages(messages=[Message(role="user", content="original question")])
+
+
+def _patch_sync_model(monkeypatch):
+    """Stub the model call so it records invocations instead of hitting an LLM."""
+    calls = []
+
+    def fake_model(*args, **kwargs):
+        calls.append(1)
+        return ModelResponse(role="assistant", content="continued")
+
+    monkeypatch.setattr(agent_run, "call_model_with_fallback", fake_model)
+    return calls
+
+
+def _empty_generator(*args, **kwargs):
+    return
+    yield
+
+
+async def _empty_async_generator(*args, **kwargs):
+    return
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Sync, non-streaming (_continue_run)
+# ---------------------------------------------------------------------------
+
+
+def test_continue_run_executes_pre_hooks(monkeypatch):
+    calls = []
+
+    @hook(run_on_continue=True)
+    def pre_hook(run_input=None, session=None, user_id=None):
+        calls.append({"session_id": getattr(session, "session_id", None), "user_id": user_id})
+
+    agent = Agent(name="hook-test-agent", pre_hooks=[pre_hook])
+    _patch_sync_model(monkeypatch)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    result = agent_run._continue_run(
+        agent,
+        run_response=_make_paused_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        session=_make_session(),
+        tools=[],
+        user_id="user-1",
+    )
+
+    assert result.status == RunStatus.completed
+    assert calls == [{"session_id": "session-1", "user_id": "user-1"}]
+
+
+def test_continue_run_pre_hook_guardrail_blocks_model_call(monkeypatch):
+    """A guardrail raising InputCheckError in a pre-hook must prevent the model
+    loop on continue_run, with the same error behavior as run()."""
+
+    @hook(run_on_continue=True)
+    def blocking_hook(run_input=None):
+        raise InputCheckError("authz denied on resume")
+
+    agent = Agent(name="guard-test-agent", pre_hooks=[blocking_hook])
+    model_calls = _patch_sync_model(monkeypatch)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    result = agent_run._continue_run(
+        agent,
+        run_response=_make_paused_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        session=_make_session(),
+        tools=[],
+        user_id="user-1",
+    )
+
+    assert model_calls == [], "model must not be invoked when a pre-hook guardrail fails"
+    assert result.status == RunStatus.error
+    assert "authz denied on resume" in str(result.content)
+
+
+# ---------------------------------------------------------------------------
+# Sync, streaming (_continue_run_stream)
+# ---------------------------------------------------------------------------
+
+
+def test_continue_run_stream_executes_pre_hooks(monkeypatch):
+    calls = []
+
+    @hook(run_on_continue=True)
+    def pre_hook(run_input=None, session=None, user_id=None):
+        calls.append(getattr(session, "session_id", None))
+
+    agent = Agent(name="hook-test-agent-stream", pre_hooks=[pre_hook])
+    monkeypatch.setattr(agent_response, "handle_model_response_stream", _empty_generator)
+    monkeypatch.setattr(agent_response, "parse_response_with_parser_model_stream", _empty_generator)
+    monkeypatch.setattr(agent_response, "generate_followups_stream", _empty_generator)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    list(
+        agent_run._continue_run_stream(
+            agent,
+            run_response=_make_paused_run(),
+            run_messages=_make_run_messages(),
+            run_context=_make_run_context(),
+            session=_make_session(),
+            tools=[],
+            user_id="user-1",
+        )
+    )
+
+    assert calls == ["session-1"]
+
+
+def test_continue_run_stream_pre_hook_guardrail_blocks_model_stream(monkeypatch):
+    @hook(run_on_continue=True)
+    def blocking_hook(run_input=None):
+        raise InputCheckError("authz denied on resume")
+
+    agent = Agent(name="guard-test-agent-stream", pre_hooks=[blocking_hook])
+    model_stream_calls = []
+
+    def recording_model_stream(*args, **kwargs):
+        model_stream_calls.append(1)
+        return
+        yield
+
+    monkeypatch.setattr(agent_response, "handle_model_response_stream", recording_model_stream)
+    monkeypatch.setattr(agent_response, "parse_response_with_parser_model_stream", _empty_generator)
+    monkeypatch.setattr(agent_response, "generate_followups_stream", _empty_generator)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    list(
+        agent_run._continue_run_stream(
+            agent,
+            run_response=_make_paused_run(),
+            run_messages=_make_run_messages(),
+            run_context=_make_run_context(),
+            session=_make_session(),
+            tools=[],
+            user_id="user-1",
+        )
+    )
+
+    assert model_stream_calls == [], "model stream must not be invoked when a pre-hook guardrail fails"
+
+
+# ---------------------------------------------------------------------------
+# Async, non-streaming (_acontinue_run)
+# ---------------------------------------------------------------------------
+
+
+def _patch_async_storage_and_tail(monkeypatch, model_calls):
+    async def fake_session(agent, session_id=None, user_id=None):
+        return AgentSession(session_id=session_id, user_id=user_id)
+
+    async def fake_model(*args, **kwargs):
+        model_calls.append(1)
+        return ModelResponse(role="assistant", content="continued")
+
+    async def async_noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(agent_storage, "aread_or_create_session", fake_session)
+    monkeypatch.setattr(agent_storage, "load_session_state", lambda *a, **k: k.get("session_state") or {})
+    monkeypatch.setattr(agent_storage, "update_metadata", lambda *a, **k: None)
+    monkeypatch.setattr(agent_tools, "determine_tools_for_model", lambda *a, **k: [])
+    monkeypatch.setattr(
+        agent_messages,
+        "get_continue_run_messages",
+        lambda *a, **k: _make_run_messages(),
+    )
+    monkeypatch.setattr(agent_run, "acall_model_with_fallback", fake_model)
+    monkeypatch.setattr(agent_run, "acleanup_and_store", async_noop)
+    monkeypatch.setattr(agent_telemetry, "alog_agent_telemetry", async_noop)
+
+
+def test_acontinue_run_executes_pre_hooks(monkeypatch):
+    async def main():
+        calls = []
+
+        @hook(run_on_continue=True)
+        async def pre_hook(run_input=None, session=None):
+            calls.append(getattr(session, "session_id", None))
+
+        agent = Agent(name="hook-test-agent-async", pre_hooks=[pre_hook])
+        model_calls = []
+        _patch_async_storage_and_tail(monkeypatch, model_calls)
+
+        result = await agent_run._acontinue_run(
+            agent,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_run(),
+            updated_tools=[],
+            user_id="user-1",
+        )
+
+        assert result.status == RunStatus.completed
+        assert model_calls == [1]
+        assert calls == ["session-1"]
+
+    asyncio.run(main())
+
+
+def test_acontinue_run_pre_hook_guardrail_blocks_model_call(monkeypatch):
+    async def main():
+        @hook(run_on_continue=True)
+        def blocking_hook(run_input=None):
+            raise InputCheckError("authz denied on resume")
+
+        agent = Agent(name="guard-test-agent-async", pre_hooks=[blocking_hook])
+        model_calls = []
+        _patch_async_storage_and_tail(monkeypatch, model_calls)
+
+        result = await agent_run._acontinue_run(
+            agent,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_run(),
+            updated_tools=[],
+            user_id="user-1",
+        )
+
+        assert model_calls == [], "model must not be invoked when a pre-hook guardrail fails"
+        assert result.status == RunStatus.error
+        assert "authz denied on resume" in str(result.content)
+
+    asyncio.run(main())
+
+
+# ---------------------------------------------------------------------------
+# Async, streaming (_acontinue_run_stream)
+# ---------------------------------------------------------------------------
+
+
+def test_acontinue_run_stream_executes_pre_hooks(monkeypatch):
+    async def main():
+        calls = []
+
+        @hook(run_on_continue=True)
+        async def pre_hook(run_input=None, session=None):
+            calls.append(getattr(session, "session_id", None))
+
+        agent = Agent(name="hook-test-agent-async-stream", pre_hooks=[pre_hook])
+        model_calls = []
+        _patch_async_storage_and_tail(monkeypatch, model_calls)
+        monkeypatch.setattr(agent_response, "ahandle_model_response_stream", _empty_async_generator)
+        monkeypatch.setattr(agent_response, "aparse_response_with_parser_model_stream", _empty_async_generator)
+        monkeypatch.setattr(agent_response, "agenerate_followups_stream", _empty_async_generator)
+
+        async for _ in agent_run._acontinue_run_stream(
+            agent,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_run(),
+            updated_tools=[],
+            user_id="user-1",
+        ):
+            pass
+
+        assert calls == ["session-1"]
+
+    asyncio.run(main())
+
+
+# ---------------------------------------------------------------------------
+# Background hooks mode (run_hooks_in_background=True)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBackgroundTasks:
+    """Minimal stand-in for fastapi.BackgroundTasks."""
+
+    def __init__(self):
+        self.queued = []
+
+    def add_task(self, func, **kwargs):
+        self.queued.append(func)
+
+
+def test_continue_run_background_mode_queues_non_guardrail_hooks(monkeypatch):
+    """With background mode on, non-guardrail pre-hooks must be queued (not run
+    inline) on continue_run — they must not silently vanish."""
+    executed = []
+
+    @hook(run_on_continue=True)
+    def audit_hook(run_input=None, session=None):
+        executed.append(1)
+
+    agent = Agent(name="bg-continue-agent", pre_hooks=[audit_hook])
+    agent._run_hooks_in_background = True
+    _patch_sync_model(monkeypatch)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+    background_tasks = _FakeBackgroundTasks()
+
+    result = agent_run._continue_run(
+        agent,
+        run_response=_make_paused_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        session=_make_session(),
+        tools=[],
+        user_id="user-1",
+        background_tasks=background_tasks,
+    )
+
+    assert result.status == RunStatus.completed
+    assert executed == [], "non-guardrail pre-hook must not run inline in background mode"
+    assert background_tasks.queued == [audit_hook], "pre-hook should be queued for background execution"
+
+
+def test_continue_run_background_mode_guardrail_runs_sync_and_blocks(monkeypatch):
+    """Guardrail-shaped pre-hooks must still run synchronously in background mode
+    so rejection propagates before the model loop (same as run())."""
+    from agno.guardrails.base import BaseGuardrail
+
+    class BlockingGuardrail(BaseGuardrail):
+        def check(self, run_input=None):
+            raise InputCheckError("blocked on resume")
+
+        async def async_check(self, run_input=None):
+            raise InputCheckError("blocked on resume (async)")
+
+    agent = Agent(name="bg-guard-agent", pre_hooks=[BlockingGuardrail().check])
+    agent._run_hooks_in_background = True
+    model_calls = _patch_sync_model(monkeypatch)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+    background_tasks = _FakeBackgroundTasks()
+
+    result = agent_run._continue_run(
+        agent,
+        run_response=_make_paused_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        session=_make_session(),
+        tools=[],
+        user_id="user-1",
+        background_tasks=background_tasks,
+    )
+
+    assert model_calls == [], "guardrail must block the model call even in background mode"
+    assert result.status == RunStatus.error
+    assert "blocked on resume" in str(result.content)
+    assert background_tasks.queued == [], "no hooks should be queued once a guardrail rejects"
+
+
+def test_acontinue_run_background_mode_guardrail_runs_sync_and_blocks(monkeypatch):
+    async def main():
+        from agno.guardrails.base import BaseGuardrail
+
+        class BlockingGuardrail(BaseGuardrail):
+            def check(self, run_input=None):
+                raise InputCheckError("blocked on resume")
+
+            async def async_check(self, run_input=None):
+                raise InputCheckError("blocked on resume (async)")
+
+        agent = Agent(name="bg-guard-agent-async", pre_hooks=[BlockingGuardrail().check])
+        agent._run_hooks_in_background = True
+        model_calls = []
+        _patch_async_storage_and_tail(monkeypatch, model_calls)
+        background_tasks = _FakeBackgroundTasks()
+
+        result = await agent_run._acontinue_run(
+            agent,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_run(),
+            updated_tools=[],
+            user_id="user-1",
+            background_tasks=background_tasks,
+        )
+
+        assert model_calls == [], "guardrail must block the model call even in background mode"
+        assert result.status == RunStatus.error
+        assert "blocked on resume" in str(result.content)
+
+    asyncio.run(main())
+
+
+# ---------------------------------------------------------------------------
+# Streaming hook events (stream_events=True)
+# ---------------------------------------------------------------------------
+
+
+def test_continue_run_stream_emits_pre_hook_events(monkeypatch):
+    """With stream_events=True, continue_run must emit the same hook lifecycle
+    events as run()."""
+    calls = []
+
+    @hook(run_on_continue=True)
+    def pre_hook(run_input=None, session=None):
+        calls.append(1)
+
+    agent = Agent(name="stream-ev-agent", pre_hooks=[pre_hook])
+    monkeypatch.setattr(agent_response, "handle_model_response_stream", _empty_generator)
+    monkeypatch.setattr(agent_response, "parse_response_with_parser_model_stream", _empty_generator)
+    monkeypatch.setattr(agent_response, "generate_followups_stream", _empty_generator)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    events = list(
+        agent_run._continue_run_stream(
+            agent,
+            run_response=_make_paused_run(),
+            run_messages=_make_run_messages(),
+            run_context=_make_run_context(),
+            session=_make_session(),
+            tools=[],
+            user_id="user-1",
+            stream_events=True,
+        )
+    )
+
+    assert calls == [1]
+    event_names = [type(e).__name__ for e in events]
+    assert any(name.startswith("PreHookStarted") for name in event_names), event_names
+    assert any(name.startswith("PreHookCompleted") for name in event_names), event_names
+
+
+# ---------------------------------------------------------------------------
+# @hook(run_on_continue=True) decorator filtering
+# ---------------------------------------------------------------------------
+
+
+def test_continue_run_skips_pre_hooks_by_default(monkeypatch):
+    """Hooks without @hook(run_on_continue=True) are skipped on continue_run."""
+    calls = []
+
+    def pre_hook(run_input=None, session=None):
+        calls.append(1)
+
+    agent = Agent(name="default-skip-hook-agent", pre_hooks=[pre_hook])
+    _patch_sync_model(monkeypatch)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    result = agent_run._continue_run(
+        agent,
+        run_response=_make_paused_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        session=_make_session(),
+        tools=[],
+        user_id="user-1",
+    )
+
+    assert result.status == RunStatus.completed
+    assert calls == [], "pre-hooks should be skipped by default on continue_run"
+
+
+def test_continue_run_runs_pre_hooks_when_decorated(monkeypatch):
+    """Pre-hooks decorated with @hook(run_on_continue=True) run on continue_run."""
+    calls = []
+
+    @hook(run_on_continue=True)
+    def opt_in_hook(run_input=None, session=None):
+        calls.append("opt_in")
+
+    def regular_hook(run_input=None, session=None):
+        calls.append("regular")
+
+    agent = Agent(name="mixed-hooks-agent", pre_hooks=[opt_in_hook, regular_hook])
+    _patch_sync_model(monkeypatch)
+    monkeypatch.setattr(agent_run, "cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(agent_telemetry, "log_agent_telemetry", lambda *a, **k: None)
+
+    result = agent_run._continue_run(
+        agent,
+        run_response=_make_paused_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        session=_make_session(),
+        tools=[],
+        user_id="user-1",
+    )
+
+    assert result.status == RunStatus.completed
+    assert calls == ["opt_in"], "only hooks with @hook(run_on_continue=True) should run"
+
+
+# ---------------------------------------------------------------------------
+# Decorator attribute tests
+# ---------------------------------------------------------------------------
+
+
+def test_decorator_combined_options():
+    """@hook with both run_in_background and run_on_continue works."""
+    from agno.hooks.decorator import should_run_in_background, should_run_on_continue
+
+    @hook(run_in_background=True, run_on_continue=True)
+    def background_audit(run_input=None):
+        pass
+
+    assert should_run_in_background(background_audit) is True
+    assert should_run_on_continue(background_audit) is True
+
+
+def test_decorator_default_false():
+    """Hooks without decorator return False for should_run_on_continue."""
+    from agno.hooks.decorator import should_run_on_continue
+
+    def plain_hook():
+        pass
+
+    assert should_run_on_continue(plain_hook) is False
+
+
+def test_decorator_bare_hook():
+    """@hook without parentheses returns False for run_on_continue."""
+    from agno.hooks.decorator import should_run_on_continue
+
+    @hook
+    def bare_hook():
+        pass
+
+    assert should_run_on_continue(bare_hook) is False
+
+
+def test_decorator_async_hook():
+    """Async hooks work with @hook(run_on_continue=True)."""
+    from agno.hooks.decorator import should_run_on_continue
+
+    @hook(run_on_continue=True)
+    async def async_hook():
+        pass
+
+    assert should_run_on_continue(async_hook) is True

--- a/libs/agno/tests/unit/team/test_continue_run_event_ordering.py
+++ b/libs/agno/tests/unit/team/test_continue_run_event_ordering.py
@@ -1,0 +1,207 @@
+"""Test event ordering on Team continue_run paths.
+
+Verifies RunContinued event is emitted BEFORE ToolCall events, matching Agent.
+"""
+
+import inspect
+
+import pytest
+
+from agno.models.message import Message
+from agno.models.response import ToolExecution
+from agno.run import RunContext, RunStatus
+from agno.run.team import (
+    RunContinuedEvent,
+    TeamRunInput,
+    TeamRunOutput,
+    ToolCallStartedEvent,
+)
+from agno.session import TeamSession
+
+
+def _create_paused_team_run() -> TeamRunOutput:
+    """Create a mock paused run with a confirmed tool."""
+    return TeamRunOutput(
+        run_id="test-run-123",
+        session_id="test-session",
+        team_id="test-team",
+        team_name="Test Team",
+        status=RunStatus.paused,
+        tools=[
+            ToolExecution(
+                tool_name="dangerous_action",
+                tool_args={"action": "test"},
+                tool_call_id="call_123",
+                requires_confirmation=True,
+                confirmed=True,
+                result=None,
+            )
+        ],
+        input=TeamRunInput(input_content="Do something dangerous"),
+        messages=[
+            Message(role="user", content="Do something dangerous"),
+            Message(role="assistant", content="I need confirmation"),
+        ],
+    )
+
+
+def test_code_order_run_continued_before_tool_updates():
+    """Verify source code has RunContinued before tool_call_updates_stream."""
+    from agno.team._run import _continue_run_stream
+
+    source = inspect.getsource(_continue_run_stream)
+    lines = source.split("\n")
+
+    tool_updates_line = None
+    run_continued_line = None
+
+    for i, line in enumerate(lines):
+        if "_handle_team_tool_call_updates_stream" in line and "yield" in line:
+            tool_updates_line = i
+        if "create_team_run_continued_event" in line:
+            run_continued_line = i
+
+    assert tool_updates_line is not None, "Could not find _handle_team_tool_call_updates_stream"
+    assert run_continued_line is not None, "Could not find create_team_run_continued_event"
+    assert run_continued_line < tool_updates_line, (
+        f"RunContinued (line {run_continued_line}) should come BEFORE tool_updates (line {tool_updates_line})"
+    )
+
+
+def test_sync_stream_event_order(monkeypatch):
+    """Test _continue_run_stream emits RunContinued before ToolCall events."""
+    from unittest.mock import MagicMock
+
+    from agno.models.response import ModelResponse
+    from agno.run.messages import RunMessages
+    from agno.team._run import _continue_run_stream
+    from agno.tools.function import Function
+
+    def dangerous_action(action: str) -> str:
+        return f"Executed: {action}"
+
+    func = Function(
+        name="dangerous_action",
+        description="A dangerous action.",
+        entrypoint=dangerous_action,
+        requires_confirmation=True,
+    )
+
+    mock_team = MagicMock()
+    mock_team.name = "Test Team"
+    mock_team.id = "test-team"
+    mock_team.retries = 0
+    mock_team.events_to_skip = []
+    mock_team.store_events = True
+    mock_team.pre_hooks = None
+    mock_team.post_hooks = None
+    mock_team._hooks_normalised = True
+    mock_team.output_model = None
+    mock_team.parser_model = None
+    mock_team.enable_session_summaries = False
+    mock_team.tool_choice = None
+    mock_team.tool_call_limit = None
+    mock_team.send_media_to_model = False
+    mock_team.compress_tool_results = False
+    mock_team.fallback_config = None
+    mock_team.model = MagicMock()
+    mock_team.model.response.return_value = ModelResponse(content="Done!")
+
+    run_response = _create_paused_team_run()
+    run_messages = RunMessages(messages=list(run_response.messages or []))
+    run_context = RunContext(run_id=run_response.run_id, session_id=run_response.session_id)
+    session = TeamSession(session_id=run_response.session_id)
+
+    events = []
+    try:
+        for event in _continue_run_stream(
+            team=mock_team,
+            run_response=run_response,
+            run_messages=run_messages,
+            run_context=run_context,
+            tools=[func],
+            session=session,
+            stream_events=True,
+        ):
+            events.append(event)
+    except Exception:
+        pass  # May fail due to incomplete mocking
+
+    run_continued_indices = [i for i, e in enumerate(events) if isinstance(e, RunContinuedEvent)]
+    tool_started_indices = [i for i, e in enumerate(events) if isinstance(e, ToolCallStartedEvent)]
+
+    if run_continued_indices and tool_started_indices:
+        assert min(run_continued_indices) < min(tool_started_indices), (
+            f"RunContinued ({min(run_continued_indices)}) must come BEFORE "
+            f"ToolCallStarted ({min(tool_started_indices)})"
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_stream_event_order(monkeypatch):
+    """Test _acontinue_run_stream emits RunContinued before ToolCall events."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from agno.models.response import ModelResponse
+    from agno.run.messages import RunMessages
+    from agno.team._run import _acontinue_run_stream
+    from agno.tools.function import Function
+
+    def dangerous_action(action: str) -> str:
+        return f"Executed: {action}"
+
+    func = Function(
+        name="dangerous_action",
+        description="A dangerous action.",
+        entrypoint=dangerous_action,
+        requires_confirmation=True,
+    )
+
+    mock_team = MagicMock()
+    mock_team.name = "Test Team"
+    mock_team.id = "test-team"
+    mock_team.retries = 0
+    mock_team.events_to_skip = []
+    mock_team.store_events = True
+    mock_team.pre_hooks = None
+    mock_team.post_hooks = None
+    mock_team._hooks_normalised = True
+    mock_team.output_model = None
+    mock_team.parser_model = None
+    mock_team.enable_session_summaries = False
+    mock_team.tool_choice = None
+    mock_team.tool_call_limit = None
+    mock_team.send_media_to_model = False
+    mock_team.compress_tool_results = False
+    mock_team.fallback_config = None
+    mock_team.model = MagicMock()
+    mock_team.model.aresponse = AsyncMock(return_value=ModelResponse(content="Done!"))
+
+    run_response = _create_paused_team_run()
+    run_messages = RunMessages(messages=list(run_response.messages or []))
+    run_context = RunContext(run_id=run_response.run_id, session_id=run_response.session_id)
+    session = TeamSession(session_id=run_response.session_id)
+
+    events = []
+    try:
+        async for event in _acontinue_run_stream(
+            team=mock_team,
+            run_response=run_response,
+            run_messages=run_messages,
+            run_context=run_context,
+            tools=[func],
+            session=session,
+            stream_events=True,
+        ):
+            events.append(event)
+    except Exception:
+        pass  # May fail due to incomplete mocking
+
+    run_continued_indices = [i for i, e in enumerate(events) if isinstance(e, RunContinuedEvent)]
+    tool_started_indices = [i for i, e in enumerate(events) if isinstance(e, ToolCallStartedEvent)]
+
+    if run_continued_indices and tool_started_indices:
+        assert min(run_continued_indices) < min(tool_started_indices), (
+            f"RunContinued ({min(run_continued_indices)}) must come BEFORE "
+            f"ToolCallStarted ({min(tool_started_indices)})"
+        )

--- a/libs/agno/tests/unit/team/test_continue_run_pre_hooks.py
+++ b/libs/agno/tests/unit/team/test_continue_run_pre_hooks.py
@@ -1,0 +1,377 @@
+"""Tests for pre-hook execution on Team continue_run paths.
+
+Regression coverage for the gap where run()/arun() execute pre_hooks but
+continue_run()/acontinue_run() (and their streaming variants) used to skip
+them — allowing HITL-resumed team runs to bypass guardrail/authz hooks.
+
+On continue_run, only hooks decorated with @hook(run_on_continue=True) or
+guardrails execute. Plain hooks are skipped since input was already validated.
+"""
+
+import asyncio
+
+import agno.team._telemetry as team_telemetry
+from agno.exceptions import InputCheckError
+from agno.hooks import hook
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+from agno.run import RunContext, RunStatus
+from agno.run.messages import RunMessages
+from agno.run.team import TeamRunInput, TeamRunOutput
+from agno.session import TeamSession
+from agno.team import _run as team_run
+from agno.team.team import Team
+
+
+def _make_paused_team_run() -> TeamRunOutput:
+    return TeamRunOutput(
+        run_id="run-1",
+        session_id="session-1",
+        status=RunStatus.paused,
+        input=TeamRunInput(input_content="original team question"),
+        messages=[Message(role="user", content="original team question")],
+    )
+
+
+def _make_run_context() -> RunContext:
+    return RunContext(run_id="run-1", session_id="session-1", user_id="user-1")
+
+
+def _make_team_session() -> TeamSession:
+    return TeamSession(session_id="session-1", user_id="user-1")
+
+
+def _make_run_messages() -> RunMessages:
+    return RunMessages(messages=[Message(role="user", content="original team question")])
+
+
+def _patch_team_sync_model(monkeypatch):
+    calls = []
+
+    def fake_model(*args, **kwargs):
+        calls.append(1)
+        return ModelResponse(role="assistant", content="continued")
+
+    monkeypatch.setattr(team_run, "call_model_with_fallback", fake_model)
+    return calls
+
+
+async def _empty_async_generator(*args, **kwargs):
+    return
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Sync, non-streaming (_continue_run)
+# ---------------------------------------------------------------------------
+
+
+def test_team_continue_run_executes_pre_hooks(monkeypatch):
+    calls = []
+
+    @hook(run_on_continue=True)
+    def pre_hook(run_input=None, session=None, user_id=None):
+        calls.append({"session_id": getattr(session, "session_id", None), "user_id": user_id})
+
+    team = Team(name="hook-test-team", members=[], pre_hooks=[pre_hook])
+    _patch_team_sync_model(monkeypatch)
+    monkeypatch.setattr(team_run, "_cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(team_telemetry, "log_team_telemetry", lambda *a, **k: None)
+
+    result = team_run._continue_run(
+        team,
+        run_response=_make_paused_team_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        tools=[],
+        session=_make_team_session(),
+        user_id="user-1",
+    )
+
+    assert result.status == RunStatus.completed
+    assert calls == [{"session_id": "session-1", "user_id": "user-1"}]
+
+
+def test_team_continue_run_pre_hook_guardrail_blocks_model_call(monkeypatch):
+    @hook(run_on_continue=True)
+    def blocking_hook(run_input=None):
+        raise InputCheckError("authz denied on team resume")
+
+    team = Team(name="guard-test-team", members=[], pre_hooks=[blocking_hook])
+    model_calls = _patch_team_sync_model(monkeypatch)
+    monkeypatch.setattr(team_run, "_cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(team_telemetry, "log_team_telemetry", lambda *a, **k: None)
+
+    result = team_run._continue_run(
+        team,
+        run_response=_make_paused_team_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        tools=[],
+        session=_make_team_session(),
+        user_id="user-1",
+    )
+
+    assert model_calls == [], "model must not be invoked when a pre-hook guardrail fails"
+    assert result.status == RunStatus.error
+    assert "authz denied on team resume" in str(result.content)
+
+
+# ---------------------------------------------------------------------------
+# Sync, streaming (_continue_run_stream)
+# ---------------------------------------------------------------------------
+
+
+def test_team_continue_run_stream_executes_pre_hooks(monkeypatch):
+    calls = []
+
+    @hook(run_on_continue=True)
+    def pre_hook(run_input=None, session=None, user_id=None):
+        calls.append(getattr(session, "session_id", None))
+
+    team = Team(name="hook-test-team-stream", members=[], pre_hooks=[pre_hook])
+
+    def empty_model_stream(*args, **kwargs):
+        return
+        yield
+
+    import agno.team._response as team_response
+
+    monkeypatch.setattr(team_response, "_handle_model_response_stream", empty_model_stream)
+    monkeypatch.setattr(team_response, "parse_response_with_parser_model_stream", empty_model_stream)
+    monkeypatch.setattr(team_response, "generate_response_with_output_model_stream", empty_model_stream)
+    monkeypatch.setattr(team_run, "_cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(team_telemetry, "log_team_telemetry", lambda *a, **k: None)
+
+    list(
+        team_run._continue_run_stream(
+            team,
+            run_response=_make_paused_team_run(),
+            run_messages=_make_run_messages(),
+            run_context=_make_run_context(),
+            tools=[],
+            session=_make_team_session(),
+            user_id="user-1",
+        )
+    )
+
+    assert calls == ["session-1"]
+
+
+# ---------------------------------------------------------------------------
+# Async, non-streaming (_acontinue_run)
+# ---------------------------------------------------------------------------
+
+
+def test_team_acontinue_run_executes_pre_hooks(monkeypatch):
+    async def main():
+        calls = []
+
+        @hook(run_on_continue=True)
+        async def pre_hook(run_input=None, session=None):
+            calls.append(getattr(session, "session_id", None))
+
+        team = Team(name="hook-test-team-async", members=[], pre_hooks=[pre_hook])
+
+        async def fake_session(team, run_context=None, session_id=None, user_id=None, run_id=None):
+            return TeamSession(session_id=session_id, user_id=user_id)
+
+        model_calls = []
+
+        async def fake_model(*args, **kwargs):
+            model_calls.append(1)
+            return ModelResponse(role="assistant", content="continued")
+
+        async def async_noop(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(team_run, "_asetup_session", fake_session)
+        monkeypatch.setattr(team_run, "acall_model_with_fallback", fake_model)
+        monkeypatch.setattr(team_run, "_acleanup_and_store", async_noop)
+        monkeypatch.setattr(team_telemetry, "alog_team_telemetry", async_noop)
+
+        result = await team_run._acontinue_run(
+            team,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_team_run(),
+            requirements=[],
+            user_id="user-1",
+        )
+
+        assert result.status == RunStatus.completed
+        assert model_calls == [1]
+        assert calls == ["session-1"]
+
+    asyncio.run(main())
+
+
+def test_team_acontinue_run_pre_hook_guardrail_blocks(monkeypatch):
+    async def main():
+        @hook(run_on_continue=True)
+        def blocking_hook(run_input=None):
+            raise InputCheckError("authz denied on team resume")
+
+        team = Team(name="guard-test-team-async", members=[], pre_hooks=[blocking_hook])
+
+        async def fake_session(team, run_context=None, session_id=None, user_id=None, run_id=None):
+            return TeamSession(session_id=session_id, user_id=user_id)
+
+        model_calls = []
+
+        async def fake_model(*args, **kwargs):
+            model_calls.append(1)
+            return ModelResponse(role="assistant", content="continued")
+
+        async def async_noop(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(team_run, "_asetup_session", fake_session)
+        monkeypatch.setattr(team_run, "acall_model_with_fallback", fake_model)
+        monkeypatch.setattr(team_run, "_acleanup_and_store", async_noop)
+        monkeypatch.setattr(team_telemetry, "alog_team_telemetry", async_noop)
+
+        result = await team_run._acontinue_run(
+            team,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_team_run(),
+            requirements=[],
+            user_id="user-1",
+        )
+
+        assert model_calls == [], "model must not be invoked when a pre-hook guardrail fails"
+        assert result.status == RunStatus.error
+        assert "authz denied on team resume" in str(result.content)
+
+    asyncio.run(main())
+
+
+# ---------------------------------------------------------------------------
+# Async, streaming (_acontinue_run_stream)
+# ---------------------------------------------------------------------------
+
+
+def test_team_acontinue_run_stream_executes_pre_hooks(monkeypatch):
+    async def main():
+        calls = []
+
+        @hook(run_on_continue=True)
+        async def pre_hook(run_input=None, session=None):
+            calls.append(getattr(session, "session_id", None))
+
+        team = Team(name="hook-test-team-async-stream", members=[], pre_hooks=[pre_hook])
+
+        async def fake_session(team, run_context=None, session_id=None, user_id=None, run_id=None):
+            return TeamSession(session_id=session_id, user_id=user_id)
+
+        async def async_noop(*args, **kwargs):
+            return None
+
+        import agno.team._response as team_response
+
+        monkeypatch.setattr(team_run, "_asetup_session", fake_session)
+        monkeypatch.setattr(team_response, "_ahandle_model_response_stream", _empty_async_generator)
+        monkeypatch.setattr(team_response, "aparse_response_with_parser_model_stream", _empty_async_generator)
+        monkeypatch.setattr(team_response, "agenerate_response_with_output_model_stream", _empty_async_generator)
+        monkeypatch.setattr(team_run, "_acleanup_and_store", async_noop)
+        monkeypatch.setattr(team_telemetry, "alog_team_telemetry", async_noop)
+
+        async for _ in team_run._acontinue_run_stream(
+            team,
+            session_id="session-1",
+            run_context=_make_run_context(),
+            run_response=_make_paused_team_run(),
+            requirements=[],
+            user_id="user-1",
+        ):
+            pass
+
+        assert calls == ["session-1"]
+
+    asyncio.run(main())
+
+
+# ---------------------------------------------------------------------------
+# Background hooks mode (run_hooks_in_background=True)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBackgroundTasks:
+    """Minimal stand-in for fastapi.BackgroundTasks."""
+
+    def __init__(self):
+        self.queued = []
+
+    def add_task(self, func, **kwargs):
+        self.queued.append(func)
+
+
+def test_team_continue_run_background_mode_queues_non_guardrail_hooks(monkeypatch):
+    executed = []
+
+    @hook(run_on_continue=True)
+    def audit_hook(run_input=None, session=None):
+        executed.append(1)
+
+    team = Team(name="bg-continue-team", members=[], pre_hooks=[audit_hook])
+    team._run_hooks_in_background = True
+    _patch_team_sync_model(monkeypatch)
+    monkeypatch.setattr(team_run, "_cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(team_telemetry, "log_team_telemetry", lambda *a, **k: None)
+    background_tasks = _FakeBackgroundTasks()
+
+    result = team_run._continue_run(
+        team,
+        run_response=_make_paused_team_run(),
+        run_messages=_make_run_messages(),
+        run_context=_make_run_context(),
+        tools=[],
+        session=_make_team_session(),
+        user_id="user-1",
+        background_tasks=background_tasks,
+    )
+
+    assert result.status == RunStatus.completed
+    assert executed == [], "non-guardrail pre-hook must not run inline in background mode"
+    assert background_tasks.queued == [audit_hook], "pre-hook should be queued for background execution"
+
+
+def test_team_continue_run_stream_emits_pre_hook_events(monkeypatch):
+    calls = []
+
+    @hook(run_on_continue=True)
+    def pre_hook(run_input=None, session=None):
+        calls.append(1)
+
+    team = Team(name="stream-ev-team", members=[], pre_hooks=[pre_hook])
+
+    def empty_model_stream(*args, **kwargs):
+        return
+        yield
+
+    import agno.team._response as team_response
+
+    monkeypatch.setattr(team_response, "_handle_model_response_stream", empty_model_stream)
+    monkeypatch.setattr(team_response, "parse_response_with_parser_model_stream", empty_model_stream)
+    monkeypatch.setattr(team_response, "generate_response_with_output_model_stream", empty_model_stream)
+    monkeypatch.setattr(team_run, "_cleanup_and_store", lambda *a, **k: None)
+    monkeypatch.setattr(team_telemetry, "log_team_telemetry", lambda *a, **k: None)
+
+    events = list(
+        team_run._continue_run_stream(
+            team,
+            run_response=_make_paused_team_run(),
+            run_messages=_make_run_messages(),
+            run_context=_make_run_context(),
+            tools=[],
+            session=_make_team_session(),
+            user_id="user-1",
+            stream_events=True,
+        )
+    )
+
+    assert calls == [1]
+    event_names = [type(e).__name__ for e in events]
+    assert any("PreHookStarted" in name for name in event_names), event_names
+    assert any("PreHookCompleted" in name for name in event_names), event_names


### PR DESCRIPTION
## Summary

Fixes pre-hook execution and event ordering on `continue_run` paths for both Agent and Team. In multi-container deployments (Kubernetes, Lambda, load-balanced servers), HITL approval clicks hit fresh processes where hooks weren't normalized — guardrails silently bypassed. Also fixes event ordering discrepancy where Team emitted events differently than Agent.

Refs #9084

---

## Architecture: Hook Normalization Flow

```
    ┌─────────────────────────────────────────────────────────────────┐
    │                  HOOK NORMALIZATION FLOW                        │
    ├─────────────────────────────────────────────────────────────────┤
    │                                                                 │
    │   User provides:                                                │
    │   ┌────────────────────────────────────────┐                    │
    │   │ pre_hooks=[MyGuardrail(), log_request] │                    │
    │   └────────────────────────┬───────────────┘                    │
    │                            │                                    │
    │                            ▼                                    │
    │   normalize_pre_hooks():                                        │
    │   ┌────────────────────────────────────────┐                    │
    │   │ BaseGuardrail instance                 │                    │
    │   │         │                              │                    │
    │   │         ▼                              │                    │
    │   │ guardrail.check  (bound method)        │◄── NORMALIZATION   │
    │   └────────────────────────────────────────┘                    │
    │                            │                                    │
    │                            ▼                                    │
    │   _hooks_normalised = True                                      │
    │                                                                 │
    └─────────────────────────────────────────────────────────────────┘
```

---

## Bug Scenario: Multi-Container HITL

```
    TIMELINE: Multi-Container HITL Flow
    ====================================

    Container A (initial run):
    ──────────────────────────
    run_dispatch()
        │
        ├── normalize_pre_hooks()      ← Converts BaseGuardrail → .check
        ├── _hooks_normalised = True
        │
        ▼
    _run()
        ├── execute_pre_hooks()        ← Works correctly ✓
        └── model call → PAUSED for tool confirmation
    
    
    Container B (continue run, FRESH process):
    ──────────────────────────────────────────
    _hooks_normalised = False              ← Fresh instance!
    
    BEFORE FIX (bug):
    ─────────────────
    continue_run_dispatch()
        │
        ├── NO normalization           ← BUG! Missing block
        │
        ▼
    _continue_run()
        └── execute_pre_hooks()
                │
                └── Raw BaseGuardrail instance passed
                    │
                    └── is_guardrail_hook() check fails  ✗
                        │
                        └── Guardrail silently BYPASSED!

    AFTER FIX:
    ──────────
    continue_run_dispatch()
        │
        ├── normalize_pre_hooks()      ← NEW: Same as run_dispatch
        ├── _hooks_normalised = True
        │
        ▼
    _continue_run()
        └── execute_pre_hooks()
                │
                └── guardrail.check method
                    │
                    └── is_guardrail_hook() → True ✓
                        │
                        └── Guardrail EXECUTES correctly
```

---

## Event Ordering Fix (Streaming)

```
    EVENT ORDERING: Agent vs Team (STREAMING)
    ==========================================

    AGENT _continue_run_stream (CORRECT):
    ──────────────────────────────────────
    1. execute_pre_hooks()         ← Can reject
    2. RunContinued event          ← Signals commitment
    3. handle_tool_call_updates()  ← Executes confirmed tools
    4. Model call
    5. Post-hooks
    
    TEAM _continue_run_stream (BEFORE - WRONG):
    ───────────────────────────────────────────
    1. execute_pre_hooks()
    2. handle_tool_call_updates()  ← Tools BEFORE RunContinued! ✗
    3. RunContinued event          ← Late!
    4. Model call
    
    TEAM _continue_run_stream (AFTER - FIXED):
    ──────────────────────────────────────────
    1. execute_pre_hooks()         ← Can reject
    2. RunContinued event          ← Signals commitment ✓
    3. handle_tool_call_updates()  ← Tools AFTER RunContinued ✓
    4. Model call
    5. Post-hooks


    Semantic meaning:
    ─────────────────
    RunContinued = "run has resumed, committed to execution"
    ToolCallStarted/Completed = "tools are now executing"
    
    Consumer expectation: RunContinued BEFORE ToolCall events
```

---

## Agent vs Team Structural Difference

```
    AGENT: Single Entry Point
    =========================
    
    continue_run_dispatch()
            │
            ├── normalize_pre_hooks()
            │
            └───────────────────────────────────┐
                                                │
                                                ▼
                                    ┌───────────────────┐
                                    │ _continue_run()   │
                                    │ or                │
                                    │ _continue_run_    │
                                    │   stream()        │
                                    └───────────────────┘


    TEAM: Complex Member Routing
    ============================
    
    continue_run_dispatch()
            │
            ├── normalize_pre_hooks()          ← NEW (this PR)
            │
            ├── Fork/regenerate paths?
            │       │
            │       └──► _continue_run()       (early return)
            │
            ├── Has member requirements?
            │       │
            │       └──► _route_requirements_to_members()
            │               │
            │               └── member.continue_run() for each
            │
            ├── Has team-level requirements?
            │       │
            │       └──► _continue_run()
            │
            └── Member-only case?
                    │
                    └──► _continue_run()
    
    
    WHY normalization is duplicated (not extracted):
    ─────────────────────────────────────────────────
    - Agent has single linear flow
    - Team has 4+ branching paths with early returns
    - Extracting requires threading through all branches
    - Inline at dispatcher top keeps invariant visible:
      "normalize BEFORE any side effects"
```

---

## Hook Filtering on continue_run

```
    HOOK FILTERING LOGIC
    ====================
    
    On initial run():
    ─────────────────
    ALL pre_hooks execute
    
    On continue_run():
    ──────────────────
    FILTER: hooks = [h for h if should_run_on_continue(h) or is_guardrail_hook(h)]
    
    
    Which hooks pass the filter:
    ────────────────────────────
    
    ┌─────────────────────────────────────────────────────────────────┐
    │  Hook Type                           │  Runs on continue_run?  │
    ├─────────────────────────────────────────────────────────────────┤
    │  Plain function                      │  NO (skipped)           │
    │  @hook()                             │  NO (skipped)           │
    │  @hook(run_on_continue=True)         │  YES ✓                  │
    │  BaseGuardrail subclass              │  YES (always) ✓         │
    │  @hook(run_in_background=True)       │  NO (skipped)           │
    │  @hook(run_on_continue=True,         │  YES ✓                  │
    │        run_in_background=True)       │                         │
    └─────────────────────────────────────────────────────────────────┘
    
    
    WHY opt-in instead of opt-out:
    ──────────────────────────────
    - Most pre-hooks validate INITIAL input (already validated)
    - Re-running logging/metrics = duplicate side effects
    - Security-critical (guardrails) ALWAYS run regardless
    - Explicit opt-in = intentional choice for security hooks
    
    
    Use cases for @hook(run_on_continue=True):
    ──────────────────────────────────────────
    - Re-authenticate service clients (multi-container)
    - Validate maintenance window (approval may be hours old)
    - Audit log approval-to-execution timing
    - Tenancy/authz checks that must run every boundary
```

---

## Why Pre-hooks Before Tool Updates

```
    EXECUTION ORDER IN _continue_run
    =================================
    
    1. execute_pre_hooks(is_continue=True)
           │
           └── Can raise InputCheckError  ← BLOCKS execution
           
    2. handle_tool_call_updates()
           │
           └── EXECUTES confirmed tools   ← Side effects!
               (API calls, DB writes, etc.)
    
    3. Model call
    
    4. Post-hooks
    
    
    WHY this order matters:
    ───────────────────────
    
    Scenario: Maintenance window check
    ──────────────────────────────────
    
    @hook(run_on_continue=True)
    def validate_maintenance_window(run_input):
        if current_hour not in ALLOWED_HOURS:
            raise InputCheckError("Outside maintenance window")
    
    
    CORRECT (pre-hooks first):
    ──────────────────────────
    1. validate_maintenance_window() → raises InputCheckError
    2. Tool execution NEVER happens ✓
    3. User gets error, can retry during window
    
    
    WRONG (tools first):
    ────────────────────
    1. handle_tool_call_updates() → sends email, deletes records
    2. validate_maintenance_window() → raises InputCheckError
    3. Damage already done! ✗
```

---

## Why No `attempt == 0` Guard in continue_run

```
    RETRY LOOP STRUCTURE COMPARISON
    ================================
    
    run() — pre-hooks INSIDE retry loop:
    ─────────────────────────────────────
    for attempt in range(num_attempts):
        if attempt == 0 and agent.pre_hooks:    ← GUARD needed
            execute_pre_hooks()                  (prevent duplicate)
        
        model_response = call_model()            ← Retryable
    
    
    continue_run() — pre-hooks OUTSIDE retry loop:
    ───────────────────────────────────────────────
    # Pre-hooks (once, outside loop)
    if agent.pre_hooks:
        execute_pre_hooks(is_continue=True)      ← No guard needed
    
    # Tool execution (once, outside loop)
    handle_tool_call_updates()
    
    # Retry loop wraps model call only
    for attempt in range(num_attempts):
        model_response = call_model()            ← Retryable
    
    
    WHY continue_run restructured this way:
    ───────────────────────────────────────
    From acontinue_run_trace.md analysis:
    
    - _apply_continue_modifiers() creates NEW run_id on fork
      → Inside loop = different run_id per retry (orphans!)
    
    - _maybe_append_input_message() appends to messages
      → Inside loop = duplicate messages per retry
    
    - handle_tool_call_updates() EXECUTES tools
      → Inside loop = sends email twice, etc.
    
    - execute_pre_hooks() has side effects
      → Inside loop = duplicate logging/metrics
    
    All these MUST be outside the retry loop.
```

---

## Code Paths Summary

### Hook Normalization Sites (4 new)

| Code Path | File | Line | Type | Change |
|-----------|------|------|------|--------|
| `Agent.continue_run_dispatch` | `agent/_run.py` | 3329-3334 | sync | +normalization |
| `Agent.acontinue_run_dispatch` | `agent/_run.py` | 4261-4266 | async | +normalization |
| `Team.continue_run_dispatch` | `team/_run.py` | 6421-6426 | sync | +normalization |
| `Team.acontinue_run_dispatch` | `team/_run.py` | 7812-7817 | async | +normalization |

### Hook Execution Sites with is_continue (8 sites)

| Code Path | File | Line | Type |
|-----------|------|------|------|
| `Agent._continue_run` | `agent/_run.py` | 3639 | sync |
| `Agent._continue_run_stream` | `agent/_run.py` | 3887 | sync stream |
| `Agent._acontinue_run` | `agent/_run.py` | 4804 | async |
| `Agent._acontinue_run_stream` | `agent/_run.py` | 5330 | async stream |
| `Team._continue_run` | `team/_run.py` | 7127 | sync |
| `Team._continue_run_stream` | `team/_run.py` | 7339 | sync stream |
| `Team._acontinue_run` | `team/_run.py` | 8108 | async |
| `Team._acontinue_run_stream` | `team/_run.py` | 8556 | async stream |

### Hook Filtering Logic (4 sites)

| Function | File | Line | Filter Logic |
|----------|------|------|--------------|
| `execute_pre_hooks` | `agent/_hooks.py` | 67-70 | `should_run_on_continue(h) or is_guardrail_hook(h)` |
| `aexecute_pre_hooks` | `agent/_hooks.py` | 188-191 | same |
| `_execute_pre_hooks` | `team/_hooks.py` | 264-267 | same |
| `_aexecute_pre_hooks` | `team/_hooks.py` | 371-374 | same |

---

## Files Changed

| File | Change |
|------|--------|
| `libs/agno/agno/agent/_run.py` | +hook normalization in continue_run dispatchers (lines 3329, 4261) |
| `libs/agno/agno/agent/_hooks.py` | +is_continue param and filtering (lines 55, 67-70, 176, 188-191) |
| `libs/agno/agno/team/_run.py` | +hook normalization (6421, 7812); event reordering in streaming |
| `libs/agno/agno/team/_hooks.py` | +is_continue param and filtering (lines 252, 264-267, 359, 371-374) |
| `libs/agno/agno/hooks/decorator.py` | +run_on_continue option for @hook decorator |
| `libs/agno/agno/hooks/__init__.py` | +export should_run_on_continue |
| `libs/agno/agno/utils/hooks.py` | +should_run_on_continue() helper |
| `cookbook/02_agents/09_hooks/pre_hook_on_continue.py` | NEW: Demo of @hook(run_on_continue=True) |
| `cookbook/05_agent_os/17_slack/hitl_multi_container.py` | NEW: Multi-container HITL pattern |
| `cookbook/05_agent_os/17_slack/hitl_incident_commander.py` | +maintenance window validation hooks |

---

## Test Coverage

| Test File | Tests | Coverage |
|-----------|-------|----------|
| `agent/test_continue_run_pre_hooks.py` | 17 | All 4 Agent continue variants, decorator behavior, background mode |
| `team/test_continue_run_pre_hooks.py` | 8 | All 4 Team continue variants, guardrail blocking |
| `team/test_continue_run_event_ordering.py` | 4 | Event order verification, code structure analysis |

**Total: 29 tests**

---

## Test Plan

- [x] All 29 regression tests pass
- [x] `./scripts/format.sh` passes
- [x] `./scripts/validate.sh` passes (pre-existing mypy errors in unrelated files)
- [x] Manual verification: hooks execute on continue_run in multi-process scenario
- [x] Manual verification: RunContinued emits before ToolCall events in streaming

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Formatted and validated: `./scripts/format.sh` and `./scripts/validate.sh`
- [x] Tests added for all code paths
- [x] Cookbooks demonstrate the pattern