### PR TITLE
feat: Fireworks trainer adapter (agno[fireworks])

### DIFF
--- a/cookbook/environments/_29_expert_iteration/README.md
+++ b/cookbook/environments/_29_expert_iteration/README.md
@@ -45,7 +45,7 @@ python cookbook/environments/_29_expert_iteration/basic.py
 # live Tinker fine-tune of Qwen/Qwen3.6-35B-A3B
 AGNO_TRAINER=tinker AGNO_RUN_FINE_TUNE=1 python cookbook/environments/_29_expert_iteration/basic.py
 
-# live Fireworks fine-tune of accounts/fireworks/models/qwen3-8b
+# live Fireworks fine-tune of accounts/fireworks/models/qwen3-4b-instruct-2507
 AGNO_TRAINER=fireworks AGNO_RUN_FINE_TUNE=1 python cookbook/environments/_29_expert_iteration/basic.py
 ```
 

--- a/cookbook/environments/_29_expert_iteration/README.md
+++ b/cookbook/environments/_29_expert_iteration/README.md
@@ -10,20 +10,43 @@ agent design — the only thing that changes is the weights.
 
 ## Files
 
-- `basic.py` — one round end to end, offline by default.
+- `basic.py` — one round end to end, offline by default, with a swappable
+  trainer backend.
 
-## Offline by default
+## One loop, swappable trainers
 
-`basic.py` defines a small scripted model and stub trainer inline so the loop
-runs with no GPU and no API key. They are stand-ins, not agno API: a real
-trainer serves real checkpoints. Set `AGNO_RUN_TINKER_FINE_TUNE=1` (with
-`TINKER_API_KEY` available) and the same file runs against `TinkerTrainer`,
-fine-tuning `Qwen/Qwen3.6-35B-A3B` for real.
+The trainer is the `Trainer` protocol's seam, and `basic.py` demonstrates it:
+the same `ImprovementLoop` runs against three backends, selected with
+`AGNO_TRAINER`:
 
-The live path costs money, so it is gated on that explicit opt-in flag — a key
-alone never triggers spend. A key is capability, not consent: with only
-`TINKER_API_KEY` set (as direnv does in many shells) the file still runs the
-free offline stub.
+| `AGNO_TRAINER` | Backend | What it shows |
+|---|---|---|
+| `stub` (default) | inline stand-ins | the shape of the loop; no GPU, no key, no spend |
+| `tinker` | `TinkerTrainer` | agno drives the training loop (forward/backward per batch) |
+| `fireworks` | `FireworksTrainer` | a managed fine-tuning job + on-demand serving |
+
+The stub trainer and scripted models are stand-ins defined in the file, not agno
+API: a real trainer serves real checkpoints.
+
+## Offline by default, and what consent means
+
+The live paths cost money, so they are gated on an explicit opt-in flag *on top
+of* the provider key: `AGNO_RUN_FINE_TUNE=1`. A key alone never triggers spend.
+A key is capability, not consent: with only `TINKER_API_KEY` or
+`FIREWORKS_API_KEY` set (as direnv does in many shells) the file still runs the
+free offline stub. (`AGNO_RUN_TINKER_FINE_TUNE=1`, the original Tinker-only
+spelling, still works and implies `AGNO_TRAINER=tinker`.)
+
+```bash
+# offline (default)
+python cookbook/environments/_29_expert_iteration/basic.py
+
+# live Tinker fine-tune of Qwen/Qwen3.6-35B-A3B
+AGNO_TRAINER=tinker AGNO_RUN_FINE_TUNE=1 python cookbook/environments/_29_expert_iteration/basic.py
+
+# live Fireworks fine-tune of accounts/fireworks/models/qwen3-8b
+AGNO_TRAINER=fireworks AGNO_RUN_FINE_TUNE=1 python cookbook/environments/_29_expert_iteration/basic.py
+```
 
 ## What has to be true for a gain to exist
 
@@ -37,7 +60,7 @@ Tool-using agents export nothing in this release — the text-only SFT format ha
 no tool representation, so the loop reports `"not_exportable"` and trains
 nothing. See [`_10_export_sft/`](../_10_export_sft/).
 
-## If you run the live path
+## If you run the live Tinker path
 
 A thinking model spends a long time inside `<think>` before the visible answer: a
 2000-token sample from a 35B MoE routinely takes minutes. The environment here sets
@@ -47,6 +70,25 @@ timeout you would notice.
 
 Budget for that: at 3 tasks and k=4 the loop samples 12 attempts for the baseline and
 12 more to measure the tuned checkpoint, either side of the fine-tune itself.
+
+## If you run the live Fireworks path
+
+Fireworks trains as a managed job (LoRA SFT is around $0.50 per million training
+tokens for this model tier — a run this size costs pennies) but **serving is the
+real cost**: neither the tuned LoRA nor the small tunable bases are serverless,
+so measuring either side of the before/after needs an on-demand deployment.
+`FireworksTrainer` creates one (BF16, addons enabled, scale-to-zero, max one
+replica, order $7/hour of GPU time while serving) and serves base and tuned from
+it so the comparison runs on identical hardware. `basic.py` calls
+`trainer.teardown()` at the end of the run to delete it; if a run dies hard,
+check the Fireworks dashboard for deployments named `agno-*`.
+
+The first request after a scale-up pays a cold-start delay — another reason the
+environment's `timeout_seconds` is generous. You will also need
+`FIREWORKS_ACCOUNT_ID` set (the trainer refuses before any spend without it),
+and the key must belong to a user or service account allowed to create
+fine-tuning jobs — an inference-scoped role gets `403` on the training
+endpoints.
 
 ## Reading the numbers honestly
 
@@ -74,5 +116,7 @@ python cookbook/environments/_29_expert_iteration/basic.py
 | Variable | Needed for |
 |---|---|
 | none | the offline run |
-| `AGNO_RUN_TINKER_FINE_TUNE=1` | opting in to the live fine-tune (spends money) |
-| `TINKER_API_KEY` | the live fine-tune branch |
+| `AGNO_TRAINER` | `stub` (default), `tinker`, or `fireworks` |
+| `AGNO_RUN_FINE_TUNE=1` | opting in to a live fine-tune (spends money) |
+| `TINKER_API_KEY` | the Tinker live path (`pip install agno[tinker]`) |
+| `FIREWORKS_API_KEY`, `FIREWORKS_ACCOUNT_ID` | the Fireworks live path (`pip install agno[fireworks]`) |

--- a/cookbook/environments/_29_expert_iteration/README.md
+++ b/cookbook/environments/_29_expert_iteration/README.md
@@ -35,7 +35,8 @@ of* the provider key: `AGNO_RUN_FINE_TUNE=1`. A key alone never triggers spend.
 A key is capability, not consent: with only `TINKER_API_KEY` or
 `FIREWORKS_API_KEY` set (as direnv does in many shells) the file still runs the
 free offline stub. (`AGNO_RUN_TINKER_FINE_TUNE=1`, the original Tinker-only
-spelling, still works and implies `AGNO_TRAINER=tinker`.)
+spelling, still works and implies `AGNO_TRAINER=tinker`; combining it with an
+explicit different `AGNO_TRAINER` is an error rather than a silent override.)
 
 ```bash
 # offline (default)

--- a/cookbook/environments/_29_expert_iteration/TEST_LOG.md
+++ b/cookbook/environments/_29_expert_iteration/TEST_LOG.md
@@ -23,6 +23,14 @@ without `AGNO_RUN_FINE_TUNE=1` raises before any client is built; (3)
 raises naming the missing key. No network call is reachable on any offline
 path.
 
+Re-run after the adversarial-review fold (same day): still PASS, identical
+numbers. Two review findings changed this file's behavior and were re-verified:
+an unmeasured round (e.g. a live baseline where every attempt times out) now
+prints a legible "round measured nothing" report instead of crashing on a None
+train_result, and a stale AGNO_RUN_TINKER_FINE_TUNE=1 export now conflicts
+loudly with an explicit different AGNO_TRAINER instead of silently selecting a
+paid Tinker run.
+
 ---
 
 ### basic.py — offline path

--- a/cookbook/environments/_29_expert_iteration/TEST_LOG.md
+++ b/cookbook/environments/_29_expert_iteration/TEST_LOG.md
@@ -77,17 +77,21 @@ routine cookbook testing, because it spends real training compute.
 
 ### basic.py — live path, Fireworks
 
-**Status:** NOT RUN (owner-gated)
+**Status:** PASS (ran live, 2026-07-22) — the loop closed on open weights.
 
 **Description:** With `AGNO_TRAINER=fireworks`, `AGNO_RUN_FINE_TUNE=1`,
 `FIREWORKS_API_KEY` and `FIREWORKS_ACCOUNT_ID` set, the same file runs
-`FireworksTrainer(base_model="accounts/fireworks/models/qwen3-8b", epochs=1)`:
-a managed LoRA SFT job (~pennies at $0.50/1M training tokens), then one
-on-demand BF16 deployment with addons enabled serving both base and tuned
-(order $7/hour of GPU time while serving; `teardown()` deletes it at the end of
-the run). Readiness notes in `specs/agno/2.8.3/notes/FIREWORKS_BUILD.md`.
+`FireworksTrainer(base_model="accounts/fireworks/models/qwen3-4b-instruct-2507",
+epochs=1, sampling_reasoning_effort="none")`: a managed LoRA SFT job (~pennies at
+$0.50/1M training tokens), then one on-demand BF16 deployment with addons enabled
+serving both base and tuned (order $7/hour of GPU time while serving; `teardown()`
+deletes it at the end of the run).
 
-**Result:** deliberately not executed in this pass — the paid run is the
-owner's step.
+**Result:** one bounded managed SFT job (1 epoch, 21 rows, never retried) moved the
+pass rate on the real 5-7-5 verifier from **baseline 0.333 to tuned 0.548**
+(14/42 -> 23/42, same deployment, same H100/BF16, 42/42 scored both sides); per-task
+highlights `debugger_3am` 2/6 -> 6/6, `prod_friday` 1/6 -> 4/6. Teardown verified 0
+deployments / 0 deployedModels left. Full narrative, the base-vs-tuned haiku, the five
+live-surfaced adapter fixes, and cost are in `specs/agno/2.8.3/notes/live-proof.md`.
 
 ---

--- a/cookbook/environments/_29_expert_iteration/TEST_LOG.md
+++ b/cookbook/environments/_29_expert_iteration/TEST_LOG.md
@@ -2,6 +2,29 @@
 
 Tested 2026-07-21 with `.venvs/demo/bin/python`.
 
+### basic.py — offline path, trainer-selection rework (2026-07-22, feat/fireworks-adapter)
+
+**Status:** PASS
+
+**Description:** Re-ran the offline loop after making the trainer selectable
+(`AGNO_TRAINER=stub|tinker|fireworks` plus the generalized consent flag
+`AGNO_RUN_FINE_TUNE=1`), with all keys explicitly stripped
+(`env -u TINKER_API_KEY -u FIREWORKS_API_KEY`). Also fixed the inline
+`StubTrainer` to digest the real dataset bytes: the loop's provenance guard now
+(correctly) refuses a checkpoint whose `dataset_digest` does not match the file
+it trained on, which the old hard-coded `"offline"` digest tripped.
+
+**Result:** The loop closed. Baseline pass rate 0.50, tuned pass rate 1.00; all
+three tasks improved by +0.50 and the diff reported "env identical, policy
+changed". Consent gates verified: (1) both keys present with no opt-in prints
+the capability-not-consent notice and runs the stub; (2) `AGNO_TRAINER=fireworks`
+without `AGNO_RUN_FINE_TUNE=1` raises before any client is built; (3)
+`AGNO_TRAINER=fireworks AGNO_RUN_FINE_TUNE=1` without `FIREWORKS_API_KEY`
+raises naming the missing key. No network call is reachable on any offline
+path.
+
+---
+
 ### basic.py — offline path
 
 **Status:** PASS
@@ -41,5 +64,22 @@ fine-tune. That run is bounded and recorded separately rather than as part of
 routine cookbook testing, because it spends real training compute.
 
 **Result:** recorded in the live-proof note.
+
+---
+
+### basic.py — live path, Fireworks
+
+**Status:** NOT RUN (owner-gated)
+
+**Description:** With `AGNO_TRAINER=fireworks`, `AGNO_RUN_FINE_TUNE=1`,
+`FIREWORKS_API_KEY` and `FIREWORKS_ACCOUNT_ID` set, the same file runs
+`FireworksTrainer(base_model="accounts/fireworks/models/qwen3-8b", epochs=1)`:
+a managed LoRA SFT job (~pennies at $0.50/1M training tokens), then one
+on-demand BF16 deployment with addons enabled serving both base and tuned
+(order $7/hour of GPU time while serving; `teardown()` deletes it at the end of
+the run). Readiness notes in `specs/agno/2.8.3/notes/FIREWORKS_BUILD.md`.
+
+**Result:** deliberately not executed in this pass — the paid run is the
+owner's step.
 
 ---

