### PR TITLE
[fix] keep datetime outside cached system prompts

### DIFF
--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -103,6 +103,31 @@ def format_message_with_state_variables(
 # ---------------------------------------------------------------------------
 
 
+def _get_datetime_context_message(agent: Agent) -> Optional[Message]:
+    if not agent.add_datetime_to_context or agent.system_message is not None or not agent.build_context:
+        return None
+
+    from datetime import datetime
+
+    tz = None
+    if agent.timezone_identifier:
+        try:
+            from zoneinfo import ZoneInfo
+
+            tz = ZoneInfo(agent.timezone_identifier)
+        except Exception as e:
+            log_warning(f"Invalid timezone identifier: {str(e)}")
+
+    time = datetime.now(tz) if tz else datetime.now()
+    formatted_time = time.strftime(agent.datetime_format) if agent.datetime_format else str(time)
+
+    return Message(
+        role="user",
+        content=f"The current time is {formatted_time}.",
+        add_to_agent_memory=False,
+    )
+
+
 def get_system_message(
     agent: Agent,
     session: AgentSession,
@@ -183,30 +208,7 @@ def get_system_message(
     # 3.2.1 Add instructions for using markdown
     if agent.markdown and output_schema is None:
         additional_information.append("Use markdown to format your answers.")
-    # 3.2.2 Add the current datetime
-    if agent.add_datetime_to_context:
-        from datetime import datetime
-
-        tz = None
-
-        if agent.timezone_identifier:
-            try:
-                from zoneinfo import ZoneInfo
-
-                tz = ZoneInfo(agent.timezone_identifier)
-            except Exception as e:
-                log_warning(f"Invalid timezone identifier: {str(e)}")
-
-        time = datetime.now(tz) if tz else datetime.now()
-
-        if agent.datetime_format:
-            formatted_time = time.strftime(agent.datetime_format)
-        else:
-            formatted_time = str(time)
-
-        additional_information.append(f"The current time is {formatted_time}.")
-
-    # 3.2.3 Add the current location
+    # 3.2.2 Add the current location
     if agent.add_location_to_context:
         from agno.utils.location import get_location
 
@@ -225,7 +227,7 @@ def get_system_message(
             if location_str:
                 additional_information.append(f"Your approximate location is: {location_str}.")
 
-    # 3.2.4 Add agent name if provided
+    # 3.2.3 Add agent name if provided
     if agent.name is not None and agent.add_name_to_context:
         additional_information.append(f"Your name is: {agent.name}.")
 
@@ -531,30 +533,7 @@ async def aget_system_message(
     # 3.2.1 Add instructions for using markdown
     if agent.markdown and output_schema is None:
         additional_information.append("Use markdown to format your answers.")
-    # 3.2.2 Add the current datetime
-    if agent.add_datetime_to_context:
-        from datetime import datetime
-
-        tz = None
-
-        if agent.timezone_identifier:
-            try:
-                from zoneinfo import ZoneInfo
-
-                tz = ZoneInfo(agent.timezone_identifier)
-            except Exception as e:
-                log_warning(f"Invalid timezone identifier: {str(e)}")
-
-        time = datetime.now(tz) if tz else datetime.now()
-
-        if agent.datetime_format:
-            formatted_time = time.strftime(agent.datetime_format)
-        else:
-            formatted_time = str(time)
-
-        additional_information.append(f"The current time is {formatted_time}.")
-
-    # 3.2.3 Add the current location
+    # 3.2.2 Add the current location
     if agent.add_location_to_context:
         from agno.utils.location import get_location
 
@@ -573,7 +552,7 @@ async def aget_system_message(
             if location_str:
                 additional_information.append(f"Your approximate location is: {location_str}.")
 
-    # 3.2.4 Add agent name if provided
+    # 3.2.3 Add agent name if provided
     if agent.name is not None and agent.add_name_to_context:
         additional_information.append(f"Your name is: {agent.name}.")
 
@@ -1180,8 +1159,9 @@ def get_run_messages(
     1. Add system message to run_messages
     2. Add extra messages to run_messages if provided
     3. Add history to run_messages
-    4. Add user message to run_messages (if input is single content)
-    5. Add input messages to run_messages if provided (if input is List[Message])
+    4. Add datetime context to run_messages if enabled
+    5. Add user message to run_messages (if input is single content)
+    6. Add input messages to run_messages if provided (if input is List[Message])
 
     Returns:
         RunMessages object with the following attributes:
@@ -1271,10 +1251,15 @@ def get_run_messages(
 
             run_messages.messages += history_copy
 
-    # 4. Add user message to run_messages
+    # 4. Add datetime context to run_messages
+    datetime_context_message = _get_datetime_context_message(agent)
+    if datetime_context_message is not None:
+        run_messages.messages.append(datetime_context_message)
+
+    # 5. Add user message to run_messages
     user_message: Optional[Message] = None
 
-    # 4.1 Build user message if input is None, str or list and not a list of Message/dict objects
+    # 5.1 Build user message if input is None, str or list and not a list of Message/dict objects
     if (
         input is None
         or isinstance(input, str)
@@ -1299,11 +1284,11 @@ def get_run_messages(
             **kwargs,
         )
 
-    # 4.2 If input is provided as a Message, use it directly
+    # 5.2 If input is provided as a Message, use it directly
     elif isinstance(input, Message):
         user_message = input
 
-    # 4.3 If input is provided as a dict, try to validate it as a Message
+    # 5.3 If input is provided as a dict, try to validate it as a Message
     elif isinstance(input, dict):
         try:
             if agent.input_schema and is_typed_dict(agent.input_schema):
@@ -1316,7 +1301,7 @@ def get_run_messages(
         except Exception as e:
             log_warning(f"Failed to validate message: {str(e)}")
 
-    # 4.4 If input is provided as a BaseModel, convert it to a Message
+    # 5.4 If input is provided as a BaseModel, convert it to a Message
     elif isinstance(input, BaseModel):
         try:
             # Create a user message with the BaseModel content
@@ -1325,7 +1310,7 @@ def get_run_messages(
         except Exception as e:
             log_warning(f"Failed to convert BaseModel to message: {str(e)}")
 
-    # 5. Add input messages to run_messages if provided (List[Message] or List[Dict])
+    # 6. Add input messages to run_messages if provided (List[Message] or List[Dict])
     if (
         isinstance(input, list)
         and len(input) > 0
@@ -1385,8 +1370,9 @@ async def aget_run_messages(
     1. Add system message to run_messages
     2. Add extra messages to run_messages if provided
     3. Add history to run_messages
-    4. Add user message to run_messages (if input is single content)
-    5. Add input messages to run_messages if provided (if input is List[Message])
+    4. Add datetime context to run_messages if enabled
+    5. Add user message to run_messages (if input is single content)
+    6. Add input messages to run_messages if provided (if input is List[Message])
 
     Returns:
         RunMessages object with the following attributes:
@@ -1476,10 +1462,15 @@ async def aget_run_messages(
 
             run_messages.messages += history_copy
 
-    # 4. Add user message to run_messages
+    # 4. Add datetime context to run_messages
+    datetime_context_message = _get_datetime_context_message(agent)
+    if datetime_context_message is not None:
+        run_messages.messages.append(datetime_context_message)
+
+    # 5. Add user message to run_messages
     user_message: Optional[Message] = None
 
-    # 4.1 Build user message if input is None, str or list and not a list of Message/dict objects
+    # 5.1 Build user message if input is None, str or list and not a list of Message/dict objects
     if (
         input is None
         or isinstance(input, str)
@@ -1504,11 +1495,11 @@ async def aget_run_messages(
             **kwargs,
         )
 
-    # 4.2 If input is provided as a Message, use it directly
+    # 5.2 If input is provided as a Message, use it directly
     elif isinstance(input, Message):
         user_message = input
 
-    # 4.3 If input is provided as a dict, try to validate it as a Message
+    # 5.3 If input is provided as a dict, try to validate it as a Message
     elif isinstance(input, dict):
         try:
             if agent.input_schema and is_typed_dict(agent.input_schema):
@@ -1521,7 +1512,7 @@ async def aget_run_messages(
         except Exception as e:
             log_warning(f"Failed to validate message: {str(e)}")
 
-    # 4.4 If input is provided as a BaseModel, convert it to a Message
+    # 5.4 If input is provided as a BaseModel, convert it to a Message
     elif isinstance(input, BaseModel):
         try:
             # Create a user message with the BaseModel content
@@ -1530,7 +1521,7 @@ async def aget_run_messages(
         except Exception as e:
             log_warning(f"Failed to convert BaseModel to message: {str(e)}")
 
-    # 5. Add input messages to run_messages if provided (List[Message] or List[Dict])
+    # 6. Add input messages to run_messages if provided (List[Message] or List[Dict])
     if (
         isinstance(input, list)
         and len(input) > 0

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -335,6 +335,31 @@ def _build_trailing_sections(
     return content
 
 
+def _get_datetime_context_message(team: "Team") -> Optional[Message]:
+    if not team.add_datetime_to_context or team.system_message is not None:
+        return None
+
+    from datetime import datetime
+
+    tz = None
+    if team.timezone_identifier:
+        try:
+            from zoneinfo import ZoneInfo
+
+            tz = ZoneInfo(team.timezone_identifier)
+        except Exception as e:
+            log_warning(f"Invalid timezone identifier: {str(e)}")
+
+    time = datetime.now(tz) if tz else datetime.now()
+    formatted_time = time.strftime(team.datetime_format) if team.datetime_format else str(time)
+
+    return Message(
+        role="user",
+        content=f"The current time is {formatted_time}.",
+        add_to_agent_memory=False,
+    )
+
+
 def get_system_message(
     team: "Team",
     session: TeamSession,
@@ -422,30 +447,7 @@ def get_system_message(
     # 1.3.1 Add instructions for using markdown
     if team.markdown and output_schema is None:
         additional_information.append("Use markdown to format your answers.")
-    # 1.3.2 Add the current datetime
-    if team.add_datetime_to_context:
-        from datetime import datetime
-
-        tz = None
-
-        if team.timezone_identifier:
-            try:
-                from zoneinfo import ZoneInfo
-
-                tz = ZoneInfo(team.timezone_identifier)
-            except Exception as e:
-                log_warning(f"Invalid timezone identifier: {str(e)}")
-
-        time = datetime.now(tz) if tz else datetime.now()
-
-        if team.datetime_format:
-            formatted_time = time.strftime(team.datetime_format)
-        else:
-            formatted_time = str(time)
-
-        additional_information.append(f"The current time is {formatted_time}.")
-
-    # 1.3.3 Add the current location
+    # 1.3.2 Add the current location
     if team.add_location_to_context:
         from agno.utils.location import get_location
 
@@ -457,7 +459,7 @@ def get_system_message(
             if location_str:
                 additional_information.append(f"Your approximate location is: {location_str}.")
 
-    # 1.3.4 Add team name if provided
+    # 1.3.3 Add team name if provided
     if team.name is not None and team.add_name_to_context:
         additional_information.append(f"Your name is: {team.name}.")
 
@@ -653,30 +655,7 @@ async def aget_system_message(
     # 1.3.1 Add instructions for using markdown
     if team.markdown and output_schema is None:
         additional_information.append("Use markdown to format your answers.")
-    # 1.3.2 Add the current datetime
-    if team.add_datetime_to_context:
-        from datetime import datetime
-
-        tz = None
-
-        if team.timezone_identifier:
-            try:
-                from zoneinfo import ZoneInfo
-
-                tz = ZoneInfo(team.timezone_identifier)
-            except Exception as e:
-                log_warning(f"Invalid timezone identifier: {str(e)}")
-
-        time = datetime.now(tz) if tz else datetime.now()
-
-        if team.datetime_format:
-            formatted_time = time.strftime(team.datetime_format)
-        else:
-            formatted_time = str(time)
-
-        additional_information.append(f"The current time is {formatted_time}.")
-
-    # 1.3.3 Add the current location
+    # 1.3.2 Add the current location
     if team.add_location_to_context:
         from agno.utils.location import get_location
 
@@ -688,7 +667,7 @@ async def aget_system_message(
             if location_str:
                 additional_information.append(f"Your approximate location is: {location_str}.")
 
-    # 1.3.4 Add team name if provided
+    # 1.3.3 Add team name if provided
     if team.name is not None and team.add_name_to_context:
         additional_information.append(f"Your name is: {team.name}.")
 
@@ -833,8 +812,8 @@ def _get_run_messages(
     1. Add system message to run_messages
     2. Add extra messages to run_messages
     3. Add history to run_messages
-    4. Add messages to run_messages if provided (messages parameter first)
-    5. Add user message to run_messages (message parameter second)
+    4. Add datetime context to run_messages if enabled
+    5. Add user message to run_messages
 
     """
     # Initialize the RunMessages object
@@ -915,7 +894,12 @@ def _get_run_messages(
             # Extend the messages with the history
             run_messages.messages += history_copy
 
-    # 5. Add user message to run_messages (message second as per Dirk's requirement)
+    # 4. Add datetime context to run_messages
+    datetime_context_message = _get_datetime_context_message(team)
+    if datetime_context_message is not None:
+        run_messages.messages.append(datetime_context_message)
+
+    # 5. Add user message to run_messages
     # 5.1 Build user message if message is None, str or list
     user_message = _get_user_message(
         team,
@@ -968,8 +952,8 @@ async def _aget_run_messages(
     1. Add system message to run_messages
     2. Add extra messages to run_messages
     3. Add history to run_messages
-    4. Add messages to run_messages if provided (messages parameter first)
-    5. Add user message to run_messages (message parameter second)
+    4. Add datetime context to run_messages if enabled
+    5. Add user message to run_messages
 
     """
     # Initialize the RunMessages object
@@ -1049,7 +1033,12 @@ async def _aget_run_messages(
             # Extend the messages with the history
             run_messages.messages += history_copy
 
-    # 5. Add user message to run_messages (message second as per Dirk's requirement)
+    # 4. Add datetime context to run_messages
+    datetime_context_message = _get_datetime_context_message(team)
+    if datetime_context_message is not None:
+        run_messages.messages.append(datetime_context_message)
+
+    # 5. Add user message to run_messages
     # 5.1 Build user message if message is None, str or list
     user_message = await _aget_user_message(
         team,

--- a/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
+++ b/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
@@ -8,15 +8,19 @@ Tests the basic caching features including:
 - Multi-block system prompt caching (static/dynamic split)
 """
 
+import time
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 
 from agno.agent import Agent, RunOutput
+from agno.agent._messages import get_run_messages
 from agno.models.anthropic import Claude, SystemPromptBlock
+from agno.run import RunContext
 from agno.session.agent import AgentSession
 from agno.utils.media import download_file
+from agno.utils.models.claude import format_messages
 
 
 def _get_large_system_prompt() -> str:
@@ -395,22 +399,42 @@ def test_build_system_shared_between_request_and_count_tokens():
     assert texts == ["Agent content.", "User static.", "User dynamic."]
 
 
-def test_agent_system_message_stays_string():
-    """Agent system message is a plain string; Claude-level blocks live on the model."""
+@pytest.mark.parametrize("user_message_role", ["user", "developer"])
+def test_agent_datetime_stays_outside_cached_system_prompt(user_message_role):
+    """Dynamic datetime context does not invalidate Claude's cached system block."""
+    claude = Claude(id="claude-sonnet-4-5-20250929", cache_system_prompt=True)
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-5-20250929", cache_system_prompt=True),
+        model=claude,
         description="Test agent",
         instructions=["Be helpful"],
         add_datetime_to_context=True,
+        datetime_format="%Y-%m-%d %H:%M:%S.%f",
+        user_message_role=user_message_role,
         telemetry=False,
     )
     session = AgentSession(session_id="test")
-    msg = agent.get_system_message(session=session)
 
-    assert msg is not None
-    assert isinstance(msg.content, str)
-    assert "Test agent" in msg.content
-    assert "The current time is" in msg.content
+    def build_request(run_id: str):
+        run_messages = get_run_messages(
+            agent,
+            run_response=RunOutput(run_id=run_id, session_id=session.session_id),
+            run_context=RunContext(run_id=run_id, session_id=session.session_id),
+            input="What time is it?",
+            session=session,
+        )
+        api_messages, system_prompt = format_messages(run_messages.messages)
+        return api_messages, system_prompt, claude._prepare_request_kwargs(system_prompt)["system"]
+
+    first_messages, first_system_prompt, first_cached_system = build_request("run-1")
+    time.sleep(0.01)
+    second_messages, second_system_prompt, second_cached_system = build_request("run-2")
+
+    assert first_system_prompt == second_system_prompt
+    assert first_cached_system == second_cached_system
+    assert first_cached_system[0]["cache_control"] == {"type": "ephemeral"}
+    assert "The current time is" not in first_system_prompt
+    assert "The current time is" in str(first_messages)
+    assert "The current time is" in str(second_messages)
 
 
 # --- Per-block TTL tests ---

--- a/libs/agno/tests/unit/agent/test_datetime_format.py
+++ b/libs/agno/tests/unit/agent/test_datetime_format.py
@@ -1,10 +1,15 @@
 """Tests for custom datetime_format on Agent."""
 
 import re
-from unittest.mock import MagicMock
+import time
+from unittest.mock import MagicMock, patch
 
-from agno.agent._messages import get_system_message
+import pytest
+
+from agno.agent._messages import aget_run_messages, get_run_messages, get_system_message
 from agno.agent.agent import Agent
+from agno.run import RunContext
+from agno.run.agent import RunOutput
 from agno.session import AgentSession
 
 # =============================================================================
@@ -73,55 +78,151 @@ def _make_agent_with_model(**kwargs) -> Agent:
     return agent
 
 
-def test_default_format_includes_full_datetime():
-    """When no datetime_format is set, the full default datetime str is used."""
-    agent = _make_agent_with_model(add_datetime_to_context=True)
+def _get_agent_run_messages(agent: Agent, input: str = "What time is it?"):
+    session = AgentSession(session_id="test-session")
+    return get_run_messages(
+        agent,
+        run_response=RunOutput(run_id="test-run", session_id=session.session_id),
+        run_context=RunContext(run_id="test-run", session_id=session.session_id),
+        input=input,
+        session=session,
+    )
+
+
+async def _aget_agent_run_messages(agent: Agent, input: str = "What time is it?"):
+    session = AgentSession(session_id="test-session")
+    return await aget_run_messages(
+        agent,
+        run_response=RunOutput(run_id="test-run", session_id=session.session_id),
+        run_context=RunContext(run_id="test-run", session_id=session.session_id),
+        input=input,
+        session=session,
+    )
+
+
+def test_system_message_is_stable_with_datetime_context_enabled():
+    agent = _make_agent_with_model(
+        instructions="Keep answers concise.",
+        add_datetime_to_context=True,
+        datetime_format="%Y-%m-%d %H:%M:%S.%f",
+    )
     session = AgentSession(session_id="test-session")
 
-    msg = get_system_message(agent, session)
+    first = get_system_message(agent, session)
+    time.sleep(0.01)
+    second = get_system_message(agent, session)
 
-    assert msg is not None
-    # Default Python datetime str format: YYYY-MM-DD HH:MM:SS.ffffff
-    assert re.search(r"The current time is \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", msg.content)
+    assert first is not None
+    assert second is not None
+    assert first.content == second.content
+    assert "The current time is" not in first.content
 
 
-def test_custom_date_only_format():
-    """When datetime_format='%Y-%m-%d', only the date portion appears."""
+def test_default_datetime_format_is_sent_after_the_system_message():
     agent = _make_agent_with_model(
+        instructions="Keep answers concise.",
+        add_datetime_to_context=True,
+    )
+
+    run_messages = _get_agent_run_messages(agent)
+    datetime_message = run_messages.messages[-2]
+
+    assert datetime_message.role == "user"
+    assert re.fullmatch(
+        r"The current time is \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d{6})?\.",
+        datetime_message.content,
+    )
+    assert datetime_message.add_to_agent_memory is False
+    assert run_messages.messages[-1] is run_messages.user_message
+
+
+def test_datetime_context_uses_user_role_when_user_message_role_is_developer():
+    agent = _make_agent_with_model(
+        instructions="Keep answers concise.",
+        add_datetime_to_context=True,
+        user_message_role="developer",
+    )
+
+    run_messages = _get_agent_run_messages(agent)
+
+    assert run_messages.messages[-2].role == "user"
+    assert run_messages.messages[-1].role == "developer"
+
+
+def test_custom_datetime_format_and_timezone_are_preserved():
+    agent = _make_agent_with_model(
+        instructions="Keep answers concise.",
+        add_datetime_to_context=True,
+        datetime_format="%Y-%m-%d %Z %z",
+        timezone_identifier="UTC",
+    )
+
+    run_messages = _get_agent_run_messages(agent)
+
+    assert re.fullmatch(
+        r"The current time is \d{4}-\d{2}-\d{2} UTC \+0000\.",
+        run_messages.messages[-2].content,
+    )
+
+
+def test_invalid_timezone_falls_back_and_keeps_datetime_outside_system_message():
+    agent = _make_agent_with_model(
+        instructions="Keep answers concise.",
         add_datetime_to_context=True,
         datetime_format="%Y-%m-%d",
+        timezone_identifier="Invalid/Timezone",
     )
-    session = AgentSession(session_id="test-session")
 
-    msg = get_system_message(agent, session)
+    with patch("agno.agent._messages.log_warning") as mock_log_warning:
+        run_messages = _get_agent_run_messages(agent)
 
-    assert msg is not None
-    # Should match YYYY-MM-DD followed by period (no time component)
-    assert re.search(r"The current time is \d{4}-\d{2}-\d{2}\.", msg.content)
+    assert run_messages.system_message is not None
+    assert "The current time is" not in str(run_messages.system_message.content)
+    assert re.fullmatch(r"The current time is \d{4}-\d{2}-\d{2}\.", run_messages.messages[-2].content)
+    mock_log_warning.assert_called_once()
+    assert "Invalid timezone identifier" in mock_log_warning.call_args.args[0]
 
 
-def test_custom_format_slash_style():
-    """Custom format with slashes: %d/%m/%Y %H:%M."""
+def test_no_datetime_message_when_disabled():
     agent = _make_agent_with_model(
-        add_datetime_to_context=True,
-        datetime_format="%d/%m/%Y %H:%M",
-    )
-    session = AgentSession(session_id="test-session")
-
-    msg = get_system_message(agent, session)
-
-    assert msg is not None
-    assert re.search(r"The current time is \d{2}/\d{2}/\d{4} \d{2}:\d{2}\.", msg.content)
-
-
-def test_no_datetime_when_disabled():
-    """When add_datetime_to_context is False, no datetime info is added."""
-    agent = _make_agent_with_model(
+        instructions="Keep answers concise.",
         add_datetime_to_context=False,
         datetime_format="%Y-%m-%d",
     )
-    session = AgentSession(session_id="test-session")
-    msg = get_system_message(agent, session)
 
-    if msg is not None:
-        assert "current time" not in msg.content.lower()
+    run_messages = _get_agent_run_messages(agent)
+
+    assert all("current time" not in str(message.content).lower() for message in run_messages.messages)
+
+
+@pytest.mark.asyncio
+async def test_async_datetime_context_matches_sync_message_semantics():
+    agent = _make_agent_with_model(
+        instructions="Keep answers concise.",
+        add_datetime_to_context=True,
+        datetime_format="%Y-%m-%d",
+        timezone_identifier="UTC",
+    )
+
+    run_messages = await _aget_agent_run_messages(agent)
+    datetime_message = run_messages.messages[-2]
+
+    assert run_messages.system_message is not None
+    assert "The current time is" not in str(run_messages.system_message.content)
+    assert re.fullmatch(r"The current time is \d{4}-\d{2}-\d{2}\.", datetime_message.content)
+    assert datetime_message.role == "user"
+    assert datetime_message.add_to_agent_memory is False
+    assert run_messages.messages[-1] is run_messages.user_message
+
+
+@pytest.mark.parametrize(
+    "agent",
+    [
+        _make_agent_with_model(system_message="Custom system", add_datetime_to_context=True),
+        _make_agent_with_model(build_context=False, add_datetime_to_context=True),
+    ],
+)
+def test_datetime_context_preserves_existing_system_message_bypass(agent: Agent):
+    run_messages = _get_agent_run_messages(agent)
+
+    assert all("current time" not in str(message.content).lower() for message in run_messages.messages)

--- a/libs/agno/tests/unit/team/test_datetime_format.py
+++ b/libs/agno/tests/unit/team/test_datetime_format.py
@@ -1,10 +1,15 @@
 """Tests for custom datetime_format on Team."""
 
 import re
-from unittest.mock import MagicMock
+import time
+from unittest.mock import MagicMock, patch
 
+import pytest
+
+from agno.run import RunContext
+from agno.run.team import TeamRunOutput
 from agno.session import TeamSession
-from agno.team._messages import get_system_message
+from agno.team._messages import _aget_run_messages, _get_run_messages, get_system_message
 from agno.team.team import Team
 
 # =============================================================================
@@ -77,53 +82,133 @@ def _make_team_with_model(**kwargs) -> Team:
     return team
 
 
-def test_default_format_includes_full_datetime():
-    """When no datetime_format is set, the full default datetime str is used."""
-    team = _make_team_with_model(add_datetime_to_context=True)
+def _get_team_run_messages(team: Team, input_message: str = "What time is it?"):
+    session = TeamSession(session_id="test-session")
+    return _get_run_messages(
+        team,
+        run_response=TeamRunOutput(run_id="test-run", session_id=session.session_id, team_id=team.id),
+        run_context=RunContext(run_id="test-run", session_id=session.session_id),
+        session=session,
+        input_message=input_message,
+    )
+
+
+async def _aget_team_run_messages(team: Team, input_message: str = "What time is it?"):
+    session = TeamSession(session_id="test-session")
+    return await _aget_run_messages(
+        team,
+        run_response=TeamRunOutput(run_id="test-run", session_id=session.session_id, team_id=team.id),
+        run_context=RunContext(run_id="test-run", session_id=session.session_id),
+        session=session,
+        input_message=input_message,
+    )
+
+
+def test_system_message_is_stable_with_datetime_context_enabled():
+    team = _make_team_with_model(
+        instructions="Keep answers concise.",
+        add_datetime_to_context=True,
+        datetime_format="%Y-%m-%d %H:%M:%S.%f",
+    )
     session = TeamSession(session_id="test-session")
 
-    msg = get_system_message(team, session)
+    first = get_system_message(team, session)
+    time.sleep(0.01)
+    second = get_system_message(team, session)
 
-    assert msg is not None
-    assert re.search(r"The current time is \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", msg.content)
+    assert first is not None
+    assert second is not None
+    assert first.content == second.content
+    assert "The current time is" not in first.content
 
 
-def test_custom_date_only_format():
-    """When datetime_format='%Y-%m-%d', only the date portion appears."""
+def test_default_datetime_format_is_sent_after_the_system_message():
     team = _make_team_with_model(
+        instructions="Keep answers concise.",
+        add_datetime_to_context=True,
+    )
+
+    run_messages = _get_team_run_messages(team)
+    datetime_message = run_messages.messages[-2]
+
+    assert datetime_message.role == "user"
+    assert re.fullmatch(
+        r"The current time is \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d{6})?\.",
+        datetime_message.content,
+    )
+    assert datetime_message.add_to_agent_memory is False
+    assert run_messages.messages[-1] is run_messages.user_message
+
+
+def test_custom_datetime_format_and_timezone_are_preserved():
+    team = _make_team_with_model(
+        instructions="Keep answers concise.",
+        add_datetime_to_context=True,
+        datetime_format="%Y-%m-%d %Z %z",
+        timezone_identifier="UTC",
+    )
+
+    run_messages = _get_team_run_messages(team)
+
+    assert re.fullmatch(
+        r"The current time is \d{4}-\d{2}-\d{2} UTC \+0000\.",
+        run_messages.messages[-2].content,
+    )
+
+
+def test_invalid_timezone_falls_back_and_keeps_datetime_outside_system_message():
+    team = _make_team_with_model(
+        instructions="Keep answers concise.",
         add_datetime_to_context=True,
         datetime_format="%Y-%m-%d",
+        timezone_identifier="Invalid/Timezone",
     )
-    session = TeamSession(session_id="test-session")
 
-    msg = get_system_message(team, session)
+    with patch("agno.team._messages.log_warning") as mock_log_warning:
+        run_messages = _get_team_run_messages(team)
 
-    assert msg is not None
-    assert re.search(r"The current time is \d{4}-\d{2}-\d{2}\.", msg.content)
+    assert run_messages.system_message is not None
+    assert "The current time is" not in str(run_messages.system_message.content)
+    assert re.fullmatch(r"The current time is \d{4}-\d{2}-\d{2}\.", run_messages.messages[-2].content)
+    mock_log_warning.assert_called_once()
+    assert "Invalid timezone identifier" in mock_log_warning.call_args.args[0]
 
 
-def test_custom_format_slash_style():
-    """Custom format with slashes: %d/%m/%Y %H:%M."""
+def test_no_datetime_message_when_disabled():
     team = _make_team_with_model(
-        add_datetime_to_context=True,
-        datetime_format="%d/%m/%Y %H:%M",
-    )
-    session = TeamSession(session_id="test-session")
-
-    msg = get_system_message(team, session)
-
-    assert msg is not None
-    assert re.search(r"The current time is \d{2}/\d{2}/\d{4} \d{2}:\d{2}\.", msg.content)
-
-
-def test_no_datetime_when_disabled():
-    """When add_datetime_to_context is False, no datetime info is added."""
-    team = _make_team_with_model(
+        instructions="Keep answers concise.",
         add_datetime_to_context=False,
         datetime_format="%Y-%m-%d",
     )
-    session = TeamSession(session_id="test-session")
-    msg = get_system_message(team, session)
 
-    if msg is not None:
-        assert "current time" not in msg.content.lower()
+    run_messages = _get_team_run_messages(team)
+
+    assert all("current time" not in str(message.content).lower() for message in run_messages.messages)
+
+
+@pytest.mark.asyncio
+async def test_async_datetime_context_matches_sync_message_semantics():
+    team = _make_team_with_model(
+        instructions="Keep answers concise.",
+        add_datetime_to_context=True,
+        datetime_format="%Y-%m-%d",
+        timezone_identifier="UTC",
+    )
+
+    run_messages = await _aget_team_run_messages(team)
+    datetime_message = run_messages.messages[-2]
+
+    assert run_messages.system_message is not None
+    assert "The current time is" not in str(run_messages.system_message.content)
+    assert re.fullmatch(r"The current time is \d{4}-\d{2}-\d{2}\.", datetime_message.content)
+    assert datetime_message.role == "user"
+    assert datetime_message.add_to_agent_memory is False
+    assert run_messages.messages[-1] is run_messages.user_message
+
+
+def test_datetime_context_preserves_existing_custom_system_message_bypass():
+    team = _make_team_with_model(system_message="Custom system", add_datetime_to_context=True)
+
+    run_messages = _get_team_run_messages(team)
+
+    assert all("current time" not in str(message.content).lower() for message in run_messages.messages)


### PR DESCRIPTION
## Summary

Fixes #9094.

`add_datetime_to_context=True` previously rendered the current datetime directly into generated Agent and Team system prompts. Because the default value includes microseconds, the cached system prefix changed on every request, preventing Anthropic's explicit prompt cache and OpenAI's automatic prefix cache from being reused reliably.

This change moves the runtime datetime into a non-persistent `user` context message immediately before the current input. The generated system prompt therefore remains byte-stable while the model still receives the current time.

The implementation:

- preserves `datetime_format` and `timezone_identifier`, including invalid-timezone fallback;
- keeps Agent and Team behavior aligned across synchronous and asynchronous paths;
- prevents the synthetic datetime message from entering persisted history with `add_to_agent_memory=False`;
- keeps the datetime outside Anthropic's cached system block even when `Agent.user_message_role="developer"`;
- does not add public APIs or modify provider adapters.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (not applicable; no public API or user workflow changed)
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach (not applicable; no competing PR was found)
- [x] This PR used AI assistance (OpenAI Codex and Claude Code); I reviewed and verified the final changes

---

## Additional Notes

Validation performed:

- Agent and Team datetime tests plus focused Anthropic cache-boundary variants: **30 passed**
- Agent and Team unit regression suites: **1065 passed, 1 skipped**
- `./scripts/format.sh`: passed
- `./scripts/validate.sh`: passed
- `git diff --check`: passed

The Anthropic regression test compares the exact generated cached system blocks across separately constructed requests without making a live API call. No provider API keys were used.

Compatibility note: callers that invoke `get_system_message()` directly will no longer find the runtime datetime in that returned message. Full Agent and Team run-message construction still supplies the datetime to the model as intended.
