### PR TITLE
fix: serialize nested executor requirements

### DIFF
--- a/libs/agno/agno/workflow/types.py
+++ b/libs/agno/agno/workflow/types.py
@@ -1145,7 +1145,10 @@ class StepRequirement:
         # Executor HITL fields
         if self.requires_executor_input:
             result["requires_executor_input"] = self.requires_executor_input
-            result["executor_requirements"] = self.executor_requirements
+            result["executor_requirements"] = [
+                req.to_dict() if hasattr(req, "to_dict") else req
+                for req in (self.executor_requirements or [])
+            ]
             result["executor_id"] = self.executor_id
             result["executor_name"] = self.executor_name
             result["executor_run_id"] = self.executor_run_id

--- a/libs/agno/agno/workflow/types.py
+++ b/libs/agno/agno/workflow/types.py
@@ -1146,8 +1146,7 @@ class StepRequirement:
         if self.requires_executor_input:
             result["requires_executor_input"] = self.requires_executor_input
             result["executor_requirements"] = [
-                req.to_dict() if hasattr(req, "to_dict") else req
-                for req in (self.executor_requirements or [])
+                req.to_dict() if hasattr(req, "to_dict") else req for req in (self.executor_requirements or [])
             ]
             result["executor_id"] = self.executor_id
             result["executor_name"] = self.executor_name

--- a/libs/agno/tests/unit/workflow/test_executor_hitl.py
+++ b/libs/agno/tests/unit/workflow/test_executor_hitl.py
@@ -12,8 +12,11 @@ Tests cover:
 - Parallel step guard for executor HITL
 """
 
+import json
 from unittest.mock import MagicMock
 
+from agno.models.response import ToolExecution
+from agno.run.requirement import RunRequirement
 from agno.run.workflow import (
     StepExecutorPausedEvent,
     WorkflowRunEvent,
@@ -192,6 +195,32 @@ class TestStepRequirementExecutorFields:
         assert d["executor_run_id"] == "run-1"
         assert d["executor_type"] == "agent"
         assert "_executor_run_response" not in d
+
+    def test_to_dict_serializes_run_requirement_objects(self):
+        """to_dict() converts nested RunRequirement objects for JSON storage."""
+        run_req = RunRequirement(
+            id="r1",
+            tool_execution=ToolExecution(
+                tool_call_id="call-1",
+                tool_name="commit_review",
+                tool_args={"row_id": "row-1"},
+                requires_confirmation=True,
+            ),
+        )
+        req = StepRequirement(
+            step_id="s1",
+            step_name="test",
+            step_index=0,
+            step_type=StepType.STEP,
+            requires_executor_input=True,
+            executor_requirements=[run_req],
+        )
+
+        d = req.to_dict()
+
+        json.dumps(d)
+        assert d["executor_requirements"][0]["id"] == "r1"
+        assert d["executor_requirements"][0]["tool_execution"]["tool_name"] == "commit_review"
 
     def test_to_dict_without_executor_fields(self):
         """to_dict() does not include executor fields when requires_executor_input is False."""


### PR DESCRIPTION
## What changed

`StepRequirement.to_dict()` now converts nested executor requirement objects through their `to_dict()` method while preserving requirements that are already dictionaries.

## Why

Executor HITL stores `RunRequirement` objects inside `executor_requirements`. Returning those model objects directly from an otherwise serialized `StepRequirement` leaves the result unsafe for standard JSON persistence.

The change also treats a missing requirement list as empty, matching the surrounding serialization behavior.

## Validation

- Added a regression test that serializes a nested `RunRequirement`/`ToolExecution` and verifies `json.dumps()` succeeds.
- `32 passed`: `libs/agno/tests/unit/workflow/test_executor_hitl.py`.
- Focused E/F lint and format checks pass.

Closes #9168