--- a/cookbook/environments/_29_expert_iteration/basic.py
+++ b/cookbook/environments/_29_expert_iteration/basic.py
@@ -35,7 +35,7 @@ from agno.scorer import CodeScorer
 from agno.trainers import Checkpoint, TrainOn, TrainResult, TrainStatus
 
 BASE_MODEL = "Qwen/Qwen3.6-35B-A3B"  # the stub's checkpoint identity, and Tinker's base
-FIREWORKS_BASE_MODEL = "accounts/fireworks/models/qwen3-8b"
+FIREWORKS_BASE_MODEL = "accounts/fireworks/models/qwen3-4b-instruct-2507"
 
 
 def is_three_lines(run, expected):
@@ -230,7 +230,12 @@ def build_trainer():
             "Serving both sides of the before/after uses one on-demand deployment; "
             "GPU time bills while it serves, and it is deleted at the end of the run."
         )
-        return FireworksTrainer(base_model=FIREWORKS_BASE_MODEL, epochs=1)
+        # reasoning_effort="none" keeps this instruct model's answer in `content`;
+        # otherwise Fireworks' reasoning parser routes the whole completion into the
+        # reasoning channel and every attempt reads as empty.
+        return FireworksTrainer(
+            base_model=FIREWORKS_BASE_MODEL, epochs=1, sampling_reasoning_effort="none"
+        )
 
     if choice != "stub":
         raise RuntimeError(

--- a/cookbook/environments/_29_expert_iteration/basic.py
+++ b/cookbook/environments/_29_expert_iteration/basic.py
@@ -6,13 +6,22 @@ Close the loop. The environment generates a dataset from what the base model
 already gets right, a trainer fine-tunes on it, and the tuned checkpoint is run
 back through the same environment so the gain is measured, not assumed.
 
-This runs offline by default against a stub trainer defined below, so the shape
-of the loop is visible without a GPU or an API key. The live path spends real
-training compute, so it requires an explicit opt-in on top of the key: set
-AGNO_RUN_TINKER_FINE_TUNE=1 (and TINKER_API_KEY) to run a real Tinker fine-tune.
+The trainer is swappable -- that is the demo. The same ImprovementLoop runs
+against three backends, selected by AGNO_TRAINER:
+
+    stub       (default) the offline stand-in below; no GPU, no key, no spend
+    tinker     TinkerTrainer -- agno drives the training loop step by step
+    fireworks  FireworksTrainer -- a managed fine-tuning job plus an
+               on-demand deployment for serving
+
+The live paths spend real training compute, so they require an explicit opt-in
+on top of the key: set AGNO_RUN_FINE_TUNE=1 as well as the provider's API key.
 A key alone never triggers spend -- a key is capability, not consent.
+(AGNO_RUN_TINKER_FINE_TUNE=1, the original Tinker-only spelling, still works
+and implies AGNO_TRAINER=tinker.)
 """
 
+import hashlib
 import os
 from itertools import cycle
 from pathlib import Path
@@ -25,7 +34,8 @@ from agno.models.response import ModelResponse
 from agno.scorer import CodeScorer
 from agno.trainers import Checkpoint, TrainOn, TrainResult, TrainStatus
 
-BASE_MODEL = "Qwen/Qwen3.6-35B-A3B"
+BASE_MODEL = "Qwen/Qwen3.6-35B-A3B"  # the stub's checkpoint identity, and Tinker's base
+FIREWORKS_BASE_MODEL = "accounts/fireworks/models/qwen3-8b"
 
 
 def is_three_lines(run, expected):
@@ -93,14 +103,17 @@ class StubTrainer:
     def fit(
         self, dataset, *, train_on: TrainOn = TrainOn.LAST_ASSISTANT
     ) -> TrainResult:
-        rows = Path(dataset).read_text(encoding="utf-8").strip().split("\n")
+        data = Path(dataset).read_bytes()
+        rows = data.decode("utf-8").strip().split("\n")
         self._round += 1
         print(f"  stub fit: round {self._round} trained on {len(rows)} conversations")
         return TrainResult(
             checkpoint=Checkpoint(
                 ref=f"stub://round-{self._round}",
                 base_model=BASE_MODEL,
-                dataset_digest="offline",
+                # The real digest of the real bytes: the loop refuses to serve a
+                # checkpoint whose provenance does not match the file it trained on.
+                dataset_digest=hashlib.sha256(data).hexdigest(),
                 hyperparams={
                     "rank": 16,
                     "learning_rate": 2e-4,
@@ -164,33 +177,82 @@ env = Environment(
 
 
 def build_trainer():
-    """The paid trainer only on explicit opt-in. A key is capability, not consent:
-    TINKER_API_KEY alone selects the stub, so an environment where the key is
-    always loaded (direnv) cannot spend a fine-tune by accident."""
+    """A paid trainer only on explicit opt-in. A key is capability, not consent:
+    an API key alone selects the stub, so an environment where keys are always
+    loaded (direnv) cannot spend a fine-tune by accident. AGNO_TRAINER picks the
+    backend; AGNO_RUN_FINE_TUNE=1 is the consent to spend."""
+    choice = os.environ.get("AGNO_TRAINER", "stub").strip().lower() or "stub"
+    consented = os.environ.get("AGNO_RUN_FINE_TUNE") == "1"
     if os.environ.get("AGNO_RUN_TINKER_FINE_TUNE") == "1":
-        if not os.environ.get("TINKER_API_KEY"):
+        choice, consented = "tinker", True
+
+    if choice == "tinker":
+        if not consented:
             raise RuntimeError(
-                "AGNO_RUN_TINKER_FINE_TUNE=1 but TINKER_API_KEY is not set; "
-                "the live fine-tune needs both."
+                "AGNO_TRAINER=tinker selected but AGNO_RUN_FINE_TUNE=1 is not set; "
+                "the live fine-tune needs the explicit consent flag."
             )
+        if not os.environ.get("TINKER_API_KEY"):
+            raise RuntimeError("The Tinker fine-tune needs TINKER_API_KEY.")
         from agno.trainers.tinker import TinkerTrainer
 
-        print(f"AGNO_RUN_TINKER_FINE_TUNE=1: fine-tuning {BASE_MODEL} for real.")
+        print(f"Trainer: Tinker. Fine-tuning {BASE_MODEL} for real.")
         return TinkerTrainer(base_model=BASE_MODEL, epochs=1)
-    if os.environ.get("TINKER_API_KEY"):
+
+    if choice == "fireworks":
+        if not consented:
+            raise RuntimeError(
+                "AGNO_TRAINER=fireworks selected but AGNO_RUN_FINE_TUNE=1 is not set; "
+                "the live fine-tune needs the explicit consent flag."
+            )
+        if not os.environ.get("FIREWORKS_API_KEY"):
+            raise RuntimeError("The Fireworks fine-tune needs FIREWORKS_API_KEY.")
+        if not os.environ.get("FIREWORKS_ACCOUNT_ID"):
+            print(
+                "FIREWORKS_ACCOUNT_ID is not set; FireworksTrainer will refuse before "
+                "any spend unless account_id is passed another way."
+            )
+        from agno.trainers.fireworks import FireworksTrainer
+
+        print(f"Trainer: Fireworks. Fine-tuning {FIREWORKS_BASE_MODEL} for real.")
         print(
-            "TINKER_API_KEY found but AGNO_RUN_TINKER_FINE_TUNE is not set: "
-            "using the offline stub. Set AGNO_RUN_TINKER_FINE_TUNE=1 to spend a real fine-tune."
+            "Serving both sides of the before/after uses one on-demand deployment; "
+            "GPU time bills while it serves, and it is deleted at the end of the run."
+        )
+        return FireworksTrainer(base_model=FIREWORKS_BASE_MODEL, epochs=1)
+
+    if choice != "stub":
+        raise RuntimeError(
+            f"Unknown AGNO_TRAINER {choice!r}: expected stub, tinker or fireworks."
+        )
+
+    keys_present = [
+        name for name in ("TINKER_API_KEY", "FIREWORKS_API_KEY") if os.environ.get(name)
+    ]
+    if keys_present:
+        print(
+            f"{' and '.join(keys_present)} found but no live trainer was opted into: "
+            "using the offline stub. Set AGNO_TRAINER=tinker or fireworks plus "
+            "AGNO_RUN_FINE_TUNE=1 to spend a real fine-tune."
         )
     else:
-        print("No TINKER_API_KEY: running the loop against the offline stub trainer.")
+        print("No trainer API key: running the loop against the offline stub trainer.")
     return StubTrainer(offline_base, [offline_tuned])
 
 
 if __name__ == "__main__":
-    loop = ImprovementLoop(env, trainer=build_trainer(), k=4)
+    trainer = build_trainer()
+    loop = ImprovementLoop(env, trainer=trainer, k=4)
 
-    report = loop.step()
+    try:
+        report = loop.step()
+    finally:
+        # FireworksTrainer serves through an on-demand deployment that bills GPU
+        # time; releasing it is part of the run. The other trainers have no
+        # serving infrastructure to release.
+        teardown = getattr(trainer, "teardown", None)
+        if teardown is not None:
+            teardown()
 
     if report.converged:
         print(f"nothing to train on: {report.converged_reason}")
@@ -200,7 +262,7 @@ if __name__ == "__main__":
         print(f"tuned pass rate:    {report.tuned_pass_rate}")
         print(report.diff)
         print(f"trained on: {report.dataset_path}")
-        print(f"loss curve: {report.train_result.step_metrics}")
+        print(f"training metrics: {report.train_result.step_metrics}")
         print("Same environment, same agent design, different weights.")
         print(
             "At 3 tasks the numbers are noisy; measure held-out tasks before claiming a gain."

--- a/cookbook/environments/_29_expert_iteration/basic.py
+++ b/cookbook/environments/_29_expert_iteration/basic.py
@@ -50,8 +50,9 @@ def is_three_lines(run, expected):
 
 # --- the offline stand-ins ---------------------------------------------------
 # A real trainer serves a real model. These two exist so this file runs with no
-# GPU and no network; the live branch at the bottom swaps in TinkerTrainer, whose
-# checkpoints are served as TinkerModel. Nothing here ships in agno.
+# GPU and no network; the live branches at the bottom swap in TinkerTrainer
+# (served as TinkerModel) or FireworksTrainer (served from an on-demand Fireworks
+# deployment). Nothing here ships in agno.
 
 
 class ScriptedModel(Model):
@@ -181,9 +182,19 @@ def build_trainer():
     an API key alone selects the stub, so an environment where keys are always
     loaded (direnv) cannot spend a fine-tune by accident. AGNO_TRAINER picks the
     backend; AGNO_RUN_FINE_TUNE=1 is the consent to spend."""
-    choice = os.environ.get("AGNO_TRAINER", "stub").strip().lower() or "stub"
+    explicit = os.environ.get("AGNO_TRAINER")
+    choice = (explicit or "stub").strip().lower() or "stub"
     consented = os.environ.get("AGNO_RUN_FINE_TUNE") == "1"
     if os.environ.get("AGNO_RUN_TINKER_FINE_TUNE") == "1":
+        # The legacy flag implies tinker-with-consent, but an explicit different
+        # AGNO_TRAINER must not be silently overridden into a paid Tinker run
+        # (a stale export of the legacy flag would otherwise beat AGNO_TRAINER=stub).
+        if explicit and choice != "tinker":
+            raise RuntimeError(
+                "AGNO_RUN_TINKER_FINE_TUNE=1 (legacy, implies tinker) conflicts with "
+                f"AGNO_TRAINER={choice!r}; unset one, or use AGNO_TRAINER=tinker "
+                "AGNO_RUN_FINE_TUNE=1."
+            )
         choice, consented = "tinker", True
 
     if choice == "tinker":
@@ -257,6 +268,19 @@ if __name__ == "__main__":
     if report.converged:
         print(f"nothing to train on: {report.converged_reason}")
         print(f"export counters: {report.export_report}")
+    elif report.unmeasured_reason is not None:
+        # A live-path shape: the baseline produced no scored attempts, or the
+        # tuned side could not be measured. With a checkpoint present, the
+        # fine-tune was paid for and is preserved on the report.
+        print(f"round measured nothing: {report.unmeasured_reason}")
+        print(f"baseline pass rate: {report.baseline_pass_rate}")
+        if report.checkpoint is not None:
+            print(
+                f"checkpoint paid for but unmeasured, preserved: {report.checkpoint.ref}"
+            )
+            print(
+                "re-measure it with run_rollouts(env, model=trainer.as_model(report.checkpoint))"
+            )
     else:
         print(f"baseline pass rate: {report.baseline_pass_rate}")
         print(f"tuned pass rate:    {report.tuned_pass_rate}")

--- a/libs/agno/agno/trainers/fireworks.py
+++ b/libs/agno/agno/trainers/fireworks.py
@@ -1,0 +1,579 @@
+"""Fine-tune an open-weights model on Fireworks, and serve the result as an agno Model.
+
+Fireworks runs supervised fine-tuning as a managed job: upload the dataset, create the
+job, poll it to a terminal state, and the platform hands back a LoRA model resource.
+Serving is the part that differs from Tinker: Fireworks does not serve fine-tuned LoRAs
+(or the small tunable base models) serverless, so measuring either side of the
+before/after needs an on-demand deployment. This trainer keeps ONE such deployment --
+the base model with PEFT addons enabled, BF16 -- and serves base and tuned from it, so
+the comparison runs on identical hardware and precision and the only difference between
+the two policies is the weights.
+
+The deployment is the cost to know about. An on-demand deployment bills GPU time while
+replicas run (order $7+/hour for a single-GPU shape); it is created with
+min_replica_count=0 so it scales to zero when idle and Fireworks auto-deletes it after
+seven idle days, and `teardown()` deletes it deterministically. Pass `deployment_id=`
+to bring your own addons-enabled deployment instead; the trainer never deletes a
+deployment it did not create. The first request after a scale-to-zero pays a cold-start
+delay, so give the environment a generous `timeout_seconds`.
+
+**Import style is a deliberate deviation.** The `fireworks` SDK is imported lazily,
+inside methods, so this module imports cleanly with the SDK uninstalled and its tests
+can inject a fake client. That is load-bearing for the offline test contract -- do not
+"fix" it to the module-level try/except convention.
+
+Consent is the caller's. `fit()` trains when called and the serving doors deploy when
+called: they do not gate spend, ask for authorization, or retry a paid job. That policy
+belongs to whoever holds the budget.
+"""
+
+import asyncio
+import hashlib
+import json
+import math
+import time
+from os import getenv
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+from uuid import uuid4
+
+from agno.models.base import Model
+from agno.models.fireworks import Fireworks
+from agno.trainers.base import Checkpoint, TrainOn, TrainResult, TrainStatus
+from agno.utils.log import log_info, log_warning
+
+# Fireworks' own dataset rules (docs.fireworks.ai, verified July 2026): at least 3
+# examples, at most 3M, and the one-shot :upload path caps the file at 150 MB. The
+# Tinker oracle's 320-conversation / 1 MiB caps deliberately do NOT apply here.
+MIN_EXAMPLES = 3
+MAX_EXAMPLES = 3_000_000
+MAX_UPLOAD_BYTES = 150 * 1024 * 1024
+
+_MESSAGE_ROLES = frozenset({"system", "user", "assistant"})
+
+# fireworks.types.SupervisedFineTuningJob.state values, verified against the SDK.
+_JOB_SUCCESS_STATES = frozenset({"JOB_STATE_COMPLETED", "JOB_STATE_EARLY_STOPPED"})
+_JOB_FAILURE_STATES = frozenset(
+    {
+        "JOB_STATE_FAILED",
+        "JOB_STATE_CANCELLED",
+        "JOB_STATE_EXPIRED",
+        "JOB_STATE_DELETING",
+        "JOB_STATE_DELETING_CLEANING_UP",
+        # Paused means account suspension or manual intervention; resuming it is a
+        # billing decision, so it is surfaced as a failure rather than waited out.
+        "JOB_STATE_PAUSED",
+    }
+)
+
+
+def validate_fireworks_sft_jsonl(path: Union[str, Path]) -> int:
+    """Validate a dataset against Fireworks' supervised fine-tuning rules.
+
+    Returns the number of examples; raises ValueError on the first violation, so a
+    malformed file is refused before any dataset or job resource is created.
+
+    This is a THIRD validator next to the byte-identical pair in
+    `agno/environments/exporters/_validate.py` / `agno/trainers/_validate.py`, and the
+    divergence is deliberate: those two encode Tinker's consumer caps (320
+    conversations, 1 MiB), Fireworks allows up to 3M examples with a 3-example
+    minimum. Do not unify them.
+
+    One rule is stricter than the platform's: each example must contain exactly one
+    assistant message, in final position. Fireworks trains on every assistant message
+    unless per-message weights say otherwise, so this is what keeps
+    `TrainOn.LAST_ASSISTANT` exact without rewriting the uploaded file. `to_sft_jsonl`
+    output satisfies it by construction; multi-assistant conversations are 2.9's
+    flattened export and get per-message weights then.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    size = len(text.encode("utf-8"))
+    if size > MAX_UPLOAD_BYTES:
+        raise ValueError(f"dataset is {size} bytes; the one-shot upload path is capped at {MAX_UPLOAD_BYTES} bytes")
+    if not text.strip():
+        raise ValueError("dataset must contain at least one conversation")
+    # Split on "\n" only, matching the canonical writer: splitlines() also breaks on
+    # U+2028/U+2029/U+0085, which json.dumps(ensure_ascii=False) emits unescaped.
+    lines = text.strip().split("\n")
+    if len(lines) < MIN_EXAMPLES:
+        raise ValueError(f"dataset has {len(lines)} examples; Fireworks requires at least {MIN_EXAMPLES}")
+    if len(lines) > MAX_EXAMPLES:
+        raise ValueError(f"dataset has {len(lines)} examples; the limit is {MAX_EXAMPLES}")
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            raise ValueError(f"line {line_number} is blank; JSONL requires one object per line")
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"line {line_number} is not valid JSON: {exc.msg}") from exc
+        if not isinstance(value, dict) or set(value) != {"messages"}:
+            raise ValueError(f"line {line_number} must contain only a messages field")
+        messages = value["messages"]
+        if not isinstance(messages, list) or not messages:
+            raise ValueError(f"line {line_number} must have a non-empty messages list")
+        assistant_positions: List[int] = []
+        for message_number, message in enumerate(messages, start=1):
+            prefix = f"line {line_number}, message {message_number}"
+            if not isinstance(message, dict) or set(message) != {"role", "content"}:
+                raise ValueError(f"{prefix} must contain only role and content")
+            role = message["role"]
+            content = message["content"]
+            if not isinstance(role, str) or role not in _MESSAGE_ROLES:
+                raise ValueError(f"{prefix} has unsupported role {role!r}")
+            if not isinstance(content, str) or not content.strip():
+                raise ValueError(f"{prefix} content must be a non-empty string")
+            if role == "assistant":
+                assistant_positions.append(message_number)
+        if not any(message["role"] == "user" for message in messages):
+            raise ValueError(f"line {line_number} must contain a user message")
+        if messages[-1]["role"] != "assistant":
+            raise ValueError(f"line {line_number} must end with an assistant message")
+        if assistant_positions != [len(messages)]:
+            raise ValueError(
+                f"line {line_number} must contain exactly one assistant message, in final position: "
+                "Fireworks trains on every assistant message, so an earlier assistant turn would be "
+                "trained on too, silently changing what train_on=LAST_ASSISTANT means"
+            )
+    return len(lines)
+
+
+class FireworksTrainer:
+    """A `Trainer` backed by Fireworks' managed supervised fine-tuning and serving.
+
+    The tuned artifact is a LoRA model resource (`accounts/<account>/models/<id>`)
+    that persists until deleted, so unlike Tinker checkpoints the ref itself is
+    durable; the dataset file plus `dataset_digest` and `hyperparams` remain the
+    reproducible provenance.
+
+    `TrainStatus.PARTIAL` is never produced: a managed job exposes no mid-run
+    recoverable checkpoint, so a job that dies mid-run is `FAILED` with nothing to
+    keep. This is a real difference from `TinkerTrainer`, which drives the training
+    loop itself and can save what the completed steps paid for.
+
+    Both `TrainOn` values are accepted and behave identically here: the dataset
+    validator admits only single-assistant-final conversations (see
+    `validate_fireworks_sft_jsonl`), on which training the last assistant message and
+    training all of them are the same thing. Data that distinguishes them arrives
+    with 2.9's multi-turn export.
+    """
+
+    def __init__(
+        self,
+        base_model: str,
+        *,
+        rank: int = 16,
+        learning_rate: float = 1e-4,
+        epochs: int = 1,
+        sampling_temperature: float = 0.7,
+        sampling_max_tokens: int = 2000,
+        account_id: Optional[str] = None,
+        deployment_id: Optional[str] = None,
+        poll_interval_seconds: float = 10.0,
+        ready_timeout_seconds: float = 1800.0,
+        train_timeout_seconds: Optional[float] = None,
+        client: Optional[Any] = None,
+    ) -> None:
+        # Every hyperparameter is validated here, before any client call could
+        # possibly be made -- a bad value that only fails inside fit() has already
+        # created billable resources.
+        if not isinstance(base_model, str) or not base_model.strip():
+            raise ValueError(f"base_model must be a non-blank model name, got {base_model!r}")
+        if isinstance(epochs, bool) or not isinstance(epochs, int) or epochs < 1:
+            raise ValueError(f"epochs must be an int >= 1, got {epochs!r}")
+        if isinstance(rank, bool) or not isinstance(rank, int) or rank < 1:
+            raise ValueError(f"rank must be an int >= 1, got {rank!r}")
+        if isinstance(sampling_max_tokens, bool) or not isinstance(sampling_max_tokens, int) or sampling_max_tokens < 1:
+            raise ValueError(f"sampling_max_tokens must be an int >= 1, got {sampling_max_tokens!r}")
+        if (
+            isinstance(learning_rate, bool)
+            or not isinstance(learning_rate, (int, float))
+            or not (math.isfinite(learning_rate) and learning_rate > 0)
+        ):
+            raise ValueError(f"learning_rate must be a finite value > 0, got {learning_rate!r}")
+        if not (math.isfinite(sampling_temperature) and sampling_temperature > 0):
+            # The negated form also rejects NaN, which passes every plain comparison.
+            raise ValueError(
+                f"sampling_temperature must be a finite value > 0, got {sampling_temperature}: at "
+                "temperature 0 all k attempts are identical and the learning zone is empty by construction"
+            )
+        if not (
+            isinstance(poll_interval_seconds, (int, float))
+            and not isinstance(poll_interval_seconds, bool)
+            and math.isfinite(poll_interval_seconds)
+            and poll_interval_seconds >= 0
+        ):
+            raise ValueError(f"poll_interval_seconds must be a finite value >= 0, got {poll_interval_seconds!r}")
+        if not (
+            isinstance(ready_timeout_seconds, (int, float))
+            and not isinstance(ready_timeout_seconds, bool)
+            and math.isfinite(ready_timeout_seconds)
+            and ready_timeout_seconds > 0
+        ):
+            raise ValueError(f"ready_timeout_seconds must be a finite value > 0, got {ready_timeout_seconds!r}")
+        if train_timeout_seconds is not None and not (
+            isinstance(train_timeout_seconds, (int, float))
+            and not isinstance(train_timeout_seconds, bool)
+            and math.isfinite(train_timeout_seconds)
+            and train_timeout_seconds > 0
+        ):
+            raise ValueError(f"train_timeout_seconds must be None or a finite value > 0, got {train_timeout_seconds!r}")
+        self.base_model = base_model
+        self.rank = rank
+        self.learning_rate = learning_rate
+        self.epochs = epochs
+        self.sampling_temperature = sampling_temperature
+        self.sampling_max_tokens = sampling_max_tokens
+        self.account_id = account_id
+        self.deployment_id = deployment_id
+        self.poll_interval_seconds = poll_interval_seconds
+        self.ready_timeout_seconds = ready_timeout_seconds
+        self.train_timeout_seconds = train_timeout_seconds
+        self._client = client
+        self._deployment_name: Optional[str] = None
+        self._created_deployment_id: Optional[str] = None
+        self._loaded_addon_ids: List[str] = []
+
+    # -- lazy SDK wiring ---------------------------------------------------------
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            from fireworks import Fireworks as FireworksClient
+
+            self._client = FireworksClient(account_id=self.account_id)
+        return self._client
+
+    def _resolve_account_id(self, client: Any) -> str:
+        for candidate in (self.account_id, getattr(client, "account_id", None), getenv("FIREWORKS_ACCOUNT_ID")):
+            if candidate:
+                return str(candidate)
+        raise ValueError(
+            "Fireworks account id required: pass account_id= to FireworksTrainer, set the "
+            "FIREWORKS_ACCOUNT_ID environment variable, or inject a client constructed with one."
+        )
+
+    def _wait_until_ready(self, what: str, fetch: Any, is_ready: Any, is_failed: Any) -> Any:
+        deadline = time.monotonic() + self.ready_timeout_seconds
+        while True:
+            resource = fetch()
+            failure = is_failed(resource)
+            if failure:
+                raise RuntimeError(f"{what} failed: {failure}")
+            if is_ready(resource):
+                return resource
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"{what} not ready after {self.ready_timeout_seconds}s")
+            time.sleep(self.poll_interval_seconds)
+
+    # -- fit ---------------------------------------------------------------------
+
+    def fit(self, dataset: Union[str, Path], *, train_on: TrainOn = TrainOn.LAST_ASSISTANT) -> TrainResult:
+        """Upload `dataset`, run a managed supervised fine-tuning job, and poll it to
+        a terminal state.
+
+        The dataset is validated before any call is made: a malformed file fails
+        here, for free, with no dataset record and no job created. A poll timeout
+        (`train_timeout_seconds`) returns `FAILED` but does NOT cancel the job -- it
+        keeps running on Fireworks and may still complete; the error names it. A job
+        is never retried.
+        """
+        path = Path(dataset)
+        # The runtime gate, before anything is created server-side.
+        n_examples = validate_fireworks_sft_jsonl(path)
+        dataset_digest = hashlib.sha256(path.read_bytes()).hexdigest()
+
+        hyperparams: Dict[str, Any] = {
+            "rank": self.rank,
+            "learning_rate": self.learning_rate,
+            "epochs": self.epochs,
+            "train_on": train_on.value,
+            # batch_size is deliberately absent: the managed job owns batching.
+        }
+        step_metrics: List[Dict[str, Any]] = []
+
+        try:
+            client = self._get_client()
+            account_id = self._resolve_account_id(client)
+
+            dataset_id = f"agno-{dataset_digest[:16]}"
+            self._upload_dataset(client, dataset_id, path, n_examples)
+
+            output_model = f"accounts/{account_id}/models/agno-sft-{uuid4().hex[:10]}"
+            job = client.supervised_fine_tuning_jobs.create(
+                dataset=f"accounts/{account_id}/datasets/{dataset_id}",
+                base_model=self.base_model,
+                output_model=output_model,
+                epochs=self.epochs,
+                learning_rate=self.learning_rate,
+                lora_rank=self.rank,
+                display_name=f"agno sft {dataset_digest[:12]}",
+            )
+            job_name = getattr(job, "name", None) or ""
+            job_id = job_name.rsplit("/", 1)[-1]
+            if not job_id:
+                return TrainResult(
+                    checkpoint=None,
+                    step_metrics=step_metrics,
+                    status=TrainStatus.FAILED,
+                    error="Fireworks did not return a job name; cannot poll the fine-tuning job",
+                )
+            log_info(f"FireworksTrainer: created fine-tuning job {job_name} -> {output_model}")
+
+            deadline = None if self.train_timeout_seconds is None else time.monotonic() + self.train_timeout_seconds
+            while True:
+                state = getattr(job, "state", None) or "JOB_STATE_UNSPECIFIED"
+                snapshot = self._progress_snapshot(job, state, step=len(step_metrics) + 1)
+                if not step_metrics or {k: v for k, v in step_metrics[-1].items() if k != "step"} != {
+                    k: v for k, v in snapshot.items() if k != "step"
+                }:
+                    step_metrics.append(snapshot)
+                if state in _JOB_SUCCESS_STATES:
+                    break
+                if state in _JOB_FAILURE_STATES:
+                    return TrainResult(
+                        checkpoint=None,
+                        step_metrics=step_metrics,
+                        status=TrainStatus.FAILED,
+                        error=f"fine-tuning job {job_name} ended {state}: {self._status_message(job)}",
+                    )
+                if deadline is not None and time.monotonic() >= deadline:
+                    return TrainResult(
+                        checkpoint=None,
+                        step_metrics=step_metrics,
+                        status=TrainStatus.FAILED,
+                        error=(
+                            f"timed out after {self.train_timeout_seconds}s waiting for {job_name}; the job "
+                            "was NOT cancelled and may still complete -- check it on Fireworks and, if it "
+                            "finishes, serve its output model directly rather than re-running fit"
+                        ),
+                    )
+                time.sleep(self.poll_interval_seconds)
+                job = client.supervised_fine_tuning_jobs.get(job_id)
+
+            ref = getattr(job, "output_model", None) or output_model
+            log_info(f"FireworksTrainer: job {job_name} completed; tuned model {ref}")
+            return TrainResult(
+                checkpoint=Checkpoint(
+                    ref=ref,
+                    base_model=self.base_model,
+                    dataset_digest=dataset_digest,
+                    hyperparams=hyperparams,
+                ),
+                step_metrics=step_metrics,
+                status=TrainStatus.COMPLETED,
+            )
+        except Exception as exc:
+            # No recovery path: a managed job that failed left nothing servable
+            # behind, and retrying it is a billing decision that belongs to the
+            # caller.
+            error = f"{type(exc).__name__}: {str(exc).strip() or 'no details'}"
+            return TrainResult(checkpoint=None, step_metrics=step_metrics, status=TrainStatus.FAILED, error=error)
+
+    async def afit(self, dataset: Union[str, Path], *, train_on: TrainOn = TrainOn.LAST_ASSISTANT) -> TrainResult:
+        """Async twin of `fit`. Upload and polling block, so they run off-thread."""
+        return await asyncio.to_thread(self.fit, dataset, train_on=train_on)
+
+    def _upload_dataset(self, client: Any, dataset_id: str, path: Path, n_examples: int) -> None:
+        """Create the dataset record and upload the file, reusing an identical prior upload.
+
+        The dataset id is derived from the file digest, so re-fitting the same bytes
+        hits the same record: a conflict on create means the contents are already
+        there and the upload is skipped once the record reports READY.
+        """
+        try:
+            client.datasets.create(dataset_id=dataset_id, dataset={"exampleCount": str(n_examples)})
+        except Exception as exc:
+            if getattr(exc, "status_code", None) != 409:
+                raise
+            existing = client.datasets.get(dataset_id=dataset_id)
+            if getattr(existing, "state", None) == "READY":
+                log_info(f"FireworksTrainer: dataset {dataset_id} already uploaded; reusing it")
+                return
+        client.datasets.upload(dataset_id=dataset_id, file=path)
+        self._wait_until_ready(
+            f"dataset {dataset_id}",
+            lambda: client.datasets.get(dataset_id=dataset_id),
+            lambda resource: getattr(resource, "state", None) == "READY",
+            lambda resource: (
+                self._status_message(resource)
+                if getattr(resource, "state", None) not in (None, "STATE_UNSPECIFIED", "UPLOADING", "READY")
+                else None
+            ),
+        )
+
+    @staticmethod
+    def _progress_snapshot(job: Any, state: str, *, step: int) -> Dict[str, Any]:
+        """Only what Fireworks actually reports. The loss curve is not surfaced as
+        JSON by the job API (it lives behind `metrics_file_signed_url`), so no
+        `mean_nll` is ever fabricated here."""
+        snapshot: Dict[str, Any] = {"step": step, "state": state}
+        progress = getattr(job, "job_progress", None)
+        percent = getattr(progress, "percent", None)
+        epoch = getattr(progress, "epoch", None)
+        if percent is not None:
+            snapshot["percent"] = percent
+        if epoch is not None:
+            snapshot["epoch"] = epoch
+        return snapshot
+
+    @staticmethod
+    def _status_message(resource: Any) -> str:
+        status = getattr(resource, "status", None)
+        message = getattr(status, "message", None)
+        return str(message) if message else "no details"
+
+    # -- serving -----------------------------------------------------------------
+
+    def _ensure_deployment(self) -> str:
+        """The one on-demand deployment base and tuned are both measured on.
+
+        Created on first use (BF16, PEFT addons enabled, min replicas 0 so idle time
+        is free, max 1 so the spend is bounded to a single replica), or resolved from
+        `deployment_id` when the caller brought their own. Billing runs while a
+        replica serves; `teardown()` deletes a created deployment deterministically,
+        and Fireworks auto-deletes a min-0 deployment after seven idle days.
+        """
+        if self._deployment_name is not None:
+            return self._deployment_name
+        client = self._get_client()
+        account_id = self._resolve_account_id(client)
+        if self.deployment_id:
+            deployment = client.deployments.get(self.deployment_id)
+            if getattr(deployment, "state", None) != "READY":
+                deployment = self._wait_for_deployment(client, self.deployment_id)
+            if getattr(deployment, "enable_addons", None) is False:
+                log_warning(
+                    f"FireworksTrainer: deployment {self.deployment_id} has addons disabled; "
+                    "serving a tuned LoRA on it will fail. Create it with enable_addons=True."
+                )
+            self._deployment_name = f"accounts/{account_id}/deployments/{self.deployment_id}"
+            return self._deployment_name
+        deployment_id = f"agno-{uuid4().hex[:10]}"
+        client.deployments.create(
+            base_model=self.base_model,
+            deployment_id=deployment_id,
+            display_name=f"agno improvement loop {deployment_id}",
+            # BF16 because FP8/FP4 deployment shapes reject PEFT addons; addons are
+            # how the tuned LoRA is served next to its base on the same hardware.
+            enable_addons=True,
+            precision="BF16",
+            min_replica_count=0,
+            max_replica_count=1,
+        )
+        self._created_deployment_id = deployment_id
+        self._wait_for_deployment(client, deployment_id)
+        self._deployment_name = f"accounts/{account_id}/deployments/{deployment_id}"
+        log_warning(
+            f"FireworksTrainer: created on-demand deployment {self._deployment_name}; GPU time bills "
+            "while it serves (it scales to zero when idle). Call teardown() to delete it when done."
+        )
+        return self._deployment_name
+
+    def _wait_for_deployment(self, client: Any, deployment_id: str) -> Any:
+        return self._wait_until_ready(
+            f"deployment {deployment_id}",
+            lambda: client.deployments.get(deployment_id),
+            lambda resource: getattr(resource, "state", None) == "READY",
+            lambda resource: (
+                self._status_message(resource)
+                if getattr(resource, "state", None) in ("FAILED", "DELETING", "DELETED")
+                else None
+            ),
+        )
+
+    def _serve(self, model_id: str) -> Model:
+        # system_prompt/instructions stay None so base and tuned share one env
+        # fingerprint; the id is the only policy difference (scorer/_model.py
+        # excludes credentials and clients from the identity payload).
+        return Fireworks(
+            id=model_id,
+            temperature=self.sampling_temperature,
+            max_tokens=self.sampling_max_tokens,
+        )
+
+    def as_model(self, checkpoint: Checkpoint) -> Model:
+        """Serve a tuned checkpoint: load its LoRA onto the shared deployment and
+        point an agno `Fireworks` model at `<model>#<deployment>`. Sampling params
+        match `base_as_model`'s, so the only difference between the two policies is
+        the weights."""
+        if checkpoint.base_model != self.base_model:
+            raise ValueError(
+                f"checkpoint was trained from base_model {checkpoint.base_model!r} but this trainer "
+                f"serves {self.base_model!r}: its LoRA cannot load onto this base's deployment, and "
+                "serving it here would stamp a false policy identity. Serve it from a trainer built "
+                "on its own base model."
+            )
+        deployment_name = self._ensure_deployment()
+        client = self._get_client()
+        try:
+            deployed = client.lora.load(model=checkpoint.ref, deployment=deployment_name)
+        except Exception as exc:
+            if getattr(exc, "status_code", None) != 409:
+                raise
+            # Already loaded on this deployment (a re-serve of the same checkpoint);
+            # nothing new to track or wait for.
+            log_info(f"FireworksTrainer: {checkpoint.ref} already loaded on {deployment_name}")
+        else:
+            deployed_name = getattr(deployed, "name", None) or ""
+            deployed_id = deployed_name.rsplit("/", 1)[-1]
+            if deployed_id:
+                self._loaded_addon_ids.append(deployed_id)
+                self._wait_until_ready(
+                    f"LoRA {checkpoint.ref} on {deployment_name}",
+                    lambda: client.lora.get(deployed_id),
+                    lambda resource: getattr(resource, "state", None) == "DEPLOYED",
+                    lambda resource: (
+                        self._status_message(resource) if getattr(resource, "state", None) == "UNDEPLOYING" else None
+                    ),
+                )
+        return self._serve(f"{checkpoint.ref}#{deployment_name}")
+
+    async def aas_model(self, checkpoint: Checkpoint) -> Model:
+        # Serving can create a deployment and poll it ready -- minutes of blocking
+        # network -- so it runs off-thread: dispatched inline it would freeze every
+        # concurrent rollout coroutine before any engine timeout could fire.
+        return await asyncio.to_thread(self.as_model, checkpoint)
+
+    def base_as_model(self) -> Model:
+        """Serve the untuned base from the same deployment the tuned checkpoint will
+        use -- the baseline a before/after can trust, measured on identical hardware
+        and precision."""
+        deployment_name = self._ensure_deployment()
+        return self._serve(f"{self.base_model}#{deployment_name}")
+
+    async def abase_as_model(self) -> Model:
+        return await asyncio.to_thread(self.base_as_model)
+
+    # -- cleanup -----------------------------------------------------------------
+
+    def teardown(self) -> None:
+        """Release the serving infrastructure this trainer created.
+
+        Unloads every LoRA it loaded, then deletes the deployment IF this trainer
+        created it -- a `deployment_id` the caller brought is never deleted. Datasets
+        and tuned model resources are left in place: they are the provenance and the
+        artifact, and they do not bill by the hour. Best-effort and idempotent.
+        """
+        if self._client is None and self._created_deployment_id is None and not self._loaded_addon_ids:
+            return
+        client = self._get_client()
+        for deployed_id in self._loaded_addon_ids:
+            try:
+                client.lora.unload(deployed_id)
+            except Exception as exc:
+                log_warning(f"FireworksTrainer: failed to unload LoRA {deployed_id}: {exc}")
+        self._loaded_addon_ids = []
+        if self._created_deployment_id is not None:
+            try:
+                client.deployments.delete(self._created_deployment_id)
+                log_info(f"FireworksTrainer: deleted deployment {self._created_deployment_id}")
+            except Exception as exc:
+                log_warning(
+                    f"FireworksTrainer: failed to delete deployment {self._created_deployment_id}: {exc}; "
+                    "delete it on Fireworks to stop it billing"
+                )
+                return
+            self._created_deployment_id = None
+            self._deployment_name = None
+
+    async def ateardown(self) -> None:
+        await asyncio.to_thread(self.teardown)

--- a/libs/agno/agno/trainers/fireworks.py
+++ b/libs/agno/agno/trainers/fireworks.py
@@ -166,8 +166,10 @@ class FireworksTrainer:
         epochs: int = 1,
         sampling_temperature: float = 0.7,
         sampling_max_tokens: int = 2000,
+        sampling_reasoning_effort: Optional[str] = None,
         account_id: Optional[str] = None,
         deployment_id: Optional[str] = None,
+        accelerator_type: str = "NVIDIA_H100_80GB",
         poll_interval_seconds: float = 10.0,
         ready_timeout_seconds: float = 1800.0,
         train_timeout_seconds: Optional[float] = None,
@@ -178,6 +180,8 @@ class FireworksTrainer:
         # created billable resources.
         if not isinstance(base_model, str) or not base_model.strip():
             raise ValueError(f"base_model must be a non-blank model name, got {base_model!r}")
+        if not isinstance(accelerator_type, str) or not accelerator_type.strip():
+            raise ValueError(f"accelerator_type must be a non-blank accelerator name, got {accelerator_type!r}")
         if isinstance(epochs, bool) or not isinstance(epochs, int) or epochs < 1:
             raise ValueError(f"epochs must be an int >= 1, got {epochs!r}")
         if isinstance(rank, bool) or not isinstance(rank, int) or rank < 1:
@@ -227,8 +231,10 @@ class FireworksTrainer:
         self.epochs = epochs
         self.sampling_temperature = sampling_temperature
         self.sampling_max_tokens = sampling_max_tokens
+        self.sampling_reasoning_effort = sampling_reasoning_effort
         self.account_id = account_id
         self.deployment_id = deployment_id
+        self.accelerator_type = accelerator_type
         self.poll_interval_seconds = poll_interval_seconds
         self.ready_timeout_seconds = ready_timeout_seconds
         self.train_timeout_seconds = train_timeout_seconds
@@ -466,6 +472,16 @@ class FireworksTrainer:
                 base_model=self.base_model,
                 deployment_id=deployment_id,
                 display_name=f"agno improvement loop {deployment_id}",
+                # The control plane requires an explicit accelerator for non-embeddings
+                # engines. An H100 80GB is the default: it holds the small tunable bases
+                # in BF16 with addons, and fresh accounts carry quota for it (the A100
+                # pool can be zero-quota'd, which 429s the create).
+                accelerator_type=self.accelerator_type,
+                # Some bases carry a default speculative-decoding draft model whose
+                # precision (FP8_MM) the cheaper accelerators reject; speculation is a
+                # latency optimization, not a correctness one, and this deployment
+                # exists to measure a before/after, so it is off.
+                disable_speculative_decoding=True,
                 # BF16 because FP8/FP4 deployment shapes reject PEFT addons; addons are
                 # how the tuned LoRA is served next to its base on the same hardware.
                 enable_addons=True,
@@ -502,10 +518,20 @@ class FireworksTrainer:
         # system_prompt/instructions stay None so base and tuned share one env
         # fingerprint; the id is the only policy difference (scorer/_model.py
         # excludes credentials and clients from the identity payload).
+        extra: Dict[str, Any] = {}
+        if self.sampling_reasoning_effort is not None:
+            # Fireworks routes reasoning to a separate response field, and its parser
+            # can classify an ENTIRE completion as reasoning on some serving templates
+            # (observed live: qwen3-4b-instruct-2507, a non-thinking instruct model,
+            # returned every token in `reasoning` and none in `content`, so no attempt
+            # could ever be scored). "none" turns the reasoning channel off. Both sides
+            # of the before/after get the same value, so the comparison holds.
+            extra["reasoning_effort"] = self.sampling_reasoning_effort
         return Fireworks(
             id=model_id,
             temperature=self.sampling_temperature,
             max_tokens=self.sampling_max_tokens,
+            **extra,
         )
 
     def as_model(self, checkpoint: Checkpoint) -> Model:
@@ -533,16 +559,25 @@ class FireworksTrainer:
         else:
             deployed_name = getattr(deployed, "name", None) or ""
             deployed_id = deployed_name.rsplit("/", 1)[-1]
-            if deployed_id:
-                self._loaded_addon_ids.append(deployed_id)
-                self._wait_until_ready(
-                    f"LoRA {checkpoint.ref} on {deployment_name}",
-                    lambda: client.lora.get(deployed_id),
-                    lambda resource: getattr(resource, "state", None) == "DEPLOYED",
-                    lambda resource: (
-                        self._status_message(resource) if getattr(resource, "state", None) == "UNDEPLOYING" else None
-                    ),
+            if not deployed_id:
+                # Without a name there is nothing to poll, and returning unwaited
+                # would hand the caller an address the gateway still 404s while the
+                # addon is DEPLOYING (observed live: a full rollout of instant
+                # model-not-found errors against a checkpoint that was fine).
+                raise RuntimeError(
+                    f"Fireworks did not return a deployed-model name for LoRA {checkpoint.ref} on "
+                    f"{deployment_name}; cannot wait for it to reach DEPLOYED, so serving it now would "
+                    "race the load and fail with model-not-found"
                 )
+            self._loaded_addon_ids.append(deployed_id)
+            self._wait_until_ready(
+                f"LoRA {checkpoint.ref} on {deployment_name}",
+                lambda: client.lora.get(deployed_id),
+                lambda resource: getattr(resource, "state", None) == "DEPLOYED",
+                lambda resource: (
+                    self._status_message(resource) if getattr(resource, "state", None) == "UNDEPLOYING" else None
+                ),
+            )
         return self._serve(f"{checkpoint.ref}#{deployment_name}")
 
     async def aas_model(self, checkpoint: Checkpoint) -> Model:
@@ -582,7 +617,10 @@ class FireworksTrainer:
         self._loaded_addon_ids = []
         if self._created_deployment_id is not None:
             try:
-                client.deployments.delete(self._created_deployment_id)
+                # ignore_checks: the control plane refuses to delete a deployment that
+                # served inference in the last hour, and this deployment just measured
+                # a rollout -- without the override every teardown would orphan it.
+                client.deployments.delete(self._created_deployment_id, ignore_checks=True)
                 log_info(f"FireworksTrainer: deleted deployment {self._created_deployment_id}")
             except Exception as exc:
                 log_warning(

--- a/libs/agno/agno/trainers/fireworks.py
+++ b/libs/agno/agno/trainers/fireworks.py
@@ -190,10 +190,14 @@ class FireworksTrainer:
             or not (math.isfinite(learning_rate) and learning_rate > 0)
         ):
             raise ValueError(f"learning_rate must be a finite value > 0, got {learning_rate!r}")
-        if not (math.isfinite(sampling_temperature) and sampling_temperature > 0):
+        if (
+            isinstance(sampling_temperature, bool)
+            or not isinstance(sampling_temperature, (int, float))
+            or not (math.isfinite(sampling_temperature) and sampling_temperature > 0)
+        ):
             # The negated form also rejects NaN, which passes every plain comparison.
             raise ValueError(
-                f"sampling_temperature must be a finite value > 0, got {sampling_temperature}: at "
+                f"sampling_temperature must be a finite value > 0, got {sampling_temperature!r}: at "
                 "temperature 0 all k attempts are identical and the learning zone is empty by construction"
             )
         if not (
@@ -270,16 +274,17 @@ class FireworksTrainer:
         """Upload `dataset`, run a managed supervised fine-tuning job, and poll it to
         a terminal state.
 
-        The dataset is validated before any call is made: a malformed file fails
-        here, for free, with no dataset record and no job created. A poll timeout
-        (`train_timeout_seconds`) returns `FAILED` but does NOT cancel the job -- it
-        keeps running on Fireworks and may still complete; the error names it. A job
-        is never retried.
+        The dataset is validated before any call is made: a file the gate rejects
+        becomes a `FAILED` result, for free, with no dataset record and no job
+        created. It is a result rather than a raise because the improvement loop
+        legitimately produces datasets below Fireworks' 3-example minimum (its own
+        floor is one exported row), and an exception out of `fit` would crash
+        `run()` mid-loop where a `FAILED` result ends it with a clean terminal
+        report. A poll timeout (`train_timeout_seconds`) returns `FAILED` but does
+        NOT cancel the job -- it keeps running on Fireworks and may still complete;
+        the error names it. A job is never retried.
         """
         path = Path(dataset)
-        # The runtime gate, before anything is created server-side.
-        n_examples = validate_fireworks_sft_jsonl(path)
-        dataset_digest = hashlib.sha256(path.read_bytes()).hexdigest()
 
         hyperparams: Dict[str, Any] = {
             "rank": self.rank,
@@ -291,6 +296,10 @@ class FireworksTrainer:
         step_metrics: List[Dict[str, Any]] = []
 
         try:
+            # The runtime gate, before anything is created server-side.
+            n_examples = validate_fireworks_sft_jsonl(path)
+            dataset_digest = hashlib.sha256(path.read_bytes()).hexdigest()
+
             client = self._get_client()
             account_id = self._resolve_account_id(client)
 
@@ -447,19 +456,28 @@ class FireworksTrainer:
                 )
             self._deployment_name = f"accounts/{account_id}/deployments/{self.deployment_id}"
             return self._deployment_name
-        deployment_id = f"agno-{uuid4().hex[:10]}"
-        client.deployments.create(
-            base_model=self.base_model,
-            deployment_id=deployment_id,
-            display_name=f"agno improvement loop {deployment_id}",
-            # BF16 because FP8/FP4 deployment shapes reject PEFT addons; addons are
-            # how the tuned LoRA is served next to its base on the same hardware.
-            enable_addons=True,
-            precision="BF16",
-            min_replica_count=0,
-            max_replica_count=1,
-        )
-        self._created_deployment_id = deployment_id
+        if self._created_deployment_id is None:
+            deployment_id = f"agno-{uuid4().hex[:10]}"
+            # Tracked BEFORE the billable call: a create whose response is lost (or
+            # whose readiness poll fails) must still leave teardown() a handle to
+            # delete, not an orphaned deployment only the dashboard knows about.
+            self._created_deployment_id = deployment_id
+            client.deployments.create(
+                base_model=self.base_model,
+                deployment_id=deployment_id,
+                display_name=f"agno improvement loop {deployment_id}",
+                # BF16 because FP8/FP4 deployment shapes reject PEFT addons; addons are
+                # how the tuned LoRA is served next to its base on the same hardware.
+                enable_addons=True,
+                precision="BF16",
+                min_replica_count=0,
+                max_replica_count=1,
+            )
+        else:
+            # A prior attempt created (or may have created) this deployment and then
+            # failed before it was ready; resolve it rather than provisioning a
+            # second one the teardown handle would no longer cover.
+            deployment_id = self._created_deployment_id
         self._wait_for_deployment(client, deployment_id)
         self._deployment_name = f"accounts/{account_id}/deployments/{deployment_id}"
         log_warning(

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -87,6 +87,9 @@ aws-bedrock = ["boto3", "aioboto3"]
 azure = ["azure-ai-inference", "aiohttp"]
 cerebras = ["cerebras-cloud-sdk"]
 cohere = ["cohere"]
+# The control-plane SDK for FireworksTrainer (datasets + fine-tuning jobs). Serving a
+# tuned model needs only the OpenAI-compatible inference path (`agno[openai]`).
+fireworks = ["fireworks-ai", "openai"]
 google = ["google-genai>=1.52.0", "pydantic>=2.12.5"]
 groq = ["groq"]
 ibm = ["ibm-watsonx-ai"]
@@ -643,6 +646,7 @@ module = [
   "celpy.*",
   "glide_sync.*",
   "tinker.*",
-  "tinker_cookbook.*"
+  "tinker_cookbook.*",
+  "fireworks.*"
 ]
 ignore_missing_imports = true

--- a/libs/agno/tests/unit/trainers/test_fireworks_trainer.py
+++ b/libs/agno/tests/unit/trainers/test_fireworks_trainer.py
@@ -8,6 +8,7 @@ path is exercised without a paid call.
 """
 
 import json
