### PR TITLE
fix: preserve executor state on workflow continuation

### DIFF
--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -286,8 +286,8 @@ def _executor_continue_run_context(paused_run_response: Any) -> RunContext:
     """
 
     return RunContext(
-        run_id=getattr(paused_run_response, "run_id", None),
-        session_id=getattr(paused_run_response, "session_id", None),
+        run_id=getattr(paused_run_response, "run_id", None) or "",
+        session_id=getattr(paused_run_response, "session_id", None) or "",
         user_id=getattr(paused_run_response, "user_id", None),
         session_state=getattr(paused_run_response, "session_state", None) or {},
     )

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -276,6 +276,23 @@ def _find_paused_executor_run(
     )
 
 
+def _executor_continue_run_context(paused_run_response: Any) -> RunContext:
+    """Build a RunContext for resuming a paused workflow step executor.
+
+    Agent/team continue paths rebuild session state from their own DB/cache
+    unless a RunContext is provided. Workflow executor pauses already persist
+    the executor RunOutput in ``step_executor_runs``; carrying its session_state
+    back into continue prevents a fresh worker from losing station state.
+    """
+
+    return RunContext(
+        run_id=getattr(paused_run_response, "run_id", None),
+        session_id=getattr(paused_run_response, "session_id", None),
+        user_id=getattr(paused_run_response, "user_id", None),
+        session_state=getattr(paused_run_response, "session_state", None) or {},
+    )
+
+
 def _apply_requirements_to_run_response(run_response: Any, requirements: list) -> None:
     """Apply resolved requirements to a paused run_response before continuing.
 
@@ -6513,10 +6530,12 @@ class Workflow:
 
         # Apply resolved requirements to the paused run_response (update tool states)
         _apply_requirements_to_run_response(paused_run_response, requirements)
+        executor_run_context = _executor_continue_run_context(paused_run_response)
 
         # Call executor's continue_run with the stored run_response
         continued_response = executor.continue_run(
             run_response=paused_run_response,
+            run_context=executor_run_context,
         )
 
         # Store executor response for potential chained HITL
@@ -6572,10 +6591,12 @@ class Workflow:
         # Find the paused executor run and apply resolved requirements
         paused_run_response = _find_paused_executor_run(workflow_run_response, step_req.executor_run_id)
         _apply_requirements_to_run_response(paused_run_response, requirements)
