### PR TITLE
fix: skip the FileSystem Postgres test lane when no server is reachable

### DIFF
--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -1208,6 +1208,26 @@ jobs:
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CI: "true"
+    # tests/integration/fs exercises DbFileSystem on Postgres as well as SQLite, and
+    # the dialects genuinely diverge: psycopg3 returns rowcount -1 for a guarded
+    # upsert, so a SQLite-only run passes a quota guard that never fires in
+    # production. Port 5532 matches cookbook/scripts/run_pgvector.sh so local and CI
+    # share one URL.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: ai
+          POSTGRES_PASSWORD: ai
+          POSTGRES_DB: ai
+        ports:
+          - 5532:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/libs/agno/tests/integration/fs/conftest.py
+++ b/libs/agno/tests/integration/fs/conftest.py
@@ -17,6 +17,7 @@ import os
 
 import pytest
 from sqlalchemy import create_engine, text
+from sqlalchemy.exc import OperationalError
 
 from agno.fs.db import DbFileSystem
 
@@ -27,10 +28,23 @@ DIALECTS = ["sqlite", "postgresql"]
 
 @pytest.fixture(scope="session")
 def pg_engine():
-    """Eager-connect Postgres engine with a private, per-process schema."""
+    """Eager-connect Postgres engine with a private, per-process schema.
+
+    Skips when no server is reachable. CI runs this directory in a job with no
+    database service (the release workflow's `test-remaining`, which excludes the
+    other db-dependent suites by path), so an unguarded connect fails the whole
+    job. Skipping keeps the SQLite half of every matrix running there while the
+    Postgres half still runs for anyone with the container up. The skip is loud
+    in pytest output, so a genuinely broken local Postgres is still visible.
+    """
     engine = create_engine(PG_URL)
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("SELECT 1"))
+    except OperationalError as e:
+        engine.dispose()
+        pytest.skip(f"Postgres not reachable at {PG_URL} ({type(e).__name__}); run cookbook/scripts/run_pgvector.sh")
     with engine.begin() as conn:
-        conn.execute(text("SELECT 1"))
         conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{PG_SCHEMA}"'))
     yield engine
     with engine.begin() as conn:

--- a/libs/agno/tests/integration/fs/conftest.py
+++ b/libs/agno/tests/integration/fs/conftest.py
@@ -43,6 +43,17 @@ def pg_engine():
             conn.execute(text("SELECT 1"))
     except OperationalError as e:
         engine.dispose()
+        # In CI this must FAIL, never skip. The dialects genuinely diverge (psycopg3
+        # returns rowcount -1 for a guarded upsert, so a SQLite-only run passes a
+        # quota guard that never fires in production), and a skip would hide the loss
+        # of that coverage behind a green build. CI provides the service; locally,
+        # skipping just means "start the container".
+        if os.environ.get("CI"):
+            pytest.fail(
+                f"Postgres is required in CI but was unreachable at {PG_URL} ({type(e).__name__}). "
+                "The Postgres lane must run here: it is the only place dialect-specific "
+                "behaviour is covered. Check the postgres service on this job."
+            )
         pytest.skip(f"Postgres not reachable at {PG_URL} ({type(e).__name__}); run cookbook/scripts/run_pgvector.sh")
     with engine.begin() as conn:
         conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{PG_SCHEMA}"'))


### PR DESCRIPTION
## Summary

Fixes the integration test failure blocking the v2.8.2 release PR (#9154), by giving CI a Postgres service rather than by skipping.

`tests/integration/fs/` landed on main with #9142. The release workflow's `test-remaining` job runs everything under `tests/integration` except an explicit ignore list, and it had **no database service** — every other db-dependent suite is excluded by path. `integration/fs` was not on that list, so CI ran the Postgres lane with no Postgres and the job failed.

## Why not just skip

The first version of this PR made the fixture skip when no server was reachable. @kaustubh was right that this is the wrong fix: it makes the job green by deleting the coverage, so Postgres-only bugs stop being caught.

That is not hypothetical here. psycopg3 returns `rowcount = -1` for a guarded `INSERT ... ON CONFLICT`, so the per-file quota guard silently never fired on Postgres while passing every SQLite test. That bug was found by running the Postgres lane. A skip would mean the next one of its kind ships.

## What this does instead

1. **`test-remaining` runs a `pgvector/pgvector:pg17` service** on port 5532, the same port `cookbook/scripts/run_pgvector.sh` uses, so local and CI share one URL. `agno[dev]` already pulls `agno[psycopg]`, so the driver was present; only the server was missing.
2. **The fixture fails, rather than skips, when `CI` is set.** The skip is kept for local runs without the container, but in CI an unreachable Postgres is now an error naming the service. A skip there would hide the loss of dialect coverage behind a green build, which is how this gap appeared in the first place.

## Verification

Three paths, locally:

| Scenario | Result |
|---|---|
| Postgres up | `109 passed` |
| Unreachable, local | `58 passed, 51 skipped` |
| Unreachable, `CI=true` | `58 passed, 51 errors` naming the service |

Full new suite `436 passed`, `./scripts/validate.sh` clean. YAML parsed to confirm the service attached to `test-remaining` and no other job changed.

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Test/CI-only change; no library code touched
- [x] `./scripts/format.sh` and `./scripts/validate.sh` clean
- [x] Verified with Postgres reachable and unreachable, in and out of CI mode

## Follow-up worth its own issue

This is the first Postgres service in `test_on_release.yml`. The pre-existing db-dependent suites (`integration/db` and friends) are still excluded by path and do not run anywhere in CI, so their dialect coverage has the same gap this PR just closed for `fs`. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
