### PR TITLE
fix: handle string status during database replay

### DIFF
--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -361,6 +361,9 @@ async def _resume_stream_generator(
     """
     buffer_status = event_buffer.get_run_status(run_id)
 
+    def _status_value(status: Any) -> str:
+        return status.value if hasattr(status, "value") else str(status or "unknown")
+
     if buffer_status is None:
         # PATH 3: Not in buffer -- fall back to database
         if session_id and not isinstance(agent, RemoteAgent):
@@ -374,7 +377,7 @@ async def _resume_stream_generator(
                 meta: dict = {
                     "event": "replay",
                     "run_id": run_id,
-                    "status": run_output.status.value if run_output.status else "unknown",
+                    "status": _status_value(run_output.status),
                     "total_events": len(run_output.events),
                     "message": "Run completed. Replaying all events from database.",
                 }
@@ -392,7 +395,7 @@ async def _resume_stream_generator(
                 meta = {
                     "event": "replay",
                     "run_id": run_id,
-                    "status": run_output.status.value if run_output.status else "unknown",
+                    "status": _status_value(run_output.status),
                     "total_events": 0,
                     "message": "Run completed but no events stored.",
                 }

--- a/libs/agno/tests/unit/os/routers/test_agents_router.py
+++ b/libs/agno/tests/unit/os/routers/test_agents_router.py
@@ -1,0 +1,46 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agno.os.routers.agents import router as agents_router
+from agno.run.base import RunStatus
+
+
+class _DatabaseAgent:
+    def __init__(self, status):
+        self.status = status
+
+    async def aget_run_output(self, **kwargs):
+        return SimpleNamespace(status=self.status, events=[])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (RunStatus.completed, RunStatus.completed.value),
+        (RunStatus.completed.value, RunStatus.completed.value),
+    ],
+)
+async def test_resume_database_replay_accepts_enum_and_string_status(monkeypatch, status, expected):
+    monkeypatch.setattr(
+        agents_router.event_buffer,
+        "get_run_status",
+        lambda run_id: None,
+    )
+
+    chunks = [
+        chunk
+        async for chunk in agents_router._resume_stream_generator(
+            agent=_DatabaseAgent(status),
+            run_id="run-1",
+            last_event_index=None,
+            session_id="session-1",
+        )
+    ]
+
+    payload = json.loads(chunks[0].split("data: ", maxsplit=1)[1])
+    assert payload["event"] == "replay"
+    assert payload["status"] == expected
+    assert payload["total_events"] == 0


### PR DESCRIPTION
## What changed

Normalizes `RunOutput.status` before writing the AgentOS `/resume` database-replay metadata. Both enum values and already-deserialized strings are accepted.

## Why

Persisted run records can expose status as a plain string. The replay fallback currently accesses `.value` unconditionally, which raises before the terminal replay metadata or stored events can be returned.

The normalization remains local to database replay and preserves the existing enum output.

## Relationship to #8133

#8133 proposed coercing statuses at every `RunOutput.from_dict` root. That is a broader serialization-contract change and is now closed in favor of this focused consumer-boundary fix. This PR fixes the observed AgentOS replay failure without changing the shape returned by all agent, team, and workflow deserializers.

## Validation

- Added regression coverage for enum and string statuses.
- `2 passed`: `libs/agno/tests/unit/os/routers/test_agents_router.py`.
- Ruff format check and focused E/F lint checks pass.

Fixes #8454