+import re
 import sys
 from types import SimpleNamespace
 
@@ -68,15 +69,16 @@ class FakeDatasetsResource:
 class FakeJobsResource:
     """Scripted job lifecycle: `create` returns the first snapshot, each `get` the next."""
 
-    def __init__(self, snapshots=None):
+    def __init__(self, snapshots=None, *, nameless=False):
         self.create_calls = []
         self.get_calls = []
         self.snapshots = snapshots
+        self._nameless = nameless
 
     def _job(self, snapshot, output_model):
         progress = snapshot.get("progress")
         return SimpleNamespace(
-            name="accounts/test-account/supervisedFineTuningJobs/job-1",
+            name=None if self._nameless else "accounts/test-account/supervisedFineTuningJobs/job-1",
             state=snapshot["state"],
             output_model=output_model,
             job_progress=SimpleNamespace(**progress) if progress else None,
@@ -120,11 +122,12 @@ class FakeDeploymentsResource:
 
 
 class FakeLoraResource:
-    def __init__(self, *, load_raises=None):
+    def __init__(self, *, load_raises=None, states=None):
         self.load_calls = []
         self.get_calls = []
         self.unload_calls = []
         self._load_raises = load_raises
+        self._states = list(states or ["DEPLOYED"])
 
     def load(self, *, model, deployment):
         self.load_calls.append({"model": model, "deployment": deployment})
@@ -136,7 +139,8 @@ class FakeLoraResource:
 
     def get(self, deployed_model_id):
         self.get_calls.append(deployed_model_id)
-        return SimpleNamespace(state="DEPLOYED", status=None)
+        state = self._states.pop(0) if len(self._states) > 1 else self._states[0]
+        return SimpleNamespace(state=state, status=None)
 
     def unload(self, deployed_model_id):
         self.unload_calls.append(deployed_model_id)
@@ -188,17 +192,22 @@ def _checkpoint(ref="accounts/test-account/models/agno-sft-abc", base_model=BASE
     ],
 )
 def test_fireworks_trainer_fit_validates_dataset(tmp_path, rows, match):
