### PR TITLE
feat: support Knowledge-level chunking defaults

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -55,10 +55,13 @@ class Knowledge(RemoteKnowledge):
     # Requires re-indexing existing data to add linked_to metadata.
     # Default is False for backwards compatibility with existing data.
     isolate_vector_search: bool = False
+    chunk_size: Optional[int] = None
+    chunk_overlap: Optional[int] = None
 
     def __post_init__(self):
         from agno.vectordb import VectorDb
 
+        self._validate_chunking_defaults()
         self.vector_db = cast(VectorDb, self.vector_db)
         if self.vector_db and not self.vector_db.exists():
             self.vector_db.create()
@@ -937,6 +940,46 @@ class Knowledge(RemoteKnowledge):
 
     # --- Reader Helper Methods ---
 
+    def _validate_chunking_defaults(self) -> None:
+        """Validate Knowledge-level chunking defaults."""
+        if self.chunk_size is not None:
+            if not isinstance(self.chunk_size, int) or isinstance(self.chunk_size, bool):
+                raise ValueError("chunk_size must be an integer")
+            if self.chunk_size <= 0:
+                raise ValueError("chunk_size must be greater than 0")
+
+        if self.chunk_overlap is not None:
+            if not isinstance(self.chunk_overlap, int) or isinstance(self.chunk_overlap, bool):
+                raise ValueError("chunk_overlap must be an integer")
+            if self.chunk_overlap < 0:
+                raise ValueError("chunk_overlap must be greater than or equal to 0")
+
+        if self.chunk_size is not None and self.chunk_overlap is not None and self.chunk_overlap >= self.chunk_size:
+            raise ValueError("chunk_overlap must be less than chunk_size")
+
+    def _has_chunking_defaults(self) -> bool:
+        return self.chunk_size is not None or self.chunk_overlap is not None
+
+    def _create_default_reader(self, reader_type: str) -> Reader:
+        """Create an automatic reader and apply this Knowledge instance's defaults."""
+        if not self._has_chunking_defaults():
+            return ReaderFactory.create_reader(reader_type)
+
+        reader_kwargs: Dict[str, Any] = {}
+        if self.chunk_size is not None:
+            reader_kwargs["chunk_size"] = self.chunk_size
+
+        reader = ReaderFactory._create_reader(reader_type, **reader_kwargs)
+        strategy = reader.chunking_strategy
+
+        if self.chunk_overlap is not None and strategy is not None and hasattr(strategy, "overlap"):
+            effective_chunk_size = getattr(strategy, "chunk_size", reader.chunk_size)
+            if self.chunk_overlap >= effective_chunk_size:
+                raise ValueError("chunk_overlap must be less than the reader chunk size")
+            setattr(strategy, "overlap", self.chunk_overlap)
+
+        return reader
+
     def _generate_reader_key(self, reader: Reader) -> str:
         """Generate a key for a reader instance."""
         if reader.name:
@@ -951,12 +994,17 @@ class Knowledge(RemoteKnowledge):
 
         if reader_type not in self.readers:
             try:
-                reader = ReaderFactory.create_reader(reader_type)
+                reader = self._create_default_reader(reader_type)
                 if reader:
                     self.readers[reader_type] = reader
                 else:
                     return None
 
+            except ValueError as e:
+                if self._has_chunking_defaults():
+                    raise
+                log_warning(f"Cannot create {reader_type} reader: {str(e)}")
+                return None
             except Exception as e:
                 log_warning(f"Cannot create {reader_type} reader: {str(e)}")
                 return None
@@ -966,7 +1014,10 @@ class Knowledge(RemoteKnowledge):
     def _select_reader(self, extension: str) -> Reader:
         """Select the appropriate reader for a file extension."""
         log_info(f"Selecting reader for extension: {extension}")
