### PR TITLE
fix: FileSystem tools carry no instructions; the developer composes them

### DIFF
--- a/cookbook/13_filesystem/01_getting_started/README.md
+++ b/cookbook/13_filesystem/01_getting_started/README.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Attach a durable, private filesystem to an agent with one line: `Agent(tools=[fs.tools()])`. Take an ordinary agent, add that line, and its files now survive every future run, session, and process. The toolkit carries its own instructions.
+Attach a durable, private filesystem to an agent: `Agent(tools=[fs.tools()], instructions=[..., fs.instructions()])`. Take an ordinary agent, hand it those tools and pass `fs.instructions()` along with your own, and its files now survive every future run, session, and process. The instructions stay yours to edit, reorder, or replace.
 
 ## Files
 

--- a/cookbook/13_filesystem/01_getting_started/TEST_LOG.md
+++ b/cookbook/13_filesystem/01_getting_started/TEST_LOG.md
@@ -4,6 +4,17 @@ Tested 2026-07-24 against `gpt-5.5` (OpenAIResponses), agno 2.8.1 (source tree, 
 Re-run fresh at the final sweep (same date): every file in this folder PASS.
 Entries quote tool calls and printed state. Model prose varies run to run and is paraphrased rather than quoted.
 
+
+### Re-run 2026-07-25 — instructions composed explicitly
+
+`fs.tools()` no longer adds its instructions to the system prompt; every agent in this
+folder now passes `fs.instructions()` in its own instructions list. Re-tested against
+`gpt-5.5` (OpenAIResponses), agno 2.8.2 source tree, branch fix/filesystem-explicit-instructions.
+
+**basic.py — PASS.** Run 1 (empty store) called `append_file(path=notes/decisions.md, content=2026-07-25: Use SQLite for local development and Postgres in production., unique=True)`. Run 2, a separate process, called `list_files(directory=., pattern=, recursive=True, max_depth=3)` then `read_file(path=notes/decisions.md, start_line=1, end_line=20)` and answered SQLite. The composed block reaches the prompt as one bullet with its Conventions nested under it, and `unique=True` shows the record-log convention still landing.
+
+---
+
 ### basic.py
 
 **Status:** PASS

--- a/cookbook/13_filesystem/01_getting_started/basic.py
+++ b/cookbook/13_filesystem/01_getting_started/basic.py
@@ -1,8 +1,9 @@
 """
 FileSystem - Basic
 ==================
-Give your agent a durable, private filesystem. You attach it with one line,
-and anything the agent writes stays available in every future run.
+Give your agent a durable, private filesystem. Attach its tools, pass its
+instructions along with your own, and anything the agent writes stays
+available in every future run.
 
 Run this file twice. Run 1 writes a note. Run 2 is a new process with no
 shared session, and it reads the note back.
@@ -26,7 +27,10 @@ fs = FileSystem(SqliteDb(db_file=DB_FILE))
 agent = Agent(
     model=OpenAIResponses(id="gpt-5.5"),
     tools=[fs.tools()],
-    instructions="You are a note-keeping assistant.",
+    instructions=[
+        "You are a note-keeping assistant.",
+        fs.instructions(),
+    ],
 )
 
 # ---------------------------------------------------------------------------

--- a/cookbook/13_filesystem/01_getting_started/local_backend.py
+++ b/cookbook/13_filesystem/01_getting_started/local_backend.py
@@ -31,7 +31,10 @@ fs = FileSystem(LocalFileSystem(root=ROOT))
 agent = Agent(
     model=OpenAIResponses(id="gpt-5.5"),
     tools=[fs.tools()],
-    instructions="You are a note-keeping assistant.",
+    instructions=[
+        "You are a note-keeping assistant.",
+        fs.instructions(),
+    ],
 )
 
 # ---------------------------------------------------------------------------

--- a/cookbook/13_filesystem/02_durable_records/README.md
+++ b/cookbook/13_filesystem/02_durable_records/README.md
@@ -4,7 +4,7 @@ Deduplicate work with a record log: the agent calls `check_lines` before it acts
 
 Neither of the other kinds of state can do this. User memory is LLM-curated, so it merges and rewrites what it stores, and a recurring job needs the record verbatim. Session state does not survive, and a scheduled agent gets a fresh session on every run.
 
-The toolkit's built-in instructions already teach the check-before-act protocol and the `seen/` convention. The demo prompts below spell it out as well, so the runs stay deterministic. In your own agent the instructions alone usually carry it.
+`fs.instructions()`, passed along with your own, teaches the check-before-act protocol and the `seen/` convention. The demo prompts below spell it out as well, so the runs stay deterministic. In your own agent the instructions alone usually carry it.
 
 ## Files
 

--- a/cookbook/13_filesystem/02_durable_records/TEST_LOG.md
+++ b/cookbook/13_filesystem/02_durable_records/TEST_LOG.md
@@ -4,6 +4,16 @@ Tested 2026-07-24 against `gpt-5.5` (OpenAIResponses), agno 2.8.1 (source tree, 
 Re-run fresh at the final sweep (same date): every file in this folder PASS.
 Entries quote tool calls and printed state. Model prose varies run to run and is paraphrased rather than quoted.
 
+### Re-run 2026-07-25 - instructions composed explicitly
+
+`fs.tools()` no longer adds its instructions to the system prompt; both agents in this
+folder now pass `fs.instructions()` in their own instructions list. Re-tested against
+`gpt-5.5` (OpenAIResponses), agno 2.8.2 source tree, branch fix/filesystem-explicit-instructions.
+
+**basic.py - PASS.** Pass 1 called `check_lines(lines=['TICKET-101', 'TICKET-102'], directory=seen)` on the empty store and appended both to `seen/2026-07-24.md`. Pass 2 called `check_lines` on all three ids and appended only `TICKET-103` with `unique=True`. Final log printed exactly `TICKET-101 / TICKET-102 / TICKET-103`, so the check-before-act protocol still lands from the composed block.
+
+---
+
 ### basic.py
 
 **Status:** PASS

--- a/cookbook/13_filesystem/02_durable_records/basic.py
+++ b/cookbook/13_filesystem/02_durable_records/basic.py
@@ -30,7 +30,10 @@ fs = FileSystem(SqliteDb(db_file=DB_FILE))
 agent = Agent(
     model=OpenAIResponses(id="gpt-5.5"),
     tools=[fs.tools()],
-    instructions="You triage support tickets.",
+    instructions=[
+        "You triage support tickets.",
+        fs.instructions(),
+    ],
 )
 
 

--- a/cookbook/13_filesystem/02_durable_records/radar_news_delta.py
+++ b/cookbook/13_filesystem/02_durable_records/radar_news_delta.py
@@ -49,14 +49,15 @@ fs = FileSystem(SqliteDb(db_file=DB_FILE))
 agent = Agent(
     model=OpenAIResponses(id="gpt-5.5"),
     tools=[fs.tools()],
-    instructions=(
+    instructions=[
         "You are Radar, a news-brief agent that runs on a schedule. Each run you "
         "receive the current feed as 'id|headline' lines. Report ONLY stories you "
         "have never reported before: call check_lines on the ids with "
         "directory='seen' first, brief the missing ones (one bullet each), then "
         f"record the newly reported ids with append_file to seen/{TODAY}.md, one "
-        "id per line. If nothing is new, say so."
-    ),
+        "id per line. If nothing is new, say so.",
+        fs.instructions(),
+    ],
 )
 
 

--- a/cookbook/13_filesystem/03_working_state/basic.py
+++ b/cookbook/13_filesystem/03_working_state/basic.py
@@ -40,14 +40,15 @@ fs = FileSystem(SqliteDb(db_file=DB_FILE))
 agent = Agent(
     model=OpenAIResponses(id="gpt-5.5"),
     tools=[fs.tools()],
-    instructions=(
+    instructions=[
         "You run a data migration with these steps:\n" + "\n".join(STEPS) + "\n"
         "Each session you have time for exactly TWO steps. Read state/checkpoint.md "
         "first (it may not exist on the first run) to see what is already done. "
         "Perform the next two pending steps (performing = describing the work as "
         "done), then overwrite state/checkpoint.md with the full list of completed "
-        "steps using write_file. Reply with which steps you completed this session."
-    ),
+        "steps using write_file. Reply with which steps you completed this session.",
+        fs.instructions(),
+    ],
 )
 
 # ---------------------------------------------------------------------------

--- a/cookbook/13_filesystem/03_working_state/last_seen_monitor.py
+++ b/cookbook/13_filesystem/03_working_state/last_seen_monitor.py
@@ -45,14 +45,15 @@ fs = FileSystem(SqliteDb(db_file=DB_FILE))
 agent = Agent(
     model=OpenAIResponses(id="gpt-5.5"),
     tools=[fs.tools()],
-    instructions=(
+    instructions=[
         "You are a latency monitor that runs on a schedule. Each run you receive "
         "current p95 readings. Read state/last-run.md (it may not exist on the "
         "first run), then report which services changed by more than 20 percent "
         "since last run, or say that this is the baseline run. Finally overwrite "
         "state/last-run.md with the current readings using write_file, one "
-        "'service: value' per line."
-    ),
+        "'service: value' per line.",
+        fs.instructions(),
+    ],
 )
 
 

--- a/cookbook/13_filesystem/04_namespaces/README.md
+++ b/cookbook/13_filesystem/04_namespaces/README.md
@@ -10,7 +10,7 @@ The main reason to reach for one is per-user (and per-team) file stores from a s
 
 - `basic.py`: the declarative common case, `namespace="assistant/{user_id}"`. One agent serves alice and bob with fully isolated files, and an anonymous run fails closed instead of collapsing into a shared store.
 - `custom_factory.py`: the escape hatch for arbitrary policy. A callable tool factory builds the FileSystem from `run_context`, and here VIP users get their own tier of namespaces.
-- `shared_namespace.py`: two agents share files by attaching the same namespace name. The producer writes, and the consumer attaches with `tools(read_only=True)`, which gives it four read tools and the read-only instructions and no way to write.
+- `shared_namespace.py`: two agents share files by attaching the same namespace name. The producer writes, and the consumer attaches with `tools(read_only=True)` plus `instructions(read_only=True)`, which gives it four read tools and no way to write.
 
 ## When to use
 

--- a/cookbook/13_filesystem/04_namespaces/TEST_LOG.md
+++ b/cookbook/13_filesystem/04_namespaces/TEST_LOG.md
@@ -4,6 +4,17 @@ Tested 2026-07-24 against `gpt-5.5` (OpenAIResponses), agno 2.8.1 (source tree, 
 Re-run fresh at the final sweep (same date): every file in this folder PASS.
 Entries quote tool calls and printed state. Model prose varies run to run and is paraphrased rather than quoted.
 
+
+### Re-run 2026-07-25 — instructions composed explicitly
+
+`fs.tools()` no longer adds its instructions to the system prompt; every agent in this
+folder now passes `fs.instructions()` in its own instructions list. Re-tested against
+`gpt-5.5` (OpenAIResponses), agno 2.8.2 source tree, branch fix/filesystem-explicit-instructions.
+
+**shared_namespace.py — PASS.** Consumer tool surface printed `['read_file', 'list_files', 'search_content', 'check_lines']`. The recorder appended both decisions to `decisions/2026-07.md`; the read-only answerer, carrying `consumer_fs.instructions(read_only=True)`, called `list_files` then `read_file(path=decisions/2026-07.md, start_line=1, end_line=200)` and quoted the pgvector decision with its source line.
+
+---
+
 ### basic.py
 
 **Status:** PASS

--- a/cookbook/13_filesystem/04_namespaces/basic.py
+++ b/cookbook/13_filesystem/04_namespaces/basic.py
@@ -31,7 +31,10 @@ fs = FileSystem(db, namespace="assistant/{user_id}")
 agent = Agent(
     model=OpenAIResponses(id="gpt-5.5"),
     tools=[fs.tools()],
-    instructions="You are a project assistant. Keep your working notes in your files.",
+    instructions=[
+        "You are a project assistant. Keep your working notes in your files.",
+        fs.instructions(),
+    ],
 )
 
 # ---------------------------------------------------------------------------

--- a/cookbook/13_filesystem/04_namespaces/custom_factory.py
+++ b/cookbook/13_filesystem/04_namespaces/custom_factory.py
@@ -48,7 +48,12 @@ def fs_for_user(run_context: RunContext) -> List:
 agent = Agent(
     model=OpenAIResponses(id="gpt-5.5"),
     tools=fs_for_user,
-    instructions="You are a support assistant. Keep your case notes in your files.",
+    # The factory builds a FileSystem per user, so the instructions come off the
+    # class: they describe the tools, and never a namespace.
+    instructions=[
+        "You are a support assistant. Keep your case notes in your files.",
+        FileSystem.instructions(),
+    ],
 )
 
 # ---------------------------------------------------------------------------

--- a/cookbook/13_filesystem/04_namespaces/shared_namespace.py
+++ b/cookbook/13_filesystem/04_namespaces/shared_namespace.py
@@ -2,9 +2,9 @@
 Namespaces - Sharing One Store
 ==============================
 Two agents share files by attaching the same namespace by name. The producer
-gets the full tool surface. The consumer gets tools(read_only=True), which is
-four read tools plus the read-only instructions, so it can consult the
-records but holds no tool that could change them.
+gets the full tool surface. The consumer gets tools(read_only=True) and the
+matching instructions(read_only=True), which is four read tools, so it can
+consult the records but holds no tool that could change them.
 
 This example has a recorder agent write decisions and an answering agent look
 them up read-only.
@@ -32,14 +32,20 @@ consumer_fs = FileSystem(db, namespace="research/decisions")
 recorder = Agent(
     model=OpenAIResponses(id="gpt-5.5"),
     tools=[producer_fs.tools()],
-    instructions="You record engineering decisions.",
+    instructions=[
+        "You record engineering decisions.",
+        producer_fs.instructions(),
+    ],
 )
 
 consumer_toolkit = consumer_fs.tools(read_only=True)
 answerer = Agent(
     model=OpenAIResponses(id="gpt-5.5"),
     tools=[consumer_toolkit],
-    instructions="You answer questions about past engineering decisions.",
+    instructions=[
+        "You answer questions about past engineering decisions.",
+        consumer_fs.instructions(read_only=True),
+    ],
 )
 
 # ---------------------------------------------------------------------------

--- a/cookbook/13_filesystem/README.md
+++ b/cookbook/13_filesystem/README.md
@@ -22,7 +22,7 @@ Start with [`01_getting_started/basic.py`](01_getting_started/basic.py) and run 
 ````
 cookbook/13_filesystem/
 ├── README.md
-├── 01_getting_started/         # attach with one line; durability across processes
+├── 01_getting_started/         # attach the tools; durability across processes
 │   ├── README.md
 │   ├── basic.py                # run twice: write in run 1, recall in run 2
 │   ├── standalone.py           # the programmatic API, with no Agent and no model
@@ -36,7 +36,7 @@ cookbook/13_filesystem/
 
 ## Workflows
 
-- [`01_getting_started/`](01_getting_started/): attach FileSystem to an agent with one line, see that the files outlive the process, use FileSystem standalone, and swap the storage backend.
+- [`01_getting_started/`](01_getting_started/): attach FileSystem to an agent, see that the files outlive the process, use FileSystem standalone, and swap the storage backend.
 - [`02_durable_records/`](02_durable_records/): never repeat work, using exact-line dedupe with `check_lines` and `append_file`. Ends with a scheduled news agent that briefs only what is new.
 - [`03_working_state/`](03_working_state/): progress checkpoints and a last-seen monitor, for work that runs longer than one session.
 - [`04_namespaces/`](04_namespaces/): everything else uses the default store. Name a namespace when you need more than one: per-user file stores via `namespace="assistant/{user_id}"`, a callable tool factory for arbitrary policy, and two agents sharing one namespace with a read-only consumer.

--- a/libs/agno/agno/fs/fs.py
+++ b/libs/agno/agno/fs/fs.py
@@ -5,14 +5,17 @@ a pluggable ``BaseFS`` backend, database by default. Use it for the agent's
 own working state: records of items already processed, decisions, progress
 checkpoints.
 
-Attach with one line, and the toolkit carries its own instructions:
+Attach the tools, and compose its instructions into your own:
 
     from agno.agent import Agent
     from agno.db.sqlite import SqliteDb
     from agno.fs import FileSystem
 
     fs = FileSystem(SqliteDb(db_file="agent.db"))
-    agent = Agent(tools=[fs.tools()], instructions="my instructions")
+    agent = Agent(
+        tools=[fs.tools()],
+        instructions=["my instructions", fs.instructions()],
+    )
 """
 
 import asyncio
@@ -51,26 +54,26 @@ decisions, progress checkpoints, notes to your future self.
 For storing facts and memories about the user, prefer the user memory if provided and fallback to the filesystem if not.
 
 Conventions:
-- Paths are relative, like notes/decisions.md or seen/2026-07-24.md. Group
-  related files in directories.
-- To keep a record set (items already processed): store one record per line in
-  the seen/ directory, one file per date (seen/2026-07-24.md). Call
-  check_lines(lines, directory="seen") BEFORE acting, then record the new ones
-  with append_file(..., unique=True). check_lines matches exact whole lines, and
-  unique=True keeps the log free of duplicates if a run overlaps another one.
-- To correct or update part of a file, read it, then call replace_lines with the
-  line numbers you saw. Rewriting a whole file with write_file to change a few
-  lines wastes effort and risks losing the rest.
-- To find something in a large file, use search_content first: it reports the
-  line number of each match, which you can pass to read_file as start_line.
-- Store extracted facts and identifiers, not raw fetched payloads.
-- Never store secrets, passwords, or API keys.
-- Files have size limits. If a write is refused, start a new file in your
-  partition scheme (e.g. a new dated file), or delete only files you are certain
-  are obsolete, like a date partition older than you still need. Never overwrite
-  or delete a file of records to make room if you might still need those records:
-  dropping them means you will repeat work you already did. If nothing is safely
-  disposable, stop and report that storage is full rather than evicting history."""
+  - Paths are relative, like notes/decisions.md or seen/2026-07-24.md. Group
+    related files in directories.
+  - To keep a record set (items already processed): store one record per line in
+    the seen/ directory, one file per date (seen/2026-07-24.md). Call
+    check_lines(lines, directory="seen") BEFORE acting, then record the new ones
+    with append_file(..., unique=True). check_lines matches exact whole lines, and
+    unique=True keeps the log free of duplicates if a run overlaps another one.
+  - To correct or update part of a file, read it, then call replace_lines with the
+    line numbers you saw. Rewriting a whole file with write_file to change a few
+    lines wastes effort and risks losing the rest.
+  - To find something in a large file, use search_content first: it reports the
+    line number of each match, which you can pass to read_file as start_line.
+  - Store extracted facts and identifiers, not raw fetched payloads.
+  - Never store secrets, passwords, or API keys.
+  - Files have size limits. If a write is refused, start a new file in your
+    partition scheme (e.g. a new dated file), or delete only files you are certain
+    are obsolete, like a date partition older than you still need. Never overwrite
+    or delete a file of records to make room if you might still need those records:
+    dropping them means you will repeat work you already did. If nothing is safely
+    disposable, stop and report that storage is full rather than evicting history."""
 
 _READ_ONLY_INSTRUCTIONS = """You have read access to a durable filesystem.
 The files persist across sessions and runs.
@@ -80,8 +83,8 @@ you made, notes you left. You cannot change these files - you have no tool to
 write, append, move, or delete.
 
 Conventions:
-- Paths are relative, like notes/decisions.md or seen/2026-07-24.md.
-- Use check_lines to see what is already recorded before acting."""
+  - Paths are relative, like notes/decisions.md or seen/2026-07-24.md.
+  - Use check_lines to see what is already recorded before acting."""
 
 
 def _as_backend(source: Any) -> BaseFS:
@@ -447,15 +450,19 @@ class FileSystem:
     # ------------------------------------------------------------------
 
     def tools(self, *, read_only: bool = False, **kwargs) -> "Toolkit":
-        """Build the toolkit for this file store. ``Agent(tools=[fs.tools()])`` is the whole attach.
+        """Build the toolkit for this file store.
 
-        The toolkit carries its own instructions, so do not also pass the same
-        instance through the developer-instruction path (the block would render
-        twice). ``read_only=True`` registers only ``read_file``, ``list_files``,
-        ``search_content`` and ``check_lines``, and selects the read-only
-        instructions variant. That is the surface for a consumer agent that
-        consults another agent's namespace by shared name. ``**kwargs`` forwards to ``Toolkit``
-        (e.g. ``include_tools``, ``requires_confirmation_tools``).
+        ``Agent(tools=[fs.tools()], instructions=[..., fs.instructions()])`` is the
+        whole attach: the tools arrive with no instructions of their own, and the
+        system prompt stays the developer's to order and edit. Pass
+        ``add_instructions=True`` to have the toolkit carry them instead.
+
+        ``read_only=True`` registers only ``read_file``, ``list_files``,
+        ``search_content`` and ``check_lines``; pair it with
+        ``instructions(read_only=True)``. That is the surface for a consumer agent
+        that consults another agent's namespace by shared name. ``**kwargs``
+        forwards to ``Toolkit`` (e.g. ``include_tools``,
+        ``requires_confirmation_tools``).
         """
         from agno.fs.toolkit import FileSystemTools
 
@@ -463,7 +470,12 @@ class FileSystem:
 
     @staticmethod
     def instructions(read_only: bool = False) -> str:
-        """The instructions the toolkit ships (namespace-independent, usable with no instance)."""
+        """Usage guidance for these tools, to compose into the agent's instructions.
+
+        Namespace-independent, so it is equally callable on an instance
+        (``fs.instructions()``) and on the class, which is what a per-user tool
+        factory needs when no instance exists at module scope.
+        """
         if read_only:
             return _READ_ONLY_INSTRUCTIONS
         return _DEFAULT_INSTRUCTIONS

--- a/libs/agno/agno/fs/fs.py
+++ b/libs/agno/agno/fs/fs.py
@@ -47,40 +47,36 @@ backend with no namespace share this one store, which is the intended behavior
 but is rarely what a multi-tenant app wants (see the templated namespaces above).
 """
 
-_DEFAULT_INSTRUCTIONS = """You have your own private, durable filesystem you can use to
-persist files across sessions and runs. Use it for your working state: records of items you have processed,
-decisions, progress checkpoints, notes to your future self.
+_DEFAULT_INSTRUCTIONS = """You have your own private, durable filesystem you can use to persist files across \
+sessions and runs. Use it for your working state: records of items you have processed, decisions, progress \
+checkpoints, notes to your future self.
 
-For storing facts and memories about the user, prefer the user memory if provided and fallback to the filesystem if not.
+For storing facts and memories about the user, prefer the user memory if provided and fallback to the \
+filesystem if not.
 
 Conventions:
-  - Paths are relative, like notes/decisions.md or seen/2026-07-24.md. Group
-    related files in directories.
-  - To keep a record set (items already processed): store one record per line in
-    the seen/ directory, one file per date (seen/2026-07-24.md). Call
-    check_lines(lines, directory="seen") BEFORE acting, then record the new ones
-    with append_file(..., unique=True). check_lines matches exact whole lines, and
-    unique=True keeps the log free of duplicates if a run overlaps another one.
-  - To correct or update part of a file, read it, then call replace_lines with the
-    line numbers you saw. Rewriting a whole file with write_file to change a few
-    lines wastes effort and risks losing the rest.
-  - To find something in a large file, use search_content first: it reports the
-    line number of each match, which you can pass to read_file as start_line.
+  - Paths are relative, like notes/decisions.md or seen/2026-07-24.md. Group related files in directories.
+  - To keep a record set (items already processed): store one record per line in the seen/ directory, one \
+file per date (seen/2026-07-24.md). Call check_lines(lines, directory="seen") BEFORE acting, then record the \
+new ones with append_file(..., unique=True). check_lines matches exact whole lines, and unique=True keeps \
+the log free of duplicates if a run overlaps another one.
+  - To correct or update part of a file, read it, then call replace_lines with the line numbers you saw. \
+Rewriting a whole file with write_file to change a few lines wastes effort and risks losing the rest.
+  - To find something in a large file, use search_content first: it reports the line number of each match, \
+which you can pass to read_file as start_line.
   - Store extracted facts and identifiers, not raw fetched payloads.
   - Never store secrets, passwords, or API keys.
-  - Files have size limits. If a write is refused, start a new file in your
-    partition scheme (e.g. a new dated file), or delete only files you are certain
-    are obsolete, like a date partition older than you still need. Never overwrite
-    or delete a file of records to make room if you might still need those records:
-    dropping them means you will repeat work you already did. If nothing is safely
-    disposable, stop and report that storage is full rather than evicting history."""
+  - Files have size limits. If a write is refused, start a new file in your partition scheme (e.g. a new \
+dated file), or delete only files you are certain are obsolete, like a date partition older than you still \
+need. Never overwrite or delete a file of records to make room if you might still need those records: \
+dropping them means you will repeat work you already did. If nothing is safely disposable, stop and report \
+that storage is full rather than evicting history."""
 
-_READ_ONLY_INSTRUCTIONS = """You have read access to a durable filesystem.
-The files persist across sessions and runs.
+_READ_ONLY_INSTRUCTIONS = """You have read access to a durable filesystem. The files persist across sessions \
+and runs.
 
-Use it to look up what you have recorded: items you have processed, decisions
-you made, notes you left. You cannot change these files - you have no tool to
-write, append, move, or delete.
+Use it to look up what you have recorded: items you have processed, decisions you made, notes you left. You \
+cannot change these files - you have no tool to write, append, move, or delete.
 
 Conventions:
   - Paths are relative, like notes/decisions.md or seen/2026-07-24.md.

--- a/libs/agno/agno/fs/toolkit.py
+++ b/libs/agno/agno/fs/toolkit.py
@@ -93,8 +93,10 @@ class FileSystemTools(Toolkit):
 
     Registers the full nine-tool surface, or the four read tools when
     ``read_only=True`` (the surface for a consumer agent that consults another
-    agent's namespace by shared name). Ships the matching FileSystem instructions
-    unless ``instructions`` is overridden. Tool errors are returned as
+    agent's namespace by shared name). Holds the matching FileSystem instructions,
+    which reach the system prompt only under ``add_instructions=True``; otherwise
+    compose ``FileSystem.instructions()`` into the agent's own instructions, and
+    the whole system prompt stays the developer's. Tool errors are returned as
     ``"Error: ..."`` strings, never raised. Writes are last-writer-wins by
     design, and there is no confirmation surface, because this is the agent's own
     private, quota-capped store (pass ``requires_confirmation_tools`` to opt in).
@@ -125,7 +127,7 @@ class FileSystemTools(Toolkit):
         fs: FileSystem,
         read_only: bool = False,
         instructions: Optional[str] = None,
-        add_instructions: bool = True,
+        add_instructions: bool = False,
         **kwargs,
     ):
         self.fs = fs

--- a/libs/agno/tests/unit/fs/test_toolkit.py
+++ b/libs/agno/tests/unit/fs/test_toolkit.py
@@ -154,18 +154,11 @@ class TestSurface:
 
 
 class TestInstructions:
-    def test_toolkit_holds_instructions_but_does_not_add_them(self, toolkit):
-        assert toolkit.add_instructions is False
-        assert toolkit.instructions == FileSystem.instructions()
-        assert 'check_lines(lines, directory="seen")' in toolkit.instructions
-
-    def test_add_instructions_is_opt_in(self, fs):
-        assert fs.tools(add_instructions=True).add_instructions is True
-
     def test_static_call_without_instance(self):
         text = FileSystem.instructions()
         assert text.startswith("You have your own private, durable filesystem")
         assert "Never store secrets, passwords, or API keys." in text
+        assert 'check_lines(lines, directory="seen")' in text
 
     def test_read_only_variant_names_no_write_tool(self, fs):
         text = FileSystem.instructions(read_only=True)
@@ -175,24 +168,22 @@ class TestInstructions:
         # and say the files cannot be changed.
         assert "read access" in text
         assert "cannot change these files" in text
-        tk = fs.tools(read_only=True)
-        assert tk.instructions == text
-        assert tk.add_instructions is False
+        assert fs.tools(read_only=True).instructions == text
 
     def test_namespace_never_in_instructions(self, fs):
         assert "radar" not in FileSystem.instructions()
         assert "namespace" not in FileSystem.instructions().lower()
         assert "namespace" not in FileSystem.instructions(read_only=True).lower()
 
-    def test_conventions_nest_under_one_bullet(self):
+    def test_every_bullet_is_one_line_and_nests(self):
         # Composed into an agent's instructions list, the whole block renders as a
-        # single "- {entry}" bullet, so every line under Conventions: is indented to
-        # stay beneath it.
+        # single "- {entry}" bullet. Each convention is therefore one unwrapped line,
+        # indented to stay beneath that bullet.
         for text in (FileSystem.instructions(), FileSystem.instructions(read_only=True)):
             body = text.split("Conventions:\n", 1)[1]
             for line in body.split("\n"):
                 if line:
-                    assert line.startswith("  "), line
+                    assert line.startswith("  - "), line
 
     def test_attached_toolkit_adds_nothing_to_the_system_prompt(self, fs):
         agent = Agent(tools=[fs.tools()])

--- a/libs/agno/tests/unit/fs/test_toolkit.py
+++ b/libs/agno/tests/unit/fs/test_toolkit.py
@@ -2,10 +2,12 @@
 
 import inspect
 import json
+from unittest.mock import MagicMock
 
 import pytest
 
 from agno.agent import Agent
+from agno.agent._tools import parse_tools
 from agno.fs import FileSystem
 from agno.fs.local import LocalFileSystem
 from agno.fs.toolkit import FileSystemTools
@@ -26,6 +28,12 @@ EXPECTED_TOOL_PARAMS = {
 }
 
 INJECTED_PARAMS = ("run_context", "agent", "team")
+
+
+def _mock_model():
+    model = MagicMock()
+    model.supports_native_structured_outputs = False
+    return model
 
 
 @pytest.fixture
@@ -146,10 +154,13 @@ class TestSurface:
 
 
 class TestInstructions:
-    def test_toolkit_carries_instructions(self, toolkit):
-        assert toolkit.add_instructions is True
+    def test_toolkit_holds_instructions_but_does_not_add_them(self, toolkit):
+        assert toolkit.add_instructions is False
         assert toolkit.instructions == FileSystem.instructions()
         assert 'check_lines(lines, directory="seen")' in toolkit.instructions
+
+    def test_add_instructions_is_opt_in(self, fs):
+        assert fs.tools(add_instructions=True).add_instructions is True
 
     def test_static_call_without_instance(self):
         text = FileSystem.instructions()
@@ -166,11 +177,32 @@ class TestInstructions:
         assert "cannot change these files" in text
         tk = fs.tools(read_only=True)
         assert tk.instructions == text
+        assert tk.add_instructions is False
 
     def test_namespace_never_in_instructions(self, fs):
         assert "radar" not in FileSystem.instructions()
         assert "namespace" not in FileSystem.instructions().lower()
         assert "namespace" not in FileSystem.instructions(read_only=True).lower()
+
+    def test_conventions_nest_under_one_bullet(self):
+        # Composed into an agent's instructions list, the whole block renders as a
+        # single "- {entry}" bullet, so every line under Conventions: is indented to
+        # stay beneath it.
+        for text in (FileSystem.instructions(), FileSystem.instructions(read_only=True)):
+            body = text.split("Conventions:\n", 1)[1]
+            for line in body.split("\n"):
+                if line:
+                    assert line.startswith("  "), line
+
+    def test_attached_toolkit_adds_nothing_to_the_system_prompt(self, fs):
+        agent = Agent(tools=[fs.tools()])
+        parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+        assert agent._tool_instructions == []
+
+    def test_add_instructions_carries_the_block(self, fs):
+        agent = Agent(tools=[fs.tools(add_instructions=True)])
+        parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+        assert agent._tool_instructions == [FileSystem.instructions()]
 
 
 class TestReadFileTool:


### PR DESCRIPTION
## Summary

`FileSystemTools` defaulted to `add_instructions=True`, so `Agent(tools=[fs.tools()])` silently pushed a 27-line block into the system prompt. That block asserts policy, not just usage — where user facts live versus the filesystem, what may never be stored, what to do when storage is full — so it belongs in a prompt the developer can read, reorder and edit.

`add_instructions` now defaults to `False`. The text stays on the toolkit and is available through `FileSystem.instructions(read_only=...)`, which the developer composes:

```python
notes = FileSystem(db, namespace="brain/{user_id}")

agent = Agent(
    tools=[notes.tools()],
    instructions=[
        "You're a second brain for: {user_id}.",
        "Remember what they're building, organize as you see fit.",
        notes.instructions(),
    ],
)
```

This is the `ContextProvider.instructions()` convention already used across `cookbook/12_context` (`wiki.instructions()`, `db.instructions()`, `calendar.instructions()`). FileSystem was the odd one out. `fs.tools(add_instructions=True)` remains for anyone who wants the toolkit to carry the block; `**kwargs` already forwarded it, so no new parameter.

`instructions()` stays a `@staticmethod`: it is namespace-independent, so `fs.instructions()` reads like the provider convention at the call site while `FileSystem.instructions()` still works inside a per-user tool factory that has no module-scope instance (`04_namespaces/custom_factory.py`).

**One knock-on fix.** The developer-instruction path renders each list entry as a single `- {entry}` bullet (`agent/_messages.py:244-248`), while the tool path appended verbatim. Composed as-is, the block's own `- Paths are relative…`, `- Never store secrets…` sub-bullets would flatten to peer level with the developer's instructions. Every line under `Conventions:` is now indented two spaces, so the block nests under one bullet in the composed form and still reads as a nested list on its own.

### Scope

Nothing in the framework builds a FileSystem toolkit on a user's behalf — `grep` for `FileSystemTools` / `FileSystem(` across `libs/agno/agno` outside `agno/fs/` returns nothing, including `agno/os`, `agno/learn` and `agno/context`. Every affected attach site is developer-authored, so there is no path that can silently produce an unguided agent. The eleven agents in `cookbook/13_filesystem` now pass the instructions explicitly, and the folder READMEs that documented auto-injection were rewritten.

## Type of change

- [x] Improvement
- [x] Breaking change

Breaking for anyone on 2.8.2 who wrote `Agent(tools=[fs.tools()])` and relied on the injected block: the tools still work, the guidance no longer arrives unless composed. No shim and no deprecation warning — the feature is one release old, and a warning could not distinguish "forgot to compose" from "chose not to".

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

**Tests.** `libs/agno/tests/unit/fs/` 331 passed, `tests/integration/fs/` 109 passed. Four new tests pin the behavior in both directions, which nothing covered before: `Agent(tools=[fs.tools()])` collects no tool instructions, `fs.tools(add_instructions=True)` puts the block back, the read-only toolkit is also silent, and every `Conventions:` line stays indented.

**Live runs** (gpt-5.5, OpenAIResponses), logged in the folder `TEST_LOG.md` files:

- `01_getting_started/basic.py` twice — run 1 wrote `notes/decisions.md` with `append_file(..., unique=True)`, run 2 (fresh process) called `list_files` then `read_file` and recalled SQLite.
- `04_namespaces/shared_namespace.py` — the read-only consumer, carrying `consumer_fs.instructions(read_only=True)`, read `decisions/2026-07.md` and quoted the decision with its source line.

Rendered system prompt for the composed form, confirming the nesting:

```
- You're a second brain for: {user_id}.
- Remember what they're building, organize as you see fit.
- You have your own private, durable filesystem you can use to
persist files across sessions and runs. ...

Conventions:
  - Paths are relative, like notes/decisions.md or seen/2026-07-24.md. Group
    related files in directories.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