-    # The gate in front of a paid call: a malformed dataset is refused before any
-    # dataset record or job is created server-side.
+    # The gate in front of a paid call: a rejected dataset becomes a FAILED result
+    # before any dataset record or job is created server-side. A result, not a
+    # raise: ImprovementLoop legitimately exports 1-2 row datasets (its floor is
+    # one written row, Fireworks' minimum is 3) and calls afit unwrapped, so an
+    # exception here would crash run() where a FAILED result ends it cleanly.
     bad = tmp_path / "bad.jsonl"
     bad.write_text("\n".join(rows) + "\n", encoding="utf-8")
 
     client = FakeFireworksClient()
     trainer = _trainer(client)
 
-    with pytest.raises(ValueError, match=match):
-        trainer.fit(bad)
+    result = trainer.fit(bad)
 
+    assert result.status == TrainStatus.FAILED
+    assert result.checkpoint is None
+    assert re.search(match, result.error)
     assert client.datasets.create_calls == []
     assert client.supervised_fine_tuning_jobs.create_calls == []
 
@@ -326,6 +335,100 @@ def test_fireworks_trainer_fit_reuses_identical_dataset(tmp_path):
     assert client.supervised_fine_tuning_jobs.create_calls
 
 
+def test_fireworks_trainer_fit_early_stopped_is_a_success(tmp_path):
+    # EARLY_STOPPED is a fully-billed terminal-good state: the tune converged early
+    # and produced a servable model. It must become COMPLETED with a checkpoint --
+    # treating it as still-running would poll to a timeout and silently discard
+    # paid compute.
+    jobs = FakeJobsResource(
+        snapshots=[
+            {"state": "JOB_STATE_RUNNING"},
+            {"state": "JOB_STATE_EARLY_STOPPED"},
+        ]
+    )
+    trainer = _trainer(FakeFireworksClient(jobs=jobs))
+
+    result = trainer.fit(_dataset(tmp_path))
+
+    assert result.status == TrainStatus.COMPLETED
+    assert isinstance(result.checkpoint, Checkpoint)
+    assert result.checkpoint.ref.startswith("accounts/test-account/models/agno-sft-")
+
+
+def test_fireworks_trainer_fit_nameless_job_fails_before_polling(tmp_path):
+    # A create response without a job name cannot be polled; fit must say so as a
+    # FAILED result rather than crash or poll a nonsense id.
+    jobs = FakeJobsResource(nameless=True)
+    trainer = _trainer(FakeFireworksClient(jobs=jobs))
+
+    result = trainer.fit(_dataset(tmp_path))
+
+    assert result.status == TrainStatus.FAILED
+    assert result.checkpoint is None
+    assert "job name" in result.error
+    assert jobs.get_calls == []
+
+
+def test_fireworks_trainer_dataset_poll_rides_uploading_to_ready(tmp_path):
+    datasets = FakeDatasetsResource(states=["UPLOADING", "READY"])
+    trainer = _trainer(FakeFireworksClient(datasets=datasets))
+
+    result = trainer.fit(_dataset(tmp_path))
+
+    assert result.status == TrainStatus.COMPLETED
+    assert len(datasets.get_calls) >= 2  # the poll loop actually ran
+
+
+def test_fireworks_trainer_dataset_failure_state_fails_the_fit(tmp_path):
+    # A dataset that leaves the UPLOADING/READY lifecycle is a processing failure;
+    # the is_failed closure must catch it rather than poll it to a timeout.
+    datasets = FakeDatasetsResource(states=["EXAMPLE_VALIDATION_FAILED"])
+    client = FakeFireworksClient(datasets=datasets)
+    trainer = _trainer(client)
+
+    result = trainer.fit(_dataset(tmp_path))
+
+    assert result.status == TrainStatus.FAILED
+    assert "dataset" in result.error
+    assert client.supervised_fine_tuning_jobs.create_calls == []
+
+
+def test_fireworks_trainer_deployment_poll_rides_creating_to_ready():
+    deployments = FakeDeploymentsResource(states=["CREATING", "READY"])
+    trainer = _trainer(FakeFireworksClient(deployments=deployments))
+
+    base = trainer.base_as_model()
+
+    assert isinstance(base, Fireworks)
+    assert len(deployments.get_calls) >= 2
+
+
+def test_fireworks_trainer_deployment_failure_raises():
+    # A deployment ending FAILED must surface immediately from the serving door;
+    # the loop routes a serving raise through its paid-but-unmeasured channel.
+    deployments = FakeDeploymentsResource(states=["FAILED"])
+    trainer = _trainer(FakeFireworksClient(deployments=deployments))
+
+    with pytest.raises(RuntimeError, match="deployment"):
+        trainer.base_as_model()
+
+
+def test_fireworks_trainer_deployment_stuck_creating_times_out():
+    deployments = FakeDeploymentsResource(states=["CREATING"])
+    trainer = _trainer(FakeFireworksClient(deployments=deployments), ready_timeout_seconds=0.01)
+
+    with pytest.raises(TimeoutError, match="deployment"):
+        trainer.base_as_model()
+
+
+def test_fireworks_trainer_lora_stuck_deploying_times_out():
+    lora = FakeLoraResource(states=["DEPLOYING"])
+    trainer = _trainer(FakeFireworksClient(lora=lora), ready_timeout_seconds=0.01)
+
+    with pytest.raises(TimeoutError, match="LoRA"):
+        trainer.as_model(_checkpoint())
+
+
 def test_fireworks_trainer_train_on_values_coincide(tmp_path):
     # The validator admits only single-assistant-final conversations, on which
     # LAST_ASSISTANT and ALL_ASSISTANT train the same tokens; both are accepted and
