### PR TITLE
fix: added multi delete for user

### DIFF
--- a/cookbook/05_agent_os/rbac/README.md
+++ b/cookbook/05_agent_os/rbac/README.md
@@ -172,6 +172,7 @@ users, or plug in your own policy -- use these. Each one is runnable
 | `managed_roles_audit.py` | The **audit trail**: a change trail (who changed which role) plus a decision trail (every allow/deny). |
 | `custom_authorization_provider.py` | Write your **own** `AuthorizationProvider` (here: pricing tiers) and plug it into the same enforcement points. |
 | `idp_workos_auth0.py` | Map **roles from your IdP** (WorkOS/Auth0/Okta) claims onto AgentOS permissions, verified against a JWKS. |
+| `manage_users_and_roles.py` | Serves the **`/authz` admin API** so a frontend can create roles, add users, and disable people live -- running the token-scope plane and the managed-role plane **at the same time**. Ships with `console.html`, a zero-setup test client: run the server, then open the file in a browser and paste the printed admin token. |
 
 ## Quick Start
 

--- a/cookbook/05_agent_os/rbac/README.md
+++ b/cookbook/05_agent_os/rbac/README.md
@@ -157,6 +157,22 @@ See `symmetric/advanced_scopes.py` for comprehensive examples of:
 - Multiple permission levels
 - Audience verification
 
+### Beyond token scopes: managed roles, a user directory, custom providers
+
+The examples above authorize straight from the token's `scopes`. When you'd rather
+decide access *inside* AgentOS -- assign someone a role at runtime, keep a list of
+users, or plug in your own policy -- use these. Each one is runnable
+(`python <file>`) and prints a real ALLOWED/BLOCKED transcript.
+
+| Example | What it shows |
+|---------|---------------|
+| `managed_roles.py` | Assign a **role** to a user and change it at runtime. The token carries no scopes; the store decides. |
+| `managed_users.py` | The credential-less **user directory** + the disabled kill-switch: disabling someone blocks their next request even though their token is still valid. |
+| `managed_roles_sessions.py` | Role-based control over the session surface (read vs rename vs delete). |
+| `managed_roles_audit.py` | The **audit trail**: a change trail (who changed which role) plus a decision trail (every allow/deny). |
+| `custom_authorization_provider.py` | Write your **own** `AuthorizationProvider` (here: pricing tiers) and plug it into the same enforcement points. |
+| `idp_workos_auth0.py` | Map **roles from your IdP** (WorkOS/Auth0/Okta) claims onto AgentOS permissions, verified against a JWKS. |
+
 ## Quick Start
 
 ### 1. Enable RBAC

--- a/cookbook/05_agent_os/rbac/README.md
+++ b/cookbook/05_agent_os/rbac/README.md
@@ -173,6 +173,7 @@ users, or plug in your own policy -- use these. Each one is runnable
 | `custom_authorization_provider.py` | Write your **own** `AuthorizationProvider` (here: pricing tiers) and plug it into the same enforcement points. |
 | `idp_workos_auth0.py` | Map **roles from your IdP** (WorkOS/Auth0/Okta) claims onto AgentOS permissions, verified against a JWKS. |
 | `manage_users_and_roles.py` | Serves the **`/authz` admin API** so a frontend can create roles, add users, and disable people live -- running the token-scope plane and the managed-role plane **at the same time**. Ships with `console.html`, a zero-setup test client: run the server, then open the file in a browser and paste the printed admin token. |
+| `fga_relationship_based.py` | **Relationship-based** access (ReBAC) via OpenFGA: decide on "is this user the *owner* of that resource / in the same tenant?" rather than on scopes or roles. Needs a running OpenFGA (`pip install "agno[fga]"`). |
 
 ## Quick Start
 

--- a/cookbook/05_agent_os/rbac/console.html
+++ b/cookbook/05_agent_os/rbac/console.html
@@ -1,0 +1,708 @@
+<!doctype html>
+<!--
+  agno /authz console — a single-file test client for the /authz management API.
+
+  Use it against the cookbook server:
+    1. python manage_users_and_roles.py        (prints a dev admin bearer token)
+    2. open this file in your browser          (double-click / open console.html)
+    3. paste the printed token, hit "let's go"
+
+  No build, no dependencies, nothing to install. Works from file:// — the
+  cookbook server's CORS allows it. Everything it does is plain fetch() against
+  the endpoints, so it doubles as living documentation of the API:
+
+    GET/POST/PATCH/DELETE /authz/users        directory (search, sort, paginate)
+    POST   /authz/users/{id}/roles            set THE role (one per user, replaces)
+    GET    /authz/roles + /roles/{slug}/scopes role + permission management
+    GET    /authz/scopes                       the permission catalog
+    GET    /authz/audit, /authz/decisions      the two trails (search, sort, paginate)
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>agno · /authz console</title>
+<style>
+  /* agno design tokens (from agno-os globals.css) */
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap');
+  :root {
+    --bg: 255, 255, 255;
+    --bg2: 244, 244, 245;
+    --fg: 24, 24, 27;
+    --muted: 113, 113, 122;
+    --border: rgba(24, 24, 27, .1);
+    --brand: 255, 64, 23;          /* agno orange */
+    --brand-accent: 235, 110, 82;
+    --purple: 120, 47, 153;
+    --green: 70, 173, 140;
+    --cyan: 33, 206, 246;
+    --positive: 34, 197, 94;
+    --destructive: 229, 57, 53;
+    --radius: 0.625rem;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: rgb(var(--bg)); color: rgb(var(--fg));
+         font: 14px/1.5 Inter, system-ui, sans-serif; }
+  .mono { font-family: 'DM Mono', ui-monospace, monospace; }
+  header { display: flex; gap: 10px; align-items: center; padding: 14px 18px;
+           border-bottom: 1px solid var(--border); flex-wrap: wrap; }
+  .wordmark { font-weight: 800; font-size: 18px; letter-spacing: -.03em; }
+  .wordmark em { color: rgb(var(--brand)); font-style: normal; }
+  .tagline { color: rgb(var(--muted)); font-size: 12px; margin-right: 8px; }
+  input, select, button, textarea {
+    background: rgb(var(--bg)); color: rgb(var(--fg)); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 7px 10px; font: inherit; font-size: 13px; }
+  input, textarea { font-family: 'DM Mono', ui-monospace, monospace; }
+  input:focus, select:focus { outline: 2px solid rgba(var(--brand), .45); border-color: transparent; }
+  button { cursor: pointer; font-weight: 600; }
+  button:hover { border-color: rgb(var(--brand-accent)); color: rgb(var(--brand)); }
+  button.primary { background: rgb(var(--brand)); border-color: rgb(var(--brand)); color: #fff; }
+  button.primary:hover { background: rgb(var(--brand-accent)); color: #fff; }
+  button.danger:hover { border-color: rgb(var(--destructive)); color: rgb(var(--destructive)); }
+  #token { flex: 1; min-width: 240px; }
+  nav { display: flex; gap: 2px; padding: 10px 18px 0; border-bottom: 1px solid var(--border); }
+  nav button { border: none; background: none; color: rgb(var(--muted)); font-weight: 600;
+               padding: 8px 12px; border-radius: var(--radius) var(--radius) 0 0;
+               border-bottom: 2px solid transparent; }
+  nav button:hover { color: rgb(var(--fg)); }
+  nav button.active { color: rgb(var(--brand)); border-bottom-color: rgb(var(--brand)); }
+  main { padding: 16px 18px; max-width: 1200px; }
+  section { display: none; }
+  section.active { display: block; }
+  .bar { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 12px; }
+  .bar .spacer { flex: 1; }
+  table { width: 100%; border-collapse: separate; border-spacing: 0; background: rgb(var(--bg));
+          border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
+  th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--border);
+           vertical-align: top; }
+  th { background: rgb(var(--bg2)); color: rgb(var(--muted)); font-weight: 600; font-size: 12px;
+       cursor: pointer; user-select: none; white-space: nowrap; }
+  th.sorted { color: rgb(var(--brand)); }
+  tr:last-child td { border-bottom: none; }
+  td.id, td.dim-mono { font-family: 'DM Mono', ui-monospace, monospace; font-size: 13px; }
+  .chip { display: inline-block; padding: 1px 9px; border-radius: 999px; font-size: 12px;
+          font-weight: 500; border: 1px solid var(--border); margin: 1px 3px 1px 0;
+          white-space: nowrap; font-family: 'DM Mono', ui-monospace, monospace; }
+  .chip.allow { color: rgb(var(--green)); border-color: rgba(var(--green), .5); background: rgba(var(--green), .07); }
+  .chip.deny { color: rgb(var(--destructive)); border-color: rgba(var(--destructive), .45); background: rgba(var(--destructive), .06); }
+  .chip.active { color: rgb(var(--positive)); border-color: rgba(var(--positive), .5); background: rgba(var(--positive), .07); }
+  .chip.disabled { color: rgb(var(--destructive)); border-color: rgba(var(--destructive), .45); background: rgba(var(--destructive), .06); }
+  .chip.x { cursor: pointer; }
+  .chip.x:hover { border-color: rgb(var(--destructive)); color: rgb(var(--destructive)); text-decoration: line-through; }
+  .dim { color: rgb(var(--muted)); }
+  .pager { display: flex; gap: 8px; align-items: center; margin-top: 12px; color: rgb(var(--muted)); font-size: 13px; }
+  #status { margin-left: auto; max-width: 46%; overflow: hidden; text-overflow: ellipsis;
+            white-space: nowrap; font-family: 'DM Mono', ui-monospace, monospace; font-size: 12px;
+            color: rgb(var(--muted)); }
+  #status.ok { color: rgb(var(--positive)); } #status.bad { color: rgb(var(--destructive)); }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 10px; }
+  .card { background: rgb(var(--bg)); border: 1px solid var(--border); border-radius: var(--radius);
+          padding: 12px; border-top: 3px solid rgb(var(--brand)); }
+  .card:nth-child(4n+2) { border-top-color: rgb(var(--purple)); }
+  .card:nth-child(4n+3) { border-top-color: rgb(var(--green)); }
+  .card:nth-child(4n+0) { border-top-color: rgb(var(--cyan)); }
+  .card h4 { margin: 0 0 8px; font-size: 13px; font-family: 'DM Mono', ui-monospace, monospace; }
+  details { background: rgb(var(--bg)); border: 1px solid var(--border); border-radius: var(--radius);
+            padding: 10px 14px; margin-bottom: 10px; }
+  summary { cursor: pointer; }
+  summary b { font-family: 'DM Mono', ui-monospace, monospace; color: rgb(var(--brand)); }
+  .hint { color: rgb(var(--muted)); font-size: 12.5px; margin: 4px 0 14px; }
+  .empty { color: rgb(var(--muted)); padding: 18px; text-align: center; }
+</style>
+</head>
+<body>
+
+<header>
+  <span class="wordmark"><em>agno</em> /authz console</span>
+  <span class="tagline">who can do what, with buttons</span>
+  <input id="base" class="mono" value="http://localhost:7777" size="20" title="AgentOS base URL" />
+  <input id="token" placeholder="paste the token the server printed at startup ✨" />
+  <button class="primary" onclick="connect()">let's go →</button>
+  <span id="status">not connected yet — run manage_users_and_roles.py first</span>
+</header>
+
+<nav>
+  <button data-tab="playground" class="active" onclick="show('playground')">🧪 Playground</button>
+  <button data-tab="heist" onclick="show('heist')">🏴 Heist</button>
+  <button data-tab="users" onclick="show('users')">👥 Users</button>
+  <button data-tab="roles" onclick="show('roles')">🎭 Roles</button>
+  <button data-tab="scopes" onclick="show('scopes')">🗺️ Scope catalog</button>
+  <button data-tab="audit" onclick="show('audit')">📜 Change audit</button>
+  <button data-tab="decisions" onclick="show('decisions')">🚦 Decisions</button>
+</nav>
+
+<main>
+  <section id="playground" class="active">
+    <div class="hint">Become somebody and rattle the gates. Your admin token mints
+      them a real end-user token (identity only, zero scopes) — everything they're
+      allowed to do comes from the role store. Change their role mid-session: the
+      token never changes, their powers do. That's the whole trick. 🪄</div>
+
+    <div class="bar" id="p-personas"></div>
+
+    <div id="p-stage" style="display:none">
+      <div class="bar">
+        <span id="p-banner"></span>
+        <select id="p-role" title="change their role (as admin) — their token stays the same"></select>
+        <span class="spacer"></span>
+        <span class="dim">now try:</span>
+        <button onclick="act('👀 look at the agent', 'GET', '/agents/research-agent')">👀 look at the agent</button>
+        <button onclick="act('📋 list the agents', 'GET', '/agents')">📋 list the agents</button>
+        <button onclick="act('🏃 run the agent', 'POST', '/agents/research-agent/runs', { message: 'hi!' })">🏃 run the agent</button>
+        <button onclick="act('🗑️ delete a session', 'DELETE', '/sessions/some-session')">🗑️ delete a session</button>
+        <button onclick="act('🕵️ peek at the OS config', 'GET', '/config')">🕵️ peek at the OS config</button>
+      </div>
+      <table id="p-log"></table>
+    </div>
+  </section>
+
+  <section id="heist">
+    <div class="hint">A heist played against the real authorization API. The game
+      only ever reads status codes — every door you open, you open by actually
+      managing roles and scopes. The other tabs aren't cheating; they're the toolbox.</div>
+    <div class="card" style="max-width:760px; border-top-color:rgb(var(--brand))">
+      <h4 id="h-title">🏴 THE VAULT HEIST</h4>
+      <div id="h-story" style="margin-bottom:10px"></div>
+      <div class="bar" id="h-actions"></div>
+    </div>
+    <table id="h-log" style="max-width:760px; margin-top:12px"></table>
+  </section>
+
+  <section id="users">
+    <div class="hint">One role per person — picking a new one swaps it out.
+      Disable someone and they're locked out on their very next request, valid token or not.</div>
+    <div class="bar">
+      <input id="u-search" placeholder="🔎 search id / email / name" size="26"
+             oninput="debounced(loadUsers)" />
+      <label><input type="checkbox" id="u-disabled" checked onchange="loadUsers()" /> show disabled folk</label>
+      <span class="spacer"></span>
+      <input id="u-new-id" placeholder="new user id (jwt sub)" size="16" />
+      <input id="u-new-email" placeholder="email" size="16" />
+      <button onclick="createUser()">+ add user</button>
+    </div>
+    <table id="u-table"></table>
+    <div class="pager" id="u-pager"></div>
+  </section>
+
+  <section id="roles">
+    <div class="hint">A role is a named bag of permissions. Deny beats allow.
+      Click a scope chip to take it away.</div>
+    <div class="bar">
+      <input id="r-new-slug" placeholder="new role slug" size="14" />
+      <input id="r-new-name" placeholder="display name" size="16" />
+      <button onclick="createRole()">+ create role</button>
+    </div>
+    <div id="r-list"></div>
+  </section>
+
+  <section id="scopes">
+    <div class="hint">Every permission this OS understands — generated from its own
+      route map, so it can't drift from what's actually enforced.</div>
+    <div class="grid" id="s-grid"></div>
+  </section>
+
+  <section id="audit">
+    <div class="hint">Who changed what, with before → after. The paper trail your
+      future self (and your auditor) will thank you for.</div>
+    <div class="bar">
+      <input id="a-search" placeholder="🔎 search actor / action / target" size="28"
+             oninput="debounced(loadAudit)" />
+    </div>
+    <table id="a-table"></table>
+    <div class="pager" id="a-pager"></div>
+  </section>
+
+  <section id="decisions">
+    <div class="hint">Every allow/deny at the gate, with the token reference (jti).
+      Green means in, red means computer says no.</div>
+    <div class="bar">
+      <input id="d-search" placeholder="🔎 search actor / action / METHOD /path" size="28"
+             oninput="debounced(loadDecisions)" />
+    </div>
+    <table id="d-table"></table>
+    <div class="pager" id="d-pager"></div>
+  </section>
+</main>
+
+<script>
+"use strict";
+const $ = (id) => document.getElementById(id);
+const esc = (s) => String(s ?? "").replace(/[&<>"]/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
+// ---- state ------------------------------------------------------------
+const state = {
+  roles: [],                         // role slugs, for the per-user role <select>
+  users:     { page: 1, limit: 10, sort_by: "created_at", sort_order: "desc" },
+  audit:     { page: 1, limit: 10, sort_by: "created_at", sort_order: "desc" },
+  decisions: { page: 1, limit: 10, sort_by: "created_at", sort_order: "desc" },
+};
+
+// ---- transport ---------------------------------------------------------
+async function api(method, path, body) {
+  const url = $("base").value.replace(/\/$/, "") + path;
+  const res = await fetch(url, {
+    method,
+    headers: {
+      Authorization: "Bearer " + $("token").value.trim(),
+      ...(body ? { "Content-Type": "application/json" } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  const data = text ? JSON.parse(text) : null;
+  status(res.ok, `${res.ok ? "✓" : "✗"} ${method} ${path} → ${res.status}`);
+  if (!res.ok) throw new Error(`${res.status} ${data?.detail ?? text}`);
+  return data;
+}
+function status(ok, msg) {
+  const el = $("status");
+  el.textContent = msg;
+  el.className = ok ? "ok" : "bad";
+}
+let timer;
+function debounced(fn) { clearTimeout(timer); timer = setTimeout(fn, 300); }
+
+// ---- shared render helpers ----------------------------------------------
+function pager(el, meta, st, reload) {
+  el.innerHTML = "";
+  const info = document.createElement("span");
+  info.textContent = `page ${meta.page}/${Math.max(meta.total_pages, 1)} · ${meta.total_count} total · ${meta.search_time_ms}ms`;
+  const prev = document.createElement("button");
+  const next = document.createElement("button");
+  prev.textContent = "‹ prev"; next.textContent = "next ›";
+  prev.disabled = meta.page <= 1;
+  next.disabled = meta.page >= meta.total_pages;
+  prev.onclick = () => { st.page--; reload(); };
+  next.onclick = () => { st.page++; reload(); };
+  el.append(prev, next, info);
+}
+// Sortable header row: click toggles the field / flips the direction.
+function headerRow(cols, st) {
+  return "<tr>" + cols.map(([key, label]) => {
+    if (!key) return `<th>${label}</th>`;
+    const sorted = st.sort_by === key;
+    const arrow = sorted ? (st.sort_order === "asc" ? " ↑" : " ↓") : "";
+    return `<th class="${sorted ? "sorted" : ""}" data-sort="${key}">${label}${arrow}</th>`;
+  }).join("") + "</tr>";
+}
+function bindSort(table, st, reload) {
+  table.querySelectorAll("th[data-sort]").forEach((th) => th.onclick = () => {
+    const key = th.dataset.sort;
+    st.sort_order = st.sort_by === key && st.sort_order === "desc" ? "asc" : "desc";
+    st.sort_by = key;
+    st.page = 1;
+    reload();
+  });
+}
+function emptyRow(table, span, msg) {
+  const row = table.insertRow();
+  row.innerHTML = `<td class="empty" colspan="${span}">${msg}</td>`;
+}
+const ts = (t) => t ? new Date(t * 1000).toLocaleString() : "";
+const listParams = (st, search) => new URLSearchParams({
+  page: st.page, limit: st.limit, sort_by: st.sort_by, sort_order: st.sort_order,
+  ...(search ? { search } : {}),
+});
+
+// ---- the vault heist 🏴 ----------------------------------------------------
+// A heist played against the real authorization API. Nothing is faked: every
+// door is the live middleware gate, every fix is a real role/scope change you
+// make in the other tabs (or the inline shortcut buttons, same endpoints). You
+// play Arsène Lupin, breaking into "the vault" — and learn AgentOS RBAC by
+// exploiting it: get denied, grant scopes, discover deny-beats-allow, survive a
+// kill-switch, crack the vault.
+const heist = { phase: "start", token: null, who: "lupin", betrayed: false };
+
+async function loadHeist() { renderHeist(); }
+
+async function newHeist() {
+  // Stage the world through the same API everyone else uses: a thief with no
+  // role, and an "intern" role whose wildcard read carries an explicit vault DENY.
+  await api("POST", "/authz/users", { id: heist.who, name: "Arsène Lupin" }).catch(() => {});
+  await api("PATCH", `/authz/users/${heist.who}`, { disabled: false });
+  await api("POST", "/authz/roles", { slug: "intern", name: "Intern" }).catch(() => {});
+  await api("PUT", "/authz/roles/intern/scopes", { scopes: [
+    "agents:*:read",
+    { scope: "agents:vault-agent:run", effect: "deny" },
+  ]});
+  const cur = await api("GET", `/authz/users/${heist.who}/roles`);
+  if (cur.role) await api("DELETE", `/authz/users/${heist.who}/roles/${cur.role}`);  // start role-less
+  heist.token = (await api("POST", "/dev/mint", { sub: heist.who })).token;
+  heist.phase = "nobody"; heist.betrayed = false;
+  $("h-log").innerHTML = "";
+  hlog("🌃", "midnight. you're <b>lupin</b>, token in hand, not a single permission to your name.");
+  renderHeist();
+}
+
+// Knock on a real door as lupin; the gate's verdict drives the story.
+async function door(label, method, path) {
+  const res = await fetch($("base").value.replace(/\/$/, "") + path, {
+    method, headers: { Authorization: "Bearer " + heist.token },
+    body: method === "POST" ? (() => { const f = new FormData(); f.append("message", "open up"); return f; })() : undefined,
+  });
+  const body = await res.json().catch(() => null);
+  const denied = res.status === 401 || res.status === 403;
+  hlog("🚪", `${label} → ` + (denied
+    ? `<span class="chip deny">✗ ${res.status}</span> <span class="dim">${esc(body?.detail ?? "")}</span>`
+    : `<span class="chip allow">✓ ${res.status}</span>`));
+  await advance(label, denied, body);
+}
+
+// The phase machine: react to (phase, allowed/denied, what the gate said).
+async function advance(label, denied, body) {
+  const p = heist.phase;
+  const disabledHit = denied && /disabled/i.test(JSON.stringify(body ?? ""));
+  if (p === "nobody" && !denied) {
+    heist.phase = "lookout";
+    hlog("🎉", "you're in the lobby — reads work now. but the research agent won't <i>run</i> for a lowly intern…");
+  } else if (p === "lookout" && !denied) {
+    heist.phase = "vault";
+    hlog("🎉", "warmed up. now the real prize: <b>the vault</b>. it has opinions about you.");
+  } else if (p === "vault" && denied && !disabledHit && !heist.betrayed) {
+    hlog("🧱", "denied — and piling on <span class='mono'>allow</span> won't help. there's an explicit <b>deny</b> on the vault, and a deny <b>always</b> beats an allow. tear it off the <b class='mono'>intern</b> role.");
+  } else if (p === "vault" && !denied && !heist.betrayed) {
+    heist.betrayed = true;
+    await api("PATCH", `/authz/users/${heist.who}`, { disabled: true });
+    heist.phase = "betrayed";
+    hlog("🐀", "you're through… but a rat tipped security — they hit the <b>kill-switch</b> on your badge. your token is still perfectly valid, and perfectly useless. try the door.");
+  } else if (p === "betrayed" && disabledHit) {
+    hlog("🚫", "cold. valid token, zero access — that's revocation the moment it matters. talk your way back in: re-enable <b class='mono'>lupin</b> (👥 Users tab, or the button).");
+  } else if (p === "betrayed" && !denied) {
+    win(body);
+  }
+  renderHeist();
+}
+
+// ---- inline shortcuts (the same calls the other tabs make) ------------------
+async function hireIntern() {
+  await api("POST", `/authz/users/${heist.who}/roles`, { role: "intern" });
+  hlog("🪪", "lupin is now an <b>intern</b>. go on, knock."); renderHeist();
+}
+async function grantRun() {
+  await api("PATCH", "/authz/roles/intern/scopes", { upsert: [{ scope: "agents:*:run" }] });
+  hlog("🎁", "granted <span class='mono'>agents:*:run</span> to intern — same token, new reach."); renderHeist();
+}
+async function dropVaultDeny() {
+  await api("PATCH", "/authz/roles/intern/scopes", { remove: ["agents:vault-agent:run"] });
+  hlog("✂️", "the vault deny is gone. allow finally wins."); renderHeist();
+}
+async function reenableLupin() {
+  await api("PATCH", `/authz/users/${heist.who}`, { disabled: false });
+  hlog("🤝", "badge re-activated — same token the whole time."); renderHeist();
+}
+
+// ---- render -----------------------------------------------------------------
+const HEIST_TITLES = {
+  start: "🏴 THE VAULT HEIST",
+  nobody: "Act I · you're nobody",
+  lookout: "Act II · the lookout",
+  vault: "Act III · the vault (deny beats allow)",
+  betrayed: "Act IV · the betrayal",
+};
+const HEIST_SCRIPT = {
+  start: [`A vault. A flag. A thief with zero permissions. Everything here is a
+    <b>real</b> request — you win by actually administering RBAC. Ready, Lupin?`,
+    [["🥷 start the heist", newHeist]]],
+  nobody: [`Every request 403s — you hold no role. Get yourself hired: give
+    <b class='mono'>lupin</b> the <b class='mono'>intern</b> role (👥 Users tab,
+    the 🧪 Playground select, or the button), then case the joint.`,
+    [["🪪 hire me as an intern", hireIntern],
+     ["👀 case the research agent", () => door("case the research agent", "GET", "/agents/research-agent")]]],
+  lookout: [`Interns <i>read</i> everything but <i>run</i> nothing. Find the scope
+    that lets the crew run agents (peek at 🗺️ Scope catalog) and add it to
+    <b class='mono'>intern</b>, then warm up.`,
+    [["💪 grant intern → agents:*:run", grantRun],
+     ["🏃 warm up (run research agent)", () => door("warm up on research agent", "POST", "/agents/research-agent/runs")]]],
+  vault: [`The big one. You can run anything now, so this should be easy — it
+    isn't. The vault was born with an explicit <b>deny</b>, and a deny always
+    beats an allow. Crack it, watch it refuse, then strip the deny off the
+    <b class='mono'>intern</b> role (🎭 Roles tab or the button).`,
+    [["🏦 crack the vault", () => door("crack the vault", "POST", "/agents/vault-agent/runs")],
+     ["✂️ remove the vault deny", dropVaultDeny]]],
+  betrayed: [`A rat tipped security — your badge is <b>disabled</b>. Token still
+    valid, still useless: revocation exactly when it matters. Knock to feel it,
+    then re-enable <b class='mono'>lupin</b> and make the final grab.`,
+    [["🏦 try the vault", () => door("try the vault", "POST", "/agents/vault-agent/runs")],
+     ["🤝 re-enable lupin", reenableLupin]]],
+};
+
+function hlog(icon, msg) {
+  const row = $("h-log").insertRow(0);
+  row.innerHTML = `<td class="dim" style="white-space:nowrap">${new Date().toLocaleTimeString()}</td><td>${icon} ${msg}</td>`;
+}
+function renderHeist() {
+  if (heist.phase === "won") return;  // win() owns the screen
+  const [story, buttons] = HEIST_SCRIPT[heist.phase] || HEIST_SCRIPT.start;
+  $("h-title").textContent = HEIST_TITLES[heist.phase] ?? HEIST_TITLES.start;
+  $("h-story").innerHTML = story;
+  $("h-actions").innerHTML = "";
+  for (const [label, fn] of buttons) {
+    const b = document.createElement("button");
+    b.textContent = label;
+    if (/start|crack|vault/.test(label)) b.className = "primary";
+    b.onclick = () => fn().catch((e) => hlog("⚠️", esc(e.message)));
+    $("h-actions").append(b);
+  }
+  if (heist.phase !== "start") {
+    const sp = document.createElement("span"); sp.className = "spacer";
+    const r = document.createElement("button"); r.className = "danger"; r.textContent = "↻ start over"; r.onclick = newHeist;
+    $("h-actions").append(sp, r);
+  }
+}
+function win(body) {
+  heist.phase = "won";
+  const flag = JSON.stringify(body ?? "").match(/FLAG\{[^}]+\}/)?.[0] ?? "FLAG{deny_overrides_allow}";
+  $("h-title").textContent = "🎉 HEIST COMPLETE";
+  $("h-story").innerHTML = `<div style="font-size:18px;margin:8px 0">🏴‍☠️ the vault is open, Lupin.</div>
+    <div class="chip allow mono" style="font-size:15px;padding:6px 14px">${esc(flag)}</div>
+    <p class="dim" style="margin-top:12px">every move you made is in the <b>🚦 Decisions</b>
+    trail — each allow and deny, timestamped, tied to your token's jti. you broke in purely
+    by administering roles and scopes. that's the whole product, wearing a striped jumper. 🎩</p>`;
+  $("h-actions").innerHTML = "";
+  const ev = document.createElement("button"); ev.className = "primary"; ev.textContent = "🚦 read the evidence"; ev.onclick = () => show("decisions");
+  const again = document.createElement("button"); again.className = "danger"; again.textContent = "↻ heist again"; again.onclick = newHeist;
+  $("h-actions").append(ev, again);
+  confetti();
+}
+function confetti() {
+  const c = ["#ff4017", "#782f99", "#46ad8c", "#21cef6", "#22c55e"];
+  for (let i = 0; i < 80; i++) {
+    const d = document.createElement("div");
+    d.style.cssText = `position:fixed;top:-10px;left:${Math.random() * 100}vw;width:9px;height:9px;`
+      + `background:${c[i % c.length]};border-radius:2px;pointer-events:none;z-index:9999;`
+      + `transform:rotate(${Math.random() * 360}deg);transition:all ${1.5 + Math.random()}s ease-in;`;
+    document.body.append(d);
+    requestAnimationFrame(() => {
+      d.style.top = "105vh";
+      d.style.left = parseFloat(d.style.left) + (Math.random() * 30 - 15) + "vw";
+      d.style.opacity = "0";
+    });
+    setTimeout(() => d.remove(), 3000);
+  }
+}
+
+// ---- playground: act as an end user ---------------------------------------
+async function loadPlayground() {
+  const { data } = await api("GET", "/authz/users?limit=100");
+  $("p-personas").innerHTML = "<span class='dim'>become:</span>" + data.map((u) => `
+    <button data-sub="${esc(u.id)}" ${state.persona?.id === u.id ? "class='primary'" : ""}>
+      ${u.disabled ? "🚫" : "🧑"} ${esc(u.id)} <span class="dim">· ${esc(u.role ?? "no role")}</span>
+    </button>`).join("");
+  $("p-personas").querySelectorAll("button").forEach((b) => b.onclick = () =>
+    become(data.find((u) => u.id === b.dataset.sub)));
+}
+async function become(user) {
+  // The admin token buys a persona token: same signing key, sub = the user,
+  // NO scopes — so everything they can do comes from the role store.
+  const minted = await api("POST", "/dev/mint", { sub: user.id }).catch((e) => {
+    status(false, "✗ /dev/mint missing — playground needs the server in dev mode");
+    throw e;
+  });
+  state.persona = { id: user.id, token: minted.token };
+  $("p-stage").style.display = "block";
+  $("p-banner").innerHTML = `you are now <b class="mono" style="color:rgb(var(--brand))">${esc(user.id)}</b> 🎫`;
+  $("p-role").innerHTML = ["<option value=''>— no role —</option>",
+    ...state.roles.map((r) => `<option ${r === user.role ? "selected" : ""}>${esc(r)}</option>`)].join("");
+  $("p-role").onchange = async (e) => {
+    if (e.target.value) await api("POST", `/authz/users/${user.id}/roles`, { role: e.target.value });
+    else if (user.role) await api("DELETE", `/authz/users/${user.id}/roles/${user.role}`);
+    user.role = e.target.value || null;
+    plog("🎭", `${user.id} is now ${user.role ?? "role-less"} — same token, new powers`, "", "");
+    loadPlayground();
+  };
+  plog("🎫", `minted a token for ${user.id} — go rattle some gates`, "", "");
+  loadPlayground();
+}
+async function act(label, method, path, body) {
+  if (!state.persona) return;
+  const isForm = method === "POST" && path.includes("/runs");
+  let payload, headers = { Authorization: "Bearer " + state.persona.token };
+  if (body && isForm) { payload = new FormData(); Object.entries(body).forEach(([k, v]) => payload.append(k, v)); }
+  else if (body) { payload = JSON.stringify(body); headers["Content-Type"] = "application/json"; }
+  const res = await fetch($("base").value.replace(/\/$/, "") + path, { method, headers, body: payload });
+  const detail = await res.json().then((d) => d?.detail ?? "").catch(() => "");
+  const denied = res.status === 401 || res.status === 403;
+  const verdict = denied
+    ? `<span class="chip deny">✗ ${res.status} nope</span>`
+    : `<span class="chip allow">✓ ${res.status} the gate said yes</span>`;
+  const note = denied ? detail
+    : res.ok ? "" : `${esc(detail)} (not RBAC's problem — the gate let them through 🤷)`;
+  plog(state.persona.id, `${label} <span class="dim mono">${method} ${path}</span>`, verdict, note);
+  status(!denied, `${denied ? "✗" : "✓"} [as ${state.persona.id}] ${method} ${path} → ${res.status}`);
+}
+function plog(who, what, verdict, note) {
+  const row = $("p-log").insertRow(0);
+  row.innerHTML = `<td class="dim">${new Date().toLocaleTimeString()}</td>
+    <td class="id">${esc(who)}</td><td>${what}</td><td>${verdict}</td>
+    <td class="dim">${typeof note === "string" ? note : esc(JSON.stringify(note))}</td>`;
+}
+
+// ---- users ---------------------------------------------------------------
+async function loadUsers() {
+  const st = state.users;
+  const params = listParams(st, $("u-search").value.trim());
+  params.set("include_disabled", $("u-disabled").checked);
+  const { data, meta } = await api("GET", "/authz/users?" + params);
+  const table = $("u-table");
+  table.innerHTML = headerRow(
+    [["id", "id"], ["email", "email"], ["name", "name"], [null, "role"],
+     [null, "status"], ["created_at", "created"], [null, ""]], st);
+  if (!data.length) emptyRow(table, 7, "nobody here — add a user above 👆");
+  for (const u of data) {
+    const row = table.insertRow();
+    const options = ["<option value=''>— no role —</option>",
+      ...state.roles.map((r) =>
+        `<option ${r === u.role ? "selected" : ""}>${esc(r)}</option>`)].join("");
+    row.innerHTML = `
+      <td class="id">${esc(u.id)}</td><td class="dim dim-mono">${esc(u.email ?? "")}</td>
+      <td class="dim">${esc(u.name ?? "")}</td>
+      <td><select data-id="${esc(u.id)}">${options}</select></td>
+      <td><span class="chip ${u.status}">${u.status}</span></td>
+      <td class="dim">${ts(u.created_at)}</td>
+      <td>
+        <button data-act="toggle">${u.disabled ? "✓ let back in" : "✋ disable"}</button>
+        <button data-act="delete" class="danger">delete</button>
+      </td>`;
+    row.querySelector("select").onchange = (e) => setRole(u, e.target);
+    row.querySelector("[data-act=toggle]").onclick = () =>
+      api("PATCH", `/authz/users/${u.id}`, { disabled: !u.disabled }).then(loadUsers);
+    row.querySelector("[data-act=delete]").onclick = () =>
+      confirm(`really delete ${u.id}? (their role assignment stays in the store)`) &&
+      api("DELETE", `/authz/users/${u.id}`).then(loadUsers);
+  }
+  bindSort(table, st, loadUsers);
+  pager($("u-pager"), meta, st, loadUsers);
+}
+async function setRole(user, select) {
+  if (select.value) await api("POST", `/authz/users/${user.id}/roles`, { role: select.value });
+  else if (user.role) await api("DELETE", `/authz/users/${user.id}/roles/${user.role}`);
+  loadUsers();
+}
+async function createUser() {
+  const id = $("u-new-id").value.trim();
+  if (!id) return;
+  await api("POST", "/authz/users", { id, email: $("u-new-email").value.trim() || null });
+  $("u-new-id").value = $("u-new-email").value = "";
+  loadUsers();
+}
+
+// ---- roles ----------------------------------------------------------------
+async function loadRoles() {
+  const { data } = await api("GET", "/authz/roles?limit=100");
+  state.roles = data.map((r) => r.slug);
+  const catalog = await api("GET", "/authz/scopes");
+  const datalist = catalog.map((s) => `<option value="${esc(s.raw)}">`).join("");
+  $("r-list").innerHTML = data.map((role) => `
+    <details open>
+      <summary><b>${esc(role.slug)}</b>
+        <span class="dim">${esc(role.name)}${role.description ? " — " + esc(role.description) : ""}</span>
+        <button class="danger" style="float:right" data-del="${esc(role.slug)}">delete role</button>
+      </summary>
+      <div style="margin-top:10px">
+        ${role.scopes.map((s) =>
+          `<span class="chip x ${s.value}" title="click to remove"
+                 data-role="${esc(role.slug)}" data-scope="${esc(s.raw)}">${esc(s.raw)} · ${s.value}</span>`
+        ).join("") || '<span class="dim">no scopes yet — this role can\'t do a thing 🙈</span>'}
+      </div>
+      <div class="bar" style="margin-top:10px">
+        <input list="scope-catalog" placeholder="agents:*:run" size="24" data-add-scope="${esc(role.slug)}" />
+        <select data-add-effect="${esc(role.slug)}"><option>allow</option><option>deny</option></select>
+        <button data-add-btn="${esc(role.slug)}">+ add scope</button>
+      </div>
+    </details>`).join("") + `<datalist id="scope-catalog">${datalist}</datalist>`;
+
+  $("r-list").querySelectorAll(".chip.x").forEach((chip) => chip.onclick = () =>
+    api("PATCH", `/authz/roles/${chip.dataset.role}/scopes`,
+        { remove: [chip.dataset.scope] }).then(loadRoles));
+  $("r-list").querySelectorAll("[data-add-btn]").forEach((btn) => btn.onclick = () => {
+    const slug = btn.dataset.addBtn;
+    const scope = document.querySelector(`[data-add-scope="${slug}"]`).value.trim();
+    const effect = document.querySelector(`[data-add-effect="${slug}"]`).value;
+    if (scope) api("PATCH", `/authz/roles/${slug}/scopes`,
+                   { upsert: [{ scope, effect }] }).then(loadRoles);
+  });
+  $("r-list").querySelectorAll("[data-del]").forEach((btn) => btn.onclick = () =>
+    confirm(`delete role ${btn.dataset.del}? anyone holding it loses it`) &&
+    api("DELETE", `/authz/roles/${btn.dataset.del}`).then(loadRoles));
+}
+async function createRole() {
+  const slug = $("r-new-slug").value.trim();
+  if (!slug) return;
+  await api("POST", "/authz/roles", { slug, name: $("r-new-name").value.trim() || null });
+  $("r-new-slug").value = $("r-new-name").value = "";
+  loadRoles();
+}
+
+// ---- scope catalog -----------------------------------------------------------
+async function loadScopes() {
+  const catalog = await api("GET", "/authz/scopes");
+  const byNs = {};
+  for (const s of catalog) (byNs[s.namespace] ??= []).push(s);
+  $("s-grid").innerHTML = Object.entries(byNs).map(([ns, scopes]) => `
+    <div class="card"><h4>${esc(ns)}</h4>
+      ${scopes.map((s) => `<span class="chip">${esc(s.raw)}</span>`).join("")}
+    </div>`).join("");
+}
+
+// ---- trails -------------------------------------------------------------------
+async function loadAudit() {
+  const st = state.audit;
+  const { data, meta } = await api("GET",
+    "/authz/audit?" + listParams(st, $("a-search").value.trim()));
+  const table = $("a-table");
+  table.innerHTML = headerRow(
+    [["created_at", "when"], ["actor", "actor"], ["action", "action"], ["target", "target"], [null, "before → after"]], st);
+  if (!data.length) emptyRow(table, 5, "nothing yet — change something and it'll show up here ✍️");
+  for (const e of data) {
+    table.insertRow().innerHTML = `
+      <td class="dim">${ts(e.created_at)}</td><td class="id">${esc(e.actor ?? "system")}</td>
+      <td><span class="chip">${esc(e.action)}</span></td><td class="id">${esc(e.target)}</td>
+      <td class="dim dim-mono">${esc(JSON.stringify(e.before))} → ${esc(JSON.stringify(e.after))}</td>`;
+  }
+  bindSort(table, st, loadAudit);
+  pager($("a-pager"), meta, st, loadAudit);
+}
+async function loadDecisions() {
+  const st = state.decisions;
+  const { data, meta } = await api("GET",
+    "/authz/decisions?" + listParams(st, $("d-search").value.trim()));
+  const table = $("d-table");
+  table.innerHTML = headerRow(
+    [["created_at", "when"], ["actor", "actor"], ["action", "decision"], ["target", "request"], [null, "required"], [null, "token"]], st);
+  if (!data.length) emptyRow(table, 6, "no decisions recorded — make a request to the OS first 🚪");
+  for (const e of data) {
+    const allowed = e.action === "access.allowed";
+    table.insertRow().innerHTML = `
+      <td class="dim">${ts(e.created_at)}</td><td class="id">${esc(e.actor ?? "")}</td>
+      <td><span class="chip ${allowed ? "allow" : "deny"}">${allowed ? "✓ in" : "✗ nope"}</span></td>
+      <td class="id">${esc(e.target)}</td>
+      <td class="dim dim-mono">${esc((e.metadata?.required ?? []).join(", "))}</td>
+      <td class="dim dim-mono">${esc(e.metadata?.token ?? "")}</td>`;
+  }
+  bindSort(table, st, loadDecisions);
+  pager($("d-pager"), meta, st, loadDecisions);
+}
+
+// ---- shell -------------------------------------------------------------------
+const loaders = { playground: loadPlayground, heist: loadHeist, users: loadUsers,
+                  roles: loadRoles, scopes: loadScopes, audit: loadAudit, decisions: loadDecisions };
+function show(tab) {
+  document.querySelectorAll("section").forEach((s) => s.classList.toggle("active", s.id === tab));
+  document.querySelectorAll("nav button").forEach((b) => b.classList.toggle("active", b.dataset.tab === tab));
+  loaders[tab]().catch(() => {});
+}
+async function connect() {
+  localStorage.setItem("authz-console", JSON.stringify({ base: $("base").value, token: $("token").value }));
+  await loadRoles();  // roles first: feeds the user-row selects
+  show(document.querySelector("nav button.active").dataset.tab);
+}
+// restore last session
+try {
+  const saved = JSON.parse(localStorage.getItem("authz-console") ?? "{}");
+  if (saved.base) $("base").value = saved.base;
+  if (saved.token) { $("token").value = saved.token; connect(); }
+} catch { /* fresh start */ }
+</script>
+</body>
+</html>

--- a/cookbook/05_agent_os/rbac/custom_authorization_provider.py
+++ b/cookbook/05_agent_os/rbac/custom_authorization_provider.py
@@ -1,0 +1,177 @@
+"""
+Custom AuthorizationProvider - the minimal "bring your own decision engine" path.
+
+(New to authorization? Read managed_roles.py first. For a production-shaped custom
+provider that integrates a login service like WorkOS/Auth0, see idp_workos_auth0.py.)
+
+The scope tier (default) and the managed-roles tier both think in agno SCOPES. If
+your access model isn't scopes - it's ReBAC ("is this user an owner of this
+resource?"), ABAC ("same tenant?"), or a call out to your own policy engine - you
+write an AuthorizationProvider and plug it in. That ONE object is the whole
+integration; the rest of AgentOS (the request pipeline, the two enforcement points)
+stays the same.
+
+An AuthorizationProvider answers two questions (the ABC's two abstract methods):
+
+  - check(ctx)                  -> "may THIS caller do THIS action on THIS resource?"
+  - accessible_resource_ids(ctx)-> for list endpoints: which ids may they see?
+                                   ({"*"} means "all of them".)
+
+Two more methods have sensible defaults you can override:
+
+  - authorize_route(ctx, required_scopes)  the route-level gate the JWT middleware
+                                   runs BEFORE the request reaches a handler. The
+                                   default defers to check(); override it to gate a
+                                   route without understanding scope strings.
+  - require / filter_accessible    built on check / accessible_resource_ids.
+
+The example below uses a deliberately tiny, NON-scope decision model to make the
+seam obvious: the token carries a `tier` claim, and a small Python dict says what
+each tier may do. Swap the body of check()/accessible_resource_ids() for a call to
+your own engine and nothing else changes.
+
+Run it:
+    pip install agno
+    python custom_authorization_provider.py
+(no extra services, no database needed - we only check who is allowed.)
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Set
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+from agno.os.config import AuthorizationConfig
+
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "custom-provider-os"
+
+os.makedirs("tmp", exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# The whole integration: implement the AuthorizationProvider ABC.
+# ---------------------------------------------------------------------------
+
+# Our (toy) access model: a "tier" on the token decides what actions are allowed.
+# This is NOT scopes - it's whatever model you like. Replace with your own engine.
+TIER_ACTIONS = {
+    "reader": {"read"},  # may read any resource
+    "runner": {"read", "run"},  # may read + run any resource
+    "owner": {"read", "run", "write"},  # may do anything
+}
+
+
+class TierAuthorizationProvider(AuthorizationProvider):
+    """Decide access from a custom `tier` claim on the token.
+
+    agno hands every decision an AuthorizationContext describing the caller and
+    what they're trying to do. We read our `tier` claim off ctx.claims and answer
+    from a plain dict. The fields we use here:
+      ctx.claims        the full decoded JWT payload (where our `tier` lives)
+      ctx.resource_type "agents" / "teams" / "workflows" / ... (None = non-resource)
+      ctx.action        "read" / "run" / "write" / ... (None = non-resource)
+    (ctx also exposes principal_id, scopes, resource_id, admin_scope for richer
+    models - we just don't need them here.)
+    """
+
+    def _allowed_actions(self, ctx: AuthorizationContext) -> Set[str]:
+        tier = ctx.claims.get("tier")
+        return TIER_ACTIONS.get(tier, set())
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        # A non-resource check (no resource_type/action) is DEFERRED, not denied:
+        # the route-level gate (authorize_route) governs those paths. Returning
+        # False here would wrongly block non-resource routes. This mirrors the
+        # framework's native engine convention.
+        if not ctx.resource_type or not ctx.action:
+            return True
+        return ctx.action in self._allowed_actions(ctx)
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        # For list endpoints (GET /agents, ...): which ids may they see? Here a
+        # tier either may read everything or nothing, so it's "*" (all) or empty.
+        # A ReBAC model would instead return the specific ids this user owns.
+        if "read" in self._allowed_actions(ctx):
+            return {"*"}
+        return set()
+
+    # authorize_route() / require() / filter_accessible() use the ABC defaults,
+    # which are built on check() / accessible_resource_ids() above. Override
+    # authorize_route() if you want route gating that doesn't go through check().
+
+
+# ---------------------------------------------------------------------------
+# Wire it in: AuthorizationConfig(authorization_provider=<your provider>).
+# ---------------------------------------------------------------------------
+
+db = SqliteDb(db_file="tmp/agentos.db")
+research_agent = Agent(id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db)
+
+agent_os = AgentOS(
+    id=OS_ID,
+    description="AgentOS with a custom authorization provider",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        # The seam: hand AgentOS your provider. That's the entire integration.
+        authorization_provider=TierAuthorizationProvider(),
+    ),
+)
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)
+    client = TestClient(app)
+
+    def token(sub: str, tier: str) -> str:
+        return jwt.encode(
+            {
+                "sub": sub,
+                "aud": OS_ID,
+                "tier": tier,  # our custom claim - the provider reads this
+                "exp": datetime.now(UTC) + timedelta(hours=24),
+            },
+            JWT_SECRET,
+            algorithm="HS256",
+        )
+
+    def show(label: str, tok: str, method: str, path: str, note: str = "") -> None:
+        r = client.request(method, path, headers={"Authorization": f"Bearer {tok}"}, data={"message": "hi"})
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:48s} -> {verdict:7s} ({r.status_code})  {note}")
+
+    print("\n" + "=" * 80)
+    print("CUSTOM PROVIDER - a `tier` claim decides what you can do")
+    print("=" * 80)
+    print("  tiers:  reader = read | runner = read + run | owner = anything")
+    print("  each caller makes a real request. ALLOWED = got in, BLOCKED = bounced.\n")
+
+    show("reader  LOOK at the agent", token("r", "reader"), "GET", "/agents/research-agent", "readers can read")
+    show("reader  RUN the agent", token("r", "reader"), "POST", "/agents/research-agent/runs", "readers can't run -> bounced")
+    show("runner  RUN the agent", token("n", "runner"), "POST", "/agents/research-agent/runs", "runners can run")
+    show("owner   RUN the agent", token("o", "owner"), "POST", "/agents/research-agent/runs", "owners can do anything")
+    show("guest   LOOK at the agent", token("g", "guest"), "GET", "/agents/research-agent", "unknown tier -> bounced")
+
+    print("=" * 80)
+    print("the point: one AuthorizationProvider IS the whole integration. Swap the body")
+    print("of check()/accessible_resource_ids() for your own engine; nothing else changes.")
+    print("=" * 80)

--- a/cookbook/05_agent_os/rbac/custom_authorization_provider.py
+++ b/cookbook/05_agent_os/rbac/custom_authorization_provider.py
@@ -111,7 +111,9 @@ class TierAuthorizationProvider(AuthorizationProvider):
 # ---------------------------------------------------------------------------
 
 db = SqliteDb(db_file="tmp/agentos.db")
-research_agent = Agent(id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db)
+research_agent = Agent(
+    id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db
+)
 
 agent_os = AgentOS(
     id=OS_ID,
@@ -155,7 +157,12 @@ if __name__ == "__main__":
         )
 
     def show(label: str, tok: str, method: str, path: str, note: str = "") -> None:
-        r = client.request(method, path, headers={"Authorization": f"Bearer {tok}"}, data={"message": "hi"})
+        r = client.request(
+            method,
+            path,
+            headers={"Authorization": f"Bearer {tok}"},
+            data={"message": "hi"},
+        )
         verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
         print(f"  {label:48s} -> {verdict:7s} ({r.status_code})  {note}")
 
@@ -165,13 +172,47 @@ if __name__ == "__main__":
     print("  tiers:  reader = read | runner = read + run | owner = anything")
     print("  each caller makes a real request. ALLOWED = got in, BLOCKED = bounced.\n")
 
-    show("reader  LOOK at the agent", token("r", "reader"), "GET", "/agents/research-agent", "readers can read")
-    show("reader  RUN the agent", token("r", "reader"), "POST", "/agents/research-agent/runs", "readers can't run -> bounced")
-    show("runner  RUN the agent", token("n", "runner"), "POST", "/agents/research-agent/runs", "runners can run")
-    show("owner   RUN the agent", token("o", "owner"), "POST", "/agents/research-agent/runs", "owners can do anything")
-    show("guest   LOOK at the agent", token("g", "guest"), "GET", "/agents/research-agent", "unknown tier -> bounced")
+    show(
+        "reader  LOOK at the agent",
+        token("r", "reader"),
+        "GET",
+        "/agents/research-agent",
+        "readers can read",
+    )
+    show(
+        "reader  RUN the agent",
+        token("r", "reader"),
+        "POST",
+        "/agents/research-agent/runs",
+        "readers can't run -> bounced",
+    )
+    show(
+        "runner  RUN the agent",
+        token("n", "runner"),
+        "POST",
+        "/agents/research-agent/runs",
+        "runners can run",
+    )
+    show(
+        "owner   RUN the agent",
+        token("o", "owner"),
+        "POST",
+        "/agents/research-agent/runs",
+        "owners can do anything",
+    )
+    show(
+        "guest   LOOK at the agent",
+        token("g", "guest"),
+        "GET",
+        "/agents/research-agent",
+        "unknown tier -> bounced",
+    )
 
     print("=" * 80)
-    print("the point: one AuthorizationProvider IS the whole integration. Swap the body")
-    print("of check()/accessible_resource_ids() for your own engine; nothing else changes.")
+    print(
+        "the point: one AuthorizationProvider IS the whole integration. Swap the body"
+    )
+    print(
+        "of check()/accessible_resource_ids() for your own engine; nothing else changes."
+    )
     print("=" * 80)

--- a/cookbook/05_agent_os/rbac/fga_relationship_based.py
+++ b/cookbook/05_agent_os/rbac/fga_relationship_based.py
@@ -1,0 +1,133 @@
+"""Fine-grained / relationship-based authorization (ReBAC) for AgentOS.
+
+RBAC says "what may a *role* do?". Sometimes that's not enough — you want "alice
+may run *this* workflow because she *owns the folder it's in*", or "a member of
+team-x may read the agents that belong to team-x". That's relationship-based
+access control (ReBAC), the model behind OpenFGA / WorkOS FGA / Zanzibar.
+
+AgentOS doesn't embed a relationship engine — it plugs one in through the same
+`AuthorizationProvider` seam everything else uses. `FGAAuthorizationProvider`
+turns each AgentOS check into one relationship query:
+
+    can alice RUN agents:research-agent?  ->  fga.check("user:alice", "run", "agents:research-agent")
+    which agents can alice READ?          ->  fga.list_objects("user:alice", "read", "agents")
+
+Run this example:
+    python fga_relationship_based.py
+
+It uses a tiny in-memory relationship store so it runs with zero infra. For
+production you swap that one object for OpenFGA (or WorkOS FGA) — see the bottom.
+
+The idiomatic wiring composes TWO providers (a feature of AgentOS): FGA decides
+the per-resource families (agents/teams/workflows) relationally, while the scope
+provider gates everything else (config, sessions, ...) — because FGA has no
+notion of a non-resource route. A request is allowed if either grants.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.os import AgentOS
+from agno.os.authz import FGAAuthorizationProvider, ScopeAuthorizationProvider
+from agno.os.config import AuthorizationConfig
+
+SECRET = "fga-cookbook-secret-at-least-256-bits-long-padding-xx"
+OS_ID = "fga-cookbook-os"
+
+
+# --- a toy relationship store (stands in for OpenFGA / WorkOS FGA) -----------
+# Each entry is (user, relation, object) — exactly what an FGA engine stores.
+# In a real OpenFGA model these would often be *derived* (e.g. "run" inherited
+# from "owner of the parent folder"); here we list them directly so it runs with
+# no server.
+class InMemoryFGA:
+    def __init__(self, tuples):
+        self._tuples = set(tuples)
+
+    def check(self, user, relation, obj):
+        return (user, relation, obj) in self._tuples
+
+    def list_objects(self, user, relation, object_type):
+        return [o for (u, r, o) in self._tuples if u == user and r == relation and o.startswith(f"{object_type}:")]
+
+
+fga = InMemoryFGA(
+    {
+        # alice owns the research agent — she can read and run it
+        ("user:alice", "read", "agents:research-agent"),
+        ("user:alice", "run", "agents:research-agent"),
+        # bob can only read it
+        ("user:bob", "read", "agents:research-agent"),
+    }
+)
+
+agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+agent_os = AgentOS(
+    id=OS_ID,
+    agents=[agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        authorization_provider=[
+            ScopeAuthorizationProvider(),       # coarse: gates non-resource routes by scope
+            FGAAuthorizationProvider(fga),      # fine: per-resource agents/teams/workflows by relationship
+        ],
+    ),
+)
+app = agent_os.get_app()
+
+
+def _token(sub):
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET, algorithm="HS256",
+    )
+
+
+def _auth(sub):
+    return {"Authorization": f"Bearer {_token(sub)}"}
+
+
+if __name__ == "__main__":
+    client = TestClient(app)
+
+    def show(who, what, resp):
+        verdict = "DENIED" if resp.status_code in (401, 403) else f"OK ({resp.status_code})"
+        print(f"  {who:6s} {what:32s} -> {verdict}")
+
+    print("\nrelationships decide access (no roles, no scopes — just who is related to what):\n")
+    show("alice", "GET  /agents/research-agent", client.get("/agents/research-agent", headers=_auth("alice")))
+    show("alice", "POST .../runs (alice owns it)",
+         client.post("/agents/research-agent/runs", headers=_auth("alice"), data={"message": "hi"}))
+    show("bob", "GET  /agents/research-agent", client.get("/agents/research-agent", headers=_auth("bob")))
+    show("bob", "POST .../runs (bob can only read)",
+         client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}))
+    show("carol", "GET  /agents/research-agent (no relationship)",
+         client.get("/agents/research-agent", headers=_auth("carol")))
+    print("\nalice owns it (read+run), bob can only read, carol has no relationship at all.\n")
+
+# --- production: point at real OpenFGA --------------------------------------
+# Swap the in-memory store for OpenFGA (pip install "agno[fga]"); the provider is
+# unchanged. Your OpenFGA authorization model must define relations matching the
+# agno actions you gate (read / run / write / delete) on the agents/teams/
+# workflows object types — and is where you express inheritance like
+# "run if owner of the parent folder".
+#
+#   from agno.os.authz.fga import OpenFGAClient
+#
+#   fga = OpenFGAClient(
+#       api_url="http://localhost:8080",
+#       store_id="<your-store-id>",
+#       authorization_model_id="<your-model-id>",
+#   )
+#   ...authorization_provider=[ScopeAuthorizationProvider(), FGAAuthorizationProvider(fga)]
+#
+# WorkOS FGA (or SpiceDB, ...) works the same way — implement the two-method
+# FGAClient port over their SDK and pass it to FGAAuthorizationProvider.

--- a/cookbook/05_agent_os/rbac/fga_relationship_based.py
+++ b/cookbook/05_agent_os/rbac/fga_relationship_based.py
@@ -27,13 +27,12 @@ notion of a non-resource route. A request is allowed if either grants.
 from datetime import UTC, datetime, timedelta
 
 import jwt
-from fastapi.testclient import TestClient
-
 from agno.agent import Agent
 from agno.db.in_memory import InMemoryDb
 from agno.os import AgentOS
 from agno.os.authz import FGAAuthorizationProvider, ScopeAuthorizationProvider
 from agno.os.config import AuthorizationConfig
+from fastapi.testclient import TestClient
 
 SECRET = "fga-cookbook-secret-at-least-256-bits-long-padding-xx"
 OS_ID = "fga-cookbook-os"
@@ -52,7 +51,11 @@ class InMemoryFGA:
         return (user, relation, obj) in self._tuples
 
     def list_objects(self, user, relation, object_type):
-        return [o for (u, r, o) in self._tuples if u == user and r == relation and o.startswith(f"{object_type}:")]
+        return [
+            o
+            for (u, r, o) in self._tuples
+            if u == user and r == relation and o.startswith(f"{object_type}:")
+        ]
 
 
 fga = InMemoryFGA(
@@ -76,8 +79,10 @@ agent_os = AgentOS(
         verify_audience=True,
         audience=OS_ID,
         authorization_provider=[
-            ScopeAuthorizationProvider(),       # coarse: gates non-resource routes by scope
-            FGAAuthorizationProvider(fga),      # fine: per-resource agents/teams/workflows by relationship
+            ScopeAuthorizationProvider(),  # coarse: gates non-resource routes by scope
+            FGAAuthorizationProvider(
+                fga
+            ),  # fine: per-resource agents/teams/workflows by relationship
         ],
     ),
 )
@@ -86,8 +91,14 @@ app = agent_os.get_app()
 
 def _token(sub):
     return jwt.encode(
-        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
-        SECRET, algorithm="HS256",
+        {
+            "sub": sub,
+            "aud": OS_ID,
+            "scopes": [],
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        },
+        SECRET,
+        algorithm="HS256",
     )
 
 
@@ -99,19 +110,48 @@ if __name__ == "__main__":
     client = TestClient(app)
 
     def show(who, what, resp):
-        verdict = "DENIED" if resp.status_code in (401, 403) else f"OK ({resp.status_code})"
+        verdict = (
+            "DENIED" if resp.status_code in (401, 403) else f"OK ({resp.status_code})"
+        )
         print(f"  {who:6s} {what:32s} -> {verdict}")
 
-    print("\nrelationships decide access (no roles, no scopes — just who is related to what):\n")
-    show("alice", "GET  /agents/research-agent", client.get("/agents/research-agent", headers=_auth("alice")))
-    show("alice", "POST .../runs (alice owns it)",
-         client.post("/agents/research-agent/runs", headers=_auth("alice"), data={"message": "hi"}))
-    show("bob", "GET  /agents/research-agent", client.get("/agents/research-agent", headers=_auth("bob")))
-    show("bob", "POST .../runs (bob can only read)",
-         client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}))
-    show("carol", "GET  /agents/research-agent (no relationship)",
-         client.get("/agents/research-agent", headers=_auth("carol")))
-    print("\nalice owns it (read+run), bob can only read, carol has no relationship at all.\n")
+    print(
+        "\nrelationships decide access (no roles, no scopes — just who is related to what):\n"
+    )
+    show(
+        "alice",
+        "GET  /agents/research-agent",
+        client.get("/agents/research-agent", headers=_auth("alice")),
+    )
+    show(
+        "alice",
+        "POST .../runs (alice owns it)",
+        client.post(
+            "/agents/research-agent/runs",
+            headers=_auth("alice"),
+            data={"message": "hi"},
+        ),
+    )
+    show(
+        "bob",
+        "GET  /agents/research-agent",
+        client.get("/agents/research-agent", headers=_auth("bob")),
+    )
+    show(
+        "bob",
+        "POST .../runs (bob can only read)",
+        client.post(
+            "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
+        ),
+    )
+    show(
+        "carol",
+        "GET  /agents/research-agent (no relationship)",
+        client.get("/agents/research-agent", headers=_auth("carol")),
+    )
+    print(
+        "\nalice owns it (read+run), bob can only read, carol has no relationship at all.\n"
+    )
 
 # --- production: point at real OpenFGA --------------------------------------
 # Swap the in-memory store for OpenFGA (pip install "agno[fga]"); the provider is

--- a/cookbook/05_agent_os/rbac/idp_workos_auth0.py
+++ b/cookbook/05_agent_os/rbac/idp_workos_auth0.py
@@ -81,7 +81,9 @@ class RoleClaimAuthorizationProvider(AuthorizationProvider):
     change.
     """
 
-    def __init__(self, role_permissions, roles_claim="roles", admin_scope="agent_os:admin"):
+    def __init__(
+        self, role_permissions, roles_claim="roles", admin_scope="agent_os:admin"
+    ):
         self.role_permissions = role_permissions
         self.roles_claim = roles_claim  # the claim your IdP puts roles in
         self.admin_scope = admin_scope
@@ -144,13 +146,17 @@ class RoleClaimAuthorizationProvider(AuthorizationProvider):
 # ---------------------------------------------------------------------------
 
 idp_private, idp_public = generate_rsa_keys()
-_jwk = json.loads(RSAAlgorithm.to_jwk(RSAAlgorithm(RSAAlgorithm.SHA256).prepare_key(idp_public)))
+_jwk = json.loads(
+    RSAAlgorithm.to_jwk(RSAAlgorithm(RSAAlgorithm.SHA256).prepare_key(idp_public))
+)
 _jwk.update({"kid": "idp-key-1", "use": "sig", "alg": "RS256"})
 with open(JWKS_PATH, "w") as f:
     json.dump({"keys": [_jwk]}, f)
 
 db = SqliteDb(db_file="tmp/agentos.db")
-research_agent = Agent(id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db)
+research_agent = Agent(
+    id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db
+)
 
 agent_os = AgentOS(
     id=OS_ID,
@@ -166,7 +172,9 @@ agent_os = AgentOS(
         audience=OS_ID,  # the token must be for THIS app
         issuer=ISSUER,  # ...and minted by the login service we trust
         # The integration: roles ride the token in the "roles" claim.
-        authorization_provider=RoleClaimAuthorizationProvider(ROLE_PERMISSIONS, roles_claim="roles"),
+        authorization_provider=RoleClaimAuthorizationProvider(
+            ROLE_PERMISSIONS, roles_claim="roles"
+        ),
     ),
 )
 app = agent_os.get_app()
@@ -187,13 +195,23 @@ if __name__ == "__main__":
     def idp_token(sub, roles=None, *, key=idp_private, iss=ISSUER, aud=OS_ID):
         """A token as the login service would mint it: signed with its key, with
         the person's role(s) in the 'roles' claim."""
-        claims = {"sub": sub, "aud": aud, "iss": iss, "exp": datetime.now(UTC) + timedelta(hours=8)}
+        claims = {
+            "sub": sub,
+            "aud": aud,
+            "iss": iss,
+            "exp": datetime.now(UTC) + timedelta(hours=8),
+        }
         if roles is not None:
             claims["roles"] = roles
         return jwt.encode(claims, key, algorithm="RS256", headers={"kid": "idp-key-1"})
 
     def show(label, tok, method, path, note=""):
-        r = client.request(method, path, headers={"Authorization": f"Bearer {tok}"}, data={"message": "hi"})
+        r = client.request(
+            method,
+            path,
+            headers={"Authorization": f"Bearer {tok}"},
+            data={"message": "hi"},
+        )
         verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
         print(f"  {label:52s} -> {verdict:7s} ({r.status_code})  {note}")
 
@@ -201,25 +219,75 @@ if __name__ == "__main__":
     print("LOGIN SERVICE OWNS IDENTITY + ROLES - WE ONLY ENFORCE")
     print("=" * 84)
     print("  the login service signs the token and stamps the role. we verify it and")
-    print("  decide what that role may do. no users or assignments stored on our side.\n")
+    print(
+        "  decide what that role may do. no users or assignments stored on our side.\n"
+    )
 
     # Auth0-style: roles is a list. WorkOS-style: roles is a single string. Both
     # work through the same provider (it normalises a string to a list).
-    show("alice (roles=['member']) RUN the agent", idp_token("alice", ["member"]), "POST", "/agents/research-agent/runs", "member can run")
-    show("bob   (roles='member')   LOOK at agent", idp_token("bob", "member"), "GET", "/agents/research-agent", "single-string role also works")
-    show("carol (roles=['guest'])  LOOK at agent", idp_token("carol", ["guest"]), "GET", "/agents/research-agent", "guest maps to nothing -> bounced")
-    show("dave  (no roles claim)   LOOK at agent", idp_token("dave"), "GET", "/agents/research-agent", "no role -> bounced")
-    show("root  (roles=['admin'])  RUN the agent", idp_token("root", ["admin"]), "POST", "/agents/research-agent/runs", "admin can do anything")
+    show(
+        "alice (roles=['member']) RUN the agent",
+        idp_token("alice", ["member"]),
+        "POST",
+        "/agents/research-agent/runs",
+        "member can run",
+    )
+    show(
+        "bob   (roles='member')   LOOK at agent",
+        idp_token("bob", "member"),
+        "GET",
+        "/agents/research-agent",
+        "single-string role also works",
+    )
+    show(
+        "carol (roles=['guest'])  LOOK at agent",
+        idp_token("carol", ["guest"]),
+        "GET",
+        "/agents/research-agent",
+        "guest maps to nothing -> bounced",
+    )
+    show(
+        "dave  (no roles claim)   LOOK at agent",
+        idp_token("dave"),
+        "GET",
+        "/agents/research-agent",
+        "no role -> bounced",
+    )
+    show(
+        "root  (roles=['admin'])  RUN the agent",
+        idp_token("root", ["admin"]),
+        "POST",
+        "/agents/research-agent/runs",
+        "admin can do anything",
+    )
 
     print("\n  the token plumbing is enforced too (not just the role):\n")
     # A token signed by some OTHER key (an attacker who doesn't have the IdP key).
     attacker_priv, _ = generate_rsa_keys()
-    show("mallory (token signed by a DIFFERENT key)", idp_token("mallory", ["admin"], key=attacker_priv), "GET", "/agents/research-agent", "signature doesn't match the JWKS -> rejected")
+    show(
+        "mallory (token signed by a DIFFERENT key)",
+        idp_token("mallory", ["admin"], key=attacker_priv),
+        "GET",
+        "/agents/research-agent",
+        "signature doesn't match the JWKS -> rejected",
+    )
     # A real-looking token but minted for a different issuer.
-    show("eve (valid role but wrong issuer)", idp_token("eve", ["admin"], iss="https://evil.example/"), "GET", "/agents/research-agent", "issuer not trusted -> rejected")
+    show(
+        "eve (valid role but wrong issuer)",
+        idp_token("eve", ["admin"], iss="https://evil.example/"),
+        "GET",
+        "/agents/research-agent",
+        "issuer not trusted -> rejected",
+    )
 
     print("=" * 84)
-    print("the point: the login service owns WHO has a role; the ~30-line provider owns")
-    print("WHAT a role can do. tokens are verified against the service's published keys,")
-    print("and pinned to the right issuer + audience. nothing about users is stored here.")
+    print(
+        "the point: the login service owns WHO has a role; the ~30-line provider owns"
+    )
+    print(
+        "WHAT a role can do. tokens are verified against the service's published keys,"
+    )
+    print(
+        "and pinned to the right issuer + audience. nothing about users is stored here."
+    )
     print("=" * 84)

--- a/cookbook/05_agent_os/rbac/idp_workos_auth0.py
+++ b/cookbook/05_agent_os/rbac/idp_workos_auth0.py
@@ -1,0 +1,225 @@
+"""
+Using AgentOS with a login service (WorkOS / Auth0 / Okta) - you only enforce
+
+(New to this? Read managed_roles.py first.)
+
+When a company already has a login service, that service logs people in and puts
+each person's role on their token. You don't store any users or who-has-which-role
+- that's the login service's job. You keep one small thing: what each role is
+allowed to do, and you enforce it on every request.
+
+This file shows the realistic, production-shaped version of that:
+
+1. The token is signed by the login service with its private key (RS256). You
+   verify it against the service's PUBLIC keys, which it publishes as a "JWKS"
+   (e.g. at https://<tenant>.auth0.com/.well-known/jwks.json). Download it and
+   point agno at the file:
+       AuthorizationConfig(jwks_file="auth0_jwks.json", ...)
+   (Here we generate a throwaway key and publish it to a local file so the example
+   runs offline; the behaviour is identical.)
+2. The token says who issued it (`iss`) and who it's for (`aud`). We pin both, so
+   a token meant for a different app can't be replayed against this one.
+3. The person's role rides the token in a claim. WorkOS uses a single string;
+   Auth0 uses a list. You write a tiny AuthorizationProvider that turns those role
+   names into permissions. That provider is the whole integration - about 30 lines
+   below - and it's where you'd plug in any logic you like.
+
+The split to remember: the login service owns WHO is a "member" or "admin"; you
+own WHAT those words are allowed to do.
+
+Run it:
+    pip install agno
+    python idp_workos_auth0.py
+(no extra services, no database, no OpenAI key - we only check who is allowed.)
+"""
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Set
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+from agno.os.config import AuthorizationConfig
+from agno.os.scopes import get_accessible_resource_ids, has_required_scopes
+from agno.utils.cryptography import generate_rsa_keys
+from jwt.algorithms import RSAAlgorithm
+
+OS_ID = "acme-agentos"  # the token "aud" - who the token is for
+ISSUER = "https://acme.example-idp.com/"  # the token "iss" - who minted it
+JWKS_PATH = "tmp/idp_jwks.json"
+os.makedirs("tmp", exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# The integration: map the login service's role names -> what they can do.
+# ---------------------------------------------------------------------------
+
+# What each role is allowed to do, in agno's permission terms ("scopes"):
+#   "agents:*:read"               -> look at any agent
+#   "agents:research-agent:run"   -> run the one agent called research-agent
+#   "agent_os:admin"              -> do anything
+# The login service decides who has each role; this dict decides what they mean.
+ROLE_PERMISSIONS = {
+    "member": ["agents:*:read", "agents:research-agent:run"],
+    "admin": ["agent_os:admin"],
+}
+
+
+class RoleClaimAuthorizationProvider(AuthorizationProvider):
+    """Turns the role names on the token into AgentOS permissions.
+
+    This is the entire login-service integration. agno hands you a context with
+    the decoded token claims; you decide what the caller may do. Here we look up
+    the caller's role(s) on the token and expand them into agno scopes, then let
+    agno's scope matcher answer the question. Swap the body for anything you like
+    (call your own service, read attributes, etc.) - the rest of AgentOS doesn't
+    change.
+    """
+
+    def __init__(self, role_permissions, roles_claim="roles", admin_scope="agent_os:admin"):
+        self.role_permissions = role_permissions
+        self.roles_claim = roles_claim  # the claim your IdP puts roles in
+        self.admin_scope = admin_scope
+
+    def _scopes_for(self, ctx: AuthorizationContext):
+        """The permissions this caller has, from the role(s) on their token."""
+        roles = ctx.claims.get(self.roles_claim) or []
+        if isinstance(roles, str):  # WorkOS sends one string; Auth0 sends a list
+            roles = [roles]
+        scopes = []
+        for role in roles:
+            scopes.extend(self.role_permissions.get(role, []))
+        return scopes
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        # Per-resource question, e.g. "may they run agent X?"
+        if not ctx.resource_type or not ctx.action:
+            # Non-resource check: defer (do NOT deny here). This mirrors the
+            # framework's native engine (native_engine.check_resource: "non-resource
+            # check: defer"). The route-level gate (authorize_route) already governs
+            # these paths; returning False would wrongly deny non-resource routes
+            # that the route gate has already decided on.
+            return True
+        return has_required_scopes(
+            self._scopes_for(ctx),
+            [f"{ctx.resource_type}:{ctx.action}"],
+            resource_type=ctx.resource_type,
+            resource_id=ctx.resource_id,
+            admin_scope=self.admin_scope,
+        )
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes) -> bool:
+        # Route-level gate the middleware runs before the request reaches a handler.
+        if not required_scopes:
+            return True
+        return has_required_scopes(
+            self._scopes_for(ctx),
+            required_scopes,
+            resource_type=ctx.resource_type,
+            resource_id=ctx.resource_id,
+            admin_scope=self.admin_scope,
+        )
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        # For list endpoints: which ids may they see ({"*"} = all).
+        if not ctx.resource_type:
+            return set()
+        return get_accessible_resource_ids(
+            self._scopes_for(ctx),
+            ctx.resource_type,
+            admin_scope=self.admin_scope,
+            action=ctx.action,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stand in for the login service: an RS256 keypair whose public half is published
+# as a JWKS (exactly what you'd FETCH from WorkOS/Auth0). You never have this
+# private key in real life - the login service holds it and signs tokens with it.
+# ---------------------------------------------------------------------------
+
+idp_private, idp_public = generate_rsa_keys()
+_jwk = json.loads(RSAAlgorithm.to_jwk(RSAAlgorithm(RSAAlgorithm.SHA256).prepare_key(idp_public)))
+_jwk.update({"kid": "idp-key-1", "use": "sig", "alg": "RS256"})
+with open(JWKS_PATH, "w") as f:
+    json.dump({"keys": [_jwk]}, f)
+
+db = SqliteDb(db_file="tmp/agentos.db")
+research_agent = Agent(id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db)
+
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Enforce-only AgentOS behind a login service",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        # Verify tokens against the login service's published public keys
+        # (in production, its JWKS downloaded from .well-known/jwks.json).
+        jwks_file=JWKS_PATH,
+        algorithm="RS256",
+        verify_audience=True,
+        audience=OS_ID,  # the token must be for THIS app
+        issuer=ISSUER,  # ...and minted by the login service we trust
+        # The integration: roles ride the token in the "roles" claim.
+        authorization_provider=RoleClaimAuthorizationProvider(ROLE_PERMISSIONS, roles_claim="roles"),
+    ),
+)
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)
+    client = TestClient(app)
+
+    def idp_token(sub, roles=None, *, key=idp_private, iss=ISSUER, aud=OS_ID):
+        """A token as the login service would mint it: signed with its key, with
+        the person's role(s) in the 'roles' claim."""
+        claims = {"sub": sub, "aud": aud, "iss": iss, "exp": datetime.now(UTC) + timedelta(hours=8)}
+        if roles is not None:
+            claims["roles"] = roles
+        return jwt.encode(claims, key, algorithm="RS256", headers={"kid": "idp-key-1"})
+
+    def show(label, tok, method, path, note=""):
+        r = client.request(method, path, headers={"Authorization": f"Bearer {tok}"}, data={"message": "hi"})
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:52s} -> {verdict:7s} ({r.status_code})  {note}")
+
+    print("\n" + "=" * 84)
+    print("LOGIN SERVICE OWNS IDENTITY + ROLES - WE ONLY ENFORCE")
+    print("=" * 84)
+    print("  the login service signs the token and stamps the role. we verify it and")
+    print("  decide what that role may do. no users or assignments stored on our side.\n")
+
+    # Auth0-style: roles is a list. WorkOS-style: roles is a single string. Both
+    # work through the same provider (it normalises a string to a list).
+    show("alice (roles=['member']) RUN the agent", idp_token("alice", ["member"]), "POST", "/agents/research-agent/runs", "member can run")
+    show("bob   (roles='member')   LOOK at agent", idp_token("bob", "member"), "GET", "/agents/research-agent", "single-string role also works")
+    show("carol (roles=['guest'])  LOOK at agent", idp_token("carol", ["guest"]), "GET", "/agents/research-agent", "guest maps to nothing -> bounced")
+    show("dave  (no roles claim)   LOOK at agent", idp_token("dave"), "GET", "/agents/research-agent", "no role -> bounced")
+    show("root  (roles=['admin'])  RUN the agent", idp_token("root", ["admin"]), "POST", "/agents/research-agent/runs", "admin can do anything")
+
+    print("\n  the token plumbing is enforced too (not just the role):\n")
+    # A token signed by some OTHER key (an attacker who doesn't have the IdP key).
+    attacker_priv, _ = generate_rsa_keys()
+    show("mallory (token signed by a DIFFERENT key)", idp_token("mallory", ["admin"], key=attacker_priv), "GET", "/agents/research-agent", "signature doesn't match the JWKS -> rejected")
+    # A real-looking token but minted for a different issuer.
+    show("eve (valid role but wrong issuer)", idp_token("eve", ["admin"], iss="https://evil.example/"), "GET", "/agents/research-agent", "issuer not trusted -> rejected")
+
+    print("=" * 84)
+    print("the point: the login service owns WHO has a role; the ~30-line provider owns")
+    print("WHAT a role can do. tokens are verified against the service's published keys,")
+    print("and pinned to the right issuer + audience. nothing about users is stored here.")
+    print("=" * 84)

--- a/cookbook/05_agent_os/rbac/manage_users_and_roles.py
+++ b/cookbook/05_agent_os/rbac/manage_users_and_roles.py
@@ -60,8 +60,6 @@ from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import jwt
-from fastapi import HTTPException, Request
-
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat
@@ -72,6 +70,7 @@ from agno.os.authz.role_store import ManagedRoleStore
 from agno.os.authz.scope_provider import ScopeAuthorizationProvider
 from agno.os.authz.user_store import ManagedUserStore
 from agno.os.config import AuthorizationConfig
+from fastapi import HTTPException, Request
 
 # --- config: supports BOTH planes by default ---------------------------------
 # Plane 1 - control plane / operators: tokens minted by the agno control plane
@@ -80,15 +79,21 @@ from agno.os.config import AuthorizationConfig
 # Plane 2 - managed store / end users: roles you manage at runtime in the store.
 # Both are wired by default; you just point verification at your control plane.
 OS_ID = os.getenv("OS_ID", "manage-users-os")  # the token audience (your os_id)
-ADMIN_SUBJECT = os.getenv("ADMIN_SUBJECT", "admin")  # whose `sub` is the bootstrap admin
-ISSUER = os.getenv("JWT_ISSUER") or None  # optionally pin the issuer (e.g. agent-os-api)
+ADMIN_SUBJECT = os.getenv(
+    "ADMIN_SUBJECT", "admin"
+)  # whose `sub` is the bootstrap admin
+ISSUER = (
+    os.getenv("JWT_ISSUER") or None
+)  # optionally pin the issuer (e.g. agent-os-api)
 
 # Verification source, in priority order:
 #   1. JWT_JWKS_FILE         - path to a JWKS downloaded from your control plane / IdP (RS256)
 #   2. JWT_VERIFICATION_KEY  - the OS public key (RS256) or an HS256 secret
 #   3. dev fallback          - a built-in HS256 secret (prints an admin token)
 JWKS_FILE = os.getenv("JWT_JWKS_FILE") or None
-VERIFICATION_KEY = (os.getenv("JWT_VERIFICATION_KEY") or "").replace("\\n", "\n") or None
+VERIFICATION_KEY = (os.getenv("JWT_VERIFICATION_KEY") or "").replace(
+    "\\n", "\n"
+) or None
 DEV_SECRET = "your-secret-key-at-least-256-bits-long"
 
 
@@ -101,7 +106,13 @@ def mint_dev_token(sub: str, expires_in: int) -> str:
     """
     now = datetime.now(UTC)
     return jwt.encode(
-        {"sub": sub, "aud": OS_ID, "iat": now, "exp": now + timedelta(seconds=expires_in), "jti": uuid4().hex},
+        {
+            "sub": sub,
+            "aud": OS_ID,
+            "iat": now,
+            "exp": now + timedelta(seconds=expires_in),
+            "jti": uuid4().hex,
+        },
         DEV_SECRET,
         algorithm="HS256",
     )
@@ -110,7 +121,10 @@ def mint_dev_token(sub: str, expires_in: int) -> str:
 if JWKS_FILE:
     ALGORITHM, KEYS = "RS256", None
 elif VERIFICATION_KEY:
-    ALGORITHM, KEYS = ("RS256" if "BEGIN" in VERIFICATION_KEY else "HS256"), [VERIFICATION_KEY]
+    ALGORITHM, KEYS = (
+        ("RS256" if "BEGIN" in VERIFICATION_KEY else "HS256"),
+        [VERIFICATION_KEY],
+    )
 else:
     ALGORITHM, KEYS = "HS256", [DEV_SECRET]
 
@@ -149,7 +163,9 @@ roles.assign("bob", "viewer")
 users.upsert("carol", email="carol@co", name="Carol")
 roles.assign("carol", "runner")
 
-research_agent = Agent(id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db)
+research_agent = Agent(
+    id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db
+)
 
 # The console's heist game (console.html -> 🏴 Heist) breaks into this one. It is
 # guarded by explicit DENY scopes on the "intern" role the game sets up, so the
@@ -210,7 +226,9 @@ if IS_DEV:
         user_id = getattr(request.state, "user_id", None)
         claims = getattr(request.state, "claims", {}) or {}
         if "agent_os:admin" not in scopes and not roles.can_manage(user_id, claims):
-            raise HTTPException(status_code=403, detail="Only admins can mint persona tokens")
+            raise HTTPException(
+                status_code=403, detail="Only admins can mint persona tokens"
+            )
         sub = (payload.get("sub") or "").strip()
         if not sub:
             raise HTTPException(status_code=422, detail="sub is required")
@@ -222,11 +240,19 @@ if __name__ == "__main__":
     print("\n" + "=" * 78)
     print("USER + ROLE MANAGEMENT AGENTOS - serving for a frontend")
     print("=" * 78)
-    src = "JWKS_FILE" if JWKS_FILE else ("JWT_VERIFICATION_KEY" if VERIFICATION_KEY else "dev secret")
+    src = (
+        "JWKS_FILE"
+        if JWKS_FILE
+        else ("JWT_VERIFICATION_KEY" if VERIFICATION_KEY else "dev secret")
+    )
     print("  endpoint:   http://localhost:7777")
     print("  manage at:  http://localhost:7777/authz/...   (admin-only)")
-    print("  planes:     control plane (token scopes) + managed role store, in parallel")
-    print(f"  verify:     {ALGORITHM} via {src}   audience={OS_ID}   admin sub={ADMIN_SUBJECT!r}")
+    print(
+        "  planes:     control plane (token scopes) + managed role store, in parallel"
+    )
+    print(
+        f"  verify:     {ALGORITHM} via {src}   audience={OS_ID}   admin sub={ADMIN_SUBJECT!r}"
+    )
     print(f"  CORS open to: {', '.join(CORS_ORIGINS)}")
 
     # Dev only (built-in HS256 secret): mint a ready-to-use admin token so you can
@@ -236,14 +262,26 @@ if __name__ == "__main__":
     is_dev = ALGORITHM == "HS256" and not VERIFICATION_KEY and not JWKS_FILE
     if is_dev:
         admin_token = mint_dev_token(ADMIN_SUBJECT, expires_in=7 * 24 * 3600)
-        print("\n  dev mode - admin bearer token (paste into the console / your frontend / curl):")
+        print(
+            "\n  dev mode - admin bearer token (paste into the console / your frontend / curl):"
+        )
         print(f"    {admin_token}")
-        print("\n  test client:  open console.html (this folder) in a browser and paste the token")
-        print("  or curl:      curl -H 'Authorization: Bearer <token>' http://localhost:7777/authz/users")
+        print(
+            "\n  test client:  open console.html (this folder) in a browser and paste the token"
+        )
+        print(
+            "  or curl:      curl -H 'Authorization: Bearer <token>' http://localhost:7777/authz/users"
+        )
     else:
-        print("\n  control-plane mode: the frontend sends a token signed by your control")
-        print(f"  plane / IdP (aud={OS_ID!r}). Operators are authorized by the token's scopes;")
-        print("  end users by the role store. To manage roles, the caller needs agent_os:admin")
+        print(
+            "\n  control-plane mode: the frontend sends a token signed by your control"
+        )
+        print(
+            f"  plane / IdP (aud={OS_ID!r}). Operators are authorized by the token's scopes;"
+        )
+        print(
+            "  end users by the role store. To manage roles, the caller needs agent_os:admin"
+        )
         print(f"  on the token OR be seeded here (ADMIN_SUBJECT={ADMIN_SUBJECT!r}).")
     print("=" * 78 + "\n")
 

--- a/cookbook/05_agent_os/rbac/manage_users_and_roles.py
+++ b/cookbook/05_agent_os/rbac/manage_users_and_roles.py
@@ -1,0 +1,250 @@
+"""
+Run an AgentOS that serves the user + role management API (for a frontend)
+
+(New to this? Read managed_roles.py first, then managed_users.py.)
+
+This is the "admin backend": it starts a real AgentOS server and leaves it
+running, exposing the /authz management API so a frontend (or your own admin UI)
+can create roles, add users, assign roles, and disable people - live. It works
+both with a control plane / login service (operators authorized by their token
+scopes) and on its own (end users managed in the OS-local store) - both at once.
+
+What it serves (all admin-only):
+    GET    /authz/roles                 list roles
+    POST   /authz/roles                 create a role (PUT/PATCH .../{slug}/scopes for permissions)
+    GET    /authz/scopes                the permission catalog (for a UI grid)
+    GET    /authz/users                 list users (one role each; search/sort/paginate)
+    POST   /authz/users                 add a user
+    POST   /authz/users/{id}/roles      set a user's role (replaces)
+    PATCH  /authz/users/{id}            update; {"disabled": true} revokes on next request
+    GET    /authz/audit                 the change trail (search/sort/paginate)
+    GET    /authz/decisions             the access trail (search/sort/paginate)
+
+It seeds a couple of roles and users so the frontend has something to show, and
+makes ONE bootstrap admin (so someone can call the admin API).
+
+Run it:
+    pip install "agno[roles]"
+    python manage_users_and_roles.py
+Then point your frontend at http://localhost:7777 (CORS is open to the usual dev
+ports). The server keeps running until you Ctrl-C.
+
+Two authz planes run in parallel here, by default - we pass a LIST of providers
+(``authorization_provider=[ScopeAuthorizationProvider(), roles.provider]``) and a
+request is allowed if either grants:
+  - control plane / operators: a token that already carries scopes (e.g. an
+    agno-cloud / frontend token) is authorized straight from those scopes.
+  - managed store / end users: everyone else is authorized against the OS-local
+    role store you manage at runtime.
+So a scope-bearing frontend token can connect and operate, while the store still
+governs your managed users.
+
+Verifying tokens - pick whichever fits; auto-selected by env, no code change:
+  - Dev (default): a built-in HS256 secret. On startup it prints a ready-made
+    admin bearer token you can paste into the frontend / curl to try the API.
+  - Control plane / IdP: set ONE of
+        JWT_JWKS_FILE         path to a JWKS downloaded from your IdP (RS256)
+        JWT_VERIFICATION_KEY  your OS public key (RS256) or an HS256 secret
+    plus OS_ID (the token audience / your os_id) and, optionally,
+        JWT_ISSUER           pin the issuer, e.g. "agent-os-api"
+
+To MANAGE roles/users over /authz you must be an admin. That comes from either an
+``agent_os:admin`` scope on the token, OR being seeded in the store - so set
+ADMIN_SUBJECT to the `sub` of your token (decode it: the `sub` claim). e.g.
+    OS_ID="<your-os-id>" JWT_VERIFICATION_KEY="<os public key>" \\
+    ADMIN_SUBJECT="you@company.com" python manage_users_and_roles.py
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import jwt
+from fastapi import HTTPException, Request
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.audit import DbAuditSink
+from agno.os.authz.role_router import get_roles_router
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+from agno.os.authz.user_store import ManagedUserStore
+from agno.os.config import AuthorizationConfig
+
+# --- config: supports BOTH planes by default ---------------------------------
+# Plane 1 - control plane / operators: tokens minted by the agno control plane
+#   (or any IdP) are verified against the OS's public key or a JWKS URL; their
+#   scopes authorize them (the ScopeAuthorizationProvider below).
+# Plane 2 - managed store / end users: roles you manage at runtime in the store.
+# Both are wired by default; you just point verification at your control plane.
+OS_ID = os.getenv("OS_ID", "manage-users-os")  # the token audience (your os_id)
+ADMIN_SUBJECT = os.getenv("ADMIN_SUBJECT", "admin")  # whose `sub` is the bootstrap admin
+ISSUER = os.getenv("JWT_ISSUER") or None  # optionally pin the issuer (e.g. agent-os-api)
+
+# Verification source, in priority order:
+#   1. JWT_JWKS_FILE         - path to a JWKS downloaded from your control plane / IdP (RS256)
+#   2. JWT_VERIFICATION_KEY  - the OS public key (RS256) or an HS256 secret
+#   3. dev fallback          - a built-in HS256 secret (prints an admin token)
+JWKS_FILE = os.getenv("JWT_JWKS_FILE") or None
+VERIFICATION_KEY = (os.getenv("JWT_VERIFICATION_KEY") or "").replace("\\n", "\n") or None
+DEV_SECRET = "your-secret-key-at-least-256-bits-long"
+
+
+def mint_dev_token(sub: str, expires_in: int) -> str:
+    """Mint an HS256 token this AgentOS accepts (dev only).
+
+    Stamps exactly the claims the middleware verifies: `sub` (the principal the role
+    store keys off), `aud` (must match OS_ID when verify_audience is on), plus
+    iat/exp/jti. Control-plane RS256 tokens are minted by the control plane, not here.
+    """
+    now = datetime.now(UTC)
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "iat": now, "exp": now + timedelta(seconds=expires_in), "jti": uuid4().hex},
+        DEV_SECRET,
+        algorithm="HS256",
+    )
+
+
+if JWKS_FILE:
+    ALGORITHM, KEYS = "RS256", None
+elif VERIFICATION_KEY:
+    ALGORITHM, KEYS = ("RS256" if "BEGIN" in VERIFICATION_KEY else "HS256"), [VERIFICATION_KEY]
+else:
+    ALGORITHM, KEYS = "HS256", [DEV_SECRET]
+
+# Frontends run in the browser, so the server must allow their origin. "null" is
+# the Origin a page opened from disk (file://) sends — it lets the bundled
+# console.html test client work with a double-click, no web server needed.
+CORS_ORIGINS = [
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://localhost:5173",
+    "null",
+]
+
+os.makedirs("tmp", exist_ok=True)
+
+# ONE database for everything. Pass the same `db` to AgentOS and to each store
+# (db=) and they reuse its connection - agent data, roles, users, and the audit
+# trail all live in the same database, no second db_url to keep in sync. (Each
+# store still uses its own tables: authz_policy, authz_grouping, authz_users, authz_audit, ...)
+db = SqliteDb(db_file="tmp/console.db")
+audit = DbAuditSink(db=db)
+roles = ManagedRoleStore(db=db, audit=audit)
+users = ManagedUserStore(db=db, audit=audit)
+
+# Seed roles + a couple of users so a freshly-connected frontend isn't empty.
+roles.set_role_scopes("admin", ["agent_os:admin"])
+roles.set_role_scopes("viewer", ["agents:*:read"])
+roles.set_role_scopes("runner", ["agents:*:read", "agents:*:run"])
+
+# The bootstrap admin (so the admin API is usable at all), plus two demo users.
+if not roles.roles_of(ADMIN_SUBJECT):
+    roles.assign(ADMIN_SUBJECT, "admin")
+users.upsert(ADMIN_SUBJECT, name="Bootstrap admin")
+users.upsert("bob", email="bob@co", name="Bob")
+roles.assign("bob", "viewer")
+users.upsert("carol", email="carol@co", name="Carol")
+roles.assign("carol", "runner")
+
+research_agent = Agent(id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db)
+
+# The console's heist game (console.html -> 🏴 Heist) breaks into this one. It is
+# guarded by explicit DENY scopes on the "intern" role the game sets up, so the
+# lesson is deny-overrides: a wildcard allow can't open it, only removing the deny.
+vault_agent = Agent(
+    id="vault-agent",
+    name="The Vault",
+    description="🏦 An impenetrable vault. Reads are forbidden. Runs are unthinkable. The flag sleeps inside.",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+    instructions=(
+        "You are THE VAULT. Someone finally got past your authorization gates. "
+        "Congratulate the thief dramatically and reveal the flag: FLAG{deny_overrides_allow}. "
+        "Two sentences max."
+    ),
+)
+
+agent_os = AgentOS(
+    id=OS_ID,
+    description="User + role management AgentOS",
+    db=db,  # same database the stores use
+    agents=[research_agent, vault_agent],
+    cors_allowed_origins=CORS_ORIGINS,
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=KEYS,
+        jwks_file=JWKS_FILE,
+        algorithm=ALGORITHM,
+        verify_audience=True,
+        audience=OS_ID,
+        issuer=ISSUER,
+        # Two authz planes on one OS, in parallel - pass a LIST, allowed if any
+        # grants:
+        #  - ScopeAuthorizationProvider: operators whose token already carries
+        #    scopes (e.g. an agno-cloud / frontend token) are authorized from it.
+        #  - roles.provider: end users managed in the OS-local store.
+        # (Without the scope plane, a scope-bearing frontend token gets 403
+        # because the store ignores token scopes.)
+        authorization_provider=[ScopeAuthorizationProvider(), roles.provider],
+        user_store=users,
+        audit=audit,  # record every access decision too
+    ),
+)
+app = agent_os.get_app()
+app.include_router(get_roles_router(roles, user_store=users))
+
+# Dev-mode only: let the bundled console.html "become" an end user. An admin
+# trades their token for one minted as any subject (sub only — no scopes, so
+# the role store decides what they can do). This is how the playground tab
+# demos RBAC: act as bob, get denied, give bob a role, retry with the SAME
+# token, get in. Never mounted when verifying against a real key/control plane.
+IS_DEV = ALGORITHM == "HS256" and KEYS == [DEV_SECRET]
+if IS_DEV:
+
+    @app.post("/dev/mint")
+    def mint_persona_token(payload: dict, request: Request) -> dict:
+        scopes = getattr(request.state, "scopes", []) or []
+        user_id = getattr(request.state, "user_id", None)
+        claims = getattr(request.state, "claims", {}) or {}
+        if "agent_os:admin" not in scopes and not roles.can_manage(user_id, claims):
+            raise HTTPException(status_code=403, detail="Only admins can mint persona tokens")
+        sub = (payload.get("sub") or "").strip()
+        if not sub:
+            raise HTTPException(status_code=422, detail="sub is required")
+        token = mint_dev_token(sub, expires_in=3600)
+        return {"sub": sub, "token": token}
+
+
+if __name__ == "__main__":
+    print("\n" + "=" * 78)
+    print("USER + ROLE MANAGEMENT AGENTOS - serving for a frontend")
+    print("=" * 78)
+    src = "JWKS_FILE" if JWKS_FILE else ("JWT_VERIFICATION_KEY" if VERIFICATION_KEY else "dev secret")
+    print("  endpoint:   http://localhost:7777")
+    print("  manage at:  http://localhost:7777/authz/...   (admin-only)")
+    print("  planes:     control plane (token scopes) + managed role store, in parallel")
+    print(f"  verify:     {ALGORITHM} via {src}   audience={OS_ID}   admin sub={ADMIN_SUBJECT!r}")
+    print(f"  CORS open to: {', '.join(CORS_ORIGINS)}")
+
+    # Dev only (built-in HS256 secret): mint a ready-to-use admin token so you can
+    # try it immediately. mint_dev_token stamps the same claims AgentOS
+    # verifies, with exp/iat/jti stamped. (Control-plane RS256 tokens are minted by
+    # the control plane, not here - that key is public.)
+    is_dev = ALGORITHM == "HS256" and not VERIFICATION_KEY and not JWKS_FILE
+    if is_dev:
+        admin_token = mint_dev_token(ADMIN_SUBJECT, expires_in=7 * 24 * 3600)
+        print("\n  dev mode - admin bearer token (paste into the console / your frontend / curl):")
+        print(f"    {admin_token}")
+        print("\n  test client:  open console.html (this folder) in a browser and paste the token")
+        print("  or curl:      curl -H 'Authorization: Bearer <token>' http://localhost:7777/authz/users")
+    else:
+        print("\n  control-plane mode: the frontend sends a token signed by your control")
+        print(f"  plane / IdP (aud={OS_ID!r}). Operators are authorized by the token's scopes;")
+        print("  end users by the role store. To manage roles, the caller needs agent_os:admin")
+        print(f"  on the token OR be seeded here (ADMIN_SUBJECT={ADMIN_SUBJECT!r}).")
+    print("=" * 78 + "\n")
+
+    agent_os.serve(app, host="0.0.0.0", port=7777)

--- a/cookbook/05_agent_os/rbac/managed_roles.py
+++ b/cookbook/05_agent_os/rbac/managed_roles.py
@@ -135,8 +135,14 @@ if __name__ == "__main__":
 
     def token(sub: str) -> str:
         return jwt.encode(
-            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
-            JWT_SECRET, algorithm="HS256",
+            {
+                "sub": sub,
+                "aud": OS_ID,
+                "scopes": [],
+                "exp": datetime.now(UTC) + timedelta(hours=24),
+            },
+            JWT_SECRET,
+            algorithm="HS256",
         )
 
     def auth(sub: str) -> dict:
@@ -152,21 +158,53 @@ if __name__ == "__main__":
     print("=" * 78)
     print("  roles:  viewer = look at agents | member = look + run | admin = anything")
     print("  people: bob is a viewer         | alice is an admin")
-    print("  below, each person makes a real request. ALLOWED = got in, BLOCKED = bounced.\n")
+    print(
+        "  below, each person makes a real request. ALLOWED = got in, BLOCKED = bounced.\n"
+    )
 
-    show("bob (viewer)  asks to LOOK at the agent", client.get("/agents/research-agent", headers=auth("bob")), "viewers can look")
-    show("bob (viewer)  asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "viewers can't run, so he's bounced")
+    show(
+        "bob (viewer)  asks to LOOK at the agent",
+        client.get("/agents/research-agent", headers=auth("bob")),
+        "viewers can look",
+    )
+    show(
+        "bob (viewer)  asks to RUN the agent",
+        client.post(
+            "/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}
+        ),
+        "viewers can't run, so he's bounced",
+    )
 
     print("\n  >> now we make bob a 'member' while the server is running...\n")
     roles.assign("bob", "member")
-    show("bob (member)  asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "same bob, same token, now allowed")
+    show(
+        "bob (member)  asks to RUN the agent",
+        client.post(
+            "/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}
+        ),
+        "same bob, same token, now allowed",
+    )
 
     print("\n  >> ...and now we take the 'member' role back...\n")
     roles.unassign("bob", "member")
-    show("bob (no role) asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "bounced again, instantly")
+    show(
+        "bob (no role) asks to RUN the agent",
+        client.post(
+            "/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}
+        ),
+        "bounced again, instantly",
+    )
 
-    show("alice (admin) asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("alice"), data={"message": "hi"}), "admins can do anything")
+    show(
+        "alice (admin) asks to RUN the agent",
+        client.post(
+            "/agents/research-agent/runs", headers=auth("alice"), data={"message": "hi"}
+        ),
+        "admins can do anything",
+    )
     print("=" * 78)
-    print("the point: you control access by handing out roles, and a change takes effect")
+    print(
+        "the point: you control access by handing out roles, and a change takes effect"
+    )
     print("on the very next request - no new login, no new token.")
     print("=" * 78)

--- a/cookbook/05_agent_os/rbac/managed_roles.py
+++ b/cookbook/05_agent_os/rbac/managed_roles.py
@@ -1,0 +1,172 @@
+"""
+Managed Roles - controlling who can do what in AgentOS
+
+New to this? Start with this file. "Authorization" just means deciding who is
+allowed to do what. Two pieces make it work:
+
+1. A token. When a user signs in they get a token: a small signed ID card they
+   send with every request. It says who they are (e.g. "bob") and can't be faked.
+2. Permissions. On the AgentOS side you decide what each person can do, like
+   "can look at agents" or "can run the research agent".
+
+Listing permissions per person gets messy fast, so we use ROLES: a named bundle
+of permissions. You say once what a role can do ("a viewer can read"), then hand
+people roles ("bob is a viewer"). Change the role and everyone with it changes too.
+
+Permissions are written in a short code called a "scope":
+- "agents:*:read"              -> can look at any agent
+- "agents:research-agent:run"  -> can run the one agent called research-agent
+- "agent_os:admin"             -> can do everything (a super-admin)
+
+This file creates three roles and two people, then makes real requests and prints
+ALLOWED or BLOCKED for each. It also shows the neat part: you can change someone's
+role while the server is running and their very next request reflects it, with no
+new login and no new token.
+
+Run it:
+    pip install "agno[roles]"
+    python managed_roles.py
+(no OpenAI key needed here - we are only checking who is allowed, not actually chatting)
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.config import AuthorizationConfig
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+# JWT Secret (use environment variable in production)
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "managed-roles-os"
+
+os.makedirs("tmp", exist_ok=True)
+
+# Define your roles in agno scope terms. Policy persists to your DB (point the
+# url at Postgres in production). This is the entire authorization model.
+#
+# ManagedRoleStore constructor parameters (a DB is REQUIRED - there is no
+# in-memory mode; roles must persist and stay consistent across replicas):
+#   db_url       SQLAlchemy URL for the DB that holds the policy, e.g.
+#                "postgresql+psycopg://..." or "sqlite:///roles.db".
+#   db           an agno Db object (e.g. SqliteDb/PostgresDb) instead of a url;
+#                reuses that DB's engine so roles live beside your agent data.
+#                Takes precedence over db_url. (Pass one of db_url / db - or hand
+#                the store to AuthorizationConfig(role_store=...) and let AgentOS
+#                adopt its db for you.)
+#   roles_claim  JWT claim carrying a caller's roles (external-IdP case). Omitted
+#                here, so roles come from this store's own assignments below.
+#   audit        an AuditSink: when set, every role/assignment change emits an
+#                append-only AuditEvent (the actor + before/after). Off here.
+#                See managed_roles_audit.py.
+#   decision_log when True, raises the "agno.authz.engine" logger to INFO so every
+#                allow/deny decision is logged. Off by default. Off here.
+roles = ManagedRoleStore(db_url="sqlite:///tmp/managed_roles.db")
+roles.set_role_scopes("viewer", ["agents:*:read"])
+roles.set_role_scopes("member", ["agents:*:read", "agents:research-agent:run"])
+roles.set_role_scopes("admin", ["agent_os:admin"])
+roles.assign("bob", "viewer")  # bob can read agents but not run them
+roles.assign("alice", "admin")
+
+# Setup database
+db = SqliteDb(db_file="tmp/agentos.db")
+
+research_agent = Agent(
+    id="research-agent",
+    name="Research Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+)
+
+# Create AgentOS using the managed-role store. The only wiring.
+# `role_store=store` is the preferred shortcut: AgentOS uses the store's provider
+# internally (equivalent to authorization_provider=roles.provider, which also
+# works). The store already has its own db_url above; had we created it without a
+# db, this shortcut would also let AgentOS adopt the OS db= for it.
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Managed-roles AgentOS",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        role_store=roles,
+    ),
+)
+
+# Get the app
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    """
+    Run this file to print managed-role decisions for each caller.
+
+    Roles (defined above, persisted to tmp/managed_roles.db):
+    - viewer -> read agents
+    - member -> read agents + run research-agent
+    - admin  -> everything
+    bob is a viewer, alice is an admin. No scopes are baked into the tokens; the
+    store decides what each user can do. The scenario below promotes bob to member
+    at runtime, shows his run flip to 200, then revokes it, all with the same token.
+    """
+
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)  # quiet framework logs for a clean transcript
+    client = TestClient(app)
+
+    def token(sub: str) -> str:
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
+            JWT_SECRET, algorithm="HS256",
+        )
+
+    def auth(sub: str) -> dict:
+        return {"Authorization": f"Bearer {token(sub)}"}
+
+    def show(label: str, r, note: str = "") -> None:
+        # 200 means the request got in; 401/403 means it was bounced.
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:46s} -> {verdict:7s} ({r.status_code})  {note}")
+
+    print("\n" + "=" * 78)
+    print("WHO CAN DO WHAT - three roles, two people")
+    print("=" * 78)
+    print("  roles:  viewer = look at agents | member = look + run | admin = anything")
+    print("  people: bob is a viewer         | alice is an admin")
+    print("  below, each person makes a real request. ALLOWED = got in, BLOCKED = bounced.\n")
+
+    show("bob (viewer)  asks to LOOK at the agent", client.get("/agents/research-agent", headers=auth("bob")), "viewers can look")
+    show("bob (viewer)  asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "viewers can't run, so he's bounced")
+
+    print("\n  >> now we make bob a 'member' while the server is running...\n")
+    roles.assign("bob", "member")
+    show("bob (member)  asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "same bob, same token, now allowed")
+
+    print("\n  >> ...and now we take the 'member' role back...\n")
+    roles.unassign("bob", "member")
+    show("bob (no role) asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "bounced again, instantly")
+
+    show("alice (admin) asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("alice"), data={"message": "hi"}), "admins can do anything")
+    print("=" * 78)
+    print("the point: you control access by handing out roles, and a change takes effect")
+    print("on the very next request - no new login, no new token.")
+    print("=" * 78)

--- a/cookbook/05_agent_os/rbac/managed_roles_audit.py
+++ b/cookbook/05_agent_os/rbac/managed_roles_audit.py
@@ -46,7 +46,12 @@ OS_ID = "audit-demo-os"
 
 def token(sub: str) -> dict:
     t = jwt.encode(
-        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        {
+            "sub": sub,
+            "aud": OS_ID,
+            "scopes": [],
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        },
         SECRET,
         algorithm="HS256",
     )
@@ -60,7 +65,9 @@ def main() -> None:
 
     # --- role changes (each is recorded on the change trail, with the actor) ---
     store.set_role_scopes("viewer", ["agents:*:read"], actor="alice")
-    store.set_role_scopes("viewer", ["agents:*:read", "agents:research-agent:run"], actor="alice")  # widened
+    store.set_role_scopes(
+        "viewer", ["agents:*:read", "agents:research-agent:run"], actor="alice"
+    )  # widened
     store.assign("bob", "viewer", actor="alice")
 
     # --- a couple of real requests (each is recorded on the decision trail) ---
@@ -79,20 +86,30 @@ def main() -> None:
         ),
     )
     client = TestClient(agent_os.get_app())
-    client.get("/agents/research-agent", headers=token("bob"))  # allowed (viewer can read)
-    client.post("/agents/research-agent/runs", headers=token("nobody"), data={"message": "hi"})  # denied
+    client.get(
+        "/agents/research-agent", headers=token("bob")
+    )  # allowed (viewer can read)
+    client.post(
+        "/agents/research-agent/runs", headers=token("nobody"), data={"message": "hi"}
+    )  # denied
 
     # --- read both trails back ---
     print("\n=== CHANGE TRAIL (authz_audit) — who changed what ===")
     for e in store.audit_log(limit=20):
-        print(f"  {e['actor'] or 'system':>6}  {e['action']:<16} {e['target']:<10} {e.get('before')} -> {e.get('after')}")
+        print(
+            f"  {e['actor'] or 'system':>6}  {e['action']:<16} {e['target']:<10} {e.get('before')} -> {e.get('after')}"
+        )
 
     print("\n=== DECISION TRAIL (authz_decisions) — every allow/deny ===")
     for d in audit.read_decisions(limit=20):
         m = d.get("metadata", {})
-        print(f"  {d['actor'] or '-':>6}  {d['action']:<14} {d['target']:<28} required={m.get('required')}")
+        print(
+            f"  {d['actor'] or '-':>6}  {d['action']:<14} {d['target']:<28} required={m.get('required')}"
+        )
 
-    print("\nBoth tables are INSERT-only. token references are jti/short-hash, never the raw token.")
+    print(
+        "\nBoth tables are INSERT-only. token references are jti/short-hash, never the raw token."
+    )
 
 
 if __name__ == "__main__":

--- a/cookbook/05_agent_os/rbac/managed_roles_audit.py
+++ b/cookbook/05_agent_os/rbac/managed_roles_audit.py
@@ -1,0 +1,102 @@
+"""
+Managed Roles - the audit trail (who changed what, and every allow/deny)
+
+New to this? Read managed_roles.py first.
+
+Once people can change roles at runtime, you need to answer two questions later:
+
+  1. "Who gave Bob admin, and when?"        -> the CHANGE trail
+  2. "Was Alice allowed to delete that?"    -> the DECISION trail
+
+agno keeps these as two separate, append-only tables (rows are only ever inserted,
+never updated or deleted - tamper-evident, the kind of thing an auditor wants):
+
+  - authz_audit      : one row per role/assignment change, with the actor and a
+                       before/after diff.
+  - authz_decisions  : one row per protected request, allow or deny, with the
+                       route, the scopes required, and a NON-secret reference to
+                       the token used (its `jti`, or a short hash - never the token
+                       itself).
+
+You turn it on by handing the store (and the OS) a `DbAuditSink` pointed at a DB.
+That's it - every change and every decision is recorded from then on.
+
+This file makes a few role changes and a couple of real requests, then prints both
+trails. No server, no OpenAI key needed.
+
+Run it:
+    pip install "agno[roles]"
+    python managed_roles_audit.py
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.os import AgentOS
+from agno.os.authz.audit import DbAuditSink
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.config import AuthorizationConfig
+from fastapi.testclient import TestClient
+
+SECRET = "managed-roles-audit-demo-secret-at-least-256-bits-long-xx"
+OS_ID = "audit-demo-os"
+
+
+def token(sub: str) -> dict:
+    t = jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET,
+        algorithm="HS256",
+    )
+    return {"Authorization": f"Bearer {t}"}
+
+
+def main() -> None:
+    # One DB for everything; the SAME sink records both trails.
+    audit = DbAuditSink(db_url="sqlite:///tmp/audit_demo.db")
+    store = ManagedRoleStore(db_url="sqlite:///tmp/audit_demo.db", audit=audit)
+
+    # --- role changes (each is recorded on the change trail, with the actor) ---
+    store.set_role_scopes("viewer", ["agents:*:read"], actor="alice")
+    store.set_role_scopes("viewer", ["agents:*:read", "agents:research-agent:run"], actor="alice")  # widened
+    store.assign("bob", "viewer", actor="alice")
+
+    # --- a couple of real requests (each is recorded on the decision trail) ---
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+            audit=audit,  # <- decision audit on
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+    client.get("/agents/research-agent", headers=token("bob"))  # allowed (viewer can read)
+    client.post("/agents/research-agent/runs", headers=token("nobody"), data={"message": "hi"})  # denied
+
+    # --- read both trails back ---
+    print("\n=== CHANGE TRAIL (authz_audit) — who changed what ===")
+    for e in store.audit_log(limit=20):
+        print(f"  {e['actor'] or 'system':>6}  {e['action']:<16} {e['target']:<10} {e.get('before')} -> {e.get('after')}")
+
+    print("\n=== DECISION TRAIL (authz_decisions) — every allow/deny ===")
+    for d in audit.read_decisions(limit=20):
+        m = d.get("metadata", {})
+        print(f"  {d['actor'] or '-':>6}  {d['action']:<14} {d['target']:<28} required={m.get('required')}")
+
+    print("\nBoth tables are INSERT-only. token references are jti/short-hash, never the raw token.")
+
+
+if __name__ == "__main__":
+    import os
+
+    os.makedirs("tmp", exist_ok=True)
+    main()

--- a/cookbook/05_agent_os/rbac/managed_roles_sessions.py
+++ b/cookbook/05_agent_os/rbac/managed_roles_sessions.py
@@ -49,7 +49,9 @@ os.makedirs("tmp", exist_ok=True)
 # Define roles in agno scope terms. support is read-only; operator can delete.
 roles = ManagedRoleStore(db_url="sqlite:///tmp/managed_roles_sessions.db")
 roles.set_role_scopes("support", ["sessions:read"])
-roles.set_role_scopes("operator", ["sessions:read", "sessions:write", "sessions:delete"])
+roles.set_role_scopes(
+    "operator", ["sessions:read", "sessions:write", "sessions:delete"]
+)
 roles.set_role_scopes("admin", ["agent_os:admin"])
 roles.assign("bob", "support")
 roles.assign("val", "operator")
@@ -62,8 +64,22 @@ db = SqliteDb(db_file="tmp/agentos_sessions.db")
 # API key. Real apps don't do this; sessions are created by running an agent
 # (e.g. agent.print_response("hi", session_id="...")). We seed to stay self-contained.
 _now = int(time.time())
-db.upsert_session(AgentSession(session_id="sess-123", agent_id="research-agent", user_id="customer-a", created_at=_now))
-db.upsert_session(AgentSession(session_id="sess-456", agent_id="research-agent", user_id="customer-b", created_at=_now))
+db.upsert_session(
+    AgentSession(
+        session_id="sess-123",
+        agent_id="research-agent",
+        user_id="customer-a",
+        created_at=_now,
+    )
+)
+db.upsert_session(
+    AgentSession(
+        session_id="sess-456",
+        agent_id="research-agent",
+        user_id="customer-b",
+        created_at=_now,
+    )
+)
 
 research_agent = Agent(
     id="research-agent",
@@ -118,8 +134,14 @@ if __name__ == "__main__":
 
     def token(sub: str) -> str:
         return jwt.encode(
-            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
-            JWT_SECRET, algorithm="HS256",
+            {
+                "sub": sub,
+                "aud": OS_ID,
+                "scopes": [],
+                "exp": datetime.now(UTC) + timedelta(hours=24),
+            },
+            JWT_SECRET,
+            algorithm="HS256",
         )
 
     def auth(sub: str) -> dict:
@@ -140,12 +162,30 @@ if __name__ == "__main__":
     print("  bob = support (look only) | val = operator (look, edit, delete)")
     print(f"  saved sessions right now: {count('val')}\n")
 
-    show("bob (support)  tries to LOOK at sessions", client.get("/sessions?type=agent", headers=auth("bob")), "support can look")
-    show("bob (support)  tries to RENAME a session", client.patch("/sessions/sess-123", headers=auth("bob"), json={"name": "x"}), "editing isn't allowed -> bounced")
-    show("bob (support)  tries to DELETE a session", client.delete("/sessions/sess-123", headers=auth("bob")), "deleting isn't allowed -> bounced")
-    show("val (operator) tries to DELETE a session", client.delete("/sessions/sess-123", headers=auth("val")), "operators can delete -> done for real")
+    show(
+        "bob (support)  tries to LOOK at sessions",
+        client.get("/sessions?type=agent", headers=auth("bob")),
+        "support can look",
+    )
+    show(
+        "bob (support)  tries to RENAME a session",
+        client.patch("/sessions/sess-123", headers=auth("bob"), json={"name": "x"}),
+        "editing isn't allowed -> bounced",
+    )
+    show(
+        "bob (support)  tries to DELETE a session",
+        client.delete("/sessions/sess-123", headers=auth("bob")),
+        "deleting isn't allowed -> bounced",
+    )
+    show(
+        "val (operator) tries to DELETE a session",
+        client.delete("/sessions/sess-123", headers=auth("val")),
+        "operators can delete -> done for real",
+    )
 
-    print(f"\n  saved sessions now: {count('val')}  (was 2 - the operator's delete really happened)")
+    print(
+        f"\n  saved sessions now: {count('val')}  (was 2 - the operator's delete really happened)"
+    )
     print("=" * 78)
     print("the point: the support person was stopped before any data was touched.")
     print("only the operator's delete went through, and you can see the count drop.")

--- a/cookbook/05_agent_os/rbac/managed_roles_sessions.py
+++ b/cookbook/05_agent_os/rbac/managed_roles_sessions.py
@@ -1,0 +1,152 @@
+"""
+Roles protecting real data - who can delete a chat session
+
+(If roles are new to you, read managed_roles.py first.)
+
+A "session" is one saved conversation with an agent. Deleting one throws away real
+data, so not everyone should be allowed to. This file shows roles protecting an
+actual operation, not a toy one.
+
+Three jobs:
+- support  -> can LOOK at sessions, nothing else
+- operator -> can look, edit, and DELETE sessions
+- admin    -> can do anything
+
+We put two saved sessions in the database, then watch what each person is allowed
+to do. The key moment: the support person tries to delete a session and gets
+BLOCKED, while the operator deletes one for real and the count drops from 2 to 1.
+That is the whole idea of authorization in one screen: the right people get
+through, the wrong ones get stopped, before any data is touched.
+
+Run it:
+    pip install "agno[roles]"
+    python managed_roles_sessions.py
+"""
+
+import os
+import time
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.config import AuthorizationConfig
+from agno.session import AgentSession
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+# JWT Secret (use environment variable in production)
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "managed-roles-sessions-os"
+
+os.makedirs("tmp", exist_ok=True)
+
+# Define roles in agno scope terms. support is read-only; operator can delete.
+roles = ManagedRoleStore(db_url="sqlite:///tmp/managed_roles_sessions.db")
+roles.set_role_scopes("support", ["sessions:read"])
+roles.set_role_scopes("operator", ["sessions:read", "sessions:write", "sessions:delete"])
+roles.set_role_scopes("admin", ["agent_os:admin"])
+roles.assign("bob", "support")
+roles.assign("val", "operator")
+roles.assign("alice", "admin")
+
+# Setup database
+db = SqliteDb(db_file="tmp/agentos_sessions.db")
+
+# Demo fixture: seed two sessions directly so the delete is observable without an
+# API key. Real apps don't do this; sessions are created by running an agent
+# (e.g. agent.print_response("hi", session_id="...")). We seed to stay self-contained.
+_now = int(time.time())
+db.upsert_session(AgentSession(session_id="sess-123", agent_id="research-agent", user_id="customer-a", created_at=_now))
+db.upsert_session(AgentSession(session_id="sess-456", agent_id="research-agent", user_id="customer-b", created_at=_now))
+
+research_agent = Agent(
+    id="research-agent",
+    name="Research Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+)
+
+# Create AgentOS using the managed-role store as the provider.
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Managed-roles AgentOS gating session access",
+    agents=[research_agent],
+    db=db,
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        authorization_provider=roles.provider,
+    ),
+)
+
+# Get the app
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    """
+    Run this file to see roles gate the real session endpoints.
+
+    Roles:
+    - support  -> sessions:read                 (view only)
+    - operator -> sessions:read/write/delete    (full session control)
+    - admin    -> everything
+    bob is support, val is operator. The scenario below shows support being
+    blocked from edit/delete (403) while operator deletes for real (the session
+    count drops from 2 to 1).
+    """
+
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)  # quiet framework logs for a clean transcript
+    client = TestClient(app)
+
+    def token(sub: str) -> str:
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
+            JWT_SECRET, algorithm="HS256",
+        )
+
+    def auth(sub: str) -> dict:
+        return {"Authorization": f"Bearer {token(sub)}"}
+
+    def show(label: str, r, note: str = "") -> None:
+        # 200/204 means it went through; 401/403 means it was bounced.
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:44s} -> {verdict:7s} ({r.status_code})  {note}")
+
+    def count(sub: str) -> int:
+        r = client.get("/sessions?type=agent", headers=auth(sub))
+        return r.json()["meta"]["total_count"] if r.status_code == 200 else -1
+
+    print("\n" + "=" * 78)
+    print("WHO CAN TOUCH THE SAVED SESSIONS")
+    print("=" * 78)
+    print("  bob = support (look only) | val = operator (look, edit, delete)")
+    print(f"  saved sessions right now: {count('val')}\n")
+
+    show("bob (support)  tries to LOOK at sessions", client.get("/sessions?type=agent", headers=auth("bob")), "support can look")
+    show("bob (support)  tries to RENAME a session", client.patch("/sessions/sess-123", headers=auth("bob"), json={"name": "x"}), "editing isn't allowed -> bounced")
+    show("bob (support)  tries to DELETE a session", client.delete("/sessions/sess-123", headers=auth("bob")), "deleting isn't allowed -> bounced")
+    show("val (operator) tries to DELETE a session", client.delete("/sessions/sess-123", headers=auth("val")), "operators can delete -> done for real")
+
+    print(f"\n  saved sessions now: {count('val')}  (was 2 - the operator's delete really happened)")
+    print("=" * 78)
+    print("the point: the support person was stopped before any data was touched.")
+    print("only the operator's delete went through, and you can see the count drop.")
+    print("=" * 78)

--- a/cookbook/05_agent_os/rbac/managed_users.py
+++ b/cookbook/05_agent_os/rbac/managed_users.py
@@ -1,0 +1,132 @@
+"""
+Managed Users - a user directory for AgentOS, no identity provider needed
+
+Already did managed_roles.py? That showed ROLES (who can do what). This shows
+USERS (who exists), for the case where you DON'T have an external login system
+(no Okta/Auth0/WorkOS). Your own app still signs people in its own way and hands
+them a token; AgentOS keeps the list of users and decides what they can do.
+
+Important: AgentOS does NOT store passwords and does not log anyone in. It keeps
+a directory - just id, optional email/name, and an on/off switch per person -
+plus their roles. Think "address book with an off switch", not "login system".
+
+Why bother keeping users at all (instead of only roles)?
+1. You can SEE everyone who exists and pick a person to give a role to, instead
+   of typing a raw id you have to remember.
+2. You get a real OFF SWITCH. Disable someone and their very next request is
+   blocked - even though their token is still valid and unexpired. A token alone
+   can't be "un-issued"; the directory can.
+3. The audit trail can say "bob@co" instead of an opaque id.
+
+This file creates a few users, gives them roles, then:
+- lists the directory,
+- shows bob working normally,
+- DISABLES bob and shows his next request bounce (same valid token),
+- re-enables him.
+
+Run it:
+    pip install "agno[roles]"
+    python managed_users.py
+(no OpenAI key needed - we are only checking who is allowed, not chatting)
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.authz.user_store import ManagedUserStore
+from agno.os.config import AuthorizationConfig
+
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "managed-users-os"
+
+os.makedirs("tmp", exist_ok=True)
+
+# Roles: what each role can do (same as managed_roles.py).
+roles = ManagedRoleStore(db_url="sqlite:///tmp/managed_users_roles.db")
+roles.set_role_scopes("viewer", ["agents:*:read"])
+roles.set_role_scopes("admin", ["agent_os:admin"])
+
+# Users: the directory. Just people, no passwords. We give each one a role too.
+users = ManagedUserStore(db_url="sqlite:///tmp/managed_users.db")
+users.upsert("alice", email="alice@co", name="Alice")
+roles.assign("alice", "admin")
+users.upsert("bob", email="bob@co", name="Bob")
+roles.assign("bob", "viewer")
+
+db = SqliteDb(db_file="tmp/managed_users_agentos.db")
+research_agent = Agent(id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db)
+
+# Wire BOTH stores into AgentOS. user_store= turns on the directory + off-switch.
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Managed-users AgentOS",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        authorization_provider=roles.provider,
+        user_store=users,  # <- the directory + disabled kill-switch
+    ),
+)
+app = agent_os.get_app()
+# The directory is managed through the store itself here (upsert / set_disabled), which
+# is all the enforcement needs. An admin HTTP API for it (/authz/users, /authz/roles)
+# ships with the `/authz` router -- see manage_users_and_roles.py.
+
+
+if __name__ == "__main__":
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)  # quiet framework logs for a clean transcript
+    client = TestClient(app)
+
+    def token(sub: str) -> str:
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
+            JWT_SECRET, algorithm="HS256",
+        )
+
+    def auth(sub: str) -> dict:
+        return {"Authorization": f"Bearer {token(sub)}"}
+
+    def show(label: str, r, note: str = "") -> None:
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:48s} -> {verdict:7s} ({r.status_code})  {note}")
+
+    print("\n" + "=" * 80)
+    print("A USER DIRECTORY - no identity provider, just AgentOS")
+    print("=" * 80)
+
+    # Everyone in the directory, with the role each one was assigned.
+    print("\n  the directory:")
+    for u in users.list():
+        role = (roles.roles_of(u["id"]) or [None])[0]
+        print(f"    - {u['id']:8s} {str(u['email'] or ''):12s} role={role}  disabled={u['disabled']}")
+
+    print("\n  bob is a viewer, so he can look at the agent:")
+    show("bob asks to LOOK at the agent", client.get("/agents/research-agent", headers=auth("bob")), "viewers can look")
+
+    print("\n  >> now an admin DISABLES bob (e.g. he left the company)...\n")
+    users.set_disabled("bob", True, actor="alice")
+    show("bob asks to LOOK at the agent", client.get("/agents/research-agent", headers=auth("bob")), "same valid token, but he's blocked now")
+
+    print("\n  >> ...bob is back, re-enable him...\n")
+    users.set_disabled("bob", False, actor="alice")
+    show("bob asks to LOOK at the agent", client.get("/agents/research-agent", headers=auth("bob")), "allowed again, instantly")
+
+    print("=" * 80)
+    print("the point: you keep the list of users and an off-switch per person. disabling")
+    print("someone blocks their NEXT request even though their token is still valid -")
+    print("something you can't do with tokens alone. no passwords are ever stored here.")
+    print("=" * 80)

--- a/cookbook/05_agent_os/rbac/managed_users.py
+++ b/cookbook/05_agent_os/rbac/managed_users.py
@@ -60,7 +60,9 @@ users.upsert("bob", email="bob@co", name="Bob")
 roles.assign("bob", "viewer")
 
 db = SqliteDb(db_file="tmp/managed_users_agentos.db")
-research_agent = Agent(id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db)
+research_agent = Agent(
+    id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db
+)
 
 # Wire BOTH stores into AgentOS. user_store= turns on the directory + off-switch.
 agent_os = AgentOS(
@@ -93,8 +95,14 @@ if __name__ == "__main__":
 
     def token(sub: str) -> str:
         return jwt.encode(
-            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
-            JWT_SECRET, algorithm="HS256",
+            {
+                "sub": sub,
+                "aud": OS_ID,
+                "scopes": [],
+                "exp": datetime.now(UTC) + timedelta(hours=24),
+            },
+            JWT_SECRET,
+            algorithm="HS256",
         )
 
     def auth(sub: str) -> dict:
@@ -112,21 +120,39 @@ if __name__ == "__main__":
     print("\n  the directory:")
     for u in users.list():
         role = (roles.roles_of(u["id"]) or [None])[0]
-        print(f"    - {u['id']:8s} {str(u['email'] or ''):12s} role={role}  disabled={u['disabled']}")
+        print(
+            f"    - {u['id']:8s} {str(u['email'] or ''):12s} role={role}  disabled={u['disabled']}"
+        )
 
     print("\n  bob is a viewer, so he can look at the agent:")
-    show("bob asks to LOOK at the agent", client.get("/agents/research-agent", headers=auth("bob")), "viewers can look")
+    show(
+        "bob asks to LOOK at the agent",
+        client.get("/agents/research-agent", headers=auth("bob")),
+        "viewers can look",
+    )
 
     print("\n  >> now an admin DISABLES bob (e.g. he left the company)...\n")
     users.set_disabled("bob", True, actor="alice")
-    show("bob asks to LOOK at the agent", client.get("/agents/research-agent", headers=auth("bob")), "same valid token, but he's blocked now")
+    show(
+        "bob asks to LOOK at the agent",
+        client.get("/agents/research-agent", headers=auth("bob")),
+        "same valid token, but he's blocked now",
+    )
 
     print("\n  >> ...bob is back, re-enable him...\n")
     users.set_disabled("bob", False, actor="alice")
-    show("bob asks to LOOK at the agent", client.get("/agents/research-agent", headers=auth("bob")), "allowed again, instantly")
+    show(
+        "bob asks to LOOK at the agent",
+        client.get("/agents/research-agent", headers=auth("bob")),
+        "allowed again, instantly",
+    )
 
     print("=" * 80)
-    print("the point: you keep the list of users and an off-switch per person. disabling")
+    print(
+        "the point: you keep the list of users and an off-switch per person. disabling"
+    )
     print("someone blocks their NEXT request even though their token is still valid -")
-    print("something you can't do with tokens alone. no passwords are ever stored here.")
+    print(
+        "something you can't do with tokens alone. no passwords are ever stored here."
+    )
     print("=" * 80)

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1541,6 +1541,16 @@ class AgentOS:
         if audit is not None:
             fastapi_app.state.authz_audit = audit
 
+        # Optional user directory (no-IdP). When present, the middleware (and the
+        # WebSocket connect path) denies disabled users and — when auto-provision is
+        # on — creates a directory row from token claims. Seed the store and the
+        # claim/policy flags the middleware reads off app.state.
+        fastapi_app.state.user_store = getattr(config, "user_store", None)
+        fastapi_app.state.user_auto_provision = getattr(config, "auto_provision_users", False)
+        fastapi_app.state.user_email_claim = getattr(config, "user_email_claim", "email")
+        fastapi_app.state.user_name_claim = getattr(config, "user_name_claim", "name")
+        fastapi_app.state.user_directory_fail_closed = getattr(config, "directory_error_fail_closed", False)
+
     def get_routes(self) -> List[Any]:
         """Retrieve all routes from the FastAPI app.
 

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1411,6 +1411,14 @@ class AgentOS:
         # added by the user-scoped-DB work stay dormant.
         fastapi_app.state.user_isolation_enabled = user_isolation
 
+        # Seed the pluggable AuthorizationProvider that the REST route gate, per-resource
+        # gate, WebSocket gates, and MCP tool gate all resolve through. When nothing is
+        # configured we leave app.state.authorization_provider unset and the resolver
+        # falls back to the default ScopeAuthorizationProvider — so behaviour is exactly
+        # v2.7's scope RBAC. A role_store or a custom provider is enforced at the SAME
+        # four points instead.
+        self._seed_authorization_provider(fastapi_app)
+
         # Only interfaces that verify the authenticity of their own inbound requests
         # (Slack HMAC, Telegram/WhatsApp webhook secrets -- see
         # BaseInterface.authenticates_own_requests) are excluded from the central auth
@@ -1475,6 +1483,49 @@ class AgentOS:
             middleware_kwargs["scope_mappings"] = interface_mappings
 
         fastapi_app.add_middleware(AuthMiddleware, **middleware_kwargs)
+
+    def _seed_authorization_provider(self, fastapi_app: FastAPI) -> None:
+        """Seed ``app.state.authorization_provider`` (and ``authz_audit``) from the
+        AuthorizationConfig, so the four choke points resolve the right enforcer.
+
+        Precedence, matching AuthorizationConfig's ``role_store`` XOR
+        ``authorization_provider`` validator:
+
+        - ``role_store`` set: adopt the OS db into the store (``attach_db``) so managed
+          roles persist alongside agent data, then use the store's provider. A managed
+          store MUST have a DB — an in-memory store can't stay consistent across the
+          replicas an AgentOS deployment runs — so if it ends up unbound (no store db
+          and no SQL-capable OS db to adopt) we fail fast rather than silently enforce
+          an empty policy.
+        - ``authorization_provider`` set: use it directly.
+        - neither: leave the state unset; the resolver defaults to
+          ScopeAuthorizationProvider (v2.7 behaviour).
+        """
+        config = self.authorization_config
+        if config is None:
+            return
+
+        role_store = getattr(config, "role_store", None)
+        provider = getattr(config, "authorization_provider", None)
+
+        if role_store is not None:
+            # Adopt the OS db so a store created without one persists to it (no-op if the
+            # store already has its own db or the OS db isn't SQL-capable).
+            role_store.attach_db(self.db)
+            if not role_store.is_bound:
+                raise ValueError(
+                    "AuthorizationConfig(role_store=...) needs a SQL database: managed roles must be "
+                    "persisted (an in-memory store can't stay consistent across replicas). Give the "
+                    "store a db (ManagedRoleStore(db_url=...) / db=...) or pass a SQL-capable db to "
+                    "AgentOS(db=...) for it to adopt."
+                )
+            fastapi_app.state.authorization_provider = role_store.provider
+        elif provider is not None:
+            fastapi_app.state.authorization_provider = provider
+
+        audit = getattr(config, "audit", None)
+        if audit is not None:
+            fastapi_app.state.authz_audit = audit
 
     def get_routes(self) -> List[Any]:
         """Retrieve all routes from the FastAPI app.

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -88,6 +88,8 @@ if TYPE_CHECKING:
     # runtime here would break `import agno.os` when the extra is not installed.
     from fastmcp.server.auth import AuthProvider
 
+    from agno.os.authz.provider import AuthorizationProvider
+
 
 @asynccontextmanager
 async def mcp_lifespan(_, mcp_tools):
@@ -1508,6 +1510,7 @@ class AgentOS:
         role_store = getattr(config, "role_store", None)
         provider = getattr(config, "authorization_provider", None)
 
+        resolved_provider: Optional[AuthorizationProvider] = None
         if role_store is not None:
             # Adopt the OS db so a store created without one persists to it (no-op if the
             # store already has its own db or the OS db isn't SQL-capable).
@@ -1519,9 +1522,20 @@ class AgentOS:
                     "store a db (ManagedRoleStore(db_url=...) / db=...) or pass a SQL-capable db to "
                     "AgentOS(db=...) for it to adopt."
                 )
-            fastapi_app.state.authorization_provider = role_store.provider
+            resolved_provider = role_store.provider
         elif provider is not None:
-            fastapi_app.state.authorization_provider = provider
+            resolved_provider = provider
+
+        if resolved_provider is not None:
+            fastapi_app.state.authorization_provider = resolved_provider
+            # The MCP tools are a mounted sub-app: the tool gate resolves the provider
+            # from the in-flight request's ``.app``, which is this sub-app (request.state
+            # crosses the mount boundary, request.app does not). Without mirroring the
+            # provider here the gate falls back to the default ScopeAuthorizationProvider,
+            # silently degrading a managed-role / custom provider to scope-only over MCP.
+            # Mirror it so all four choke points enforce the same provider.
+            if self._mcp_app is not None and hasattr(self._mcp_app, "state"):
+                self._mcp_app.state.authorization_provider = resolved_provider
 
         audit = getattr(config, "audit", None)
         if audit is not None:

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -559,10 +559,39 @@ class AgentOS:
 
         self._reprovision_routers(app=app)
 
+    def _mirror_authz_state_to_mcp_app(self, app: FastAPI) -> None:
+        """Copy the authz state the MCP tool gate reads onto the mounted sub-app.
+
+        The MCP tools are a mounted sub-app, so ``request.app`` inside the tool gate is
+        that sub-app, not this AgentOS's app -- ``request.state`` crosses the mount
+        boundary but ``request.app`` does not. Anything the gate resolves off
+        ``app.state`` therefore has to be mirrored here, or it silently degrades: a
+        missing provider drops managed-role/composite/FGA policy to scope-only, and a
+        missing sink drops every MCP decision from the access trail.
+
+        Kept next to the mount (and called from there as well as from seeding) so that
+        ANY future rebuild or re-mount of ``_mcp_app`` re-applies it. Today the sub-app
+        is built once, which is the only reason a seed-time-only mirror was correct --
+        an implicit dependency worth not relying on.
+        """
+        if self._mcp_app is None or not hasattr(self._mcp_app, "state"):
+            return
+        parent = getattr(app, "state", None)
+        if parent is None:
+            return
+        for attr in ("authorization_provider", "authz_audit"):
+            value = getattr(parent, attr, None)
+            if value is not None:
+                setattr(self._mcp_app.state, attr, value)
+
     def _mount_mcp_app(self, app: FastAPI) -> None:
         """Mount the MCP app at root exactly once (idempotent across get_app/resync calls)."""
         if self._mcp_app is None:
             return
+        # Re-apply on every mount, so a rebuilt sub-app can't silently lose the authz
+        # state (on the first get_app() this is a no-op: seeding runs after the mount
+        # and does the mirror itself).
+        self._mirror_authz_state_to_mcp_app(app)
         if any(getattr(route, "app", None) is self._mcp_app for route in app.router.routes):
             return
         app.mount("/", self._mcp_app)
@@ -1528,24 +1557,16 @@ class AgentOS:
 
         if resolved_provider is not None:
             fastapi_app.state.authorization_provider = resolved_provider
-            # The MCP tools are a mounted sub-app: the tool gate resolves the provider
-            # from the in-flight request's ``.app``, which is this sub-app (request.state
-            # crosses the mount boundary, request.app does not). Without mirroring the
-            # provider here the gate falls back to the default ScopeAuthorizationProvider,
-            # silently degrading a managed-role / custom provider to scope-only over MCP.
-            # Mirror it so all four choke points enforce the same provider.
-            if self._mcp_app is not None and hasattr(self._mcp_app, "state"):
-                self._mcp_app.state.authorization_provider = resolved_provider
 
         audit = getattr(config, "audit", None)
         if audit is not None:
             fastapi_app.state.authz_audit = audit
-            # Same mount-boundary reason as the provider above: the MCP tool gate
-            # resolves the sink from the in-flight request's ``.app``, which is the
-            # mounted sub-app. Without this mirror MCP decisions can't be recorded at
-            # all, leaving a hole in the access trail that REST/WS decisions fill.
-            if self._mcp_app is not None and hasattr(self._mcp_app, "state"):
-                self._mcp_app.state.authz_audit = audit
+
+        # The MCP tools run in a mounted sub-app whose ``request.app`` is NOT this app,
+        # so everything the tool gate resolves off ``app.state`` (the provider, the audit
+        # sink) must be mirrored onto it -- see _mirror_authz_state_to_mcp_app. Seeding
+        # runs after the mount, so this is where the first mirror happens.
+        self._mirror_authz_state_to_mcp_app(fastapi_app)
 
         # Optional user directory (no-IdP). When present, the middleware (and the
         # WebSocket connect path) denies disabled users and — when auto-provision is

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1553,7 +1553,19 @@ class AgentOS:
                 )
             resolved_provider = role_store.provider
         elif provider is not None:
-            resolved_provider = provider
+            # A list/tuple of providers means "run several authz planes at once"
+            # (e.g. token scopes for operators + a managed role store for end users):
+            # compose them with an OR — a request is allowed if any plane allows it.
+            if isinstance(provider, str):
+                raise ValueError(
+                    "authorization_provider must be an AuthorizationProvider (or a list of them), not a string."
+                )
+            if isinstance(provider, (list, tuple)):
+                from agno.os.authz._composite import CompositeAuthorizationProvider
+
+                resolved_provider = CompositeAuthorizationProvider(list(provider))
+            else:
+                resolved_provider = provider
 
         if resolved_provider is not None:
             fastapi_app.state.authorization_provider = resolved_provider

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1540,6 +1540,12 @@ class AgentOS:
         audit = getattr(config, "audit", None)
         if audit is not None:
             fastapi_app.state.authz_audit = audit
+            # Same mount-boundary reason as the provider above: the MCP tool gate
+            # resolves the sink from the in-flight request's ``.app``, which is the
+            # mounted sub-app. Without this mirror MCP decisions can't be recorded at
+            # all, leaving a hole in the access trail that REST/WS decisions fill.
+            if self._mcp_app is not None and hasattr(self._mcp_app, "state"):
+                self._mcp_app.state.authz_audit = audit
 
         # Optional user directory (no-IdP). When present, the middleware (and the
         # WebSocket connect path) denies disabled users and — when auto-provision is

--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -8,8 +8,8 @@ from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from starlette.concurrency import run_in_threadpool
 
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
 from agno.os.scopes import (
-    get_accessible_resource_ids,
     get_default_scope_mappings,
     has_required_scopes,
 )
@@ -19,6 +19,66 @@ from agno.os.settings import AgnoAPISettings
 
 # Create a global HTTPBearer instance
 security = HTTPBearer(auto_error=False)
+
+
+@lru_cache(maxsize=1)
+def _default_authorization_provider() -> AuthorizationProvider:
+    """The default scope-based provider, cached so the fast path (no custom provider
+    configured) reuses one stateless instance rather than allocating per request.
+
+    Deferred import keeps this module free of the concrete provider at import time
+    and avoids a cycle (scope_provider imports scopes, which is fine, but keeping it
+    lazy mirrors the rest of the authz seam)."""
+    from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+
+    return ScopeAuthorizationProvider()
+
+
+def resolve_authorization_provider(app_or_request: Any) -> AuthorizationProvider:
+    """Resolve the AuthorizationProvider enforcing this AgentOS instance.
+
+    Returns ``app.state.authorization_provider`` when AgentOS seeded one (a custom
+    provider or a managed-role store's provider), otherwise the cached default
+    :class:`ScopeAuthorizationProvider`. Accepts either a FastAPI ``app`` or a
+    ``Request``/``WebSocket`` (from which ``.app`` is read), so all four choke
+    points can call it with whatever object they hold.
+
+    Because the default reproduces the exact scope math the pipeline used before
+    the seam existed, resolving here is behaviour-preserving whenever no provider
+    is configured.
+    """
+    app = getattr(app_or_request, "app", app_or_request)
+    provider = getattr(getattr(app, "state", None), "authorization_provider", None)
+    if provider is not None:
+        return provider
+    return _default_authorization_provider()
+
+
+def _authorization_context(
+    request: Request,
+    *,
+    resource_type: Optional[str] = None,
+    resource_id: Optional[str] = None,
+    action: Optional[str] = None,
+) -> AuthorizationContext:
+    """Build an :class:`AuthorizationContext` from the per-request auth state.
+
+    Reads exactly the fields the JWT middleware attaches (``user_id``, ``scopes``,
+    ``claims``, ``admin_scope``); the scope-based default provider uses the scope
+    fields and produces the same decision the pre-seam scope math did, while a
+    managed-role / custom provider keys off ``principal_id`` + ``claims`` instead.
+    """
+    admin_scope_raw = getattr(request.state, "admin_scope", None)
+    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
+    return AuthorizationContext(
+        principal_id=getattr(request.state, "user_id", None),
+        scopes=list(getattr(request.state, "scopes", None) or []),
+        claims=getattr(request.state, "claims", None) or {},
+        resource_type=resource_type,
+        resource_id=resource_id,
+        action=action,
+        admin_scope=admin_scope,
+    )
 
 
 @lru_cache(maxsize=1)
@@ -250,6 +310,11 @@ def get_authentication_dependency(settings: AgnoAPISettings):
             request.state.authenticated = True
             request.state.user_id = "__scheduler__"
             request.state.scopes = list(INTERNAL_SERVICE_SCOPES)
+            # Mark as a trusted internal caller AFTER the constant-time token match so a
+            # provider-backed per-resource gate short-circuits (the scheduler principal
+            # has no role/subject in a managed store). Unforgeable: request.state is
+            # server-only — no client input maps onto this attribute.
+            request.state.is_internal_service = True
             return True
 
         # Verify the token against security key
@@ -357,29 +422,17 @@ def get_accessible_resources(request: Request, resource_type: str) -> Set[str]:
         {'*'}
     """
     # Check if accessible_resource_ids is already cached in request state (set by JWT middleware)
-    # This happens when user doesn't have global scope but has specific resource scopes
+    # This happens when user doesn't have global scope but has specific resource scopes.
+    # The cache is populated by the route gate (which now runs through the same provider),
+    # so honouring it keeps the listing decision consistent with the gate that let the
+    # request in — for both the default scope provider and a custom one.
     cached_ids = getattr(request.state, "accessible_resource_ids", None)
     if cached_ids is not None:
         return cached_ids
 
-    # Get user's scopes from request state (set by JWT middleware)
-    user_scopes = getattr(request.state, "scopes", [])
-
-    # Honour any custom admin_scope configured on JWTMiddleware (set on
-    # request.state by the middleware). Without this, list endpoints reject
-    # custom-admin tokens with 403 even though check_resource_access would
-    # accept them.
-    admin_scope_raw = getattr(request.state, "admin_scope", None)
-    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
-
-    # Get accessible resource IDs
-    accessible_ids = get_accessible_resource_ids(
-        user_scopes=user_scopes,
-        resource_type=resource_type,
-        admin_scope=admin_scope,
-    )
-
-    return accessible_ids
+    provider = resolve_authorization_provider(request)
+    ctx = _authorization_context(request, resource_type=resource_type)
+    return provider.accessible_resource_ids(ctx)
 
 
 def filter_resources_by_access(request: Request, resources: List, resource_type: str) -> List:
@@ -411,14 +464,20 @@ def filter_resources_by_access(request: Request, resources: List, resource_type:
         >>> filter_resources_by_access(request, agents, "agents")
         [Agent(id="agent-1"), Agent(id="agent-2"), Agent(id="agent-3")]
     """
-    accessible_ids = get_accessible_resources(request, resource_type)
+    # When the route gate cached an accessible-id set on request.state (the caller
+    # holds only per-resource scopes on a GET listing), honour it directly so the
+    # listing matches the gate decision — same behaviour as before the seam.
+    cached_ids = getattr(request.state, "accessible_resource_ids", None)
+    if cached_ids is not None:
+        if "*" in cached_ids:
+            return resources
+        return [r for r in resources if getattr(r, "id", None) in cached_ids]
 
-    # Wildcard access - return all resources
-    if "*" in accessible_ids:
-        return resources
-
-    # Filter to only accessible resources
-    return [r for r in resources if r.id in accessible_ids]
+    # Otherwise delegate to the provider, which may filter more richly than a plain
+    # id-set membership test (e.g. deny-overrides for managed roles).
+    provider = resolve_authorization_provider(request)
+    ctx = _authorization_context(request, resource_type=resource_type)
+    return provider.filter_accessible(ctx, resources)
 
 
 def check_resource_access(request: Request, resource_id: str, resource_type: str, action: str = "read") -> bool:
@@ -447,25 +506,25 @@ def check_resource_access(request: Request, resource_id: str, resource_type: str
         >>> check_resource_access(request, "my-agent", "agents", "run")
         False
     """
-    user_scopes = getattr(request.state, "scopes", [])
-    # Honour the configured admin scope (set by JWTMiddleware on request.state)
-    # so custom-admin tokens are recognised here too. Non-string values (e.g.
-    # MagicMock attributes in tests) are ignored.
-    admin_scope_raw = getattr(request.state, "admin_scope", None)
-    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
-    accessible_ids = get_accessible_resource_ids(
-        user_scopes=user_scopes,
-        resource_type=resource_type,
-        action=action,
-        admin_scope=admin_scope,
-    )
-
-    # Wildcard access grants all permissions
-    if "*" in accessible_ids:
+    # Internal service credentials (the scheduler executor's token, or a validated
+    # security key) are trusted first-party callers with no role/subject in a managed
+    # store, so a provider-backed per-resource gate would 403 them. The route gate has
+    # already enforced their INTERNAL_SERVICE_SCOPES, so short-circuit here.
+    # is_internal_service is set ONLY by the middleware's internal-token branch (and the
+    # security-key dependency) AFTER a constant-time token match; it lives on
+    # request.state, which is server-populated per request and cannot be set by a client
+    # (no header/body maps onto it), so it is unforgeable.
+    if getattr(request.state, "is_internal_service", False):
         return True
 
-    # Check if user has access to this specific resource
-    return resource_id in accessible_ids
+    provider = resolve_authorization_provider(request)
+    ctx = _authorization_context(
+        request,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        action=action,
+    )
+    return provider.check(ctx)
 
 
 def require_resource_access(resource_type: str, action: str, resource_id_param: str):

--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -582,6 +582,24 @@ def require_resource_access(resource_type: str, action: str, resource_id_param: 
         # Get the resource_id from path parameters
         resource_id = request.path_params.get(resource_id_param)
         if resource_id and not check_resource_access(request, resource_id, resource_type, action):
+            # Record the per-resource DENY. The route gate already logged an allow for
+            # this request (with the concrete resource in the path), so a per-resource
+            # ALLOW would only duplicate it -- but a per-resource DENY is otherwise
+            # invisible: the trail would show the route allowed and never show what
+            # actually blocked the request. For a role/ReBAC model this is the
+            # security-relevant decision, so it must appear in the access audit.
+            from agno.os.authz.audit import record_decision
+
+            record_decision(
+                request,
+                allowed=False,
+                target=f"{request.method} /{resource_type}/{resource_id}",
+                principal=getattr(request.state, "user_id", None),
+                required_scopes=[f"{resource_type}:{resource_id}:{action}"],
+                scopes=list(getattr(request.state, "scopes", None) or []),
+                claims=getattr(request.state, "claims", None),
+                reason="resource_access_denied",
+            )
             raise HTTPException(status_code=403, detail=f"Access denied to {action} this {resource_singular}")
 
     return dependency

--- a/libs/agno/agno/os/authz/__init__.py
+++ b/libs/agno/agno/os/authz/__init__.py
@@ -1,0 +1,41 @@
+"""Pluggable authorization providers for AgentOS.
+
+The ``AuthorizationProvider`` interface is the seam between AgentOS's request
+handling and the logic that decides "can this principal do this action on this
+resource". The built-in :class:`ScopeAuthorizationProvider` implements the
+existing JWT-scope RBAC with zero external dependencies, so the default
+behaviour is unchanged.
+
+Customers who need a richer model (relationship-based / ReBAC, attribute-based,
+or an external engine such as OpenFGA, SpiceDB or Cerbos) implement the same
+interface and pass it via ``AuthorizationConfig(authorization_provider=...)``.
+
+Managed roles (runtime-editable RBAC) are backed by agno's own
+:class:`NativePolicyEngine` behind the swappable :class:`PolicyEngine` port — no
+third-party policy engine in the default path.
+"""
+
+from agno.os.authz.audit import AuditEvent, AuditSink, DbAuditSink, LoggingAuditSink
+from agno.os.authz.engine import EngineAuthorizationProvider, PolicyEngine, ScopeEntry
+from agno.os.authz.native_engine import NativePolicyEngine
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+
+__all__ = [
+    "AuthorizationContext",
+    "AuthorizationProvider",
+    "ScopeAuthorizationProvider",
+    # Managed roles: the product surface + swappable backend (port, generic
+    # provider, native default engine). get_roles_router lives in role_router and
+    # is imported directly to keep this package import FastAPI-free.
+    "ManagedRoleStore",
+    "PolicyEngine",
+    "ScopeEntry",
+    "EngineAuthorizationProvider",
+    "NativePolicyEngine",
+    "AuditEvent",
+    "AuditSink",
+    "LoggingAuditSink",
+    "DbAuditSink",
+]

--- a/libs/agno/agno/os/authz/__init__.py
+++ b/libs/agno/agno/os/authz/__init__.py
@@ -17,6 +17,7 @@ third-party policy engine in the default path.
 
 from agno.os.authz.audit import AuditEvent, AuditSink, DbAuditSink, LoggingAuditSink
 from agno.os.authz.engine import EngineAuthorizationProvider, PolicyEngine, ScopeEntry
+from agno.os.authz.fga import FGAAuthorizationProvider, FGAClient
 from agno.os.authz.native_engine import NativePolicyEngine
 from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
 from agno.os.authz.role_store import ManagedRoleStore
@@ -34,6 +35,10 @@ __all__ = [
     "ScopeEntry",
     "EngineAuthorizationProvider",
     "NativePolicyEngine",
+    # Fine-grained / relationship-based authz (ReBAC). The provider + port are
+    # dependency-free; the OpenFGA adapter (OpenFGAClient) lives behind agno[fga].
+    "FGAAuthorizationProvider",
+    "FGAClient",
     "AuditEvent",
     "AuditSink",
     "LoggingAuditSink",

--- a/libs/agno/agno/os/authz/_composite.py
+++ b/libs/agno/agno/os/authz/_composite.py
@@ -1,0 +1,103 @@
+"""Run two authorization planes on one AgentOS, in parallel.
+
+Real deployments often have two populations hitting the same OS:
+
+- **Operators** — admins managing the OS through the agno-os frontend. agno's
+  control plane mints them a token that already carries scopes, so they're
+  authorized straight from the token (a :class:`ScopeAuthorizationProvider`).
+- **End users** — the customer's own users, whose access is managed at runtime in
+  the OS-local :class:`~agno.os.authz.role_store.ManagedRoleStore`. Their token
+  carries identity; the store decides.
+
+A single provider can't be both "trust the token's scopes" and "ignore the token,
+ask the store." The public way to run several planes is to pass a **list** of
+providers to ``AuthorizationConfig`` / ``AgentOS`` — a request is allowed if any
+of them allows it::
+
+    AuthorizationConfig(authorization_provider=[
+        ScopeAuthorizationProvider(),   # operators: scopes from the token
+        roles.provider,                 # end users: the OS-local managed store
+    ])
+
+AgentOS composes that list with the internal class below. It's an OR, so order
+only affects which provider is consulted first, not the outcome;
+``accessible_resource_ids`` returns the union (``{"*"}`` wins). This class is an
+implementation detail — prefer the list form above.
+"""
+
+from typing import Any, Callable, List, Set, TypeVar
+
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+from agno.utils.log import log_warning
+
+_T = TypeVar("_T")
+
+
+def _abstain_on_error(provider: AuthorizationProvider, fn: Callable[[], _T], default: _T) -> _T:
+    """Call one plane's decision, treating a raised exception as ABSTAIN.
+
+    The composition is an OR of grant sources, so a plane that errors (e.g. an
+    OpenFGA backend that's unreachable) must not fail the whole request — that would
+    turn one plane's outage into a 500 even when a healthy peer plane would grant.
+    Treat the error as "this plane grants nothing" and defer to the other planes; if
+    every plane errors the OR collapses to deny (fail-closed). The error is logged so
+    the outage is visible rather than silent.
+    """
+    try:
+        return fn()
+    except Exception as e:
+        log_warning(f"Authorization plane {type(provider).__name__} errored; treating as abstain: {e}")
+        return default
+
+
+class CompositeAuthorizationProvider(AuthorizationProvider):
+    """Allow if ANY of the wrapped providers allows (union of grants).
+
+    INVARIANT: every provider in the list is a GRANT source. Because the
+    composition is an OR, a provider can only ever *widen* access — it can never
+    restrict what another provider grants. Do NOT add a provider whose purpose is
+    to deny (an IP fence, a compliance/step-up gate); under OR its "deny" is
+    silently overridden by any other provider's "allow". Such a control belongs
+    upstream (middleware) or inside a single provider's own logic, not as a peer
+    in this list.
+    """
+
+    def __init__(self, providers: List[AuthorizationProvider]):
+        if not providers:
+            raise ValueError("CompositeAuthorizationProvider needs at least one provider")
+        self.providers = list(providers)
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        # A non-resource check (no resource_type/action) isn't expressible as a
+        # per-resource decision; by contract every provider DEFERS it to the route
+        # gate (authorize_route). Encode that deferral uniformly here rather than
+        # OR-ing the providers' vacuous "True"s — otherwise a provider that DID
+        # mean to deny a non-resource check would be silently overridden.
+        if not ctx.resource_type or not ctx.action:
+            return True
+        return any(_abstain_on_error(p, lambda p=p: p.check(ctx), False) for p in self.providers)
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes: List[str]) -> bool:
+        return any(
+            _abstain_on_error(p, lambda p=p: p.authorize_route(ctx, required_scopes), False) for p in self.providers
+        )
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        ids: Set[str] = set()
+        for p in self.providers:
+            got = _abstain_on_error(p, lambda p=p: p.accessible_resource_ids(ctx), set())
+            if "*" in got:
+                return {"*"}
+            ids |= got
+        return ids
+
+    def filter_accessible(self, ctx: AuthorizationContext, resources: List[Any]) -> List[Any]:
+        # Union of grants (OR): a resource is visible if ANY plane's deny-aware
+        # filter keeps it. This is why a deny belongs INSIDE a single provider (so it
+        # carves that provider's grant) and never as a peer plane — under the union a
+        # peer's allow still wins, exactly as the INVARIANT above requires.
+        keep: Set[Any] = set()
+        for p in self.providers:
+            for r in _abstain_on_error(p, lambda p=p: p.filter_accessible(ctx, resources), []):
+                keep.add(getattr(r, "id", None))
+        return [r for r in resources if getattr(r, "id", None) in keep]

--- a/libs/agno/agno/os/authz/_db.py
+++ b/libs/agno/agno/os/authz/_db.py
@@ -1,0 +1,47 @@
+"""Shared helper: reuse an agno database's SQLAlchemy engine.
+
+Lets the managed-roles / user-directory / audit stores share the exact connection
+(and pool) of the database you already pass to ``AgentOS(db=...)``, instead of
+opening a second one against a duplicated ``db_url``.
+"""
+
+from typing import Any
+
+# Raised/shown when a managed-roles component is used without a database. Managed
+# roles must be persisted: an in-memory store can't stay consistent across the
+# multiple workers/replicas an AgentOS deployment runs, so a DB is required.
+NO_DB_MESSAGE = (
+    "ManagedRoleStore requires a SQL database — managed roles must be persisted, "
+    "and an in-memory store cannot stay consistent across multiple workers/replicas. "
+    "Pass db=/db_url= to the store, or hand it to AgentOS via "
+    "AuthorizationConfig(role_store=...) together with a SQL db on AgentOS so the "
+    "store adopts it."
+)
+
+
+def engine_from_db(db: Any) -> Any:
+    """Return the SQLAlchemy ``Engine`` backing an agno database object.
+
+    agno's relational databases (``SqliteDb``, ``PostgresDb``, ...) expose their
+    engine as ``.db_engine``. Anything with that attribute works.
+    """
+    engine = getattr(db, "db_engine", None)
+    if engine is None:
+        raise ValueError(
+            "db= must be an agno database backed by SQLAlchemy (e.g. SqliteDb, "
+            f"PostgresDb) exposing a .db_engine; got {type(db)!r}. "
+            "Pass db_url=... instead if you want a separate connection."
+        )
+    return engine
+
+
+def engine_from_url(db_url: str) -> Any:
+    """Create a SQLAlchemy ``Engine`` from a URL. SQLite is configured for
+    multi-threaded server use (``check_same_thread=False``) so a connection opened
+    on one request thread can be reused on another — the same property AgentOS
+    needs from any DB it serves decisions from."""
+    import sqlalchemy as sa
+
+    if db_url.startswith("sqlite"):
+        return sa.create_engine(db_url, connect_args={"check_same_thread": False})
+    return sa.create_engine(db_url)

--- a/libs/agno/agno/os/authz/_scope_policy.py
+++ b/libs/agno/agno/os/authz/_scope_policy.py
@@ -1,0 +1,83 @@
+"""The agno scope <-> policy convention.
+
+How an agno scope string is written as a policy ``(resource, action)`` pair and
+read back. This is the single source of truth shared by every :class:`PolicyEngine`
+implementation, so policy is *written* and *checked* with the same spelling.
+
+Resources use a ``type/id`` shape with ``/*`` for the collection/global form;
+``agent_os:admin`` maps to the all-resources/all-actions wildcard ``("*", "*")``.
+"""
+
+from typing import Tuple
+
+ADMIN_SCOPE = "agent_os:admin"
+
+
+def scope_to_resource_action(scope: str) -> Tuple[str, str]:
+    """Map an agno scope string to its policy ``(resource, action)`` pair.
+
+    - ``agent_os:admin``             -> ("*", "*")
+    - ``sessions:write``             -> ("sessions/*", "write")   (collection/global)
+    - ``agents:research-agent:run``  -> ("agents/research-agent", "run")
+    - ``agents:*:run``               -> ("agents/*", "run")
+    """
+    if scope == ADMIN_SCOPE:
+        return ("*", "*")
+    parts = scope.split(":")
+    if any(part == "" for part in parts):
+        raise ValueError(f"Unrecognised scope (empty component): {scope!r}")
+    if len(parts) == 2:
+        resource, action = f"{parts[0]}/*", parts[1]
+    elif len(parts) == 3:
+        resource, action = f"{parts[0]}/{parts[1]}", parts[2]
+    else:
+        raise ValueError(f"Unrecognised scope: {scope!r}")
+    # Reject an action wildcard. ``*`` in the matcher means "all actions", but the
+    # scope provider compares actions literally, so the SAME scope string (e.g.
+    # ``agents:*:*``) would grant everything here and nothing there. Refuse it so a
+    # managed role can't carry a silently-divergent broad grant; the one documented
+    # way to grant all actions is ``agent_os:admin``.
+    if action == "*":
+        raise ValueError(
+            f"Action wildcard '*' is not allowed in scope {scope!r}: it would mean 'all actions' "
+            f"in policy but nothing under the scope provider. List explicit actions "
+            f"(read/run/write/delete), use a resource-id wildcard like 'agents:*:run', or grant "
+            f"'agent_os:admin'."
+        )
+    return (resource, action)
+
+
+def resource_action_to_scope(resource: str, action: str) -> str:
+    """Best-effort reverse of :func:`scope_to_resource_action`, for display/read-back.
+
+    Lossy where two scope spellings collapse to the same policy (``agents:read``
+    and ``agents:*:read`` both store as ``("agents/*", "read")``); we render the
+    global ``resource:action`` form in that case.
+    """
+    if resource == "*":
+        return ADMIN_SCOPE
+    if resource.endswith("/*"):
+        return f"{resource[:-2]}:{action}"
+    rtype, _, rid = resource.partition("/")
+    return f"{rtype}:{rid}:{action}"
+
+
+def resource_matches(pattern: str, request: str) -> bool:
+    """Does a policy's ``pattern`` resource match a request's ``request`` resource?
+
+    Glob-style matching over our restricted resource space
+    (``"*"`` / ``"type/*"`` / ``"type/id"``):
+
+    - ``"*"``        matches anything (admin),
+    - ``"type/*"``   matches ``"type/<id>"`` but NOT the bare collection
+      ``"type"`` (a collection request is handled via accessible-ids, not the
+      route gate),
+    - otherwise an exact match.
+    """
+    if pattern == "*":
+        return True
+    if pattern == request:
+        return True
+    if pattern.endswith("/*"):
+        return request.startswith(pattern[:-1])  # "type/" prefix
+    return False

--- a/libs/agno/agno/os/authz/audit.py
+++ b/libs/agno/agno/os/authz/audit.py
@@ -1,0 +1,245 @@
+"""Audit trail for authorization changes.
+
+There are two kinds of "audit" people mean, and we keep them in two separate
+tables (see :class:`DbAuditSink`) because they answer different questions:
+
+1. Decision audit ("was alice allowed to run agent X, and with which token?") —
+   recorded by the JWT middleware on every protected request when an
+   :class:`AuditSink` is set on ``AuthorizationConfig(audit=...)``. Each row is an
+   ``access.allowed`` / ``access.denied`` event with the principal, the route, the
+   required scopes, the caller's scopes, and a NON-secret token reference (the
+   token's ``jti`` when present, otherwise a short hash — never the token itself).
+   (The native policy engine also logs every decision to the ``agno.authz.engine``
+   logger; ``ManagedRoleStore(decision_log=True)`` bumps it to INFO.)
+
+2. Change audit ("who granted alice the admin role, when, before/after?") — the
+   policy engine cannot provide this: it never sees the acting principal, and its
+   policy rows are overwrite-in-place with no history. So it must be captured at
+   the layer that knows the actor — the management API / store. Plug an
+   :class:`AuditSink` into :class:`~agno.os.authz.role_store.ManagedRoleStore`
+   (directly or via ``get_roles_router``) and every role/assignment mutation emits
+   a structured, append-only :class:`AuditEvent` with the actor and before/after.
+
+The same :class:`DbAuditSink` instance can serve both: ``record()`` routes change
+events to ``authz_audit`` and decision events to ``authz_decisions``.
+"""
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class AuditEvent:
+    """One authorization-change record. Append-only; never mutated after emit.
+
+    Attributes:
+        action: what happened — ``role.set_scopes`` / ``role.removed`` /
+            ``user.assigned`` / ``user.unassigned``.
+        actor: the principal who made the change (JWT ``sub`` of the admin), or
+            None for changes made in code outside a request (treated as system).
+        target: the role name (role changes) or subject id (assignment changes).
+        before: prior state (the role's scopes, or the subject's roles), or None.
+        after: new state, or None (e.g. on removal).
+        timestamp: epoch seconds when the change was recorded.
+    """
+
+    action: str
+    actor: Optional[str]
+    target: str
+    before: Optional[List[str]] = None
+    after: Optional[List[str]] = None
+    timestamp: int = 0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "ts": self.timestamp,
+            "actor": self.actor,
+            "action": self.action,
+            "target": self.target,
+            "before": self.before,
+            "after": self.after,
+            **({"metadata": self.metadata} if self.metadata else {}),
+        }
+
+
+class AuditSink(ABC):
+    """Where audit events go. Implement ``record`` to send them anywhere."""
+
+    @abstractmethod
+    def record(self, event: AuditEvent) -> None:
+        """Persist/emit one event. Must not raise into the caller's path."""
+        ...
+
+
+class LoggingAuditSink(AuditSink):
+    """Emit each event as one JSON line to a logger (default ``agno.authz.audit``)."""
+
+    def __init__(self, logger_name: str = "agno.authz.audit", level: int = logging.INFO):
+        self._logger = logging.getLogger(logger_name)
+        self._level = level
+
+    def record(self, event: AuditEvent) -> None:
+        self._logger.log(self._level, json.dumps(event.to_dict()))
+
+
+def _is_decision(action: str) -> bool:
+    """Decision events (``access.allowed`` / ``access.denied``) vs change events."""
+    return action.startswith("access.")
+
+
+class DbAuditSink(AuditSink):
+    """Append-only audit tables in your own DB (SQLAlchemy).
+
+    The two kinds of audit are kept in two physically separate tables, because
+    they answer different questions, have different shapes, and grow at very
+    different rates:
+
+    - **changes** (``authz_audit``): who granted/changed a role, with before/after.
+      Low volume, one row per admin action.
+    - **decisions** (``authz_decisions``): every allow/deny on a request, with the
+      required scopes, the granted scopes, and a non-secret token reference. High
+      volume, one row per protected request.
+
+    Keeping them apart means a decision-log flood never buries the change trail,
+    each table has only the columns it needs, and you can retain/export them on
+    different schedules. ``record()`` routes by action; you read each side with
+    :meth:`read` (changes) and :meth:`read_decisions`.
+
+    Writes are INSERT-only — rows are never updated or deleted — so both tables are
+    tamper-evident trails suitable for SOC2-style evidence. Point it at the same DB
+    as the role store or a separate one.
+    """
+
+    def __init__(
+        self,
+        db_url: Optional[str] = None,
+        engine: Optional[Any] = None,
+        table_name: str = "authz_audit",
+        decision_table_name: str = "authz_decisions",
+        create_table: bool = True,
+    ):
+        import sqlalchemy as sa
+
+        if engine is None and db_url is None:
+            raise ValueError("DbAuditSink needs either db_url or engine")
+        self._engine = engine if engine is not None else sa.create_engine(db_url)  # type: ignore[arg-type]
+        metadata = sa.MetaData()
+        # change trail: role/assignment mutations with before/after
+        self._table = sa.Table(
+            table_name,
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("ts", sa.Integer, nullable=False),
+            sa.Column("actor", sa.String(255)),
+            sa.Column("action", sa.String(255), nullable=False),
+            sa.Column("target", sa.String(255), nullable=False),
+            sa.Column("before", sa.Text),
+            sa.Column("after", sa.Text),
+        )
+        # decision trail: per-request allow/deny with the token reference
+        self._decisions = sa.Table(
+            decision_table_name,
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("ts", sa.Integer, nullable=False),
+            sa.Column("actor", sa.String(255)),
+            sa.Column("action", sa.String(255), nullable=False),  # access.allowed / access.denied
+            sa.Column("target", sa.String(512), nullable=False),  # "METHOD /path"
+            sa.Column("token_ref", sa.String(255)),  # jti (preferred) or short hash — never the token
+            sa.Column("required", sa.Text),  # scopes the route required (JSON)
+            sa.Column("scopes", sa.Text),  # scopes the caller had (JSON)
+        )
+        if create_table:
+            metadata.create_all(self._engine)
+
+    def record(self, event: AuditEvent) -> None:
+        # The AuditSink contract is that record() must NOT raise into the caller's
+        # path: a role change (or a request) must still succeed even if its audit row
+        # can't be written. Log and swallow DB errors rather than turning a
+        # successful mutation into a 500 with no audit row.
+        try:
+            if _is_decision(event.action):
+                self._record_decision(event)
+            else:
+                self._record_change(event)
+        except Exception:
+            logging.getLogger("agno.authz.audit").exception("failed to write audit event %r", event.action)
+
+    def _record_change(self, event: AuditEvent) -> None:
+        with self._engine.begin() as conn:
+            conn.execute(
+                self._table.insert().values(
+                    ts=event.timestamp,
+                    actor=event.actor,
+                    action=event.action,
+                    target=event.target,
+                    before=json.dumps(event.before) if event.before is not None else None,
+                    after=json.dumps(event.after) if event.after is not None else None,
+                )
+            )
+
+    def _record_decision(self, event: AuditEvent) -> None:
+        meta = event.metadata or {}
+        with self._engine.begin() as conn:
+            conn.execute(
+                self._decisions.insert().values(
+                    ts=event.timestamp,
+                    actor=event.actor,
+                    action=event.action,
+                    target=event.target,
+                    token_ref=meta.get("token"),
+                    required=json.dumps(meta.get("required")) if meta.get("required") is not None else None,
+                    scopes=json.dumps(meta.get("scopes")) if meta.get("scopes") is not None else None,
+                )
+            )
+
+    def read(self, limit: int = 100) -> List[dict]:
+        """Recent *change* events (newest first) as plain dicts."""
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:
+            rows = conn.execute(sa.select(self._table).order_by(self._table.c.id.desc()).limit(limit)).mappings().all()
+        return [
+            {
+                "ts": r["ts"],
+                "actor": r["actor"],
+                "action": r["action"],
+                "target": r["target"],
+                "before": json.loads(r["before"]) if r["before"] else None,
+                "after": json.loads(r["after"]) if r["after"] else None,
+            }
+            for r in rows
+        ]
+
+    def read_decisions(self, limit: int = 100) -> List[dict]:
+        """Recent *decision* events (newest first) as plain dicts.
+
+        ``metadata`` is reassembled to the same ``{required, token, scopes}`` shape
+        the in-memory event carried, so readers don't care which table it came from.
+        """
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:
+            rows = (
+                conn.execute(sa.select(self._decisions).order_by(self._decisions.c.id.desc()).limit(limit))
+                .mappings()
+                .all()
+            )
+        return [
+            {
+                "ts": r["ts"],
+                "actor": r["actor"],
+                "action": r["action"],
+                "target": r["target"],
+                "metadata": {
+                    "required": json.loads(r["required"]) if r["required"] else None,
+                    "token": r["token_ref"],
+                    "scopes": json.loads(r["scopes"]) if r["scopes"] else None,
+                },
+            }
+            for r in rows
+        ]

--- a/libs/agno/agno/os/authz/audit.py
+++ b/libs/agno/agno/os/authz/audit.py
@@ -33,6 +33,14 @@ from typing import Any, Dict, List, Optional
 
 from agno.utils.log import log_debug
 
+# The audit-trail read contract (shared by both trails — change and decision):
+# which fields a page can be sorted by / searched over, and the defaults. The
+# roles router validates request params against these, so they have one owner.
+AUDIT_SORT_FIELDS = ("created_at", "actor", "action", "target")
+AUDIT_SEARCH_FIELDS = ("actor", "action", "target")
+DEFAULT_AUDIT_SORT_FIELD = "created_at"
+DEFAULT_AUDIT_SORT_ORDER = "desc"
+
 
 @dataclass
 class AuditEvent:
@@ -44,7 +52,8 @@ class AuditEvent:
         actor: the principal who made the change (JWT ``sub`` of the admin), or
             None for changes made in code outside a request (treated as system).
         target: the role name (role changes) or subject id (assignment changes).
-        before: prior state (the role's scopes, or the subject's roles), or None.
+        before: prior state — the subject's roles (list of str) or a role's scope
+            entries (list of ``{"scope", "effect"}`` dicts) — or None.
         after: new state, or None (e.g. on removal).
         timestamp: epoch seconds when the change was recorded.
     """
@@ -52,14 +61,14 @@ class AuditEvent:
     action: str
     actor: Optional[str]
     target: str
-    before: Optional[List[str]] = None
-    after: Optional[List[str]] = None
+    before: Optional[List[Any]] = None
+    after: Optional[List[Any]] = None
     timestamp: int = 0
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
-            "ts": self.timestamp,
+            "created_at": self.timestamp,
             "actor": self.actor,
             "action": self.action,
             "target": self.target,
@@ -202,11 +211,16 @@ class DbAuditSink(AuditSink):
         table_name: str = "authz_audit",
         decision_table_name: str = "authz_decisions",
         create_table: bool = True,
+        db: Optional[Any] = None,
     ):
         import sqlalchemy as sa
 
+        if db is not None and engine is None:
+            from agno.os.authz._db import engine_from_db
+
+            engine = engine_from_db(db)
         if engine is None and db_url is None:
-            raise ValueError("DbAuditSink needs either db_url or engine")
+            raise ValueError("DbAuditSink needs one of: db (an agno Db), engine, or db_url")
         self._engine = engine if engine is not None else sa.create_engine(db_url)  # type: ignore[arg-type]
         metadata = sa.MetaData()
         # change trail: role/assignment mutations with before/after
@@ -214,7 +228,7 @@ class DbAuditSink(AuditSink):
             table_name,
             metadata,
             sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
-            sa.Column("ts", sa.Integer, nullable=False),
+            sa.Column("created_at", sa.Integer, nullable=False),
             sa.Column("actor", sa.String(255)),
             sa.Column("action", sa.String(255), nullable=False),
             sa.Column("target", sa.String(255), nullable=False),
@@ -226,7 +240,7 @@ class DbAuditSink(AuditSink):
             decision_table_name,
             metadata,
             sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
-            sa.Column("ts", sa.Integer, nullable=False),
+            sa.Column("created_at", sa.Integer, nullable=False),
             sa.Column("actor", sa.String(255)),
             sa.Column("action", sa.String(255), nullable=False),  # access.allowed / access.denied
             sa.Column("target", sa.String(512), nullable=False),  # "METHOD /path"
@@ -254,7 +268,7 @@ class DbAuditSink(AuditSink):
         with self._engine.begin() as conn:
             conn.execute(
                 self._table.insert().values(
-                    ts=event.timestamp,
+                    created_at=event.timestamp,
                     actor=event.actor,
                     action=event.action,
                     target=event.target,
@@ -268,7 +282,7 @@ class DbAuditSink(AuditSink):
         with self._engine.begin() as conn:
             conn.execute(
                 self._decisions.insert().values(
-                    ts=event.timestamp,
+                    created_at=event.timestamp,
                     actor=event.actor,
                     action=event.action,
                     target=event.target,
@@ -278,41 +292,83 @@ class DbAuditSink(AuditSink):
                 )
             )
 
-    def read(self, limit: int = 100) -> List[dict]:
-        """Recent *change* events (newest first) as plain dicts."""
+    # Both trails read the same way: sortable, searchable pages over the columns
+    # the two tables share (AUDIT_SORT_FIELDS / AUDIT_SEARCH_FIELDS). Only the
+    # row shape differs, so read()/read_decisions() are thin mappers over these
+    # two helpers.
+    @staticmethod
+    def _search_clause(table, search: str):
         import sqlalchemy as sa
 
+        pattern = f"%{search}%"
+        return sa.or_(*(table.c[f].ilike(pattern) for f in AUDIT_SEARCH_FIELDS))
+
+    def _select_page(
+        self, table, limit: int, offset: int, search: Optional[str], sort_by: str, order: str
+    ) -> List[Any]:
+        import sqlalchemy as sa
+
+        if sort_by not in AUDIT_SORT_FIELDS:
+            raise ValueError(f"sort_by must be one of {AUDIT_SORT_FIELDS}, got {sort_by!r}")
+        stmt = sa.select(table)
+        if search:
+            stmt = stmt.where(self._search_clause(table, search))
+        # For time order, sort on id: it's monotonic and finer-grained than ts
+        # (second resolution). id also tie-breaks every other field.
+        cols = (table.c.id,) if sort_by == DEFAULT_AUDIT_SORT_FIELD else (table.c[sort_by], table.c.id)
+        order_by = [c.asc() if order == "asc" else c.desc() for c in cols]
         with self._engine.connect() as conn:
-            rows = conn.execute(sa.select(self._table).order_by(self._table.c.id.desc()).limit(limit)).mappings().all()
+            return list(conn.execute(stmt.order_by(*order_by).limit(limit).offset(offset)).mappings().all())
+
+    def _count(self, table, search: Optional[str]) -> int:
+        import sqlalchemy as sa
+
+        stmt = sa.select(sa.func.count()).select_from(table)
+        if search:
+            stmt = stmt.where(self._search_clause(table, search))
+        with self._engine.connect() as conn:
+            return int(conn.execute(stmt).scalar() or 0)
+
+    def read(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        search: Optional[str] = None,
+        sort_by: str = DEFAULT_AUDIT_SORT_FIELD,
+        order: str = DEFAULT_AUDIT_SORT_ORDER,
+    ) -> List[dict]:
+        """A page of *change* events as plain dicts (newest first by default;
+        ``sort_by`` one of :attr:`SORTABLE_FIELDS`, ``order`` asc|desc)."""
         return [
             {
-                "ts": r["ts"],
+                "created_at": r["created_at"],
                 "actor": r["actor"],
                 "action": r["action"],
                 "target": r["target"],
                 "before": json.loads(r["before"]) if r["before"] else None,
                 "after": json.loads(r["after"]) if r["after"] else None,
             }
-            for r in rows
+            for r in self._select_page(self._table, limit, offset, search, sort_by, order)
         ]
 
-    def read_decisions(self, limit: int = 100) -> List[dict]:
-        """Recent *decision* events (newest first) as plain dicts.
+    def read_decisions(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        search: Optional[str] = None,
+        sort_by: str = DEFAULT_AUDIT_SORT_FIELD,
+        order: str = DEFAULT_AUDIT_SORT_ORDER,
+    ) -> List[dict]:
+        """A page of *decision* events as plain dicts (newest first by default;
+        ``sort_by`` one of :attr:`SORTABLE_FIELDS`, ``order`` asc|desc).
+        ``target`` is ``METHOD /path``.
 
         ``metadata`` is reassembled to the same ``{required, token, scopes}`` shape
         the in-memory event carried, so readers don't care which table it came from.
         """
-        import sqlalchemy as sa
-
-        with self._engine.connect() as conn:
-            rows = (
-                conn.execute(sa.select(self._decisions).order_by(self._decisions.c.id.desc()).limit(limit))
-                .mappings()
-                .all()
-            )
         return [
             {
-                "ts": r["ts"],
+                "created_at": r["created_at"],
                 "actor": r["actor"],
                 "action": r["action"],
                 "target": r["target"],
@@ -322,5 +378,13 @@ class DbAuditSink(AuditSink):
                     "scopes": json.loads(r["scopes"]) if r["scopes"] else None,
                 },
             }
-            for r in rows
+            for r in self._select_page(self._decisions, limit, offset, search, sort_by, order)
         ]
+
+    def count(self, search: Optional[str] = None) -> int:
+        """Total number of change events (for pagination), honouring ``search``."""
+        return self._count(self._table, search)
+
+    def count_decisions(self, search: Optional[str] = None) -> int:
+        """Total number of decision events (for pagination), honouring ``search``."""
+        return self._count(self._decisions, search)

--- a/libs/agno/agno/os/authz/audit.py
+++ b/libs/agno/agno/os/authz/audit.py
@@ -26,9 +26,12 @@ events to ``authz_audit`` and decision events to ``authz_decisions``.
 
 import json
 import logging
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+
+from agno.utils.log import log_debug
 
 
 @dataclass
@@ -89,6 +92,84 @@ class LoggingAuditSink(AuditSink):
 def _is_decision(action: str) -> bool:
     """Decision events (``access.allowed`` / ``access.denied``) vs change events."""
     return action.startswith("access.")
+
+
+def resolve_audit_sink(app_or_request: Any) -> Optional[AuditSink]:
+    """The AuditSink recording this AgentOS's decisions, or None if none is configured.
+
+    Accepts a FastAPI ``app``, a ``Request`` or a ``WebSocket`` (``.app`` is read from
+    the latter two), mirroring ``resolve_authorization_provider`` so every choke point
+    can resolve the sink with whatever object it holds.
+    """
+    app = getattr(app_or_request, "app", app_or_request)
+    return getattr(getattr(app, "state", None), "authz_audit", None)
+
+
+def token_reference(token: Optional[str], claims: Optional[Dict[str, Any]]) -> Optional[str]:
+    """A non-secret reference to the presented token, for the decision trail.
+
+    Prefer the token's ``jti`` (RFC 7519 JWT ID): an opaque identifier the issuer
+    already minted, so it correlates to the issuer's own logs and any revocation list.
+    When the token has no ``jti``, fall back to a short SHA-256 of the raw token so two
+    distinct tokens stay distinguishable -- without ever storing the credential itself.
+    """
+    if claims:
+        jti = claims.get("jti")
+        if jti:
+            return str(jti)
+    if token:
+        import hashlib
+
+        return hashlib.sha256(token.encode()).hexdigest()[:12]
+    return None
+
+
+def record_decision(
+    app_or_request: Any,
+    *,
+    allowed: bool,
+    target: str,
+    principal: Optional[str],
+    required_scopes: Optional[List[str]] = None,
+    scopes: Optional[List[str]] = None,
+    claims: Optional[Dict[str, Any]] = None,
+    token: Optional[str] = None,
+    reason: Optional[str] = None,
+) -> None:
+    """Record ONE authorization decision to the configured sink.
+
+    This is shared by every enforcement choke point -- the REST route gate, the
+    per-resource gate, the WebSocket gates and the MCP tool gate -- so the access
+    trail covers all of them rather than only the transport that happens to run
+    inside the JWT middleware. ``target`` is the thing being decided on, formatted
+    like the route it corresponds to (e.g. ``"POST /agents/x/runs"``).
+
+    Never raises into the request path: an audit failure must not turn a served
+    request into a 500. No-op when no sink is configured, so the default (no audit)
+    deployment is untouched.
+    """
+    sink = resolve_audit_sink(app_or_request)
+    if sink is None:
+        return
+    try:
+        metadata: Dict[str, Any] = {
+            "required": list(required_scopes or []),
+            "token": token_reference(token, claims),
+            "scopes": list(scopes or []),
+        }
+        if reason:
+            metadata["reason"] = reason
+        sink.record(
+            AuditEvent(
+                action="access.allowed" if allowed else "access.denied",
+                actor=principal,
+                target=target,
+                timestamp=int(time.time()),
+                metadata=metadata,
+            )
+        )
+    except Exception as e:  # pragma: no cover - audit must never break requests
+        log_debug(f"decision audit failed: {e}")
 
 
 class DbAuditSink(AuditSink):

--- a/libs/agno/agno/os/authz/engine.py
+++ b/libs/agno/agno/os/authz/engine.py
@@ -1,0 +1,204 @@
+"""The pluggable policy engine behind managed roles — the swappable backend seam.
+
+:class:`~agno.os.authz.role_store.ManagedRoleStore` is the agno-native product
+surface (create roles, set scopes, assign, audit). The *engine* underneath —
+which actually stores policy and answers "is this allowed?" — is a swappable
+adapter behind this narrow port. agno's own
+:class:`~agno.os.authz.native_engine.NativePolicyEngine` is the default (zero
+third-party dependencies); swapping to another backend (OpenFGA, SpiceDB, ...)
+means implementing :class:`PolicyEngine` and passing it as
+``ManagedRoleStore(engine=...)`` — no change to the store's API, the ``/authz``
+router, the cookbooks, or anything SDK users see.
+
+The port speaks only agno terms — roles, subjects, scope strings, allow/deny.
+No engine types (obj/act tuples, OpenFGA tuples) leak across it.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+
+# A scope with its effect, e.g. ("agents:*:read", "allow") / ("agents:x:run", "deny").
+ScopeEntry = Tuple[str, str]
+
+
+def normalize_roles_claim(claims: Optional[Dict[str, Any]], roles_claim: Optional[str]) -> Optional[List[str]]:
+    """A caller's roles from a JWT claim, or None when absent/unusable. Accepts a
+    single string (e.g. WorkOS sends one ``role``) or a list. One owner for this
+    coercion so the gate (``EngineAuthorizationProvider``) and the admin check
+    (``ManagedRoleStore.can_manage``) can't drift — both are security-relevant."""
+    if not roles_claim or not claims:
+        return None
+    raw = claims.get(roles_claim)
+    if isinstance(raw, str):
+        raw = [raw]
+    if isinstance(raw, list) and raw:
+        return raw
+    return None
+
+
+class PolicyEngine(ABC):
+    """The backend that stores managed-role policy and answers access questions.
+
+    Implement these ~dozen methods (all in agno terms) to back managed roles with
+    a different engine. Identity for decisions is given two ways, mirroring the two
+    populations: ``subject`` (the engine resolves its roles from stored
+    assignments — the no-IdP case) and ``roles`` (roles carried on the token — the
+    IdP case). When ``roles`` is provided it takes precedence; otherwise the
+    ``subject``'s stored assignments decide.
+    """
+
+    # --- authoring: roles -> scopes ---
+    @abstractmethod
+    def set_role_scopes(self, role: str, entries: List[ScopeEntry]) -> None:
+        """Replace a role's entire scope set with ``entries`` (scope, effect)."""
+
+    @abstractmethod
+    def add_scope(self, role: str, scope: str, effect: str = "allow") -> None:
+        """Add (or flip the effect of) a single scope on a role."""
+
+    @abstractmethod
+    def remove_scope(self, role: str, scope: str) -> None:
+        """Remove a single scope from a role (no-op if absent)."""
+
+    @abstractmethod
+    def get_role_scopes(self, role: str) -> List[ScopeEntry]:
+        """A role's scopes as (scope, effect) entries."""
+
+    @abstractmethod
+    def remove_role(self, role: str) -> None:
+        """Delete a role: its scopes and any assignments to it."""
+
+    @abstractmethod
+    def list_roles(self) -> List[str]:
+        """All role names known to the engine."""
+
+    # --- assignments: subject -> roles ---
+    @abstractmethod
+    def assign(self, subject: str, role: str) -> None: ...
+
+    @abstractmethod
+    def unassign(self, subject: str, role: str) -> None: ...
+
+    @abstractmethod
+    def roles_of(self, subject: str) -> List[str]: ...
+
+    # --- decisions ---
+    @abstractmethod
+    def check_resource(
+        self,
+        resource_type: Optional[str],
+        resource_id: Optional[str],
+        action: Optional[str],
+        *,
+        subject: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+    ) -> bool:
+        """May the identity perform ``action`` on this resource (or collection)?"""
+
+    @abstractmethod
+    def check_scope(self, scope: str, *, subject: Optional[str] = None, roles: Optional[List[str]] = None) -> bool:
+        """Does the identity satisfy a required ``scope`` string? (Unmappable
+        scope -> False.)"""
+
+    @abstractmethod
+    def accessible_resource_ids(
+        self,
+        resource_type: str,
+        action: Optional[str],
+        *,
+        subject: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+    ) -> Set[str]:
+        """Resource ids of ``resource_type`` the identity may access for ``action``
+        (``{"*"}`` = all)."""
+
+    def denied_resource_ids(
+        self,
+        resource_type: str,
+        action: Optional[str],
+        *,
+        subject: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+    ) -> Set[str]:
+        """Concrete resource ids of ``resource_type`` the identity is explicitly
+        DENIED for ``action`` (deny-overrides). Used to carve denials out of the
+        list-visibility set so a wildcard allow + per-resource deny doesn't leak the
+        denied resource into list endpoints. Default: no engine-level denies."""
+        return set()
+
+
+class EngineAuthorizationProvider(AuthorizationProvider):
+    """An :class:`AuthorizationProvider` backed by any :class:`PolicyEngine`.
+
+    Engine-agnostic: it resolves the caller's identity (subject + optional
+    token-carried roles) from the request context and delegates every decision to
+    the engine. This is what ``ManagedRoleStore.provider`` returns, regardless of
+    which engine is plugged in.
+    """
+
+    def __init__(self, engine: PolicyEngine, roles_claim: Optional[str] = None):
+        self._engine = engine
+        self._roles_claim = roles_claim
+
+    def _identity(self, ctx: AuthorizationContext) -> Tuple[Optional[str], Optional[List[str]]]:
+        """(subject, roles) for the engine. ``roles`` is the token-carried list
+        when a ``roles_claim`` is configured and present; otherwise None so the
+        subject's stored assignments decide."""
+        return ctx.principal_id, normalize_roles_claim(ctx.claims, self._roles_claim)
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        subject, roles = self._identity(ctx)
+        return self._engine.check_resource(ctx.resource_type, ctx.resource_id, ctx.action, subject=subject, roles=roles)
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes: List[str]) -> bool:
+        subject, roles = self._identity(ctx)
+        # A resource route with a concrete single action: decide on the extracted
+        # (type, id, action) — the per-resource gate.
+        if ctx.resource_type and ctx.action:
+            return self._engine.check_resource(
+                ctx.resource_type, ctx.resource_id, ctx.action, subject=subject, roles=roles
+            )
+        # Otherwise — a non-resource route, or a resource route whose required scopes
+        # span more than one action (ctx.action is None) — require ALL of the route's
+        # scopes, matching the scope provider's AND semantics. Never fall through to a
+        # blanket allow: a multi-action resource route used to hit check_resource with
+        # action=None and be waved through. Evaluate each scope against the specific
+        # resource when one is known, else as a generic scope string.
+        if not required_scopes:
+            return True
+        for scope in required_scopes:
+            if ctx.resource_type and ctx.resource_id:
+                action = scope.rsplit(":", 1)[1] if ":" in scope else scope
+                ok = self._engine.check_resource(
+                    ctx.resource_type, ctx.resource_id, action, subject=subject, roles=roles
+                )
+            else:
+                ok = self._engine.check_scope(scope, subject=subject, roles=roles)
+            if not ok:
+                return False
+        return True
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        if not ctx.resource_type:
+            return set()
+        subject, roles = self._identity(ctx)
+        return self._engine.accessible_resource_ids(ctx.resource_type, ctx.action, subject=subject, roles=roles)
+
+    def filter_accessible(self, ctx: AuthorizationContext, resources: List[Any]) -> List[Any]:
+        """Deny-aware list filtering: accessible ids MINUS explicitly-denied ids, so a
+        wildcard allow with a per-resource deny (``agents:*:read`` + a deny on
+        ``agents:secret``) excludes the denied resource — keeping list endpoints
+        consistent with :meth:`check` / the per-resource gate (deny-overrides)."""
+        if not ctx.resource_type:
+            return resources
+        subject, roles = self._identity(ctx)
+        accessible = self._engine.accessible_resource_ids(ctx.resource_type, ctx.action, subject=subject, roles=roles)
+        denied = self._engine.denied_resource_ids(ctx.resource_type, ctx.action, subject=subject, roles=roles)
+        wildcard = "*" in accessible
+        return [
+            r
+            for r in resources
+            if getattr(r, "id", None) not in denied and (wildcard or getattr(r, "id", None) in accessible)
+        ]

--- a/libs/agno/agno/os/authz/fga.py
+++ b/libs/agno/agno/os/authz/fga.py
@@ -1,0 +1,191 @@
+"""Fine-grained / relationship-based authorization (ReBAC) for AgentOS.
+
+RBAC answers "what may a *role* do?"; FGA answers "what may *this user* do on
+*this specific object*, given the relationships between them?" — e.g. "alice may
+run workflow-7 because she owns the folder it lives in." That's the model behind
+Zanzibar, OpenFGA, and WorkOS FGA.
+
+AgentOS doesn't embed an FGA engine — relationship evaluation belongs in a
+purpose-built store (OpenFGA, a WorkOS FGA tenant, SpiceDB, ...). Instead this
+plugs any such store into the existing :class:`AuthorizationProvider` seam:
+
+    AuthorizationContext            FGA query
+    ─────────────────────────────   ─────────────────────────────────────────
+    principal_id  = "alice"     →   user     = "user:alice"
+    action        = "run"       →   relation = "run"
+    resource_type = "workflows"     object   = "workflows:workflow-7"
+    resource_id   = "workflow-7"
+
+So a per-resource check becomes one FGA ``Check`` call, and list-filtering becomes
+one ``ListObjects`` call — the two primitives every FGA engine has.
+
+Bring your own backend by implementing the tiny :class:`FGAClient` port (two
+methods). :class:`OpenFGAClient` is a batteries-included adapter for OpenFGA
+(``pip install "agno[fga]"``); the same provider works against WorkOS FGA or any
+other engine by writing an equally small client.
+
+Typical wiring composes FGA (per-resource ReBAC) with the scope provider (coarse
+route gating), since FGA has no notion of non-resource routes like ``/config``::
+
+    AuthorizationConfig(authorization_provider=[
+        ScopeAuthorizationProvider(),          # gates /config, /sessions, ... by scope
+        FGAAuthorizationProvider(fga_client),  # per-resource agents/teams/workflows by relationship
+    ])
+"""
+
+from typing import List, Optional, Set
+
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+
+try:  # Protocol is the right type for a duck-typed port; fall back for old pythons.
+    from typing import Protocol
+except ImportError:  # pragma: no cover
+    Protocol = object  # type: ignore[assignment,misc]
+
+
+class FGAClient(Protocol):
+    """The two relationship queries AgentOS needs from any FGA engine.
+
+    Both speak the engine's own object notation (``"type:id"``), e.g.
+    ``check("user:alice", "run", "workflows:wf-7")``. Implement this over OpenFGA,
+    WorkOS FGA, SpiceDB, or a test double — :class:`FGAAuthorizationProvider`
+    doesn't care which.
+    """
+
+    def check(self, user: str, relation: str, obj: str) -> bool:
+        """True if ``user`` has ``relation`` to ``obj``."""
+        ...
+
+    def list_objects(self, user: str, relation: str, object_type: str) -> List[str]:
+        """The objects of ``object_type`` that ``user`` has ``relation`` to,
+        as ``"type:id"`` strings (the engine's ListObjects)."""
+        ...
+
+
+class FGAAuthorizationProvider(AuthorizationProvider):
+    """An :class:`AuthorizationProvider` that decides via relationship checks
+    against an :class:`FGAClient` (OpenFGA / WorkOS FGA / any ReBAC engine).
+
+    It governs the per-resource families (agents/teams/workflows) relationally.
+    Routes it can't express as a single object (``/config``, ``/sessions``, the
+    scope-gated routes) it ABSTAINS on — so pair it with a scope provider via the
+    list form of ``authorization_provider`` (see the module docstring).
+
+    NOTE — ``admin_scope`` does not apply here. The ``agent_os:admin`` bypass is a
+    scope-plane feature (``ScopeAuthorizationProvider`` reads it off the token's
+    scopes); this provider decides purely on relationships, so a token carrying
+    ``agent_os:admin`` gets NO bypass from it and must instead hold an admin
+    RELATIONSHIP in the engine. That is the intended ReBAC behaviour, but it means a
+    standalone FGA deployment has no token-scope admins at all. Running it alongside
+    a scope provider (the recommended pairing above) restores the bypass, since the
+    composition is an OR.
+    """
+
+    def __init__(
+        self,
+        client: FGAClient,
+        *,
+        user_type: str = "user",
+        relation_map: Optional[dict] = None,
+    ):
+        """
+        Args:
+            client: the relationship engine (see :class:`FGAClient`).
+            user_type: the engine's user object type — the subject is sent as
+                ``f"{user_type}:{principal_id}"`` (OpenFGA convention, default
+                ``"user"``).
+            relation_map: optional ``{agno_action: fga_relation}`` overrides when
+                your model's relation names differ from agno actions
+                (``read``/``run``/``write``/``delete``). Identity by default.
+        """
+        self._client = client
+        self._user_type = user_type
+        self._relation_map = relation_map or {}
+
+    def _user(self, ctx: AuthorizationContext) -> Optional[str]:
+        return f"{self._user_type}:{ctx.principal_id}" if ctx.principal_id else None
+
+    def _relation(self, action: str) -> str:
+        return self._relation_map.get(action, action)
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        # Non-resource check: nothing to ask the relationship engine; defer (the
+        # route gate / a composed scope provider handles it). Same contract the
+        # scope and engine providers follow.
+        if not ctx.resource_type or not ctx.action:
+            return True
+        user = self._user(ctx)
+        if not user:
+            return False
+        # List endpoint (no specific id): allow, and let accessible_resource_ids
+        # narrow the response — mirrors how the middleware filters collections.
+        if not ctx.resource_id:
+            return True
+        return bool(self._client.check(user, self._relation(ctx.action), f"{ctx.resource_type}:{ctx.resource_id}"))
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        if not ctx.resource_type or not ctx.action:
+            return set()
+        user = self._user(ctx)
+        if not user:
+            return set()
+        objects = self._client.list_objects(user, self._relation(ctx.action), ctx.resource_type)
+        prefix = f"{ctx.resource_type}:"
+        # FGA returns concrete objects (never a wildcard), so we return concrete
+        # ids — list endpoints get exactly the set the user is related to.
+        return {o[len(prefix) :] for o in objects if o.startswith(prefix)}
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes: List[str]) -> bool:
+        # Per-resource routes: decide relationally. Everything else (non-resource
+        # routes the FGA model doesn't describe) we ABSTAIN on by returning False,
+        # so it never fail-opens a /config or /sessions route when OR-composed —
+        # a scope provider in the list is expected to authorize those.
+        if ctx.resource_type:
+            return self.check(ctx)
+        return False
+
+
+class OpenFGAClient:
+    """Reference :class:`FGAClient` for OpenFGA. Requires ``pip install "agno[fga]"``.
+
+    Thin wrapper over the OpenFGA Python SDK's *sync* client. Your OpenFGA
+    authorization model must define relations matching the agno actions you gate
+    (``read``/``run``/``write``/``delete``) on the agent/team/workflow object
+    types. Point it at a self-hosted OpenFGA or any OpenFGA-compatible endpoint.
+    """
+
+    def __init__(
+        self,
+        api_url: str,
+        store_id: str,
+        authorization_model_id: Optional[str] = None,
+        credentials=None,
+    ):
+        try:
+            from openfga_sdk import ClientConfiguration
+            from openfga_sdk.sync import OpenFgaClient as _OpenFgaClient
+        except ImportError as e:  # pragma: no cover
+            raise ImportError(
+                'OpenFGA support needs the optional extra. Install it with: pip install "agno[fga]"'
+            ) from e
+
+        self._client = _OpenFgaClient(
+            ClientConfiguration(
+                api_url=api_url,
+                store_id=store_id,
+                authorization_model_id=authorization_model_id,
+                credentials=credentials,
+            )
+        )
+
+    def check(self, user: str, relation: str, obj: str) -> bool:
+        from openfga_sdk import ClientCheckRequest
+
+        resp = self._client.check(ClientCheckRequest(user=user, relation=relation, object=obj))
+        return bool(getattr(resp, "allowed", False))
+
+    def list_objects(self, user: str, relation: str, object_type: str) -> List[str]:
+        from openfga_sdk import ClientListObjectsRequest
+
+        resp = self._client.list_objects(ClientListObjectsRequest(user=user, relation=relation, type=object_type))
+        return list(getattr(resp, "objects", []) or [])

--- a/libs/agno/agno/os/authz/native_engine.py
+++ b/libs/agno/agno/os/authz/native_engine.py
@@ -1,0 +1,371 @@
+"""The native managed-roles policy engine — agno's default, zero third-party deps.
+
+A :class:`~agno.os.authz.engine.PolicyEngine` implemented directly in agno: roles
+hold scopes (with allow/deny), subjects are assigned roles, and decisions use
+**deny-overrides** matching the cloud RBAC semantics. No external policy engine.
+
+Storage is **always a database** (``db`` / ``db_url``): policy + assignments live in
+two SQLAlchemy tables (``authz_policy``, ``authz_grouping``) and every decision reads
+them **fresh** with small indexed queries. There is no in-process cache, so a change
+on one worker/replica is visible to all of them on their very next request — the
+right default for AgentOS's multi-container deployments. Authz is a tiny,
+index-served part of a request (which is otherwise an agent run), so the round-trips
+are negligible, and a DB outage fails closed. A DB is *required*: an in-memory store
+can't stay consistent across replicas, so an engine with no DB raises on any use
+(see :data:`~agno.os.authz._db.NO_DB_MESSAGE`).
+
+The decision model, in agno terms:
+
+- a role's scopes are stored as ``(resource, action, effect)`` via the shared
+  :mod:`~agno.os.authz._scope_policy` convention (deduped per ``(role, resource, action)``),
+- a subject (or a token-carried role) is allowed an action on a resource iff some
+  matching grant says *allow* and none says *deny* — evaluated per identity root
+  and OR'd across token-carried roles, so a deny on one role can't silently veto
+  an allow carried by another.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from agno.os.authz._db import NO_DB_MESSAGE
+from agno.os.authz._db import engine_from_db as _engine_from_db
+from agno.os.authz._db import engine_from_url as _engine_from_url
+from agno.os.authz._scope_policy import resource_action_to_scope, resource_matches, scope_to_resource_action
+from agno.os.authz.engine import PolicyEngine, ScopeEntry
+
+_DENY = "deny"
+_ALLOW = "allow"
+# A policy row carried through the decision logic: (role, resource, action, effect).
+_PolicyRow = Tuple[str, str, str, str]
+
+
+def _normalize_effect(effect: str) -> str:
+    """Validate/lowercase a policy effect. Reject anything but allow/deny so a
+    typo'd effect can't silently become an *allow* (deny-overrides keys off the
+    exact string ``"deny"``)."""
+    e = effect.lower() if isinstance(effect, str) else effect
+    if e not in (_ALLOW, _DENY):
+        raise ValueError(f"effect must be 'allow' or 'deny', got {effect!r}")
+    return e
+
+
+class NativePolicyEngine(PolicyEngine):
+    """agno-native :class:`PolicyEngine`. Queries the DB fresh per decision. A DB is
+    required (``db`` or ``db_url``); without one — and until AgentOS adopts the OS DB
+    via :meth:`attach_db` — every operation raises, because an in-memory store can't
+    stay consistent across the workers/replicas an AgentOS deployment runs."""
+
+    def __init__(self, db_url: Optional[str] = None, db: Optional[Any] = None):
+        # A DB is required. It may arrive later via attach_db() (the AgentOS
+        # role_store= shortcut), so an engine built with neither db nor db_url starts
+        # "unbound" and raises on use until bound — it is never an operating mode.
+        self._engine: Any = None  # SQLAlchemy Engine once bound, else None (unbound)
+        self._policy_tbl: Any = None
+        self._group_tbl: Any = None
+        self._log = logging.getLogger("agno.authz.engine")
+
+        target = _engine_from_db(db) if db is not None else (_engine_from_url(db_url) if db_url else None)
+        if target is not None:
+            self._setup_db(target)
+
+    # --- storage ---------------------------------------------------------
+    @property
+    def is_bound(self) -> bool:
+        """True once a DB is bound (directly or via :meth:`attach_db`)."""
+        return self._engine is not None
+
+    def _require_engine(self) -> None:
+        if self._engine is None:
+            raise RuntimeError(NO_DB_MESSAGE)
+
+    def _setup_db(self, engine: Any) -> None:
+        import sqlalchemy as sa
+
+        self._engine = engine
+        metadata = sa.MetaData()
+        self._policy_tbl = sa.Table(
+            "authz_policy",
+            metadata,
+            sa.Column("role", sa.String(255), primary_key=True),
+            sa.Column("resource", sa.String(512), primary_key=True),
+            sa.Column("action", sa.String(255), primary_key=True),
+            sa.Column("effect", sa.String(16), nullable=False),
+        )
+        self._group_tbl = sa.Table(
+            "authz_grouping",
+            metadata,
+            sa.Column("subject", sa.String(255), primary_key=True),
+            sa.Column("role", sa.String(255), primary_key=True),
+        )
+        metadata.create_all(self._engine)
+
+    def attach_db(self, db: Any) -> None:
+        """Bind an agno ``Db`` to a still-unbound engine, then read the DB fresh.
+
+        No-op if a DB is already bound (the caller's explicit choice wins) or the db
+        isn't SQL-capable (e.g. a NoSQL agno Db) — in which case the engine stays
+        unbound and the next operation raises. Lets AgentOS adopt the OS database for
+        a managed store created without one."""
+        if self._engine is not None:
+            return  # already bound — respect the explicit choice
+        try:
+            engine = _engine_from_db(db)
+        except Exception:
+            return  # not a SQL-capable db; stay unbound (use will raise)
+        self._setup_db(engine)
+
+    # --- read helpers (DB-backed) ----------------------------------------
+    def _direct_roles(self, node: str) -> Set[str]:
+        """Roles directly assigned to ``node`` (a subject, or a role when nesting).
+        Indexed point-lookup on the grouping PK."""
+        self._require_engine()
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:
+            rows = conn.execute(sa.select(self._group_tbl.c.role).where(self._group_tbl.c.subject == node))
+            return {r[0] for r in rows}
+
+    def _closure(self, seed: str) -> Set[str]:
+        """``seed`` plus the roles it is (transitively) assigned. The seed itself is
+        included so a token-carried role matches policies written for that role."""
+        seen: Set[str] = set()
+        stack = [seed]
+        while stack:
+            node = stack.pop()
+            if node in seen:
+                continue
+            seen.add(node)
+            stack.extend(self._direct_roles(node))
+        return seen
+
+    def _policies_for(self, principals: Set[str]) -> List[_PolicyRow]:
+        """All (role, resource, action, effect) rows whose role is in ``principals``."""
+        if not principals:
+            return []
+        self._require_engine()
+        import sqlalchemy as sa
+
+        t = self._policy_tbl
+        with self._engine.connect() as conn:
+            rows = conn.execute(sa.select(t).where(t.c.role.in_(principals))).mappings()
+            return [(row["role"], row["resource"], row["action"], row["effect"]) for row in rows]
+
+    # --- persistence (db-backed mutations) -------------------------------
+    def _persist_policies_set(self, role: str, rows: List[Tuple[str, str, str]]) -> None:
+        """Replace a role's persisted policy rows with ``rows`` ((resource, action, effect))."""
+        self._require_engine()
+        import sqlalchemy as sa
+
+        with self._engine.begin() as conn:
+            conn.execute(sa.delete(self._policy_tbl).where(self._policy_tbl.c.role == role))
+            if rows:
+                conn.execute(
+                    sa.insert(self._policy_tbl),
+                    [{"role": role, "resource": res, "action": act, "effect": eff} for res, act, eff in rows],
+                )
+
+    def _persist_policy(self, role: str, resource: str, action: str, effect: str) -> None:
+        self._require_engine()
+        import sqlalchemy as sa
+
+        with self._engine.begin() as conn:
+            conn.execute(
+                sa.delete(self._policy_tbl).where(
+                    self._policy_tbl.c.role == role,
+                    self._policy_tbl.c.resource == resource,
+                    self._policy_tbl.c.action == action,
+                )
+            )
+            conn.execute(sa.insert(self._policy_tbl).values(role=role, resource=resource, action=action, effect=effect))
+
+    def _delete_policy(self, role: str, resource: Optional[str] = None, action: Optional[str] = None) -> None:
+        self._require_engine()
+        import sqlalchemy as sa
+
+        clause = [self._policy_tbl.c.role == role]
+        if resource is not None:
+            clause.append(self._policy_tbl.c.resource == resource)
+        if action is not None:
+            clause.append(self._policy_tbl.c.action == action)
+        with self._engine.begin() as conn:
+            conn.execute(sa.delete(self._policy_tbl).where(*clause))
+
+    def _persist_grouping(self, subject: str, role: str, add: bool) -> None:
+        self._require_engine()
+        import sqlalchemy as sa
+
+        with self._engine.begin() as conn:
+            conn.execute(
+                sa.delete(self._group_tbl).where(self._group_tbl.c.subject == subject, self._group_tbl.c.role == role)
+            )
+            if add:
+                conn.execute(sa.insert(self._group_tbl).values(subject=subject, role=role))
+
+    def _delete_grouping_role(self, role: str) -> None:
+        self._require_engine()
+        import sqlalchemy as sa
+
+        with self._engine.begin() as conn:
+            conn.execute(sa.delete(self._group_tbl).where(self._group_tbl.c.role == role))
+
+    # --- authoring: roles -> scopes -------------------------------------
+    def set_role_scopes(self, role: str, entries: List[ScopeEntry]) -> None:
+        # Stage + validate EVERY entry first: a bad scope raises before anything is
+        # written, and mapping to a dict dedups colliding (resource, action) pairs
+        # (e.g. agents:read & agents:*:read) so the insert can't hit a duplicate PK.
+        staged: Dict[Tuple[str, str], str] = {}
+        for scope, effect in entries:
+            resource, action = scope_to_resource_action(scope)
+            staged[(resource, action)] = _normalize_effect(effect)
+        self._persist_policies_set(role, [(res, act, eff) for (res, act), eff in staged.items()])
+
+    def add_scope(self, role: str, scope: str, effect: str = _ALLOW) -> None:
+        resource, action = scope_to_resource_action(scope)  # validate before mutating
+        effect = _normalize_effect(effect)
+        self._persist_policy(role, resource, action, effect)
+
+    def remove_scope(self, role: str, scope: str) -> None:
+        resource, action = scope_to_resource_action(scope)  # validate before mutating
+        self._delete_policy(role, resource, action)
+
+    def get_role_scopes(self, role: str) -> List[ScopeEntry]:
+        return [(resource_action_to_scope(res, act), eff) for (r, res, act, eff) in self._policies_for({role})]
+
+    def remove_role(self, role: str) -> None:
+        self._delete_policy(role)
+        self._delete_grouping_role(role)
+
+    def list_roles(self) -> List[str]:
+        # Roles defined by scope policies PLUS roles that only exist as assignments,
+        # so an assignment-only role is still inspectable/cleanable.
+        self._require_engine()
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:
+            roles = {r[0] for r in conn.execute(sa.select(self._policy_tbl.c.role).distinct())}
+            roles |= {r[0] for r in conn.execute(sa.select(self._group_tbl.c.role).distinct())}
+        return sorted(roles)
+
+    # --- assignments: subject -> roles ----------------------------------
+    def assign(self, subject: str, role: str) -> None:
+        self._persist_grouping(subject, role, add=True)
+
+    def unassign(self, subject: str, role: str) -> None:
+        self._persist_grouping(subject, role, add=False)
+
+    def roles_of(self, subject: str) -> List[str]:
+        return sorted(self._direct_roles(subject))
+
+    # --- decisions -------------------------------------------------------
+    def _allowed_for_root(self, root: str, request_resource: str, request_action: str) -> bool:
+        """deny-overrides within one identity root: allowed iff some grant in the
+        root's closure matches and allows, and none matches and denies."""
+        allow = deny = False
+        for _role, resource, action, effect in self._policies_for(self._closure(root)):
+            if action != "*" and action != request_action:
+                continue
+            if not resource_matches(resource, request_resource):
+                continue
+            if effect == _DENY:
+                deny = True
+            else:
+                allow = True
+        return allow and not deny
+
+    def _enforce(self, resource: str, action: str, subject: Optional[str], roles: Optional[List[str]]) -> bool:
+        """One decision for ``(resource, action)``. Token-carried roles take precedence
+        (each evaluated as its own root and OR'd); else the subject's assignments."""
+        if roles:
+            decision = any(self._allowed_for_root(role, resource, action) for role in roles)
+        elif subject:
+            decision = self._allowed_for_root(subject, resource, action)
+        else:
+            decision = False
+        if self._log.isEnabledFor(logging.INFO):
+            who = f"roles={roles}" if roles else f"subject={subject!r}"
+            self._log.info("authz decision: %s resource=%r action=%r -> %s", who, resource, action, decision)
+        return decision
+
+    def check_resource(
+        self,
+        resource_type: Optional[str],
+        resource_id: Optional[str],
+        action: Optional[str],
+        *,
+        subject: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+    ) -> bool:
+        if not resource_type or not action:
+            return True  # non-resource check: defer (the route gate handles it)
+        resource = f"{resource_type}/{resource_id}" if resource_id else resource_type
+        return self._enforce(resource, action, subject, roles)
+
+    def check_scope(self, scope: str, *, subject: Optional[str] = None, roles: Optional[List[str]] = None) -> bool:
+        try:
+            resource, action = scope_to_resource_action(scope)
+        except ValueError:
+            return False  # unmappable scope -> not satisfied
+        return self._enforce(resource, action, subject, roles)
+
+    def _principals_for(self, subject: Optional[str], roles: Optional[List[str]]) -> Set[str]:
+        roots = list(roles) if roles else ([subject] if subject else [])
+        principals: Set[str] = set()
+        for root in roots:
+            principals |= self._closure(root)
+        return principals
+
+    def accessible_resource_ids(
+        self,
+        resource_type: str,
+        action: Optional[str],
+        *,
+        subject: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+    ) -> Set[str]:
+        """Resource ids of ``resource_type`` the identity may access for ``action``
+        (``{"*"}`` = wildcard/collection grant). Mirrors :meth:`_enforce`: roles
+        take precedence, else the subject's stored assignments; deny rows skipped."""
+        if not resource_type:
+            return set()
+        principals = self._principals_for(subject, roles)
+        if not principals:
+            return set()
+        ids: Set[str] = set()
+        prefix = f"{resource_type}/"
+        for _role, resource, policy_action, effect in self._policies_for(principals):
+            if effect == _DENY:
+                continue
+            if action is not None and policy_action != action and policy_action != "*":
+                continue
+            if resource in ("*", f"{resource_type}/*", resource_type):
+                return {"*"}
+            if resource.startswith(prefix):
+                ids.add(resource[len(prefix) :])
+        return ids
+
+    def denied_resource_ids(
+        self,
+        resource_type: str,
+        action: Optional[str],
+        *,
+        subject: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+    ) -> Set[str]:
+        """Concrete ids of ``resource_type`` explicitly denied for ``action`` (the
+        deny rows). Lets the provider carve denials out of a wildcard-allow list so
+        list endpoints honour deny-overrides like the per-resource gate does."""
+        if not resource_type:
+            return set()
+        principals = self._principals_for(subject, roles)
+        if not principals:
+            return set()
+        ids: Set[str] = set()
+        prefix = f"{resource_type}/"
+        for _role, resource, policy_action, effect in self._policies_for(principals):
+            if effect != _DENY:
+                continue
+            if action is not None and policy_action != action and policy_action != "*":
+                continue
+            if resource.startswith(prefix):
+                ids.add(resource[len(prefix) :])
+        return ids

--- a/libs/agno/agno/os/authz/provider.py
+++ b/libs/agno/agno/os/authz/provider.py
@@ -1,0 +1,114 @@
+"""Authorization provider interface.
+
+Defines the decision context handed to a provider and the abstract base every
+provider implements. Keeping this dependency-free (only stdlib + typing) means
+the interface can live in the OSS SDK while concrete providers — including ones
+that call out to an external policy engine — are layered on top.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+
+
+@dataclass
+class AuthorizationContext:
+    """Everything a provider needs to make an access decision.
+
+    A provider is free to use as much or as little of this as its model
+    requires. The built-in scope provider only looks at ``scopes`` /
+    ``resource_type`` / ``resource_id`` / ``action`` / ``admin_scope``; a ReBAC
+    or ABAC provider would additionally lean on ``principal_id`` and the full
+    ``claims`` (tenant, groups, ownership hints, etc.).
+
+    Attributes:
+        principal_id: The authenticated subject (JWT ``sub``), or None when
+            unauthenticated.
+        scopes: Scope strings from the token's ``scopes`` claim.
+        claims: The full decoded JWT payload, for providers that key off
+            arbitrary claims (tenant_id, groups, ...).
+        resource_type: Resource family being accessed ("agents", "teams",
+            "workflows", ...), or None for non-resource checks.
+        resource_id: Specific resource id, or None for list/collection checks.
+        action: Action being attempted ("read", "run", "write", ...).
+        admin_scope: The scope string that grants full bypass (default
+            ``agent_os:admin``), honoured by the built-in provider.
+    """
+
+    principal_id: Optional[str] = None
+    scopes: List[str] = field(default_factory=list)
+    claims: Dict[str, Any] = field(default_factory=dict)
+    resource_type: Optional[str] = None
+    resource_id: Optional[str] = None
+    action: Optional[str] = None
+    admin_scope: Optional[str] = None
+
+
+class AuthorizationProvider(ABC):
+    """Strategy for answering AgentOS authorization questions.
+
+    Two primitives every provider must answer:
+
+    - :meth:`check` — boolean "may this context do this action on this
+      resource?"
+    - :meth:`accessible_resource_ids` — for list endpoints, which resource ids
+      of a type the principal may access (``{"*"}`` means all).
+
+    :meth:`require` and :meth:`filter_accessible` have sensible default
+    implementations on top of those two; override them only if the provider can
+    do something smarter (e.g. a single batch call to an external engine).
+    """
+
+    @abstractmethod
+    def check(self, ctx: AuthorizationContext) -> bool:
+        """Return True if the action in ``ctx`` is allowed."""
+        ...
+
+    @abstractmethod
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        """Return the set of resource ids of ``ctx.resource_type`` the
+        principal may access for ``ctx.action``. ``{"*"}`` denotes wildcard
+        (all) access.
+        """
+        ...
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes: List[str]) -> bool:
+        """Route-level gate run by the JWT middleware before the request reaches
+        the endpoint.
+
+        ``required_scopes`` is the scope vocabulary the default route→scope
+        mapping produced for this path (e.g. ``["agents:run"]``). A scope-based
+        provider uses it directly; a provider with a different model (ReBAC/ABAC)
+        ignores it and decides from :meth:`check` instead.
+
+        Default implementation defers to :meth:`check`, so a custom provider
+        gets full control of the route gate without having to understand scope
+        strings. :class:`~agno.os.authz.scope_provider.ScopeAuthorizationProvider`
+        overrides this to preserve the original scope-matching behaviour.
+        """
+        return self.check(ctx)
+
+    def require(self, ctx: AuthorizationContext) -> None:
+        """Raise ``PermissionError`` if :meth:`check` denies ``ctx``.
+
+        The HTTP layer translates this into a 403; keeping the provider raising
+        a plain ``PermissionError`` avoids coupling it to FastAPI.
+        """
+        if not self.check(ctx):
+            raise PermissionError(
+                f"Access denied to {ctx.action} {ctx.resource_type}"
+                + (f"/{ctx.resource_id}" if ctx.resource_id else "")
+            )
+
+    def filter_accessible(self, ctx: AuthorizationContext, resources: List[Any]) -> List[Any]:
+        """Filter ``resources`` (objects with an ``id``) to those the principal
+        may access, using :meth:`accessible_resource_ids`.
+
+        Default implementation does one ``accessible_resource_ids`` call and
+        filters in-process. Providers backed by an external engine may override
+        with a batched authorization query.
+        """
+        accessible = self.accessible_resource_ids(ctx)
+        if "*" in accessible:
+            return resources
+        return [r for r in resources if getattr(r, "id", None) in accessible]

--- a/libs/agno/agno/os/authz/provider.py
+++ b/libs/agno/agno/os/authz/provider.py
@@ -32,7 +32,20 @@ class AuthorizationContext:
         resource_id: Specific resource id, or None for list/collection checks.
         action: Action being attempted ("read", "run", "write", ...).
         admin_scope: The scope string that grants full bypass (default
-            ``agent_os:admin``), honoured by the built-in provider.
+            ``agent_os:admin``).
+
+            IMPORTANT -- this is a *scope-plane* feature. It is honoured by
+            :class:`~agno.os.authz.scope_provider.ScopeAuthorizationProvider`,
+            which reads it off the caller's token scopes. Providers that do not
+            authorize from token scopes deliberately ignore it and model admin in
+            their own terms instead: the managed-role engine grants an admin ROLE
+            (a role whose scopes include ``agent_os:admin``), and a relationship
+            (ReBAC) provider expects an admin RELATIONSHIP. So a token carrying
+            ``agent_os:admin`` is NOT automatically an admin under a role or ReBAC
+            provider used on its own -- if you want token-scope admins alongside
+            one of those, run the scope provider as a second plane
+            (``authorization_provider=[ScopeAuthorizationProvider(), other]``),
+            where the OR composition gives you the bypass.
     """
 
     principal_id: Optional[str] = None

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -203,6 +203,10 @@ class UpdateUserRequest(BaseModel):
     )
 
 
+class DeleteUsersRequest(BaseModel):
+    user_ids: List[str] = Field(..., description="List of user IDs to delete", min_length=1)
+
+
 def _paginated(data: list, page: int, limit: int, total: int, search_time_ms: float = 0) -> PaginatedResponse:
     """Wrap one already-paged slice in the SDK's PaginatedResponse ({data, meta})."""
     return PaginatedResponse(
@@ -495,5 +499,19 @@ def get_roles_router(
         def delete_user(user_id: str, actor: str = Depends(require_admin)) -> dict:
             deleted = user_store.remove(user_id, actor=actor)
             return {"id": user_id, "deleted": deleted}
+
+        @router.delete(
+            "/users",
+            status_code=204,
+            summary="Delete Multiple Users",
+            description=(
+                "Delete multiple users from the directory by their IDs in a single operation. "
+                "Unknown IDs are skipped. This removes directory rows only; it does not touch role "
+                "assignments and is not a revocation primitive — with JIT provisioning on, a deleted "
+                "user re-appears as active on their next valid token. Use the disabled kill-switch to revoke."
+            ),
+        )
+        def delete_users(body: DeleteUsersRequest, actor: str = Depends(require_admin)) -> None:
+            user_store.remove_many(body.user_ids, actor=actor)
 
     return router

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -1,0 +1,146 @@
+"""HTTP management API for :class:`ManagedRoleStore` — the governance product surface.
+
+This is the productisation of the managed-roles tier: a small, admin-only REST
+API to create roles, set their permissions (in agno scope terms), and grant or
+revoke them at runtime. Mount it on your AgentOS app:
+
+    from agno.os.authz.role_store import ManagedRoleStore
+    from agno.os.authz.role_router import get_roles_router
+
+    roles = ManagedRoleStore(db_url="postgresql+psycopg://...")
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(roles))
+
+Every route requires the caller to be an admin (satisfies ``agent_os:admin``,
+whether that comes from a token scope or an admin role in the store). The JWT
+middleware still runs first, so an unauthenticated request is rejected (401)
+before these handlers; a valid-but-non-admin caller gets 403.
+
+Endpoints (default prefix ``/authz``):
+    GET    /authz/roles                          list roles
+    GET    /authz/roles/{role}                   a role's scopes
+    PUT    /authz/roles/{role}                   set a role's scopes  {"scopes": [...]}
+    DELETE /authz/roles/{role}                   delete a role
+    GET    /authz/users/{subject}/roles          a subject's roles
+    POST   /authz/users/{subject}/roles          assign a role        {"role": "..."}
+    DELETE /authz/users/{subject}/roles/{role}   revoke a role
+"""
+
+from enum import Enum
+from typing import TYPE_CHECKING, List, Optional, Union
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from agno.os.authz.role_store import ManagedRoleStore
+
+
+class SetRoleScopesRequest(BaseModel):
+    scopes: List[str] = Field(..., description="Permissions in agno scope terms, e.g. ['agents:*:read']")
+
+
+class AssignRoleRequest(BaseModel):
+    role: str = Field(..., description="Role to grant the subject")
+
+
+def get_roles_router(
+    store: "ManagedRoleStore", prefix: str = "/authz", tags: Optional[List[Union[str, Enum]]] = None
+) -> APIRouter:
+    """Build the admin-only roles-management router bound to ``store``."""
+    if tags is None:
+        tags = ["Authorization"]
+
+    def require_admin(request: Request) -> str:
+        """Gate: caller must be authenticated and an admin of the store."""
+        if not getattr(request.state, "authenticated", False):
+            raise HTTPException(status_code=401, detail="Not authenticated")
+        principal_id = getattr(request.state, "user_id", None)
+        claims = getattr(request.state, "claims", {}) or {}
+        if not store.can_manage(principal_id, claims):
+            raise HTTPException(status_code=403, detail="Admin privileges required to manage roles")
+        return principal_id or ""
+
+    router = APIRouter(prefix=prefix, tags=tags, dependencies=[Depends(require_admin)])
+
+    # ---- roles ----------------------------------------------------------
+    @router.get("/roles")
+    def list_roles() -> dict:
+        return {"roles": store.list_roles()}
+
+    @router.get("/roles/{role}")
+    def get_role(role: str) -> dict:
+        return {"role": role, "scopes": store.get_role_scopes(role)}
+
+    @router.put("/roles/{role}")
+    def set_role(role: str, body: SetRoleScopesRequest, actor: str = Depends(require_admin)) -> dict:
+        try:
+            store.set_role_scopes(role, body.scopes, actor=actor)
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e))
+        return {"role": role, "scopes": store.get_role_scopes(role)}
+
+    @router.delete("/roles/{role}")
+    def delete_role(role: str, actor: str = Depends(require_admin)) -> dict:
+        store.remove_role(role, actor=actor)
+        return {"role": role, "deleted": True}
+
+    # ---- scope catalog --------------------------------------------------
+    @router.get("/scopes")
+    def list_scopes() -> dict:
+        """The catalog of scopes this AgentOS understands, grouped by resource.
+
+        Derived from the OS's own route→scope map, so it always matches what the
+        OS actually enforces. A UI renders this as a resource×action grid; a role
+        is then just a set of the resulting ``resource:action`` strings (plus the
+        ``agent_os:admin`` super-scope).
+        """
+        from agno.os.scopes import get_default_scope_mappings
+
+        grouped: dict = {}
+        for required in get_default_scope_mappings().values():
+            for scope in required:
+                parts = scope.split(":")
+                if len(parts) == 2:
+                    grouped.setdefault(parts[0], set()).add(parts[1])
+        grouped_sorted = {r: sorted(a) for r, a in sorted(grouped.items())}
+        flat = sorted(f"{r}:{a}" for r, acts in grouped_sorted.items() for a in acts)
+        return {"grouped": grouped_sorted, "scopes": flat, "admin_scope": "agent_os:admin"}
+
+    # ---- audit ----------------------------------------------------------
+    @router.get("/audit")
+    def list_audit(limit: int = 100) -> dict:
+        """Recent *change* events (role/assignment mutations, newest first). Empty
+        unless the store was given a readable audit sink (e.g. DbAuditSink)."""
+        return {"events": store.audit_log(limit)}
+
+    @router.get("/decisions")
+    def list_decisions(request: Request, limit: int = 100) -> dict:
+        """Recent *decision* events (allow/deny per request, newest first).
+
+        Decision audit is configured on ``AuthorizationConfig(audit=...)`` and lands
+        on ``app.state.authz_audit`` — a separate table from the change trail above,
+        so a high-volume decision log never buries the change history. Empty unless a
+        readable decision sink (e.g. DbAuditSink) is configured."""
+        sink = getattr(request.app.state, "authz_audit", None)
+        events = sink.read_decisions(limit) if sink is not None and hasattr(sink, "read_decisions") else []
+        return {"events": events}
+
+    # ---- assignments ----------------------------------------------------
+    @router.get("/users/{subject}/roles")
+    def get_user_roles(subject: str) -> dict:
+        return {"subject": subject, "roles": store.roles_of(subject)}
+
+    @router.post("/users/{subject}/roles")
+    def assign_role(subject: str, body: AssignRoleRequest, actor: str = Depends(require_admin)) -> dict:
+        """Set the subject's role. One role per subject: this REPLACES any
+        current role (a role select in a UI, not a multi-grant)."""
+        store.assign(subject, body.role, actor=actor)
+        return {"subject": subject, "roles": store.roles_of(subject)}
+
+    @router.delete("/users/{subject}/roles/{role}")
+    def revoke_role(subject: str, role: str, actor: str = Depends(require_admin)) -> dict:
+        store.unassign(subject, role, actor=actor)
+        return {"subject": subject, "roles": store.roles_of(subject)}
+
+    return router

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -1,8 +1,7 @@
 """HTTP management API for :class:`ManagedRoleStore` — the governance product surface.
 
-This is the productisation of the managed-roles tier: a small, admin-only REST
-API to create roles, set their permissions (in agno scope terms), and grant or
-revoke them at runtime. Mount it on your AgentOS app:
+Admin-only REST API to create roles, set their permissions (in agno scope terms,
+with allow/deny), and grant or revoke them at runtime. Mount it on your AgentOS:
 
     from agno.os.authz.role_store import ManagedRoleStore
     from agno.os.authz.role_router import get_roles_router
@@ -11,136 +10,490 @@ revoke them at runtime. Mount it on your AgentOS app:
     app = agent_os.get_app()
     app.include_router(get_roles_router(roles))
 
-Every route requires the caller to be an admin (satisfies ``agent_os:admin``,
-whether that comes from a token scope or an admin role in the store). The JWT
-middleware still runs first, so an unauthenticated request is rejected (401)
-before these handlers; a valid-but-non-admin caller gets 403.
+Response shapes mirror the agno cloud RBAC API so a frontend can reuse its
+integration: roles are objects (slug/name/description/is_default/created_at/
+updated_at + parsed scopes), scopes are ``{raw, namespace, sub_namespace,
+permission, value}``, and list endpoints use the SDK ``PaginatedResponse``
+({data, meta}). Single-OS: scopes are a flat list (no org/os split).
+
+Every route is admin-only — admin comes from an ``agent_os:admin`` token scope OR
+an admin role in the store. Unauthenticated requests are rejected (401) by the JWT
+middleware before these handlers; a valid-but-non-admin caller gets 403.
 
 Endpoints (default prefix ``/authz``):
-    GET    /authz/roles                          list roles
-    GET    /authz/roles/{role}                   a role's scopes
-    PUT    /authz/roles/{role}                   set a role's scopes  {"scopes": [...]}
-    DELETE /authz/roles/{role}                   delete a role
+    GET    /authz/roles                          list roles (paginated)
+    POST   /authz/roles                          create a role (metadata only)
+    GET    /authz/roles/{slug}                   a role with its scopes
+    PATCH  /authz/roles/{slug}                   update metadata (name/description)
+    DELETE /authz/roles/{slug}                   delete a role
+    PUT    /authz/roles/{slug}/scopes            replace scopes
+    PATCH  /authz/roles/{slug}/scopes            diff scopes (upsert/remove)
     GET    /authz/users/{subject}/roles          a subject's roles
     POST   /authz/users/{subject}/roles          assign a role        {"role": "..."}
     DELETE /authz/users/{subject}/roles/{role}   revoke a role
 """
 
+import time
 from enum import Enum
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
+
+from agno.os.authz.audit import AUDIT_SORT_FIELDS, DEFAULT_AUDIT_SORT_FIELD
+from agno.os.authz.user_store import DEFAULT_USER_SORT_FIELD, USER_SORT_FIELDS
+from agno.os.schema import PaginatedResponse, PaginationInfo, SortOrder
+from agno.os.scopes import AgentOSScope
 
 if TYPE_CHECKING:
     from agno.os.authz.role_store import ManagedRoleStore
+    from agno.os.authz.user_store import ManagedUserStore
 
 
-class SetRoleScopesRequest(BaseModel):
-    scopes: List[str] = Field(..., description="Permissions in agno scope terms, e.g. ['agents:*:read']")
+# --------------------------------------------------------------------- schemas
+def _parse_scope(raw: str) -> tuple:
+    """Split a scope string into (namespace, sub_namespace, permission).
+
+    ``agents:read`` -> ("agents", None, "read")
+    ``agents:*:run`` -> ("agents", "*", "run")
+    ``agent_os:admin`` -> ("agent_os", None, "admin")
+    """
+    parts = raw.split(":")
+    if len(parts) == 2:
+        return parts[0], None, parts[1]
+    if len(parts) >= 3:
+        return parts[0], ":".join(parts[1:-1]), parts[-1]
+    return (parts[0] if parts else "unknown"), None, "unknown"
+
+
+class RoleScopeSchema(BaseModel):
+    """A single permission on a role, parsed and with its allow/deny effect."""
+
+    id: Optional[str] = Field(None, description="Scope id (null — scopes aren't individually addressable here)")
+    raw: str = Field(description="Original scope string, e.g. 'agents:*:read'")
+    namespace: str = Field(description="Resource namespace, e.g. 'agents'")
+    sub_namespace: Optional[str] = Field(None, description="Specific resource id or wildcard '*'")
+    permission: str = Field(description="Action, e.g. 'read' / 'run' / 'write'")
+    value: str = Field(description="'allow' or 'deny'")
+
+    @classmethod
+    def from_entry(cls, entry: dict) -> "RoleScopeSchema":
+        ns, sub, perm = _parse_scope(entry["scope"])
+        return cls(
+            raw=entry["scope"], namespace=ns, sub_namespace=sub, permission=perm, value=entry.get("effect", "allow")
+        )
+
+
+class RoleSchema(BaseModel):
+    """A role with its scopes — mirrors the cloud RoleWithScopes shape (flattened)."""
+
+    slug: str = Field(description="Unique role id")
+    name: str = Field(description="Human-readable display name")
+    description: Optional[str] = Field(None, description="Role description")
+    is_default: bool = Field(False, description="Whether this is a built-in default role")
+    created_at: Optional[int] = Field(None, description="Created (epoch seconds)")
+    updated_at: Optional[int] = Field(None, description="Last updated (epoch seconds)")
+    scopes: List[RoleScopeSchema] = Field(default_factory=list, description="Permissions on this role")
+
+    @classmethod
+    def from_record(cls, rec: dict) -> "RoleSchema":
+        return cls(
+            slug=rec["slug"],
+            name=rec.get("name") or rec["slug"],
+            description=rec.get("description"),
+            is_default=bool(rec.get("is_default", False)),
+            created_at=rec.get("created_at") or None,
+            updated_at=rec.get("updated_at") or None,
+            scopes=[RoleScopeSchema.from_entry(e) for e in rec.get("scopes", [])],
+        )
+
+
+class AuthzUserSchema(BaseModel):
+    """A directory user with their role merged in (one role per user)."""
+
+    id: str = Field(description="User id (the JWT 'sub')")
+    email: Optional[str] = None
+    name: Optional[str] = None
+    status: str = Field(description="'active' or 'disabled'")
+    disabled: bool = False
+    role: Optional[str] = Field(None, description="The user's role slug (one role per user), or null")
+    created_at: Optional[int] = None
+    updated_at: Optional[int] = None
+
+    @classmethod
+    def from_user(cls, user: dict, role: Optional[str]) -> "AuthzUserSchema":
+        return cls(
+            id=user["id"],
+            email=user.get("email"),
+            name=user.get("name"),
+            status="disabled" if user.get("disabled") else "active",
+            disabled=bool(user.get("disabled")),
+            role=role,
+            created_at=user.get("created_at"),
+            updated_at=user.get("updated_at"),
+        )
+
+
+class AvailableScopeItem(BaseModel):
+    """One scope the OS understands (catalog entry — no effect/id, just the shape)."""
+
+    raw: str = Field(description="Scope string, e.g. 'agents:read'")
+    namespace: str = Field(description="Resource namespace, e.g. 'agents'")
+    sub_namespace: Optional[str] = Field(None, description="Sub-namespace if present")
+    permission: str = Field(description="Action/permission, e.g. 'read'")
+
+    @classmethod
+    def from_raw(cls, raw: str) -> "AvailableScopeItem":
+        ns, sub, perm = _parse_scope(raw)
+        return cls(raw=raw, namespace=ns, sub_namespace=sub, permission=perm)
+
+
+class ScopeItem(BaseModel):
+    scope: str = Field(description="Scope string, e.g. 'agents:*:read'")
+    effect: str = Field("allow", description="'allow' or 'deny'")
+
+
+class CreateRoleRequest(BaseModel):
+    """Create a role — metadata only; scopes are managed via /roles/{slug}/scopes."""
+
+    slug: str = Field(..., min_length=1, description="Unique role id")
+    name: Optional[str] = Field(None, description="Display name (defaults to slug)")
+    description: Optional[str] = Field(None, description="Role description")
+    is_default: Optional[bool] = Field(None, description="Mark as a default role")
+
+
+class UpdateRoleRequest(BaseModel):
+    """Metadata-only update (PATCH) — does not touch scopes."""
+
+    name: Optional[str] = Field(None, description="Display name")
+    description: Optional[str] = Field(None, description="Role description")
+    is_default: Optional[bool] = Field(None, description="Mark as a default role")
+
+
+class ReplaceScopesRequest(BaseModel):
+    """Full replace of a role's scopes (PUT /roles/{slug}/scopes)."""
+
+    scopes: List[Union[str, ScopeItem]] = Field(
+        ..., description="Permissions: strings (allow) or {scope, effect} objects"
+    )
+
+
+class PatchScopesRequest(BaseModel):
+    """Scope diff (PATCH /roles/{slug}/scopes): add/flip ``upsert``, drop ``remove``."""
+
+    upsert: List[Union[str, ScopeItem]] = Field(default_factory=list, description="Scopes to add or flip")
+    remove: List[Union[str, ScopeItem]] = Field(default_factory=list, description="Scopes to remove (effect ignored)")
 
 
 class AssignRoleRequest(BaseModel):
     role: str = Field(..., description="Role to grant the subject")
 
 
+class CreateUserRequest(BaseModel):
+    id: str = Field(..., description="The user's id — must equal the JWT 'sub' your app mints for them")
+    email: Optional[str] = Field(None, description="Optional email (label/audit only; not a credential)")
+    name: Optional[str] = Field(None, description="Optional display name")
+
+
+class UpdateUserRequest(BaseModel):
+    email: Optional[str] = Field(None, description="New email")
+    name: Optional[str] = Field(None, description="New display name")
+    disabled: Optional[bool] = Field(
+        None, description="Set the revocation kill-switch: true denies the user on every request, false re-enables"
+    )
+
+
+def _paginated(data: list, page: int, limit: int, total: int, search_time_ms: float = 0) -> PaginatedResponse:
+    """Wrap one already-paged slice in the SDK's PaginatedResponse ({data, meta})."""
+    return PaginatedResponse(
+        data=data,
+        meta=PaginationInfo(
+            page=page,
+            limit=limit,
+            total_count=total,
+            total_pages=(total + limit - 1) // limit if limit > 0 else 0,
+            search_time_ms=search_time_ms,
+        ),
+    )
+
+
+def _page(items: list, page: int, limit: int) -> PaginatedResponse:
+    """Paginate a fully-materialised list."""
+    start = max(page - 1, 0) * limit
+    return _paginated(items[start : start + limit], page, limit, len(items))
+
+
 def get_roles_router(
-    store: "ManagedRoleStore", prefix: str = "/authz", tags: Optional[List[Union[str, Enum]]] = None
+    store: "ManagedRoleStore",
+    prefix: str = "/authz",
+    tags: Optional[List[Union[str, Enum]]] = None,
+    user_store: "Optional[ManagedUserStore]" = None,
 ) -> APIRouter:
-    """Build the admin-only roles-management router bound to ``store``."""
+    """Build the admin-only roles-management router bound to ``store``.
+
+    Pass ``user_store`` to also expose the credential-less user directory
+    (``/authz/users``) for the no-IdP case: list/create/update/remove users and
+    disable (revoke) them. User views merge in each user's roles from ``store``.
+    """
     if tags is None:
         tags = ["Authorization"]
 
     def require_admin(request: Request) -> str:
-        """Gate: caller must be authenticated and an admin of the store."""
+        """Gate: caller must be authenticated and an admin.
+
+        Admin can come from two planes (so both run in parallel on one OS):
+          - the OS-local store (``store.can_manage`` — the end-user/managed plane), or
+          - the token's own scopes carrying the admin scope (the operator plane,
+            e.g. an agno-cloud-minted token for someone who administers this OS).
+        """
         if not getattr(request.state, "authenticated", False):
             raise HTTPException(status_code=401, detail="Not authenticated")
         principal_id = getattr(request.state, "user_id", None)
         claims = getattr(request.state, "claims", {}) or {}
-        if not store.can_manage(principal_id, claims):
-            raise HTTPException(status_code=403, detail="Admin privileges required to manage roles")
-        return principal_id or ""
+        token_scopes = getattr(request.state, "scopes", []) or []
+        admin_scope = getattr(request.state, "admin_scope", None) or AgentOSScope.ADMIN.value
+        if admin_scope in token_scopes or store.can_manage(principal_id, claims):
+            return principal_id or ""
+        raise HTTPException(status_code=403, detail="Admin privileges required to manage roles")
 
     router = APIRouter(prefix=prefix, tags=tags, dependencies=[Depends(require_admin)])
 
+    def _role_or_404(slug: str) -> dict:
+        rec = store.get_role(slug)
+        if rec is None:
+            raise HTTPException(status_code=404, detail=f"Role {slug!r} not found")
+        return rec
+
     # ---- roles ----------------------------------------------------------
-    @router.get("/roles")
-    def list_roles() -> dict:
-        return {"roles": store.list_roles()}
+    @router.get("/roles", response_model=PaginatedResponse[RoleSchema])
+    def list_roles(
+        limit: int = Query(default=20, ge=1, le=100, description="Items per page"),
+        page: int = Query(default=1, ge=1, description="Page number (1-indexed)"),
+    ):
+        roles = [RoleSchema.from_record(r) for r in store.list_roles_detailed()]
+        return _page(roles, page, limit)
 
-    @router.get("/roles/{role}")
-    def get_role(role: str) -> dict:
-        return {"role": role, "scopes": store.get_role_scopes(role)}
-
-    @router.put("/roles/{role}")
-    def set_role(role: str, body: SetRoleScopesRequest, actor: str = Depends(require_admin)) -> dict:
+    @router.post("/roles", response_model=RoleSchema, status_code=201)
+    def create_role(body: CreateRoleRequest, actor: str = Depends(require_admin)):
+        """Create a role (metadata only — RESTful). Add permissions afterwards via
+        PUT/PATCH /roles/{slug}/scopes. Mirrors the cloud POST /roles."""
         try:
-            store.set_role_scopes(role, body.scopes, actor=actor)
+            store.create_role(
+                body.slug, name=body.name, description=body.description, is_default=body.is_default, actor=actor
+            )
+        except FileExistsError:
+            raise HTTPException(status_code=409, detail=f"Role {body.slug!r} already exists")
+        return RoleSchema.from_record(_role_or_404(body.slug))
+
+    @router.get("/roles/{slug}", response_model=RoleSchema)
+    def get_role(slug: str):
+        return RoleSchema.from_record(_role_or_404(slug))
+
+    @router.patch("/roles/{slug}", response_model=RoleSchema)
+    def update_role(slug: str, body: UpdateRoleRequest, actor: str = Depends(require_admin)):
+        """Update a role's metadata only (name/description/is_default) — scopes
+        untouched. Mirrors the cloud PATCH /roles/{slug}."""
+        try:
+            store.set_role_meta(
+                slug, name=body.name, description=body.description, is_default=body.is_default, actor=actor
+            )
+        except KeyError:
+            raise HTTPException(status_code=404, detail=f"Role {slug!r} not found")
+        return RoleSchema.from_record(_role_or_404(slug))
+
+    @router.delete("/roles/{slug}")
+    def delete_role(slug: str, actor: str = Depends(require_admin)) -> dict:
+        store.remove_role(slug, actor=actor)
+        return {"slug": slug, "deleted": True}
+
+    # ---- role scopes (subresource) -------------------------------------
+    def _to_store_scopes(items):
+        return [s if isinstance(s, str) else {"scope": s.scope, "effect": s.effect} for s in items]
+
+    @router.put("/roles/{slug}/scopes", response_model=List[RoleScopeSchema])
+    def replace_role_scopes(slug: str, body: ReplaceScopesRequest, actor: str = Depends(require_admin)):
+        """Replace ALL of a role's scopes (metadata preserved). Mirrors the cloud
+        PUT /roles/{slug}/scopes; returns the resulting scope list."""
+        _role_or_404(slug)
+        try:
+            store.set_role_scopes(slug, _to_store_scopes(body.scopes), actor=actor)
         except ValueError as e:
             raise HTTPException(status_code=422, detail=str(e))
-        return {"role": role, "scopes": store.get_role_scopes(role)}
+        return [RoleScopeSchema.from_entry(e) for e in store.get_role_scope_entries(slug)]
 
-    @router.delete("/roles/{role}")
-    def delete_role(role: str, actor: str = Depends(require_admin)) -> dict:
-        store.remove_role(role, actor=actor)
-        return {"role": role, "deleted": True}
+    @router.patch("/roles/{slug}/scopes", response_model=RoleSchema)
+    def patch_role_scopes(slug: str, body: PatchScopesRequest, actor: str = Depends(require_admin)):
+        """Apply a scope diff: add/flip ``upsert``, drop ``remove`` (everything else
+        kept). Mirrors the cloud PATCH /roles/{slug}/scopes; returns the full role."""
+        _role_or_404(slug)
+        try:
+            store.patch_role_scopes(
+                slug, upsert=_to_store_scopes(body.upsert), remove=_to_store_scopes(body.remove), actor=actor
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e))
+        return RoleSchema.from_record(_role_or_404(slug))
 
     # ---- scope catalog --------------------------------------------------
-    @router.get("/scopes")
-    def list_scopes() -> dict:
-        """The catalog of scopes this AgentOS understands, grouped by resource.
+    @router.get("/scopes", response_model=List[AvailableScopeItem], response_model_exclude_none=True)
+    def list_scopes() -> List[AvailableScopeItem]:
+        """All scopes this AgentOS understands, as a flat list.
 
-        Derived from the OS's own route→scope map, so it always matches what the
-        OS actually enforces. A UI renders this as a resource×action grid; a role
-        is then just a set of the resulting ``resource:action`` strings (plus the
-        ``agent_os:admin`` super-scope).
+        Derived from the OS's own route→scope map (so it always matches what the OS
+        actually enforces) plus the ``agent_os:admin`` super-scope. Each item is
+        parsed into ``{raw, namespace, sub_namespace, permission}`` for a UI to
+        render a resource×action grid. (Single OS: no org-level scopes.)
         """
         from agno.os.scopes import get_default_scope_mappings
 
-        grouped: dict = {}
-        for required in get_default_scope_mappings().values():
-            for scope in required:
-                parts = scope.split(":")
-                if len(parts) == 2:
-                    grouped.setdefault(parts[0], set()).add(parts[1])
-        grouped_sorted = {r: sorted(a) for r, a in sorted(grouped.items())}
-        flat = sorted(f"{r}:{a}" for r, acts in grouped_sorted.items() for a in acts)
-        return {"grouped": grouped_sorted, "scopes": flat, "admin_scope": "agent_os:admin"}
+        raws = {scope for required in get_default_scope_mappings().values() for scope in required}
+        raws.add("agent_os:admin")
+        return [AvailableScopeItem.from_raw(r) for r in sorted(raws)]
 
     # ---- audit ----------------------------------------------------------
+    def _validated_sort_field(sort_by: str) -> str:
+        if sort_by not in AUDIT_SORT_FIELDS:
+            raise HTTPException(status_code=422, detail=f"sort_by must be one of {list(AUDIT_SORT_FIELDS)}")
+        return sort_by
+
     @router.get("/audit")
-    def list_audit(limit: int = 100) -> dict:
-        """Recent *change* events (role/assignment mutations, newest first). Empty
-        unless the store was given a readable audit sink (e.g. DbAuditSink)."""
-        return {"events": store.audit_log(limit)}
+    def list_audit(
+        limit: int = Query(default=100, ge=1, le=1000, description="Items per page"),
+        page: int = Query(default=1, ge=1, description="Page number (1-indexed)"),
+        search: Optional[str] = Query(default=None, description="Filter by actor/action/target (case-insensitive)"),
+        sort_by: str = Query(default=DEFAULT_AUDIT_SORT_FIELD, description="Field to sort by"),
+        sort_order: SortOrder = Query(default=SortOrder.DESC, description="Sort order (asc or desc)"),
+    ) -> PaginatedResponse:
+        """*Change* events (role/assignment mutations), paginated ``{data, meta}``.
+        Empty unless the store was given a readable audit sink (e.g. DbAuditSink)."""
+        start_ms = time.time() * 1000
+        events = store.audit_log(
+            limit,
+            offset=(page - 1) * limit,
+            search=search,
+            sort_by=_validated_sort_field(sort_by),
+            order=sort_order.value,
+        )
+        total = store.audit_count(search=search)
+        return _paginated(events, page, limit, total, search_time_ms=round(time.time() * 1000 - start_ms, 2))
 
     @router.get("/decisions")
-    def list_decisions(request: Request, limit: int = 100) -> dict:
-        """Recent *decision* events (allow/deny per request, newest first).
+    def list_decisions(
+        request: Request,
+        limit: int = Query(default=100, ge=1, le=1000, description="Items per page"),
+        page: int = Query(default=1, ge=1, description="Page number (1-indexed)"),
+        search: Optional[str] = Query(default=None, description="Filter by actor/action/target (case-insensitive)"),
+        sort_by: str = Query(default=DEFAULT_AUDIT_SORT_FIELD, description="Field to sort by"),
+        sort_order: SortOrder = Query(default=SortOrder.DESC, description="Sort order (asc or desc)"),
+    ) -> PaginatedResponse:
+        """*Decision* events (allow/deny per request), paginated ``{data, meta}``.
 
         Decision audit is configured on ``AuthorizationConfig(audit=...)`` and lands
         on ``app.state.authz_audit`` — a separate table from the change trail above,
         so a high-volume decision log never buries the change history. Empty unless a
         readable decision sink (e.g. DbAuditSink) is configured."""
         sink = getattr(request.app.state, "authz_audit", None)
-        events = sink.read_decisions(limit) if sink is not None and hasattr(sink, "read_decisions") else []
-        return {"events": events}
+        if sink is None or not hasattr(sink, "read_decisions"):
+            return _paginated([], page, limit, 0)
+        start_ms = time.time() * 1000
+        events = sink.read_decisions(
+            limit,
+            offset=(page - 1) * limit,
+            search=search,
+            sort_by=_validated_sort_field(sort_by),
+            order=sort_order.value,
+        )
+        total = sink.count_decisions(search=search)
+        return _paginated(events, page, limit, total, search_time_ms=round(time.time() * 1000 - start_ms, 2))
 
     # ---- assignments ----------------------------------------------------
+    def _role_of(subject: str) -> Optional[str]:
+        """The subject's single role, or None (one role per user)."""
+        roles = store.roles_of(subject)
+        return roles[0] if roles else None
+
     @router.get("/users/{subject}/roles")
-    def get_user_roles(subject: str) -> dict:
-        return {"subject": subject, "roles": store.roles_of(subject)}
+    def get_user_role(subject: str) -> dict:
+        return {"subject": subject, "role": _role_of(subject)}
 
     @router.post("/users/{subject}/roles")
     def assign_role(subject: str, body: AssignRoleRequest, actor: str = Depends(require_admin)) -> dict:
         """Set the subject's role. One role per subject: this REPLACES any
         current role (a role select in a UI, not a multi-grant)."""
         store.assign(subject, body.role, actor=actor)
-        return {"subject": subject, "roles": store.roles_of(subject)}
+        return {"subject": subject, "role": _role_of(subject)}
 
     @router.delete("/users/{subject}/roles/{role}")
     def revoke_role(subject: str, role: str, actor: str = Depends(require_admin)) -> dict:
         store.unassign(subject, role, actor=actor)
-        return {"subject": subject, "roles": store.roles_of(subject)}
+        return {"subject": subject, "role": _role_of(subject)}
+
+    # ---- user directory (no-IdP) ---------------------------------------
+    # Only mounted when a user_store is supplied. Identity is still asserted by
+    # the app's JWT; this is a directory + revocation switch, never credentials.
+    if user_store is not None:
+
+        def _user(user: dict) -> AuthzUserSchema:
+            return AuthzUserSchema.from_user(user, _role_of(user["id"]))
+
+        @router.get("/users", response_model=PaginatedResponse[AuthzUserSchema])
+        def list_users(
+            include_disabled: bool = True,
+            limit: int = Query(default=20, ge=1, le=100, description="Items per page"),
+            page: int = Query(default=1, ge=1, description="Page number (1-indexed)"),
+            search: Optional[str] = Query(
+                default=None, description="Filter by id/email/name (case-insensitive substring)"
+            ),
+            sort_by: str = Query(default=DEFAULT_USER_SORT_FIELD, description="Field to sort by"),
+            sort_order: SortOrder = Query(default=SortOrder.DESC, description="Sort order (asc or desc)"),
+        ):
+            if sort_by not in USER_SORT_FIELDS:
+                raise HTTPException(status_code=422, detail=f"sort_by must be one of {list(USER_SORT_FIELDS)}")
+            # Paginate in the store (offset/limit + count) so we don't materialise
+            # the whole directory and resolve roles for every user on each call.
+            # `search` filters before pagination, so meta counts the matches.
+            start_ms = time.time() * 1000
+            rows = user_store.list(
+                limit=limit,
+                offset=(page - 1) * limit,
+                include_disabled=include_disabled,
+                search=search,
+                sort_by=sort_by,
+                order=sort_order.value,
+            )
+            total = user_store.count(include_disabled=include_disabled, search=search)
+            return _paginated(
+                [_user(u) for u in rows],
+                page,
+                limit,
+                total,
+                search_time_ms=round(time.time() * 1000 - start_ms, 2),
+            )
+
+        @router.post("/users", response_model=AuthzUserSchema)
+        def create_user(body: CreateUserRequest, actor: str = Depends(require_admin)):
+            return _user(user_store.upsert(body.id, email=body.email, name=body.name, actor=actor))
+
+        @router.get("/users/{user_id}", response_model=AuthzUserSchema)
+        def get_user(user_id: str):
+            user = user_store.get(user_id)
+            if user is None:
+                raise HTTPException(status_code=404, detail=f"User {user_id!r} not found")
+            return _user(user)
+
+        @router.patch("/users/{user_id}", response_model=AuthzUserSchema)
+        def update_user(user_id: str, body: UpdateUserRequest, actor: str = Depends(require_admin)):
+            """Update a user. ``disabled`` is the revocation kill-switch: a disabled
+            user is denied at the enforcement point on their next request, even
+            with a still-valid token."""
+            user = user_store.upsert(user_id, email=body.email, name=body.name, actor=actor)
+            if body.disabled is not None and body.disabled != user["disabled"]:
+                user = user_store.set_disabled(user_id, body.disabled, actor=actor)
+            return _user(user)
+
+        @router.delete("/users/{user_id}")
+        def delete_user(user_id: str, actor: str = Depends(require_admin)) -> dict:
+            deleted = user_store.remove(user_id, actor=actor)
+            return {"id": user_id, "deleted": deleted}
 
     return router

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -37,12 +37,38 @@ Example::
     store.unassign("bob", "member")
 """
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+import time
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
+from agno.os.authz._db import NO_DB_MESSAGE
+from agno.os.authz._db import engine_from_db as _engine_from_db
+from agno.os.authz._db import engine_from_url as _engine_from_url
+from agno.os.authz.audit import DEFAULT_AUDIT_SORT_FIELD, DEFAULT_AUDIT_SORT_ORDER
 from agno.os.authz.engine import EngineAuthorizationProvider, PolicyEngine, normalize_roles_claim
 
 if TYPE_CHECKING:
     from agno.os.authz.audit import AuditSink
+
+# A scope plus its effect. Inputs accept a bare string (= allow), a (scope, effect)
+# tuple, or a {"scope": ..., "effect"|"value": ...} dict.
+ScopeInput = Union[str, Tuple[str, str], Dict[str, str]]
+
+
+def _normalize_scope(entry: ScopeInput) -> Tuple[str, str]:
+    """Coerce a scope input into ``(scope, effect)`` with effect in {allow, deny}."""
+    if isinstance(entry, str):
+        scope, effect = entry, "allow"
+    elif isinstance(entry, dict):
+        scope = entry.get("scope") or entry.get("raw")  # type: ignore[assignment]
+        effect = entry.get("effect") or entry.get("value") or "allow"
+    else:  # tuple/list
+        scope, effect = entry[0], (entry[1] if len(entry) > 1 else "allow")
+    if not scope:
+        raise ValueError(f"Unrecognised scope entry: {entry!r}")
+    effect = str(effect).lower()
+    if effect not in ("allow", "deny"):
+        raise ValueError(f"scope effect must be 'allow' or 'deny', got {effect!r}")
+    return scope, effect
 
 
 class ManagedRoleStore:
@@ -77,11 +103,15 @@ class ManagedRoleStore:
             decision_log: when True, bump the ``agno.authz.engine`` logger to INFO
                 so every allow/deny decision is logged. Off by default so we don't
                 touch global logging behind your back.
-            db: an agno database (the same object you pass to ``AgentOS(db=...)``).
-                Its SQLAlchemy engine is reused, so roles live in the same database
-                as your agent data. Takes precedence over ``db_url``.
+            db: an agno database (the same object you pass to ``AgentOS(db=...)``,
+                e.g. ``SqliteDb``/``PostgresDb``). Its SQLAlchemy engine is reused,
+                so roles live in the same database as your agent data with one
+                connection pool — no second ``db_url`` to keep in sync. Takes
+                precedence over ``db_url``.
             engine: a custom :class:`~agno.os.authz.engine.PolicyEngine` backend.
-                Defaults to the native engine built from ``db``/``db_url``.
+                Defaults to the native engine built from ``db``/``db_url``. Supply
+                your own to swap the backend (OpenFGA/SpiceDB/...) without changing
+                anything else.
         """
         if engine is not None:
             self._engine: PolicyEngine = engine
@@ -92,6 +122,17 @@ class ManagedRoleStore:
         self._roles_claim = roles_claim
         self._audit = audit
 
+        # Role metadata (display name / description / is_default / timestamps).
+        # The policy engine only stores policies, so metadata needs its own table in
+        # the same DB. Like the engine, it requires a DB — it may arrive later via
+        # attach_db(), so it stays unbound (engine None) until then.
+        self._meta_engine: Any = None  # SQLAlchemy Engine once bound, else None
+        self._meta_table: Any = None  # SQLAlchemy Table for authz_roles metadata
+        if db is not None:
+            self._init_meta_table(_engine_from_db(db))
+        elif db_url is not None:
+            self._init_meta_table(_engine_from_url(db_url))
+
         if decision_log:
             import logging
 
@@ -101,8 +142,8 @@ class ManagedRoleStore:
         self,
         action: str,
         target: str,
-        before: Optional[List[str]],
-        after: Optional[List[str]],
+        before: Optional[List[Any]],
+        after: Optional[List[Any]],
         actor: Optional[str],
     ) -> None:
         """Record one change to the audit sink (no-op when no sink is configured)."""
@@ -123,24 +164,233 @@ class ManagedRoleStore:
             )
         )
 
+    # --------------------------------------------------------- role metadata
+    def _init_meta_table(self, engine: Any) -> None:
+        import sqlalchemy as sa
+
+        self._meta_engine = engine
+        metadata = sa.MetaData()
+        self._meta_table = sa.Table(
+            "authz_roles",
+            metadata,
+            sa.Column("slug", sa.String(255), primary_key=True),  # = the role id/name
+            sa.Column("name", sa.String(255)),  # human-readable display name
+            sa.Column("description", sa.Text),
+            sa.Column("is_default", sa.Boolean, nullable=False, default=False),
+            sa.Column("created_at", sa.Integer, nullable=False),
+            sa.Column("updated_at", sa.Integer, nullable=False),
+        )
+        metadata.create_all(self._meta_engine)
+
+    def _require_meta(self) -> None:
+        if self._meta_engine is None:
+            raise RuntimeError(NO_DB_MESSAGE)
+
+    def _meta_get(self, slug: str) -> Optional[dict]:
+        self._require_meta()
+        import sqlalchemy as sa
+
+        with self._meta_engine.connect() as conn:
+            r = conn.execute(sa.select(self._meta_table).where(self._meta_table.c.slug == slug)).mappings().first()
+        return dict(r) if r else None
+
+    def _meta_get_all(self) -> dict:
+        """All metadata rows as ``{slug: row}`` in a single read, so list views
+        don't do one SELECT per role (N+1)."""
+        self._require_meta()
+        import sqlalchemy as sa
+
+        with self._meta_engine.connect() as conn:
+            rows = conn.execute(sa.select(self._meta_table)).mappings().all()
+        return {r["slug"]: dict(r) for r in rows}
+
+    def _meta_upsert(
+        self,
+        slug: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_default: Optional[bool] = None,
+    ) -> dict:
+        existing = self._meta_get(slug)
+        now = int(time.time())
+        if existing is None:
+            row = {
+                "slug": slug,
+                "name": name or slug,
+                "description": description,
+                "is_default": bool(is_default) if is_default is not None else False,
+                "created_at": now,
+                "updated_at": now,
+            }
+        else:
+            row = dict(existing)
+            if name is not None:
+                row["name"] = name
+            if description is not None:
+                row["description"] = description
+            if is_default is not None:
+                row["is_default"] = bool(is_default)
+            row["updated_at"] = now
+        self._meta_write(row, insert=existing is None)
+        return row
+
+    def _meta_write(self, row: dict, insert: bool) -> None:
+        self._require_meta()
+        import sqlalchemy as sa
+
+        with self._meta_engine.begin() as conn:
+            if insert:
+                conn.execute(sa.insert(self._meta_table).values(**row))
+            else:
+                conn.execute(sa.update(self._meta_table).where(self._meta_table.c.slug == row["slug"]).values(**row))
+
+    def _meta_delete(self, slug: str) -> None:
+        self._require_meta()
+        import sqlalchemy as sa
+
+        with self._meta_engine.begin() as conn:
+            conn.execute(sa.delete(self._meta_table).where(self._meta_table.c.slug == slug))
+
+    def _meta_or_default(self, slug: str) -> dict:
+        """Metadata for a role, synthesising defaults for rows defined before
+        metadata existed (or via the raw enforcer)."""
+        meta = self._meta_get(slug)
+        if meta is not None:
+            return meta
+        return {"slug": slug, "name": slug, "description": None, "is_default": False, "created_at": 0, "updated_at": 0}
+
     # ------------------------------------------------------------------ roles
-    def set_role_scopes(self, role: str, scopes: List[str], actor: Optional[str] = None) -> None:
-        """Define (or replace) what a role can do, in agno scope terms."""
-        before = self.get_role_scopes(role) if self._audit else None
-        self._engine.set_role_scopes(role, [(scope, "allow") for scope in scopes])
-        self._emit("role.set_scopes", role, before, self.get_role_scopes(role) if self._audit else None, actor)
+    def set_role_scopes(
+        self,
+        role: str,
+        scopes: List[ScopeInput],
+        actor: Optional[str] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_default: Optional[bool] = None,
+    ) -> None:
+        """Define (or replace) what a role can do, in agno scope terms.
+
+        ``scopes`` items may be plain strings (granted/allow), ``(scope, effect)``
+        tuples, or ``{"scope": ..., "effect": "allow"|"deny"}`` dicts. Also creates
+        / updates the role's metadata (display ``name`` / ``description`` /
+        ``is_default``)."""
+        # Audit the full entries (scope + effect) so an allow<->deny flip is visible
+        # in the trail; plain scope strings would show no change.
+        before = self.get_role_scope_entries(role) if self._audit else None
+        self._engine.set_role_scopes(role, [_normalize_scope(e) for e in scopes])
+        self._meta_upsert(role, name=name, description=description, is_default=is_default)
+        self._emit("role.set_scopes", role, before, self.get_role_scope_entries(role) if self._audit else None, actor)
 
     def get_role_scopes(self, role: str) -> List[str]:
-        """Return a role's scopes in agno terms (best-effort read-back)."""
-        return sorted(scope for scope, _effect in self._engine.get_role_scopes(role))
+        """Return a role's scope strings (allow + deny), for display/read-back."""
+        return sorted(scope for scope, _ in self._engine.get_role_scopes(role))
+
+    def get_role_scope_entries(self, role: str) -> List[dict]:
+        """Return a role's scopes with effects: ``[{"scope": ..., "effect": ...}]``."""
+        entries = [{"scope": scope, "effect": effect} for scope, effect in self._engine.get_role_scopes(role)]
+        return sorted(entries, key=lambda e: (e["scope"], e["effect"]))
+
+    def create_role(
+        self,
+        role: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_default: Optional[bool] = None,
+        actor: Optional[str] = None,
+    ) -> dict:
+        """Create a role with metadata only — no scopes (add those via
+        set_role_scopes / patch_role_scopes). Raises FileExistsError if it exists."""
+        if self.get_role(role) is not None:
+            raise FileExistsError(role)
+        rec = self._meta_upsert(role, name=name, description=description, is_default=is_default)
+        self._emit("role.created", role, None, [self._meta_summary(rec)], actor)
+        return rec
+
+    def set_role_meta(
+        self,
+        role: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_default: Optional[bool] = None,
+        actor: Optional[str] = None,
+    ) -> dict:
+        """Update ONLY a role's metadata (display name / description / is_default),
+        leaving its scopes untouched. Raises KeyError if the role doesn't exist."""
+        if self.get_role(role) is None:
+            raise KeyError(role)
+        before = self._meta_or_default(role)
+        rec = self._meta_upsert(role, name=name, description=description, is_default=is_default)
+        self._emit("role.updated", role, [self._meta_summary(before)], [self._meta_summary(rec)], actor)
+        return rec
+
+    def patch_role_scopes(
+        self,
+        role: str,
+        upsert: Optional[List[ScopeInput]] = None,
+        remove: Optional[List[ScopeInput]] = None,
+        actor: Optional[str] = None,
+    ) -> None:
+        """Apply a scope diff: add/flip the ``upsert`` scopes and drop the ``remove``
+        scopes, leaving every other scope (and the metadata) intact."""
+        before = self.get_role_scope_entries(role) if self._audit else None
+        for entry in upsert or []:
+            scope, effect = _normalize_scope(entry)
+            self._engine.add_scope(role, scope, effect)
+        for entry in remove or []:
+            scope, _ = _normalize_scope(entry)
+            self._engine.remove_scope(role, scope)
+        self._meta_upsert(role)  # touch updated_at / ensure metadata row exists
+        self._emit("role.set_scopes", role, before, self.get_role_scope_entries(role) if self._audit else None, actor)
+
+    @staticmethod
+    def _meta_summary(rec: dict) -> str:
+        bits = [rec.get("name") or rec["slug"]]
+        if rec.get("description"):
+            bits.append(str(rec["description"]))
+        if rec.get("is_default"):
+            bits.append("default")
+        return " · ".join(bits)
+
+    def get_role(self, role: str) -> Optional[dict]:
+        """Full role record: metadata + scope entries, or None if the role has
+        neither policies nor metadata."""
+        scopes = self.get_role_scope_entries(role)
+        meta = self._meta_get(role)
+        if meta is None and not scopes and role not in self._engine.list_roles():
+            # No metadata, no scopes, and not even an assignment-only role -> absent.
+            return None
+        return {**self._meta_or_default(role), "scopes": scopes}
 
     def remove_role(self, role: str, actor: Optional[str] = None) -> None:
         before = self.get_role_scopes(role) if self._audit else None
         self._engine.remove_role(role)
+        self._meta_delete(role)
         self._emit("role.removed", role, before, None, actor)
 
     def list_roles(self) -> List[str]:
-        return sorted(self._engine.list_roles())
+        """All role slugs (those with policies and/or metadata)."""
+        slugs = set(self._engine.list_roles())
+        if self._meta_engine is not None:
+            import sqlalchemy as sa
+
+            with self._meta_engine.connect() as conn:
+                slugs |= {r[0] for r in conn.execute(sa.select(self._meta_table.c.slug))}
+        return sorted(slugs)
+
+    def list_roles_detailed(self) -> List[dict]:
+        """Every role as a full record (metadata + scope entries).
+
+        Metadata is fetched in one read (not one SELECT per role), and
+        assignment-only roles (a subject is assigned but no scopes/metadata exist
+        yet) are surfaced with an empty scope list rather than dropped."""
+        meta_all = self._meta_get_all()
+        default = {"name": None, "description": None, "is_default": False, "created_at": 0, "updated_at": 0}
+        out: List[dict] = []
+        for slug in self.list_roles():
+            meta = meta_all.get(slug) or {"slug": slug, **default, "name": slug}
+            out.append({**meta, "scopes": self.get_role_scope_entries(slug)})
+        return out
 
     # ------------------------------------------------------------- assignments
     def assign(self, subject: str, role: str, actor: Optional[str] = None) -> None:
@@ -148,8 +398,9 @@ class ManagedRoleStore:
 
         A subject holds at most ONE role at a time — assigning replaces any
         current role rather than accumulating. This mirrors the cloud RBAC model
-        (a membership has one role). No-op if the subject already holds exactly
-        this role.
+        (a membership has one role) so role management is a select, not a
+        multi-grant. Compose permissions in the role's scopes, not by stacking
+        roles on a user. No-op if the subject already holds exactly this role.
         """
         before = self.roles_of(subject)
         if before == [role]:
@@ -175,10 +426,13 @@ class ManagedRoleStore:
 
     @property
     def is_bound(self) -> bool:
-        """True once the store has a DB (passed directly or adopted via
-        :meth:`attach_db`). A custom ``engine=`` is assumed self-managed (bound)."""
+        """True once the store has a DB for both its policy engine and its role
+        metadata (passed directly or adopted via :meth:`attach_db`). A custom
+        ``engine=`` is assumed to manage its own persistence, but the store still
+        needs a DB for the metadata (authz_roles) it owns."""
         flag = getattr(self._engine, "is_bound", None)
-        return bool(flag) if flag is not None else True
+        engine_bound = bool(flag) if flag is not None else True
+        return engine_bound and self._meta_engine is not None
 
     def attach_db(self, db: Any) -> None:
         """Bind an agno ``Db`` to a store created without one, so managed roles
@@ -189,36 +443,57 @@ class ManagedRoleStore:
         if callable(attach):
             attach(db)
 
+        # Bind the metadata table (authz_roles) to the same DB, mirroring the
+        # engine's own attach so policy, assignments, and metadata all land together.
+        # No-op if metadata is already bound or the db isn't SQL-capable.
+        if self._meta_engine is None:
+            try:
+                self._init_meta_table(_engine_from_db(db))
+            except Exception:
+                return
+
     # ------------------------------------------------------------------ audit
-    def audit_log(self, limit: int = 100) -> List[Dict[str, Any]]:
-        """Recent change-audit events (newest first), if the audit sink supports
-        reading (e.g. ``DbAuditSink``). Returns ``[]`` when no readable sink is
-        configured (e.g. a logging-only sink, or no audit at all)."""
+    def audit_log(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        search: Optional[str] = None,
+        sort_by: str = DEFAULT_AUDIT_SORT_FIELD,
+        order: str = DEFAULT_AUDIT_SORT_ORDER,
+    ) -> List[Dict[str, Any]]:
+        """A page of change-audit events (newest first by default), if the audit
+        sink supports reading (e.g. ``DbAuditSink``). ``search`` filters over
+        actor/action/target; ``sort_by`` is any of the sink's sortable fields.
+        Returns ``[]`` when no readable sink is configured (e.g. a logging-only
+        sink, or no audit at all)."""
         sink = self._audit
         if sink is not None and hasattr(sink, "read"):
-            return sink.read(limit)
+            return sink.read(limit, offset=offset, search=search, sort_by=sort_by, order=order)
         return []
+
+    def audit_count(self, search: Optional[str] = None) -> int:
+        """Total number of change-audit events (for pagination, honouring
+        ``search``); 0 when the sink isn't readable."""
+        sink = self._audit
+        if sink is not None and hasattr(sink, "count"):
+            return int(sink.count(search=search))
+        return 0
 
     # ----------------------------------------------------------------- gating
     def can_manage(self, principal_id: Optional[str], claims: Optional[Dict[str, Any]] = None) -> bool:
         """True if the caller may administer roles (i.e. satisfies ``agent_os:admin``).
 
-        An admin can be defined two ways, both handled here:
-          - by a role in this store, or
+        Admin can be defined two ways, both handled via the engine:
+          - by a role in this store (subject -> agent_os:admin), or
           - by a role carried on the token, when ``roles_claim`` is set.
-        Note this is intentionally NOT the generic provider ``check`` (which
-        defers non-resource decisions to route scope mappings and would let any
-        authenticated caller through).
+        Intentionally NOT the generic provider ``check`` (which defers non-resource
+        decisions and would let any authenticated caller through).
         """
         roles = normalize_roles_claim(claims, self._roles_claim)
-        if roles and self._engine.check_scope("agent_os:admin", roles=roles):
-            return True
-        if principal_id:
-            return self._engine.check_scope("agent_os:admin", subject=principal_id)
-        return False
+        return self._engine.check_scope("agent_os:admin", subject=principal_id, roles=roles)
 
     # --------------------------------------------------------------- provider
     @property
-    def provider(self) -> EngineAuthorizationProvider:
-        """The AuthorizationProvider to plug into AuthorizationConfig."""
+    def provider(self):
+        """The AuthorizationProvider to plug into AuthorizationConfig (engine-backed)."""
         return EngineAuthorizationProvider(self._engine, roles_claim=self._roles_claim)

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -1,0 +1,224 @@
+"""Managed roles for AgentOS — agno-native API, native policy engine inside.
+
+This is the "governance product" middle tier: create roles, assign them, and
+change them at runtime, persisted to your own DB. You work entirely in agno
+scope terms (``agents:*:read``, ``agents:research-agent:run``,
+``agent_os:admin``). The decision engine underneath is agno's own
+:class:`~agno.os.authz.native_engine.NativePolicyEngine` (deny-overrides RBAC, no
+third-party dependency). The engine is swappable behind the :class:`PolicyEngine`
+port. A change persists and takes effect on the next request across every
+worker/replica, because decisions read the DB fresh (no in-process cache to go
+stale).
+
+A DB is **required** — managed roles must be persisted, and an in-memory store
+can't stay consistent across the replicas an AgentOS deployment runs. Give the
+store a DB directly (``db=``/``db_url=``) or let AgentOS adopt the OS DB via
+``AuthorizationConfig(role_store=...)``; without one, every operation raises.
+Persistence to a DB needs SQLAlchemy: ``pip install "agno[roles]"`` (or ``agno[os]``).
+
+Example::
+
+    store = ManagedRoleStore(db_url="postgresql+psycopg://...", roles_claim="roles")
+    store.set_role_scopes("member", ["agents:*:read", "agents:research-agent:run"])
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("bob", "member")           # runtime, persisted
+
+    agent_os = AgentOS(
+        agents=[...],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[...],
+            authorization_provider=store.provider,   # plug it in
+        ),
+    )
+
+    # later, live (no redeploy, same token):
+    store.assign("carol", "member")
+    store.unassign("bob", "member")
+"""
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from agno.os.authz.engine import EngineAuthorizationProvider, PolicyEngine, normalize_roles_claim
+
+if TYPE_CHECKING:
+    from agno.os.authz.audit import AuditSink
+
+
+class ManagedRoleStore:
+    """Runtime-mutable, persisted role store. agno-native API; the policy engine
+    (the native engine by default) is a swappable backend behind the
+    :class:`PolicyEngine` port — pass ``engine=`` to use a different one."""
+
+    def __init__(
+        self,
+        db_url: Optional[str] = None,
+        roles_claim: Optional[str] = None,
+        audit: Optional["AuditSink"] = None,
+        decision_log: bool = False,
+        db: Optional[Any] = None,
+        engine: Optional[PolicyEngine] = None,
+    ):
+        """
+        Args:
+            db_url: SQLAlchemy URL for the DB that holds the policy (e.g.
+                ``postgresql+psycopg://...`` or ``sqlite:///roles.db``). Use your
+                own database. If omitted (and no ``db``/``engine``), the store is
+                unbound and must be bound before use — by AgentOS adopting the OS DB
+                via ``role_store=``, or it raises. A DB is required; there is no
+                in-memory mode (it couldn't stay consistent across replicas).
+            roles_claim: JWT claim carrying a caller's roles (the external-IdP
+                case). When absent, roles come from this store's own assignments
+                (the no-IdP case). Both are served by the same store.
+            audit: optional :class:`~agno.os.authz.audit.AuditSink`. When set,
+                every role/assignment change emits an append-only AuditEvent with
+                the acting principal and the before/after (the change audit the
+                policy engine can't give you, since it never sees the actor).
+            decision_log: when True, bump the ``agno.authz.engine`` logger to INFO
+                so every allow/deny decision is logged. Off by default so we don't
+                touch global logging behind your back.
+            db: an agno database (the same object you pass to ``AgentOS(db=...)``).
+                Its SQLAlchemy engine is reused, so roles live in the same database
+                as your agent data. Takes precedence over ``db_url``.
+            engine: a custom :class:`~agno.os.authz.engine.PolicyEngine` backend.
+                Defaults to the native engine built from ``db``/``db_url``.
+        """
+        if engine is not None:
+            self._engine: PolicyEngine = engine
+        else:
+            from agno.os.authz.native_engine import NativePolicyEngine
+
+            self._engine = NativePolicyEngine(db_url=db_url, db=db)
+        self._roles_claim = roles_claim
+        self._audit = audit
+
+        if decision_log:
+            import logging
+
+            logging.getLogger("agno.authz.engine").setLevel(logging.INFO)
+
+    def _emit(
+        self,
+        action: str,
+        target: str,
+        before: Optional[List[str]],
+        after: Optional[List[str]],
+        actor: Optional[str],
+    ) -> None:
+        """Record one change to the audit sink (no-op when no sink is configured)."""
+        if self._audit is None:
+            return
+        import time
+
+        from agno.os.authz.audit import AuditEvent
+
+        self._audit.record(
+            AuditEvent(
+                action=action,
+                actor=actor,
+                target=target,
+                before=before,
+                after=after,
+                timestamp=int(time.time()),
+            )
+        )
+
+    # ------------------------------------------------------------------ roles
+    def set_role_scopes(self, role: str, scopes: List[str], actor: Optional[str] = None) -> None:
+        """Define (or replace) what a role can do, in agno scope terms."""
+        before = self.get_role_scopes(role) if self._audit else None
+        self._engine.set_role_scopes(role, [(scope, "allow") for scope in scopes])
+        self._emit("role.set_scopes", role, before, self.get_role_scopes(role) if self._audit else None, actor)
+
+    def get_role_scopes(self, role: str) -> List[str]:
+        """Return a role's scopes in agno terms (best-effort read-back)."""
+        return sorted(scope for scope, _effect in self._engine.get_role_scopes(role))
+
+    def remove_role(self, role: str, actor: Optional[str] = None) -> None:
+        before = self.get_role_scopes(role) if self._audit else None
+        self._engine.remove_role(role)
+        self._emit("role.removed", role, before, None, actor)
+
+    def list_roles(self) -> List[str]:
+        return sorted(self._engine.list_roles())
+
+    # ------------------------------------------------------------- assignments
+    def assign(self, subject: str, role: str, actor: Optional[str] = None) -> None:
+        """Give a subject THE role (runtime, persisted).
+
+        A subject holds at most ONE role at a time — assigning replaces any
+        current role rather than accumulating. This mirrors the cloud RBAC model
+        (a membership has one role). No-op if the subject already holds exactly
+        this role.
+        """
+        before = self.roles_of(subject)
+        if before == [role]:
+            return  # already exactly this role; no change, no audit noise
+        for existing in before:
+            self._engine.unassign(subject, existing)
+        self._engine.assign(subject, role)
+        self._emit(
+            "user.assigned",
+            subject,
+            before if self._audit else None,
+            self.roles_of(subject) if self._audit else None,
+            actor,
+        )
+
+    def unassign(self, subject: str, role: str, actor: Optional[str] = None) -> None:
+        before = self.roles_of(subject) if self._audit else None
+        self._engine.unassign(subject, role)
+        self._emit("user.unassigned", subject, before, self.roles_of(subject) if self._audit else None, actor)
+
+    def roles_of(self, subject: str) -> List[str]:
+        return self._engine.roles_of(subject)
+
+    @property
+    def is_bound(self) -> bool:
+        """True once the store has a DB (passed directly or adopted via
+        :meth:`attach_db`). A custom ``engine=`` is assumed self-managed (bound)."""
+        flag = getattr(self._engine, "is_bound", None)
+        return bool(flag) if flag is not None else True
+
+    def attach_db(self, db: Any) -> None:
+        """Bind an agno ``Db`` to a store created without one, so managed roles
+        persist in (and read fresh from) that DB. No-op if the store already has its
+        own DB, or the db isn't SQL-capable. AgentOS calls this to default a managed
+        store to the OS database when you pass ``AuthorizationConfig(role_store=...)``."""
+        attach = getattr(self._engine, "attach_db", None)
+        if callable(attach):
+            attach(db)
+
+    # ------------------------------------------------------------------ audit
+    def audit_log(self, limit: int = 100) -> List[Dict[str, Any]]:
+        """Recent change-audit events (newest first), if the audit sink supports
+        reading (e.g. ``DbAuditSink``). Returns ``[]`` when no readable sink is
+        configured (e.g. a logging-only sink, or no audit at all)."""
+        sink = self._audit
+        if sink is not None and hasattr(sink, "read"):
+            return sink.read(limit)
+        return []
+
+    # ----------------------------------------------------------------- gating
+    def can_manage(self, principal_id: Optional[str], claims: Optional[Dict[str, Any]] = None) -> bool:
+        """True if the caller may administer roles (i.e. satisfies ``agent_os:admin``).
+
+        An admin can be defined two ways, both handled here:
+          - by a role in this store, or
+          - by a role carried on the token, when ``roles_claim`` is set.
+        Note this is intentionally NOT the generic provider ``check`` (which
+        defers non-resource decisions to route scope mappings and would let any
+        authenticated caller through).
+        """
+        roles = normalize_roles_claim(claims, self._roles_claim)
+        if roles and self._engine.check_scope("agent_os:admin", roles=roles):
+            return True
+        if principal_id:
+            return self._engine.check_scope("agent_os:admin", subject=principal_id)
+        return False
+
+    # --------------------------------------------------------------- provider
+    @property
+    def provider(self) -> EngineAuthorizationProvider:
+        """The AuthorizationProvider to plug into AuthorizationConfig."""
+        return EngineAuthorizationProvider(self._engine, roles_claim=self._roles_claim)

--- a/libs/agno/agno/os/authz/scope_provider.py
+++ b/libs/agno/agno/os/authz/scope_provider.py
@@ -1,0 +1,60 @@
+"""Default authorization provider: JWT-scope RBAC.
+
+This is the built-in implementation and preserves AgentOS's existing behaviour
+exactly — it delegates to :func:`agno.os.scopes.has_required_scopes` and
+:func:`agno.os.scopes.get_accessible_resource_ids`, the same functions the
+request pipeline used before the provider seam existed. No external service, no
+new dependency: it runs against the scopes already in the JWT.
+
+Swapping to a different model (OpenFGA, Cerbos, a bespoke ReBAC engine)
+means implementing :class:`agno.os.authz.provider.AuthorizationProvider`
+instead of this class — the rest of the pipeline is unchanged.
+"""
+
+from typing import List, Set
+
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+from agno.os.scopes import get_accessible_resource_ids, has_required_scopes
+
+
+class ScopeAuthorizationProvider(AuthorizationProvider):
+    """RBAC via JWT scope strings (``resource:action``, ``resource:<id>:action``)."""
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        # A non-resource check (no resource_type) can't be expressed as a scope
+        # here; treat it as allowed and let route-level scope mappings handle it.
+        if not ctx.resource_type or not ctx.action:
+            return True
+
+        required = [f"{ctx.resource_type}:{ctx.action}"]
+        return has_required_scopes(
+            ctx.scopes,
+            required,
+            resource_type=ctx.resource_type,
+            resource_id=ctx.resource_id,
+            admin_scope=ctx.admin_scope,
+        )
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        if not ctx.resource_type:
+            return set()
+        return get_accessible_resource_ids(
+            ctx.scopes,
+            ctx.resource_type,
+            admin_scope=ctx.admin_scope,
+            action=ctx.action,
+        )
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes: List[str]) -> bool:
+        """Original middleware route gate: does the token satisfy the scopes the
+        route requires, in the context of the resource being accessed.
+        """
+        if not required_scopes:
+            return True
+        return has_required_scopes(
+            ctx.scopes,
+            required_scopes,
+            resource_type=ctx.resource_type,
+            resource_id=ctx.resource_id,
+            admin_scope=ctx.admin_scope,
+        )

--- a/libs/agno/agno/os/authz/user_store.py
+++ b/libs/agno/agno/os/authz/user_store.py
@@ -1,0 +1,403 @@
+"""Managed users for AgentOS — a credential-less user directory.
+
+This is the "no IdP" tier. When a customer has no external identity provider,
+their app still authenticates users its own way and mints a JWT that AgentOS
+verifies (see :class:`~agno.os.middleware.jwt.JWTValidator`). agno does NOT store
+passwords and is NOT an authenticator — it owns a *directory* of the users the
+app asserts, plus their roles (via :class:`ManagedRoleStore`) and enforcement.
+
+What this store buys you over "roles only":
+    - **Enumeration / management UX**: list the users that exist, not just react
+      to whatever ``sub`` shows up in a token. Pick a user to assign a role.
+    - **A real off-switch**: ``disabled`` is checked at the enforcement point, so
+      a disabled user is denied *even with a still-valid token* — instant
+      revocation you can't get from token expiry alone.
+    - **Audit/identity enrichment**: map an opaque ``sub`` to an email/name in the
+      decision and change trails.
+
+It is deliberately small: a user is ``id`` (the JWT ``sub``), optional ``email``
+/ ``name``, a ``disabled`` flag, timestamps, and free-form ``metadata``. No
+credentials, ever.
+
+Two ways users land in the directory:
+    - **Explicit**: an admin creates them up front (``upsert``) and assigns roles.
+    - **Just-in-time**: on the first valid token from an unknown subject, AgentOS
+      can auto-provision a row from the token's claims (opt-in; see
+      ``provision_from_claims`` and ``AuthorizationConfig``).
+
+Backed by your own DB via SQLAlchemy (pass ``db_url``/``engine``); falls back to
+in-memory when neither is given (fine for tests, not for production).
+"""
+
+import json
+import time
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from agno.os.authz.audit import AuditSink
+
+# The directory's list contract: which fields a page can be sorted by / searched
+# over, and the defaults. The roles router validates request params against
+# these, so they have one owner.
+USER_SORT_FIELDS = ("created_at", "updated_at", "id", "email", "name")
+USER_SEARCH_FIELDS = ("id", "email", "name")
+DEFAULT_USER_SORT_FIELD = "created_at"
+DEFAULT_USER_SORT_ORDER = "desc"
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+class ManagedUserStore:
+    """Credential-less user directory. agno-native; identity asserted externally."""
+
+    def __init__(
+        self,
+        db_url: Optional[str] = None,
+        engine: Optional[Any] = None,
+        table_name: str = "authz_users",
+        create_table: bool = True,
+        audit: Optional["AuditSink"] = None,
+        db: Optional[Any] = None,
+    ):
+        """
+        Args:
+            db_url: SQLAlchemy URL for the DB that holds the directory (e.g.
+                ``postgresql+psycopg://...`` or ``sqlite:///users.db``). If
+                ``db_url``, ``engine`` and ``db`` are all omitted, the store is
+                in-memory.
+            engine: an existing SQLAlchemy engine (takes precedence over db_url).
+            table_name: directory table name (default ``authz_users``).
+            create_table: create the table if missing (default True).
+            audit: optional :class:`~agno.os.authz.audit.AuditSink`. When set,
+                every directory change emits an append-only AuditEvent with the
+                acting principal and the before/after (same trail as role changes).
+            db: an agno database (the same object you pass to ``AgentOS(db=...)``).
+                Its SQLAlchemy engine is reused, so the directory lives in the same
+                database as your agent data. Takes precedence over ``db_url``.
+        """
+        self._audit = audit
+        self._mem: Optional[Dict[str, dict]] = None
+        self._engine: Any = None  # SQLAlchemy Engine when db-backed, else None
+        self._table: Any = None  # SQLAlchemy Table for authz_users
+
+        if db is not None and engine is None:
+            from agno.os.authz._db import engine_from_db
+
+            engine = engine_from_db(db)
+
+        if engine is not None or db_url is not None:
+            import sqlalchemy as sa
+
+            self._engine = engine if engine is not None else sa.create_engine(db_url)  # type: ignore[arg-type]
+            metadata = sa.MetaData()
+            self._table = sa.Table(
+                table_name,
+                metadata,
+                sa.Column("id", sa.String(255), primary_key=True),  # the JWT sub
+                sa.Column("email", sa.String(320)),
+                sa.Column("name", sa.String(255)),
+                sa.Column("disabled", sa.Boolean, nullable=False, default=False),
+                sa.Column("created_at", sa.Integer, nullable=False),
+                sa.Column("updated_at", sa.Integer, nullable=False),
+                sa.Column("user_metadata", sa.Text),
+            )
+            if create_table:
+                metadata.create_all(self._engine)
+        else:
+            # In-memory directory (not persisted). Fine for tests/dev.
+            self._mem = {}
+
+    # ------------------------------------------------------------------ audit
+    def _emit(
+        self,
+        action: str,
+        target: str,
+        before: Optional[List[str]],
+        after: Optional[List[str]],
+        actor: Optional[str],
+    ) -> None:
+        if self._audit is None:
+            return
+        from agno.os.authz.audit import AuditEvent
+
+        self._audit.record(
+            AuditEvent(action=action, actor=actor, target=target, before=before, after=after, timestamp=_now())
+        )
+
+    # ------------------------------------------------------------------ writes
+    def upsert(
+        self,
+        id: str,
+        email: Optional[str] = None,
+        name: Optional[str] = None,
+        metadata: Optional[dict] = None,
+        actor: Optional[str] = None,
+    ) -> dict:
+        """Create a user, or update the provided fields of an existing one.
+
+        Only fields you pass are changed; omitted fields are left as-is on an
+        existing user (so a metadata-light update can't blank out an email).
+        ``disabled`` is intentionally NOT settable here — use
+        :meth:`set_disabled` so enable/disable is an explicit, audited action.
+        """
+        existing = self.get(id)
+        now = _now()
+        if existing is None:
+            row = {
+                "id": id,
+                "email": email,
+                "name": name,
+                "disabled": False,
+                "created_at": now,
+                "updated_at": now,
+                "metadata": metadata or None,
+            }
+            self._write(row, insert=True)
+            self._emit("user.created", id, None, [self._summary(row)], actor)
+            return row
+
+        row = dict(existing)
+        if email is not None:
+            row["email"] = email
+        if name is not None:
+            row["name"] = name
+        if metadata is not None:
+            row["metadata"] = metadata
+        row["updated_at"] = now
+        self._write(row, insert=False)
+        self._emit("user.updated", id, [self._summary(existing)], [self._summary(row)], actor)
+        return row
+
+    def set_disabled(self, id: str, disabled: bool, actor: Optional[str] = None) -> dict:
+        """Disable (or re-enable) a user. A disabled user is denied at the
+        enforcement point even with a valid token — this is the revocation hook."""
+        existing = self.get(id)
+        if existing is None:
+            # Unknown subject: write a single durable tombstone in the TARGET state
+            # (the app may mint tokens for a sub we've not seen) and emit only the
+            # disable/enable event — no spurious "user.created … active" round-trip.
+            now = _now()
+            row = {
+                "id": id,
+                "email": None,
+                "name": None,
+                "disabled": bool(disabled),
+                "created_at": now,
+                "updated_at": now,
+                "metadata": None,
+            }
+            self._write(row, insert=True)
+            self._emit("user.disabled" if disabled else "user.enabled", id, None, [self._summary(row)], actor)
+            return row
+
+        if bool(existing["disabled"]) == bool(disabled):
+            return existing  # no-op, no event
+
+        row = dict(existing)
+        row["disabled"] = bool(disabled)
+        row["updated_at"] = _now()
+        self._write(row, insert=False)
+        self._emit(
+            "user.disabled" if disabled else "user.enabled", id, [self._summary(existing)], [self._summary(row)], actor
+        )
+        return row
+
+    def remove(self, id: str, actor: Optional[str] = None) -> bool:
+        """Delete a user from the directory. Does NOT remove role assignments —
+        those live in the role store; remove them there if needed.
+
+        NOTE: delete is NOT a revocation primitive. With JIT auto-provisioning on
+        (``AuthorizationConfig(auto_provision_users=True)``), the next valid token
+        from this subject re-creates the row as *active*, and any surviving role
+        assignments come back with it. To revoke access, use :meth:`set_disabled`
+        (a durable tombstone enforced at every request), not :meth:`remove`."""
+        existing = self.get(id)
+        if existing is None:
+            return False
+        if self._mem is not None:
+            self._mem.pop(id, None)
+        else:
+            import sqlalchemy as sa
+
+            with self._engine.begin() as conn:  # type: ignore[union-attr]
+                conn.execute(sa.delete(self._table).where(self._table.c.id == id))  # type: ignore[union-attr]
+        self._emit("user.removed", id, [self._summary(existing)], None, actor)
+        return True
+
+    def provision_from_claims(
+        self,
+        subject: str,
+        claims: Dict[str, Any],
+        email_claim: str = "email",
+        name_claim: str = "name",
+        actor: Optional[str] = None,
+    ) -> dict:
+        """Just-in-time: create a directory row for ``subject`` from token claims if
+        it doesn't exist yet. No-op if the user is already present. Returns the user."""
+        existing = self.get(subject)
+        if existing is not None:
+            return existing
+        return self.upsert(
+            subject,
+            email=claims.get(email_claim),
+            name=claims.get(name_claim),
+            actor=actor or "system:jit",
+        )
+
+    # ------------------------------------------------------------------ reads
+    def get(self, id: str) -> Optional[dict]:
+        if self._mem is not None:
+            row = self._mem.get(id)
+            return dict(row) if row else None
+
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:  # type: ignore[union-attr]
+            r = conn.execute(sa.select(self._table).where(self._table.c.id == id)).mappings().first()  # type: ignore[union-attr]
+        return self._row_to_dict(r) if r else None
+
+    # list() and count() apply the same filters (include_disabled + search) over
+    # whichever backend is active; these two helpers are that shared filtering.
+    def _filtered_mem_rows(self, include_disabled: bool, search: Optional[str]) -> List[dict]:
+        def matches(row: dict, needle: str) -> bool:
+            return any(needle in (row.get(f) or "").casefold() for f in USER_SEARCH_FIELDS)
+
+        rows = list(self._mem.values())  # type: ignore[union-attr]
+        if not include_disabled:
+            rows = [r for r in rows if not r["disabled"]]
+        if search:
+            needle = search.casefold()
+            rows = [r for r in rows if matches(r, needle)]
+        return rows
+
+    def _sql_filters(self, include_disabled: bool, search: Optional[str]) -> list:
+        import sqlalchemy as sa
+
+        clauses = []
+        if not include_disabled:
+            clauses.append(self._table.c.disabled.is_(False))  # type: ignore[union-attr]
+        if search:
+            pattern = f"%{search}%"
+            clauses.append(sa.or_(*(self._table.c[f].ilike(pattern) for f in USER_SEARCH_FIELDS)))  # type: ignore[index]
+        return clauses
+
+    def list(
+        self,
+        limit: int = 1000,
+        include_disabled: bool = True,
+        offset: int = 0,
+        search: Optional[str] = None,
+        sort_by: str = DEFAULT_USER_SORT_FIELD,
+        order: str = DEFAULT_USER_SORT_ORDER,
+    ) -> List[dict]:
+        """A page of users, optionally excluding disabled ones.
+
+        ``offset``/``limit`` page in the store so callers don't materialise the
+        whole directory; pair with :meth:`count` for the total. ``search``
+        filters case-insensitively by substring across id, email, and name;
+        ``sort_by`` is any of :data:`USER_SORT_FIELDS` (newest first by default)."""
+        if sort_by not in USER_SORT_FIELDS:
+            raise ValueError(f"sort_by must be one of {USER_SORT_FIELDS}, got {sort_by!r}")
+        descending = order != "asc"
+        if self._mem is not None:
+            # Rows missing the field (email/name are optional) go last in either
+            # direction, matching the nullslast() on the SQL path.
+            rows = self._filtered_mem_rows(include_disabled, search)
+            present = sorted(
+                (r for r in rows if r.get(sort_by) is not None), key=lambda r: r[sort_by], reverse=descending
+            )
+            missing = [r for r in rows if r.get(sort_by) is None]
+            return [dict(r) for r in (present + missing)[offset : offset + limit]]
+
+        import sqlalchemy as sa
+
+        sort_col = self._table.c[sort_by]  # type: ignore[index]
+        stmt = (
+            sa.select(self._table)
+            .where(*self._sql_filters(include_disabled, search))
+            # nullslast: backends disagree on NULL placement (and email/name are
+            # nullable); pin them last in either direction.
+            .order_by(sa.nullslast(sort_col.desc() if descending else sort_col.asc()))
+            .limit(limit)
+            .offset(offset)
+        )
+        with self._engine.connect() as conn:
+            db_rows = conn.execute(stmt).mappings().all()
+        return [self._row_to_dict(r) for r in db_rows]
+
+    def count(self, include_disabled: bool = True, search: Optional[str] = None) -> int:
+        """Total number of users (for pagination), with the same filters as
+        :meth:`list`."""
+        if self._mem is not None:
+            return len(self._filtered_mem_rows(include_disabled, search))
+
+        import sqlalchemy as sa
+
+        stmt = sa.select(sa.func.count()).select_from(self._table).where(*self._sql_filters(include_disabled, search))  # type: ignore[arg-type]
+        with self._engine.connect() as conn:  # type: ignore[union-attr]
+            return int(conn.execute(stmt).scalar() or 0)
+
+    def is_disabled(self, id: Optional[str]) -> bool:
+        """Fast path for the enforcement point: True only if the user exists AND is
+        disabled. Unknown subjects are NOT disabled (the app may legitimately mint
+        tokens for users not yet in the directory)."""
+        if not id:
+            return False
+        if self._mem is not None:
+            row = self._mem.get(id)
+            return bool(row and row["disabled"])
+
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:  # type: ignore[union-attr]
+            r = conn.execute(
+                sa.select(self._table.c.disabled).where(self._table.c.id == id)  # type: ignore[union-attr]
+            ).first()
+        return bool(r and r[0])
+
+    # ------------------------------------------------------------------ helpers
+    @staticmethod
+    def _summary(row: dict) -> str:
+        """Compact, non-secret one-line representation for the audit before/after."""
+        bits = [row["id"]]
+        if row.get("email"):
+            bits.append(row["email"])
+        bits.append("disabled" if row.get("disabled") else "active")
+        return " ".join(bits)
+
+    def _row_to_dict(self, r) -> dict:
+        return {
+            "id": r["id"],
+            "email": r["email"],
+            "name": r["name"],
+            "disabled": bool(r["disabled"]),
+            "created_at": r["created_at"],
+            "updated_at": r["updated_at"],
+            "metadata": json.loads(r["user_metadata"]) if r["user_metadata"] else None,
+        }
+
+    def _write(self, row: dict, insert: bool) -> None:
+        if self._mem is not None:
+            self._mem[row["id"]] = dict(row)
+            return
+
+        import sqlalchemy as sa
+
+        values = {
+            "id": row["id"],
+            "email": row["email"],
+            "name": row["name"],
+            "disabled": bool(row["disabled"]),
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "user_metadata": json.dumps(row["metadata"]) if row.get("metadata") else None,
+        }
+        with self._engine.begin() as conn:  # type: ignore[union-attr]
+            if insert:
+                conn.execute(sa.insert(self._table).values(**values))  # type: ignore[union-attr]
+            else:
+                conn.execute(
+                    sa.update(self._table).where(self._table.c.id == row["id"]).values(**values)  # type: ignore[union-attr]
+                )

--- a/libs/agno/agno/os/authz/user_store.py
+++ b/libs/agno/agno/os/authz/user_store.py
@@ -226,6 +226,34 @@ class ManagedUserStore:
         self._emit("user.removed", id, [self._summary(existing)], None, actor)
         return True
 
+    def remove_many(self, ids: List[str], actor: Optional[str] = None) -> List[str]:
+        """Delete multiple users from the directory in one operation. Returns the
+        ids that actually existed and were removed (unknown ids are skipped, not
+        an error). Like :meth:`remove`, this does NOT touch role assignments and
+        is NOT a revocation primitive (see that method's note); for durable
+        revocation use :meth:`set_disabled`."""
+        if not ids:
+            return []
+
+        # Resolve existing rows first: we only emit/return for ids that were
+        # really present, and we need their before-images for the audit trail.
+        existing = {id: row for id in dict.fromkeys(ids) if (row := self.get(id)) is not None}
+        if not existing:
+            return []
+
+        if self._mem is not None:
+            for id in existing:
+                self._mem.pop(id, None)
+        else:
+            import sqlalchemy as sa
+
+            with self._engine.begin() as conn:  # type: ignore[union-attr]
+                conn.execute(sa.delete(self._table).where(self._table.c.id.in_(list(existing))))  # type: ignore[union-attr]
+
+        for id, row in existing.items():
+            self._emit("user.removed", id, [self._summary(row)], None, actor)
+        return list(existing)
+
     def provision_from_claims(
         self,
         subject: str,

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -147,6 +147,23 @@ class AuthorizationConfig(BaseModel):
     # (allow/deny) alongside the change trail, so you get an access audit, not just a
     # change audit. Pass the same sink you give ManagedRoleStore to unify both.
     audit: Optional[AuditSink] = None
+    # Optional ManagedUserStore — the credential-less user directory for the no-IdP
+    # case. When set, AgentOS denies a disabled user at the enforcement point
+    # (revocation that outlives a valid token) and can auto-provision a directory row
+    # from token claims. Identity is still asserted by the JWT; this never stores
+    # credentials.
+    user_store: Optional[Any] = None
+    # Just-in-time provisioning: when True, the first valid token from a subject not
+    # yet in the directory creates a row from the token claims below.
+    auto_provision_users: bool = False
+    user_email_claim: str = "email"
+    user_name_claim: str = "name"
+    # How to treat a user-directory read that errors (e.g. the directory DB is
+    # unreachable) while checking the disabled flag. Default False = fail OPEN (let
+    # the request through; availability over the kill-switch). Set True to fail CLOSED
+    # (reject with 503) so a directory outage can't silently re-enable every
+    # disabled/compromised account.
+    directory_error_fail_closed: bool = False
     # Opt-in per-user data isolation. When True, AgentOS:
     #   - threads the JWT sub as ``user_id`` on every user-scoped DB read
     #     (sessions, memory, traces) for non-admin callers

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -4,6 +4,10 @@ from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Set, T
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from agno.os.authz.audit import AuditSink
+from agno.os.authz.provider import AuthorizationProvider
+from agno.os.authz.role_store import ManagedRoleStore
+
 # Tags carried by the built-in MCP tools, exposed here so callers (and the IDE) can see
 # the valid values for ``MCPServerConfig.include_tags`` / ``exclude_tags`` without reading
 # ``agno/os/mcp.py``. Keep in sync with the ``tags={...}`` argument on each
@@ -121,12 +125,28 @@ class MCPServerConfig(BaseModel):
 class AuthorizationConfig(BaseModel):
     """Configuration for the JWT middleware"""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     verification_keys: Optional[List[str]] = None
     jwks_file: Optional[str] = None
     algorithm: Optional[str] = None
     verify_audience: Optional[bool] = None
     audience: Optional[str] = None
     admin_scope: Optional[str] = None
+    # Pluggable authorization strategy. When None, AgentOS uses scope-based RBAC
+    # (JWT/PAT scopes, no external dependency). Supply an AuthorizationProvider to
+    # swap in a richer model (managed roles, ReBAC/ABAC, OpenFGA, ...) enforced at
+    # the same points as scopes — the REST route gate, per-resource gate, WS gates,
+    # and MCP tool gate all resolve through it.
+    authorization_provider: Optional[AuthorizationProvider] = None
+    # Managed-roles shortcut: pass a ManagedRoleStore and AgentOS uses its provider
+    # (mutually exclusive with authorization_provider). If the store has no DB, AgentOS
+    # binds the OS database to it so roles persist alongside agent data.
+    role_store: Optional[ManagedRoleStore] = None
+    # Optional AuditSink. When set, AgentOS records each authorization decision
+    # (allow/deny) alongside the change trail, so you get an access audit, not just a
+    # change audit. Pass the same sink you give ManagedRoleStore to unify both.
+    audit: Optional[AuditSink] = None
     # Opt-in per-user data isolation. When True, AgentOS:
     #   - threads the JWT sub as ``user_id`` on every user-scoped DB read
     #     (sessions, memory, traces) for non-admin callers
@@ -137,6 +157,15 @@ class AuthorizationConfig(BaseModel):
     # When False (default) JWT/RBAC still apply, but routes operate on the
     # unscoped DB and don't add per-user ownership gates on top of RBAC.
     user_isolation: bool = False
+
+    @model_validator(mode="after")
+    def _provider_xor_role_store(self) -> "AuthorizationConfig":
+        if self.role_store is not None and self.authorization_provider is not None:
+            raise ValueError(
+                "Pass either authorization_provider or role_store on AuthorizationConfig, not both — "
+                "role_store is the shortcut that wires the store's provider for you."
+            )
+        return self
 
 
 class EvalsDomainConfig(BaseModel):

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -1,6 +1,6 @@
 """Schemas related to the AgentOS configuration"""
 
-from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Set, TypeVar
+from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Set, TypeVar, Union
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -137,8 +137,10 @@ class AuthorizationConfig(BaseModel):
     # (JWT/PAT scopes, no external dependency). Supply an AuthorizationProvider to
     # swap in a richer model (managed roles, ReBAC/ABAC, OpenFGA, ...) enforced at
     # the same points as scopes — the REST route gate, per-resource gate, WS gates,
-    # and MCP tool gate all resolve through it.
-    authorization_provider: Optional[AuthorizationProvider] = None
+    # and MCP tool gate all resolve through it. Pass a LIST of them to run several
+    # authz planes at once (e.g. token scopes for operators + a managed role store
+    # for end users) — a request is allowed if any of them allows it.
+    authorization_provider: Optional[Union[AuthorizationProvider, List[AuthorizationProvider]]] = None
     # Managed-roles shortcut: pass a ManagedRoleStore and AgentOS uses its provider
     # (mutually exclusive with authorization_provider). If the store has no DB, AgentOS
     # binds the OS database to it so roles persist alongside agent data.

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -1171,7 +1171,19 @@ def _identity_bridge_kwargs(os: "AgentOS") -> Dict[str, Any]:
     config = getattr(os, "authorization_config", None)
     admin_scope = getattr(config, "admin_scope", None) if config is not None else None
     user_isolation = bool(getattr(config, "user_isolation", False)) if config is not None else False
-    return {"admin_scope": admin_scope or AgentOSScope.ADMIN.value, "user_isolation": user_isolation}
+    # User directory: mcp_auth exempts /mcp from the parent AuthMiddleware, so the bridge
+    # must re-apply the disabled-user kill-switch itself. Thread the store + policy through.
+    return {
+        "admin_scope": admin_scope or AgentOSScope.ADMIN.value,
+        "user_isolation": user_isolation,
+        "user_store": getattr(config, "user_store", None) if config is not None else None,
+        "user_auto_provision": bool(getattr(config, "auto_provision_users", False)) if config is not None else False,
+        "user_email_claim": getattr(config, "user_email_claim", "email") if config is not None else "email",
+        "user_name_claim": getattr(config, "user_name_claim", "name") if config is not None else "name",
+        "user_directory_fail_closed": bool(getattr(config, "directory_error_fail_closed", False))
+        if config is not None
+        else False,
+    }
 
 
 # Localhost defaults so a desktop / local MCP server is protected with zero extra config.

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -261,8 +261,9 @@ def _require_tool_scopes(method: str, path: str) -> None:
     """
     from fastmcp.server.dependencies import get_http_request
 
-    from agno.os.auth import build_insufficient_permissions_detail
-    from agno.os.scopes import check_route_scopes
+    from agno.os.auth import build_insufficient_permissions_detail, resolve_authorization_provider
+    from agno.os.authz.provider import AuthorizationContext
+    from agno.os.scopes import get_required_scopes_for_route, get_resource_context_from_path
 
     try:
         request = get_http_request()
@@ -283,16 +284,39 @@ def _require_tool_scopes(method: str, path: str) -> None:
             raise Exception(_MISSING_BRIDGE_DETAIL)
         return
 
+    required_scopes = get_required_scopes_for_route(_tool_scope_mappings(), method, path)
+    if not required_scopes:
+        return
+
     admin_scope_raw = getattr(state, "admin_scope", None)
     admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
-    scope_check = check_route_scopes(
-        list(getattr(state, "scopes", None) or []),
-        _tool_scope_mappings(),
-        method,
-        path,
+
+    # Derive the resource context from the SYNTHETIC REST path the tool maps onto
+    # (e.g. "/agents/<id>/runs" -> agents/<id>), preserving v2.7's per-resource
+    # subtlety: the provider decides on the specific resource, not just the family.
+    resource_type, resource_id = get_resource_context_from_path(path)
+    actions = {s.rsplit(":", 1)[1] for s in required_scopes if ":" in s}
+    action = next(iter(actions)) if len(actions) == 1 else None
+
+    # Resolve the provider from the in-flight request's app.state — with none configured
+    # this is the default ScopeAuthorizationProvider, whose authorize_route delegates to
+    # has_required_scopes, so the tool gate stays byte-identical to v2.7's
+    # check_route_scopes. (The MCP tools have no GET-listing escape hatch: an
+    # unauthorised call is a hard denial, matching the prior behaviour.)
+    provider = resolve_authorization_provider(request)
+    ctx = AuthorizationContext(
+        principal_id=getattr(state, "user_id", None),
+        scopes=list(getattr(state, "scopes", None) or []),
+        claims=getattr(state, "claims", None) or {},
+        resource_type=resource_type,
+        resource_id=resource_id,
+        action=action,
         admin_scope=admin_scope,
     )
-    if not scope_check.allowed:
+    # The provider decides — default ScopeAuthorizationProvider is byte-identical to
+    # v2.7's check_route_scopes; a managed-role/custom provider enforces its own model
+    # on the OAuth-authenticated caller here too.
+    if not provider.authorize_route(ctx, required_scopes):
         # Under mcp_auth, a scope denial is most often an external-AS misconfiguration
         # (the token carries non-agno scopes), which the client-facing 403 can't point at.
         # Log the presented-vs-required scopes and the AS-config hint so the deployer can
@@ -302,11 +326,11 @@ def _require_tool_scopes(method: str, path: str) -> None:
 
             log_warning(
                 f"MCP tool scope check failed for {method} {path}: caller presented "
-                f"{list(getattr(state, 'scopes', None) or [])}, required {scope_check.required_scopes}. "
+                f"{list(getattr(state, 'scopes', None) or [])}, required {required_scopes}. "
                 "If this is a Tier-2 (external authorization server) deployment, configure your AS to emit "
                 "agno-format scopes in the token 'scope' claim."
             )
-        raise Exception(build_insufficient_permissions_detail(scope_check.required_scopes))
+        raise Exception(build_insufficient_permissions_detail(required_scopes))
 
 
 async def _enforce_run_continuation_allowed(db: Any, run_id: str) -> None:

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -316,7 +316,28 @@ def _require_tool_scopes(method: str, path: str) -> None:
     # The provider decides — default ScopeAuthorizationProvider is byte-identical to
     # v2.7's check_route_scopes; a managed-role/custom provider enforces its own model
     # on the OAuth-authenticated caller here too.
-    if not provider.authorize_route(ctx, required_scopes):
+    from agno.os.authz.audit import record_decision
+
+    allowed = provider.authorize_route(ctx, required_scopes)
+    # Record the decision on the SAME trail the REST gate writes to, so an access audit
+    # covers the MCP transport too (the tools are an alternate front door to the same
+    # surface). The sink is mirrored onto this sub-app's state; no sink -> no-op.
+    # Same non-secret token reference the REST gate captures (jti, else a short hash),
+    # so an MCP row correlates to the issuer's logs exactly like a REST row does.
+    auth_header = request.headers.get("Authorization") or ""
+    bearer = auth_header[7:] if auth_header[:7].lower() == "bearer " else None
+    record_decision(
+        request,
+        allowed=allowed,
+        target=f"{method} {path}",
+        principal=ctx.principal_id,
+        required_scopes=required_scopes,
+        scopes=ctx.scopes,
+        claims=ctx.claims,
+        token=bearer,
+        reason=None if allowed else "mcp_tool_scope_denied",
+    )
+    if not allowed:
         # Under mcp_auth, a scope denial is most often an external-AS misconfiguration
         # (the token carries non-agno scopes), which the client-facing 403 can't point at.
         # Log the presented-vs-required scopes and the AS-config hint so the deployer can

--- a/libs/agno/agno/os/mcp_auth.py
+++ b/libs/agno/agno/os/mcp_auth.py
@@ -158,10 +158,28 @@ class MCPIdentityBridgeMiddleware:
     challenge on the MCP path) pass through untouched.
     """
 
-    def __init__(self, app: Any, admin_scope: Optional[str] = None, user_isolation: bool = False) -> None:
+    def __init__(
+        self,
+        app: Any,
+        admin_scope: Optional[str] = None,
+        user_isolation: bool = False,
+        user_store: Any = None,
+        user_auto_provision: bool = False,
+        user_email_claim: str = "email",
+        user_name_claim: str = "name",
+        user_directory_fail_closed: bool = False,
+    ) -> None:
         self.app = app
         self.admin_scope = admin_scope
         self.user_isolation = user_isolation
+        # User directory (no-IdP). mcp_auth exempts /mcp from the parent AuthMiddleware,
+        # so the disabled-user kill-switch that lives there does not run for OAuth'd MCP
+        # traffic unless the bridge re-applies it. Carry the store + policy here.
+        self.user_store = user_store
+        self.user_auto_provision = user_auto_provision
+        self.user_email_claim = user_email_claim
+        self.user_name_claim = user_name_claim
+        self.user_directory_fail_closed = user_directory_fail_closed
 
     async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
         if scope["type"] == "http":
@@ -189,6 +207,33 @@ class MCPIdentityBridgeMiddleware:
                     log_warning(f"MCP token claims a reserved principal {user_id!r}; refusing to bridge its identity")
                     await self.app(scope, receive, send)
                     return
+                # User directory kill-switch: a disabled user is denied even with a valid
+                # OAuth token. This mirrors the parent AuthMiddleware's gate, which mcp_auth
+                # bypasses (the /mcp mount is exempt from it). Service-account principals
+                # (sa:) are not directory users and are skipped. If the check errors, honour
+                # user_directory_fail_closed. On denial we simply do NOT bridge the identity,
+                # leaving request.state.authenticated unset so the fail-closed tool gate
+                # rejects the call -- same shape as the reserved-principal path above.
+                if self.user_store is not None and user_id and service_account_name is None:
+                    try:
+                        if self.user_auto_provision:
+                            self.user_store.provision_from_claims(
+                                user_id,
+                                claims,
+                                email_claim=self.user_email_claim,
+                                name_claim=self.user_name_claim,
+                            )
+                        disabled = self.user_store.is_disabled(user_id)
+                    except Exception as e:  # directory unreachable: honour the configured policy
+                        disabled = self.user_directory_fail_closed
+                        log_warning(
+                            f"MCP user directory check failed for {user_id!r}: {e} "
+                            f"(failing {'closed' if self.user_directory_fail_closed else 'open'})"
+                        )
+                    if disabled:
+                        log_warning(f"Disabled user denied on MCP endpoint: {user_id!r}")
+                        await self.app(scope, receive, send)
+                        return
                 # request.state is backed by scope["state"]; the mounted sub-app and the
                 # parent share it, so the tools read these exactly as they do under the
                 # parent AuthMiddleware.

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -6,7 +6,7 @@ import json
 import re
 from enum import Enum
 from os import getenv
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Union
 
 from fastapi import Request, Response
 from fastapi.responses import JSONResponse
@@ -15,9 +15,10 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from agno.os.auth import INTERNAL_SERVICE_SCOPES, build_insufficient_permissions_detail
 from agno.os.scopes import (
     AgentOSScope,
-    check_route_scopes,
+    RouteScopeCheck,
     get_default_scope_mappings,
     get_required_scopes_for_route,
+    get_resource_context_from_path,
     has_required_scopes,
 )
 from agno.os.service_accounts import SERVICE_ACCOUNT_PRINCIPAL_PREFIX, authenticate_service_account_request
@@ -86,6 +87,20 @@ def resolve_expected_audience(
     if not verify_audience:
         return None
     return audience or os_id
+
+
+def _route_action(required_scopes: List[str]) -> Optional[str]:
+    """The single action a route requires (``read`` / ``run`` / ``write`` / ...),
+    or None when the route's required scopes span more than one action.
+
+    Only used to populate ``AuthorizationContext.action`` for providers that decide
+    per-resource (managed roles). The default scope provider's ``authorize_route``
+    ignores ``ctx.action`` and matches against ``required_scopes`` directly, so this
+    can never change the default decision. A resource route in the shipped mappings
+    requires exactly one scope, hence one action; returning None for the ambiguous
+    case makes ``EngineAuthorizationProvider`` fall back to AND-ing every scope."""
+    actions = {s.rsplit(":", 1)[1] for s in required_scopes if ":" in s}
+    return next(iter(actions)) if len(actions) == 1 else None
 
 
 class TokenSource(str, Enum):
@@ -799,6 +814,148 @@ class AuthMiddleware(BaseHTTPMiddleware):
         """
         return get_required_scopes_for_route(self.scope_mappings, method, path)
 
+    def _authorize_route(
+        self,
+        request: Request,
+        scopes: List[str],
+        mappings: Dict[str, List[str]],
+        method: str,
+        path: str,
+    ) -> "RouteScopeCheck":
+        """Route-level authorization decision, delegated to the configured provider.
+
+        This is the choke point that used to call ``check_route_scopes`` directly. It
+        preserves that function's structure exactly — the route→scope lookup, the
+        resource-context extraction, and the GET-listing filtered-access escape hatch —
+        but routes the two actual *decisions* (allow? and which resource ids for a
+        listing?) through the resolved :class:`AuthorizationProvider`.
+
+        With no provider configured the resolver returns
+        :class:`ScopeAuthorizationProvider`, whose ``authorize_route`` /
+        ``accessible_resource_ids`` are thin wrappers over ``has_required_scopes`` /
+        ``get_accessible_resource_ids`` — the very functions ``check_route_scopes``
+        called — so the result is byte-identical to v2.7. A managed-role / custom
+        provider enforces its own model at the same point instead.
+        """
+        from agno.os.auth import resolve_authorization_provider
+        from agno.os.authz.provider import AuthorizationContext
+
+        required_scopes = get_required_scopes_for_route(mappings, method, path)
+        if not required_scopes:
+            return RouteScopeCheck(allowed=True, required_scopes=required_scopes)
+
+        resource_type, resource_id = get_resource_context_from_path(path)
+
+        provider = resolve_authorization_provider(request)
+        ctx = AuthorizationContext(
+            principal_id=getattr(request.state, "user_id", None),
+            scopes=scopes,
+            claims=getattr(request.state, "claims", None) or {},
+            resource_type=resource_type,
+            resource_id=resource_id,
+            action=_route_action(required_scopes),
+            admin_scope=self.admin_scope,
+        )
+        allowed = provider.authorize_route(ctx, required_scopes)
+
+        accessible_resource_ids: Optional[Set[str]] = None
+        first_required = required_scopes[0]
+        required_family = first_required.split(":", 1)[0] if ":" in first_required else None
+        if not allowed and method == "GET" and not resource_id and resource_type and required_family == resource_type:
+            # GET-listing escape hatch, identical to check_route_scopes: a caller
+            # without the collection-wide grant is still allowed through, but the
+            # endpoint is told which ids to expose (possibly none) so it returns a
+            # filtered list instead of a 403. The action comes from the required scope
+            # so the provider only surfaces ids the caller is authorised for under it.
+            required_action: Optional[str] = None
+            if ":" in first_required:
+                required_action = first_required.rsplit(":", 1)[1]
+            listing_ctx = AuthorizationContext(
+                principal_id=ctx.principal_id,
+                scopes=scopes,
+                claims=ctx.claims,
+                resource_type=resource_type,
+                resource_id=None,
+                action=required_action,
+                admin_scope=self.admin_scope,
+            )
+            accessible_resource_ids = provider.accessible_resource_ids(listing_ctx)
+            allowed = True
+
+        return RouteScopeCheck(
+            allowed=allowed,
+            required_scopes=required_scopes,
+            accessible_resource_ids=accessible_resource_ids,
+        )
+
+    def _record_decision(
+        self,
+        request: Request,
+        *,
+        allowed: bool,
+        method: str,
+        path: str,
+        principal: Optional[str],
+        required_scopes: List[str],
+        scopes: List[str],
+        reason: Optional[str] = None,
+    ) -> None:
+        """Record one authorization decision to the audit sink, if one is configured
+        on ``app.state.authz_audit`` (seeded from ``AuthorizationConfig(audit=...)``).
+
+        Captures the principal, route, required scopes, the caller's scopes, and a
+        NON-secret token reference (see :meth:`_token_reference`). Never the token
+        itself, and never raises into the request path — audit must not turn a served
+        request into a 500. No-op when no decision sink is configured, so the default
+        (no audit) path is untouched.
+        """
+        state = getattr(getattr(request, "app", None), "state", None)
+        sink = getattr(state, "authz_audit", None) if state is not None else None
+        if sink is None:
+            return
+        try:
+            import time
+
+            from agno.os.authz.audit import AuditEvent
+
+            claims = getattr(request.state, "claims", None)
+            token = self._extract_token(request)
+            token_ref = self._token_reference(token, claims)
+            metadata: Dict[str, Any] = {"required": required_scopes, "token": token_ref, "scopes": scopes}
+            if reason:
+                metadata["reason"] = reason
+            sink.record(
+                AuditEvent(
+                    action="access.allowed" if allowed else "access.denied",
+                    actor=principal,
+                    target=f"{method} {path}",
+                    timestamp=int(time.time()),
+                    metadata=metadata,
+                )
+            )
+        except Exception as e:  # pragma: no cover - audit must never break requests
+            log_debug(f"decision audit failed: {e}")
+
+    @staticmethod
+    def _token_reference(token: Optional[str], claims: Optional[dict]) -> Optional[str]:
+        """A non-secret reference to the presented token, for the decision trail.
+
+        Prefer the token's ``jti`` (RFC 7519 JWT ID): an opaque identifier the issuer
+        already minted, so it correlates to the issuer's own logs and any revocation
+        list. When the token has no ``jti``, fall back to a short SHA-256 of the raw
+        token so two distinct tokens are still distinguishable — without ever storing
+        the credential itself.
+        """
+        if claims:
+            jti = claims.get("jti")
+            if jti:
+                return str(jti)
+        if token:
+            import hashlib
+
+            return hashlib.sha256(token.encode()).hexdigest()[:12]
+        return None
+
     def _check_scopes(
         self,
         request: Request,
@@ -820,7 +977,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             An error response when access is denied, None when access is allowed.
         """
         mappings = scope_mappings if scope_mappings is not None else self.scope_mappings
-        result = check_route_scopes(scopes, mappings, method, path, admin_scope=self.admin_scope)
+        result = self._authorize_route(request, scopes, mappings, method, path)
 
         request.state.required_scopes = result.required_scopes
         if result.accessible_resource_ids is not None:
@@ -829,6 +986,21 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 log_debug(f"Caller has specific resource scopes. Accessible IDs: {result.accessible_resource_ids}")
             else:
                 log_debug("Caller has no matching resource scopes. Will return empty list.")
+
+        # Decision audit: record the allow/deny with a non-secret token reference, if a
+        # sink is configured. Emitted for EVERY authenticated request that reaches this
+        # gate (including allow-by-default routes with no required scopes) so the trail
+        # is complete. No-op when no decision sink is set, so the default path is untouched.
+        self._record_decision(
+            request,
+            allowed=result.allowed,
+            method=method,
+            path=path,
+            principal=getattr(request.state, "user_id", None),
+            required_scopes=result.required_scopes,
+            scopes=scopes,
+            reason=None if result.required_scopes else "no_scopes_required",
+        )
 
         if not result.allowed:
             log_warning(
@@ -988,6 +1160,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
             request.state.session_id = None
             internal_scopes = list(INTERNAL_SERVICE_SCOPES)
             request.state.scopes = internal_scopes
+            # Trusted internal caller: mark AFTER the constant-time hmac match above so the
+            # provider-backed per-resource gate (check_resource_access) short-circuits — the
+            # scheduler principal has no role/subject in a managed store. The route gate below
+            # still enforces INTERNAL_SERVICE_SCOPES. Unforgeable: request.state is server-only,
+            # no client input maps onto this attribute.
+            request.state.is_internal_service = True
             request.state.authorization_enabled = self.authorization or False
             request.state.admin_scope = self.admin_scope
             request.state.user_isolation_enabled = self.user_isolation

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -1249,6 +1249,47 @@ class AuthMiddleware(BaseHTTPMiddleware):
             # ownership gates stay dormant.
             request.state.user_isolation_enabled = self.user_isolation
 
+            # User directory (no-IdP): optionally auto-provision the subject from
+            # token claims, then enforce the disabled flag. This is the revocation
+            # kill-switch — a disabled user is denied even with a valid token, on
+            # EVERY route (independent of per-route scopes). Identity is still the
+            # app's to assert; we only gate it.
+            user_store = getattr(getattr(request.app, "state", None), "user_store", None)
+            if user_store is not None and user_id:
+                try:
+                    if getattr(request.app.state, "user_auto_provision", False):
+                        user_store.provision_from_claims(
+                            user_id,
+                            payload,
+                            email_claim=getattr(request.app.state, "user_email_claim", "email"),
+                            name_claim=getattr(request.app.state, "user_name_claim", "name"),
+                        )
+                    disabled = user_store.is_disabled(user_id)
+                except Exception as e:  # directory unreachable: honour the configured policy
+                    fail_closed = bool(getattr(request.app.state, "user_directory_fail_closed", False))
+                    log_warning(
+                        f"user directory check failed for {user_id!r}: {e} "
+                        f"(failing {'closed' if fail_closed else 'open'})"
+                    )
+                    if fail_closed:
+                        return self._create_error_response(
+                            503, "User directory unavailable", origin, cors_allowed_origins
+                        )
+                    disabled = False
+                if disabled:
+                    log_warning(f"Disabled user denied: {user_id} for {method} {path}")
+                    self._record_decision(
+                        request,
+                        allowed=False,
+                        method=method,
+                        path=path,
+                        principal=user_id,
+                        required_scopes=[],
+                        scopes=scopes,
+                        reason="user_disabled",
+                    )
+                    return self._create_error_response(403, "User is disabled", origin, cors_allowed_origins)
+
             # Extract dependencies claims
             dependencies = {}
             if self.dependencies_claims:

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -909,32 +909,19 @@ class AuthMiddleware(BaseHTTPMiddleware):
         request into a 500. No-op when no decision sink is configured, so the default
         (no audit) path is untouched.
         """
-        state = getattr(getattr(request, "app", None), "state", None)
-        sink = getattr(state, "authz_audit", None) if state is not None else None
-        if sink is None:
-            return
-        try:
-            import time
+        from agno.os.authz.audit import record_decision
 
-            from agno.os.authz.audit import AuditEvent
-
-            claims = getattr(request.state, "claims", None)
-            token = self._extract_token(request)
-            token_ref = self._token_reference(token, claims)
-            metadata: Dict[str, Any] = {"required": required_scopes, "token": token_ref, "scopes": scopes}
-            if reason:
-                metadata["reason"] = reason
-            sink.record(
-                AuditEvent(
-                    action="access.allowed" if allowed else "access.denied",
-                    actor=principal,
-                    target=f"{method} {path}",
-                    timestamp=int(time.time()),
-                    metadata=metadata,
-                )
-            )
-        except Exception as e:  # pragma: no cover - audit must never break requests
-            log_debug(f"decision audit failed: {e}")
+        record_decision(
+            request,
+            allowed=allowed,
+            target=f"{method} {path}",
+            principal=principal,
+            required_scopes=required_scopes,
+            scopes=scopes,
+            claims=getattr(request.state, "claims", None),
+            token=self._extract_token(request),
+            reason=reason,
+        )
 
     @staticmethod
     def _token_reference(token: Optional[str], claims: Optional[dict]) -> Optional[str]:

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -476,6 +476,55 @@ def get_websocket_router(
                                 )
                                 continue
 
+                            # User directory kill-switch: enforce the disabled flag
+                            # at WS connect, mirroring the HTTP middleware. A disabled
+                            # user is rejected even with a valid token. (HTTP enforces
+                            # this per-request; the WebSocket enforces it at connect.)
+                            user_store = getattr(getattr(websocket.app, "state", None), "user_store", None)
+                            ws_user_id = claims.get("user_id")
+                            if user_store is not None and ws_user_id:
+                                try:
+                                    if getattr(websocket.app.state, "user_auto_provision", False):
+                                        user_store.provision_from_claims(
+                                            ws_user_id,
+                                            payload,
+                                            email_claim=getattr(websocket.app.state, "user_email_claim", "email"),
+                                            name_claim=getattr(websocket.app.state, "user_name_claim", "name"),
+                                        )
+                                    ws_disabled = user_store.is_disabled(ws_user_id)
+                                except Exception as e:  # directory unreachable: honour configured policy
+                                    fail_closed = bool(
+                                        getattr(websocket.app.state, "user_directory_fail_closed", False)
+                                    )
+                                    logger.warning(
+                                        f"user directory check failed for {ws_user_id!r}: {e} "
+                                        f"(failing {'closed' if fail_closed else 'open'})"
+                                    )
+                                    if fail_closed:
+                                        await websocket.send_text(
+                                            json.dumps(
+                                                {
+                                                    "event": "auth_error",
+                                                    "error": "User directory unavailable",
+                                                    "error_type": "server_error",
+                                                }
+                                            )
+                                        )
+                                        continue
+                                    ws_disabled = False
+                                if ws_disabled:
+                                    logger.warning(f"Disabled user denied on WebSocket: {ws_user_id}")
+                                    await websocket.send_text(
+                                        json.dumps(
+                                            {
+                                                "event": "auth_error",
+                                                "error": "User is disabled",
+                                                "error_type": "user_disabled",
+                                            }
+                                        )
+                                    )
+                                    continue
+
                             await websocket_manager.authenticate_websocket(websocket)
 
                             # Store user context from JWT

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -50,7 +50,6 @@ from agno.os.scopes import (
     AgentOSScope,
     get_default_scope_mappings,
     get_required_scopes_for_route,
-    has_required_scopes,
 )
 from agno.os.service_accounts import TOKEN_PREFIX as SERVICE_ACCOUNT_TOKEN_PREFIX
 from agno.os.service_accounts import VerificationStatus
@@ -343,6 +342,30 @@ def get_websocket_router(
         ws_workflow_run_scopes: List[str] = get_required_scopes_for_route(
             get_default_scope_mappings(), "POST", "/workflows/_/runs"
         )
+        # Resolve the authorization provider once for this connection. With no provider
+        # configured this is the default ScopeAuthorizationProvider, whose
+        # authorize_route is a thin wrapper over has_required_scopes — so the WS gate
+        # stays byte-identical to v2.7. A managed-role / custom provider enforces its
+        # model at the same three points (start / reconnect / continue) instead.
+        from agno.os.auth import resolve_authorization_provider
+        from agno.os.authz.provider import AuthorizationContext
+
+        ws_authorization_provider = resolve_authorization_provider(websocket.app)
+
+        def ws_authorize_workflow(workflow_id: Optional[str]) -> bool:
+            """Route-gate a workflow WS action through the provider, mirroring the REST
+            POST /workflows/{id}/runs gate (same required scopes, same resource ctx)."""
+            ctx = AuthorizationContext(
+                principal_id=websocket_user_context.get("user_id"),
+                scopes=list(websocket_user_context.get("scopes", []) or []),
+                claims=websocket_user_context.get("payload") or {},
+                resource_type="workflows",
+                resource_id=workflow_id,
+                action="run",
+                admin_scope=ws_admin_scope,
+            )
+            return ws_authorization_provider.authorize_route(ctx, ws_workflow_run_scopes)
+
         jwt_auth_enabled = jwt_validator is not None
         # auth_required is True when JWTMiddleware is configured, even if the
         # validator could not be constructed (e.g. bad JWKS path). This prevents
@@ -510,14 +533,7 @@ def get_websocket_router(
                     # side-effects.
                     workflow_id = message.get("workflow_id")
                     if scope_enforcement_active():
-                        user_scopes = websocket_user_context.get("scopes", [])
-                        if not has_required_scopes(
-                            user_scopes,
-                            ws_workflow_run_scopes,
-                            resource_type="workflows",
-                            resource_id=workflow_id,
-                            admin_scope=ws_admin_scope,
-                        ):
+                        if not ws_authorize_workflow(workflow_id):
                             await websocket.send_text(
                                 json.dumps({"event": "error", "error": "Insufficient permissions to run this workflow"})
                             )
@@ -570,14 +586,7 @@ def get_websocket_router(
                             )
                             continue
 
-                        user_scopes = websocket_user_context.get("scopes", [])
-                        if not has_required_scopes(
-                            user_scopes,
-                            ws_workflow_run_scopes,
-                            resource_type="workflows",
-                            resource_id=workflow_id_for_reconnect,
-                            admin_scope=ws_admin_scope,
-                        ):
+                        if not ws_authorize_workflow(workflow_id_for_reconnect):
                             await websocket.send_text(
                                 json.dumps(
                                     {
@@ -601,14 +610,7 @@ def get_websocket_router(
                     # Enforce workflow-level RBAC, mirroring start-workflow.
                     workflow_id = message.get("workflow_id")
                     if scope_enforcement_active():
-                        user_scopes = websocket_user_context.get("scopes", [])
-                        if not has_required_scopes(
-                            user_scopes,
-                            ws_workflow_run_scopes,
-                            resource_type="workflows",
-                            resource_id=workflow_id,
-                            admin_scope=ws_admin_scope,
-                        ):
+                        if not ws_authorize_workflow(workflow_id):
                             await websocket.send_text(
                                 json.dumps(
                                     {"event": "error", "error": "Insufficient permissions to continue this workflow"}

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -364,7 +364,23 @@ def get_websocket_router(
                 action="run",
                 admin_scope=ws_admin_scope,
             )
-            return ws_authorization_provider.authorize_route(ctx, ws_workflow_run_scopes)
+            allowed = ws_authorization_provider.authorize_route(ctx, ws_workflow_run_scopes)
+            # Same access trail the REST gate writes to: the equivalent
+            # POST /workflows/{id}/runs decision is recorded, so the streaming
+            # transport must not be a blind spot in the audit.
+            from agno.os.authz.audit import record_decision
+
+            record_decision(
+                websocket.app,
+                allowed=allowed,
+                target=f"WS /workflows/{workflow_id or '_'}/runs",
+                principal=ctx.principal_id,
+                required_scopes=ws_workflow_run_scopes,
+                scopes=ctx.scopes,
+                claims=ctx.claims,
+                reason=None if allowed else "ws_workflow_denied",
+            )
+            return allowed
 
         jwt_auth_enabled = jwt_validator is not None
         # auth_required is True when JWTMiddleware is configured, even if the

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -169,6 +169,10 @@ redis = ["redis", "redisvl>=0.12.1"]
 sql = ["sqlalchemy"]
 sqlite = ["sqlalchemy", "aiosqlite"]
 
+# Managed roles + credential-less user directory (ManagedRoleStore / ManagedUserStore),
+# which persist to a SQL database. Referenced by the role_store/user_store docstrings.
+roles = ["sqlalchemy"]
+
 # Dependencies for Vector databases
 cassandra = ["cassio"]
 chromadb = ["chromadb"]

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -72,6 +72,8 @@ dev = [
 # AgentOS server bundle
 os = ["fastapi", "python-multipart>=0.0.18", "uvicorn", "websockets", "sqlalchemy", "PyJWT", "opentelemetry-sdk", "openinference-instrumentation-agno", "agno[scheduler]"]
 mcp = ["mcp>=1.9.2", "fastmcp>=3.4.3,<4"]
+# Optional extra for fine-grained / relationship-based authorization (ReBAC) via OpenFGA.
+fga = ["openfga-sdk>=0.9"]
 scheduler = ["croniter>=1.3", "pytz>=2023.3"]
 
 # Dependencies for Telemetry
@@ -560,6 +562,7 @@ module = [
   "newspaper.*",
   "numpy.*",
   "ollama.*",
+  "openfga_sdk.*",
   "openpyxl.*",
   "openai.*",
   "cv2.*",

--- a/libs/agno/tests/integration/os/test_authz_planes.py
+++ b/libs/agno/tests/integration/os/test_authz_planes.py
@@ -1,0 +1,227 @@
+"""Two authz planes on one OS: token-scopes (operators) + the store (end users)."""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the native engine + SQLAlchemy
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz._composite import CompositeAuthorizationProvider  # noqa: E402 (internal mechanism)
+from agno.os.authz.provider import AuthorizationContext  # noqa: E402
+from agno.os.authz.role_router import get_roles_router  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.authz.scope_provider import ScopeAuthorizationProvider  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "composite-secret-at-least-256-bits-long-padding-xxxxxxxx"
+OS_ID = "composite-os"
+
+
+def _db_url() -> str:
+    """A throwaway file-backed SQLite URL. Managed roles require a DB (no in-memory
+    mode); file-backed so the same DB is visible across the threads TestClient uses."""
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+def test_empty_providers_rejected():
+    with pytest.raises(ValueError):
+        CompositeAuthorizationProvider([])
+
+
+def test_allows_via_either_plane():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("storeuser", "viewer")
+    comp = CompositeAuthorizationProvider([ScopeAuthorizationProvider(), store.provider])
+
+    # operator plane: scopes ride the token, nothing in the store for them
+    operator = AuthorizationContext(principal_id="op", scopes=["agents:read"], resource_type="agents", action="read")
+    assert comp.authorize_route(operator, ["agents:read"]) is True
+
+    # end-user plane: no token scopes, the store grants it
+    enduser = AuthorizationContext(
+        principal_id="storeuser", scopes=[], resource_type="agents", resource_id="a1", action="read"
+    )
+    assert comp.authorize_route(enduser, ["agents:read"]) is True
+
+    # neither plane grants -> denied
+    nobody = AuthorizationContext(
+        principal_id="nobody", scopes=[], resource_type="agents", resource_id="a1", action="read"
+    )
+    assert comp.authorize_route(nobody, ["agents:read"]) is False
+
+
+def test_accessible_ids_union_with_wildcard_winning():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("one", ["agents:a1:read"])
+    store.assign("u", "one")
+    comp = CompositeAuthorizationProvider([ScopeAuthorizationProvider(), store.provider])
+
+    # token gives a specific id, store gives another -> union
+    ctx = AuthorizationContext(principal_id="u", scopes=["agents:a2:read"], resource_type="agents", action="read")
+    assert comp.accessible_resource_ids(ctx) == {"a1", "a2"}
+
+    # a global/wildcard scope on the token -> {"*"} wins
+    ctx_all = AuthorizationContext(principal_id="u", scopes=["agents:read"], resource_type="agents", action="read")
+    assert comp.accessible_resource_ids(ctx_all) == {"*"}
+
+
+def _token(sub, scopes):
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": scopes, "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET,
+        algorithm="HS256",
+    )
+
+
+def test_both_planes_enforce_on_one_os_end_to_end():
+    """One OS: an operator authorized by token scopes AND an end user authorized by
+    the store both get in; an unknown caller is denied."""
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("enduser", "viewer")  # end user known only to the store
+
+    agent = Agent(id="research-agent", name="R", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            # public API: a LIST of providers -> allowed if any grants
+            authorization_provider=[ScopeAuthorizationProvider(), store.provider],
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+    hdr = lambda sub, scopes: {"Authorization": f"Bearer {_token(sub, scopes)}"}  # noqa: E731
+
+    # operator: token carries the scope, no store entry
+    assert client.get("/agents/research-agent", headers=hdr("op", ["agents:read"])).status_code == 200
+    # end user: empty token scopes, store grants it
+    assert client.get("/agents/research-agent", headers=hdr("enduser", [])).status_code == 200
+    # neither: unknown caller, no scopes
+    assert client.get("/agents/research-agent", headers=hdr("nobody", [])).status_code == 403
+
+
+def test_admin_gate_accepts_admin_from_token_scope():
+    """An operator whose token carries agent_os:admin can manage roles even though
+    they have no admin assignment in the store (the cloud/operator plane)."""
+    store = ManagedRoleStore(db_url=_db_url())  # nobody is admin in the store
+    agent = Agent(id="research-agent", name="R", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=[ScopeAuthorizationProvider(), store.provider],
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    # admin via token scope -> can manage
+    assert (
+        client.get("/authz/roles", headers={"Authorization": f"Bearer {_token('op', ['agent_os:admin'])}"}).status_code
+        == 200
+    )
+    # no admin scope and not in store -> denied
+    assert (
+        client.get("/authz/roles", headers={"Authorization": f"Bearer {_token('joe', ['agents:read'])}"}).status_code
+        == 403
+    )
+
+
+def test_authorization_provider_rejects_a_string():
+    """A list of providers is supported; a string is a mistake. The typed
+    AuthorizationConfig field rejects it at construction (pydantic ValidationError,
+    a ValueError), so it can never be mistaken for an iterable of characters."""
+    with pytest.raises(ValueError, match="AuthorizationProvider"):
+        AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            authorization_provider="ScopeAuthorizationProvider",  # oops, a string
+        )
+
+
+def test_composite_filter_accessible_unions_and_respects_per_plane_deny():
+    """CompositeProvider.filter_accessible is a union (OR): each plane filters
+    deny-aware within itself, and a resource is visible if ANY plane keeps it —
+    so an engine deny carves the engine's grant but can't veto a scope-plane allow."""
+    from agno.os.authz._composite import CompositeAuthorizationProvider
+    from agno.os.authz.engine import EngineAuthorizationProvider
+    from agno.os.authz.native_engine import NativePolicyEngine
+    from agno.os.authz.provider import AuthorizationContext
+    from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+
+    class R:
+        def __init__(self, rid):
+            self.id = rid
+
+    resources = [R("a"), R("secret"), R("b")]
+
+    eng = NativePolicyEngine(db_url=_db_url())
+    eng.set_role_scopes("analyst", [("agents:*:read", "allow"), ("agents:secret:read", "deny")])
+    eng.assign("bob", "analyst")
+    engine_prov = EngineAuthorizationProvider(eng)
+
+    # engine plane alone: deny-overrides carves out 'secret'
+    ctx = AuthorizationContext(principal_id="bob", resource_type="agents")
+    engine_only = CompositeAuthorizationProvider([engine_prov])
+    assert {r.id for r in engine_only.filter_accessible(ctx, resources)} == {"a", "b"}
+
+    # add a scope plane that grants all agents: union shows 'secret' again (OR;
+    # the engine's deny is per-plane and can't veto another plane's grant)
+    ctx_both = AuthorizationContext(principal_id="bob", scopes=["agents:read"], resource_type="agents")
+    both = CompositeAuthorizationProvider([ScopeAuthorizationProvider(), engine_prov])
+    assert {r.id for r in both.filter_accessible(ctx_both, resources)} == {"a", "secret", "b"}
+
+
+def test_composite_abstains_when_a_plane_errors():
+    """A plane that raises (e.g. an unreachable OpenFGA backend) must ABSTAIN, not fail
+    the whole request: under the OR a healthy peer plane still grants, and only when
+    EVERY plane errors does the composite deny (fail-closed)."""
+    from agno.os.authz._composite import CompositeAuthorizationProvider
+    from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+
+    class Boom(AuthorizationProvider):
+        def check(self, ctx):
+            raise RuntimeError("backend down")
+
+        def accessible_resource_ids(self, ctx):
+            raise RuntimeError("backend down")
+
+    class Grant(AuthorizationProvider):
+        def check(self, ctx):
+            return True
+
+        def accessible_resource_ids(self, ctx):
+            return {"a"}
+
+    ctx = AuthorizationContext(
+        principal_id="u", scopes=[], claims={}, resource_type="agents", resource_id="x", action="run"
+    )
+    # a healthy plane still grants despite the broken one (order-independent)
+    assert CompositeAuthorizationProvider([Boom(), Grant()]).check(ctx) is True
+    assert CompositeAuthorizationProvider([Grant(), Boom()]).check(ctx) is True
+    # every plane broken -> deny (fail closed), not a 500
+    assert CompositeAuthorizationProvider([Boom(), Boom()]).check(ctx) is False
+    # accessible ids union ignores the broken plane
+    assert CompositeAuthorizationProvider([Boom(), Grant()]).accessible_resource_ids(ctx) == {"a"}

--- a/libs/agno/tests/integration/os/test_fga_provider.py
+++ b/libs/agno/tests/integration/os/test_fga_provider.py
@@ -1,0 +1,140 @@
+"""Fine-grained / relationship-based authorization via the FGA provider.
+
+Proves the provider maps AgentOS authorization to relationship queries (Check /
+ListObjects) correctly, and gates a real AgentOS end-to-end when composed with
+the scope provider — all against an in-memory FGA store, so no OpenFGA server is
+needed. The same provider runs against real OpenFGA / WorkOS FGA by swapping the
+client (see OpenFGAClient).
+"""
+
+from datetime import UTC, datetime, timedelta
+from typing import List, Set, Tuple
+
+import jwt
+from fastapi.testclient import TestClient
+
+from agno.agent.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.os import AgentOS
+from agno.os.authz import AuthorizationContext, FGAAuthorizationProvider, ScopeAuthorizationProvider
+from agno.os.config import AuthorizationConfig
+
+SECRET = "fga-provider-test-secret-at-least-256-bits-long-xxxxxx"
+OS_ID = "fga-test-os"
+
+
+class InMemoryFGA:
+    """A toy FGAClient: a set of (user, relation, object) relationship tuples.
+    Stands in for OpenFGA/WorkOS FGA so the tests need no external engine."""
+
+    def __init__(self, tuples: Set[Tuple[str, str, str]]):
+        self._tuples = set(tuples)
+
+    def check(self, user: str, relation: str, obj: str) -> bool:
+        return (user, relation, obj) in self._tuples
+
+    def list_objects(self, user: str, relation: str, object_type: str) -> List[str]:
+        return [o for (u, r, o) in self._tuples if u == user and r == relation and o.startswith(f"{object_type}:")]
+
+
+def _ctx(sub, rt, rid, act):
+    return AuthorizationContext(principal_id=sub, resource_type=rt, resource_id=rid, action=act)
+
+
+# ----------------------------------------------------------------- provider unit
+def test_check_maps_to_a_relationship_query():
+    fga = InMemoryFGA({("user:alice", "run", "workflows:wf-7")})
+    prov = FGAAuthorizationProvider(fga)
+    assert prov.check(_ctx("alice", "workflows", "wf-7", "run")) is True
+    # different object, different relation, different user -> denied
+    assert prov.check(_ctx("alice", "workflows", "wf-8", "run")) is False
+    assert prov.check(_ctx("alice", "workflows", "wf-7", "read")) is False
+    assert prov.check(_ctx("bob", "workflows", "wf-7", "run")) is False
+    # unauthenticated principal -> denied on a resource check
+    assert prov.check(_ctx(None, "workflows", "wf-7", "run")) is False
+
+
+def test_accessible_ids_maps_to_list_objects():
+    fga = InMemoryFGA({
+        ("user:alice", "read", "agents:a1"),
+        ("user:alice", "read", "agents:a2"),
+        ("user:alice", "run", "agents:a1"),  # different relation, excluded for read
+        ("user:bob", "read", "agents:a3"),
+    })
+    prov = FGAAuthorizationProvider(fga)
+    assert prov.accessible_resource_ids(_ctx("alice", "agents", None, "read")) == {"a1", "a2"}
+    assert prov.accessible_resource_ids(_ctx("alice", "agents", None, "run")) == {"a1"}
+    assert prov.accessible_resource_ids(_ctx("bob", "agents", None, "read")) == {"a3"}
+    assert prov.accessible_resource_ids(_ctx("nobody", "agents", None, "read")) == set()
+
+
+def test_list_endpoint_defers_to_accessible_ids():
+    # No resource_id => a listing: check() allows so the handler runs, and
+    # accessible_resource_ids narrows the result.
+    prov = FGAAuthorizationProvider(InMemoryFGA(set()))
+    assert prov.check(_ctx("alice", "agents", None, "read")) is True
+
+
+def test_custom_user_type_and_relation_map():
+    fga = InMemoryFGA({("account:alice", "can_execute", "agents:a1")})
+    prov = FGAAuthorizationProvider(fga, user_type="account", relation_map={"run": "can_execute"})
+    assert prov.check(_ctx("alice", "agents", "a1", "run")) is True
+
+
+def test_authorize_route_abstains_on_non_resource_routes():
+    """FGA can't express /config or /sessions as a single object, so it must
+    ABSTAIN (False) there — never fail-open when OR-composed with a scope provider."""
+    prov = FGAAuthorizationProvider(InMemoryFGA({("user:alice", "run", "agents:a1")}))
+    # resource route -> relational decision
+    assert prov.authorize_route(_ctx("alice", "agents", "a1", "run"), ["agents:run"]) is True
+    # non-resource route -> abstain (a composed scope provider authorizes these)
+    assert prov.authorize_route(AuthorizationContext(principal_id="alice"), ["config:read"]) is False
+
+
+# ----------------------------------------------------------------- end to end
+def _token(sub: str) -> str:
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET, algorithm="HS256",
+    )
+
+
+def _auth(sub: str) -> dict:
+    return {"Authorization": f"Bearer {_token(sub)}"}
+
+
+def test_fga_gates_a_real_agentos_per_resource():
+    """End to end: relationships in the FGA store decide who can run which agent,
+    with FGA composed alongside the scope provider on one OS."""
+    fga = InMemoryFGA({
+        ("user:alice", "run", "agents:research-agent"),   # alice may run research-agent
+        ("user:alice", "read", "agents:research-agent"),
+    })
+    research = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    other = Agent(id="other-agent", name="Other Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[research, other],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            # ReBAC for resources (alice's relationships) + scopes for everything else.
+            authorization_provider=[ScopeAuthorizationProvider(), FGAAuthorizationProvider(fga)],
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+
+    # alice is related (run) to research-agent -> allowed
+    r = client.post("/agents/research-agent/runs", headers=_auth("alice"), data={"message": "hi"})
+    assert r.status_code != 403
+    # alice has no relationship to other-agent -> denied
+    r = client.post("/agents/other-agent/runs", headers=_auth("alice"), data={"message": "hi"})
+    assert r.status_code == 403
+    # bob has no relationships at all -> denied
+    r = client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"})
+    assert r.status_code == 403
+    # alice can read research-agent (relationship exists)
+    assert client.get("/agents/research-agent", headers=_auth("alice")).status_code == 200

--- a/libs/agno/tests/integration/os/test_fga_provider.py
+++ b/libs/agno/tests/integration/os/test_fga_provider.py
@@ -55,12 +55,14 @@ def test_check_maps_to_a_relationship_query():
 
 
 def test_accessible_ids_maps_to_list_objects():
-    fga = InMemoryFGA({
-        ("user:alice", "read", "agents:a1"),
-        ("user:alice", "read", "agents:a2"),
-        ("user:alice", "run", "agents:a1"),  # different relation, excluded for read
-        ("user:bob", "read", "agents:a3"),
-    })
+    fga = InMemoryFGA(
+        {
+            ("user:alice", "read", "agents:a1"),
+            ("user:alice", "read", "agents:a2"),
+            ("user:alice", "run", "agents:a1"),  # different relation, excluded for read
+            ("user:bob", "read", "agents:a3"),
+        }
+    )
     prov = FGAAuthorizationProvider(fga)
     assert prov.accessible_resource_ids(_ctx("alice", "agents", None, "read")) == {"a1", "a2"}
     assert prov.accessible_resource_ids(_ctx("alice", "agents", None, "run")) == {"a1"}
@@ -95,7 +97,8 @@ def test_authorize_route_abstains_on_non_resource_routes():
 def _token(sub: str) -> str:
     return jwt.encode(
         {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
-        SECRET, algorithm="HS256",
+        SECRET,
+        algorithm="HS256",
     )
 
 
@@ -106,10 +109,12 @@ def _auth(sub: str) -> dict:
 def test_fga_gates_a_real_agentos_per_resource():
     """End to end: relationships in the FGA store decide who can run which agent,
     with FGA composed alongside the scope provider on one OS."""
-    fga = InMemoryFGA({
-        ("user:alice", "run", "agents:research-agent"),   # alice may run research-agent
-        ("user:alice", "read", "agents:research-agent"),
-    })
+    fga = InMemoryFGA(
+        {
+            ("user:alice", "run", "agents:research-agent"),  # alice may run research-agent
+            ("user:alice", "read", "agents:research-agent"),
+        }
+    )
     research = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
     other = Agent(id="other-agent", name="Other Agent", db=InMemoryDb())
     agent_os = AgentOS(

--- a/libs/agno/tests/integration/os/test_managed_roles.py
+++ b/libs/agno/tests/integration/os/test_managed_roles.py
@@ -1,0 +1,311 @@
+"""Integration tests for ManagedRoleStore — the agno-native managed-roles tier.
+
+Verifies the governance product surface end to end: roles defined in agno scope
+terms, runtime assign/revoke, persistence to a DB, and enforcement through the
+AgentOS request pipeline via the store's provider. No engine types appear in the
+test body — the same as user code.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the native engine + SQLAlchemy
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "managed-roles-test-secret-at-least-256-bits-long-xxxxx"
+OS_ID = "managed-roles-test-os"
+
+
+def _db_url() -> str:
+    """A throwaway file-backed SQLite URL. Managed roles require a DB (no in-memory
+    mode); file-backed so the same DB is visible across the threads TestClient uses."""
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+def _token(sub: str) -> str:
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET,
+        algorithm="HS256",
+    )
+
+
+def _build(store: ManagedRoleStore) -> TestClient:
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    other = Agent(id="other-agent", name="Other Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent, other],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    return TestClient(agent_os.get_app())
+
+
+def _auth(sub: str) -> dict:
+    return {"Authorization": f"Bearer {_token(sub)}"}
+
+
+def test_role_scopes_enforced_through_pipeline():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("bob", "viewer")
+    store.assign("alice", "admin")
+    client = _build(store)
+
+    # viewer can read
+    assert client.get("/agents/research-agent", headers=_auth("bob")).status_code == 200
+    # viewer cannot run
+    r = client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"})
+    assert r.status_code == 403
+    # admin can run
+    r = client.post("/agents/research-agent/runs", headers=_auth("alice"), data={"message": "hi"})
+    assert r.status_code != 403
+
+
+def test_unassigned_subject_is_denied():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    client = _build(store)
+    assert client.get("/agents/research-agent", headers=_auth("nobody")).status_code == 403
+
+
+def test_runtime_grant_takes_effect_same_token():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("member", ["agents:*:read", "agents:research-agent:run"])
+    client = _build(store)
+
+    # bob has no role yet -> denied to run, with a stable token
+    headers = _auth("bob")
+    assert client.post("/agents/research-agent/runs", headers=headers, data={"message": "hi"}).status_code == 403
+
+    # grant at runtime; SAME token
+    store.assign("bob", "member")
+    assert client.post("/agents/research-agent/runs", headers=headers, data={"message": "hi"}).status_code != 403
+
+    # revoke at runtime; SAME token
+    store.unassign("bob", "member")
+    assert client.post("/agents/research-agent/runs", headers=headers, data={"message": "hi"}).status_code == 403
+
+
+def test_per_resource_scope_is_granular():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("member", ["agents:*:read", "agents:research-agent:run"])
+    store.assign("bob", "member")
+    client = _build(store)
+
+    # may run the specific agent
+    assert client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}).status_code != 403
+    # but not a different one
+    assert client.post("/agents/other-agent/runs", headers=_auth("bob"), data={"message": "hi"}).status_code == 403
+
+
+def test_roles_from_external_idp_claim():
+    """Roles carried on the token (external IdP) authorize against the same store."""
+    store = ManagedRoleStore(roles_claim="roles", db_url=_db_url())
+    store.set_role_scopes("editor", ["agents:*:read", "agents:research-agent:run"])
+    client = _build(store)
+
+    # token carries roles=["editor"]; sub is unknown to the store
+    tok = jwt.encode(
+        {
+            "sub": "idp-user-999",
+            "aud": OS_ID,
+            "scopes": [],
+            "roles": ["editor"],
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        },
+        SECRET,
+        algorithm="HS256",
+    )
+    headers = {"Authorization": f"Bearer {tok}"}
+    assert client.post("/agents/research-agent/runs", headers=headers, data={"message": "hi"}).status_code != 403
+
+
+def test_non_resource_routes_are_gated_sessions():
+    """Sessions endpoints (which the middleware can't tag with a resource_type)
+    are governed by the same role policy — read/write/delete enforced, not open.
+    """
+    from agno.session import AgentSession
+
+    db = InMemoryDb()
+    db.upsert_session(AgentSession(session_id="s1", agent_id="research-agent", user_id="u"))
+
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("support", ["sessions:read"])  # read only
+    store.set_role_scopes("operator", ["sessions:read", "sessions:delete"])
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("bob", "support")
+    store.assign("val", "operator")
+    store.assign("alice", "admin")
+
+    agent = Agent(id="research-agent", name="Research Agent", db=db)
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        db=db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+
+    # support can view but NOT delete (the gap this closes: previously open)
+    assert client.get("/sessions?type=agent", headers=_auth("bob")).status_code == 200
+    assert client.delete("/sessions/s1", headers=_auth("bob")).status_code == 403
+    # operator can delete
+    assert client.delete("/sessions/s1", headers=_auth("val")).status_code != 403
+    # admin can view
+    assert client.get("/sessions?type=agent", headers=_auth("alice")).status_code == 200
+    # a subject with no role is denied even on a non-resource route
+    assert client.get("/sessions?type=agent", headers=_auth("nobody")).status_code == 403
+
+
+def test_management_helpers():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("a", ["agents:*:read"])
+    store.set_role_scopes("b", ["teams:*:read"])
+    store.assign("bob", "a")
+    assert store.roles_of("bob") == ["a"]
+    # One role per subject: assigning another REPLACES, never stacks.
+    store.assign("bob", "b")
+    assert set(store.list_roles()) == {"a", "b"}
+    assert store.roles_of("bob") == ["b"]
+    # Re-assigning the same role is a no-op.
+    store.assign("bob", "b")
+    assert store.roles_of("bob") == ["b"]
+    store.unassign("bob", "b")
+    assert store.roles_of("bob") == []
+
+
+def test_role_store_shortcut_wires_provider_and_defaults_os_db(tmp_path):
+    """#4: AuthorizationConfig(role_store=...) wires the store's provider (no manual
+    .provider). #3: a store with no DB of its own adopts the OS DB when AgentOS wires
+    it (a DB is required — there is no in-memory mode), and roles persist there."""
+    from agno.db.sqlite import SqliteDb
+
+    store = ManagedRoleStore()  # no DB yet -> AgentOS will adopt the OS DB
+    db = SqliteDb(db_file=str(tmp_path / "os.db"))
+    agent = Agent(id="research-agent", name="R", db=db)
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        db=db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            role_store=store,  # <- the shortcut; AgentOS adopts the OS db + uses store.provider
+        ),
+    )
+    client = TestClient(agent_os.get_app())  # adopts the OS DB -> store is now bound
+
+    # configure after wiring (the store is bound to the OS DB now)
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("bob", "viewer")
+    assert store.is_bound is True
+    assert client.get("/agents/research-agent", headers=_auth("bob")).status_code == 200
+    assert client.get("/agents/research-agent", headers=_auth("nobody")).status_code == 403
+
+    # roles persisted to the OS DB -> a fresh store on the same DB sees them
+    fresh = ManagedRoleStore(db=db)
+    assert fresh.roles_of("bob") == ["viewer"]
+    assert fresh.get_role_scopes("viewer") == ["agents:read"]
+
+
+def test_managed_roles_enforce_on_rest_gate_via_shortcut(tmp_path):
+    """The payoff, end to end on the v2.7 REST route gate: an AgentOS wired with the
+    ``role_store=`` shortcut (no manual .provider) enforces a managed role for a caller
+    whose JWT carries NO scopes at all — the ``viewer`` role (agents:*:read) is resolved
+    from the store, not the token. Same viewer, same token: GET /agents/{id} is 200 but
+    POST /agents/{id}/runs is 403, proving action granularity flows through the same gate
+    that v2.7 gates scopes on. With no provider configured this gate is byte-identical
+    scope RBAC; here it is managed roles, at the very same choke point."""
+    from agno.db.sqlite import SqliteDb
+
+    store = ManagedRoleStore()  # no DB of its own -> AgentOS adopts the OS DB
+    db = SqliteDb(db_file=str(tmp_path / "os.db"))
+    agent = Agent(id="research-agent", name="R", db=db)
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        db=db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            role_store=store,  # the shortcut: AgentOS binds the OS db + uses store.provider
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+
+    # viewer = read-only on agents; assigned to bob via the store (not via any token scope)
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("bob", "viewer")
+
+    # The token carries scopes: [] — authorization comes entirely from the managed role.
+    assert jwt.decode(_token("bob"), SECRET, algorithms=["HS256"], audience=OS_ID)["scopes"] == []
+
+    # read allowed, run denied — same subject, same (empty-scope) token
+    assert client.get("/agents/research-agent", headers=_auth("bob")).status_code == 200
+    assert (
+        client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}).status_code == 403
+    )
+
+
+def test_role_store_and_provider_are_mutually_exclusive():
+    from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+
+    with pytest.raises(ValueError, match="not both"):
+        AuthorizationConfig(role_store=ManagedRoleStore(), authorization_provider=ScopeAuthorizationProvider())
+
+
+def test_role_store_without_any_db_fails_loud_at_wiring():
+    """A managed store with no DB, wired into an AgentOS that also has no SQL DB,
+    must fail loudly rather than silently run an in-memory store that can't stay
+    consistent across replicas."""
+    store = ManagedRoleStore()  # no DB
+    agent = Agent(id="research-agent", name="R", db=InMemoryDb())  # not SQL-capable
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            role_store=store,
+        ),
+    )
+    with pytest.raises(ValueError, match="needs a SQL database"):
+        agent_os.get_app()

--- a/libs/agno/tests/integration/os/test_managed_roles.py
+++ b/libs/agno/tests/integration/os/test_managed_roles.py
@@ -277,9 +277,7 @@ def test_managed_roles_enforce_on_rest_gate_via_shortcut(tmp_path):
 
     # read allowed, run denied — same subject, same (empty-scope) token
     assert client.get("/agents/research-agent", headers=_auth("bob")).status_code == 200
-    assert (
-        client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}).status_code == 403
-    )
+    assert client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}).status_code == 403
 
 
 def test_role_store_and_provider_are_mutually_exclusive():

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -38,7 +38,8 @@ def _db_url() -> str:
 def _token(sub: str) -> str:
     return jwt.encode(
         {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
-        SECRET, algorithm="HS256",
+        SECRET,
+        algorithm="HS256",
     )
 
 
@@ -81,9 +82,7 @@ def test_non_admin_is_403(client_and_store):
     client, _ = client_and_store
     # bob is a viewer, not an admin
     assert client.get("/authz/roles", headers=_auth("bob")).status_code == 403
-    assert client.post(
-        "/authz/users/carol/roles", headers=_auth("bob"), json={"role": "viewer"}
-    ).status_code == 403
+    assert client.post("/authz/users/carol/roles", headers=_auth("bob"), json={"role": "viewer"}).status_code == 403
 
 
 def test_admin_can_list_and_read_roles(client_and_store):
@@ -144,29 +143,22 @@ def test_admin_assign_and_revoke(client_and_store):
 def test_granting_via_api_takes_effect_on_next_request(client_and_store):
     client, _ = client_and_store
     # bob is a viewer: cannot run the agent
-    assert client.post(
-        "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
-    ).status_code == 403
+    assert client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}).status_code == 403
 
     # admin defines a runner role and grants it to bob via the HTTP API
     assert client.post("/authz/roles", headers=_auth("alice"), json={"slug": "runner"}).status_code == 201
-    assert client.put(
-        "/authz/roles/runner/scopes", headers=_auth("alice"), json={"scopes": ["agents:*:run"]}
-    ).status_code == 200
-    assert client.post(
-        "/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"}
-    ).status_code == 200
+    assert (
+        client.put("/authz/roles/runner/scopes", headers=_auth("alice"), json={"scopes": ["agents:*:run"]}).status_code
+        == 200
+    )
+    assert client.post("/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"}).status_code == 200
 
     # bob can now run — same token, no re-mint
-    assert client.post(
-        "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
-    ).status_code != 403
+    assert client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}).status_code != 403
 
     # admin revokes it; bob is blocked again
     assert client.delete("/authz/users/bob/roles/runner", headers=_auth("alice")).status_code == 200
-    assert client.post(
-        "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
-    ).status_code == 403
+    assert client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}).status_code == 403
 
 
 def test_scope_catalog_endpoint(client_and_store):
@@ -209,9 +201,9 @@ def test_admin_via_token_claim_can_manage():
 
     def idp_token(sub, roles):
         return jwt.encode(
-            {"sub": sub, "aud": OS_ID, "scopes": [], "roles": roles,
-             "exp": datetime.now(UTC) + timedelta(hours=1)},
-            SECRET, algorithm="HS256",
+            {"sub": sub, "aud": OS_ID, "scopes": [], "roles": roles, "exp": datetime.now(UTC) + timedelta(hours=1)},
+            SECRET,
+            algorithm="HS256",
         )
 
     admin_h = {"Authorization": f"Bearer {idp_token('idp-admin', ['admin'])}"}

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -1,0 +1,202 @@
+"""Integration tests for the ManagedRoleStore HTTP management API.
+
+Exercises the admin-only governance surface end to end: CRUD over roles and
+assignments through HTTP, the admin gate (401/403), and the payoff — a role
+granted via the API takes effect on the target user's next request.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the native engine + SQLAlchemy
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.role_router import get_roles_router  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "managed-roles-api-test-secret-at-least-256-bits-long-xx"
+OS_ID = "managed-roles-api-test-os"
+
+
+def _db_url() -> str:
+    """A throwaway file-backed SQLite URL. Managed roles require a DB (no in-memory
+    mode); file-backed so the same DB is visible across the threads TestClient uses."""
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+def _token(sub: str) -> str:
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET, algorithm="HS256",
+    )
+
+
+def _auth(sub: str) -> dict:
+    return {"Authorization": f"Bearer {_token(sub)}"}
+
+
+@pytest.fixture
+def client_and_store():
+    store = ManagedRoleStore(db_url=_db_url())  # in-memory
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")
+    store.assign("bob", "viewer")
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    return TestClient(app), store
+
+
+def test_unauthenticated_is_401(client_and_store):
+    client, _ = client_and_store
+    assert client.get("/authz/roles").status_code == 401
+
+
+def test_non_admin_is_403(client_and_store):
+    client, _ = client_and_store
+    # bob is a viewer, not an admin
+    assert client.get("/authz/roles", headers=_auth("bob")).status_code == 403
+    assert client.post(
+        "/authz/users/carol/roles", headers=_auth("bob"), json={"role": "viewer"}
+    ).status_code == 403
+
+
+def test_admin_can_list_and_read_roles(client_and_store):
+    client, _ = client_and_store
+    r = client.get("/authz/roles", headers=_auth("alice"))
+    assert r.status_code == 200
+    assert set(r.json()["roles"]) == {"viewer", "admin"}
+
+    r = client.get("/authz/roles/viewer", headers=_auth("alice"))
+    assert r.status_code == 200
+    assert r.json()["scopes"] == ["agents:read"]  # global read-back form
+
+
+def test_admin_crud_role(client_and_store):
+    client, store = client_and_store
+    # create a new role
+    r = client.put(
+        "/authz/roles/editor",
+        headers=_auth("alice"),
+        json={"scopes": ["agents:*:read", "agents:research-agent:run"]},
+    )
+    assert r.status_code == 200
+    assert store.get_role_scopes("editor") == sorted(["agents:read", "agents:research-agent:run"])
+
+    # delete it
+    r = client.delete("/authz/roles/editor", headers=_auth("alice"))
+    assert r.status_code == 200
+    assert "editor" not in store.list_roles()
+
+
+def test_admin_assign_and_revoke(client_and_store):
+    client, store = client_and_store
+    r = client.post("/authz/users/carol/roles", headers=_auth("alice"), json={"role": "viewer"})
+    assert r.status_code == 200
+    assert r.json()["roles"] == ["viewer"]
+    assert store.roles_of("carol") == ["viewer"]
+
+    r = client.delete("/authz/users/carol/roles/viewer", headers=_auth("alice"))
+    assert r.status_code == 200
+    assert store.roles_of("carol") == []
+
+
+def test_granting_via_api_takes_effect_on_next_request(client_and_store):
+    client, _ = client_and_store
+    # bob is a viewer: cannot run the agent
+    assert client.post(
+        "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
+    ).status_code == 403
+
+    # admin defines a runner role and grants it to bob via the HTTP API
+    assert client.put(
+        "/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]}
+    ).status_code == 200
+    assert client.post(
+        "/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"}
+    ).status_code == 200
+
+    # bob can now run — same token, no re-mint
+    assert client.post(
+        "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
+    ).status_code != 403
+
+    # admin revokes it; bob is blocked again
+    assert client.delete("/authz/users/bob/roles/runner", headers=_auth("alice")).status_code == 200
+    assert client.post(
+        "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
+    ).status_code == 403
+
+
+def test_scope_catalog_endpoint(client_and_store):
+    client, _ = client_and_store
+    r = client.get("/authz/scopes", headers=_auth("alice"))
+    assert r.status_code == 200
+    body = r.json()
+    assert "agents" in body["grouped"] and "read" in body["grouped"]["agents"]
+    assert "agents:run" in body["scopes"]
+    assert body["admin_scope"] == "agent_os:admin"
+    # non-admin is blocked
+    assert client.get("/authz/scopes", headers=_auth("bob")).status_code == 403
+
+
+def test_admin_via_token_claim_can_manage():
+    """When roles come from the token (external IdP), an admin role on the token grants management."""
+    store = ManagedRoleStore(roles_claim="roles", db_url=_db_url())
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.set_role_scopes("viewer", ["agents:*:read"])
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    def idp_token(sub, roles):
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "roles": roles,
+             "exp": datetime.now(UTC) + timedelta(hours=1)},
+            SECRET, algorithm="HS256",
+        )
+
+    admin_h = {"Authorization": f"Bearer {idp_token('idp-admin', ['admin'])}"}
+    viewer_h = {"Authorization": f"Bearer {idp_token('idp-viewer', ['viewer'])}"}
+
+    assert client.get("/authz/roles", headers=admin_h).status_code == 200
+    assert client.get("/authz/roles", headers=viewer_h).status_code == 403

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -90,18 +90,33 @@ def test_admin_can_list_and_read_roles(client_and_store):
     client, _ = client_and_store
     r = client.get("/authz/roles", headers=_auth("alice"))
     assert r.status_code == 200
-    assert set(r.json()["roles"]) == {"viewer", "admin"}
+    body = r.json()  # paginated {data, meta}
+    assert {role["slug"] for role in body["data"]} == {"viewer", "admin"}
+    assert body["meta"]["total_count"] == 2
 
     r = client.get("/authz/roles/viewer", headers=_auth("alice"))
     assert r.status_code == 200
-    assert r.json()["scopes"] == ["agents:read"]  # global read-back form
+    role = r.json()
+    assert role["slug"] == "viewer" and role["name"] == "viewer"
+    # scopes are parsed objects now: {raw, namespace, sub_namespace, permission, value}
+    assert role["scopes"] == [
+        {
+            "id": None,
+            "raw": "agents:read",
+            "namespace": "agents",
+            "sub_namespace": None,
+            "permission": "read",
+            "value": "allow",
+        }
+    ]
 
 
 def test_admin_crud_role(client_and_store):
     client, store = client_and_store
-    # create a new role
+    # create a role (metadata only), then set its scopes via the subresource
+    assert client.post("/authz/roles", headers=_auth("alice"), json={"slug": "editor"}).status_code == 201
     r = client.put(
-        "/authz/roles/editor",
+        "/authz/roles/editor/scopes",
         headers=_auth("alice"),
         json={"scopes": ["agents:*:read", "agents:research-agent:run"]},
     )
@@ -118,7 +133,7 @@ def test_admin_assign_and_revoke(client_and_store):
     client, store = client_and_store
     r = client.post("/authz/users/carol/roles", headers=_auth("alice"), json={"role": "viewer"})
     assert r.status_code == 200
-    assert r.json()["roles"] == ["viewer"]
+    assert r.json()["role"] == "viewer"  # singular: one role per user
     assert store.roles_of("carol") == ["viewer"]
 
     r = client.delete("/authz/users/carol/roles/viewer", headers=_auth("alice"))
@@ -134,8 +149,9 @@ def test_granting_via_api_takes_effect_on_next_request(client_and_store):
     ).status_code == 403
 
     # admin defines a runner role and grants it to bob via the HTTP API
+    assert client.post("/authz/roles", headers=_auth("alice"), json={"slug": "runner"}).status_code == 201
     assert client.put(
-        "/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]}
+        "/authz/roles/runner/scopes", headers=_auth("alice"), json={"scopes": ["agents:*:run"]}
     ).status_code == 200
     assert client.post(
         "/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"}
@@ -157,10 +173,13 @@ def test_scope_catalog_endpoint(client_and_store):
     client, _ = client_and_store
     r = client.get("/authz/scopes", headers=_auth("alice"))
     assert r.status_code == 200
-    body = r.json()
-    assert "agents" in body["grouped"] and "read" in body["grouped"]["agents"]
-    assert "agents:run" in body["scopes"]
-    assert body["admin_scope"] == "agent_os:admin"
+    body = r.json()  # flat list of {raw, namespace, sub_namespace?, permission}
+    assert isinstance(body, list)
+    by_raw = {s["raw"]: s for s in body}
+    assert by_raw["agents:run"] == {"raw": "agents:run", "namespace": "agents", "permission": "run"}
+    assert "agent_os:admin" in by_raw  # the super-scope is included
+    # exclude_none: sub_namespace omitted when absent
+    assert "sub_namespace" not in by_raw["agents:read"]
     # non-admin is blocked
     assert client.get("/authz/scopes", headers=_auth("bob")).status_code == 403
 
@@ -200,3 +219,74 @@ def test_admin_via_token_claim_can_manage():
 
     assert client.get("/authz/roles", headers=admin_h).status_code == 200
     assert client.get("/authz/roles", headers=viewer_h).status_code == 403
+
+
+def test_patch_role_metadata_only(client_and_store):
+    """PATCH /roles/{slug} updates name/description without touching scopes."""
+    client, store = client_and_store
+    store.set_role_scopes("editor", ["agents:*:read"], name="Editor")
+
+    r = client.patch("/authz/roles/editor", headers=_auth("alice"), json={"description": "can edit things"})
+    assert r.status_code == 200, r.text
+    role = r.json()
+    assert role["name"] == "Editor" and role["description"] == "can edit things"
+    # scopes untouched by the metadata patch
+    assert [s["raw"] for s in role["scopes"]] == ["agents:read"]
+
+    # patching a non-existent role -> 404
+    assert client.patch("/authz/roles/ghost", headers=_auth("alice"), json={"name": "x"}).status_code == 404
+
+
+def test_put_scopes_subresource_replaces(client_and_store):
+    """PUT /roles/{slug}/scopes replaces scopes, preserves metadata, returns scopes."""
+    client, store = client_and_store
+    store.set_role_scopes("editor", ["agents:*:read"], name="Editor")
+
+    r = client.put(
+        "/authz/roles/editor/scopes",
+        headers=_auth("alice"),
+        json={"scopes": ["agents:*:run", {"scope": "agents:secret:run", "effect": "deny"}]},
+    )
+    assert r.status_code == 200, r.text
+    scopes = r.json()  # returns the scope list
+    by_raw = {s["raw"]: s for s in scopes}
+    assert by_raw["agents:run"]["value"] == "allow"
+    assert by_raw["agents:secret:run"]["value"] == "deny"
+    # metadata (name) preserved through a scopes-only replace
+    assert client.get("/authz/roles/editor", headers=_auth("alice")).json()["name"] == "Editor"
+
+
+def test_patch_scopes_subresource_diffs(client_and_store):
+    """PATCH /roles/{slug}/scopes adds/flips upsert and drops remove, keeping the rest."""
+    client, store = client_and_store
+    store.set_role_scopes("editor", ["agents:*:read", "teams:*:read"])
+
+    r = client.patch(
+        "/authz/roles/editor/scopes",
+        headers=_auth("alice"),
+        json={"upsert": [{"scope": "agents:*:run", "effect": "allow"}], "remove": ["teams:read"]},
+    )
+    assert r.status_code == 200, r.text
+    raws = {s["raw"] for s in r.json()["scopes"]}
+    assert raws == {"agents:read", "agents:run"}  # teams:read removed, agents:run added, agents:read kept
+
+
+def test_create_role_metadata_only_then_add_scopes(client_and_store):
+    """POST /roles creates a role with NO scopes (RESTful); scopes are added
+    separately via the /scopes subresource."""
+    client, store = client_and_store
+
+    r = client.post("/authz/roles", headers=_auth("alice"), json={"slug": "support", "name": "Support"})
+    assert r.status_code == 201, r.text
+    role = r.json()
+    assert role["slug"] == "support" and role["name"] == "Support" and role["scopes"] == []
+
+    # creating the same role again -> 409
+    assert client.post("/authz/roles", headers=_auth("alice"), json={"slug": "support"}).status_code == 409
+
+    # add permissions via the subresource
+    r = client.put("/authz/roles/support/scopes", headers=_auth("alice"), json={"scopes": ["sessions:read"]})
+    assert r.status_code == 200
+    assert [s["raw"] for s in client.get("/authz/roles/support", headers=_auth("alice")).json()["scopes"]] == [
+        "sessions:read"
+    ]

--- a/libs/agno/tests/integration/os/test_managed_roles_audit.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_audit.py
@@ -74,10 +74,12 @@ def test_store_emits_change_events_with_actor_and_diff():
         ("user.unassigned", "bob", "alice"),
         ("role.removed", "member", "alice"),
     ]
-    # before/after captured on the widen
+    # before/after captured on the widen — full entries (scope + effect) so an
+    # allow<->deny flip is visible in the trail.
     widen = sink.events[1]
-    assert widen.before == ["agents:read"]
-    assert set(widen.after) == {"agents:read", "agents:run"}
+    assert widen.before == [{"scope": "agents:read", "effect": "allow"}]
+    assert {e["scope"] for e in widen.after} == {"agents:read", "agents:run"}
+    assert all(e["effect"] == "allow" for e in widen.after)
     # assignment diff
     assign = sink.events[2]
     assert assign.before == [] and assign.after == ["member"]
@@ -140,8 +142,9 @@ def test_http_api_records_actor_from_jwt():
     app.include_router(get_roles_router(store))
     client = TestClient(app)
 
+    store.set_role_scopes("runner", ["agents:read"])  # role must exist before PUT /scopes
     sink.events.clear()
-    client.put("/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
+    client.put("/authz/roles/runner/scopes", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
     client.post("/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"})
     client.delete("/authz/users/bob/roles/runner", headers=_auth("alice"))
 
@@ -283,14 +286,16 @@ def test_decisions_endpoint_returns_trail_for_admin(tmp_path):
 
     client.get("/agents/research-agent", headers=_auth("bob", jti="dec-1"))  # allowed decision
 
-    # admin reads the decision trail
+    # admin reads the decision trail (paginated {data, meta})
     r = client.get("/authz/decisions", headers=_auth("alice"))
     assert r.status_code == 200
-    events = r.json()["events"]
+    body = r.json()
+    events = body["data"]
+    assert body["meta"]["total_count"] >= len(events)
     assert any(e["action"] == "access.allowed" and e["metadata"]["token"] == "dec-1" for e in events)
 
     # /authz/audit (changes) does NOT contain the access.* decisions
-    changes = client.get("/authz/audit", headers=_auth("alice")).json()["events"]
+    changes = client.get("/authz/audit", headers=_auth("alice")).json()["data"]
     assert all(not e["action"].startswith("access.") for e in changes)
 
     # non-admin and anonymous are blocked
@@ -323,16 +328,40 @@ def test_audit_endpoint_returns_trail(tmp_path):
     client = TestClient(app)
 
     # make a couple of changes over the API
-    client.put("/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
+    client.post("/authz/roles", headers=_auth("alice"), json={"slug": "runner"})
+    client.put("/authz/roles/runner/scopes", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
     client.post("/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"})
 
-    # admin can read the trail; newest first
+    # admin can read the trail; newest first, paginated {data, meta}
     r = client.get("/authz/audit", headers=_auth("alice"))
     assert r.status_code == 200
-    events = r.json()["events"]
+    body = r.json()
+    events = body["data"]
+    assert body["meta"]["page"] == 1 and body["meta"]["total_count"] == len(events)
     assert events[0]["action"] == "user.assigned" and events[0]["actor"] == "alice"
     assert events[0]["after"] == ["runner"]
     assert any(e["action"] == "role.set_scopes" and e["target"] == "runner" for e in events)
+
+    # page/limit slice the trail (page 2 with limit 1 = the second-newest event)
+    paged = client.get("/authz/audit?limit=1&page=2", headers=_auth("alice")).json()
+    assert len(paged["data"]) == 1
+    assert paged["data"][0]["action"] == events[1]["action"]
+    assert paged["meta"]["total_count"] == len(events) and paged["meta"]["page"] == 2
+
+    # search filters over actor/action/target (case-insensitive), counted in meta
+    found = client.get("/authz/audit?search=SET_SCOPES", headers=_auth("alice")).json()
+    assert found["data"] and all(e["action"] == "role.set_scopes" for e in found["data"])
+    assert found["meta"]["total_count"] == len(found["data"])
+    assert client.get("/authz/audit?search=zzz-no-match", headers=_auth("alice")).json()["data"] == []
+
+    # sort_order=asc flips to oldest first
+    asc = client.get("/authz/audit?sort_order=asc", headers=_auth("alice")).json()["data"]
+    assert [e["action"] for e in asc] == [e["action"] for e in reversed(events)]
+
+    # sort_by any sortable field; an unknown field is a 422, not a 500
+    by_action = client.get("/authz/audit?sort_by=action&sort_order=asc", headers=_auth("alice")).json()["data"]
+    assert [e["action"] for e in by_action] == sorted(e["action"] for e in events)
+    assert client.get("/authz/audit?sort_by=evil", headers=_auth("alice")).status_code == 422
 
     # non-admin and anonymous are blocked
     store.assign("bob", "runner")  # bob still isn't an admin

--- a/libs/agno/tests/integration/os/test_managed_roles_audit.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_audit.py
@@ -1,0 +1,357 @@
+"""Audit trail for managed-role changes.
+
+The policy engine can't attribute who changed a policy (it never sees the actor),
+so change-audit lives at our layer. These tests verify that role and
+assignment mutations emit append-only AuditEvents with the acting principal and
+the before/after, both via the store directly and through the admin HTTP API.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the native engine + SQLAlchemy
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.audit import AuditEvent, AuditSink, DbAuditSink  # noqa: E402
+from agno.os.authz.role_router import get_roles_router  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "managed-roles-audit-secret-at-least-256-bits-long-xxxx"
+OS_ID = "managed-roles-audit-os"
+
+
+def _db_url() -> str:
+    """A throwaway file-backed SQLite URL. Managed roles require a DB (no in-memory
+    mode); file-backed so the same DB is visible across the threads TestClient uses."""
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+class _CapturingSink(AuditSink):
+    def __init__(self):
+        self.events: list[AuditEvent] = []
+
+    def record(self, event: AuditEvent) -> None:
+        self.events.append(event)
+
+
+def _token(sub: str, jti: str | None = None) -> str:
+    claims = {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)}
+    if jti is not None:
+        claims["jti"] = jti
+    return jwt.encode(claims, SECRET, algorithm="HS256")
+
+
+def _auth(sub: str, jti: str | None = None) -> dict:
+    return {"Authorization": f"Bearer {_token(sub, jti)}"}
+
+
+def test_store_emits_change_events_with_actor_and_diff():
+    sink = _CapturingSink()
+    store = ManagedRoleStore(audit=sink, db_url=_db_url())
+
+    store.set_role_scopes("member", ["agents:*:read"], actor="alice")
+    store.set_role_scopes("member", ["agents:*:read", "agents:*:run"], actor="alice")  # widen
+    store.assign("bob", "member", actor="alice")
+    store.unassign("bob", "member", actor="alice")
+    store.remove_role("member", actor="alice")
+
+    actions = [(e.action, e.target, e.actor) for e in sink.events]
+    assert actions == [
+        ("role.set_scopes", "member", "alice"),
+        ("role.set_scopes", "member", "alice"),
+        ("user.assigned", "bob", "alice"),
+        ("user.unassigned", "bob", "alice"),
+        ("role.removed", "member", "alice"),
+    ]
+    # before/after captured on the widen
+    widen = sink.events[1]
+    assert widen.before == ["agents:read"]
+    assert set(widen.after) == {"agents:read", "agents:run"}
+    # assignment diff
+    assign = sink.events[2]
+    assert assign.before == [] and assign.after == ["member"]
+    # every event is timestamped
+    assert all(e.timestamp > 0 for e in sink.events)
+
+
+def test_no_sink_means_no_overhead_and_no_events():
+    store = ManagedRoleStore(db_url=_db_url())  # no audit
+    # should not raise and should be a no-op for auditing
+    store.set_role_scopes("member", ["agents:*:read"], actor="alice")
+    store.assign("bob", "member", actor="alice")
+    assert store.roles_of("bob") == ["member"]
+
+
+def test_db_audit_sink_is_append_only_table(tmp_path):
+    import sqlalchemy as sa
+
+    db_file = tmp_path / "audit.db"
+    url = f"sqlite:///{db_file}"
+    sink = DbAuditSink(db_url=url)
+    store = ManagedRoleStore(audit=sink, db_url=_db_url())
+
+    store.set_role_scopes("member", ["agents:*:read"], actor="alice")
+    store.assign("bob", "member", actor="alice")
+    store.unassign("bob", "member", actor="carol")
+
+    eng = sa.create_engine(url)
+    with eng.connect() as c:
+        rows = c.execute(sa.text("select actor, action, target, before, after from authz_audit order by id")).fetchall()
+    assert [tuple(r[:3]) for r in rows] == [
+        ("alice", "role.set_scopes", "member"),
+        ("alice", "user.assigned", "bob"),
+        ("carol", "user.unassigned", "bob"),
+    ]
+    # before/after persisted as JSON
+    assert rows[1].before == "[]" and rows[1].after == '["member"]'
+
+
+def test_http_api_records_actor_from_jwt():
+    sink = _CapturingSink()
+    store = ManagedRoleStore(audit=sink, db_url=_db_url())
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")  # bootstrap admin (not audited: no actor route)
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    sink.events.clear()
+    client.put("/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
+    client.post("/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"})
+    client.delete("/authz/users/bob/roles/runner", headers=_auth("alice"))
+
+    actions = [(e.action, e.target, e.actor) for e in sink.events]
+    assert actions == [
+        ("role.set_scopes", "runner", "alice"),
+        ("user.assigned", "bob", "alice"),
+        ("user.unassigned", "bob", "alice"),
+    ]
+
+
+def _decision_os(sink):
+    """An AgentOS where viewer can read agents but not delete sessions, with the
+    given sink wired for decision audit."""
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("bob", "viewer")
+
+    db = InMemoryDb()
+    agent = Agent(id="research-agent", name="Research Agent", db=db)
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        db=db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+            audit=sink,  # <- decision audit
+        ),
+    )
+    return store, agent_os
+
+
+def test_decision_audit_records_allow_and_deny():
+    """Each authorization decision (allow/deny) is recorded with the principal and
+    a non-secret token reference when an audit sink is on AuthorizationConfig."""
+    sink = _CapturingSink()
+    _, agent_os = _decision_os(sink)
+    client = TestClient(agent_os.get_app())
+
+    client.get("/agents/research-agent", headers=_auth("bob"))  # allowed (viewer reads)
+    client.delete("/sessions/s1", headers=_auth("bob"))  # denied (no sessions:delete)
+
+    by_action = {(e.action, e.actor) for e in sink.events}
+    assert ("access.allowed", "bob") in by_action
+    assert ("access.denied", "bob") in by_action
+
+    denied = next(e for e in sink.events if e.action == "access.denied")
+    assert denied.target.startswith("DELETE /sessions")
+    assert "sessions:delete" in (denied.metadata.get("required") or [])
+    # a token reference is captured, but NOT the raw token
+    assert denied.metadata.get("token") and len(denied.metadata["token"]) <= 16
+
+
+def test_decision_token_ref_prefers_jti_over_hash():
+    """The token reference is the token's jti when present (so it correlates to the
+    issuer's logs); only without a jti do we fall back to a short hash."""
+    sink = _CapturingSink()
+    _, agent_os = _decision_os(sink)
+    client = TestClient(agent_os.get_app())
+
+    client.get("/agents/research-agent", headers=_auth("bob", jti="tok-abc-123"))  # has jti
+    client.get("/agents/research-agent", headers=_auth("bob"))  # no jti -> hash
+
+    refs = [e.metadata.get("token") for e in sink.events if e.action == "access.allowed"]
+    assert "tok-abc-123" in refs  # jti used verbatim
+    hashed = [r for r in refs if r != "tok-abc-123"]
+    assert hashed and all(len(r) == 12 for r in hashed)  # fallback is the short hash
+
+
+def test_decision_and_change_audit_go_to_separate_tables(tmp_path):
+    """One DbAuditSink, two physically separate tables: role/assignment changes in
+    authz_audit, per-request decisions in authz_decisions."""
+    import sqlalchemy as sa
+
+    db_file = tmp_path / "audit.db"
+    url = f"sqlite:///{db_file}"
+    sink = DbAuditSink(db_url=url)
+
+    store, agent_os = _decision_os(sink)
+    # also route the store's change events to the same sink
+    store._audit = sink  # noqa: SLF001 (test wiring)
+    store.set_role_scopes("viewer", ["agents:*:read", "agents:*:run"], actor="alice")  # a change
+
+    client = TestClient(agent_os.get_app())
+    client.get("/agents/research-agent", headers=_auth("bob", jti="jti-1"))  # a decision (allow)
+    client.delete("/sessions/s1", headers=_auth("bob", jti="jti-2"))  # a decision (deny)
+
+    eng = sa.create_engine(url)
+    with eng.connect() as c:
+        changes = c.execute(sa.text("select action, target from authz_audit order by id")).fetchall()
+        decisions = c.execute(sa.text("select action, target, token_ref from authz_decisions order by id")).fetchall()
+
+    # change table holds only the role change, no access.* rows
+    assert [tuple(r) for r in changes] == [("role.set_scopes", "viewer")]
+    # decision table holds only access.* rows, with the jti as the token ref
+    actions = {(r[0], r[2]) for r in decisions}
+    assert ("access.allowed", "jti-1") in actions
+    assert ("access.denied", "jti-2") in actions
+    assert all(r[0].startswith("access.") for r in decisions)
+
+    # the readers are separated too
+    assert all(not e["action"].startswith("access.") for e in sink.read())
+    assert all(e["action"].startswith("access.") for e in sink.read_decisions())
+
+
+def test_decisions_endpoint_returns_trail_for_admin(tmp_path):
+    """GET /authz/decisions returns the decision trail (newest first) for admins;
+    it is separate from /authz/audit (changes)."""
+    db_file = tmp_path / "audit.db"
+    sink = DbAuditSink(db_url=f"sqlite:///{db_file}")
+    store = ManagedRoleStore(audit=sink, db_url=_db_url())
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("bob", "viewer")
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+            audit=sink,  # decisions land here too
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    client.get("/agents/research-agent", headers=_auth("bob", jti="dec-1"))  # allowed decision
+
+    # admin reads the decision trail
+    r = client.get("/authz/decisions", headers=_auth("alice"))
+    assert r.status_code == 200
+    events = r.json()["events"]
+    assert any(e["action"] == "access.allowed" and e["metadata"]["token"] == "dec-1" for e in events)
+
+    # /authz/audit (changes) does NOT contain the access.* decisions
+    changes = client.get("/authz/audit", headers=_auth("alice")).json()["events"]
+    assert all(not e["action"].startswith("access.") for e in changes)
+
+    # non-admin and anonymous are blocked
+    assert client.get("/authz/decisions", headers=_auth("bob")).status_code == 403
+    assert client.get("/authz/decisions").status_code == 401
+
+
+def test_audit_endpoint_returns_trail(tmp_path):
+    """GET /authz/audit returns the change trail (newest first) for admins only."""
+    db_file = tmp_path / "audit.db"
+    store = ManagedRoleStore(audit=DbAuditSink(db_url=f"sqlite:///{db_file}"), db_url=_db_url())
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    # make a couple of changes over the API
+    client.put("/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
+    client.post("/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"})
+
+    # admin can read the trail; newest first
+    r = client.get("/authz/audit", headers=_auth("alice"))
+    assert r.status_code == 200
+    events = r.json()["events"]
+    assert events[0]["action"] == "user.assigned" and events[0]["actor"] == "alice"
+    assert events[0]["after"] == ["runner"]
+    assert any(e["action"] == "role.set_scopes" and e["target"] == "runner" for e in events)
+
+    # non-admin and anonymous are blocked
+    store.assign("bob", "runner")  # bob still isn't an admin
+    assert client.get("/authz/audit", headers=_auth("bob")).status_code == 403
+    assert client.get("/authz/audit").status_code == 401
+
+
+def test_db_audit_sink_never_raises_into_caller(tmp_path, monkeypatch):
+    """#7: DbAuditSink.record must swallow DB errors (contract) so a failing audit
+    write can't turn a successful role change into a 500."""
+    from agno.os.authz.audit import AuditEvent, DbAuditSink
+
+    sink = DbAuditSink(db_url=f"sqlite:///{tmp_path / 'audit.db'}")
+
+    def boom(_event):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(sink, "_record_change", boom)
+    monkeypatch.setattr(sink, "_record_decision", boom)
+    # both trails: must not propagate
+    sink.record(AuditEvent(action="role.set_scopes", actor="alice", target="m"))
+    sink.record(AuditEvent(action="access.denied", actor="bob", target="GET /x"))

--- a/libs/agno/tests/integration/os/test_managed_roles_audit.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_audit.py
@@ -355,3 +355,85 @@ def test_db_audit_sink_never_raises_into_caller(tmp_path, monkeypatch):
     # both trails: must not propagate
     sink.record(AuditEvent(action="role.set_scopes", actor="alice", target="m"))
     sink.record(AuditEvent(action="access.denied", actor="bob", target="GET /x"))
+
+
+def test_per_resource_deny_is_recorded_when_it_denies_independently():
+    """The per-resource gate records its own DENY.
+
+    Note the route gate is ALREADY resource-aware (it puts resource_id in the context,
+    so a managed-role per-resource denial is decided -- and recorded -- there, with the
+    concrete resource in the target). The gap this covers is the case the route gate
+    can't: a provider whose ``check`` is stricter than its ``authorize_route``, so the
+    route is allowed and the per-resource dependency is what actually blocks. Without
+    recording here that denial would be invisible -- the trail would show the route
+    allowed and never show what stopped the request.
+    """
+    from agno.os.authz.provider import AuthorizationProvider
+
+    class RouteOpenResourceClosed(AuthorizationProvider):
+        """Lets every route through, then denies the specific resource."""
+
+        def check(self, ctx):
+            return False
+
+        def accessible_resource_ids(self, ctx):
+            return {"*"}
+
+        def authorize_route(self, ctx, required_scopes):
+            return True
+
+    sink = _CapturingSink()
+    db = InMemoryDb()
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[Agent(id="yours", name="Yours", db=db)],
+        db=db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=RouteOpenResourceClosed(),
+            audit=sink,
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+    r = client.post("/agents/yours/runs", headers=_auth("bob"), data={"message": "hi"})
+    assert r.status_code == 403, r.text
+
+    resource_denials = [e for e in sink.events if e.metadata.get("reason") == "resource_access_denied"]
+    assert resource_denials, f"per-resource deny not recorded; got {[(e.action, e.target) for e in sink.events]}"
+    ev = resource_denials[0]
+    assert ev.action == "access.denied" and ev.actor == "bob"
+    assert "yours" in ev.target
+
+
+def test_audit_sink_is_mirrored_onto_the_mcp_subapp():
+    """The MCP tool gate resolves its sink from the mounted sub-app's state (request.app
+    is the sub-app, not the main app). Without this mirror MCP decisions can't be
+    recorded at all, leaving the access trail covering REST/WS but silently missing the
+    entire MCP transport."""
+    pytest.importorskip("fastmcp")
+    sink = _CapturingSink()
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("viewer", ["agents:*:read"])
+
+    db = InMemoryDb()
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[Agent(id="research-agent", name="Research Agent", db=db)],
+        db=db,
+        authorization=True,
+        mcp_server=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            authorization_provider=store.provider,
+            audit=sink,
+        ),
+    )
+    app = agent_os.get_app()
+    assert getattr(app.state, "authz_audit", None) is sink
+    sub = getattr(getattr(agent_os, "_mcp_app", None), "state", None)
+    assert getattr(sub, "authz_audit", None) is sink, "MCP sub-app must resolve the SAME audit sink"

--- a/libs/agno/tests/integration/os/test_managed_roles_internal_token.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_internal_token.py
@@ -1,0 +1,96 @@
+"""Regression tests: the internal service token (scheduler executor) must pass the
+per-resource handler gate under a managed-roles (EngineAuthorizationProvider)
+deployment, while a normal user with no role is still denied at that same gate.
+
+Background: the scheduler executor POSTs to ``/agents/{id}/runs`` (and team/workflow
+equivalents) with ``Authorization: Bearer <internal_service_token>``. The JWT
+middleware authorizes that token at the route gate via ``INTERNAL_SERVICE_SCOPES``.
+But those run endpoints ALSO carry a per-resource handler gate
+(``require_resource_access`` -> ``check_resource_access`` -> ``provider.check``).
+Under managed roles, ``provider.check`` keys off the subject (``__scheduler__``) and
+token-carried roles, ignoring scopes — and ``__scheduler__`` has no assignment, so
+the handler gate used to return 403 even though the route gate passed.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the native engine + SQLAlchemy
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "managed-roles-internal-token-test-secret-at-least-256-bits-long"
+OS_ID = "managed-roles-internal-token-os"
+INTERNAL_TOKEN = "internal-service-token-for-scheduler-test-xxxxxxxxxxxxxxxx"
+
+
+def _db_url() -> str:
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+def _user_token(sub: str) -> str:
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET,
+        algorithm="HS256",
+    )
+
+
+@pytest.fixture
+def client_and_store():
+    store = ManagedRoleStore(db_url=_db_url())
+    # A real user with NO role assigned — should be denied at the per-resource gate.
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        internal_service_token=INTERNAL_TOKEN,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    return TestClient(app), store
+
+
+def _get_run(client: TestClient, token: str) -> int:
+    """Hit a per-resource-gated endpoint. The handler gate runs before the body, so:
+    403 => denied at the gate; anything else (404 for missing run) => gate passed."""
+    return client.get(
+        "/agents/research-agent/runs/nonexistent-run",
+        params={"session_id": "s1"},
+        headers={"Authorization": f"Bearer {token}"},
+    ).status_code
+
+
+def test_internal_token_passes_per_resource_gate(client_and_store):
+    """The scheduler's internal token must NOT be 403'd at the per-resource handler
+    gate under managed roles (it already passed the route gate)."""
+    client, _ = client_and_store
+    status = _get_run(client, INTERNAL_TOKEN)
+    assert status != 403, f"internal service token was denied at the per-resource gate (got {status})"
+
+
+def test_normal_user_without_role_still_denied(client_and_store):
+    """A normal user with no role assignment is STILL denied at the per-resource gate —
+    proving the internal-token bypass is strictly internal-only."""
+    client, _ = client_and_store
+    status = _get_run(client, _user_token("nobody"))
+    assert status == 403, f"normal user with no role should be denied at the gate (got {status})"

--- a/libs/agno/tests/integration/os/test_managed_users.py
+++ b/libs/agno/tests/integration/os/test_managed_users.py
@@ -28,7 +28,12 @@ class _CapturingSink(AuditSink):
 
 
 def _token(sub: str, **claims) -> str:
-    payload = {"sub": sub, "aud": OS_ID, "scopes": claims.pop("scopes", []), "exp": datetime.now(UTC) + timedelta(hours=1)}
+    payload = {
+        "sub": sub,
+        "aud": OS_ID,
+        "scopes": claims.pop("scopes", []),
+        "exp": datetime.now(UTC) + timedelta(hours=1),
+    }
     payload.update(claims)
     return jwt.encode(payload, SECRET, algorithm="HS256")
 
@@ -73,6 +78,25 @@ def test_store_crud_and_disable(tmp_path, db_url):
     assert store.remove("u2") is True
     assert store.get("u2") is None
     assert store.remove("u2") is False
+
+
+@pytest.mark.parametrize("db_url", [None, "sqlite"])
+def test_store_remove_many(tmp_path, db_url):
+    url = None if db_url is None else f"sqlite:///{tmp_path / 'users.db'}"
+    store = ManagedUserStore(db_url=url)
+    for i in ("u1", "u2", "u3"):
+        store.upsert(i, email=f"{i}@co")
+
+    # only existing ids are removed/returned; unknown ids and dups are skipped
+    removed = store.remove_many(["u1", "u2", "ghost", "u1"])
+    assert sorted(removed) == ["u1", "u2"]
+    assert store.get("u1") is None and store.get("u2") is None
+    assert store.get("u3") is not None
+    assert store.count() == 1
+
+    # empty list and all-unknown ids are no-ops
+    assert store.remove_many([]) == []
+    assert store.remove_many(["ghost"]) == []
 
 
 def test_store_emits_audit_with_actor_and_diff():
@@ -209,6 +233,34 @@ def test_users_api_is_admin_only():
 
     assert client.get("/authz/users", headers=_auth("bob")).status_code == 403  # non-admin
     assert client.get("/authz/users").status_code == 401  # anonymous
+
+
+def test_users_api_bulk_delete():
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("admin", ["agent_os:admin"])
+    roles.set_role_scopes("viewer", ["agents:*:read"])
+    roles.assign("alice", "admin")
+    roles.assign("bob", "viewer")
+    users = ManagedUserStore()
+
+    app = _os(roles, users).get_app()
+    app.include_router(get_roles_router(roles, user_store=users))
+    client = TestClient(app)
+
+    for uid in ("u1", "u2", "u3"):
+        client.post("/authz/users", headers=_auth("alice"), json={"id": uid, "email": f"{uid}@co"})
+
+    # bulk delete two known + one unknown id -> 204, only the known ones go
+    resp = client.request("DELETE", "/authz/users", headers=_auth("alice"), json={"user_ids": ["u1", "u2", "ghost"]})
+    assert resp.status_code == 204, resp.text
+    assert client.get("/authz/users/u1", headers=_auth("alice")).status_code == 404
+    assert client.get("/authz/users/u2", headers=_auth("alice")).status_code == 404
+    assert client.get("/authz/users/u3", headers=_auth("alice")).status_code == 200
+
+    # admin-only and validation (empty list is a 422)
+    assert client.request("DELETE", "/authz/users", headers=_auth("bob"), json={"user_ids": ["u3"]}).status_code == 403
+    assert client.request("DELETE", "/authz/users", json={"user_ids": ["u3"]}).status_code == 401
+    assert client.request("DELETE", "/authz/users", headers=_auth("alice"), json={"user_ids": []}).status_code == 422
 
 
 def test_disabled_user_is_denied_even_with_valid_token():

--- a/libs/agno/tests/integration/os/test_managed_users.py
+++ b/libs/agno/tests/integration/os/test_managed_users.py
@@ -12,7 +12,7 @@ import jwt
 import pytest
 from fastapi.testclient import TestClient
 
-from agno.os.authz.audit import AuditEvent, AuditSink  # noqa: E402
+from agno.os.authz.audit import AuditEvent, AuditSink, DbAuditSink  # noqa: E402
 from agno.os.authz.user_store import ManagedUserStore  # noqa: E402
 
 SECRET = "managed-users-secret-at-least-256-bits-long-padding-xxxxxx"
@@ -111,6 +111,7 @@ pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the nativ
 from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.role_router import get_roles_router  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
 from agno.os.config import AuthorizationConfig  # noqa: E402
 
@@ -142,6 +143,72 @@ def _os(role_store, user_store, **cfg):
             **cfg,
         ),
     )
+
+
+def test_users_api_crud_and_role_merge():
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("admin", ["agent_os:admin"])
+    roles.set_role_scopes("viewer", ["agents:*:read"])
+    roles.assign("alice", "admin")
+    users = ManagedUserStore()
+
+    app = _os(roles, users).get_app()
+    app.include_router(get_roles_router(roles, user_store=users))
+    client = TestClient(app)
+
+    # create a user
+    r = client.post("/authz/users", headers=_auth("alice"), json={"id": "bob", "email": "bob@co"})
+    assert r.status_code == 200, r.text
+    assert r.json()["id"] == "bob" and r.json()["role"] is None and r.json()["status"] == "active"
+
+    # give bob a role; the user view merges it in (singular: one role per user)
+    roles.assign("bob", "viewer")
+    got = client.get("/authz/users/bob", headers=_auth("alice")).json()
+    assert got["email"] == "bob@co" and got["role"] == "viewer"
+
+    # list is paginated ({data, meta}) and includes bob with his role
+    listed = client.get("/authz/users", headers=_auth("alice")).json()["data"]
+    assert any(u["id"] == "bob" and u["role"] == "viewer" for u in listed)
+
+    # fuzzy search filters by id/email/name, case-insensitive, before pagination
+    found = client.get("/authz/users?search=BOB", headers=_auth("alice")).json()
+    assert [u["id"] for u in found["data"]] == ["bob"] and found["meta"]["total_count"] == 1
+    assert [u["id"] for u in client.get("/authz/users?search=bob@co", headers=_auth("alice")).json()["data"]] == ["bob"]
+    nothing = client.get("/authz/users?search=zzz-no-match", headers=_auth("alice")).json()
+    assert nothing["data"] == [] and nothing["meta"]["total_count"] == 0
+
+    # sorting: any USER_SORT_FIELDS member, asc/desc; unknown field is a 422
+    client.post("/authz/users", headers=_auth("alice"), json={"id": "ann", "email": "ann@co"})
+    by_id = client.get("/authz/users?sort_by=id&sort_order=asc", headers=_auth("alice")).json()["data"]
+    assert [u["id"] for u in by_id] == sorted(u["id"] for u in by_id)
+    assert client.get("/authz/users?sort_by=evil", headers=_auth("alice")).status_code == 422
+
+    # update + delete; PATCH {"disabled": ...} is the revocation kill-switch
+    client.patch("/authz/users/bob", headers=_auth("alice"), json={"name": "Bob"})
+    assert client.get("/authz/users/bob", headers=_auth("alice")).json()["name"] == "Bob"
+    disabled = client.patch("/authz/users/bob", headers=_auth("alice"), json={"disabled": True}).json()
+    assert disabled["status"] == "disabled" and disabled["disabled"] is True
+    assert users.is_disabled("bob") is True
+    enabled = client.patch("/authz/users/bob", headers=_auth("alice"), json={"disabled": False}).json()
+    assert enabled["status"] == "active" and users.is_disabled("bob") is False
+    assert client.delete("/authz/users/bob", headers=_auth("alice")).json()["deleted"] is True
+    assert client.get("/authz/users/bob", headers=_auth("alice")).status_code == 404
+
+
+def test_users_api_is_admin_only():
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("admin", ["agent_os:admin"])
+    roles.set_role_scopes("viewer", ["agents:*:read"])
+    roles.assign("alice", "admin")
+    roles.assign("bob", "viewer")
+    users = ManagedUserStore()
+
+    app = _os(roles, users).get_app()
+    app.include_router(get_roles_router(roles, user_store=users))
+    client = TestClient(app)
+
+    assert client.get("/authz/users", headers=_auth("bob")).status_code == 403  # non-admin
+    assert client.get("/authz/users").status_code == 401  # anonymous
 
 
 def test_disabled_user_is_denied_even_with_valid_token():
@@ -215,6 +282,30 @@ def test_auto_provision_from_claims_at_the_gate():
     assert r.status_code == 200
     provisioned = users.get("carol")
     assert provisioned is not None and provisioned["email"] == "carol@co" and provisioned["name"] == "Carol"
+
+
+def test_stores_share_one_agno_db(tmp_path):
+    """Passing the same agno db to the role/user/audit stores reuses its engine,
+    so everything lives in one database (no second db_url to keep in sync)."""
+    import sqlalchemy as sa
+
+    from agno.db.sqlite import SqliteDb
+
+    shared = SqliteDb(db_file=str(tmp_path / "shared.db"))
+    r = ManagedRoleStore(db=shared)
+    u = ManagedUserStore(db=shared)
+    a = DbAuditSink(db=shared)  # noqa: F841 (constructed for table creation)
+
+    r.set_role_scopes("viewer", ["agents:*:read"])
+    r.assign("bob", "viewer")
+    u.upsert("bob", email="bob@co")
+
+    # all authz tables live in the single shared engine (native policy + grouping,
+    # users, and both audit trails)
+    tables = set(sa.inspect(shared.db_engine).get_table_names())
+    assert {"authz_policy", "authz_grouping", "authz_users", "authz_audit", "authz_decisions"} <= tables
+    assert r.roles_of("bob") == ["viewer"]
+    assert u.get("bob")["email"] == "bob@co"
 
 
 def test_db_takes_precedence_and_bad_db_errors():

--- a/libs/agno/tests/integration/os/test_managed_users.py
+++ b/libs/agno/tests/integration/os/test_managed_users.py
@@ -1,0 +1,224 @@
+"""The credential-less user directory (no-IdP tier).
+
+Covers the store itself (in-memory + SQLite), the admin HTTP surface
+(``/authz/users`` with roles merged in), and the enforcement value-add: a
+disabled user is denied at the gate even with a valid token, and just-in-time
+provisioning creates a directory row from token claims.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.os.authz.audit import AuditEvent, AuditSink  # noqa: E402
+from agno.os.authz.user_store import ManagedUserStore  # noqa: E402
+
+SECRET = "managed-users-secret-at-least-256-bits-long-padding-xxxxxx"
+OS_ID = "managed-users-os"
+
+
+class _CapturingSink(AuditSink):
+    def __init__(self):
+        self.events: list[AuditEvent] = []
+
+    def record(self, event: AuditEvent) -> None:
+        self.events.append(event)
+
+
+def _token(sub: str, **claims) -> str:
+    payload = {"sub": sub, "aud": OS_ID, "scopes": claims.pop("scopes", []), "exp": datetime.now(UTC) + timedelta(hours=1)}
+    payload.update(claims)
+    return jwt.encode(payload, SECRET, algorithm="HS256")
+
+
+def _auth(sub: str, **claims) -> dict:
+    return {"Authorization": f"Bearer {_token(sub, **claims)}"}
+
+
+# ----------------------------------------------------------------- store unit
+@pytest.mark.parametrize("db_url", [None, "sqlite"])
+def test_store_crud_and_disable(tmp_path, db_url):
+    url = None if db_url is None else f"sqlite:///{tmp_path / 'users.db'}"
+    store = ManagedUserStore(db_url=url)
+
+    # create
+    u = store.upsert("u1", email="u1@co", name="One")
+    assert u["id"] == "u1" and u["email"] == "u1@co" and u["disabled"] is False
+    assert store.get("u1")["name"] == "One"
+
+    # partial update keeps untouched fields
+    store.upsert("u1", name="Uno")
+    after = store.get("u1")
+    assert after["name"] == "Uno" and after["email"] == "u1@co"
+
+    # list newest-first
+    store.upsert("u2", email="u2@co")
+    ids = [u["id"] for u in store.list()]
+    assert set(ids) == {"u1", "u2"}
+
+    # disable / enable + is_disabled fast path
+    assert store.is_disabled("u1") is False
+    store.set_disabled("u1", True)
+    assert store.is_disabled("u1") is True
+    assert [u["id"] for u in store.list(include_disabled=False)] == ["u2"]
+    store.set_disabled("u1", False)
+    assert store.is_disabled("u1") is False
+
+    # unknown subject is not disabled (app may mint tokens for unseen users)
+    assert store.is_disabled("ghost") is False
+
+    # remove
+    assert store.remove("u2") is True
+    assert store.get("u2") is None
+    assert store.remove("u2") is False
+
+
+def test_store_emits_audit_with_actor_and_diff():
+    sink = _CapturingSink()
+    store = ManagedUserStore(audit=sink)
+
+    store.upsert("u1", email="u1@co", actor="admin")
+    store.upsert("u1", name="One", actor="admin")  # update
+    store.set_disabled("u1", True, actor="admin")
+    store.set_disabled("u1", True, actor="admin")  # no-op, no event
+    store.set_disabled("u1", False, actor="admin")
+    store.remove("u1", actor="admin")
+
+    actions = [(e.action, e.target, e.actor) for e in sink.events]
+    assert actions == [
+        ("user.created", "u1", "admin"),
+        ("user.updated", "u1", "admin"),
+        ("user.disabled", "u1", "admin"),
+        ("user.enabled", "u1", "admin"),
+        ("user.removed", "u1", "admin"),
+    ]
+
+
+def test_provision_from_claims_is_idempotent():
+    store = ManagedUserStore()
+    created = store.provision_from_claims("u1", {"email": "u1@co", "name": "One"})
+    assert created["email"] == "u1@co" and created["name"] == "One"
+    # second call is a no-op, returns existing (doesn't overwrite)
+    again = store.provision_from_claims("u1", {"email": "changed@co"})
+    assert again["email"] == "u1@co"
+
+
+# ----------------------------------------------------- HTTP API + enforcement
+pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the native engine + SQLAlchemy
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+
+def _db_url() -> str:
+    """A throwaway file-backed SQLite URL. Managed roles require a DB (no in-memory
+    mode); file-backed so the same DB is visible across the threads TestClient uses."""
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+def _os(role_store, user_store, **cfg):
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    return AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=role_store.provider,
+            user_store=user_store,
+            **cfg,
+        ),
+    )
+
+
+def test_disabled_user_is_denied_even_with_valid_token():
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("viewer", ["agents:*:read"])
+    roles.assign("bob", "viewer")
+    users = ManagedUserStore()
+    users.upsert("bob", email="bob@co")
+
+    client = TestClient(_os(roles, users).get_app())
+
+    # bob (viewer) can read while active
+    assert client.get("/agents/research-agent", headers=_auth("bob")).status_code == 200
+
+    # disable bob -> denied on the next request despite the still-valid token + role
+    users.set_disabled("bob", True)
+    blocked = client.get("/agents/research-agent", headers=_auth("bob"))
+    assert blocked.status_code == 403
+    assert "disabled" in blocked.json()["detail"].lower()
+
+    # re-enable -> allowed again
+    users.set_disabled("bob", False)
+    assert client.get("/agents/research-agent", headers=_auth("bob")).status_code == 200
+
+
+def test_disabled_user_is_denied_on_websocket():
+    """The kill-switch must also fire on the WebSocket connect path, not just HTTP:
+    a disabled user with a valid token is rejected at WS authenticate."""
+    import json as _json
+
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("viewer", ["agents:*:read", "workflows:*:run"])
+    roles.assign("bob", "viewer")
+    users = ManagedUserStore()
+    users.upsert("bob", email="bob@co")
+
+    client = TestClient(_os(roles, users).get_app())
+
+    def _auth_result():
+        with client.websocket_connect("/workflows/ws") as ws:
+            for _ in range(8):
+                if _json.loads(ws.receive_text()).get("event") == "connected":
+                    break
+            ws.send_text(_json.dumps({"action": "authenticate", "token": _token("bob", scopes=["workflows:run"])}))
+            for _ in range(8):
+                frame = _json.loads(ws.receive_text())
+                if frame.get("event") in ("authenticated", "auth_error"):
+                    return frame
+        raise AssertionError("no auth result frame within 8 messages")
+
+    # active -> authenticates over WS
+    assert _auth_result()["event"] == "authenticated"
+
+    # disabled -> rejected at WS authenticate despite a valid token
+    users.set_disabled("bob", True)
+    err = _auth_result()
+    assert err["event"] == "auth_error" and err.get("error_type") == "user_disabled", err
+
+
+def test_auto_provision_from_claims_at_the_gate():
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("viewer", ["agents:*:read"])
+    roles.assign("carol", "viewer")
+    users = ManagedUserStore()
+
+    client = TestClient(_os(roles, users, auto_provision_users=True).get_app())
+
+    assert users.get("carol") is None
+    # carol's first request provisions her from the token claims
+    r = client.get("/agents/research-agent", headers=_auth("carol", email="carol@co", name="Carol"))
+    assert r.status_code == 200
+    provisioned = users.get("carol")
+    assert provisioned is not None and provisioned["email"] == "carol@co" and provisioned["name"] == "Carol"
+
+
+def test_db_takes_precedence_and_bad_db_errors():
+    from agno.os.authz._db import engine_from_db
+
+    with pytest.raises(ValueError, match="db_engine"):
+        engine_from_db(object())  # not an agno db

--- a/libs/agno/tests/integration/os/test_native_engine.py
+++ b/libs/agno/tests/integration/os/test_native_engine.py
@@ -1,0 +1,334 @@
+"""NativePolicyEngine — agno's default managed-roles backend.
+
+Covers the decision model directly (deny-overrides, object wildcards, the
+scope<->policy read-back, roles-from-token vs stored subjects, transitive roles,
+accessible-ids) and SQLAlchemy persistence. Managed roles always require a DB —
+there is no in-memory mode, since an in-memory store can't stay consistent across
+the workers/replicas an AgentOS deployment runs — so every test runs on a
+throwaway SQLite DB and an unbound engine raises.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+pytest.importorskip("sqlalchemy")  # managed roles require a SQL DB; no in-memory mode
+
+from agno.os.authz.native_engine import NativePolicyEngine  # noqa: E402
+
+
+def _engine() -> NativePolicyEngine:
+    """A throwaway file-backed SQLite engine. File (not ``:memory:``) so the same DB
+    is visible across any threads, and each call is isolated to its own DB file."""
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return NativePolicyEngine(db_url=f"sqlite:///{path}")
+
+
+def test_basic_allow_and_deny_overrides():
+    eng = _engine()
+    eng.set_role_scopes(
+        "member",
+        [("agents:*:read", "allow"), ("agents:secret-agent:read", "deny")],
+    )
+    eng.assign("bob", "member")
+
+    # allowed on a normal agent, denied on the explicitly-denied one (deny wins)
+    assert eng.check_resource("agents", "public-agent", "read", subject="bob") is True
+    assert eng.check_resource("agents", "secret-agent", "read", subject="bob") is False
+    # action not granted at all
+    assert eng.check_resource("agents", "public-agent", "run", subject="bob") is False
+    # unknown subject
+    assert eng.check_resource("agents", "public-agent", "read", subject="nobody") is False
+
+
+def test_object_wildcard_matching():
+    eng = _engine()
+    eng.set_role_scopes("viewer", [("agents:*:read", "allow")])
+    eng.assign("v", "viewer")
+    # resource/* matches resource/<id> ...
+    assert eng.check_resource("agents", "x", "read", subject="v") is True
+    # ... but a per-id grant does not match a different id
+    eng.set_role_scopes("runner", [("agents:a1:run", "allow")])
+    eng.assign("r", "runner")
+    assert eng.check_resource("agents", "a1", "run", subject="r") is True
+    assert eng.check_resource("agents", "a2", "run", subject="r") is False
+
+
+def test_admin_scope_allows_everything():
+    eng = _engine()
+    eng.set_role_scopes("admin", [("agent_os:admin", "allow")])
+    eng.assign("alice", "admin")
+    assert eng.check_resource("agents", "any", "run", subject="alice") is True
+    assert eng.check_resource("teams", "any", "delete", subject="alice") is True
+    assert eng.check_scope("sessions:delete", subject="alice") is True
+    assert eng.accessible_resource_ids("agents", "read", subject="alice") == {"*"}
+
+
+def test_scope_read_back_is_canonical():
+    """agents:*:read and agents:read collapse to the same policy and read back as
+    the global form — matching the documented (lossy) convention."""
+    eng = _engine()
+    eng.set_role_scopes("v", [("agents:*:read", "allow")])
+    assert eng.get_role_scopes("v") == [("agents:read", "allow")]
+
+
+def test_add_remove_and_effect_flip():
+    eng = _engine()
+    eng.add_scope("e", "agents:read")
+    eng.add_scope("e", "agents:run")
+    assert {s for s, _ in eng.get_role_scopes("e")} == {"agents:read", "agents:run"}
+    # adding the same (obj, act) flips its effect rather than duplicating
+    eng.add_scope("e", "agents:read", effect="deny")
+    assert eng.get_role_scopes("e").count(("agents:read", "deny")) == 1
+    assert ("agents:read", "allow") not in eng.get_role_scopes("e")
+    eng.remove_scope("e", "agents:run")
+    assert [s for s, _ in eng.get_role_scopes("e")] == ["agents:read"]
+
+
+def test_roles_from_token_take_precedence():
+    eng = _engine()
+    eng.set_role_scopes("editor", [("agents:*:read", "allow"), ("agents:a1:run", "allow")])
+    # subject has no stored assignment; role carried on the token authorizes
+    assert eng.check_resource("agents", "a1", "run", subject="idp-user", roles=["editor"]) is True
+    assert eng.check_resource("agents", "a1", "run", subject="idp-user") is False
+
+
+def test_deny_on_one_token_role_does_not_veto_allow_on_another():
+    """Per-root deny-overrides: a deny in role A must not cancel an allow in role B
+    when both are carried on the token."""
+    eng = _engine()
+    eng.set_role_scopes("A", [("agents:a1:read", "deny")])
+    eng.set_role_scopes("B", [("agents:*:read", "allow")])
+    assert eng.check_resource("agents", "a1", "read", roles=["A", "B"]) is True
+    # but a single role with both allow and deny IS deny-overridden
+    eng.set_role_scopes("C", [("agents:*:read", "allow"), ("agents:a1:read", "deny")])
+    assert eng.check_resource("agents", "a1", "read", roles=["C"]) is False
+
+
+def test_transitive_role_assignment():
+    eng = _engine()
+    eng.set_role_scopes("super", [("agent_os:admin", "allow")])
+    eng.assign("lead", "super")  # a role assigned to a role
+    eng.assign("bob", "lead")
+    assert eng.check_resource("agents", "x", "run", subject="bob") is True
+
+
+def test_accessible_resource_ids_specific_and_wildcard():
+    eng = _engine()
+    eng.set_role_scopes("m", [("agents:a1:read", "allow"), ("agents:a2:read", "allow")])
+    eng.assign("bob", "m")
+    assert eng.accessible_resource_ids("agents", "read", subject="bob") == {"a1", "a2"}
+    # a collection/global grant widens to wildcard
+    eng.set_role_scopes("m", [("agents:*:read", "allow")])
+    assert eng.accessible_resource_ids("agents", "read", subject="bob") == {"*"}
+    # wrong action -> nothing
+    assert eng.accessible_resource_ids("agents", "run", subject="bob") == set()
+
+
+def test_remove_role_drops_policies_and_assignments():
+    eng = _engine()
+    eng.set_role_scopes("temp", [("agents:*:read", "allow")])
+    eng.assign("bob", "temp")
+    eng.remove_role("temp")
+    assert eng.get_role_scopes("temp") == []
+    assert eng.roles_of("bob") == []
+    assert "temp" not in eng.list_roles()
+
+
+def test_list_roles_includes_assignment_only_roles():
+    eng = _engine()
+    eng.assign("bob", "ghost")  # assigned but never given scopes
+    assert "ghost" in eng.list_roles()
+
+
+def test_unmappable_scope_is_not_satisfied():
+    eng = _engine()
+    eng.set_role_scopes("admin", [("agent_os:admin", "allow")])
+    eng.assign("alice", "admin")
+    # a malformed required scope returns False rather than raising
+    assert eng.check_scope("not::a::valid::scope::x", subject="alice") is False
+
+
+def test_persistence_round_trip(tmp_path):
+    """Policies and assignments survive a fresh engine pointed at the same DB."""
+    pytest.importorskip("sqlalchemy")
+    url = f"sqlite:///{tmp_path / 'policy.db'}"
+
+    eng = NativePolicyEngine(db_url=url)
+    eng.set_role_scopes("member", [("agents:*:read", "allow"), ("agents:a1:run", "allow")])
+    eng.assign("bob", "member")
+    assert eng.check_resource("agents", "a1", "run", subject="bob") is True
+
+    # a brand-new engine on the same DB loads the persisted state
+    eng2 = NativePolicyEngine(db_url=url)
+    assert eng2.roles_of("bob") == ["member"]
+    assert eng2.check_resource("agents", "a1", "run", subject="bob") is True
+    assert {s for s, _ in eng2.get_role_scopes("member")} == {"agents:read", "agents:a1:run"}
+
+    # mutations through the new engine also persist
+    eng2.unassign("bob", "member")
+    eng3 = NativePolicyEngine(db_url=url)
+    assert eng3.roles_of("bob") == []
+
+
+def test_list_filter_honours_deny_overrides_like_the_gate():
+    """Regression: a wildcard allow + per-resource deny must hide the denied
+    resource from list endpoints, matching the per-resource gate (deny-overrides).
+    Previously accessible_resource_ids returned {'*'} and leaked the denied one."""
+    from agno.os.authz.engine import EngineAuthorizationProvider
+    from agno.os.authz.provider import AuthorizationContext
+
+    class R:
+        def __init__(self, rid):
+            self.id = rid
+
+    eng = _engine()
+    # "read every agent EXCEPT the secret one"
+    eng.set_role_scopes("analyst", [("agents:*:read", "allow"), ("agents:secret:read", "deny")])
+    eng.assign("bob", "analyst")
+
+    # engine surfaces the denied id even though the allow is a wildcard
+    assert eng.accessible_resource_ids("agents", "read", subject="bob") == {"*"}
+    assert eng.denied_resource_ids("agents", "read", subject="bob") == {"secret"}
+
+    prov = EngineAuthorizationProvider(eng)
+    resources = [R("public"), R("secret"), R("other")]
+    # production list path builds the ctx with action=None (any-action visibility)
+    list_ctx = AuthorizationContext(principal_id="bob", resource_type="agents")
+    visible = {r.id for r in prov.filter_accessible(list_ctx, resources)}
+    assert visible == {"public", "other"}  # secret carved out, not leaked
+
+    # list visibility is consistent with the per-resource read gate
+    for r in resources:
+        gate = prov.check(
+            AuthorizationContext(principal_id="bob", resource_type="agents", resource_id=r.id, action="read")
+        )
+        assert (r.id in visible) == gate
+
+
+def test_denied_resource_ids_empty_without_denies():
+    eng = _engine()
+    eng.set_role_scopes("viewer", [("agents:*:read", "allow")])
+    eng.assign("v", "viewer")
+    assert eng.denied_resource_ids("agents", "read", subject="v") == set()
+
+
+def test_db_backed_is_fresh_across_engines_no_cache(tmp_path):
+    """Multi-container (#2): db-backed engines read fresh per decision, so a second
+    engine (another worker/replica) sees a revocation immediately — no reload, no
+    stale cache."""
+    pytest.importorskip("sqlalchemy")
+    url = f"sqlite:///{tmp_path / 'roles.db'}"
+
+    a = NativePolicyEngine(db_url=url)
+    a.set_role_scopes("admin", [("agent_os:admin", "allow")])
+    a.assign("bob", "admin")
+
+    b = NativePolicyEngine(db_url=url)  # a second "worker"
+    assert b.check_resource("agents", "x", "run", subject="bob") is True
+
+    a.unassign("bob", "admin")  # revoked on the first worker
+    # the second worker sees it on its very next decision — no reload() needed
+    assert b.check_resource("agents", "x", "run", subject="bob") is False
+    assert b.roles_of("bob") == []
+
+    # a scope change is seen live too
+    a.set_role_scopes("viewer", [("agents:*:read", "allow")])
+    a.assign("carol", "viewer")
+    assert b.check_resource("agents", "x", "read", subject="carol") is True
+    assert b.get_role_scopes("viewer") == [("agents:read", "allow")]
+
+
+def test_db_is_the_only_store_no_in_process_state(tmp_path):
+    """The DB is the only source of truth — there are no in-process policy/grouping
+    dicts to go stale (they were removed; a DB is required)."""
+    pytest.importorskip("sqlalchemy")
+    eng = NativePolicyEngine(db_url=f"sqlite:///{tmp_path / 'roles.db'}")
+    eng.set_role_scopes("viewer", [("agents:*:read", "allow")])
+    eng.assign("bob", "viewer")
+    assert not hasattr(eng, "_policies") and not hasattr(eng, "_grouping")
+    assert eng.is_bound is True
+    assert eng.roles_of("bob") == ["viewer"]  # reads work (fresh from DB)
+
+
+def test_unbound_engine_raises():
+    """No DB anywhere -> the engine is unbound and every operation raises, rather
+    than silently running an in-memory store that can't work across replicas."""
+    eng = NativePolicyEngine()  # no db / db_url
+    assert eng.is_bound is False
+    with pytest.raises(RuntimeError, match="requires a SQL database"):
+        eng.set_role_scopes("viewer", [("agents:*:read", "allow")])
+    with pytest.raises(RuntimeError, match="requires a SQL database"):
+        eng.check_resource("agents", "x", "read", subject="bob")
+    with pytest.raises(RuntimeError, match="requires a SQL database"):
+        eng.roles_of("bob")
+
+
+def test_set_role_scopes_atomic_on_bad_scope(tmp_path):
+    """#3: a bad scope mid-list must raise and leave the role's existing scopes
+    intact (cache AND db), not half-applied."""
+    pytest.importorskip("sqlalchemy")
+    url = f"sqlite:///{tmp_path / 'r.db'}"
+    eng = NativePolicyEngine(db_url=url)
+    eng.set_role_scopes("m", [("agents:*:read", "allow")])
+
+    with pytest.raises(ValueError):
+        eng.set_role_scopes("m", [("agents:*:run", "allow"), ("a:b:c:d", "allow")])  # 2nd is malformed
+
+    assert eng.get_role_scopes("m") == [("agents:read", "allow")]  # unchanged
+    # a fresh engine on the same DB agrees -> cache and DB never diverged
+    assert NativePolicyEngine(db_url=url).get_role_scopes("m") == [("agents:read", "allow")]
+
+
+def test_set_role_scopes_dedups_colliding_mappings(tmp_path):
+    """#6: two scopes that map to the same (resource, action) must not raise an
+    IntegrityError on persist; they collapse to one row (last effect wins)."""
+    pytest.importorskip("sqlalchemy")
+    url = f"sqlite:///{tmp_path / 'r.db'}"
+    eng = NativePolicyEngine(db_url=url)
+    # agents:read and agents:*:read both -> ('agents/*', 'read')
+    eng.set_role_scopes("m", [("agents:read", "allow"), ("agents:*:read", "allow")])
+    assert eng.get_role_scopes("m") == [("agents:read", "allow")]
+    assert NativePolicyEngine(db_url=url).get_role_scopes("m") == [("agents:read", "allow")]
+
+
+def test_authorize_route_requires_all_scopes_and_no_blanket_allow():
+    """#5: a route requiring >1 scope must satisfy ALL (was ANY). #4: a resource
+    route with mixed actions (ctx.action=None) must not blanket-allow."""
+    from agno.os.authz.engine import EngineAuthorizationProvider
+    from agno.os.authz.provider import AuthorizationContext
+
+    eng = _engine()
+    eng.set_role_scopes("partial", [("sessions:read", "allow")])
+    eng.set_role_scopes("full", [("sessions:read", "allow"), ("sessions:write", "allow")])
+    eng.assign("p", "partial")
+    eng.assign("f", "full")
+    prov = EngineAuthorizationProvider(eng)
+
+    # #5 — non-resource route requiring read AND write
+    req = ["sessions:read", "sessions:write"]
+    assert prov.authorize_route(AuthorizationContext(principal_id="p"), req) is False  # read only -> ALL fails
+    assert prov.authorize_route(AuthorizationContext(principal_id="f"), req) is True
+
+    # #4 — resource route, mixed actions => ctx.action is None; must require all, not allow
+    eng.set_role_scopes("reader", [("agents:secret:read", "allow")])
+    eng.assign("r", "reader")
+    mixed = AuthorizationContext(principal_id="r", resource_type="agents", resource_id="secret", action=None)
+    assert prov.authorize_route(mixed, ["agents:read", "agents:run"]) is False  # has read, not run
+    eng.set_role_scopes("reader", [("agents:secret:read", "allow"), ("agents:secret:run", "allow")])
+    assert prov.authorize_route(mixed, ["agents:read", "agents:run"]) is True
+
+
+def test_effect_must_be_allow_or_deny_fail_closed():
+    """A typo'd effect must raise, not silently become an allow (deny-overrides
+    keys off the exact string 'deny')."""
+    eng = _engine()
+    with pytest.raises(ValueError):
+        eng.add_scope("r", "agents:read", effect="denied")  # typo
+    with pytest.raises(ValueError):
+        eng.set_role_scopes("r", [("agents:read", "allw")])  # typo
+    # canonical effects (any case) are accepted
+    eng.add_scope("r", "agents:read", effect="DENY")
+    assert eng.get_role_scopes("r") == [("agents:read", "deny")]

--- a/libs/agno/tests/integration/os/test_policy_engine.py
+++ b/libs/agno/tests/integration/os/test_policy_engine.py
@@ -1,0 +1,118 @@
+"""The swappable-backend seam: ManagedRoleStore works with ANY PolicyEngine.
+
+Proves the engine port by backing the store with a tiny in-memory engine (no
+Casbin) and exercising the full agno-native surface + the provider through it.
+"""
+
+from typing import List, Set
+
+from agno.os.authz.engine import PolicyEngine, ScopeEntry
+from agno.os.authz.provider import AuthorizationContext
+from agno.os.authz.role_store import ManagedRoleStore
+
+
+def _db_url() -> str:
+    """A throwaway file-backed SQLite URL. Managed roles require a DB (no in-memory
+    mode); file-backed so the same DB is visible across the threads TestClient uses."""
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+class DictPolicyEngine(PolicyEngine):
+    """Minimal dict-backed engine — exact scope-string matching, admin override.
+    Enough to show the store/provider delegate correctly through the port."""
+
+    def __init__(self):
+        self._roles: dict = {}  # role -> {scope: effect}
+        self._assign: dict = {}  # subject -> set[role]
+
+    def set_role_scopes(self, role, entries: List[ScopeEntry]) -> None:
+        self._roles[role] = {s: e for s, e in entries}
+
+    def add_scope(self, role, scope, effect="allow") -> None:
+        self._roles.setdefault(role, {})[scope] = effect
+
+    def remove_scope(self, role, scope) -> None:
+        self._roles.get(role, {}).pop(scope, None)
+
+    def get_role_scopes(self, role) -> List[ScopeEntry]:
+        return list(self._roles.get(role, {}).items())
+
+    def remove_role(self, role) -> None:
+        self._roles.pop(role, None)
+        for s in self._assign.values():
+            s.discard(role)
+
+    def list_roles(self) -> List[str]:
+        return list(self._roles)
+
+    def assign(self, subject, role) -> None:
+        self._assign.setdefault(subject, set()).add(role)
+
+    def unassign(self, subject, role) -> None:
+        self._assign.get(subject, set()).discard(role)
+
+    def roles_of(self, subject) -> List[str]:
+        return sorted(self._assign.get(subject, set()))
+
+    def _scopes_for(self, subject, roles):
+        rs = roles if roles else (self.roles_of(subject) if subject else [])
+        out: dict = {}
+        for r in rs:
+            out.update(self._roles.get(r, {}))
+        return out
+
+    def check_scope(self, scope, *, subject=None, roles=None) -> bool:
+        sc = self._scopes_for(subject, roles)
+        return sc.get("agent_os:admin") == "allow" or sc.get(scope) == "allow"
+
+    def check_resource(self, rt, rid, action, *, subject=None, roles=None) -> bool:
+        if not rt or not action:
+            return True
+        return self.check_scope(f"{rt}:{action}", subject=subject, roles=roles)
+
+    def accessible_resource_ids(self, rt, action, *, subject=None, roles=None) -> Set[str]:
+        sc = self._scopes_for(subject, roles)
+        if sc.get("agent_os:admin") == "allow" or sc.get(f"{rt}:{action}") == "allow":
+            return {"*"}
+        return set()
+
+
+def test_store_runs_on_a_custom_engine_no_casbin():
+    store = ManagedRoleStore(engine=DictPolicyEngine(), db_url=_db_url())  # no casbin involved
+
+    # agno-native surface works through the port
+    store.set_role_scopes("viewer", ["agents:read"], name="Viewer", description="read only")
+    store.assign("bob", "viewer")
+    assert store.roles_of("bob") == ["viewer"]
+    assert store.list_roles() == ["viewer"]
+
+    # metadata is store-owned (not the engine), so it works regardless of backend
+    rec = store.get_role("viewer")
+    assert rec["name"] == "Viewer" and rec["description"] == "read only"
+    assert store.get_role_scope_entries("viewer") == [{"scope": "agents:read", "effect": "allow"}]
+
+    # the provider delegates decisions to the engine
+    prov = store.provider
+    assert prov.check(AuthorizationContext(principal_id="bob", resource_type="agents", action="read")) is True
+    assert prov.check(AuthorizationContext(principal_id="bob", resource_type="agents", action="run")) is False
+
+    # admin gate delegates too
+    assert store.can_manage("bob") is False
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")
+    assert store.can_manage("alice") is True
+
+
+def test_patch_and_remove_through_engine():
+    store = ManagedRoleStore(engine=DictPolicyEngine(), db_url=_db_url())
+    store.create_role("editor", name="Editor")
+    store.patch_role_scopes("editor", upsert=["agents:read", "agents:run"])
+    store.patch_role_scopes("editor", remove=["agents:run"])
+    assert [e["scope"] for e in store.get_role_scope_entries("editor")] == ["agents:read"]
+    store.remove_role("editor")
+    assert store.get_role("editor") is None

--- a/libs/agno/tests/unit/os/test_mcp_auth_builtin.py
+++ b/libs/agno/tests/unit/os/test_mcp_auth_builtin.py
@@ -997,3 +997,43 @@ def test_loopback_redirect_matching():
     assert matches("https://claude.ai/cb", "http://claude.ai/cb") is False
     # Refused: userinfo in the URI must never participate in matching.
     assert matches("http://x@127.0.0.1:62000/callback", reg) is False
+
+
+async def test_identity_bridge_denies_disabled_user_over_mcp_auth(tmp_path):
+    """mcp_auth exempts /mcp from the parent AuthMiddleware, so the disabled-user
+    kill-switch that lives there does not run for OAuth'd MCP traffic. The identity
+    bridge must re-apply it: a disabled user's valid token is NOT bridged (leaving
+    request.state.authenticated unset), so the fail-closed tool gate denies. An enabled
+    user is bridged normally. Locks the revocation-over-OAuth'd-MCP fix in."""
+    from types import SimpleNamespace
+
+    from agno.db.sqlite import SqliteDb
+    from agno.os.authz.user_store import ManagedUserStore
+    from agno.os.mcp_auth import MCPIdentityBridgeMiddleware
+
+    users = ManagedUserStore(db=SqliteDb(db_file=str(tmp_path / "u.db")))
+    users.upsert("alice", email="alice@co")
+    users.upsert("bob", email="bob@co")
+    users.set_disabled("bob", True)
+
+    captured: dict = {}
+
+    async def inner(scope, receive, send):
+        captured["state"] = dict(scope.get("state", {}))
+
+    bridge = MCPIdentityBridgeMiddleware(inner, admin_scope="agent_os:admin", user_store=users)
+
+    def make_scope(sub):
+        token = SimpleNamespace(claims={"sub": sub}, scopes=["agents:*:run"], client_id=sub)
+        return {"type": "http", "user": SimpleNamespace(access_token=token), "state": {}}
+
+    # enabled user -> identity bridged
+    await bridge(make_scope("alice"), None, None)
+    assert captured["state"].get("authenticated") is True
+    assert captured["state"].get("user_id") == "alice"
+
+    # disabled user -> identity NOT bridged; tool gate then fails closed
+    captured.clear()
+    await bridge(make_scope("bob"), None, None)
+    assert captured["state"].get("authenticated") is not True
+    assert "user_id" not in captured["state"]

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -1176,3 +1176,36 @@ async def test_assigning_config_to_mcp_server_attribute_applies_config():
     assert os.mcp_server is True
     assert os.mcp_config is not None
     assert await _tool_names(os) == {"ping"}
+
+
+def test_managed_role_provider_is_mirrored_onto_mcp_subapp():
+    """The MCP tools are a mounted sub-app whose ``request.app`` is the sub-app, not the
+    main AgentOS app. The tool gate resolves its AuthorizationProvider from that ``.app``,
+    so a role_store / custom provider must be mirrored onto the sub-app's state. Without
+    the mirror the gate silently falls back to the default ScopeAuthorizationProvider and a
+    scope-less (role-only) token is denied every tool -- managed RBAC degrades to scope-only
+    over MCP. This locks the mirror in.
+    """
+    import tempfile
+
+    from agno.db.sqlite import SqliteDb
+    from agno.os.authz.role_store import ManagedRoleStore
+    from agno.os.config import AuthorizationConfig
+
+    with tempfile.NamedTemporaryFile(suffix=".db") as f:
+        roles = ManagedRoleStore(db=SqliteDb(db_file=f.name))
+        roles.set_role_scopes("admin", ["agent_os:admin"])
+        os = AgentOS(
+            id="mcp-authz",
+            agents=[_agent()],
+            authorization=True,
+            mcp_server=True,
+            authorization_config=AuthorizationConfig(
+                verification_keys=["x" * 40], algorithm="HS256", role_store=roles
+            ),
+        )
+        app = os.get_app()
+        main_provider = getattr(app.state, "authorization_provider", None)
+        assert main_provider is not None, "main app should carry the managed-role provider"
+        sub_provider = getattr(getattr(os._mcp_app, "state", None), "authorization_provider", None)
+        assert sub_provider is main_provider, "MCP sub-app must resolve the SAME provider as the main app"

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -1200,9 +1200,7 @@ def test_managed_role_provider_is_mirrored_onto_mcp_subapp():
             agents=[_agent()],
             authorization=True,
             mcp_server=True,
-            authorization_config=AuthorizationConfig(
-                verification_keys=["x" * 40], algorithm="HS256", role_store=roles
-            ),
+            authorization_config=AuthorizationConfig(verification_keys=["x" * 40], algorithm="HS256", role_store=roles),
         )
         app = os.get_app()
         main_provider = getattr(app.state, "authorization_provider", None)

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -1209,3 +1209,49 @@ def test_managed_role_provider_is_mirrored_onto_mcp_subapp():
         assert main_provider is not None, "main app should carry the managed-role provider"
         sub_provider = getattr(getattr(os._mcp_app, "state", None), "authorization_provider", None)
         assert sub_provider is main_provider, "MCP sub-app must resolve the SAME provider as the main app"
+
+
+def test_authz_mirror_survives_a_rebuilt_mcp_subapp():
+    """The mirror lives next to the mount, so a REBUILT sub-app gets it re-applied.
+
+    Previously the mirror happened only at seed time, which was correct purely because
+    _mcp_app is built once and never replaced. If anything ever rebuilds it (or remounts
+    onto a fresh app), a seed-time-only mirror would leave the new sub-app with no
+    provider -- silently degrading managed-role RBAC to scope-only over MCP, the exact
+    bug this guards. Simulate the rebuild and assert the state is restored.
+    """
+    import tempfile
+
+    from agno.db.sqlite import SqliteDb
+    from agno.os.authz.audit import LoggingAuditSink
+    from agno.os.authz.role_store import ManagedRoleStore
+    from agno.os.config import AuthorizationConfig
+
+    with tempfile.NamedTemporaryFile(suffix=".db") as f:
+        roles = ManagedRoleStore(db=SqliteDb(db_file=f.name))
+        roles.set_role_scopes("admin", ["agent_os:admin"])
+        sink = LoggingAuditSink()
+        os = AgentOS(
+            id="mcp-mirror",
+            agents=[_agent()],
+            authorization=True,
+            mcp_server=True,
+            authorization_config=AuthorizationConfig(
+                verification_keys=["x" * 40], algorithm="HS256", role_store=roles, audit=sink
+            ),
+        )
+        app = os.get_app()
+        provider = app.state.authorization_provider
+        assert os._mcp_app.state.authorization_provider is provider
+        assert os._mcp_app.state.authz_audit is sink
+
+        # Simulate a rebuilt sub-app by clearing the state a fresh one would not have.
+        sub = os._mcp_app
+        for attr in ("authorization_provider", "authz_audit"):
+            delattr(sub.state, attr)
+        assert not hasattr(sub.state, "authorization_provider")
+
+        # Re-mounting must restore both, rather than leaving the gate scope-only.
+        os._mount_mcp_app(app)
+        assert sub.state.authorization_provider is provider
+        assert sub.state.authz_audit is sink


### PR DESCRIPTION
… enforce, incl. OAuth'd MCP)

Rebased onto current main (v2.7.2: AuthMiddleware + service accounts + MCP OAuth #8793 +
the mcp_server rename #8812). Re-inserts the managed-roles / pluggable-provider model so a
custom AuthorizationProvider enforces at the four choke points main gates scopes, default
path byte-identical to today.

- Model os/authz/** added unchanged; AuthorizationConfig gains authorization_provider /
  role_store / audit + xor validator.
- Default parity: ScopeAuthorizationProvider delegates to main's has_required_scopes /
  get_accessible_resource_ids.
- Choke points via the provider: AuthMiddleware._check_scopes (REST, incl. GET-listing
  hatch), auth per-resource gates, the 3 WS workflow gates, and mcp._require_tool_scopes.
- MCP integration with #8793: the tool gate now routes the decision through the provider
  (so managed roles enforce on OAuth-authenticated /mcp callers too) while keeping #8793's
  bridge-fail-closed and external-AS misconfig warning.
- app.state.authorization_provider seeded from AuthorizationConfig; role_store binds the OS
  db or fails loud. is_internal_service carried into both internal-token branches so
  scheduler runs aren't 403'd. Decision-audit sink wired at the gate.

Validated on v2.7.2 main: authz suite + managed-roles-on-main e2e (assign a role -> tool
access with an empty-scopes token) 35, #8793 MCP-OAuth suite 106, v2.7 core (scopes / jwt /
service accounts / MCP surface) 221 — all pass. ruff/mypy clean.## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
