### PR TITLE
[feat] Add Azure DevOps tools (wiki, repos, boards)

### DIFF
--- a/cookbook/91_tools/azure_devops/README.md
+++ b/cookbook/91_tools/azure_devops/README.md
@@ -1,0 +1,36 @@
+# Azure DevOps Tools
+
+Three toolkits to integrate agents with Azure DevOps:
+
+- `AzureDevOpsReposTools` — Git repositories (list repos, read files, file tree).
+- `AzureDevOpsWikiTools` — project wikis (list wikis, read/list/search pages).
+- `AzureDevOpsBoardsTools` — boards (work items, comments, sprints, fields).
+
+## Setup
+
+Create a personal access token (PAT) in Azure DevOps with the scopes you need
+(Code, Wiki, Work Items) and set:
+
+```bash
+export AZURE_DEVOPS_ORG_URL="https://dev.azure.com/my-org"
+export AZURE_DEVOPS_PAT="your-personal-access-token"
+export AZURE_DEVOPS_PROJECT="MyProject"
+```
+
+Install the dependency:
+
+```bash
+pip install azure-devops
+```
+
+## Examples
+
+```bash
+python cookbook/91_tools/azure_devops/repos_tools.py
+python cookbook/91_tools/azure_devops/wiki_tools.py
+python cookbook/91_tools/azure_devops/boards_tools.py
+```
+
+Each toolkit accepts `organization_url`, `personal_access_token` and `project` directly,
+falling back to the environment variables above. The `project` set on the toolkit is the
+default; every tool also accepts an optional `project` argument to override it per call.

--- a/cookbook/91_tools/azure_devops/boards_tools.py
+++ b/cookbook/91_tools/azure_devops/boards_tools.py
@@ -1,0 +1,35 @@
+"""
+Azure DevOps Boards Tools
+
+Setup:
+1. Create a personal access token (PAT) in Azure DevOps with Work Items (read and write) scope.
+2. Set environment variables:
+   - AZURE_DEVOPS_ORG_URL: Your organization URL (e.g. https://dev.azure.com/my-org)
+   - AZURE_DEVOPS_PAT: Your personal access token
+   - AZURE_DEVOPS_PROJECT: Default project name or ID
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.azure_devops import AzureDevOpsBoardsTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=[
+        "Use Azure DevOps boards tools to manage work items, sprints and comments.",
+        "Use read-only operations unless explicitly asked to create or update work items.",
+    ],
+    tools=[AzureDevOpsBoardsTools()],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "List the current sprints and show the work items in the active sprint."
+    )

--- a/cookbook/91_tools/azure_devops/repos_tools.py
+++ b/cookbook/91_tools/azure_devops/repos_tools.py
@@ -1,0 +1,34 @@
+"""
+Azure DevOps Repos Tools
+
+Setup:
+1. Create a personal access token (PAT) in Azure DevOps with Code (read) scope.
+2. Set environment variables:
+   - AZURE_DEVOPS_ORG_URL: Your organization URL (e.g. https://dev.azure.com/my-org)
+   - AZURE_DEVOPS_PAT: Your personal access token
+   - AZURE_DEVOPS_PROJECT: Default project name or ID
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.azure_devops import AzureDevOpsReposTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=[
+        "Use Azure DevOps repository tools to answer questions about code repositories.",
+    ],
+    tools=[AzureDevOpsReposTools()],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "List the repositories in the project and show the file tree of the first one."
+    )

