### PR TITLE
fix: Add missing compress_tool_results parameter to AIMLAPI._format_message

### DIFF
--- a/libs/agno/agno/models/aimlapi/aimlapi.py
+++ b/libs/agno/agno/models/aimlapi/aimlapi.py
@@ -45,17 +45,17 @@ class AIMLAPI(OpenAILike):
                 )
         return super()._get_client_params()
 
-    def _format_message(self, message: Message) -> Dict[str, Any]:
-        """
-        Minimal additional formatter that only replaces None with empty string.
+    def _format_message(self, message: Message, compress_tool_results: bool = False) -> Dict[str, Any]:
+        """Minimal additional formatter that only replaces None with empty string.
 
         Args:
             message (Message): The message to format.
+            compress_tool_results (bool): Whether to compress tool results.
 
         Returns:
             Dict[str, Any]: The formatted message, where 'content = None' is replaced with the empty string.
         """
-        formatted: dict = super()._format_message(message)
+        formatted: dict = super()._format_message(message, compress_tool_results)
 
         formatted["content"] = "" if formatted.get("content") is None else formatted["content"]
 


### PR DESCRIPTION
## Summary
AIMLAPI._format_message() is missing the `compress_tool_results` parameter that the parent class `OpenAIChat._format_message()` expects. When callers pass `compress_tool_results=True`, Python raises `TypeError: takes 2 positional arguments but 3 were given`.

This was likely an oversight when the AIMLAPI model was added — every other model subclass that overrides `_format_message` includes this parameter.

## Changes
- Added `compress_tool_results: bool = False` parameter to `AIMLAPI._format_message()`
- Pass it through to `super()._format_message()`
- Updated docstring accordingly

Fixes #9034

## Checklist
- [x] Bug fix
- [x] Existing tests should cover this (signature matching parent class)