### PR TITLE
fix: replace mutable default arguments (B006) in MCPToolbox and PDFReader

### DIFF
--- a/libs/agno/agno/knowledge/reader/pdf_reader.py
+++ b/libs/agno/agno/knowledge/reader/pdf_reader.py
@@ -96,7 +96,7 @@ async def _async_ocr_reader(page: Any) -> str:
 
 def _clean_page_numbers(
     page_content_list: List[str],
-    extra_content: List[str] = [],
+    extra_content: Optional[List[str]] = None,
     page_start_numbering_format: str = PAGE_START_NUMBERING_FORMAT_DEFAULT,
     page_end_numbering_format: str = PAGE_END_NUMBERING_FORMAT_DEFAULT,
 ) -> Tuple[List[str], Optional[int]]:
@@ -121,8 +121,10 @@ def _clean_page_numbers(
         - If at least a specified ratio of pages (defined by `PAGE_NUMBERING_CORRECTNESS_RATIO_FOR_REMOVAL`) has correct sequential numbering,
           the page numbers are processed.
         - If page numbers are found, the function will add formatted page numbers to each page's content if `page_start_numbering_format` or
-          `page_end_numbering_format` is provided.
+        `page_end_numbering_format` is provided.
     """
+    extra_content = extra_content or []
+
     assert len(extra_content) == 0 or len(extra_content) == len(page_content_list), (
         "Please provide an equally sized list of extra content if provided."
     )

--- a/libs/agno/agno/tools/mcp_toolbox.py
+++ b/libs/agno/agno/tools/mcp_toolbox.py
@@ -104,7 +104,7 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
 
     def _handle_auth_params(
         self,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
     ):
@@ -139,19 +139,19 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
     async def load_tool(
         self,
         tool_name: str,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
-        bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        bound_params: Optional[dict[str, Union[Any, Callable[[], Any]]]] = None,
     ) -> Function:
         """Loads the tool with the given tool name from the Toolbox service.
 
         Args:
             tool_name (str): The name of the tool to load.
-            auth_token_getters (dict[str, Callable[[], str]], optional): A mapping of authentication source names to functions that retrieve ID tokens. Defaults to {}.
+            auth_token_getters (Optional[dict[str, Callable[[], str]]], optional): A mapping of authentication source names to functions that retrieve ID tokens. Defaults to None.
             auth_tokens (Optional[dict[str, Callable[[], str]]], optional): Deprecated. Use `auth_token_getters` instead.
             auth_headers (Optional[dict[str, Callable[[], str]]], optional): Deprecated. Use `auth_token_getters` instead.
-            bound_params (dict[str, Union[Any, Callable[[], Any]]], optional): A mapping of parameter names to their bound values. Defaults to {}.
+            bound_params (Optional[dict[str, Union[Any, Callable[[], Any]]]], optional): A mapping of parameter names to their bound values. Defaults to None.
 
         Raises:
             RuntimeError: If the tool is not found in the MCP functions registry.
@@ -164,6 +164,8 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
             auth_tokens=auth_tokens,
             auth_headers=auth_headers,
         )