--- a/cookbook/91_tools/azure_devops/wiki_tools.py
+++ b/cookbook/91_tools/azure_devops/wiki_tools.py
@@ -1,0 +1,34 @@
+"""
+Azure DevOps Wiki Tools
+
+Setup:
+1. Create a personal access token (PAT) in Azure DevOps with Wiki (read) scope.
+2. Set environment variables:
+   - AZURE_DEVOPS_ORG_URL: Your organization URL (e.g. https://dev.azure.com/my-org)
+   - AZURE_DEVOPS_PAT: Your personal access token
+   - AZURE_DEVOPS_PROJECT: Default project name or ID
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.azure_devops import AzureDevOpsWikiTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=[
+        "Use Azure DevOps wiki tools to find and summarize documentation.",
+    ],
+    tools=[AzureDevOpsWikiTools()],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "List the wikis in the project and search the first wiki for pages about onboarding."
+    )

--- a/libs/agno/agno/tools/azure_devops/__init__.py
+++ b/libs/agno/agno/tools/azure_devops/__init__.py
@@ -1,0 +1,26 @@
+__all__ = [
+    "AzureDevOpsBaseTools",
+    "AzureDevOpsBoardsTools",
+    "AzureDevOpsReposTools",
+    "AzureDevOpsWikiTools",
+]
+
+
+def __getattr__(name: str):
+    if name == "AzureDevOpsBaseTools":
+        from agno.tools.azure_devops.base import AzureDevOpsBaseTools
+
+        return AzureDevOpsBaseTools
+    if name == "AzureDevOpsBoardsTools":
+        from agno.tools.azure_devops.boards import AzureDevOpsBoardsTools
+
+        return AzureDevOpsBoardsTools
+    if name == "AzureDevOpsReposTools":
+        from agno.tools.azure_devops.repos import AzureDevOpsReposTools
+
+        return AzureDevOpsReposTools
+    if name == "AzureDevOpsWikiTools":
+        from agno.tools.azure_devops.wiki import AzureDevOpsWikiTools
+
+        return AzureDevOpsWikiTools
+    raise AttributeError(f"module 'agno.tools.azure_devops' has no attribute {name!r}")

--- a/libs/agno/agno/tools/azure_devops/base.py
+++ b/libs/agno/agno/tools/azure_devops/base.py
@@ -1,0 +1,90 @@
+from os import getenv
+from typing import Any, Dict, Optional
+
+from agno.tools import Toolkit
+
+try:
+    from azure.devops.connection import Connection
+    from msrest.authentication import BasicAuthentication
+except ImportError:
+    raise ImportError("`azure-devops` not installed. Please install using `pip install azure-devops`")
+
+
+class AzureDevOpsBaseTools(Toolkit):
+    """Shared base for Azure DevOps toolkits.
+
+    Holds the organization URL, personal access token and default project, builds the
+    Azure DevOps SDK connection lazily and exposes typed clients plus project resolution.
+    """
+
+    def __init__(
+        self,
+        organization_url: Optional[str] = None,
+        personal_access_token: Optional[str] = None,
+        project: Optional[str] = None,
+        **kwargs: Any,
+    ):
+        self.organization_url = organization_url or getenv("AZURE_DEVOPS_ORG_URL")
+        self.personal_access_token = personal_access_token or getenv("AZURE_DEVOPS_PAT")
+        self.project = project or getenv("AZURE_DEVOPS_PROJECT")
+
+        if not self.organization_url:
+            raise ValueError(
+                "Azure DevOps organization URL not provided. "
+                "Pass organization_url or set the AZURE_DEVOPS_ORG_URL environment variable."
+            )
+        if not self.personal_access_token:
+            raise ValueError(
+                "Azure DevOps personal access token not provided. "
+                "Pass personal_access_token or set the AZURE_DEVOPS_PAT environment variable."
+            )
+
+        self._connection: Optional[Connection] = None
+        self._clients: Dict[str, Any] = {}
+
+        super().__init__(**kwargs)
+
+    def _get_connection(self) -> Connection:
+        if self._connection is None:
+            credentials = BasicAuthentication("", self.personal_access_token or "")
+            self._connection = Connection(base_url=self.organization_url, creds=credentials)
+        return self._connection
+
+    def _get_client(self, key: str) -> Any:
+        if key not in self._clients:
+            clients = self._get_connection().clients
+            factories = {
+                "git": clients.get_git_client,
+                "wiki": clients.get_wiki_client,
+                "work": clients.get_work_client,
+                "wit": clients.get_work_item_tracking_client,
+                "core": clients.get_core_client,
+            }
+            client = factories[key]()
+            if client is None:
+                raise RuntimeError(f"Failed to get Azure DevOps {key} client.")
+            self._clients[key] = client
+        return self._clients[key]
+
+    def _get_git_client(self) -> Any:
+        return self._get_client("git")
+
+    def _get_wiki_client(self) -> Any:
+        return self._get_client("wiki")
+
+    def _get_work_client(self) -> Any:
+        return self._get_client("work")
+
+    def _get_wit_client(self) -> Any:
+        return self._get_client("wit")
+
+    def _get_core_client(self) -> Any:
+        return self._get_client("core")
+
+    def _resolve_project(self, project: Optional[str] = None) -> str:
+        resolved = project or self.project
+        if not resolved:
+            raise ValueError(
+                "Azure DevOps project not provided. Pass project or set the AZURE_DEVOPS_PROJECT environment variable."
+            )
+        return resolved

--- a/libs/agno/agno/tools/azure_devops/boards.py
+++ b/libs/agno/agno/tools/azure_devops/boards.py
@@ -1,0 +1,881 @@
+import asyncio
+import json
+from typing import Any, Dict, List, Optional
+
+from agno.tools.azure_devops.base import AzureDevOpsBaseTools
+from agno.utils.log import log_debug, log_error
+
+try:
+    from azure.devops.v7_1.work_item_tracking.models import (
+        CommentCreate,
+        JsonPatchOperation,
+        TeamContext,
+        Wiql,
+    )
+except ImportError:
+    raise ImportError("`azure-devops` not installed. Please install using `pip install azure-devops`")
+
+
+def _format_field_value(field_value: Any) -> str:
+    if field_value is None:
+        return "None"
+    if isinstance(field_value, dict):
+        if "displayName" in field_value:
+            return f"{field_value.get('displayName')} ({field_value.get('uniqueName', '')})"
+        return ", ".join([f"{k}: {v}" for k, v in field_value.items()])
+    if hasattr(field_value, "display_name") and hasattr(field_value, "unique_name"):
+        return f"{field_value.display_name} ({field_value.unique_name})"
+    if hasattr(field_value, "display_name"):
+        return field_value.display_name
+    return str(field_value)
+
+
+def _format_work_item(work_item: Any, project_fields: Any) -> str:
+    field_map = {field.reference_name: field.name for field in project_fields}
+    fields = work_item.fields or {}
+    details = [f"# Work Item {work_item.id}"]
+
+    for field_name in sorted(fields.keys()):
+        formatted_value = _format_field_value(fields[field_name])
+        friendly_name = field_map.get(field_name, field_name)
+        details.append(f"- **{friendly_name}**: {formatted_value}")
+
+    work_item_url = ""
+    if getattr(work_item, "relations", None):
+        details.append("\n## Related Items")
+        for link in work_item.relations:
+            direct_url = link.url.replace("_apis/wit/workItems", "_workitems/edit")
+            work_item_url = direct_url
+            details.append(f"- {link.rel} URL: {direct_url}")
+            if getattr(link, "attributes", None):
+                details.append(f"  :: Attributes: {link.attributes}")
+
+    base_url = "/".join(work_item_url.split("/")[:-1])
+    base_url = base_url + "/" + str(work_item.id)
+    details.append(f"Work Item URL: [link]({base_url})")
+
+    return "\n".join(details)
+
+
+def _format_work_item_custom(work_item: Any) -> str:
+    base_url = work_item.url.replace("_apis/wit/workItems", "_workitems/edit")
+    fields = work_item.fields or {}
+
+    desired_fields = [
+        "System.Title",
+        "System.IterationPath",
+        "System.BoardColumn",
+        "System.WorkItemType",
+        "System.State",
+        "System.Reason",
+        "System.AssignedTo",
+        "System.CreatedDate",
+        "System.CreatedBy",
+        "System.ChangedDate",
+        "System.ChangedBy",
+        "System.CommentCount",
+        "Microsoft.VSTS.Common.ClosedDate",
+        "Microsoft.VSTS.Scheduling.OriginalEstimate",
+        "Microsoft.VSTS.Scheduling.RemainingWork",
+        "Microsoft.VSTS.Scheduling.CompletedWork",
+        "Microsoft.VSTS.Common.Priority",
+        "Microsoft.VSTS.Common.ValueArea",
+        "System.Parent",
+    ]
+
+    details = [f"# Work Item {work_item.id}", f"Work Item URL: [link]({base_url})"]
+    for key in desired_fields:
+        value = fields.get(key)
+        if isinstance(value, dict) and "displayName" in value:
+            value = value["displayName"]
+        details.append(f"- {key}: {value}")
+
+    return "\n".join(details)
+
+
+def _format_comment(comment: Any) -> str:
+    created_date = ""
+    if getattr(comment, "created_date", None):
+        created_date = f" on {comment.created_date}"
+
+    author = "Unknown"
+    if getattr(comment, "created_by", None) and getattr(comment.created_by, "display_name", None):
+        author = comment.created_by.display_name
+
+    text = comment.text if getattr(comment, "text", None) else "No text"
+    return f"## Comment by {author}{created_date}:\n{text}"
+
+
+def _format_standard_fields(
+    title: Optional[str],
+    description: Optional[str],
+    state: Optional[str],
+    assigned_to: Optional[str],
+    iteration_path: Optional[str],
+    area_path: Optional[str],
+    story_points: Optional[str],
+    priority: Optional[str],
+    tags: Optional[str],
+) -> Dict[str, Any]:
+    fields: Dict[str, Any] = {}
+    if title:
+        fields["System.Title"] = title
+    if description:
+        fields["System.Description"] = description
+    if state:
+        fields["System.State"] = state
+    if assigned_to:
+        fields["System.AssignedTo"] = assigned_to
+    if iteration_path:
+        fields["System.IterationPath"] = iteration_path
+    if area_path:
+        fields["System.AreaPath"] = area_path
+    if story_points is not None:
+        fields["Microsoft.VSTS.Scheduling.StoryPoints"] = str(story_points)
+    if priority is not None:
+        fields["Microsoft.VSTS.Common.Priority"] = str(priority)
+    if tags:
+        fields["System.Tags"] = tags
+    return fields
+
+
+def _ensure_system_prefix(field_name: str) -> str:
+    if field_name.startswith("System.") or field_name.startswith("Microsoft."):
+        return field_name
+
+    common_fields = {
+        "title": "System.Title",
+        "description": "System.Description",
+        "state": "System.State",
+        "assignedto": "System.AssignedTo",
+        "assigned": "System.AssignedTo",
+        "iterationpath": "System.IterationPath",
+        "iteration": "System.IterationPath",
+        "areapath": "System.AreaPath",
+        "area": "System.AreaPath",
+        "tags": "System.Tags",
+        "storypoints": "Microsoft.VSTS.Scheduling.StoryPoints",
+        "priority": "Microsoft.VSTS.Common.Priority",
+    }
+    normalized = field_name.lower().replace("_", "").replace(" ", "")
+    return common_fields.get(normalized, field_name)
+
+
+def _build_field_document(fields: Dict[str, Any], operation: str = "add") -> List[Any]:
+    document = []
+    for field_name, field_value in fields.items():
+        path = field_name if field_name.startswith("/fields/") else f"/fields/{field_name}"
+        document.append(JsonPatchOperation(op=operation, path=path, value=field_value))
+    return document
+
+
+def _build_link_document(target_id: Any, link_type: str, org_url: str) -> List[Any]:
+    return [
+        JsonPatchOperation(
+            op="add",
+            path="/relations/-",
+            value={"rel": link_type, "url": f"{org_url}/_apis/wit/workItems/{target_id}"},
+        )
+    ]
+
+
+class AzureDevOpsBoardsTools(AzureDevOpsBaseTools):
+    """Toolkit for Azure DevOps Boards: work items, comments, sprints and fields."""
+
+    def __init__(
+        self,
+        organization_url: Optional[str] = None,
+        personal_access_token: Optional[str] = None,
+        project: Optional[str] = None,
+        enable_search_tasks: bool = True,
+        enable_get_task: bool = True,
+        enable_create_task: bool = True,
+        enable_update_task: bool = True,
+        enable_add_parent_child_link: bool = True,
+        enable_get_task_comment: bool = True,
+        enable_add_task_comment: bool = True,
+        enable_get_sprints: bool = True,
+        enable_get_fields: bool = True,
+        **kwargs: Any,
+    ):
+        tools: List[Any] = []
+        async_tools: List[tuple[Any, str]] = []
+
+        if enable_search_tasks:
+            tools.append(self.search_tasks)
+            async_tools.append((self.asearch_tasks, "search_tasks"))
+        if enable_get_task:
+            tools.append(self.get_task)
+            async_tools.append((self.aget_task, "get_task"))
+        if enable_create_task:
+            tools.append(self.create_task)
+            async_tools.append((self.acreate_task, "create_task"))
+        if enable_update_task:
+            tools.append(self.update_task)
+            async_tools.append((self.aupdate_task, "update_task"))
+        if enable_add_parent_child_link:
+            tools.append(self.add_parent_child_link)
+            async_tools.append((self.aadd_parent_child_link, "add_parent_child_link"))
+        if enable_get_task_comment:
+            tools.append(self.get_task_comment)
+            async_tools.append((self.aget_task_comment, "get_task_comment"))
+        if enable_add_task_comment:
+            tools.append(self.add_task_comment)
+            async_tools.append((self.aadd_task_comment, "add_task_comment"))
+        if enable_get_sprints:
+            tools.append(self.get_sprints)
+            async_tools.append((self.aget_sprints, "get_sprints"))
+        if enable_get_fields:
+            tools.append(self.get_fields)
+            async_tools.append((self.aget_fields, "get_fields"))
+
+        super().__init__(
+            organization_url=organization_url,
+            personal_access_token=personal_access_token,
+            project=project,
+            name="azure_devops_boards",
+            tools=tools,
+            async_tools=async_tools,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Private helpers that require SDK clients
+    # ------------------------------------------------------------------ #
+    def _get_team_members(self, project: str) -> str:
+        core_client = self._get_core_client()
+        teams = core_client.get_teams(project_id=project)
+        if not teams:
+            raise Exception(f"Team not found in project '{project}'.")
+        team = teams[0]
+        members = core_client.get_team_members_with_extended_properties(project_id=project, team_id=team.id)
+        return ", ".join([member.identity.display_name for member in members])
+
+    def _get_valid_states(self, project: str, work_item_type: str) -> str:
+        wit_client = self._get_wit_client()
+        work_item_type_def = wit_client.get_work_item_type(project=project, type=work_item_type)
+        return ", ".join([state.name for state in work_item_type_def.states])
+
+    def _get_valid_iteration_paths(self, project: str) -> str:
+        work_client = self._get_work_client()
+        team_iterations = work_client.get_team_iterations(team_context=TeamContext(project_id=project))
+        return ", ".join([iteration.path for iteration in team_iterations])
+
+    def _get_valid_board_columns(self, project: str, work_item_type: str) -> str:
+        work_client = self._get_work_client()
+        team_context = TeamContext(project_id=project)
+        board_refs = work_client.get_boards(team_context=team_context)
+
+        matching_board = None
+        for ref in board_refs:
+            board = work_client.get_board(team_context=team_context, id=ref.id)
+            if board.work_item_type.lower() == work_item_type.lower():
+                matching_board = board
+                break
+        if not matching_board:
+            return ""
+
+        board_columns = work_client.get_board_columns(team_context=team_context, id=matching_board.id)
+        return ", ".join([col.name for col in board_columns.value])
+
+    # ------------------------------------------------------------------ #
+    # Public tools
+    # ------------------------------------------------------------------ #
+    def search_tasks(
+        self,
+        wiql_fields: str = "[System.Id]",
+        wiql_where: Optional[str] = None,
+        wiql_order: Optional[str] = None,
+        top: int = 30,
+        project: Optional[str] = None,
+    ) -> str:
+        """Execute a WIQL query to retrieve work items from Azure DevOps.
+
+        Args:
+            wiql_fields: Comma-separated fields for the SELECT clause. Defaults to "[System.Id]".
+            wiql_where: Optional additional WHERE conditions (combined with the project filter).
+            wiql_order: Optional ORDER BY clause.
+            top: Maximum number of work items to return. Defaults to 30.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the formatted work items or an error.
+        """
+        resolved_project = None
+        try:
+            resolved_project = self._resolve_project(project)
+            wit_client = self._get_wit_client()
+            team_context = TeamContext(project_id=resolved_project)
+
+            fields = wiql_fields.strip() if wiql_fields and wiql_fields.strip() else "[System.Id]"
+            additional_where = wiql_where.strip() if wiql_where else ""
+            where_clause = "[System.TeamProject] = @project"
+            if additional_where:
+                where_clause = f"{where_clause} AND {additional_where}"
+
+            wiql_query = f"SELECT {fields}\nFROM WorkItems\nWHERE {where_clause}"
+            if wiql_order and wiql_order.strip():
+                wiql_query += f"\nORDER BY {wiql_order.strip()}"
+
+            wiql_results = wit_client.query_by_wiql(Wiql(query=wiql_query), team_context, top=top).work_items
+            if not wiql_results:
+                return json.dumps({"results": [], "message": "No work items found matching the query."})
+
+            work_item_ids = [int(item.id) for item in wiql_results]
+            work_items = wit_client.get_work_items(ids=work_item_ids, expand="Fields", error_policy="omit")
+            formatted = [_format_work_item_custom(item) for item in work_items if item]
+            return json.dumps({"results": formatted})
+        except Exception as e:
+            log_error(f"Error searching Azure DevOps work items: {e}")
+            message = str(e)
+            if "TF51011" in message or "The specified iteration path does not exist" in message:
+                sprints = self._safe(self._get_valid_iteration_paths, resolved_project)
+                return json.dumps(
+                    {
+                        "error": "The specified sprint does not exist or is incorrect.",
+                        "available_sprints": sprints,
+                    }
+                )
+            return json.dumps({"error": message})
+
+    async def asearch_tasks(
+        self,
+        wiql_fields: str = "[System.Id]",
+        wiql_where: Optional[str] = None,
+        wiql_order: Optional[str] = None,
+        top: int = 30,
+        project: Optional[str] = None,
+    ) -> str:
+        """Execute a WIQL query to retrieve work items from Azure DevOps (async).
+
+        Args:
+            wiql_fields: Comma-separated fields for the SELECT clause. Defaults to "[System.Id]".
+            wiql_where: Optional additional WHERE conditions (combined with the project filter).
+            wiql_order: Optional ORDER BY clause.
+            top: Maximum number of work items to return. Defaults to 30.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the formatted work items or an error.
+        """
+        return await asyncio.to_thread(self.search_tasks, wiql_fields, wiql_where, wiql_order, top, project)
+
+    def get_task(self, item_id: str, project: Optional[str] = None) -> str:
+        """Retrieve detailed information about one or multiple work items.
+
+        Args:
+            item_id: A single work item ID, or several IDs separated by commas.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the formatted work item(s) or an error.
+        """
+        try:
+            resolved_project = self._resolve_project(project)
+            wit_client = self._get_wit_client()
+            project_fields = wit_client.get_fields(project=resolved_project)
+
+            if "," in item_id:
+                ids = [int(part.strip()) for part in item_id.split(",") if part.strip()]
+                work_items = wit_client.get_work_items(
+                    ids=ids, project=resolved_project, error_policy="omit", expand="all"
+                )
+                formatted = [_format_work_item(item, project_fields) for item in work_items if item]
+                if not formatted:
+                    return json.dumps({"results": [], "message": "No work items found."})
+                return json.dumps({"results": formatted})
+
+            work_item = wit_client.get_work_item(id=int(item_id), project=resolved_project, expand="all")
+            return json.dumps({"result": _format_work_item(work_item, project_fields)})
+        except Exception as e:
+            log_error(f"Error retrieving Azure DevOps work item(s): {e}")
+            return json.dumps({"error": str(e)})
+
+    async def aget_task(self, item_id: str, project: Optional[str] = None) -> str:
+        """Retrieve detailed information about one or multiple work items (async).
+
+        Args:
+            item_id: A single work item ID, or several IDs separated by commas.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the formatted work item(s) or an error.
+        """
+        return await asyncio.to_thread(self.get_task, item_id, project)
+
+    def create_task(
+        self,
+        title: str,
+        work_item_type: str,
+        description: Optional[str] = None,
+        state: Optional[str] = None,
+        assigned_to: Optional[str] = None,
+        parent_id: Optional[str] = None,
+        iteration_path: Optional[str] = None,
+        area_path: Optional[str] = None,
+        story_points: Optional[str] = None,
+        priority: Optional[str] = None,
+        tags: Optional[str] = None,
+        fields: Optional[Dict[str, Any]] = None,
+        project: Optional[str] = None,
+    ) -> str:
+        """Create a new work item in Azure DevOps.
+
+        Args:
+            title: The work item title.
+            work_item_type: The work item type (e.g. "Task", "Bug", "User Story").
+            description: Optional description.
+            state: Optional initial state.
+            assigned_to: Optional assignee (must be a valid team member).
+            parent_id: Optional parent work item ID to link as a child.
+            iteration_path: Optional iteration (sprint) path.
+            area_path: Optional area path.
+            story_points: Optional story points value.
+            priority: Optional priority value.
+            tags: Optional semicolon-separated tags.
+            fields: Optional extra fields as a dict of field name to value.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the created work item or an error with valid-value hints.
+        """
+        resolved_project = None
+        try:
+            resolved_project = self._resolve_project(project)
+            wit_client = self._get_wit_client()
+            project_fields = wit_client.get_fields(project=resolved_project)
+
+            all_fields = _format_standard_fields(
+                title, description, state, assigned_to, iteration_path, area_path, story_points, priority, tags
+            )
+            if fields:
+                for field_name, field_value in fields.items():
+                    all_fields[_ensure_system_prefix(field_name)] = field_value
+
+            if not all_fields.get("System.Title"):
+                return json.dumps({"error": "Title is required for work item creation."})
+
+            document = _build_field_document(all_fields)
+            new_work_item = wit_client.create_work_item(
+                document=document, project=resolved_project, type=work_item_type
+            )
+
+            if parent_id:
+                try:
+                    link_document = _build_link_document(
+                        parent_id, "System.LinkTypes.Hierarchy-Reverse", self.organization_url or ""
+                    )
+                    new_work_item = wit_client.update_work_item(
+                        document=link_document, id=new_work_item.id, project=resolved_project
+                    )
+                except Exception as link_error:
+                    return json.dumps(
+                        {
+                            "result": _format_work_item(new_work_item, project_fields),
+                            "warning": "Work item created, but failed to link to the parent work item.",
+                            "details": str(link_error),
+                        }
+                    )
+
+            log_debug(f"Created Azure DevOps work item {new_work_item.id}")
+            return json.dumps({"result": _format_work_item(new_work_item, project_fields)})
+        except Exception as e:
+            return json.dumps(
+                self._field_error(e, resolved_project, work_item_type, assigned_to, state, iteration_path)
+            )
+
+    async def acreate_task(
+        self,
+        title: str,
+        work_item_type: str,
+        description: Optional[str] = None,
+        state: Optional[str] = None,
+        assigned_to: Optional[str] = None,
+        parent_id: Optional[str] = None,
+        iteration_path: Optional[str] = None,
+        area_path: Optional[str] = None,
+        story_points: Optional[str] = None,
+        priority: Optional[str] = None,
+        tags: Optional[str] = None,
+        fields: Optional[Dict[str, Any]] = None,
+        project: Optional[str] = None,
+    ) -> str:
+        """Create a new work item in Azure DevOps (async).
+
+        Args:
+            title: The work item title.
+            work_item_type: The work item type (e.g. "Task", "Bug", "User Story").
+            description: Optional description.
+            state: Optional initial state.
+            assigned_to: Optional assignee (must be a valid team member).
+            parent_id: Optional parent work item ID to link as a child.
+            iteration_path: Optional iteration (sprint) path.
+            area_path: Optional area path.
+            story_points: Optional story points value.
+            priority: Optional priority value.
+            tags: Optional semicolon-separated tags.
+            fields: Optional extra fields as a dict of field name to value.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the created work item or an error with valid-value hints.
+        """
+        return await asyncio.to_thread(
+            self.create_task,
+            title,
+            work_item_type,
+            description,
+            state,
+            assigned_to,
+            parent_id,
+            iteration_path,
+            area_path,
+            story_points,
+            priority,
+            tags,
+            fields,
+            project,
+        )
+
+    def update_task(
+        self,
+        item_id: str,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        state: Optional[str] = None,
+        assigned_to: Optional[str] = None,
+        iteration_path: Optional[str] = None,
+        area_path: Optional[str] = None,
+        story_points: Optional[str] = None,
+        priority: Optional[str] = None,
+        tags: Optional[str] = None,
+        fields: Optional[Dict[str, Any]] = None,
+        project: Optional[str] = None,
+    ) -> str:
+        """Modify an existing work item's fields and properties.
+
+        Args:
+            item_id: The work item ID to update.
+            title: Optional new title.
+            description: Optional new description.
+            state: Optional new state.
+            assigned_to: Optional new assignee (must be a valid team member).
+            iteration_path: Optional new iteration (sprint) path.
+            area_path: Optional new area path.
+            story_points: Optional new story points value.
+            priority: Optional new priority value.
+            tags: Optional new semicolon-separated tags.
+            fields: Optional extra fields as a dict of field name to value.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the updated work item or an error with valid-value hints.
+        """
+        resolved_project = None
+        try:
+            resolved_project = self._resolve_project(project)
+            wit_client = self._get_wit_client()
+            project_fields = wit_client.get_fields(project=resolved_project)
+
+            all_fields = _format_standard_fields(
+                title, description, state, assigned_to, iteration_path, area_path, story_points, priority, tags
+            )
+            if isinstance(fields, dict):
+                for field_name, field_value in fields.items():
+                    all_fields[_ensure_system_prefix(field_name)] = field_value
+
+            if not all_fields:
+                return json.dumps({"error": "At least one field must be specified for update."})
+
+            document = _build_field_document(all_fields, "replace")
+            updated_work_item = wit_client.update_work_item(
+                document=document, id=int(item_id), project=resolved_project
+            )
+            log_debug(f"Updated Azure DevOps work item {item_id}")
+            return json.dumps({"result": _format_work_item(updated_work_item, project_fields)})
+        except Exception as e:
+            error = self._field_error(e, resolved_project, "Task", assigned_to, state, iteration_path)
+            if "field 'system.boardcolumn" in str(e).lower() and resolved_project:
+                columns = self._safe(self._get_valid_board_columns, resolved_project, "Task")
+                error = {"error": "Invalid board column.", "valid_columns": columns}
+            return json.dumps(error)
+
+    async def aupdate_task(
+        self,
+        item_id: str,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        state: Optional[str] = None,
+        assigned_to: Optional[str] = None,
+        iteration_path: Optional[str] = None,
+        area_path: Optional[str] = None,
+        story_points: Optional[str] = None,
+        priority: Optional[str] = None,
+        tags: Optional[str] = None,
+        fields: Optional[Dict[str, Any]] = None,
+        project: Optional[str] = None,
+    ) -> str:
+        """Modify an existing work item's fields and properties (async).
+
+        Args:
+            item_id: The work item ID to update.
+            title: Optional new title.
+            description: Optional new description.
+            state: Optional new state.
+            assigned_to: Optional new assignee (must be a valid team member).
+            iteration_path: Optional new iteration (sprint) path.
+            area_path: Optional new area path.
+            story_points: Optional new story points value.
+            priority: Optional new priority value.
+            tags: Optional new semicolon-separated tags.
+            fields: Optional extra fields as a dict of field name to value.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the updated work item or an error with valid-value hints.
+        """
+        return await asyncio.to_thread(
+            self.update_task,
+            item_id,
+            title,
+            description,
+            state,
+            assigned_to,
+            iteration_path,
+            area_path,
+            story_points,
+            priority,
+            tags,
+            fields,
+            project,
+        )
+
+    def add_parent_child_link(
+        self,
+        parent_id: str,
+        child_id: str,
+        project: Optional[str] = None,
+    ) -> str:
+        """Add a parent-child relationship between two work items.
+
+        Args:
+            parent_id: The parent work item ID.
+            child_id: The child work item ID.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the updated child work item or an error.
+        """
+        try:
+            resolved_project = self._resolve_project(project)
+            wit_client = self._get_wit_client()
+            project_fields = wit_client.get_fields(project=resolved_project)
+
+            link_document = _build_link_document(
+                parent_id, "System.LinkTypes.Hierarchy-Reverse", self.organization_url or ""
+            )
+            updated_work_item = wit_client.update_work_item(
+                document=link_document, id=int(child_id), project=resolved_project
+            )
+            return json.dumps({"result": _format_work_item(updated_work_item, project_fields)})
+        except Exception as e:
+            log_error(f"Error adding Azure DevOps parent-child link: {e}")
+            return json.dumps({"error": str(e)})
+
+    async def aadd_parent_child_link(
+        self,
+        parent_id: str,
+        child_id: str,
+        project: Optional[str] = None,
+    ) -> str:
+        """Add a parent-child relationship between two work items (async).
+
+        Args:
+            parent_id: The parent work item ID.
+            child_id: The child work item ID.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the updated child work item or an error.
+        """
+        return await asyncio.to_thread(self.add_parent_child_link, parent_id, child_id, project)
+
+    def get_task_comment(self, item_id: str, project: Optional[str] = None) -> str:
+        """Retrieve all user-submitted comments from a work item.
+
+        Args:
+            item_id: The work item ID.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the formatted comments or an error.
+        """
+        try:
+            resolved_project = self._resolve_project(project)
+            wit_client = self._get_wit_client()
+            comments = wit_client.get_comments(project=resolved_project, work_item_id=int(item_id))
+            formatted = [_format_comment(comment) for comment in comments.comments]
+            if not formatted:
+                return json.dumps({"comments": [], "message": "No comments found for this work item."})
+            return json.dumps({"comments": formatted})
+        except Exception as e:
+            log_error(f"Error getting Azure DevOps work item comments: {e}")
+            return json.dumps({"error": str(e)})
+
+    async def aget_task_comment(self, item_id: str, project: Optional[str] = None) -> str:
+        """Retrieve all user-submitted comments from a work item (async).
+
+        Args:
+            item_id: The work item ID.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the formatted comments or an error.
+        """
+        return await asyncio.to_thread(self.get_task_comment, item_id, project)
+
+    def add_task_comment(self, item_id: str, comment: str, project: Optional[str] = None) -> str:
+        """Add a new comment to a work item.
+
+        Args:
+            item_id: The work item ID.
+            comment: The comment text to add.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the created comment or an error.
+        """
+        try:
+            resolved_project = self._resolve_project(project)
+            wit_client = self._get_wit_client()
+            new_comment = wit_client.add_comment(
+                request=CommentCreate(text=comment), project=resolved_project, work_item_id=int(item_id)
+            )
+            return json.dumps({"result": _format_comment(new_comment)})
+        except Exception as e:
+            log_error(f"Error adding Azure DevOps work item comment: {e}")
+            return json.dumps({"error": str(e)})
+
+    async def aadd_task_comment(self, item_id: str, comment: str, project: Optional[str] = None) -> str:
+        """Add a new comment to a work item (async).
+
+        Args:
+            item_id: The work item ID.
+            comment: The comment text to add.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the created comment or an error.
+        """
+        return await asyncio.to_thread(self.add_task_comment, item_id, comment, project)
+
+    def get_sprints(self, project: Optional[str] = None) -> str:
+        """Retrieve the list of sprints (iterations) from an Azure DevOps project.
+
+        Args:
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the list of sprints (name, path, is_current).
+        """
+        try:
+            resolved_project = self._resolve_project(project)
+            work_client = self._get_work_client()
+            team_iterations = work_client.get_team_iterations(team_context=TeamContext(project_id=resolved_project))
+            sprints = [
+                {
+                    "name": item.name,
+                    "path": item.path,
+                    "is_current": getattr(item.attributes, "time_frame", None) == "current",
+                }
+                for item in team_iterations
+            ]
+            return json.dumps({"sprints": sprints})
+        except Exception as e:
+            log_error(f"Error getting Azure DevOps sprints: {e}")
+            return json.dumps({"error": str(e)})
+
+    async def aget_sprints(self, project: Optional[str] = None) -> str:
+        """Retrieve the list of sprints (iterations) from an Azure DevOps project (async).
+
+        Args:
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the list of sprints (name, path, is_current).
+        """
+        return await asyncio.to_thread(self.get_sprints, project)
+
+    def get_fields(self, project: Optional[str] = None) -> str:
+        """Retrieve the list of fields available in an Azure DevOps project.
+
+        Args:
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string mapping field reference names to display names.
+        """
+        try:
+            resolved_project = self._resolve_project(project)
+            wit_client = self._get_wit_client()
+            project_fields = wit_client.get_fields(project=resolved_project)
+            field_map = {field.reference_name: field.name for field in project_fields}
+            return json.dumps({"fields": field_map})
+        except Exception as e:
+            log_error(f"Error getting Azure DevOps fields: {e}")
+            return json.dumps({"error": str(e)})
+
+    async def aget_fields(self, project: Optional[str] = None) -> str:
+        """Retrieve the list of fields available in an Azure DevOps project (async).
+
+        Args:
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string mapping field reference names to display names.
+        """
+        return await asyncio.to_thread(self.get_fields, project)
+
+    # ------------------------------------------------------------------ #
+    # Error enrichment
+    # ------------------------------------------------------------------ #
+    def _field_error(
+        self,
+        error: Exception,
+        project: Optional[str],
+        work_item_type: str,
+        assigned_to: Optional[str],
+        state: Optional[str],
+        iteration_path: Optional[str],
+    ) -> Dict[str, Any]:
+        message = str(error)
+        lowered = message.lower()
+        log_error(f"Error on Azure DevOps work item operation: {message}")
+
+        if not project:
+            return {"error": message}
+
+        if "unknown identity" in lowered:
+            return {
+                "error": f"Invalid assignee: '{assigned_to}' is not recognized as a member of the team.",
+                "valid_assignees": self._safe(self._get_team_members, project),
+            }
+        if "field 'state' contains" in lowered:
+            return {
+                "error": f"Invalid state: '{state}' is not valid for work item type '{work_item_type}'.",
+                "valid_states": self._safe(self._get_valid_states, project, work_item_type),
+            }
+        if "field 'system.iterationpath'" in lowered:
+            return {
+                "error": f"Invalid iteration path: '{iteration_path}' is not a recognized sprint.",
+                "valid_iteration_paths": self._safe(self._get_valid_iteration_paths, project),
+            }
+        return {"error": message}
+
+    @staticmethod
+    def _safe(func: Any, *args: Any) -> str:
+        try:
+            return func(*args)
+        except Exception as e:
+            log_error(f"Failed to fetch valid values: {e}")
+            return ""

--- a/libs/agno/agno/tools/azure_devops/repos.py
+++ b/libs/agno/agno/tools/azure_devops/repos.py
@@ -1,0 +1,165 @@
+import asyncio
+import json
+from typing import Any, List, Optional
+
+from agno.tools.azure_devops.base import AzureDevOpsBaseTools
+from agno.utils.log import log_debug, log_error
+
+
+class AzureDevOpsReposTools(AzureDevOpsBaseTools):
+    """Toolkit for Azure DevOps Git repositories."""
+
+    def __init__(
+        self,
+        organization_url: Optional[str] = None,
+        personal_access_token: Optional[str] = None,
+        project: Optional[str] = None,
+        enable_list_repos: bool = True,
+        enable_read_repository_file: bool = True,
+        enable_get_repo_file_tree: bool = True,
+        **kwargs: Any,
+    ):
+        tools: List[Any] = []
+        async_tools: List[tuple[Any, str]] = []
+
+        if enable_list_repos:
+            tools.append(self.list_repos)
+            async_tools.append((self.alist_repos, "list_repos"))
+        if enable_read_repository_file:
+            tools.append(self.read_repository_file)
+            async_tools.append((self.aread_repository_file, "read_repository_file"))
+        if enable_get_repo_file_tree:
+            tools.append(self.get_repo_file_tree)
+            async_tools.append((self.aget_repo_file_tree, "get_repo_file_tree"))
+
+        super().__init__(
+            organization_url=organization_url,
+            personal_access_token=personal_access_token,
+            project=project,
+            name="azure_devops_repos",
+            tools=tools,
+            async_tools=async_tools,
+            **kwargs,
+        )
+
+    def list_repos(self, project: Optional[str] = None) -> str:
+        """List all Git repositories in an Azure DevOps project.
+
+        Args:
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the list of repositories (id, name, is_disabled).
+        """
+        try:
+            git_client = self._get_git_client()
+            repos = git_client.get_repositories(project=self._resolve_project(project))
+            data = [{"id": repo.id, "name": repo.name, "is_disabled": repo.is_disabled} for repo in repos]
+            log_debug(f"Listed {len(data)} Azure DevOps repositories")
+            return json.dumps({"repos": data})
+        except Exception as e:
+            log_error(f"Error listing Azure DevOps repositories: {e}")
+            return json.dumps({"error": str(e)})
+
+    async def alist_repos(self, project: Optional[str] = None) -> str:
+        """List all Git repositories in an Azure DevOps project (async).
+
+        Args:
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the list of repositories (id, name, is_disabled).
+        """
+        return await asyncio.to_thread(self.list_repos, project)
+
+    def read_repository_file(
+        self,
+        repository_id: str,
+        path: str = "/README.md",
+        project: Optional[str] = None,
+    ) -> str:
+        """Read the content of a specific file from an Azure DevOps Git repository.
+
+        Args:
+            repository_id: The repository ID or name.
+            path: Path to the file inside the repository. Defaults to "/README.md".
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the file path and its content.
+        """
+        try:
+            git_client = self._get_git_client()
+            item = git_client.get_item(
+                repository_id=repository_id,
+                path=path,
+                project=self._resolve_project(project),
+                include_content=True,
+            )
+            return json.dumps({"path": path, "content": item.content})
+        except Exception as e:
+            log_error(f"Error reading Azure DevOps repository file: {e}")
+            return json.dumps({"error": str(e)})
+
+    async def aread_repository_file(
+        self,
+        repository_id: str,
+        path: str = "/README.md",
+        project: Optional[str] = None,
+    ) -> str:
+        """Read the content of a specific file from an Azure DevOps Git repository (async).
+
+        Args:
+            repository_id: The repository ID or name.
+            path: Path to the file inside the repository. Defaults to "/README.md".
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the file path and its content.
+        """
+        return await asyncio.to_thread(self.read_repository_file, repository_id, path, project)
+
+    def get_repo_file_tree(
+        self,
+        repository_id: str,
+        project: Optional[str] = None,
+    ) -> str:
+        """List the full directory tree of an Azure DevOps Git repository.
+
+        Args:
+            repository_id: The repository ID or name.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the list of paths, each marked as DIR or FILE.
+        """
+        try:
+            git_client = self._get_git_client()
+            items = git_client.get_items(
+                repository_id=repository_id,
+                project=self._resolve_project(project),
+                scope_path="/",
+                recursion_level="full",
+                include_content_metadata=True,
+            )
+            paths = [f"{item.path} - {'DIR' if item.is_folder else 'FILE'}" for item in items]
+            return json.dumps({"files": paths})
+        except Exception as e:
+            log_error(f"Error getting Azure DevOps repository file tree: {e}")
+            return json.dumps({"error": str(e)})
+
+    async def aget_repo_file_tree(
+        self,
+        repository_id: str,
+        project: Optional[str] = None,
+    ) -> str:
+        """List the full directory tree of an Azure DevOps Git repository (async).
+
+        Args:
+            repository_id: The repository ID or name.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the list of paths, each marked as DIR or FILE.
+        """
+        return await asyncio.to_thread(self.get_repo_file_tree, repository_id, project)

--- a/libs/agno/agno/tools/azure_devops/wiki.py
+++ b/libs/agno/agno/tools/azure_devops/wiki.py
@@ -1,0 +1,275 @@
+import asyncio
+import json
+from typing import Any, Dict, List, Optional
+
+from agno.tools.azure_devops.base import AzureDevOpsBaseTools
+from agno.utils.log import log_debug, log_error
+
+try:
+    from azure.devops.v7_1.wiki.models import WikiPagesBatchRequest
+except ImportError:
+    raise ImportError("`azure-devops` not installed. Please install using `pip install azure-devops`")
+
+
+def _format_wiki_page(page: Any) -> Dict[str, Any]:
+    return {
+        "id": page.id,
+        "content": page.content,
+        "is_parent_page": page.is_parent_page,
+        "order": page.order,
+        "path": page.path,
+        "remote_url": page.remote_url,
+        "sub_pages": page.sub_pages,
+    }
+
+
+class AzureDevOpsWikiTools(AzureDevOpsBaseTools):
+    """Toolkit for Azure DevOps project wikis."""
+
+    def __init__(
+        self,
+        organization_url: Optional[str] = None,
+        personal_access_token: Optional[str] = None,
+        project: Optional[str] = None,
+        enable_get_wiki_list: bool = True,
+        enable_get_wiki_pages: bool = True,
+        enable_list_wiki_pages: bool = True,
+        enable_search_in_wiki_pages: bool = True,
+        **kwargs: Any,
+    ):
+        tools: List[Any] = []
+        async_tools: List[tuple[Any, str]] = []
+
+        if enable_get_wiki_list:
+            tools.append(self.get_wiki_list)
+            async_tools.append((self.aget_wiki_list, "get_wiki_list"))
+        if enable_get_wiki_pages:
+            tools.append(self.get_wiki_pages)
+            async_tools.append((self.aget_wiki_pages, "get_wiki_pages"))
+        if enable_list_wiki_pages:
+            tools.append(self.list_wiki_pages)
+            async_tools.append((self.alist_wiki_pages, "list_wiki_pages"))
+        if enable_search_in_wiki_pages:
+            tools.append(self.search_in_wiki_pages)
+            async_tools.append((self.asearch_in_wiki_pages, "search_in_wiki_pages"))
+
+        super().__init__(
+            organization_url=organization_url,
+            personal_access_token=personal_access_token,
+            project=project,
+            name="azure_devops_wiki",
+            tools=tools,
+            async_tools=async_tools,
+            **kwargs,
+        )
+
+    def get_wiki_list(self, project: Optional[str] = None) -> str:
+        """List all wikis available in an Azure DevOps project.
+
+        Args:
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the list of wikis (id, name, remote_url, path).
+        """
+        try:
+            wiki_client = self._get_wiki_client()
+            wikis = wiki_client.get_all_wikis(project=self._resolve_project(project))
+            data = [
+                {
+                    "id": wiki.id,
+                    "name": wiki.name,
+                    "remote_url": wiki.remote_url,
+                    "path": wiki.mapped_path,
+                }
+                for wiki in wikis
+            ]
+            log_debug(f"Listed {len(data)} Azure DevOps wikis")
+            return json.dumps({"wikis": data})
+        except Exception as e:
+            log_error(f"Error listing Azure DevOps wikis: {e}")
+            return json.dumps({"error": str(e)})
+
+    async def aget_wiki_list(self, project: Optional[str] = None) -> str:
+        """List all wikis available in an Azure DevOps project (async).
+
+        Args:
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the list of wikis (id, name, remote_url, path).
+        """
+        return await asyncio.to_thread(self.get_wiki_list, project)
+
+    def get_wiki_pages(
+        self,
+        wiki_identifier: str,
+        path: str = "/",
+        project: Optional[str] = None,
+    ) -> str:
+        """Retrieve a page from a specific Azure DevOps wiki, including its content.
+
+        Args:
+            wiki_identifier: The wiki ID or name.
+            path: Path of the wiki page. Defaults to the wiki root "/".
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the wiki page details and content.
+        """
+        try:
+            wiki_client = self._get_wiki_client()
+            response = wiki_client.get_page(
+                project=self._resolve_project(project),
+                wiki_identifier=wiki_identifier,
+                path=path,
+                include_content=True,
+            )
+            return json.dumps({"wiki_page": _format_wiki_page(response.page)})
+        except Exception as e:
+            log_error(f"Error getting Azure DevOps wiki page: {e}")
+            return json.dumps({"error": str(e)})
+
+    async def aget_wiki_pages(
+        self,
+        wiki_identifier: str,
+        path: str = "/",
+        project: Optional[str] = None,
+    ) -> str:
+        """Retrieve a page from a specific Azure DevOps wiki, including its content (async).
+
+        Args:
+            wiki_identifier: The wiki ID or name.
+            path: Path of the wiki page. Defaults to the wiki root "/".
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the wiki page details and content.
+        """
+        return await asyncio.to_thread(self.get_wiki_pages, wiki_identifier, path, project)
+
+    def list_wiki_pages(
+        self,
+        wiki_identifier: str,
+        project: Optional[str] = None,
+    ) -> str:
+        """List all pages available in a specific Azure DevOps wiki.
+
+        Args:
+            wiki_identifier: The wiki ID or name.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the list of pages (path, url, view_stats).
+        """
+        try:
+            data = self._list_wiki_pages(self._resolve_project(project), wiki_identifier)
+            return json.dumps({"wiki_pages": data})
+        except Exception as e:
+            log_error(f"Error listing Azure DevOps wiki pages: {e}")
+            return json.dumps({"error": str(e)})
+
+    async def alist_wiki_pages(
+        self,
+        wiki_identifier: str,
+        project: Optional[str] = None,
+    ) -> str:
+        """List all pages available in a specific Azure DevOps wiki (async).
+
+        Args:
+            wiki_identifier: The wiki ID or name.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the list of pages (path, url, view_stats).
+        """
+        return await asyncio.to_thread(self.list_wiki_pages, wiki_identifier, project)
+
+    def search_in_wiki_pages(
+        self,
+        wiki_identifier: str,
+        search_term: str,
+        project: Optional[str] = None,
+    ) -> str:
+        """Search for pages within a specific Azure DevOps wiki using a text term.
+
+        Args:
+            wiki_identifier: The wiki ID or name.
+            search_term: Text term to match against page paths and content.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the matching pages (path, url, content_preview).
+        """
+        try:
+            resolved_project = self._resolve_project(project)
+            wiki_client = self._get_wiki_client()
+            pages = self._list_wiki_pages(resolved_project, wiki_identifier)
+
+            matching_pages = []
+            term = search_term.lower()
+            for page_info in pages:
+                try:
+                    response = wiki_client.get_page(
+                        project=resolved_project,
+                        wiki_identifier=wiki_identifier,
+                        path=page_info["path"],
+                        include_content=True,
+                    )
+                    content = response.page.content
+                    if term in page_info["path"].lower() or (content and term in content.lower()):
+                        matching_pages.append(
+                            {
+                                "path": page_info["path"],
+                                "url": page_info["url"],
+                                "content_preview": (
+                                    content[:200] + "..." if content and len(content) > 200 else content
+                                ),
+                            }
+                        )
+                except Exception:
+                    continue
+
+            return json.dumps({"results": matching_pages})
+        except Exception as e:
+            log_error(f"Error searching Azure DevOps wiki pages: {e}")
+            return json.dumps({"error": str(e)})
+
+    async def asearch_in_wiki_pages(
+        self,
+        wiki_identifier: str,
+        search_term: str,
+        project: Optional[str] = None,
+    ) -> str:
+        """Search for pages within a specific Azure DevOps wiki using a text term (async).
+
+        Args:
+            wiki_identifier: The wiki ID or name.
+            search_term: Text term to match against page paths and content.
+            project: Azure DevOps project name or ID. Defaults to the toolkit's configured project.
+
+        Returns:
+            JSON string with the matching pages (path, url, content_preview).
+        """
+        return await asyncio.to_thread(self.search_in_wiki_pages, wiki_identifier, search_term, project)
+
+    def _list_wiki_pages(self, project: str, wiki_identifier: str) -> List[Dict[str, Any]]:
+        wiki_client = self._get_wiki_client()
+        pages_batch_request = WikiPagesBatchRequest(top=100)
+        pages = wiki_client.get_pages_batch(
+            project=project,
+            wiki_identifier=wiki_identifier,
+            pages_batch_request=pages_batch_request,
+        )
+        return [
+            {
+                "path": page.path,
+                "url": getattr(page, "url", ""),
+                "view_stats": (
+                    [{"date": stat.date.isoformat(), "count": stat.count} for stat in page.view_stats]
+                    if page.view_stats
+                    else []
+                ),
+            }
+            for page in pages
+        ]

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -109,6 +109,7 @@ cel = ["cel-python"]
 agentql = ["agentql"]
 apify = ["apify-client"]
 arxiv = ["arxiv"]
+azure-devops = ["azure-devops", "msrest"]
 brave = ["brave-search"]
 browserbase = ["browserbase", "playwright"]
 cartesia = ["cartesia"]
@@ -256,6 +257,7 @@ tools = [
   "agno[agentql]",
   "agno[apify]",
   "agno[arxiv]",
+  "agno[azure-devops]",
   # "agno[brave]",  # Excluded: brave-search 0.2.0 ships invalid metadata (bad httpx specifier) that uv cannot parse; test_setup.sh installs it with --no-deps
   "agno[browserbase]",
   "agno[cartesia]",
@@ -491,6 +493,8 @@ module = [
   "atlassian.*",
   "azure.ai.inference.*",
   "azure.core.*",
+  "azure.devops.*",
+  "msrest.*",
   "boto3.*",
   "botocore.*",
   "bs4.*",

--- a/libs/agno/tests/unit/tools/test_azure_devops_base.py
+++ b/libs/agno/tests/unit/tools/test_azure_devops_base.py
@@ -1,0 +1,63 @@
+"""Unit tests for AzureDevOpsBaseTools."""
+
+from unittest.mock import patch
+
+import pytest
+
+from agno.tools.azure_devops.base import AzureDevOpsBaseTools
+
+ENV = {
+    "AZURE_DEVOPS_ORG_URL": "https://dev.azure.com/org",
+    "AZURE_DEVOPS_PAT": "test_pat",
+    "AZURE_DEVOPS_PROJECT": "MyProject",
+}
+
+
+def test_init_with_params():
+    tools = AzureDevOpsBaseTools(
+        organization_url="https://dev.azure.com/org",
+        personal_access_token="pat",
+        project="Proj",
+    )
+    assert tools.organization_url == "https://dev.azure.com/org"
+    assert tools.personal_access_token == "pat"
+    assert tools.project == "Proj"
+
+
+def test_init_with_env():
+    with patch.dict("os.environ", ENV, clear=False):
+        tools = AzureDevOpsBaseTools()
+        assert tools.organization_url == "https://dev.azure.com/org"
+        assert tools.project == "MyProject"
+
+
+def test_init_missing_org_url_raises():
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError):
+            AzureDevOpsBaseTools(personal_access_token="pat")
+
+
+def test_init_missing_pat_raises():
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError):
+            AzureDevOpsBaseTools(organization_url="https://dev.azure.com/org")
+
+
+def test_resolve_project_uses_default():
+    tools = AzureDevOpsBaseTools(
+        organization_url="https://dev.azure.com/org", personal_access_token="pat", project="Default"
+    )
+    assert tools._resolve_project() == "Default"
+
+
+def test_resolve_project_override():
+    tools = AzureDevOpsBaseTools(
+        organization_url="https://dev.azure.com/org", personal_access_token="pat", project="Default"
+    )
+    assert tools._resolve_project("Other") == "Other"
+
+
+def test_resolve_project_missing_raises():
+    tools = AzureDevOpsBaseTools(organization_url="https://dev.azure.com/org", personal_access_token="pat")
+    with pytest.raises(ValueError):
+        tools._resolve_project()

--- a/libs/agno/tests/unit/tools/test_azure_devops_boards.py
+++ b/libs/agno/tests/unit/tools/test_azure_devops_boards.py
@@ -1,0 +1,177 @@
+"""Unit tests for AzureDevOpsBoardsTools."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from agno.tools.azure_devops.boards import AzureDevOpsBoardsTools
+
+
+def _field(reference_name, name):
+    field = Mock()
+    field.reference_name = reference_name
+    field.name = name
+    return field
+
+
+@pytest.fixture
+def boards_tools():
+    tools = AzureDevOpsBoardsTools(
+        organization_url="https://dev.azure.com/org",
+        personal_access_token="pat",
+        project="MyProject",
+    )
+    tools._clients["wit"] = Mock()
+    tools._clients["work"] = Mock()
+    tools._clients["core"] = Mock()
+    return tools
+
+
+def test_init_registers_all_tools():
+    tools = AzureDevOpsBoardsTools(
+        organization_url="https://dev.azure.com/org", personal_access_token="pat", project="P"
+    )
+    names = {func.name for func in tools.functions.values()}
+    assert names == {
+        "search_tasks",
+        "get_task",
+        "create_task",
+        "update_task",
+        "add_parent_child_link",
+        "get_task_comment",
+        "add_task_comment",
+        "get_sprints",
+        "get_fields",
+    }
+
+
+def test_init_selective_tools():
+    tools = AzureDevOpsBoardsTools(
+        organization_url="https://dev.azure.com/org",
+        personal_access_token="pat",
+        project="P",
+        enable_create_task=False,
+        enable_update_task=False,
+    )
+    names = {func.name for func in tools.functions.values()}
+    assert "create_task" not in names
+    assert "search_tasks" in names
+
+
+def test_async_variants_registered():
+    tools = AzureDevOpsBoardsTools(
+        organization_url="https://dev.azure.com/org", personal_access_token="pat", project="P"
+    )
+    async_names = {func.name for func in tools.async_functions.values()}
+    assert "create_task" in async_names
+
+
+def test_get_fields_success(boards_tools):
+    boards_tools._clients["wit"].get_fields.return_value = [
+        _field("System.Title", "Title"),
+        _field("System.State", "State"),
+    ]
+    result = json.loads(boards_tools.get_fields())
+    assert result["fields"]["System.Title"] == "Title"
+
+
+def test_get_sprints_success(boards_tools):
+    iteration = Mock()
+    iteration.name = "Sprint 1"
+    iteration.path = "MyProject\\Sprint 1"
+    iteration.attributes = Mock(time_frame="current")
+    boards_tools._clients["work"].get_team_iterations.return_value = [iteration]
+
+    result = json.loads(boards_tools.get_sprints())
+    assert result["sprints"][0]["name"] == "Sprint 1"
+    assert result["sprints"][0]["is_current"] is True
+
+
+def test_get_task_single_success(boards_tools):
+    boards_tools._clients["wit"].get_fields.return_value = [_field("System.Title", "Title")]
+    work_item = Mock()
+    work_item.id = 42
+    work_item.fields = {"System.Title": "My task"}
+    work_item.relations = []
+    boards_tools._clients["wit"].get_work_item.return_value = work_item
+
+    result = json.loads(boards_tools.get_task("42"))
+    assert "Work Item 42" in result["result"]
+    assert "My task" in result["result"]
+
+
+def test_create_task_success(boards_tools):
+    boards_tools._clients["wit"].get_fields.return_value = [_field("System.Title", "Title")]
+    created = Mock()
+    created.id = 100
+    created.fields = {"System.Title": "New task"}
+    created.relations = []
+    boards_tools._clients["wit"].create_work_item.return_value = created
+
+    result = json.loads(boards_tools.create_task(title="New task", work_item_type="Task"))
+    assert "Work Item 100" in result["result"]
+
+
+def test_create_task_requires_title(boards_tools):
+    boards_tools._clients["wit"].get_fields.return_value = []
+    result = json.loads(boards_tools.create_task(title="", work_item_type="Task"))
+    assert "error" in result
+
+
+def test_add_task_comment_success(boards_tools):
+    new_comment = Mock()
+    new_comment.text = "Nice work"
+    new_comment.created_by = Mock(display_name="Jane")
+    new_comment.created_date = None
+    boards_tools._clients["wit"].add_comment.return_value = new_comment
+
+    result = json.loads(boards_tools.add_task_comment("42", "Nice work"))
+    assert "Nice work" in result["result"]
+    assert "Jane" in result["result"]
+
+
+def test_get_task_comment_empty(boards_tools):
+    comments = Mock()
+    comments.comments = []
+    boards_tools._clients["wit"].get_comments.return_value = comments
+
+    result = json.loads(boards_tools.get_task_comment("42"))
+    assert result["comments"] == []
+
+
+def test_search_tasks_no_results(boards_tools):
+    query_result = Mock()
+    query_result.work_items = []
+    boards_tools._clients["wit"].query_by_wiql.return_value = query_result
+
+    result = json.loads(boards_tools.search_tasks())
+    assert result["results"] == []
+
+
+def test_update_task_requires_field(boards_tools):
+    boards_tools._clients["wit"].get_fields.return_value = []
+    result = json.loads(boards_tools.update_task("42"))
+    assert "error" in result
+
+
+def test_create_task_invalid_assignee_hint(boards_tools):
+    boards_tools._clients["wit"].get_fields.return_value = [_field("System.Title", "Title")]
+    boards_tools._clients["wit"].create_work_item.side_effect = Exception("unknown identity found")
+
+    team = Mock()
+    team.id = "team-1"
+    boards_tools._clients["core"].get_teams.return_value = [team]
+    member = Mock()
+    member.identity = Mock(display_name="Jane Doe")
+    boards_tools._clients["core"].get_team_members_with_extended_properties.return_value = [member]
+
+    result = json.loads(boards_tools.create_task(title="X", work_item_type="Task", assigned_to="ghost"))
+    assert "Jane Doe" in result["valid_assignees"]
+
+
+@pytest.mark.asyncio
+async def test_aget_fields_success(boards_tools):
+    boards_tools._clients["wit"].get_fields.return_value = [_field("System.Title", "Title")]
+    result = json.loads(await boards_tools.aget_fields())
+    assert result["fields"]["System.Title"] == "Title"