-        return ReaderFactory.get_reader_for_extension(extension)
+        reader, _ = self._select_reader_by_extension(extension)
+        if reader is None:
+            raise ValueError(f"No reader available for extension: {extension}")
+        return reader
 
     def _should_include_file(self, file_path: str, include: Optional[List[str]], exclude: Optional[List[str]]) -> bool:
         """
@@ -1179,19 +1230,28 @@ class Knowledge(RemoteKnowledge):
             return provided_reader, ""
 
         file_extension = file_extension.lower()
-        if file_extension == ".csv":
+        if file_extension in [".csv", "text/csv"]:
             return self.csv_reader, "data.csv"
-        elif file_extension == ".pdf":
+        elif file_extension in [".pdf", "application/pdf"]:
             return self.pdf_reader, ""
-        elif file_extension == ".docx":
+        elif file_extension in [
+            ".docx",
+            ".doc",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ]:
             return self.docx_reader, ""
         elif file_extension == ".pptx":
             return self.pptx_reader, ""
         elif file_extension == ".json":
             return self.json_reader, ""
-        elif file_extension == ".markdown":
+        elif file_extension in [".md", ".markdown"]:
             return self.markdown_reader, ""
-        elif file_extension in [".xlsx", ".xls"]:
+        elif file_extension in [
+            ".xlsx",
+            ".xls",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.ms-excel",
+        ]:
             return self.excel_reader, ""
         else:
             return self.text_reader, ""
@@ -1375,7 +1435,7 @@ class Knowledge(RemoteKnowledge):
                 if content.reader:
                     reader = content.reader
                 else:
-                    reader = ReaderFactory.get_reader_for_extension(path.suffix)
+                    reader = self._select_reader(path.suffix)
                     log_debug(f"Using Reader: {reader.__class__.__name__}")
 
                 if reader:
@@ -1460,7 +1520,7 @@ class Knowledge(RemoteKnowledge):
                 if content.reader:
                     reader = content.reader
                 else:
-                    reader = ReaderFactory.get_reader_for_extension(path.suffix)
+                    reader = self._select_reader(path.suffix)
                     log_debug(f"Using Reader: {reader.__class__.__name__}")
 
                 if reader:

--- a/libs/agno/agno/knowledge/reader/reader_factory.py
+++ b/libs/agno/agno/knowledge/reader/reader_factory.py
@@ -370,14 +370,18 @@ class ReaderFactory:
         if reader_key in cls._reader_cache:
             return cls._reader_cache[reader_key]
 
-        # Get the reader method and create the instance
-        reader_method = cls._get_reader_method(reader_key)
-        reader = reader_method(**kwargs)
+        reader = cls._create_reader(reader_key, **kwargs)
 
         # Cache the reader
         cls._reader_cache[reader_key] = reader
 
         return reader
+
+    @classmethod
+    def _create_reader(cls, reader_key: str, **kwargs) -> Reader:
+        """Create a reader without adding it to the global reader cache."""
+        reader_method = cls._get_reader_method(reader_key)
+        return reader_method(**kwargs)
 
     @classmethod
     def get_reader_for_extension(cls, extension: str) -> Reader:

--- a/libs/agno/tests/unit/knowledge/chunking/test_knowledge_chunking_defaults.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_knowledge_chunking_defaults.py
@@ -1,0 +1,274 @@
+from typing import List
+
+import pytest
+
+from agno.knowledge.chunking.fixed import FixedSizeChunking
+from agno.knowledge.chunking.row import RowChunking
+from agno.knowledge.document.base import Document
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader import ReaderFactory
+from agno.knowledge.reader.text_reader import TextReader
+from agno.vectordb.base import VectorDb
+
+
+class CapturingVectorDb(VectorDb):
+    def __init__(self):
+        self.inserted_documents: List[Document] = []
+
+    def create(self) -> None:
+        pass
+
+    async def async_create(self) -> None:
+        pass
+
+    def name_exists(self, name: str) -> bool:
+        return False
+
+    def async_name_exists(self, name: str) -> bool:
+        return False
+
+    def id_exists(self, id: str) -> bool:
+        return False
+
+    def content_hash_exists(self, content_hash: str) -> bool:
+        return False
+
+    def insert(self, content_hash: str, documents, filters=None) -> None:
+        self.inserted_documents.extend(documents)
+
+    async def async_insert(self, content_hash: str, documents, filters=None) -> None:
+        self.inserted_documents.extend(documents)
+
+    def upsert(self, content_hash: str, documents, filters=None) -> None:
+        self.inserted_documents.extend(documents)
+
+    async def async_upsert(self, content_hash: str, documents, filters=None) -> None:
+        self.inserted_documents.extend(documents)
+
+    def upsert_available(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5, filters=None):
+        return []
+
+    async def async_search(self, query: str, limit: int = 5, filters=None):
+        return []
+
+    def drop(self) -> None:
+        pass
+
+    async def async_drop(self) -> None:
+        pass
+
+    def exists(self) -> bool:
+        return True
+
+    async def async_exists(self) -> bool:
+        return True
+
+    def delete(self) -> bool:
+        return True
+
+    def delete_by_id(self, id: str) -> bool:
+        return True
+
+    def delete_by_name(self, name: str) -> bool:
+        return True
+
+    def delete_by_metadata(self, metadata) -> bool:
+        return True
+
+    def delete_by_content_id(self, content_id: str) -> bool:
+        return True
+
+    def update_metadata(self, content_id: str, metadata) -> None:
+        pass
+
+    def get_supported_search_types(self):
+        return ["vector"]
+
+
+@pytest.fixture(autouse=True)
+def clear_reader_factory_cache():
+    ReaderFactory.clear_cache()
+    yield
+    ReaderFactory.clear_cache()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"chunk_size": 0}, "chunk_size must be greater than 0"),
+        ({"chunk_size": -1}, "chunk_size must be greater than 0"),
+        ({"chunk_size": True}, "chunk_size must be an integer"),
+        ({"chunk_overlap": -1}, "chunk_overlap must be greater than or equal to 0"),
+        ({"chunk_overlap": False}, "chunk_overlap must be an integer"),
+        (
+            {"chunk_size": 100, "chunk_overlap": 100},
+            "chunk_overlap must be less than chunk_size",
+        ),
+        (
+            {"chunk_size": 100, "chunk_overlap": 101},
+            "chunk_overlap must be less than chunk_size",
+        ),
+    ],
+)
+def test_knowledge_validates_chunking_defaults(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        Knowledge(**kwargs)
+
+
+def test_none_defaults_preserve_shared_factory_reader_behavior():
+    first = Knowledge()
+    second = Knowledge()
+
+    assert first.text_reader is second.text_reader
+    assert first.text_reader.chunk_size == 5000
+    assert isinstance(first.text_reader.chunking_strategy, FixedSizeChunking)
+    assert first.text_reader.chunking_strategy.overlap == 0
+
+
+def test_knowledge_defaults_configure_automatic_reader():
+    knowledge = Knowledge(chunk_size=100, chunk_overlap=20)
+
+    reader = knowledge.text_reader
+
+    assert reader.chunk_size == 100
+    assert isinstance(reader.chunking_strategy, FixedSizeChunking)
+    assert reader.chunking_strategy.chunk_size == 100
+    assert reader.chunking_strategy.overlap == 20
+
+
+def test_chunk_size_default_can_be_configured_independently():
+    knowledge = Knowledge(chunk_size=100)
+
+    reader = knowledge.text_reader
+
+    assert reader.chunk_size == 100
+    assert reader.chunking_strategy.chunk_size == 100
+    assert reader.chunking_strategy.overlap == 0
+
+
+def test_chunk_overlap_default_can_be_configured_independently():
+    knowledge = Knowledge(chunk_overlap=20)
+
+    reader = knowledge.text_reader
+
+    assert reader.chunk_size == 5000
+    assert reader.chunking_strategy.chunk_size == 5000
+    assert reader.chunking_strategy.overlap == 20
+
+
+def test_configured_readers_are_isolated_from_other_knowledge_and_factory_cache():
+    cached_reader = ReaderFactory.create_reader("text")
+    first = Knowledge(chunk_size=100, chunk_overlap=10)
+    second = Knowledge(chunk_size=200, chunk_overlap=20)
+
+    first_reader = first.text_reader
+    second_reader = second.text_reader
+
+    assert first_reader is not second_reader
+    assert first_reader is not cached_reader
+    assert second_reader is not cached_reader
+    assert first_reader.chunking_strategy.chunk_size == 100
+    assert second_reader.chunking_strategy.chunk_size == 200
+    assert cached_reader.chunking_strategy.chunk_size == 5000
+    assert cached_reader.chunking_strategy.overlap == 0
+
+
+def test_reader_factory_keeps_existing_public_cache_behavior():
+    first = ReaderFactory.create_reader("text", chunk_size=100)
+    second = ReaderFactory.create_reader("text", chunk_size=200)
+
+    assert second is first
+    assert second.chunking_strategy.chunk_size == 100
+
+
+def test_explicit_reader_configuration_takes_precedence():
+    strategy = FixedSizeChunking(chunk_size=250, overlap=25)
+    explicit_reader = TextReader(chunk_size=250, chunking_strategy=strategy)
+    knowledge = Knowledge(
+        chunk_size=100,
+        chunk_overlap=10,
+        readers={"text": explicit_reader},
+    )
+
+    assert knowledge.text_reader is explicit_reader
+    assert explicit_reader.chunk_size == 250
+    assert explicit_reader.chunking_strategy is strategy
+    assert strategy.chunk_size == 250
+    assert strategy.overlap == 25
+
+
+def test_per_content_reader_configuration_takes_precedence():
+    strategy = FixedSizeChunking(chunk_size=250, overlap=25)
+    explicit_reader = TextReader(chunk_size=250, chunking_strategy=strategy)
+    vector_db = CapturingVectorDb()
+    knowledge = Knowledge(vector_db=vector_db, chunk_size=20, chunk_overlap=5)
+
+    knowledge.insert(
+        text_content="alpha beta gamma delta epsilon zeta eta theta",
+        reader=explicit_reader,
+        upsert=False,
+    )
+
+    assert explicit_reader.chunk_size == 250
+    assert explicit_reader.chunking_strategy is strategy
+    assert strategy.chunk_size == 250
+    assert strategy.overlap == 25
+    assert len(vector_db.inserted_documents) == 1
+
+
+def test_knowledge_defaults_do_not_replace_unsupported_row_strategy():
+    knowledge = Knowledge(chunk_size=100, chunk_overlap=10)
+
+    reader = knowledge.csv_reader
+
+    assert isinstance(reader.chunking_strategy, RowChunking)
+
+
+def test_overlap_only_is_validated_against_effective_reader_chunk_size():
+    knowledge = Knowledge(chunk_overlap=5000)
+
+    with pytest.raises(ValueError, match="chunk_overlap must be less than the reader chunk size"):
+        _ = knowledge.text_reader
+
+
+def test_sync_text_ingestion_uses_knowledge_chunking_defaults():
+    vector_db = CapturingVectorDb()
+    knowledge = Knowledge(vector_db=vector_db, chunk_size=20, chunk_overlap=5)
+
+    knowledge.insert(text_content="alpha beta gamma delta epsilon zeta eta theta", upsert=False)
+
+    contents = [document.content for document in vector_db.inserted_documents]
+    assert len(contents) > 1
+    assert all(len(content) <= 20 for content in contents)
+    assert contents[0][-5:] == contents[1][:5]
+
+
+@pytest.mark.asyncio
+async def test_async_text_ingestion_matches_sync_chunking_defaults():
+    text = "alpha beta gamma delta epsilon zeta eta theta"
+    sync_db = CapturingVectorDb()
+    async_db = CapturingVectorDb()
+
+    Knowledge(vector_db=sync_db, chunk_size=20, chunk_overlap=5).insert(text_content=text, upsert=False)
+    await Knowledge(vector_db=async_db, chunk_size=20, chunk_overlap=5).ainsert(text_content=text, upsert=False)
+
+    assert [document.content for document in async_db.inserted_documents] == [
+        document.content for document in sync_db.inserted_documents
+    ]
+
+
+def test_local_path_uses_knowledge_configured_reader(tmp_path):
+    path = tmp_path / "knowledge-defaults.txt"
+    path.write_text("alpha beta gamma delta epsilon zeta eta theta", encoding="utf-8")
+    vector_db = CapturingVectorDb()
+    cached_reader = ReaderFactory.create_reader("text")
+    knowledge = Knowledge(vector_db=vector_db, chunk_size=20, chunk_overlap=5)
+
+    knowledge.insert(path=str(path), upsert=False)
+
+    assert len(vector_db.inserted_documents) > 1
+    assert knowledge.text_reader is not cached_reader
+    assert cached_reader.chunking_strategy.chunk_size == 5000


### PR DESCRIPTION
## Summary

Closes #9024.

Adds optional `chunk_size` and `chunk_overlap` defaults to `Knowledge`, so a knowledge base can define a consistent chunking policy for automatically selected readers.

The implementation:

- validates Knowledge-level values while keeping both fields optional for backward compatibility;
- applies defaults only to readers automatically created for that `Knowledge` instance;
- avoids mutating or reusing configured readers through the global `ReaderFactory` cache;
- preserves explicit Knowledge-level and per-content reader configuration;
- leaves chunking strategies that do not support overlap unchanged;
- keeps synchronous and asynchronous ingestion behavior aligned, including local-path ingestion.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (validation messages and focused implementation docstrings added; no guide changes required)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (not applicable; behavior is covered by focused unit tests)
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach (not applicable; no competing PR was found)
- [x] This PR used AI assistance (OpenAI Codex and Claude Code); I reviewed and verified the final changes

---

## Additional Notes

Precedence remains backward-compatible:

1. Explicit per-content reader or chunking-strategy configuration
2. Explicit Knowledge reader configuration
3. Knowledge-level `chunk_size` and `chunk_overlap` defaults
4. Existing reader and chunking-strategy defaults

Validation performed:

- Focused Knowledge chunking and related reader regressions: **53 passed**
- `./scripts/format.sh`: passed
- `./scripts/validate.sh`: passed
- `git diff --check upstream/main...HEAD`: passed

All tests are offline and do not require API keys.