@@ -344,35 +447,46 @@ def test_fireworks_trainer_train_on_values_coincide(tmp_path):
     }
 
 
-def test_fireworks_trainer_guards_every_hyperparameter_before_any_client_call():
-    calls = []
-
-    class Guarded(FireworksTrainer):
-        def _get_client(self):
-            calls.append(1)
-            raise AssertionError("client reached")
-
-    for kwargs, match in [
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
         ({"base_model": ""}, "base_model"),
         ({"base_model": "   "}, "base_model"),
         ({"epochs": 0}, "epochs"),
         ({"epochs": True}, "epochs"),
+        ({"epochs": 1.5}, "epochs"),
         ({"rank": 0}, "rank"),
+        ({"rank": -8}, "rank"),
         ({"rank": True}, "rank"),
         ({"learning_rate": 0.0}, "learning_rate"),
+        ({"learning_rate": -1e-4}, "learning_rate"),
         ({"learning_rate": float("nan")}, "learning_rate"),
         ({"learning_rate": float("inf")}, "learning_rate"),
+        ({"learning_rate": True}, "learning_rate"),
         ({"sampling_temperature": 0.0}, "sampling_temperature"),
+        ({"sampling_temperature": -0.5}, "sampling_temperature"),
         ({"sampling_temperature": float("nan")}, "sampling_temperature"),
+        ({"sampling_temperature": float("inf")}, "sampling_temperature"),
+        ({"sampling_temperature": True}, "sampling_temperature"),
+        ({"sampling_temperature": "0.7"}, "sampling_temperature"),
         ({"sampling_max_tokens": 0}, "sampling_max_tokens"),
+        ({"sampling_max_tokens": True}, "sampling_max_tokens"),
         ({"poll_interval_seconds": -1}, "poll_interval_seconds"),
+        ({"poll_interval_seconds": float("nan")}, "poll_interval_seconds"),
         ({"ready_timeout_seconds": 0}, "ready_timeout_seconds"),
+        ({"ready_timeout_seconds": float("inf")}, "ready_timeout_seconds"),
         ({"train_timeout_seconds": 0}, "train_timeout_seconds"),
-    ]:
-        with pytest.raises(ValueError, match=match):
-            Guarded(**{"base_model": BASE_MODEL, **kwargs})
-
-    assert calls == []
+        ({"train_timeout_seconds": float("nan")}, "train_timeout_seconds"),
+    ],
+)
+def test_fireworks_trainer_guards_every_hyperparameter(kwargs, match):
+    # A bad value that only fails inside fit() has already created billable
+    # resources, so everything is validated in __init__ -- which builds no client
+    # (the SDK import and client construction are lazy in _get_client), so the
+    # refusal provably precedes any client call. Bools are int subclasses that
+    # sail past plain < 1 checks; NaN passes every plain comparison.
+    with pytest.raises(ValueError, match=match):
+        FireworksTrainer(**{"base_model": BASE_MODEL, **kwargs})
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/tests/unit/trainers/test_fireworks_trainer.py
+++ b/libs/agno/tests/unit/trainers/test_fireworks_trainer.py
@@ -1,0 +1,579 @@
+"""FireworksTrainer against a fake Fireworks SDK client.
+
+The `fireworks` SDK is not installed here and no FIREWORKS_API_KEY is needed. The
+fakes mirror the real SDK's resource layout -- `client.datasets`,
+`client.supervised_fine_tuning_jobs`, `client.deployments`, `client.lora` -- and its
+response shapes (`state` enums, `job_progress`, resource `name`s), so the managed-job
+path is exercised without a paid call.
+"""
+
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from agno.agent import Agent
+from agno.environments import Environment, Task
+from agno.environments.environment import _env_fingerprint_of, _policy_fingerprint_of
+from agno.models.fireworks import Fireworks
+from agno.scorer import CodeScorer
+from agno.trainers.base import Checkpoint, TrainOn, TrainStatus
+from agno.trainers.fireworks import FireworksTrainer, validate_fireworks_sft_jsonl
+
+BASE_MODEL = "accounts/fireworks/models/qwen3-8b"
+
+CONVERSATION = {
+    "messages": [
+        {"role": "user", "content": "the sea"},
+        {"role": "assistant", "content": "an old silent pond"},
+    ]
+}
+
+
+def _dataset(tmp_path, rows=3, name="train.jsonl"):
+    path = tmp_path / name
+    path.write_text("\n".join(json.dumps(CONVERSATION) for _ in range(rows)) + "\n", encoding="utf-8")
+    return path
+
+
+class FakeAPIError(Exception):
+    def __init__(self, status_code, message="api error"):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class FakeDatasetsResource:
+    def __init__(self, *, create_raises=None, states=None):
+        self.create_calls = []
+        self.upload_calls = []
+        self.get_calls = []
+        self._create_raises = create_raises
+        self._states = list(states or ["READY"])
+
+    def create(self, *, dataset_id, dataset):
+        self.create_calls.append({"dataset_id": dataset_id, "dataset": dataset})
+        if self._create_raises is not None:
+            raise self._create_raises
+
+    def upload(self, *, dataset_id, file):
+        self.upload_calls.append({"dataset_id": dataset_id, "file": file})
+
+    def get(self, dataset_id):
+        self.get_calls.append(dataset_id)
+        state = self._states.pop(0) if len(self._states) > 1 else self._states[0]
+        return SimpleNamespace(state=state, status=None)
+
+
+class FakeJobsResource:
+    """Scripted job lifecycle: `create` returns the first snapshot, each `get` the next."""
+
+    def __init__(self, snapshots=None):
+        self.create_calls = []
+        self.get_calls = []
+        self.snapshots = snapshots
+
+    def _job(self, snapshot, output_model):
+        progress = snapshot.get("progress")
+        return SimpleNamespace(
+            name="accounts/test-account/supervisedFineTuningJobs/job-1",
+            state=snapshot["state"],
+            output_model=output_model,
+            job_progress=SimpleNamespace(**progress) if progress else None,
+            status=SimpleNamespace(message=snapshot.get("message")) if snapshot.get("message") else None,
+        )
+
+    def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        snapshots = self.snapshots if self.snapshots is not None else [{"state": "JOB_STATE_COMPLETED"}]
+        self._pending = list(snapshots)
+        return self._advance()
+
+    def _advance(self):
+        # Consume the script, then repeat the last snapshot forever.
+        snapshot = self._pending.pop(0) if len(self._pending) > 1 else self._pending[0]
+        return self._job(snapshot, self.create_calls[-1].get("output_model"))
+
+    def get(self, job_id):
+        self.get_calls.append(job_id)
+        return self._advance()
+
+
+class FakeDeploymentsResource:
+    def __init__(self, *, states=None, enable_addons=True):
+        self.create_calls = []
+        self.get_calls = []
+        self.delete_calls = []
+        self._states = list(states or ["READY"])
+        self._enable_addons = enable_addons
+
+    def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+
+    def get(self, deployment_id):
+        self.get_calls.append(deployment_id)
+        state = self._states.pop(0) if len(self._states) > 1 else self._states[0]
+        return SimpleNamespace(state=state, status=None, enable_addons=self._enable_addons)
+
+    def delete(self, deployment_id):
+        self.delete_calls.append(deployment_id)
+
+
+class FakeLoraResource:
+    def __init__(self, *, load_raises=None):
+        self.load_calls = []
+        self.get_calls = []
+        self.unload_calls = []
+        self._load_raises = load_raises
+
+    def load(self, *, model, deployment):
+        self.load_calls.append({"model": model, "deployment": deployment})
+        if self._load_raises is not None:
+            raise self._load_raises
+        return SimpleNamespace(
+            name=f"accounts/test-account/deployedModels/dm-{len(self.load_calls)}", state="DEPLOYING"
+        )
+
+    def get(self, deployed_model_id):
+        self.get_calls.append(deployed_model_id)
+        return SimpleNamespace(state="DEPLOYED", status=None)
+
+    def unload(self, deployed_model_id):
+        self.unload_calls.append(deployed_model_id)
+
+
+class FakeFireworksClient:
+    def __init__(self, **overrides):
+        self.account_id = overrides.pop("account_id", "test-account")
+        self.datasets = overrides.pop("datasets", FakeDatasetsResource())
+        self.supervised_fine_tuning_jobs = overrides.pop("jobs", FakeJobsResource())
+        self.deployments = overrides.pop("deployments", FakeDeploymentsResource())
+        self.lora = overrides.pop("lora", FakeLoraResource())
+        assert not overrides, f"unknown fake overrides: {sorted(overrides)}"
+
+
+def _trainer(client=None, **kwargs):
+    kwargs.setdefault("poll_interval_seconds", 0.0)
+    return FireworksTrainer(BASE_MODEL, client=client or FakeFireworksClient(), **kwargs)
+
+
+def _checkpoint(ref="accounts/test-account/models/agno-sft-abc", base_model=BASE_MODEL):
+    return Checkpoint(ref=ref, base_model=base_model, dataset_digest="abc", hyperparams={})
+
+
+# ---------------------------------------------------------------------------
+# The dataset gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rows", "match"),
+    [
+        (['{"messages": [{"role": "user", "content": "only a user turn"}]}'] * 3, "assistant"),
+        ([json.dumps(CONVERSATION)] * 2, "at least 3"),
+        (["not json"] * 3, "not valid JSON"),
+        (['{"messages": []}'] * 3, "non-empty messages"),
+        (['{"messages": [{"role": "tool", "content": "x"}, {"role": "assistant", "content": "y"}]}'] * 3, "role"),
+        (['{"messages": [{"role": "user", "content": "x"}, {"role": "assistant", "content": " "}]}'] * 3, "content"),
+        (
+            [
+                '{"messages": [{"role": "assistant", "content": "a"}, {"role": "user", "content": "x"}, '
+                '{"role": "assistant", "content": "b"}]}'
+            ]
+            * 3,
+            "exactly one assistant",
+        ),
+        (['{"messages": [{"role": "user", "content": "x", "weight": 0}]}'] * 3, "only role and content"),
+        (['{"messages": [{"role": "user", "content": "x"}], "weight": 1}'] * 3, "only a messages field"),
+    ],
+)
+def test_fireworks_trainer_fit_validates_dataset(tmp_path, rows, match):
+    # The gate in front of a paid call: a malformed dataset is refused before any
+    # dataset record or job is created server-side.
+    bad = tmp_path / "bad.jsonl"
+    bad.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    client = FakeFireworksClient()
+    trainer = _trainer(client)
+
+    with pytest.raises(ValueError, match=match):
+        trainer.fit(bad)
+
+    assert client.datasets.create_calls == []
+    assert client.supervised_fine_tuning_jobs.create_calls == []
+
+
+def test_fireworks_validator_accepts_the_exporter_shape(tmp_path):
+    # to_sft_jsonl output -- system/user/assistant, one assistant, final -- passes,
+    # and Tinker's 320-conversation cap deliberately does not apply.
+    row = {
+        "messages": [
+            {"role": "system", "content": "Write a haiku."},
+            {"role": "user", "content": "the sea"},
+            {"role": "assistant", "content": "an old silent pond"},
+        ]
+    }
+    path = tmp_path / "ok.jsonl"
+    path.write_text("\n".join(json.dumps(row) for _ in range(400)) + "\n", encoding="utf-8")
+
+    assert validate_fireworks_sft_jsonl(path) == 400
+
+
+# ---------------------------------------------------------------------------
+# The managed-job lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_fireworks_trainer_fit_maps_job_lifecycle(tmp_path):
+    # COMPLETED becomes a completed TrainResult whose checkpoint points at the tuned
+    # model resource; the poll snapshots carry only what Fireworks reported.
+    jobs = FakeJobsResource(
+        snapshots=[
+            {"state": "JOB_STATE_PENDING"},
+            {"state": "JOB_STATE_RUNNING", "progress": {"percent": 50, "epoch": 0}},
+            {"state": "JOB_STATE_COMPLETED"},
+        ]
+    )
+    client = FakeFireworksClient(jobs=jobs)
+    trainer = _trainer(client, rank=8, learning_rate=2e-4, epochs=2)
+
+    result = trainer.fit(_dataset(tmp_path))
+
+    assert result.status == TrainStatus.COMPLETED
+    assert result.error is None
+    assert isinstance(result.checkpoint, Checkpoint)
+    assert result.checkpoint.base_model == BASE_MODEL
+    assert result.checkpoint.ref.startswith("accounts/test-account/models/agno-sft-")
+    assert result.checkpoint.dataset_digest
+    # batch_size is deliberately absent: the managed job owns batching.
+    assert set(result.checkpoint.hyperparams) == {"rank", "learning_rate", "epochs", "train_on"}
+
+    create = jobs.create_calls[0]
+    assert create["base_model"] == BASE_MODEL
+    assert create["dataset"] == f"accounts/test-account/datasets/agno-{result.checkpoint.dataset_digest[:16]}"
+    assert create["output_model"] == result.checkpoint.ref
+    assert create["lora_rank"] == 8
+    assert create["learning_rate"] == 2e-4
+    assert create["epochs"] == 2
+
+    # The dataset really went up first, and was polled to READY.
+    assert client.datasets.create_calls[0]["dataset"] == {"exampleCount": "3"}
+    assert client.datasets.upload_calls[0]["file"] == _dataset(tmp_path)
+    assert client.datasets.get_calls
+
+    # Snapshots record state transitions with only Fireworks-reported fields; no
+    # fabricated loss curve.
+    assert [snapshot["state"] for snapshot in result.step_metrics] == [
+        "JOB_STATE_PENDING",
+        "JOB_STATE_RUNNING",
+        "JOB_STATE_COMPLETED",
+    ]
+    assert result.step_metrics[1]["percent"] == 50
+    assert result.step_metrics[1]["epoch"] == 0
+    assert all("mean_nll" not in snapshot for snapshot in result.step_metrics)
+
+    # fit never touches serving: no deployment exists until a serving door is opened.
+    assert client.deployments.create_calls == []
+    assert client.lora.load_calls == []
+
+
+def test_fireworks_trainer_fit_failed_job(tmp_path):
+    jobs = FakeJobsResource(
+        snapshots=[
+            {"state": "JOB_STATE_RUNNING"},
+            {"state": "JOB_STATE_FAILED", "message": "dataset schema rejected"},
+        ]
+    )
+    trainer = _trainer(FakeFireworksClient(jobs=jobs))
+
+    result = trainer.fit(_dataset(tmp_path))
+
+    assert result.status == TrainStatus.FAILED
+    assert result.checkpoint is None
+    assert "JOB_STATE_FAILED" in result.error
+    assert "dataset schema rejected" in result.error
+    # There is no recovery path on a managed job: FAILED means nothing was kept.
+    assert result.step_metrics  # the observed states are still reported
+
+
+def test_fireworks_trainer_fit_timeout_does_not_cancel(tmp_path):
+    # A poll timeout gives up WAITING, not the job: no cancel, no retry, and the
+    # error says the job may still complete.
+    jobs = FakeJobsResource(snapshots=[{"state": "JOB_STATE_RUNNING"}])
+    client = FakeFireworksClient(jobs=jobs)
+    trainer = _trainer(client, train_timeout_seconds=0.01)
+
+    result = trainer.fit(_dataset(tmp_path))
+
+    assert result.status == TrainStatus.FAILED
+    assert result.checkpoint is None
+    assert "NOT cancelled" in result.error
+    assert "job-1" in result.error
+    assert len(jobs.create_calls) == 1  # never re-created / retried
+
+
+def test_fireworks_trainer_fit_reuses_identical_dataset(tmp_path):
+    # The dataset id derives from the file digest, so re-fitting the same bytes hits
+    # a 409 on create and skips the upload instead of failing.
+    datasets = FakeDatasetsResource(create_raises=FakeAPIError(409, "already exists"))
+    client = FakeFireworksClient(datasets=datasets)
+    trainer = _trainer(client)
+
+    result = trainer.fit(_dataset(tmp_path))
+
+    assert result.status == TrainStatus.COMPLETED
+    assert datasets.upload_calls == []
+    assert client.supervised_fine_tuning_jobs.create_calls
+
+
+def test_fireworks_trainer_train_on_values_coincide(tmp_path):
+    # The validator admits only single-assistant-final conversations, on which
+    # LAST_ASSISTANT and ALL_ASSISTANT train the same tokens; both are accepted and
+    # recorded, and the job request is identical either way.
+    client = FakeFireworksClient()
+    trainer = _trainer(client)
+
+    last = trainer.fit(_dataset(tmp_path))
+    everything = trainer.fit(_dataset(tmp_path), train_on=TrainOn.ALL_ASSISTANT)
+
+    assert last.checkpoint.hyperparams["train_on"] == "last_assistant"
+    assert everything.checkpoint.hyperparams["train_on"] == "all_assistant"
+    first, second = client.supervised_fine_tuning_jobs.create_calls
+    assert {k: v for k, v in first.items() if k != "output_model"} == {
+        k: v for k, v in second.items() if k != "output_model"
+    }
+
+
+def test_fireworks_trainer_guards_every_hyperparameter_before_any_client_call():
+    calls = []
+
+    class Guarded(FireworksTrainer):
+        def _get_client(self):
+            calls.append(1)
+            raise AssertionError("client reached")
+
+    for kwargs, match in [
+        ({"base_model": ""}, "base_model"),
+        ({"base_model": "   "}, "base_model"),
+        ({"epochs": 0}, "epochs"),
+        ({"epochs": True}, "epochs"),
+        ({"rank": 0}, "rank"),
+        ({"rank": True}, "rank"),
+        ({"learning_rate": 0.0}, "learning_rate"),
+        ({"learning_rate": float("nan")}, "learning_rate"),
+        ({"learning_rate": float("inf")}, "learning_rate"),
+        ({"sampling_temperature": 0.0}, "sampling_temperature"),
+        ({"sampling_temperature": float("nan")}, "sampling_temperature"),
+        ({"sampling_max_tokens": 0}, "sampling_max_tokens"),
+        ({"poll_interval_seconds": -1}, "poll_interval_seconds"),
+        ({"ready_timeout_seconds": 0}, "ready_timeout_seconds"),
+        ({"train_timeout_seconds": 0}, "train_timeout_seconds"),
+    ]:
+        with pytest.raises(ValueError, match=match):
+            Guarded(**{"base_model": BASE_MODEL, **kwargs})
+
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Serving -- one deployment, two policies
+# ---------------------------------------------------------------------------
+
+
+def test_fireworks_trainer_as_model_returns_fireworks_model():
+    client = FakeFireworksClient()
+    trainer = _trainer(client, sampling_temperature=0.9, sampling_max_tokens=1234)
+    checkpoint = _checkpoint()
+
+    base = trainer.base_as_model()
+    tuned = trainer.as_model(checkpoint)
+
+    assert isinstance(base, Fireworks) and isinstance(tuned, Fireworks)
+
+    # ONE deployment serves both sides, so the before/after runs on identical
+    # hardware and precision.
+    assert len(client.deployments.create_calls) == 1
+    create = client.deployments.create_calls[0]
+    assert create["base_model"] == BASE_MODEL
+    assert create["enable_addons"] is True
+    assert create["precision"] == "BF16"
+    assert create["min_replica_count"] == 0
+    assert create["max_replica_count"] == 1
+    deployment_name = f"accounts/test-account/deployments/{create['deployment_id']}"
+
+    assert base.id == f"{BASE_MODEL}#{deployment_name}"
+    assert tuned.id == f"{checkpoint.ref}#{deployment_name}"
+
+    # The tuned LoRA was loaded onto that deployment and polled to DEPLOYED.
+    assert client.lora.load_calls == [{"model": checkpoint.ref, "deployment": deployment_name}]
+    assert client.lora.get_calls
+
+    for model in (base, tuned):
+        assert model.temperature == 0.9
+        assert model.max_tokens == 1234
+        assert model.system_prompt is None and model.instructions is None
+
+    # Serving never trains.
+    assert client.supervised_fine_tuning_jobs.create_calls == []
+
+
+def test_fireworks_trainer_as_model_rejects_foreign_checkpoint():
+    trainer = _trainer()
+    foreign = _checkpoint(base_model="accounts/fireworks/models/qwen3-4b")
+
+    with pytest.raises(ValueError, match="qwen3-4b"):
+        trainer.as_model(foreign)
+
+
+def test_fireworks_trainer_byo_deployment_is_used_and_never_deleted():
+    client = FakeFireworksClient()
+    trainer = _trainer(client, deployment_id="my-deployment")
+
+    base = trainer.base_as_model()
+    trainer.as_model(_checkpoint())
+    trainer.teardown()
+
+    assert client.deployments.create_calls == []  # brought, not created
+    assert base.id == f"{BASE_MODEL}#accounts/test-account/deployments/my-deployment"
+    assert client.deployments.delete_calls == []  # never deleted
+    assert client.lora.unload_calls == ["dm-1"]  # but our addon is unloaded
+
+
+def test_fireworks_trainer_teardown_deletes_created_deployment():
+    client = FakeFireworksClient()
+    trainer = _trainer(client)
+
+    trainer.base_as_model()
+    trainer.as_model(_checkpoint())
+    trainer.teardown()
+    trainer.teardown()  # idempotent
+
+    created_id = client.deployments.create_calls[0]["deployment_id"]
+    assert client.deployments.delete_calls == [created_id]
+    assert client.lora.unload_calls == ["dm-1"]
+
+
+def test_fireworks_trainer_already_loaded_lora_is_reused():
+    lora = FakeLoraResource(load_raises=FakeAPIError(409, "already loaded"))
+    client = FakeFireworksClient(lora=lora)
+    trainer = _trainer(client)
+    checkpoint = _checkpoint()
+
+    tuned = trainer.as_model(checkpoint)
+
+    assert isinstance(tuned, Fireworks)
+    assert tuned.id.startswith(f"{checkpoint.ref}#")
+    assert lora.get_calls == []  # nothing new to wait for
+
+
+# ---------------------------------------------------------------------------
+# Fingerprints -- the identity the whole before/after rests on
+# ---------------------------------------------------------------------------
+
+
+def three_lines(run, expected):
+    return len([line for line in run.content.strip().split("\n") if line.strip()]) == 3
+
+
+def test_fireworks_trainer_policy_diverges_env_matches():
+    # Base and tuned must differ in POLICY and agree on ENVIRONMENT. Get the first
+    # wrong and diff.policy_changed reads False while the pass rate rises; get the
+    # second wrong and diff() raises MismatchError instead of measuring.
+    trainer = _trainer()
+
+    base = trainer.base_as_model()
+    tuned = trainer.as_model(_checkpoint())
+
+    assert base.id != tuned.id
+    assert base.provider == tuned.provider == "Fireworks"
+
+    base_policy = _policy_fingerprint_of(base)
+    tuned_policy = _policy_fingerprint_of(tuned)
+    assert base_policy is not None and tuned_policy is not None
+    assert base_policy != tuned_policy
+
+    # Model-level prompt fields stay None, so the env fingerprint is unmoved by the
+    # model swap.
+    agent = Agent(model=base)
+    env = Environment(
+        name="fp",
+        agent=agent,
+        tasks=(Task(id="sea", input="the sea"),),
+        scorer=CodeScorer(three_lines),
+    )
+    base_env = _env_fingerprint_of(env, agent, model=base)
+    tuned_env = _env_fingerprint_of(env, agent, model=tuned)
+    assert base_env is not None
+    assert base_env == tuned_env
+
+
+# ---------------------------------------------------------------------------
+# Async twins, and the offline contract
+# ---------------------------------------------------------------------------
+
+
+async def test_fireworks_trainer_afit_matches_fit(tmp_path):
+    sync_trainer = _trainer()
+    async_trainer = _trainer()
+
+    sync_result = sync_trainer.fit(_dataset(tmp_path))
+    async_result = await async_trainer.afit(_dataset(tmp_path))
+
+    assert async_result.status == sync_result.status == TrainStatus.COMPLETED
+    assert async_result.checkpoint.dataset_digest == sync_result.checkpoint.dataset_digest
+    assert async_result.checkpoint.hyperparams == sync_result.checkpoint.hyperparams
+    assert [s["state"] for s in async_result.step_metrics] == [s["state"] for s in sync_result.step_metrics]
+
+    assert isinstance(await async_trainer.aas_model(async_result.checkpoint), Fireworks)
+    assert isinstance(await async_trainer.abase_as_model(), Fireworks)
+    await async_trainer.ateardown()
+
+
+async def test_fireworks_trainer_serving_doors_do_not_block_the_event_loop():
+    # Serving can create a deployment and poll it ready -- blocking network calls.
+    # Dispatched inline they would freeze every concurrent rollout coroutine.
+    import asyncio
+    import threading
+    import time
+
+    loop_thread = threading.current_thread()
+    serving_threads = []
+
+    class BlockingDeployments(FakeDeploymentsResource):
+        def create(self, **kwargs):
+            serving_threads.append(threading.current_thread())
+            time.sleep(0.2)  # a slow control-plane call
+            super().create(**kwargs)
+
+    trainer = _trainer(FakeFireworksClient(deployments=BlockingDeployments()))
+
+    ticks = 0
+
+    async def tick_while_serving():
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    ticker = asyncio.ensure_future(tick_while_serving())
+    try:
+        await trainer.abase_as_model()
+        await trainer.aas_model(_checkpoint())
+    finally:
+        ticker.cancel()
+
+    assert ticks >= 5  # the event loop kept turning
+    assert serving_threads and all(thread is not loop_thread for thread in serving_threads)
+
+
+def test_fireworks_trainer_never_imports_the_sdk_with_an_injected_client(tmp_path):
+    # The offline contract, stated literally: a full train-and-serve pass through an
+    # injected fake never imports the fireworks SDK (which is not installed here).
+    trainer = _trainer()
+
+    result = trainer.fit(_dataset(tmp_path))
+    trainer.base_as_model()
+    trainer.as_model(result.checkpoint)
+    trainer.teardown()
+
+    assert "fireworks" not in sys.modules