--- a/libs/agno/tests/unit/tools/test_azure_devops_repos.py
+++ b/libs/agno/tests/unit/tools/test_azure_devops_repos.py
@@ -1,0 +1,104 @@
+"""Unit tests for AzureDevOpsReposTools."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from agno.tools.azure_devops.repos import AzureDevOpsReposTools
+
+
+@pytest.fixture
+def repos_tools():
+    tools = AzureDevOpsReposTools(
+        organization_url="https://dev.azure.com/org",
+        personal_access_token="pat",
+        project="MyProject",
+    )
+    tools._clients["git"] = Mock()
+    return tools
+
+
+def test_init_registers_all_tools():
+    tools = AzureDevOpsReposTools(
+        organization_url="https://dev.azure.com/org", personal_access_token="pat", project="P"
+    )
+    names = [func.name for func in tools.functions.values()]
+    assert "list_repos" in names
+    assert "read_repository_file" in names
+    assert "get_repo_file_tree" in names
+
+
+def test_init_selective_tools():
+    tools = AzureDevOpsReposTools(
+        organization_url="https://dev.azure.com/org",
+        personal_access_token="pat",
+        project="P",
+        enable_read_repository_file=False,
+        enable_get_repo_file_tree=False,
+    )
+    names = [func.name for func in tools.functions.values()]
+    assert "list_repos" in names
+    assert "read_repository_file" not in names
+
+
+def test_async_variants_registered():
+    tools = AzureDevOpsReposTools(
+        organization_url="https://dev.azure.com/org", personal_access_token="pat", project="P"
+    )
+    async_names = [func.name for func in tools.async_functions.values()]
+    assert "list_repos" in async_names
+
+
+def test_list_repos_success(repos_tools):
+    repo = Mock()
+    repo.id = "r1"
+    repo.name = "repo-one"
+    repo.is_disabled = False
+    repos_tools._clients["git"].get_repositories.return_value = [repo]
+
+    result = json.loads(repos_tools.list_repos())
+    assert result["repos"][0]["name"] == "repo-one"
+    repos_tools._clients["git"].get_repositories.assert_called_once_with(project="MyProject")
+
+
+def test_read_repository_file_success(repos_tools):
+    item = Mock()
+    item.content = "# Hello"
+    repos_tools._clients["git"].get_item.return_value = item
+
+    result = json.loads(repos_tools.read_repository_file("r1", "/README.md"))
+    assert result["content"] == "# Hello"
+    assert result["path"] == "/README.md"
+
+
+def test_get_repo_file_tree_success(repos_tools):
+    folder = Mock()
+    folder.path = "/src"
+    folder.is_folder = True
+    file_item = Mock()
+    file_item.path = "/src/main.py"
+    file_item.is_folder = False
+    repos_tools._clients["git"].get_items.return_value = [folder, file_item]
+
+    result = json.loads(repos_tools.get_repo_file_tree("r1"))
+    assert "/src - DIR" in result["files"]
+    assert "/src/main.py - FILE" in result["files"]
+
+
+def test_list_repos_error_returns_json(repos_tools):
+    repos_tools._clients["git"].get_repositories.side_effect = Exception("boom")
+    result = json.loads(repos_tools.list_repos())
+    assert result["error"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_alist_repos_success(repos_tools):
+    repo = Mock()
+    repo.id = "r1"
+    repo.name = "repo-one"
+    repo.is_disabled = False
+    repos_tools._clients["git"].get_repositories.return_value = [repo]
+
+    result = json.loads(await repos_tools.alist_repos())
+    assert result["repos"][0]["name"] == "repo-one"

--- a/libs/agno/tests/unit/tools/test_azure_devops_wiki.py
+++ b/libs/agno/tests/unit/tools/test_azure_devops_wiki.py
@@ -1,0 +1,119 @@
+"""Unit tests for AzureDevOpsWikiTools."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from agno.tools.azure_devops.wiki import AzureDevOpsWikiTools
+
+
+@pytest.fixture
+def wiki_tools():
+    tools = AzureDevOpsWikiTools(
+        organization_url="https://dev.azure.com/org",
+        personal_access_token="pat",
+        project="MyProject",
+    )
+    tools._clients["wiki"] = Mock()
+    return tools
+
+
+def test_init_registers_all_tools():
+    tools = AzureDevOpsWikiTools(organization_url="https://dev.azure.com/org", personal_access_token="pat", project="P")
+    names = [func.name for func in tools.functions.values()]
+    assert set(names) == {
+        "get_wiki_list",
+        "get_wiki_pages",
+        "list_wiki_pages",
+        "search_in_wiki_pages",
+    }
+
+
+def test_init_selective_tools():
+    tools = AzureDevOpsWikiTools(
+        organization_url="https://dev.azure.com/org",
+        personal_access_token="pat",
+        project="P",
+        enable_search_in_wiki_pages=False,
+    )
+    names = [func.name for func in tools.functions.values()]
+    assert "search_in_wiki_pages" not in names
+
+
+def test_get_wiki_list_success(wiki_tools):
+    wiki = Mock()
+    wiki.id = "w1"
+    wiki.name = "Docs"
+    wiki.remote_url = "https://example/wiki"
+    wiki.mapped_path = "/"
+    wiki_tools._clients["wiki"].get_all_wikis.return_value = [wiki]
+
+    result = json.loads(wiki_tools.get_wiki_list())
+    assert result["wikis"][0]["name"] == "Docs"
+    wiki_tools._clients["wiki"].get_all_wikis.assert_called_once_with(project="MyProject")
+
+
+def test_get_wiki_pages_success(wiki_tools):
+    page = Mock()
+    page.id = 1
+    page.content = "content"
+    page.is_parent_page = False
+    page.order = 0
+    page.path = "/Home"
+    page.remote_url = "https://example/Home"
+    page.sub_pages = []
+    response = Mock()
+    response.page = page
+    wiki_tools._clients["wiki"].get_page.return_value = response
+
+    result = json.loads(wiki_tools.get_wiki_pages("Docs", "/Home"))
+    assert result["wiki_page"]["path"] == "/Home"
+
+
+def test_list_wiki_pages_success(wiki_tools):
+    page = Mock()
+    page.path = "/Home"
+    page.url = "https://example/Home"
+    page.view_stats = []
+    wiki_tools._clients["wiki"].get_pages_batch.return_value = [page]
+
+    result = json.loads(wiki_tools.list_wiki_pages("Docs"))
+    assert result["wiki_pages"][0]["path"] == "/Home"
+
+
+def test_search_in_wiki_pages_matches_content(wiki_tools):
+    listed = Mock()
+    listed.path = "/Home"
+    listed.url = "https://example/Home"
+    listed.view_stats = []
+    wiki_tools._clients["wiki"].get_pages_batch.return_value = [listed]
+
+    page = Mock()
+    page.content = "this mentions agno framework"
+    response = Mock()
+    response.page = page
+    wiki_tools._clients["wiki"].get_page.return_value = response
+
+    result = json.loads(wiki_tools.search_in_wiki_pages("Docs", "agno"))
+    assert len(result["results"]) == 1
+    assert result["results"][0]["path"] == "/Home"
+
+
+def test_get_wiki_list_error_returns_json(wiki_tools):
+    wiki_tools._clients["wiki"].get_all_wikis.side_effect = Exception("boom")
+    result = json.loads(wiki_tools.get_wiki_list())
+    assert result["error"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_aget_wiki_list_success(wiki_tools):
+    wiki = Mock()
+    wiki.id = "w1"
+    wiki.name = "Docs"
+    wiki.remote_url = "https://example/wiki"
+    wiki.mapped_path = "/"
+    wiki_tools._clients["wiki"].get_all_wikis.return_value = [wiki]
+
+    result = json.loads(await wiki_tools.aget_wiki_list())
+    assert result["wikis"][0]["name"] == "Docs"


### PR DESCRIPTION
## Summary

closes #9176

Adds three new toolkits to integrate agents with Azure DevOps, following the `google/`
sub-package layout (one `Toolkit` per file, shared base, lazy re-exports):

- `AzureDevOpsReposTools` — Git repositories: `list_repos`, `read_repository_file`, `get_repo_file_tree`.
- `AzureDevOpsWikiTools` — project wikis: `get_wiki_list`, `get_wiki_pages`, `list_wiki_pages`, `search_in_wiki_pages`.
- `AzureDevOpsBoardsTools` — boards: `search_tasks`, `get_task`, `create_task`, `update_task`,
  `add_parent_child_link`, `get_task_comment`, `add_task_comment`, `get_sprints`, `get_fields`.

Details:
- Authentication via Personal Access Token. Constructor accepts `organization_url`,
  `personal_access_token` and `project`, each falling back to `AZURE_DEVOPS_ORG_URL`,
  `AZURE_DEVOPS_PAT` and `AZURE_DEVOPS_PROJECT`. The `project` is a default that every tool can
  override per call.
- Every public method has both sync and async variants. The `azure-devops` SDK is synchronous, so
  async variants use `asyncio.to_thread` (same pattern already used by `google/drive.py` and
  `workspace.py`).
- Tools are registered by `enable_*` flags and return JSON strings; errors are returned as
  `{"error": ...}`, enriched with valid-value hints (assignees, states, iteration paths) where useful.
- New optional dependency `azure-devops` declared in `libs/agno/pyproject.toml` (extra `azure-devops`,
  added to the `tools` group and mypy overrides).
- Unit tests for the four modules and cookbook examples for the three toolkits.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- This PR was developed with AI assistance (Claude Code), porting an internal Azure DevOps
  integration to agno conventions. All code was human-reviewed.
- Requires the `azure-devops` package (installed via the new `azure-devops` extra); the toolkits
  fail fast with an install hint if it is missing.
- Smoke-tested against a real Azure DevOps organization (e.g. `get_sprints` correctly identifies
  the active sprint).