### PR TITLE
[feat] Add Live Tennis API toolkit (LiveTennisTools)

### DIFF
--- a/cookbook/91_tools/livetennis_tools.py
+++ b/cookbook/91_tools/livetennis_tools.py
@@ -1,0 +1,51 @@
+"""
+Live Tennis Tools
+=============================
+
+Demonstrates the Live Tennis API tools: live scores, match details, player
+search, and upcoming fixtures across the ATP and WTA tours.
+
+Requirements:
+- A Live Tennis API key — get a free one (1,000 requests/day) at
+  https://livetennisapi.com/subscribe/free
+
+No extra packages are required (uses httpx, an agno core dependency).
+
+Set the following environment variable (or pass api_key to LiveTennisTools directly):
+
+    export LIVETENNISAPI_KEY="your_api_key"
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.livetennis import LiveTennisTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+
+agent = Agent(
+    name="Tennis Agent",
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[LiveTennisTools()],  # all functions are enabled by default
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # Live scores, optionally filtered by tour
+    agent.print_response("Which tennis matches are live right now on the ATP tour?")
+
+    # Player search + profile
+    agent.print_response("Find the player Carlos Alcaraz and show his profile")
+
+    # Match details and score (the agent chains get_live_matches -> get_match_score)
+    agent.print_response(
+        "Get the current score of any live match and summarize it point by point"
+    )
+
+    # Upcoming fixtures
+    agent.print_response("What are the next 5 upcoming tennis fixtures?")

--- a/libs/agno/agno/tools/livetennis.py
+++ b/libs/agno/agno/tools/livetennis.py
@@ -1,0 +1,194 @@
+import json
+from os import getenv
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agno.tools import Toolkit
+from agno.utils.log import log_debug, logger
+
+
+class LiveTennisTools(Toolkit):
+    """
+    LiveTennisTools is a toolkit for live and historical tennis data from the
+    Live Tennis API (https://livetennisapi.com): live scores, match details,
+    player search and upcoming fixtures across the ATP and WTA tours.
+
+    Get a free API key (1,000 requests/day) at https://livetennisapi.com/subscribe/free.
+
+    Args:
+        api_key (Optional[str]): Live Tennis API key. Falls back to the
+            LIVETENNISAPI_KEY environment variable.
+        base_url (str): Base URL of the Live Tennis API. Default is the public v1 API.
+        enable_get_live_matches (bool): Register the get_live_matches tool. Default is True.
+        enable_get_match (bool): Register the get_match tool. Default is True.
+        enable_get_match_score (bool): Register the get_match_score tool. Default is True.
+        enable_search_players (bool): Register the search_players tool. Default is True.
+        enable_get_player (bool): Register the get_player tool. Default is True.
+        enable_get_upcoming_fixtures (bool): Register the get_upcoming_fixtures tool. Default is True.
+        all (bool): Register all tools regardless of the individual enable_* flags. Default is False.
+        timeout (int): Per-request HTTP timeout in seconds. Default is 30.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.livetennisapi.com/api/public/v1",
+        enable_get_live_matches: bool = True,
+        enable_get_match: bool = True,
+        enable_get_match_score: bool = True,
+        enable_search_players: bool = True,
+        enable_get_player: bool = True,
+        enable_get_upcoming_fixtures: bool = True,
+        all: bool = False,
+        timeout: int = 30,
+        **kwargs,
+    ):
+        resolved_api_key = api_key or getenv("LIVETENNISAPI_KEY")
+        if not resolved_api_key:
+            raise ValueError(
+                "Live Tennis API key is required. Provide it as an argument or set the "
+                "LIVETENNISAPI_KEY environment variable. "
+                "Get a free key at https://livetennisapi.com/subscribe/free"
+            )
+        self.api_key: str = resolved_api_key
+
+        self.base_url = base_url.rstrip("/")
+
+        tools: List[Any] = []
+        if all or enable_get_live_matches:
+            tools.append(self.get_live_matches)
+        if all or enable_get_match:
+            tools.append(self.get_match)
+        if all or enable_get_match_score:
+            tools.append(self.get_match_score)
+        if all or enable_search_players:
+            tools.append(self.search_players)
+        if all or enable_get_player:
+            tools.append(self.get_player)
+        if all or enable_get_upcoming_fixtures:
+            tools.append(self.get_upcoming_fixtures)
+
+        super().__init__(name="livetennis_tools", tools=tools, timeout=timeout, **kwargs)
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        """Make an authenticated GET request to the Live Tennis API.
+
+        Args:
+            path (str): API path relative to the base URL, e.g. "/matches".
+            params (Optional[Dict[str, Any]]): Query parameters for the request.
+
+        Returns:
+            Any: The decoded JSON response, or a dict with an "error" key on failure.
+        """
+        url = f"{self.base_url}{path}"
+        try:
+            response = httpx.get(
+                url,
+                params=params,
+                headers={"x-api-key": self.api_key},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                logger.error(f"Live Tennis API request unauthorized: {url}")
+                return {
+                    "error": "Unauthorized: invalid or missing API key. "
+                    "Get a free key at https://livetennisapi.com/subscribe/free"
+                }
+            logger.error(f"Live Tennis API request failed with status {e.response.status_code}: {url}")
+            return {"error": f"HTTP {e.response.status_code}: {e.response.text}"}
+        except httpx.HTTPError as e:
+            logger.error(f"Error making request to {url}: {e}")
+            return {"error": str(e)}
+
+    def get_live_matches(self, tour: Optional[str] = None, limit: int = 20) -> str:
+        """Get tennis matches that are currently in progress, with live scores.
+
+        Args:
+            tour (Optional[str]): Filter by tour, e.g. "atp" or "wta". Default is all tours.
+            limit (int): Maximum number of matches to return. Default is 20.
+
+        Returns:
+            str: JSON string with the list of live matches (players, tournament, current score).
+        """
+        log_debug(f"Getting live tennis matches (tour={tour}, limit={limit})")
+        params: Dict[str, Any] = {"status": "live", "limit": max(1, limit)}
+        if tour is not None and tour.strip():
+            params["tour"] = tour.strip().lower()
+        return json.dumps(self._get("/matches", params), indent=2)
+
+    def get_match(self, match_id: str) -> str:
+        """Get full details for a specific tennis match by its match ID.
+
+        Args:
+            match_id (str): The ID of the match, as returned by get_live_matches or
+                get_upcoming_fixtures.
+
+        Returns:
+            str: JSON string with the match details (players, tournament, round, status, start time).
+        """
+        if not match_id or not match_id.strip():
+            return json.dumps({"error": "match_id cannot be empty"})
+        log_debug(f"Getting tennis match: {match_id}")
+        return json.dumps(self._get(f"/matches/{match_id.strip()}"), indent=2)
+
+    def get_match_score(self, match_id: str) -> str:
+        """Get the current score for a specific tennis match by its match ID.
+
+        Args:
+            match_id (str): The ID of the match, as returned by get_live_matches or
+                get_upcoming_fixtures.
+
+        Returns:
+            str: JSON string with the match score (sets, games, and current game points).
+        """
+        if not match_id or not match_id.strip():
+            return json.dumps({"error": "match_id cannot be empty"})
+        log_debug(f"Getting score for tennis match: {match_id}")
+        return json.dumps(self._get(f"/matches/{match_id.strip()}/score"), indent=2)
+
+    def search_players(self, query: str, limit: int = 10) -> str:
+        """Search for tennis players by name.
+
+        Args:
+            query (str): Full or partial player name to search for, e.g. "Alcaraz".
+            limit (int): Maximum number of players to return. Default is 10.
+
+        Returns:
+            str: JSON string with the matching players (name, player ID, tour, ranking).
+        """
+        if not query or not query.strip():
+            return json.dumps({"error": "query cannot be empty"})
+        log_debug(f"Searching tennis players: {query}")
+        params = {"search": query.strip(), "limit": max(1, limit)}
+        return json.dumps(self._get("/players", params), indent=2)
+
+    def get_player(self, player_id: str) -> str:
+        """Get profile details for a specific tennis player by their player ID.
+
+        Args:
+            player_id (str): The ID of the player, as returned by search_players.
+
+        Returns:
+            str: JSON string with the player profile (name, country, ranking, tour).
+        """
+        if not player_id or not player_id.strip():
+            return json.dumps({"error": "player_id cannot be empty"})
+        log_debug(f"Getting tennis player: {player_id}")
+        return json.dumps(self._get(f"/players/{player_id.strip()}"), indent=2)
+
+    def get_upcoming_fixtures(self, limit: int = 10) -> str:
+        """Get upcoming scheduled tennis fixtures (matches that have not started yet).
+
+        Args:
+            limit (int): Maximum number of fixtures to return. Default is 10.
+
+        Returns:
+            str: JSON string with the upcoming fixtures (players, tournament, scheduled start time).
+        """
+        log_debug(f"Getting upcoming tennis fixtures (limit={limit})")
+        params = {"limit": max(1, limit)}
+        return json.dumps(self._get("/fixtures", params), indent=2)

--- a/libs/agno/agno/tools/livetennis.py
+++ b/libs/agno/agno/tools/livetennis.py
@@ -10,11 +10,13 @@ from agno.utils.log import log_debug, logger
 
 class LiveTennisTools(Toolkit):
     """
-    LiveTennisTools is a toolkit for live and historical tennis data from the
-    Live Tennis API (https://livetennisapi.com): live scores, match details,
-    player search and upcoming fixtures across the ATP and WTA tours.
+    LiveTennisTools is a toolkit for live tennis data from the Live Tennis API
+    (https://livetennisapi.com): live scores, match details, player search and
+    upcoming fixtures across the ATP and WTA tours. Historical results are a
+    separate paid product on that API and are not exposed here.
 
     Get a free API key (1,000 requests/day) at https://livetennisapi.com/subscribe/free.
+    Every endpoint this toolkit calls is on that free tier.
 
     Args:
         api_key (Optional[str]): Live Tennis API key. Falls back to the

--- a/libs/agno/tests/unit/tools/test_livetennis.py
+++ b/libs/agno/tests/unit/tools/test_livetennis.py
@@ -1,0 +1,287 @@
+"""Unit tests for LiveTennisTools"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from agno.tools.livetennis import LiveTennisTools
+
+BASE_URL = "https://api.livetennisapi.com/api/public/v1"
+
+
+def make_response(json_data, status_code=200):
+    """Build a MagicMock httpx response with the given JSON body and status."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = json_data
+    if status_code >= 400:
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"HTTP {status_code}", request=MagicMock(), response=response
+        )
+    else:
+        response.raise_for_status.return_value = None
+    return response
+
+
+@pytest.fixture
+def tools():
+    """Create a LiveTennisTools instance with a test API key."""
+    return LiveTennisTools(api_key="test-api-key")
+
+
+class TestLiveTennisToolsInitialization:
+    """Tests for LiveTennisTools initialization"""
+
+    def test_default_initialization(self, tools):
+        """Default initialization registers all six tools"""
+        assert tools.name == "livetennis_tools"
+        assert tools.api_key == "test-api-key"
+        assert set(tools.functions.keys()) == {
+            "get_live_matches",
+            "get_match",
+            "get_match_score",
+            "search_players",
+            "get_player",
+            "get_upcoming_fixtures",
+        }
+
+    def test_api_key_from_env(self, monkeypatch):
+        """The API key is read from LIVETENNISAPI_KEY when not passed explicitly"""
+        monkeypatch.setenv("LIVETENNISAPI_KEY", "env-key")
+        tools = LiveTennisTools()
+        assert tools.api_key == "env-key"
+
+    def test_missing_api_key_raises(self, monkeypatch):
+        """A missing API key fails fast with a pointer to the env var"""
+        monkeypatch.delenv("LIVETENNISAPI_KEY", raising=False)
+        with pytest.raises(ValueError, match="LIVETENNISAPI_KEY"):
+            LiveTennisTools()
+
+    def test_disabled_flag_unregisters_tool(self):
+        """A disabled enable_* flag keeps that function out of the registry"""
+        tools = LiveTennisTools(api_key="k", enable_get_live_matches=False)
+        assert "get_live_matches" not in tools.functions
+        assert "get_match" in tools.functions
+
+    def test_all_flag_overrides_individual_flags(self):
+        """all=True registers every tool regardless of the individual enable_* flags"""
+        tools = LiveTennisTools(
+            api_key="k",
+            enable_get_live_matches=False,
+            enable_get_match=False,
+            enable_get_match_score=False,
+            enable_search_players=False,
+            enable_get_player=False,
+            enable_get_upcoming_fixtures=False,
+            all=True,
+        )
+        assert len(tools.functions) == 6
+
+    def test_base_url_trailing_slash_normalized(self):
+        """A trailing slash on base_url does not produce double slashes in request URLs"""
+        tools = LiveTennisTools(api_key="k", base_url=f"{BASE_URL}/")
+        assert tools.base_url == BASE_URL
+
+
+class TestGetLiveMatches:
+    """Tests for get_live_matches"""
+
+    def test_success(self, tools):
+        """get_live_matches hits /matches with status=live and returns the payload"""
+        matches = [{"id": "m1", "players": ["A", "B"]}]
+        with patch("agno.tools.livetennis.httpx.get", return_value=make_response(matches)) as mock_get:
+            result = tools.get_live_matches()
+
+        mock_get.assert_called_once_with(
+            f"{BASE_URL}/matches",
+            params={"status": "live", "limit": 20},
+            headers={"x-api-key": "test-api-key"},
+            timeout=30,
+        )
+        assert json.loads(result) == matches
+
+    def test_tour_filter_normalized(self, tools):
+        """The tour filter is stripped, lowercased, and forwarded"""
+        with patch("agno.tools.livetennis.httpx.get", return_value=make_response([])) as mock_get:
+            tools.get_live_matches(tour=" ATP ", limit=5)
+
+        assert mock_get.call_args.kwargs["params"] == {"status": "live", "limit": 5, "tour": "atp"}
+
+    def test_blank_tour_omitted(self, tools):
+        """A blank tour string is not sent as a filter"""
+        with patch("agno.tools.livetennis.httpx.get", return_value=make_response([])) as mock_get:
+            tools.get_live_matches(tour="  ")
+
+        assert "tour" not in mock_get.call_args.kwargs["params"]
+
+    def test_limit_clamped_to_minimum(self, tools):
+        """A non-positive limit is clamped to 1"""
+        with patch("agno.tools.livetennis.httpx.get", return_value=make_response([])) as mock_get:
+            tools.get_live_matches(limit=0)
+
+        assert mock_get.call_args.kwargs["params"]["limit"] == 1
+
+    def test_unauthorized(self, tools):
+        """A 401 maps to a clear unauthorized error with the free-key URL"""
+        response = make_response({"error": "unauthorized"}, status_code=401)
+        with patch("agno.tools.livetennis.httpx.get", return_value=response):
+            result = tools.get_live_matches()
+
+        payload = json.loads(result)
+        assert "Unauthorized" in payload["error"]
+        assert "livetennisapi.com/subscribe/free" in payload["error"]
+
+    def test_http_error(self, tools):
+        """A non-401 HTTP error surfaces the status code"""
+        response = make_response({"error": "boom"}, status_code=500)
+        response.text = "internal error"
+        with patch("agno.tools.livetennis.httpx.get", return_value=response):
+            result = tools.get_live_matches()
+
+        assert "HTTP 500" in json.loads(result)["error"]
+
+    def test_network_error(self, tools):
+        """A transport-level failure returns an error payload instead of raising"""
+        with patch("agno.tools.livetennis.httpx.get", side_effect=httpx.ConnectError("connection refused")):
+            result = tools.get_live_matches()
+
+        assert "connection refused" in json.loads(result)["error"]
+
+
+class TestGetMatch:
+    """Tests for get_match"""
+
+    def test_success(self, tools):
+        """get_match hits /matches/{id} and returns the payload"""
+        match = {"id": "m1", "tournament": "Wimbledon"}
+        with patch("agno.tools.livetennis.httpx.get", return_value=make_response(match)) as mock_get:
+            result = tools.get_match("m1")
+
+        mock_get.assert_called_once_with(
+            f"{BASE_URL}/matches/m1",
+            params=None,
+            headers={"x-api-key": "test-api-key"},
+            timeout=30,
+        )
+        assert json.loads(result) == match
+
+    def test_empty_match_id(self, tools):
+        """An empty match_id fails closed and never calls the API"""
+        with patch("agno.tools.livetennis.httpx.get") as mock_get:
+            result = tools.get_match("  ")
+
+        assert "match_id" in json.loads(result)["error"]
+        mock_get.assert_not_called()
+
+
+class TestGetMatchScore:
+    """Tests for get_match_score"""
+
+    def test_success(self, tools):
+        """get_match_score hits /matches/{id}/score and returns the payload"""
+        score = {"sets": [[6, 4], [3, 3]], "serving": "home"}
+        with patch("agno.tools.livetennis.httpx.get", return_value=make_response(score)) as mock_get:
+            result = tools.get_match_score("m1")
+
+        assert mock_get.call_args.args[0] == f"{BASE_URL}/matches/m1/score"
+        assert json.loads(result) == score
+
+    def test_empty_match_id(self, tools):
+        """An empty match_id fails closed and never calls the API"""
+        with patch("agno.tools.livetennis.httpx.get") as mock_get:
+            result = tools.get_match_score("")
+
+        assert "match_id" in json.loads(result)["error"]
+        mock_get.assert_not_called()
+
+
+class TestSearchPlayers:
+    """Tests for search_players"""
+
+    def test_success(self, tools):
+        """search_players hits /players with search + limit and returns the payload"""
+        players = [{"id": "p1", "name": "Carlos Alcaraz"}]
+        with patch("agno.tools.livetennis.httpx.get", return_value=make_response(players)) as mock_get:
+            result = tools.search_players("Alcaraz")
+
+        mock_get.assert_called_once_with(
+            f"{BASE_URL}/players",
+            params={"search": "Alcaraz", "limit": 10},
+            headers={"x-api-key": "test-api-key"},
+            timeout=30,
+        )
+        assert json.loads(result) == players
+
+    def test_query_stripped(self, tools):
+        """Whitespace around the query is stripped before it is sent"""
+        with patch("agno.tools.livetennis.httpx.get", return_value=make_response([])) as mock_get:
+            tools.search_players("  Sinner  ", limit=3)
+
+        assert mock_get.call_args.kwargs["params"] == {"search": "Sinner", "limit": 3}
+
+    def test_empty_query(self, tools):
+        """An empty query fails closed and never calls the API"""
+        with patch("agno.tools.livetennis.httpx.get") as mock_get:
+            result = tools.search_players("   ")
+
+        assert "query" in json.loads(result)["error"]
+        mock_get.assert_not_called()
+
+
+class TestGetPlayer:
+    """Tests for get_player"""
+
+    def test_success(self, tools):
+        """get_player hits /players/{id} and returns the payload"""
+        player = {"id": "p1", "name": "Iga Swiatek", "tour": "wta"}
+        with patch("agno.tools.livetennis.httpx.get", return_value=make_response(player)) as mock_get:
+            result = tools.get_player("p1")
+
+        assert mock_get.call_args.args[0] == f"{BASE_URL}/players/p1"
+        assert json.loads(result) == player
+
+    def test_empty_player_id(self, tools):
+        """An empty player_id fails closed and never calls the API"""
+        with patch("agno.tools.livetennis.httpx.get") as mock_get:
+            result = tools.get_player("")
+
+        assert "player_id" in json.loads(result)["error"]
+        mock_get.assert_not_called()
+
+
+class TestGetUpcomingFixtures:
+    """Tests for get_upcoming_fixtures"""
+
+    def test_success(self, tools):
+        """get_upcoming_fixtures hits /fixtures with the limit and returns the payload"""
+        fixtures = [{"id": "f1", "start_time": "2026-07-25T13:00:00Z"}]
+        with patch("agno.tools.livetennis.httpx.get", return_value=make_response(fixtures)) as mock_get:
+            result = tools.get_upcoming_fixtures(limit=5)
+
+        mock_get.assert_called_once_with(
+            f"{BASE_URL}/fixtures",
+            params={"limit": 5},
+            headers={"x-api-key": "test-api-key"},
+            timeout=30,
+        )
+        assert json.loads(result) == fixtures
+
+    def test_limit_clamped_to_minimum(self, tools):
+        """A non-positive limit is clamped to 1"""
+        with patch("agno.tools.livetennis.httpx.get", return_value=make_response([])) as mock_get:
+            tools.get_upcoming_fixtures(limit=-3)
+
+        assert mock_get.call_args.kwargs["params"]["limit"] == 1
+
+
+class TestTimeoutForwarding:
+    """The toolkit-level timeout is forwarded to each HTTP request"""
+
+    def test_custom_timeout(self):
+        tools = LiveTennisTools(api_key="k", timeout=5)
+        with patch("agno.tools.livetennis.httpx.get", return_value=make_response([])) as mock_get:
+            tools.get_upcoming_fixtures()
+
+        assert mock_get.call_args.kwargs["timeout"] == 5


### PR DESCRIPTION
## Summary

Fixes #9297

Adds `LiveTennisTools`, an official toolkit from the **Live Tennis API team** (vendor-authored, in the same shape as the recently merged PlivoTools) for live tennis data: live scores, match details/score, player search/profiles, and upcoming fixtures across ATP/WTA.

- REST API `https://api.livetennisapi.com/api/public/v1`, authenticated via `x-api-key`; key from the constructor or the `LIVETENNISAPI_KEY` env var. Free tier: 1,000 req/day — https://livetennisapi.com/subscribe/free
- **Zero new dependencies** — uses `httpx`, already an agno core dependency. No `pyproject.toml`, extras, or mypy-override changes.
- 6 tools with `enable_*` / `all` flags, JSON-string returns, fail-closed input validation, and 401 mapped to an actionable error.
- 25 mocked unit tests + a cookbook recipe (`cookbook/91_tools/livetennis_tools.py`).

## Type of change

- [x] New feature

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Ran `./scripts/format.sh` and `./scripts/validate.sh`
- [x] Performed a self-review of my own code
- [x] Added docstrings and documentation
- [x] Added a cookbook example
- [x] Tested in a clean environment (fresh `uv venv`, Python 3.12)
- [x] Tests added — 25 passed; neighbouring toolkit tests still green (89 passed)

## Duplicate and AI-Generated PR Check

- [x] Searched open PRs — no existing Live Tennis toolkit PR.
- [x] **AI-assistance disclosure:** this PR was developed with AI assistance (Claude Code), authored and submitted on behalf of the Live Tennis API team. The code, tests, and docs have been human-reviewed and the author understands and stands behind all changes. Tests are fully mocked — no live API calls in CI.

## Additional Notes

**Vendor disclosure:** we are the Live Tennis API team submitting our own official Agno integration, the same pattern as the vendor-authored PlivoTools. No API key is embedded anywhere in the diff; all tests mock HTTP. A keyless call returns 401 `{"error":"unauthorized"}`, which the toolkit surfaces along with the free-key signup link.

Verified locally against current `main` (branch merged with `origin/main`, fresh `uv venv` on Python 3.12, `uv pip install -e "libs/agno[dev]"`):

- `pytest libs/agno/tests/unit/tools/test_livetennis.py` → 25 passed
- `ruff check libs/agno cookbook` → all checks passed
- `ruff format --check` → clean
- `mypy libs/agno/agno/tools/livetennis.py --config-file libs/agno/pyproject.toml` → no issues found

Second commit (`cbfc6d5`) is a docstring correction only: the class docstring described the toolkit as covering "historical" data. It does not — all six tools call free-tier live endpoints, and historical results are a separate paid product on that API. No behaviour change.