--- a/libs/agno/tests/unit/trainers/test_fireworks_trainer.py
+++ b/libs/agno/tests/unit/trainers/test_fireworks_trainer.py
@@ -117,8 +117,11 @@ class FakeDeploymentsResource:
         state = self._states.pop(0) if len(self._states) > 1 else self._states[0]
         return SimpleNamespace(state=state, status=None, enable_addons=self._enable_addons)
 
-    def delete(self, deployment_id):
+    def delete(self, deployment_id, **kwargs):
+        # The real API refuses to delete a deployment that served inference in the
+        # last hour unless ignore_checks is passed; record it so the contract is pinned.
         self.delete_calls.append(deployment_id)
+        self.delete_kwargs = kwargs
 
 
 class FakeLoraResource:
@@ -564,6 +567,9 @@ def test_fireworks_trainer_teardown_deletes_created_deployment():
 
     created_id = client.deployments.create_calls[0]["deployment_id"]
     assert client.deployments.delete_calls == [created_id]
+    # Without ignore_checks the control plane 400s on any deployment that served
+    # inference in the last hour -- which is every deployment this trainer measures on.
+    assert client.deployments.delete_kwargs == {"ignore_checks": True}
     assert client.lora.unload_calls == ["dm-1"]
 
 


### PR DESCRIPTION
## Summary

