### PR TITLE
chore: Release v2.8.4

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "2.8.3"
+version = "2.8.4"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"


### PR DESCRIPTION
## **New Features**

- **Entity memory, revamped — the second brain becomes buildable:** entity memory now accumulates the people, projects and systems around a user without fragmenting or going stale. `remember_about("Sarah Chen", ...)` upserts by name (the store slugifies ids and resolves name, alias and type drift); a new fact retires the one it contradicts through a threshold-gated supersession judge, and facts render with as-of dates; `recall(message)` injects the top-k relevant entities plus an always-present entity directory, so "not in the directory" is a grounded no. Capture is AGENTIC-only through four tools — `remember_about` (including the `note=` pointer), `link_entities` (reciprocal edges), `search_entities` (query optional = browse), `forget` (retire a fact or relationship, archive an entity). See [cookbook/08_learning/04_entity_memory](https://github.com/agno-agi/agno/tree/main/cookbook/08_learning/04_entity_memory) and the flagship [second_brain](https://github.com/agno-agi/agno/tree/main/cookbook/examples/second_brain), which serves one brain over AgentOS REST and `/mcp`.
- **Real search on the learnings table:** a new `search_learnings` on `BaseDb`/`AsyncBaseDb`, implemented for `SqliteDb`, `PostgresDb` and `AsyncPostgresDb` (JSONB `CAST` + `ILIKE`, separator- and case-folded on both sides, errors raised rather than swallowed). Replaces the scan of the ~15 most recently updated rows that made a brain degrade as it grew. Other backends keep the client-side path and warn once, naming the consequence.
- **The manual door for `LearningMachine`:** place `get_tools()`, `instructions()` and `build_context()` by hand, the way `FileSystem` composes, with `capture_hook()` as the escape hatch for ALWAYS-mode capture. `build_context()` is now data-only and `instructions()` carries the guidance, so the automatic path renders exactly what the manual one does. See [cookbook/08_learning/11_composition](https://github.com/agno-agi/agno/tree/main/cookbook/08_learning/11_composition).
- **TrustedRouter** is available as an `OpenAILike` model class. [Cookbooks](https://github.com/agno-agi/agno/tree/main/cookbook/90_models/trustedrouter)

## **Improvements**

- **The current message reaches the learning stores.** Agent and team runs now thread the live `RunContext` — metadata, dependencies, session state and the message itself — into `recall` / `build_context` / `process`, with signature-filtered dispatch so third-party custom stores written against the old signature keep working. This is the single dropped parameter that made entity memory write-only.
- **Learning config round-trips.** `to_dict`/`from_dict` preserve per-store mode, namespace, `enable_*` and schema, so an AGENTIC machine saved and reloaded through `Agent.save()`/`Agent.load()` no longer comes back as ALWAYS with no tools.
- **Bounded, honest rendering.** Top-N live facts with dates, last-N events, a truncation marker ("6 of 19 facts") and one-hop linked entity names, all behind config knobs.
- **Visibility where the framework used to go quiet:** a run with `user_id=None` while per-user stores are configured, and a hand-placed machine with no `model=` (capture is a model call), each warn once.
- **`decision_log`** stops writing contentless rows, and its recall is cross-session again.

## **Bug Fixes**

- Concurrent tool calls in one assistant turn no longer overwrite each other: entity writes take a per-entity lock and the FileSystem write tools take a per-file one, so two note edits or two entity writes in a turn both land instead of one silently winning.
- Entity resolution no longer merges things that are not the same: `C`, `C++` and `C#` stay three entities, accented names stay distinct (`Müller` vs `Möller`), and two different canonical types never merge.
- A relationship that stops being true can be retired the way it is rendered — including accented far ends, same-slug siblings and a relation stated from both directions.
- Blank tool arguments — which strict schemas make models send — are treated as "not supplied" rather than as filters or as an instruction to clear a stored value.
- Skill script and reference tools accept null path arguments (#9096); nested executor requirements serialize correctly (#9162).

## **Breaking Changes**

- **`EntityMemoryStore`:** AGENTIC-only, four tools. `create_entity`/`update_entity`/`add_fact`/`add_event` → one `remember_about` call; `add_relationship` → `link_entities`; `update_fact`/`delete_fact` → state the new fact (supersession retires the old one) or `forget(entity, fact=...)`; deleting an entity → `forget(entity)` archives it reversibly, `store.delete()` still hard-deletes. `LearningMode.ALWAYS` on entity memory now raises.
- **`FileSystem` defaults:** `tools()` returns the notes seven. `tools(allow_delete=True)` restores `delete_file`; `include_tools` selects from the whole surface including `check_lines`; `FULL_TOOLS` is still exported. The default `instructions()` text was rewritten around the notes contract.
- **Prompt strings:** the fact-supersession judge wording changed. Operators who overrode the three prompt strings on `EntityMemoryConfig` should re-check their overrides against the new defaults.
