### PR TITLE
[fix] Hide member HITL placeholder from direct responses

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -737,7 +737,6 @@ def _get_delegate_task_function(
                 member_agent_task,  # type: ignore
                 member_session_state_copy,  # type: ignore
             )
-            yield f"Member '{member_agent.name}' requires human input before continuing."
             return
 
         if not stream:
@@ -923,7 +922,6 @@ def _get_delegate_task_function(
                 member_agent_task,  # type: ignore
                 member_session_state_copy,  # type: ignore
             )
-            yield f"Member '{member_agent.name}' requires human input before continuing."
             return
 
         if not stream:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5884,7 +5884,14 @@ def _build_continuation_message(member_results: List[str]) -> str:
 
 def _tool_result_requires_human_input(tool: ToolExecution) -> bool:
     result = tool.result or ""
-    return isinstance(result, str) and "requires human input" in result.lower()
+    if isinstance(result, str) and "requires human input" in result.lower():
+        return True
+
+    return (
+        tool.tool_name in {"delegate_task_to_member", "delegate_task_to_members"}
+        and tool.child_run_id is not None
+        and not result
+    )
 
 
 def _prepare_member_hitl_continuation(

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -702,6 +702,28 @@ class TestToolResultRequiresHumanInput:
         tool = _make_tool_execution(result={"key": "requires human input"})
         assert _tool_result_requires_human_input(tool) is False
 
+    def test_empty_delegate_result_with_child_run(self):
+        from agno.team._run import _tool_result_requires_human_input
+
+        tool = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            child_run_id="member-run-1",
+            result="",
+        )
+        assert _tool_result_requires_human_input(tool) is True
+
+    def test_empty_delegate_result_without_child_run(self):
+        from agno.team._run import _tool_result_requires_human_input
+
+        tool = _make_tool_execution(tool_name="delegate_task_to_member", result="")
+        assert _tool_result_requires_human_input(tool) is False
+
+    def test_empty_non_delegate_result_with_child_run(self):
+        from agno.team._run import _tool_result_requires_human_input
+
+        tool = _make_tool_execution(tool_name="some_other_tool", child_run_id="member-run-1", result="")
+        assert _tool_result_requires_human_input(tool) is False
+
 
 # ===========================================================================
 # 13. _prepare_member_hitl_continuation improvements
@@ -760,6 +782,23 @@ class TestPrepareMemberHitlContinuation:
         _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
 
         assert "Done" in tool.result
+
+    def test_updates_hidden_paused_delegate_result(self):
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="tc-1",
+            child_run_id="member-run-1",
+            result="",
+        )
+        run_response = self._make_run_response_with_tools([tool])
+        run_messages = self._make_run_messages(["tc-1"])
+
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+
+        assert "Done" in tool.result
+        assert "Done" in run_messages.messages[0].content
 
     def test_updates_multiple_matching_tools(self):
         from agno.team._run import _prepare_member_hitl_continuation

--- a/libs/agno/tests/unit/team/test_delegate_hitl_placeholder.py
+++ b/libs/agno/tests/unit/team/test_delegate_hitl_placeholder.py
@@ -1,0 +1,82 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agno.agent import Agent
+from agno.models.response import ToolExecution
+from agno.run import RunContext, RunStatus
+from agno.run.agent import RunOutput
+from agno.run.requirement import RunRequirement
+from agno.run.team import TeamRunOutput
+from agno.session import TeamSession
+from agno.team._default_tools import _get_delegate_task_function
+from agno.team.team import Team
+
+
+def _paused_member_output() -> RunOutput:
+    requirement = RunRequirement(
+        ToolExecution(
+            tool_name="external_tool",
+            tool_call_id="external-call",
+            external_execution_required=True,
+        )
+    )
+    return RunOutput(
+        run_id="member-run",
+        status=RunStatus.paused,
+        requirements=[requirement],
+    )
+
+
+def _delegation_context(member: Agent, *, async_mode: bool):
+    team = Team(name="Router", members=[member], respond_directly=True)
+    run_output = TeamRunOutput(
+        run_id="team-run",
+        session_id="session-1",
+        tools=[
+            ToolExecution(
+                tool_name="delegate_task_to_member",
+                tool_call_id="delegate-call",
+            )
+        ],
+    )
+    run_context = RunContext(run_id="team-run", session_id="session-1", session_state={})
+    session = TeamSession(session_id="session-1")
+    delegate = _get_delegate_task_function(
+        team,
+        run_output,
+        run_context,
+        session,
+        {},
+        async_mode=async_mode,
+    )
+    return delegate, run_output
+
+
+def _assert_pause_linkage(run_output: TeamRunOutput) -> None:
+    assert run_output.tools is not None
+    assert run_output.tools[0].child_run_id == "member-run"
+    assert run_output.requirements is not None
+    assert run_output.requirements[0].member_run_id == "member-run"
+
+
+def test_paused_member_delegate_does_not_yield_placeholder() -> None:
+    member = Agent(id="worker", name="Worker")
+    member.run = MagicMock(return_value=_paused_member_output())
+    delegate, run_output = _delegation_context(member, async_mode=False)
+
+    assert delegate.show_result is True
+    assert list(delegate.entrypoint(member_id="worker", task="do it")) == []
+    _assert_pause_linkage(run_output)
+
+
+@pytest.mark.asyncio
+async def test_paused_member_async_delegate_does_not_yield_placeholder() -> None:
+    member = Agent(id="worker", name="Worker")
+    member.arun = AsyncMock(return_value=_paused_member_output())
+    delegate, run_output = _delegation_context(member, async_mode=True)
+
+    assert delegate.show_result is True
+    output = [item async for item in delegate.entrypoint(member_id="worker", task="do it")]
+    assert output == []
+    _assert_pause_linkage(run_output)


### PR DESCRIPTION
## Summary

Related to #9069.

This PR fixes the user-visible placeholder leak when a directly responding team member pauses for human input:

- stop sync and async delegate generators without yielding the internal pause sentinel
- identify the paused delegation through its existing child_run_id when continuing
- retain support for persisted runs that contain the legacy sentinel text
- add sync, async, and continuation regression tests

This intentionally addresses only the placeholder-leak half of #9069. PR #8529 covers the separate route-mode continuation behavior that skips the additional leader model call.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) - not applicable; no public API changed
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) - not applicable
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

AI-assisted with Codex and reviewed against the surrounding delegation and continuation paths before submission.

Validation:

- Team unit suite: 545 passed, 2 skipped
- Focused continuation and placeholder tests: 64 passed
- Ruff check: passed
- Ruff format check: passed
- Mypy on all changed source and test files: passed
- git diff --check: clean

The repository scripts were not run directly because this is a Windows environment; their equivalent Ruff and Mypy checks were run on every changed file.