A second `Trainer` adapter: `FireworksTrainer` does for Fireworks what `TinkerTrainer` does for Tinker, so the same `ImprovementLoop` can fine-tune and measure on Fireworks — the "bring your own trainer" seam proving itself. The protocol, `Checkpoint`/`TrainResult`/`TrainOn`, the loop, `to_sft_jsonl`, and the test doubles are all unchanged; Fireworks just plugs in.

**`libs/agno/agno/trainers/fireworks.py`** (new, behind `agno[fireworks]` = `fireworks-ai` + `openai`, lazy in-method SDK imports):

- `fit`: validates the JSONL against Fireworks' own rules **before any call** (min 3 / max 3M examples, 150 MB one-shot upload cap — deliberately not Tinker's 320-conv/1 MiB caps; plus exactly-one-final-assistant per example, which is what keeps `TrainOn.LAST_ASSISTANT` exact without rewriting the uploaded file), uploads the dataset (digest-derived id, 409 → reuse), creates a managed SFT job, polls to terminal state, and returns the tuned LoRA model resource as `Checkpoint.ref` with `dataset_digest` = sha256 of the trained file. `step_metrics` carries only what Fireworks reports (state/percent/epoch — the loss curve is not in the job JSON and is never fabricated). A poll timeout returns `FAILED` **without cancelling** the job; nothing is auto-retried. `PARTIAL` is never produced — a managed job has no mid-run recoverable checkpoint (documented as the honest difference from Tinker).
- `as_model` / `base_as_model`: Fireworks retired serverless LoRA serving, and the small tunable bases are not serverless either — so the trainer keeps **one** on-demand deployment (base model, `enable_addons=True`, BF16, min replicas 0, max 1) and serves both sides from it as `agno.models.fireworks.Fireworks(id="<model>#<deployment>")`. Identical hardware and precision either side of the diff; ids differ → policy fingerprints diverge; prompt fields stay `None` → env fingerprints match (pinned by a test that computes real fingerprints from real served models). `deployment_id=` is the BYO escape hatch; `teardown()`/`ateardown()` unloads loaded LoRAs and deletes the deployment iff the trainer created it.
- Async twins `afit`/`aas_model`/`abase_as_model` run off-thread (event-loop liveness pinned by test).

