### PR TITLE
fix: allow local AgentOS UI on port 8000

### DIFF
--- a/libs/agno/agno/os/settings.py
+++ b/libs/agno/agno/os/settings.py
@@ -43,6 +43,8 @@ class AgnoAPISettings(BaseSettings):
         valid_cors.extend(
             [
                 "http://localhost:3000",
+                "http://localhost:8000",
+                "http://127.0.0.1:8000",
                 "https://agno.com",
                 "https://www.agno.com",
                 "https://app.agno.com",

--- a/libs/agno/tests/unit/os/test_settings.py
+++ b/libs/agno/tests/unit/os/test_settings.py
@@ -1,0 +1,8 @@
+from agno.os.settings import AgnoAPISettings
+
+
+def test_default_cors_origins_allow_local_agno_os_frontend() -> None:
+    origins = AgnoAPISettings().cors_origin_list or []
+
+    assert "http://localhost:8000" in origins
+    assert "http://127.0.0.1:8000" in origins


### PR DESCRIPTION
## Summary
- allow localhost:8000 and 127.0.0.1:8000 in the AgentOS SDK default CORS origins
- add a unit test covering both local frontend origins

## Test plan
- PYTHONPATH=$PWD/libs/agno pytest libs/agno/tests/unit/os/test_settings.py -q
- ruff format --check
- ruff check

Supports agno-os PR #959.