+        executor_run_context = _executor_continue_run_context(paused_run_response)
 
         # Call executor's continue_run with the stored run_response (streaming).
         response_stream = executor.continue_run(
             run_response=paused_run_response,
+            run_context=executor_run_context,
             stream=True,
             stream_events=True,
             yield_run_output=True,
@@ -6660,11 +6681,13 @@ class Workflow:
         # Find the paused executor run and apply resolved requirements
         paused_run_response = _find_paused_executor_run(workflow_run_response, step_req.executor_run_id)
         _apply_requirements_to_run_response(paused_run_response, requirements)
+        executor_run_context = _executor_continue_run_context(paused_run_response)
 
         # Call executor's acontinue_run with the stored run_response (streaming).
         # stream_events=True ensures RunCompleted/RunError lifecycle events are emitted.
         response_stream = executor.acontinue_run(
             run_response=paused_run_response,
+            run_context=executor_run_context,
             stream=True,
             stream_events=True,
             yield_run_output=True,
@@ -6744,10 +6767,12 @@ class Workflow:
         # Find the paused executor run and apply resolved requirements
         paused_run_response = _find_paused_executor_run(workflow_run_response, step_req.executor_run_id)
         _apply_requirements_to_run_response(paused_run_response, requirements)
+        executor_run_context = _executor_continue_run_context(paused_run_response)
 
         # Call executor's acontinue_run with the stored run_response
         continued_response = await executor.acontinue_run(
             run_response=paused_run_response,
+            run_context=executor_run_context,
         )
 
         # Store executor response for potential chained HITL

--- a/libs/agno/tests/unit/workflow/test_executor_continue_run_context.py
+++ b/libs/agno/tests/unit/workflow/test_executor_continue_run_context.py
@@ -1,0 +1,122 @@
+from agno.db.in_memory import InMemoryDb
+from agno.models.response import ToolExecution
+from agno.run import RunContext
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.requirement import RunRequirement
+from agno.workflow.step import Step
+from agno.workflow.types import StepInput, StepOutput
+from agno.workflow.workflow import Workflow
+
+
+class _PausingAgent:
+    store_media = True
+    store_tool_messages = True
+    store_history_messages = True
+
+    id = "pausing-agent"
+    agent_id = id
+    name = "Pausing Agent"
+
+    def __init__(self):
+        self.continue_contexts = []
+
+    def run(self, **kwargs):
+        tool = ToolExecution(
+            tool_call_id="confirm-1",
+            tool_name="confirm_artifact",
+            tool_args={},
+            requires_confirmation=True,
+        )
+        return RunOutput(
+            run_id=kwargs["run_id"],
+            agent_id=self.agent_id,
+            agent_name=self.name,
+            session_id=kwargs.get("session_id"),
+            status=RunStatus.paused,
+            tools=[tool],
+            requirements=[RunRequirement(tool_execution=tool)],
+            session_state=kwargs.get("session_state"),
+        )
+
+    async def arun(self, **kwargs):
+        return self.run(**kwargs)
+
+    def continue_run(self, *, run_response, run_context=None, **kwargs):
+        self.continue_contexts.append(run_context)
+        assert isinstance(run_context, RunContext)
+        assert run_context.session_state == {"artifact": {"id": "artifact-1"}}
+        assert all(requirement.is_resolved() for requirement in run_response.requirements)
+        return RunOutput(
+            run_id=run_response.run_id,
+            agent_id=self.agent_id,
+            agent_name=self.name,
+            session_id=run_response.session_id,
+            status=RunStatus.completed,
+            requirements=run_response.requirements,
+            session_state=run_response.session_state,
+        )
+
+    async def acontinue_run(self, *, run_response, run_context=None, **kwargs):
+        return self.continue_run(
+            run_response=run_response,
+            run_context=run_context,
+            **kwargs,
+        )
+
+
+def _finish(step_input: StepInput) -> StepOutput:
+    return StepOutput(content="finished")
+
+
+def _workflow(agent: _PausingAgent) -> Workflow:
+    return Workflow(
+        name="executor-context",
+        db=InMemoryDb(),
+        telemetry=False,
+        steps=[
+            Step(name="pause", agent=agent),
+            Step(name="finish", executor=_finish),
+        ],
+    )
+
+
+def _confirm_requirement(run_output: RunOutput) -> None:
+    requirement = run_output.step_requirements[-1].executor_requirements[0]
+    if isinstance(requirement, dict):
+        requirement["confirmation"] = True
+        requirement["tool_execution"]["confirmed"] = True
+    else:
+        requirement.confirm()
+
+
+def test_sync_executor_continue_restores_persisted_session_state():
+    agent = _PausingAgent()
+    workflow = _workflow(agent)
+    paused = workflow.run(
+        input="start",
+        session_id="session-1",
+        session_state={"artifact": {"id": "artifact-1"}},
+    )
+    _confirm_requirement(paused)
+
+    completed = workflow.continue_run(paused)
+
+    assert completed.status == RunStatus.completed
+    assert len(agent.continue_contexts) == 1
+
+
+async def test_async_executor_continue_restores_persisted_session_state():
+    agent = _PausingAgent()
+    workflow = _workflow(agent)
+    paused = await workflow.arun(
+        input="start",
+        session_id="session-1",
+        session_state={"artifact": {"id": "artifact-1"}},
+    )
+    _confirm_requirement(paused)
+
+    completed = await workflow.acontinue_run(paused)
+
+    assert completed.status == RunStatus.completed
+    assert len(agent.continue_contexts) == 1


### PR DESCRIPTION
## What changed

Builds a `RunContext` from the paused executor `RunOutput` and passes it to all four sync/async, streaming/non-streaming executor continuation paths.

## Why

Workflow executor pauses already persist the executor output in `step_executor_runs`. On a fresh worker, calling the executor's continuation without that context can rebuild state from an empty cache and lose the paused run's `session_state`.

This keeps continuation state anchored to the persisted executor run for agents and teams across every workflow continuation path.

## Validation

- Added sync and async regression tests using an in-memory workflow and a pausing executor.
- `2 passed`: `libs/agno/tests/unit/workflow/test_executor_continue_run_context.py`.
- Focused E/F lint and format checks pass.

Fixes #8901