### PR TITLE
feat: support OpenAI-compatible transcription endpoints

### DIFF
--- a/cookbook/91_tools/models/funasr_openai_compatible.py
+++ b/cookbook/91_tools/models/funasr_openai_compatible.py
@@ -1,0 +1,38 @@
+"""Use a self-hosted FunASR server as an OpenAI-compatible transcription backend.
+
+Start the official FunASR example server first:
+
+    cd examples/openai_api
+    pip install funasr fastapi uvicorn python-multipart
+    python server.py --model sensevoice --device cuda --port 8000
+
+See https://github.com/modelscope/FunASR/tree/main/examples/openai_api for
+CPU, Docker, security, and other model options. SenseVoice supports Chinese,
+Cantonese, English, Japanese, and Korean, plus emotion and audio-event output.
+The OpenAITools transcription method returns the transcript text.
+"""
+
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.tools.openai import OpenAITools
+from agno.utils.media import download_file
+
+audio_url = "https://agno-public.s3.amazonaws.com/demo_data/sample_conversation.wav"
+audio_path = Path("tmp/sample_conversation.wav")
+
+agent = Agent(
+    tools=[
+        OpenAITools(
+            base_url="http://localhost:8000/v1",
+            transcription_model="sensevoice",
+            enable_image_generation=False,
+            enable_speech_generation=False,
+        )
+    ],
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    download_file(audio_url, audio_path)
+    agent.print_response(f"Transcribe the audio file at {audio_path}")

--- a/libs/agno/agno/tools/openai.py
+++ b/libs/agno/agno/tools/openai.py
@@ -1,5 +1,5 @@
 from os import getenv
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import uuid4
 
 from agno.agent import Agent
@@ -37,6 +37,8 @@ class OpenAITools(Toolkit):
         image_quality (str, optional): Quality setting for image generation.
         image_size (str, optional): Size setting for image generation.
         image_style (str, optional): Style setting for image generation.
+        base_url (str, optional): Base URL for an OpenAI-compatible API.
+        client_params (dict, optional): Additional parameters passed to the OpenAI client.
     """
 
     def __init__(
@@ -54,11 +56,18 @@ class OpenAITools(Toolkit):
         image_quality: Optional[str] = None,
         image_size: Optional[Literal["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"]] = None,
         image_style: Optional[Literal["vivid", "natural"]] = None,
+        base_url: Optional[str] = None,
+        client_params: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
+        self.base_url = base_url
+        self.client_params = client_params or {}
         self.api_key = api_key or getenv("OPENAI_API_KEY")
         if not self.api_key:
-            raise ValueError("OPENAI_API_KEY not set. Please set the OPENAI_API_KEY environment variable.")
+            if self.base_url or self.client_params.get("base_url"):
+                self.api_key = "not-provided"
+            else:
+                raise ValueError("OPENAI_API_KEY not set. Please set the OPENAI_API_KEY environment variable.")
 
         self.transcription_model = transcription_model
         # Store TTS defaults
@@ -80,6 +89,13 @@ class OpenAITools(Toolkit):
 
         super().__init__(name="openai_tools", tools=tools, **kwargs)
 
+    def _get_client_params(self) -> Dict[str, Any]:
+        client_params: Dict[str, Any] = {"api_key": self.api_key}
+        if self.base_url is not None:
+            client_params["base_url"] = self.base_url
+        client_params.update(self.client_params)
+        return client_params
+
     def transcribe_audio(self, audio_path: str) -> str:
         """Transcribe audio file using OpenAI's Whisper API
         Args:
@@ -88,7 +104,7 @@ class OpenAITools(Toolkit):
         log_debug(f"Transcribing audio from {audio_path}")
         try:
             with open(audio_path, "rb") as audio_file:
-                transcript = OpenAIClient(api_key=self.api_key).audio.transcriptions.create(
+                transcript = OpenAIClient(**self._get_client_params()).audio.transcriptions.create(
                     model=self.transcription_model,
                     file=audio_file,
                     response_format="text",
@@ -121,13 +137,13 @@ class OpenAITools(Toolkit):
             # gpt-image-1 by default outputs a base64 encoded image but other models do not
             # so we add a response_format parameter to have consistent output.
             if self.image_model and self.image_model.startswith("gpt-image"):
-                response = OpenAIClient(api_key=self.api_key).images.generate(
+                response = OpenAIClient(**self._get_client_params()).images.generate(
                     model=self.image_model,
                     prompt=prompt,
                     **extra_params,  # type: ignore
                 )
             else:
-                response = OpenAIClient(api_key=self.api_key).images.generate(
+                response = OpenAIClient(**self._get_client_params()).images.generate(
                     model=self.image_model,
                     prompt=prompt,
                     response_format="b64_json",
@@ -175,7 +191,7 @@ class OpenAITools(Toolkit):
             text_input (str): The text to synthesize into speech.
         """
         try:
-            response = OpenAIClient(api_key=self.api_key).audio.speech.create(
+            response = OpenAIClient(**self._get_client_params()).audio.speech.create(
                 model=self.tts_model,
                 voice=self.tts_voice,
                 input=text_input,

--- a/libs/agno/tests/unit/tools/test_openai_tools.py
+++ b/libs/agno/tests/unit/tools/test_openai_tools.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 pytest.importorskip("openai")
@@ -93,3 +94,52 @@ def test_transcribe_audio_does_not_leak_descriptors_in_a_loop(audio_file):
 
     assert len(opened) == 5
     assert all(handle.closed for handle in opened)
+
+
+def test_transcribe_audio_supports_unauthenticated_openai_compatible_server(audio_file, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    captured = {}
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        captured["request"] = request
+        captured["body"] = request.read()
+        return httpx.Response(200, text="hello from FunASR", headers={"content-type": "text/plain"})
+
+    with httpx.Client(transport=httpx.MockTransport(handle_request)) as http_client:
+        tools = OpenAITools(
+            base_url="http://localhost:8000/v1",
+            transcription_model="sensevoice",
+            client_params={"http_client": http_client},
+            enable_image_generation=False,
+            enable_speech_generation=False,
+        )
+        result = tools.transcribe_audio(audio_file)
+
+    assert result == "hello from FunASR"
+    assert str(captured["request"].url) == "http://localhost:8000/v1/audio/transcriptions"
+    assert captured["request"].headers["authorization"] == "Bearer not-provided"
+    assert captured["request"].headers["content-type"].startswith("multipart/form-data;")
+    assert b'name="model"' in captured["body"]
+    assert b"sensevoice" in captured["body"]
+    assert b'filename="clip.wav"' in captured["body"]
+
+
+def test_transcribe_audio_passes_auth_and_custom_client_headers(audio_file):
+    tools = OpenAITools(
+        api_key="secret-key",
+        base_url="https://speech.example.com/v1",
+        client_params={"default_headers": {"X-Tenant": "demo"}},
+        enable_image_generation=False,
+        enable_speech_generation=False,
+    )
+
+    with patch("agno.tools.openai.OpenAIClient") as mock_client:
+        mock_client.return_value.audio.transcriptions.create.return_value = "authenticated transcript"
+        result = tools.transcribe_audio(audio_file)
+
+    assert result == "authenticated transcript"
+    mock_client.assert_called_once_with(
+        api_key="secret-key",
+        base_url="https://speech.example.com/v1",
+        default_headers={"X-Tenant": "demo"},
+    )


### PR DESCRIPTION
## Summary

Allow `OpenAITools` to use self-hosted and third-party OpenAI-compatible endpoints.

- add `base_url` and `client_params` configuration while preserving the existing OpenAI default;
- allow custom endpoints without requiring callers to provide a real API key, using the SDK placeholder only when a custom endpoint is configured;
- pass the same client configuration to transcription, image, and speech calls;
- add a focused FunASR cookbook using the official `/v1/audio/transcriptions` server example;
- cover the actual multipart HTTP request, authentication/header configuration, success, and server errors without downloading model weights.

Closes #8374.

## Relationship to #8501

#8501 closes #8506 and adds an in-process FunASRTools class backed by the optional FunASR Python package. This PR does not duplicate that implementation: it extends the existing OpenAITools client so an agent can call a separately deployed OpenAI-compatible service. The two approaches have disjoint source files, dependencies, tests, and deployment tradeoffs.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation performed locally:

- `./scripts/format.sh`: passed for all packages and cookbooks.
- Full `ruff check`, agnoctl mypy, cookbook ruff, and cookbook pattern checks: passed.
- `mypy libs/agno/agno/tools/openai.py --follow-imports=skip`: passed.
- `pytest libs/agno/tests/unit/tools/test_openai_tools.py -q`: 5 passed.
- Cookbook `py_compile` and `git diff --check`: passed.

The full repository `./scripts/validate.sh` still reports 38 mypy errors in 12 untouched upstream files. None are in this PR's files; the full error list was reviewed before submission.

The FunASR cookbook keeps model capabilities configuration-specific and links to the official server example for CPU, Docker, security, and model options. It disables image and speech tools because the example server only implements transcription.