**Cookbook** (`_29_expert_iteration`): the trainer is now selectable — `AGNO_TRAINER=stub|tinker|fireworks` behind a generalized `AGNO_RUN_FINE_TUNE=1` consent gate (`AGNO_RUN_TINKER_FINE_TUNE=1` still works and implies tinker). A key alone never spends. The inline `StubTrainer` now digests the real dataset bytes — the loop's round-3 provenance guard (correctly) refuses the old hard-coded `"offline"` digest. `teardown()` runs in a `finally`.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Offline contract, verified literally:** 59 new tests (96 across `tests/unit/trainers/`, 327 across trainers+environments+models/tinker) run with `fireworks-ai` uninstalled, keys stripped (`env -u FIREWORKS_API_KEY -u FIREWORKS_ACCOUNT_ID -u TINKER_API_KEY`), no network — a fake SDK client is injected through the same seam `TinkerTrainer` uses. A named test asserts a full fit+serve+teardown pass never imports the SDK.

**API shapes verified against the live platform (July 2026)** — `fireworks-ai` 1.2.3 (Stainless) resource surface, job/dataset/deployment/deployed-model state enums read from the SDK source, and the serverless-LoRA retirement double-checked adversarially. Details, the serving-cost decision, and live-readiness results (control plane reachable, key valid, `qwen3-8b` confirmed `tunable`/`supervisedLoraTunable`) are in `specs/agno/2.8.3/notes/FIREWORKS_BUILD.md`.

**Adversarially reviewed pre-PR:** a 4-lens review workflow (contracts / SDK fidelity / tests / cookbook, 15 agents, every finding independently verified) confirmed 9 findings — the notable one being that Fireworks' 3-example dataset minimum sat below the loop's 1-row export floor and crashed `run()` instead of ending it with a clean FAILED report. All folded in the second commit; details in the build report.

**No paid run in this PR.** The live fine-tune is the owner's next step (estimated < $10, dominated by deployment GPU-time). Base: `accounts/fireworks/models/qwen3-8b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)