+        auth_token_getters = auth_token_getters or {}
+        bound_params = bound_params or {}
 
         core_sync_tool = await self.__core_client.load_tool(
             name=tool_name,
@@ -179,20 +181,20 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
     async def load_toolset(
         self,
         toolset_name: Optional[str] = None,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
-        bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        bound_params: Optional[dict[str, Union[Any, Callable[[], Any]]]] = None,
         strict: bool = False,
     ) -> List[Function]:
         """Loads tools from the configured toolset.
 
         Args:
             toolset_name (Optional[str], optional): The name of the toolset to load. Defaults to None.
-            auth_token_getters (dict[str, Callable[[], str]], optional): A mapping of authentication source names to functions that retrieve ID tokens. Defaults to {}.
+            auth_token_getters (Optional[dict[str, Callable[[], str]]], optional): A mapping of authentication source names to functions that retrieve ID tokens. Defaults to None.
             auth_tokens (Optional[dict[str, Callable[[], str]]], optional): Deprecated. Use `auth_token_getters` instead.
             auth_headers (Optional[dict[str, Callable[[], str]]], optional): Deprecated. Use `auth_token_getters` instead.
-            bound_params (dict[str, Union[Any, Callable[[], Any]]], optional): A mapping of parameter names to their bound values. Defaults to {}.
+            bound_params (Optional[dict[str, Union[Any, Callable[[], Any]]]], optional): A mapping of parameter names to their bound values. Defaults to None.
             strict (bool, optional): If True, raises an error if *any* loaded tool instance fails
                 to utilize all of the given parameters or auth tokens. (if any
                 provided). If False (default), raises an error only if a
@@ -207,6 +209,8 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
             auth_tokens=auth_tokens,
             auth_headers=auth_headers,
         )
+        auth_token_getters = auth_token_getters or {}
+        bound_params = bound_params or {}
 
         core_sync_tools = await self.__core_client.load_toolset(
             name=toolset_name,
@@ -226,16 +230,16 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
     async def load_multiple_toolsets(
         self,
         toolset_names: List[str],
-        auth_token_getters: dict[str, Callable[[], str]] = {},
-        bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
+        bound_params: Optional[dict[str, Union[Any, Callable[[], Any]]]] = None,
         strict: bool = False,
     ) -> List[Function]:
         """Load tools from multiple toolsets.
 
         Args:
             toolset_names (List[str]): A list of toolset names to load.
-            auth_token_getters (dict[str, Callable[[], str]], optional): A mapping of authentication source names to functions that retrieve ID tokens. Defaults to {}.
-            bound_params (dict[str, Union[Any, Callable[[], Any]]], optional): A mapping of parameter names to their bound values. Defaults to {}.
+            auth_token_getters (Optional[dict[str, Callable[[], str]]], optional): A mapping of authentication source names to functions that retrieve ID tokens. Defaults to None.
+            bound_params (Optional[dict[str, Union[Any, Callable[[], Any]]]], optional): A mapping of parameter names to their bound values. Defaults to None.
             strict (bool, optional): If True, raises an error if *any* loaded tool instance fails to utilize all of the given parameters or auth tokens. Defaults to False.
 
         Returns:

--- a/libs/agno/tests/unit/reader/test_pdf_reader.py
+++ b/libs/agno/tests/unit/reader/test_pdf_reader.py
@@ -532,3 +532,25 @@ def test_pdf_reader_multiple_instances_independent():
     assert reader1.chunking_strategy is not reader2.chunking_strategy
     assert reader1.chunking_strategy.chunk_size == 300
     assert reader2.chunking_strategy.chunk_size == 400
+
+
+def test_clean_page_numbers_extra_content_default_is_none():
+    """Regression: mutable default argument (B006) must not be used for extra_content."""
+    import inspect
+
+    default = inspect.signature(_clean_page_numbers).parameters["extra_content"].default
+    assert default is None
+
+
+def test_clean_page_numbers_default_extra_content_matches_empty_list():
+    """Omitting extra_content must behave exactly like passing an empty list.
+
+    NOTE: _clean_page_numbers mutates its input list in place, so each call must
+    receive a fresh copy to keep the two invocations independent.
+    """
+    content = ["1 Introduction", "2 Background"]
+    expected, expected_shift = _clean_page_numbers(list(content), extra_content=[])
+    actual, actual_shift = _clean_page_numbers(list(content))
+
+    assert actual == expected
+    assert actual_shift == expected_shift

--- a/libs/agno/tests/unit/tools/test_mcp_toolbox.py
+++ b/libs/agno/tests/unit/tools/test_mcp_toolbox.py
@@ -1,0 +1,24 @@
+import inspect
+
+from agno.tools.mcp_toolbox import MCPToolbox
+
+
+def test_mcp_toolbox_auth_params_defaults_are_none():
+    """Regression test for mutable default arguments (B006).
+
+    The auth/dict parameters on MCPToolbox auth helpers must default to None,
+    not a shared mutable ``{}`` instance, so calls do not leak state between
+    each other (including a latent credentials-leakage path on auth_token_getters).
+    """
+    handle_default = inspect.signature(MCPToolbox._handle_auth_params).parameters["auth_token_getters"].default
+    assert handle_default is None
+
+    for fn_name in ("load_tool", "load_toolset", "load_multiple_toolsets"):
+        sig = inspect.signature(getattr(MCPToolbox, fn_name))
+        assert sig.parameters["auth_token_getters"].default is None
+        assert sig.parameters["bound_params"].default is None
+
+
+def test_handle_auth_params_without_args_returns_none():
+    """Calling _handle_auth_params with no args must return None, not a shared dict."""
+    assert MCPToolbox._handle_auth_params(None) is None


### PR DESCRIPTION
## Summary
- Replaced the mutable default arguments (`= {}` / `= []`) flagged by ruff rule **B006** in the `MCPToolbox` auth helpers (`_handle_auth_params`, `load_tool`, `load_toolset`, `load_multiple_toolsets`) and in `PDFReader._clean_page_numbers` with `None`, adding `or {}` / `or []` fallbacks inside the function bodies.
- This closes a potential cross-call state/credential leak: the shared `auth_token_getters={}` default could be observed or mutated across calls via the underlying `ToolboxClient`.
- Behavior is fully equivalent to the previous `{}`/`[]` defaults — the `or {}` / `or []` guards ensure a fresh dict/list is used on each call — so this is a non-breaking bug fix.
- Note: issue #8155 originally reported 10 occurrences. `Toolkit.__init__(tools=[])` and `Searxng.__init__(engines=[])` were already fixed on `main`; this PR handles the remaining 8.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the AGENTS.md / CONTRIBUTING guidelines.
- [x] Added regression tests in `tests/unit/tools/test_mcp_toolbox.py` and `tests/unit/reader/test_pdf_reader.py`.
- [x] Ran `ruff format` and `ruff check` on the changed files (all pass, including an explicit `B006` scan).
- [x] Ran the new regression tests via `pytest`; all 4 pass.

## Test plan
```bash
cd libs/agno
uv run pytest \
  tests/unit/reader/test_pdf_reader.py::test_clean_page_numbers_extra_content_default_is_none \
  tests/unit/reader/test_pdf_reader.py::test_clean_page_numbers_default_extra_content_matches_empty_list \
  tests/unit/tools/test_mcp_toolbox.py
```

## Changed files
- `libs/agno/agno/tools/mcp_toolbox.py` — `auth_token_getters`/`bound_params` defaults changed to `None` + `Optional`; `or {}` fallbacks added in `load_tool` and `load_toolset`.
- `libs/agno/agno/knowledge/reader/pdf_reader.py` — `_clean_page_numbers` `extra_content` default changed to `None` + `Optional`, with an `or []` fallback.
- `libs/agno/tests/unit/reader/test_pdf_reader.py` — +2 regression tests.
- `libs/agno/tests/unit/tools/test_mcp_toolbox.py` — new file, +2 regression tests.

## Follow-up (not in this PR)
The repo does not currently enable ruff rule B006 (`grep B006` across the repo returns nothing). Consider adding `B006` to `[tool.ruff.lint]` in `libs/agno/pyproject.toml` to prevent regressions. This PR only fixes the existing instances and avoids unrelated refactors.

Relates to #8155
