### PR TITLE
feat: AgentOSTools read-only platform ops toolkit

### DIFF
--- a/cookbook/05_agent_os/25_agentos_tools/README.md
+++ b/cookbook/05_agent_os/25_agentos_tools/README.md
@@ -1,0 +1,42 @@
+# AgentOS Tools
+
+AgentOSTools gives an agent a read-only ops view of the AgentOS it runs on:
+usage, latency, failures, tool statistics, schedules, eval history, pending
+approvals and runtime-built components. The toolkit takes the database, never
+the AgentOS instance — agents are constructed before the OS, so every tool
+reads only from `db`.
+
+## Files
+
+| File | What it teaches |
+|---|---|
+| `platform_ops_agent.py` | Generate traced activity with a worker agent, then answer platform questions with an ops agent using AgentOSTools. |
+
+## Prerequisites
+
+```bash
+./scripts/demo_setup.sh
+export OPENAI_API_KEY=...
+```
+
+## Run platform_ops_agent.py
+
+```bash
+.venvs/demo/bin/python cookbook/05_agent_os/25_agentos_tools/platform_ops_agent.py
+```
+
+The demo runs the worker agent twice, verifies the activity is visible through
+the toolkit (run counts, tool statistics, session metrics), then asks the ops
+agent for a platform summary.
+
+## Notes
+
+- Every tool is read-only. Schedule, approval and component management are
+  deliberately not exposed, so the toolkit is safe to reach from any frontend.
+- Sensitive payloads are never returned: span attributes, approval tool
+  arguments and schedule run input/output can hold conversation content and are
+  excluded from every tool result.
+- Per-surface flags (`metrics`, `traces`, `schedules`, `evals`, `components`,
+  `approvals`) control which tools a deployment exposes.
+- On SQLite, `p95_duration_ms` is reported as null (no SQL percentile support);
+  PostgreSQL reports real percentiles. The payload says so when it applies.

--- a/cookbook/05_agent_os/25_agentos_tools/README.md
+++ b/cookbook/05_agent_os/25_agentos_tools/README.md
@@ -31,8 +31,12 @@ agent for a platform summary.
 
 ## Notes
 
-- Every tool is read-only. Schedule, approval and component management are
-  deliberately not exposed, so the toolkit is safe to reach from any frontend.
+- No tool mutates platform state; schedule, approval and component management
+  are deliberately not exposed. The one write is the metrics rollup refresh
+  inside `get_platform_metrics` (derived data, no user content). The tools read
+  the database directly, so AgentOS endpoint scopes do not apply — expose the
+  ops agent to operators, and trim surfaces with the enable flags for wider
+  audiences.
 - Sensitive payloads are never returned: span attributes, approval tool
   arguments and schedule run input/output can hold conversation content and are
   excluded from every tool result.

--- a/cookbook/05_agent_os/25_agentos_tools/TEST_LOG.md
+++ b/cookbook/05_agent_os/25_agentos_tools/TEST_LOG.md
@@ -1,6 +1,8 @@
 # Test Log — 25_agentos_tools
 
-Tested 2026-07-26 on branch `feat/agentos-tools` (base `main` @ f2fdceeb7) with
+Tested 2026-07-27 on branch `feat/agentos-tools` (tip `567cbdaa0` plus the
+review-fix pass: schedule error redaction, page-scoped history summary,
+span-stats paging tiebreak, performance eval run times) with
 `.venvs/demo/bin/python` and `OPENAI_API_KEY` set.
 
 ### platform_ops_agent.py
@@ -13,20 +15,30 @@ Tested 2026-07-26 on branch `feat/agentos-tools` (base `main` @ f2fdceeb7) with
 with tracing enabled on the AgentOS. Runs the worker twice (calculator tool calls),
 then verifies through AgentOSTools directly: get_run_activity reports 2 traces for
 `research-worker` with duration aggregates, get_tool_activity lists the calculator
-tools and model calls, get_platform_metrics reports 1 agent session with token
-totals. Finally the ops agent answers a platform-summary question.
+tools and model calls, get_platform_metrics reports the session with token totals.
+Finally the ops agent answers a platform-summary question.
 
-**Result:** Self-verification passed (2 worker traces, tools `add`/`multiply`
-visible, 1 session with 1,561 total tokens in metrics). The ops agent produced a
-grounded summary: per-agent run table, tool telemetry including the
-"p95_duration_ms is not available on this database backend" note, token usage,
-model mix (gpt-5.5: 2 runs) and daily activity for 2026-07-26.
+**Result:** Self-verification passed: 2 worker traces at 3,440.5 ms average with
+0 errors, tools `add`/`multiply` visible, 1 session with 1,561 total tokens at
+mid-demo. The ops agent produced a grounded summary: a per-agent run table
+(research-worker, 2 runs, 1 session, 3,440.5 ms avg, 3,798.0 ms max, 0 errors),
+one endpoint-level trace reported separately from component-attributed traces,
+tool and model-call telemetry repeating the "p95_duration_ms is not available on
+this database backend" note, token usage (1,508 input / 53 output / 1,561 total),
+model mix (gpt-5.5: 2 runs) — and it closed with "The platform does not report
+monetary cost, only token totals" instead of estimating a spend figure.
 
 ---
 
 ## Validation
 
-- Run activity, tool activity and platform metrics all read back real traced data.
+- Run activity, tool activity and platform metrics all read back real traced
+  data; the demo's built-in assertions (at least 2 worker traces, at least 1
+  agent session) passed.
 - Truncation and backend-capability notes surface in the payloads and the agent
-  repeats them instead of overstating.
+  repeats them instead of overstating; asked about spend, it gives token totals
+  and says cost is not tracked.
 - No sensitive payloads (span attributes, tool arguments) appear in any output.
+- Reading the same database after the demo shows the ops agent's own run in the
+  platform data (sessions rise to 2, model mix to 3 runs): the toolkit observes
+  the OS it runs on, including itself.

--- a/cookbook/05_agent_os/25_agentos_tools/TEST_LOG.md
+++ b/cookbook/05_agent_os/25_agentos_tools/TEST_LOG.md
@@ -1,0 +1,32 @@
+# Test Log — 25_agentos_tools
+
+Tested 2026-07-26 on branch `feat/agentos-tools` (base `main` @ f2fdceeb7) with
+`.venvs/demo/bin/python` and `OPENAI_API_KEY` set.
+
+### platform_ops_agent.py
+
+**Status:** PASS
+
+**Test mode:** LIVE
+
+**Description:** Constructs a worker agent and an ops agent sharing one SqliteDb,
+with tracing enabled on the AgentOS. Runs the worker twice (calculator tool calls),
+then verifies through AgentOSTools directly: get_run_activity reports 2 traces for
+`research-worker` with duration aggregates, get_tool_activity lists the calculator
+tools and model calls, get_platform_metrics reports 1 agent session with token
+totals. Finally the ops agent answers a platform-summary question.
+
+**Result:** Self-verification passed (2 worker traces, tools `add`/`multiply`
+visible, 1 session with 1,561 total tokens in metrics). The ops agent produced a
+grounded summary: per-agent run table, tool telemetry including the
+"p95_duration_ms is not available on this database backend" note, token usage,
+model mix (gpt-5.5: 2 runs) and daily activity for 2026-07-26.
+
+---
+
+## Validation
+
+- Run activity, tool activity and platform metrics all read back real traced data.
+- Truncation and backend-capability notes surface in the payloads and the agent
+  repeats them instead of overstating.
+- No sensitive payloads (span attributes, tool arguments) appear in any output.

--- a/cookbook/05_agent_os/25_agentos_tools/platform_ops_agent.py
+++ b/cookbook/05_agent_os/25_agentos_tools/platform_ops_agent.py
@@ -1,0 +1,112 @@
+"""Platform Ops Agent
+==================
+
+Give an agent a read-only ops view of the AgentOS it runs on with AgentOSTools.
+A worker agent generates real traced activity, then an ops agent reads usage,
+latency and tool statistics back from the same database and answers questions
+about the platform.
+
+AgentOSTools takes the database, never the AgentOS instance: agents are built
+before the OS, so every tool reads only from db.
+
+Prerequisites: export OPENAI_API_KEY=...
+Run: .venvs/demo/bin/python cookbook/05_agent_os/25_agentos_tools/platform_ops_agent.py
+Try: ask the ops agent "Which tool was slowest today?" or "How many runs failed?"
+"""
+
+import json
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.tools.agentos import AgentOSTools
+from agno.tools.calculator import CalculatorTools
+
+DB_DIR = Path(__file__).parent / "tmp"
+DB_DIR.mkdir(exist_ok=True)
+
+db = SqliteDb(id="platform-ops-db", db_file=str(DB_DIR / "platform_ops.db"))
+
+# ---------------------------------------------------------------------------
+# A worker agent that produces traced activity
+# ---------------------------------------------------------------------------
+
+worker = Agent(
+    id="research-worker",
+    name="Research Worker",
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[CalculatorTools()],
+    instructions="Answer briefly. Use the calculator for any arithmetic.",
+    db=db,
+)
+
+# ---------------------------------------------------------------------------
+# The ops agent that answers questions about the platform
+# ---------------------------------------------------------------------------
+
+ops_agent = Agent(
+    id="platform-ops",
+    name="Platform Ops",
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[AgentOSTools(db=db)],
+    instructions=[
+        "You answer operations questions about this AgentOS deployment.",
+        "Ground every number in a tool result and mention the time window.",
+    ],
+    db=db,
+    markdown=True,
+)
+
+agent_os = AgentOS(
+    id="platform-ops-os",
+    name="Platform Ops AgentOS",
+    description="AgentOS with a worker agent and a read-only platform ops agent.",
+    agents=[worker, ops_agent],
+    db=db,
+    tracing=True,
+)
+app = agent_os.get_app()
+
+
+def run_demo() -> None:
+    # Generate traced activity for the ops agent to report on
+    worker.run("What is 41 * 73?", session_id="ops-demo-session", user_id="demo-user")
+    worker.run("What is 12 + 30?", session_id="ops-demo-session", user_id="demo-user")
+
+    # Verify the platform data is visible through the toolkit before asking the agent
+    toolkit = AgentOSTools(db=db)
+
+    activity = json.loads(toolkit.get_run_activity(days=1))
+    worker_rows = [
+        row for row in activity["agents"] if row["agent_id"] == "research-worker"
+    ]
+    if not worker_rows or worker_rows[0]["total_traces"] < 2:
+        raise RuntimeError(
+            f"Expected at least 2 worker traces, got: {activity['agents']}"
+        )
+    print("Run activity:", worker_rows[0]["total_traces"], "worker traces,")
+    print("  avg duration:", worker_rows[0]["avg_duration_ms"], "ms")
+
+    tools = json.loads(toolkit.get_tool_activity(days=1))
+    tool_names = [row["name"] for row in tools["tools_most_used"]]
+    print("Tools used:", tool_names)
+
+    metrics = json.loads(toolkit.get_platform_metrics(days=1))
+    if metrics["totals"]["agent_sessions"] < 1:
+        raise RuntimeError(
+            f"Expected at least 1 agent session in metrics, got: {metrics['totals']}"
+        )
+    print("Sessions today:", metrics["totals"]["agent_sessions"])
+    print("Tokens today:", metrics["totals"]["total_tokens"])
+
+    # Now let the ops agent answer from the same data
+    ops_agent.print_response(
+        "Summarize activity on this platform: how many runs, by which agents, "
+        "which tools were used, and how many tokens were spent."
+    )
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/cookbook/05_agent_os/README.md
+++ b/cookbook/05_agent_os/README.md
@@ -55,6 +55,7 @@ surface.
 | [22_studio](./22_studio/) | Compose, version, inspect, and approve AgentOS components with the Registry, StudioTools, and components API. |
 | [23_skills](./23_skills/) | Serve local skills through an Agent and execute checked-in skill scripts through the AgentOS run API. |
 | [24_showcase](./24_showcase/) | Run the secure, traced capstone with RAG, web and finance research, a Team, and a real evaluation. |
+| [25_agentos_tools](./25_agentos_tools/) | Answer platform ops questions (usage, latency, tool statistics) with an agent using AgentOSTools. |
 
 ## Canonical ports
 
@@ -100,6 +101,7 @@ surface.
 | `22_studio` | `OPENAI_API_KEY`; `ANTHROPIC_API_KEY` for Claude-backed runs | Local synchronous SQLite for Registry and components CRUD |
 | `23_skills` | `OPENAI_API_KEY` | Local sample-skill files with executable Python scripts |
 | `24_showcase` | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OS_SECURITY_KEY` | `./cookbook/scripts/run_pgvector.sh`, internet access, and tracing |
+| `25_agentos_tools` | `OPENAI_API_KEY` | Local SQLite with tracing enabled |
 
 Run cookbook files with `.venvs/demo/bin/python`. Development checks use
 `.venv`.

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -501,7 +501,7 @@ class BaseDb(ABC):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session or by component.
 
@@ -518,6 +518,8 @@ class BaseDb(ABC):
             group_by: Grouping key. "session" (default) groups by session_id and keeps
                 the original output shape. "agent", "team" and "workflow" group by the
                 corresponding component id and add duration and error aggregates.
+                "endpoint" groups traces that carry no component id at all (HTTP/MCP
+                entrypoint wrappers) by trace name, with the same aggregates.
                 Backends may support only the default "session" grouping.
 
         Returns:
@@ -529,6 +531,7 @@ class BaseDb(ABC):
                 total_sessions, avg_duration_ms, p95_duration_ms, max_duration_ms,
                 error_traces (traces with status ERROR), first_trace_at (datetime),
                 last_trace_at (datetime). Traces without the grouping id are excluded.
+                With group_by="endpoint", the grouping key is name instead of <group>_id.
 
         Raises:
             NotImplementedError: If the backend does not support the requested grouping.
@@ -1853,7 +1856,7 @@ class AsyncBaseDb(ABC):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session or by component.
 
@@ -1870,6 +1873,8 @@ class AsyncBaseDb(ABC):
             group_by: Grouping key. "session" (default) groups by session_id and keeps
                 the original output shape. "agent", "team" and "workflow" group by the
                 corresponding component id and add duration and error aggregates.
+                "endpoint" groups traces that carry no component id at all (HTTP/MCP
+                entrypoint wrappers) by trace name, with the same aggregates.
                 Backends may support only the default "session" grouping.
 
         Returns:
@@ -1881,6 +1886,7 @@ class AsyncBaseDb(ABC):
                 total_sessions, avg_duration_ms, p95_duration_ms, max_duration_ms,
                 error_traces (traces with status ERROR), first_trace_at (datetime),
                 last_trace_at (datetime). Traces without the grouping id are excluded.
+                With group_by="endpoint", the grouping key is name instead of <group>_id.
 
         Raises:
             NotImplementedError: If the backend does not support the requested grouping.

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from datetime import date, datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Set, Tuple, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -501,8 +501,9 @@ class BaseDb(ABC):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
-        """Get trace statistics grouped by session.
+        """Get trace statistics grouped by session or by component.
 
         Args:
             user_id: Filter by user ID.
@@ -511,14 +512,26 @@ class BaseDb(ABC):
             workflow_id: Filter by workflow ID.
             start_time: Filter sessions with traces created after this datetime.
             end_time: Filter sessions with traces created before this datetime.
-            limit: Maximum number of sessions to return per page.
+            limit: Maximum number of groups to return per page.
             page: Page number (1-indexed).
             filter_expr: Advanced filter expression dict (from FilterExpr.to_dict()).
+            group_by: Grouping key. "session" (default) groups by session_id and keeps
+                the original output shape. "agent", "team" and "workflow" group by the
+                corresponding component id and add duration and error aggregates.
+                Backends may support only the default "session" grouping.
 
         Returns:
-            tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
-                Each dict contains: session_id, user_id, agent_id, team_id, total_traces,
-                first_trace_at (datetime), last_trace_at (datetime).
+            tuple[List[Dict], int]: Tuple of (list of stats dicts, total count).
+                With group_by="session", each dict contains: session_id, user_id,
+                agent_id, team_id, workflow_id, total_traces, first_trace_at (datetime),
+                last_trace_at (datetime).
+                With a component grouping, each dict contains: <group>_id, total_traces,
+                total_sessions, avg_duration_ms, p95_duration_ms, max_duration_ms,
+                error_traces (traces with status ERROR), first_trace_at (datetime),
+                last_trace_at (datetime). Traces without the grouping id are excluded.
+
+        Raises:
+            NotImplementedError: If the backend does not support the requested grouping.
         """
         raise NotImplementedError
 
@@ -569,6 +582,47 @@ class BaseDb(ABC):
 
         Returns:
             List[Span]: List of matching spans.
+        """
+        raise NotImplementedError
+
+    # This method is optional. Override in subclasses that support SQL-side span aggregation.
+    def get_span_stats(
+        self,
+        agent_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        name: Optional[str] = None,
+        span_type: Optional[str] = None,
+        limit: Optional[int] = 20,
+        page: Optional[int] = 1,
+        sort_by: str = "total_calls",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """Get span statistics aggregated by span name.
+
+        Aggregates over span names, durations and status only. Never reads span
+        attributes payloads, which can hold full conversation content.
+
+        Args:
+            agent_id: Only include spans belonging to traces of this agent.
+            team_id: Only include spans belonging to traces of this team.
+            workflow_id: Only include spans belonging to traces of this workflow.
+            start_time: Only include spans starting after this datetime.
+            end_time: Only include spans starting before this datetime.
+            name: Filter by exact span name.
+            span_type: Filter by span type (e.g. AGENT, LLM, TOOL, CHAIN).
+            limit: Maximum number of groups to return per page.
+            page: Page number (1-indexed).
+            sort_by: Aggregate to sort by: total_calls, avg_duration_ms,
+                p95_duration_ms, max_duration_ms, error_count or last_called_at.
+            sort_order: "asc" or "desc".
+
+        Returns:
+            Tuple[List[Dict], int]: Tuple of (list of stats dicts, total count of groups).
+                Each dict contains: name, span_type, total_calls, avg_duration_ms,
+                p95_duration_ms, max_duration_ms, error_count, last_called_at (datetime).
         """
         raise NotImplementedError
 
@@ -1799,8 +1853,9 @@ class AsyncBaseDb(ABC):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
-        """Get trace statistics grouped by session.
+        """Get trace statistics grouped by session or by component.
 
         Args:
             user_id: Filter by user ID.
@@ -1809,14 +1864,26 @@ class AsyncBaseDb(ABC):
             workflow_id: Filter by workflow ID.
             start_time: Filter sessions with traces created after this datetime.
             end_time: Filter sessions with traces created before this datetime.
-            limit: Maximum number of sessions to return per page.
+            limit: Maximum number of groups to return per page.
             page: Page number (1-indexed).
             filter_expr: Advanced filter expression dict (from FilterExpr.to_dict()).
+            group_by: Grouping key. "session" (default) groups by session_id and keeps
+                the original output shape. "agent", "team" and "workflow" group by the
+                corresponding component id and add duration and error aggregates.
+                Backends may support only the default "session" grouping.
 
         Returns:
-            tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
-                Each dict contains: session_id, user_id, agent_id, team_id, total_traces,
-                first_trace_at (datetime), last_trace_at (datetime).
+            tuple[List[Dict], int]: Tuple of (list of stats dicts, total count).
+                With group_by="session", each dict contains: session_id, user_id,
+                agent_id, team_id, workflow_id, total_traces, first_trace_at (datetime),
+                last_trace_at (datetime).
+                With a component grouping, each dict contains: <group>_id, total_traces,
+                total_sessions, avg_duration_ms, p95_duration_ms, max_duration_ms,
+                error_traces (traces with status ERROR), first_trace_at (datetime),
+                last_trace_at (datetime). Traces without the grouping id are excluded.
+
+        Raises:
+            NotImplementedError: If the backend does not support the requested grouping.
         """
         raise NotImplementedError
 
@@ -1867,6 +1934,47 @@ class AsyncBaseDb(ABC):
 
         Returns:
             List[Span]: List of matching spans.
+        """
+        raise NotImplementedError
+
+    # This method is optional. Override in subclasses that support SQL-side span aggregation.
+    async def get_span_stats(
+        self,
+        agent_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        name: Optional[str] = None,
+        span_type: Optional[str] = None,
+        limit: Optional[int] = 20,
+        page: Optional[int] = 1,
+        sort_by: str = "total_calls",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """Get span statistics aggregated by span name.
+
+        Aggregates over span names, durations and status only. Never reads span
+        attributes payloads, which can hold full conversation content.
+
+        Args:
+            agent_id: Only include spans belonging to traces of this agent.
+            team_id: Only include spans belonging to traces of this team.
+            workflow_id: Only include spans belonging to traces of this workflow.
+            start_time: Only include spans starting after this datetime.
+            end_time: Only include spans starting before this datetime.
+            name: Filter by exact span name.
+            span_type: Filter by span type (e.g. AGENT, LLM, TOOL, CHAIN).
+            limit: Maximum number of groups to return per page.
+            page: Page number (1-indexed).
+            sort_by: Aggregate to sort by: total_calls, avg_duration_ms,
+                p95_duration_ms, max_duration_ms, error_count or last_called_at.
+            sort_order: "asc" or "desc".
+
+        Returns:
+            Tuple[List[Dict], int]: Tuple of (list of stats dicts, total count of groups).
+                Each dict contains: name, span_type, total_calls, avg_duration_ms,
+                p95_duration_ms, max_duration_ms, error_count, last_called_at (datetime).
         """
         raise NotImplementedError
 

--- a/libs/agno/agno/db/clickhouse/clickhouse.py
+++ b/libs/agno/agno/db/clickhouse/clickhouse.py
@@ -436,7 +436,7 @@ class ClickhouseDb(BaseDb):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> Tuple[List[Dict[str, Any]], int]:
         if group_by != "session":
             raise NotImplementedError(

--- a/libs/agno/agno/db/clickhouse/clickhouse.py
+++ b/libs/agno/agno/db/clickhouse/clickhouse.py
@@ -20,7 +20,7 @@ Typical usage::
 """
 
 from datetime import date, datetime, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
 
 from agno.db.base import BaseDb, ComponentType
 from agno.db.clickhouse.schemas import SPANS_DDL, TRACES_DDL, VERSIONS_DDL
@@ -436,7 +436,13 @@ class ClickhouseDb(BaseDb):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> Tuple[List[Dict[str, Any]], int]:
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
         try:
             qualified = self._get_table("traces")
             if qualified is None:

--- a/libs/agno/agno/db/dynamo/dynamo.py
+++ b/libs/agno/agno/db/dynamo/dynamo.py
@@ -2548,7 +2548,7 @@ class DynamoDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 

--- a/libs/agno/agno/db/dynamo/dynamo.py
+++ b/libs/agno/agno/db/dynamo/dynamo.py
@@ -2,7 +2,7 @@ import json
 import time
 from datetime import date, datetime, timedelta, timezone
 from os import getenv
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 
 if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
@@ -2548,6 +2548,7 @@ class DynamoDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 
@@ -2560,12 +2561,19 @@ class DynamoDb(BaseDb):
             end_time: Filter sessions with traces created before this datetime.
             limit: Maximum number of sessions to return per page.
             page: Page number (1-indexed).
+            group_by: Only the default "session" grouping is supported by this backend.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
                 Each dict contains: session_id, user_id, agent_id, team_id, workflow_id, total_traces,
                 first_trace_at, last_trace_at.
         """
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
+
         try:
             table_name = self._get_table("traces")
             if table_name is None:

--- a/libs/agno/agno/db/firestore/firestore.py
+++ b/libs/agno/agno/db/firestore/firestore.py
@@ -2134,7 +2134,7 @@ class FirestoreDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 

--- a/libs/agno/agno/db/firestore/firestore.py
+++ b/libs/agno/agno/db/firestore/firestore.py
@@ -1,7 +1,7 @@
 import json
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union, cast
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -2134,6 +2134,7 @@ class FirestoreDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 
@@ -2146,12 +2147,19 @@ class FirestoreDb(BaseDb):
             end_time: Filter sessions with traces created before this datetime.
             limit: Maximum number of sessions to return per page.
             page: Page number (1-indexed).
+            group_by: Only the default "session" grouping is supported by this backend.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
                 Each dict contains: session_id, user_id, agent_id, team_id, workflow_id, total_traces,
                 first_trace_at, last_trace_at.
         """
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
+
         try:
             collection_ref = self._get_collection(table_type="traces")
             if collection_ref is None:

--- a/libs/agno/agno/db/gcs_json/gcs_json_db.py
+++ b/libs/agno/agno/db/gcs_json/gcs_json_db.py
@@ -1,7 +1,7 @@
 import json
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -1632,6 +1632,7 @@ class GcsJsonDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 
@@ -1644,12 +1645,19 @@ class GcsJsonDb(BaseDb):
             end_time: Filter sessions with traces created before this datetime.
             limit: Maximum number of sessions to return per page.
             page: Page number (1-indexed).
+            group_by: Only the default "session" grouping is supported by this backend.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
                 Each dict contains: session_id, user_id, agent_id, team_id, workflow_id, total_traces,
                 first_trace_at, last_trace_at.
         """
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
+
         try:
             traces = self._read_json_file(self.trace_table_name, create_table_if_not_found=False)
             if not traces:

--- a/libs/agno/agno/db/gcs_json/gcs_json_db.py
+++ b/libs/agno/agno/db/gcs_json/gcs_json_db.py
@@ -1632,7 +1632,7 @@ class GcsJsonDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -1,7 +1,7 @@
 import time
 from copy import deepcopy
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import uuid4
 
 from agno.db.base import BaseDb, SessionType
@@ -1271,6 +1271,7 @@ class InMemoryDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 
@@ -1283,12 +1284,18 @@ class InMemoryDb(BaseDb):
             end_time: Filter sessions with traces created before this datetime.
             limit: Maximum number of sessions to return per page.
             page: Page number (1-indexed).
+            group_by: Only the default "session" grouping is supported by this backend.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
                 Each dict contains: session_id, user_id, agent_id, team_id, workflow_id, total_traces,
                 first_trace_at, last_trace_at.
         """
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
         raise NotImplementedError
 
     # --- Spans ---

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -1271,7 +1271,7 @@ class InMemoryDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 

--- a/libs/agno/agno/db/json/json_db.py
+++ b/libs/agno/agno/db/json/json_db.py
@@ -1613,7 +1613,7 @@ class JsonDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 

--- a/libs/agno/agno/db/json/json_db.py
+++ b/libs/agno/agno/db/json/json_db.py
@@ -3,7 +3,7 @@ import os
 import time
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -1613,6 +1613,7 @@ class JsonDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 
@@ -1625,10 +1626,16 @@ class JsonDb(BaseDb):
             end_time: Filter sessions with traces created before this datetime.
             limit: Maximum number of sessions to return per page.
             page: Page number (1-indexed).
+            group_by: Only the default "session" grouping is supported by this backend.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
         """
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
         try:
             traces = self._read_json_file(self.trace_table_name, create_table_if_not_found=False)
             if not traces:

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -2649,7 +2649,7 @@ class AsyncMongoDb(AsyncBaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import uuid4
 
 try:
@@ -2649,6 +2649,7 @@ class AsyncMongoDb(AsyncBaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 
@@ -2661,12 +2662,18 @@ class AsyncMongoDb(AsyncBaseDb):
             end_time: Filter sessions with traces created before this datetime.
             limit: Maximum number of sessions to return per page.
             page: Page number (1-indexed).
+            group_by: Only the default "session" grouping is supported by this backend.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
                 Each dict contains: session_id, user_id, agent_id, team_id, total_traces,
                 workflow_id, first_trace_at, last_trace_at.
         """
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
         try:
             collection = await self._get_collection(table_type="traces")
             if collection is None:

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -2487,7 +2487,7 @@ class MongoDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -1,7 +1,7 @@
 import time
 from datetime import date, datetime, timedelta, timezone
 from importlib import metadata
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import uuid4
 
 try:
@@ -2487,6 +2487,7 @@ class MongoDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 
@@ -2499,12 +2500,18 @@ class MongoDb(BaseDb):
             end_time: Filter sessions with traces created before this datetime.
             limit: Maximum number of sessions to return per page.
             page: Page number (1-indexed).
+            group_by: Only the default "session" grouping is supported by this backend.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
                 Each dict contains: session_id, user_id, agent_id, team_id, total_traces,
                 workflow_id, first_trace_at, last_trace_at.
         """
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
         try:
             collection = self._get_collection(table_type="traces")
             if collection is None:

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -2746,7 +2746,7 @@ class AsyncMySQLDb(AsyncBaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -1,6 +1,6 @@
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -2746,6 +2746,7 @@ class AsyncMySQLDb(AsyncBaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 
@@ -2758,12 +2759,19 @@ class AsyncMySQLDb(AsyncBaseDb):
             end_time: Filter sessions with traces created before this datetime.
             limit: Maximum number of sessions to return per page.
             page: Page number (1-indexed).
+            group_by: Only the default "session" grouping is supported by this backend.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
                 Each dict contains: session_id, user_id, agent_id, team_id, total_traces,
                 workflow_id, first_trace_at, last_trace_at.
         """
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
+
         try:
             table = await self._get_table(table_type="traces")
             if table is None:

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -1,6 +1,6 @@
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -2765,6 +2765,7 @@ class MySQLDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 
@@ -2777,12 +2778,19 @@ class MySQLDb(BaseDb):
             end_time: Filter sessions with traces created before this datetime.
             limit: Maximum number of sessions to return per page.
             page: Page number (1-indexed).
+            group_by: Only the default "session" grouping is supported by this backend.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
                 Each dict contains: session_id, user_id, agent_id, team_id, total_traces,
                 workflow_id, first_trace_at, last_trace_at.
         """
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
+
         try:
             table = self._get_table(table_type="traces")
             if table is None:

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -2765,7 +2765,7 @@ class MySQLDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -153,6 +153,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             bind=self.db_engine,
             expire_on_commit=False,
         )
+        # Zero means never refreshed; get_metrics uses this to refresh lazily, at most once per minute
+        self._metrics_refreshed_at: float = 0.0
 
     async def close(self) -> None:
         """Close database connections and dispose of the connection pool.
@@ -1744,6 +1746,9 @@ class AsyncPostgresDb(AsyncBaseDb):
             Exception: If an error occurs during metrics calculation.
         """
         try:
+            # Stamp first so failed runs are throttled too instead of retried on every read
+            self._metrics_refreshed_at = time.time()
+
             table = await self._get_table(table_type="metrics", create_table_if_not_found=True)
             if table is None:
                 return None
@@ -1811,8 +1816,8 @@ class AsyncPostgresDb(AsyncBaseDb):
     ) -> Tuple[List[dict], Optional[int]]:
         """Get all metrics matching the given date range.
 
-        Metrics for days not yet calculated are refreshed first, so results are
-        current even on deployments where nothing calls the refresh endpoint.
+        Metrics are refreshed lazily, at most once per minute per process, so results
+        stay current even on deployments where nothing calls the refresh endpoint.
 
         Args:
             starting_date (Optional[date]): The starting date to filter metrics by.
@@ -1825,11 +1830,13 @@ class AsyncPostgresDb(AsyncBaseDb):
             Exception: If an error occurs during retrieval.
         """
         try:
-            # Refresh before reading. Dates with complete metrics are skipped, so this is cheap.
-            try:
-                await self.calculate_metrics()
-            except Exception as e:
-                log_warning(f"Could not refresh metrics before reading them: {str(e)}")
+            # Refresh at most once per minute per process: recalculating the current
+            # day scans all of today's sessions, too costly for every read.
+            if time.time() - self._metrics_refreshed_at >= 60:
+                try:
+                    await self.calculate_metrics()
+                except Exception as e:
+                    log_warning(f"Could not refresh metrics before reading them: {str(e)}")
 
             table = await self._get_table(table_type="metrics", create_table_if_not_found=True)
             if table is None:
@@ -2691,7 +2698,7 @@ class AsyncPostgresDb(AsyncBaseDb):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session or by component.
 
@@ -2708,8 +2715,10 @@ class AsyncPostgresDb(AsyncBaseDb):
             group_by: Grouping key. "session" (default) groups by session_id and keeps
                 the original output shape, ordered by last activity. "agent", "team" and
                 "workflow" group by the corresponding component id, add duration and
-                error aggregates, and are ordered by total_traces descending. Traces
-                without the grouping id are excluded.
+                error aggregates, and are ordered by total_traces descending; traces
+                without the grouping id are excluded. "endpoint" groups traces that
+                carry no component id at all (HTTP/MCP entrypoint wrappers) by trace
+                name, with the same aggregates.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of stats dicts, total count).
@@ -2718,9 +2727,10 @@ class AsyncPostgresDb(AsyncBaseDb):
                 With a component grouping, each dict contains: <group>_id, total_traces,
                 total_sessions, avg_duration_ms, p95_duration_ms, max_duration_ms,
                 error_traces (traces with status ERROR), first_trace_at, last_trace_at.
+                With group_by="endpoint", the grouping key is name instead of <group>_id.
         """
-        if group_by not in ("session", "agent", "team", "workflow"):
-            raise ValueError(f"Invalid group_by value: {group_by!r}. Allowed: session, agent, team, workflow")
+        if group_by not in ("session", "agent", "team", "workflow", "endpoint"):
+            raise ValueError(f"Invalid group_by value: {group_by!r}. Allowed: session, agent, team, workflow, endpoint")
 
         try:
             table = await self._get_table(table_type="traces")
@@ -2745,14 +2755,26 @@ class AsyncPostgresDb(AsyncBaseDb):
                         .group_by(table.c.session_id)
                     )
                 else:
-                    group_column = {
-                        "agent": table.c.agent_id,
-                        "team": table.c.team_id,
-                        "workflow": table.c.workflow_id,
-                    }[group_by]
+                    if group_by == "endpoint":
+                        # Endpoint-level traces (HTTP/MCP entrypoint wrappers) carry no component ids
+                        group_column = table.c.name
+                        group_label = "name"
+                        group_filter = and_(
+                            table.c.agent_id.is_(None),
+                            table.c.team_id.is_(None),
+                            table.c.workflow_id.is_(None),
+                        )
+                    else:
+                        group_column = {
+                            "agent": table.c.agent_id,
+                            "team": table.c.team_id,
+                            "workflow": table.c.workflow_id,
+                        }[group_by]
+                        group_label = f"{group_by}_id"
+                        group_filter = group_column.isnot(None)  # Only traces attributed to the grouping component
                     base_stmt = (
                         select(
-                            group_column.label(f"{group_by}_id"),
+                            group_column.label(group_label),
                             func.count(table.c.trace_id).label("total_traces"),
                             func.count(distinct(table.c.session_id)).label("total_sessions"),
                             func.avg(table.c.duration_ms).label("avg_duration_ms"),
@@ -2762,7 +2784,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                             func.min(table.c.created_at).label("first_trace_at"),
                             func.max(table.c.created_at).label("last_trace_at"),
                         )
-                        .where(group_column.isnot(None))  # Only traces attributed to the grouping component
+                        .where(group_filter)
                         .group_by(group_column)
                     )
 
@@ -2835,7 +2857,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                     else:
                         stats_list.append(
                             {
-                                f"{group_by}_id": getattr(row, f"{group_by}_id"),
+                                group_label: getattr(row, group_label),
                                 "total_traces": row.total_traces,
                                 "total_sessions": row.total_sessions,
                                 "avg_duration_ms": round(float(row.avg_duration_ms), 1)

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -3117,7 +3117,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                 order_by = sort_col.asc() if sort_order == "asc" else sort_col.desc()
 
                 offset = (page - 1) * limit if page and limit else 0
-                paginated_stmt = stmt.order_by(order_by, table.c.name).limit(limit).offset(offset)
+                paginated_stmt = stmt.order_by(order_by, table.c.name, span_type_col).limit(limit).offset(offset)
 
                 result = await sess.execute(paginated_stmt)
                 results = result.fetchall()

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -1,6 +1,6 @@
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union, cast
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -36,7 +36,7 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import sanitize_postgres_string, sanitize_postgres_strings
 
 try:
-    from sqlalchemy import ForeignKey, Index, String, Table, UniqueConstraint, and_, case, func, or_, update
+    from sqlalchemy import ForeignKey, Index, String, Table, UniqueConstraint, and_, case, distinct, func, or_, update
     from sqlalchemy.dialects import postgresql
     from sqlalchemy.dialects.postgresql import TIMESTAMP
     from sqlalchemy.exc import ProgrammingError
@@ -1811,6 +1811,9 @@ class AsyncPostgresDb(AsyncBaseDb):
     ) -> Tuple[List[dict], Optional[int]]:
         """Get all metrics matching the given date range.
 
+        Metrics for days not yet calculated are refreshed first, so results are
+        current even on deployments where nothing calls the refresh endpoint.
+
         Args:
             starting_date (Optional[date]): The starting date to filter metrics by.
             ending_date (Optional[date]): The ending date to filter metrics by.
@@ -1822,6 +1825,12 @@ class AsyncPostgresDb(AsyncBaseDb):
             Exception: If an error occurs during retrieval.
         """
         try:
+            # Refresh before reading. Dates with complete metrics are skipped, so this is cheap.
+            try:
+                await self.calculate_metrics()
+            except Exception as e:
+                log_warning(f"Could not refresh metrics before reading them: {str(e)}")
+
             table = await self._get_table(table_type="metrics", create_table_if_not_found=True)
             if table is None:
                 return [], None
@@ -2682,8 +2691,9 @@ class AsyncPostgresDb(AsyncBaseDb):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
-        """Get trace statistics grouped by session.
+        """Get trace statistics grouped by session or by component.
 
         Args:
             user_id: Filter by user ID.
@@ -2692,36 +2702,69 @@ class AsyncPostgresDb(AsyncBaseDb):
             workflow_id: Filter by workflow ID.
             start_time: Filter sessions with traces created after this datetime.
             end_time: Filter sessions with traces created before this datetime.
-            limit: Maximum number of sessions to return per page.
+            limit: Maximum number of groups to return per page.
             page: Page number (1-indexed).
             filter_expr: Advanced filter expression dict (from FilterExpr.to_dict()).
+            group_by: Grouping key. "session" (default) groups by session_id and keeps
+                the original output shape, ordered by last activity. "agent", "team" and
+                "workflow" group by the corresponding component id, add duration and
+                error aggregates, and are ordered by total_traces descending. Traces
+                without the grouping id are excluded.
 
         Returns:
-            tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
-                Each dict contains: session_id, user_id, agent_id, team_id, total_traces,
-                workflow_id, first_trace_at, last_trace_at.
+            tuple[List[Dict], int]: Tuple of (list of stats dicts, total count).
+                With group_by="session", each dict contains: session_id, user_id,
+                agent_id, team_id, workflow_id, total_traces, first_trace_at, last_trace_at.
+                With a component grouping, each dict contains: <group>_id, total_traces,
+                total_sessions, avg_duration_ms, p95_duration_ms, max_duration_ms,
+                error_traces (traces with status ERROR), first_trace_at, last_trace_at.
         """
+        if group_by not in ("session", "agent", "team", "workflow"):
+            raise ValueError(f"Invalid group_by value: {group_by!r}. Allowed: session, agent, team, workflow")
+
         try:
             table = await self._get_table(table_type="traces")
             if table is None:
                 return [], 0
 
             async with self.async_session_factory() as sess:
-                # Build base query grouped by session_id
-                base_stmt = (
-                    select(
-                        table.c.session_id,
-                        func.max(table.c.user_id).label("user_id"),
-                        func.max(table.c.agent_id).label("agent_id"),
-                        func.max(table.c.team_id).label("team_id"),
-                        func.max(table.c.workflow_id).label("workflow_id"),
-                        func.count(table.c.trace_id).label("total_traces"),
-                        func.min(table.c.created_at).label("first_trace_at"),
-                        func.max(table.c.created_at).label("last_trace_at"),
+                if group_by == "session":
+                    # Build base query grouped by session_id
+                    base_stmt = (
+                        select(
+                            table.c.session_id,
+                            func.max(table.c.user_id).label("user_id"),
+                            func.max(table.c.agent_id).label("agent_id"),
+                            func.max(table.c.team_id).label("team_id"),
+                            func.max(table.c.workflow_id).label("workflow_id"),
+                            func.count(table.c.trace_id).label("total_traces"),
+                            func.min(table.c.created_at).label("first_trace_at"),
+                            func.max(table.c.created_at).label("last_trace_at"),
+                        )
+                        .where(table.c.session_id.isnot(None))  # Only sessions with session_id
+                        .group_by(table.c.session_id)
                     )
-                    .where(table.c.session_id.isnot(None))  # Only sessions with session_id
-                    .group_by(table.c.session_id)
-                )
+                else:
+                    group_column = {
+                        "agent": table.c.agent_id,
+                        "team": table.c.team_id,
+                        "workflow": table.c.workflow_id,
+                    }[group_by]
+                    base_stmt = (
+                        select(
+                            group_column.label(f"{group_by}_id"),
+                            func.count(table.c.trace_id).label("total_traces"),
+                            func.count(distinct(table.c.session_id)).label("total_sessions"),
+                            func.avg(table.c.duration_ms).label("avg_duration_ms"),
+                            func.percentile_cont(0.95).within_group(table.c.duration_ms).label("p95_duration_ms"),
+                            func.max(table.c.duration_ms).label("max_duration_ms"),
+                            func.sum(case((table.c.status == "ERROR", 1), else_=0)).label("error_traces"),
+                            func.min(table.c.created_at).label("first_trace_at"),
+                            func.max(table.c.created_at).label("last_trace_at"),
+                        )
+                        .where(group_column.isnot(None))  # Only traces attributed to the grouping component
+                        .group_by(group_column)
+                    )
 
                 # Apply filters
                 if user_id is not None:
@@ -2753,13 +2796,18 @@ class AsyncPostgresDb(AsyncBaseDb):
                     except (KeyError, TypeError) as e:
                         raise ValueError(f"Invalid filter expression: {e}") from e
 
-                # Get total count of sessions
+                # Get total count of groups
                 count_stmt = select(func.count()).select_from(base_stmt.alias())
                 total_count = await sess.scalar(count_stmt) or 0
 
                 # Apply pagination and ordering
                 offset = (page - 1) * limit if page and limit else 0
-                paginated_stmt = base_stmt.order_by(func.max(table.c.created_at).desc()).limit(limit).offset(offset)
+                order_by: List[Any] = (
+                    [func.max(table.c.created_at).desc()]
+                    if group_by == "session"
+                    else [func.count(table.c.trace_id).desc(), group_column]
+                )
+                paginated_stmt = base_stmt.order_by(*order_by).limit(limit).offset(offset)
 
                 result = await sess.execute(paginated_stmt)
                 results = result.fetchall()
@@ -2767,26 +2815,41 @@ class AsyncPostgresDb(AsyncBaseDb):
                 # Convert to list of dicts with datetime objects
                 stats_list = []
                 for row in results:
-                    # Convert ISO strings to datetime objects
-                    first_trace_at_str = row.first_trace_at
-                    last_trace_at_str = row.last_trace_at
-
                     # Parse ISO format strings to datetime objects
-                    first_trace_at = datetime.fromisoformat(first_trace_at_str.replace("Z", "+00:00"))
-                    last_trace_at = datetime.fromisoformat(last_trace_at_str.replace("Z", "+00:00"))
+                    first_trace_at = datetime.fromisoformat(row.first_trace_at.replace("Z", "+00:00"))
+                    last_trace_at = datetime.fromisoformat(row.last_trace_at.replace("Z", "+00:00"))
 
-                    stats_list.append(
-                        {
-                            "session_id": row.session_id,
-                            "user_id": row.user_id,
-                            "agent_id": row.agent_id,
-                            "team_id": row.team_id,
-                            "workflow_id": row.workflow_id,
-                            "total_traces": row.total_traces,
-                            "first_trace_at": first_trace_at,
-                            "last_trace_at": last_trace_at,
-                        }
-                    )
+                    if group_by == "session":
+                        stats_list.append(
+                            {
+                                "session_id": row.session_id,
+                                "user_id": row.user_id,
+                                "agent_id": row.agent_id,
+                                "team_id": row.team_id,
+                                "workflow_id": row.workflow_id,
+                                "total_traces": row.total_traces,
+                                "first_trace_at": first_trace_at,
+                                "last_trace_at": last_trace_at,
+                            }
+                        )
+                    else:
+                        stats_list.append(
+                            {
+                                f"{group_by}_id": getattr(row, f"{group_by}_id"),
+                                "total_traces": row.total_traces,
+                                "total_sessions": row.total_sessions,
+                                "avg_duration_ms": round(float(row.avg_duration_ms), 1)
+                                if row.avg_duration_ms is not None
+                                else None,
+                                "p95_duration_ms": round(float(row.p95_duration_ms), 1)
+                                if row.p95_duration_ms is not None
+                                else None,
+                                "max_duration_ms": row.max_duration_ms,
+                                "error_traces": row.error_traces,
+                                "first_trace_at": first_trace_at,
+                                "last_trace_at": last_trace_at,
+                            }
+                        )
 
                 return stats_list, total_count
 
@@ -2921,6 +2984,151 @@ class AsyncPostgresDb(AsyncBaseDb):
         except Exception as e:
             log_error(f"Error getting spans: {str(e)}")
             return []
+
+    async def get_span_stats(
+        self,
+        agent_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        name: Optional[str] = None,
+        span_type: Optional[str] = None,
+        limit: Optional[int] = 20,
+        page: Optional[int] = 1,
+        sort_by: str = "total_calls",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """Get span statistics aggregated SQL-side by span name and span type.
+
+        Only span names, durations and status are aggregated. The span attributes
+        payload, which can hold full conversation content, is never selected — the
+        single "openinference.span.kind" key is extracted in SQL as the span type.
+
+        Args:
+            agent_id: Only include spans belonging to traces of this agent.
+            team_id: Only include spans belonging to traces of this team.
+            workflow_id: Only include spans belonging to traces of this workflow.
+            start_time: Only include spans starting after this datetime.
+            end_time: Only include spans starting before this datetime.
+            name: Filter by exact span name.
+            span_type: Filter by span type (e.g. AGENT, LLM, TOOL, CHAIN).
+            limit: Maximum number of groups to return per page.
+            page: Page number (1-indexed).
+            sort_by: Aggregate to sort by: total_calls, avg_duration_ms,
+                p95_duration_ms, max_duration_ms, error_count or last_called_at.
+            sort_order: "asc" or "desc".
+
+        Returns:
+            Tuple[List[Dict], int]: Tuple of (list of stats dicts, total count of groups).
+                Each dict contains: name, span_type, total_calls, avg_duration_ms,
+                p95_duration_ms, max_duration_ms, error_count, last_called_at (datetime).
+        """
+        try:
+            table = await self._get_table(table_type="spans")
+            if table is None:
+                log_debug("Spans table not found")
+                return [], 0
+
+            span_type_col = table.c.attributes["openinference.span.kind"].astext
+
+            total_calls_col = func.count(table.c.span_id)
+            avg_duration_col = func.avg(table.c.duration_ms)
+            p95_duration_col = func.percentile_cont(0.95).within_group(table.c.duration_ms)
+            max_duration_col = func.max(table.c.duration_ms)
+            error_count_col = func.sum(case((table.c.status_code == "ERROR", 1), else_=0))
+            last_called_at_col = func.max(table.c.start_time)
+
+            async with self.async_session_factory() as sess:
+                stmt = select(
+                    table.c.name,
+                    span_type_col.label("span_type"),
+                    total_calls_col.label("total_calls"),
+                    avg_duration_col.label("avg_duration_ms"),
+                    p95_duration_col.label("p95_duration_ms"),
+                    max_duration_col.label("max_duration_ms"),
+                    error_count_col.label("error_count"),
+                    last_called_at_col.label("last_called_at"),
+                ).group_by(table.c.name, span_type_col)
+
+                # Component filters live on the traces table
+                if agent_id or team_id or workflow_id:
+                    traces_table = await self._get_table(table_type="traces")
+                    if traces_table is None:
+                        log_debug("Traces table not found")
+                        return [], 0
+                    stmt = stmt.select_from(table.join(traces_table, table.c.trace_id == traces_table.c.trace_id))
+                    if agent_id:
+                        stmt = stmt.where(traces_table.c.agent_id == agent_id)
+                    if team_id:
+                        stmt = stmt.where(traces_table.c.team_id == team_id)
+                    if workflow_id:
+                        stmt = stmt.where(traces_table.c.workflow_id == workflow_id)
+
+                if start_time:
+                    # Convert datetime to ISO string for comparison
+                    stmt = stmt.where(table.c.start_time >= start_time.isoformat())
+                if end_time:
+                    # Convert datetime to ISO string for comparison
+                    stmt = stmt.where(table.c.start_time <= end_time.isoformat())
+                if name:
+                    stmt = stmt.where(table.c.name == name)
+                if span_type:
+                    stmt = stmt.where(span_type_col == span_type)
+
+                # Get total count of groups
+                count_stmt = select(func.count()).select_from(stmt.alias())
+                total_count = await sess.scalar(count_stmt) or 0
+
+                sort_columns = {
+                    "total_calls": total_calls_col,
+                    "avg_duration_ms": avg_duration_col,
+                    "p95_duration_ms": p95_duration_col,
+                    "max_duration_ms": max_duration_col,
+                    "error_count": error_count_col,
+                    "last_called_at": last_called_at_col,
+                }
+                sort_col = sort_columns.get(sort_by)
+                if sort_col is None:
+                    log_debug(f"Invalid sort field: '{sort_by}'. Sorting by total_calls.")
+                    sort_col = total_calls_col
+                order_by = sort_col.asc() if sort_order == "asc" else sort_col.desc()
+
+                offset = (page - 1) * limit if page and limit else 0
+                paginated_stmt = stmt.order_by(order_by, table.c.name).limit(limit).offset(offset)
+
+                result = await sess.execute(paginated_stmt)
+                results = result.fetchall()
+
+                stats_list = []
+                for row in results:
+                    last_called_at = (
+                        datetime.fromisoformat(row.last_called_at.replace("Z", "+00:00"))
+                        if row.last_called_at
+                        else None
+                    )
+                    stats_list.append(
+                        {
+                            "name": row.name,
+                            "span_type": row.span_type,
+                            "total_calls": row.total_calls,
+                            "avg_duration_ms": round(float(row.avg_duration_ms), 1)
+                            if row.avg_duration_ms is not None
+                            else None,
+                            "p95_duration_ms": round(float(row.p95_duration_ms), 1)
+                            if row.p95_duration_ms is not None
+                            else None,
+                            "max_duration_ms": row.max_duration_ms,
+                            "error_count": row.error_count,
+                            "last_called_at": last_called_at,
+                        }
+                    )
+
+                return stats_list, total_count
+
+        except Exception as e:
+            log_error(f"Error getting span stats: {str(e)}")
+            return [], 0
 
     # -- Learning methods --
     async def get_learning(

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -3588,7 +3588,7 @@ class PostgresDb(BaseDb):
                 order_by = sort_col.asc() if sort_order == "asc" else sort_col.desc()
 
                 offset = (page - 1) * limit if page and limit else 0
-                paginated_stmt = stmt.order_by(order_by, table.c.name).limit(limit).offset(offset)
+                paginated_stmt = stmt.order_by(order_by, table.c.name, span_type_col).limit(limit).offset(offset)
 
                 results = sess.execute(paginated_stmt).fetchall()
 

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -196,6 +196,8 @@ class PostgresDb(BaseDb):
 
         # Initialize database session
         self.Session: scoped_session = scoped_session(sessionmaker(bind=self.db_engine, expire_on_commit=False))
+        # Zero means never refreshed; get_metrics uses this to refresh lazily, at most once per minute
+        self._metrics_refreshed_at: float = 0.0
 
     # -- Serialization methods --
     def to_dict(self):
@@ -1981,6 +1983,9 @@ class PostgresDb(BaseDb):
             Exception: If an error occurs during metrics calculation.
         """
         try:
+            # Stamp first so failed runs are throttled too instead of retried on every read
+            self._metrics_refreshed_at = time.time()
+
             table = self._get_table(table_type="metrics", create_table_if_not_found=True)
             if table is None:
                 return None
@@ -2050,8 +2055,8 @@ class PostgresDb(BaseDb):
     ) -> Tuple[List[dict], Optional[int]]:
         """Get all metrics matching the given date range.
 
-        Metrics for days not yet calculated are refreshed first, so results are
-        current even on deployments where nothing calls the refresh endpoint.
+        Metrics are refreshed lazily, at most once per minute per process, so results
+        stay current even on deployments where nothing calls the refresh endpoint.
 
         Args:
             starting_date (Optional[date]): The starting date to filter metrics by.
@@ -2064,11 +2069,13 @@ class PostgresDb(BaseDb):
             Exception: If an error occurs during retrieval.
         """
         try:
-            # Refresh before reading. Dates with complete metrics are skipped, so this is cheap.
-            try:
-                self.calculate_metrics()
-            except Exception as e:
-                log_warning(f"Could not refresh metrics before reading them: {str(e)}")
+            # Refresh at most once per minute per process: recalculating the current
+            # day scans all of today's sessions, too costly for every read.
+            if time.time() - self._metrics_refreshed_at >= 60:
+                try:
+                    self.calculate_metrics()
+                except Exception as e:
+                    log_warning(f"Could not refresh metrics before reading them: {str(e)}")
 
             table = self._get_table(table_type="metrics", create_table_if_not_found=True)
             if table is None:
@@ -3164,7 +3171,7 @@ class PostgresDb(BaseDb):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session or by component.
 
@@ -3181,8 +3188,10 @@ class PostgresDb(BaseDb):
             group_by: Grouping key. "session" (default) groups by session_id and keeps
                 the original output shape, ordered by last activity. "agent", "team" and
                 "workflow" group by the corresponding component id, add duration and
-                error aggregates, and are ordered by total_traces descending. Traces
-                without the grouping id are excluded.
+                error aggregates, and are ordered by total_traces descending; traces
+                without the grouping id are excluded. "endpoint" groups traces that
+                carry no component id at all (HTTP/MCP entrypoint wrappers) by trace
+                name, with the same aggregates.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of stats dicts, total count).
@@ -3191,9 +3200,10 @@ class PostgresDb(BaseDb):
                 With a component grouping, each dict contains: <group>_id, total_traces,
                 total_sessions, avg_duration_ms, p95_duration_ms, max_duration_ms,
                 error_traces (traces with status ERROR), first_trace_at, last_trace_at.
+                With group_by="endpoint", the grouping key is name instead of <group>_id.
         """
-        if group_by not in ("session", "agent", "team", "workflow"):
-            raise ValueError(f"Invalid group_by value: {group_by!r}. Allowed: session, agent, team, workflow")
+        if group_by not in ("session", "agent", "team", "workflow", "endpoint"):
+            raise ValueError(f"Invalid group_by value: {group_by!r}. Allowed: session, agent, team, workflow, endpoint")
 
         try:
             table = self._get_table(table_type="traces")
@@ -3219,14 +3229,26 @@ class PostgresDb(BaseDb):
                         .group_by(table.c.session_id)
                     )
                 else:
-                    group_column = {
-                        "agent": table.c.agent_id,
-                        "team": table.c.team_id,
-                        "workflow": table.c.workflow_id,
-                    }[group_by]
+                    if group_by == "endpoint":
+                        # Endpoint-level traces (HTTP/MCP entrypoint wrappers) carry no component ids
+                        group_column = table.c.name
+                        group_label = "name"
+                        group_filter = and_(
+                            table.c.agent_id.is_(None),
+                            table.c.team_id.is_(None),
+                            table.c.workflow_id.is_(None),
+                        )
+                    else:
+                        group_column = {
+                            "agent": table.c.agent_id,
+                            "team": table.c.team_id,
+                            "workflow": table.c.workflow_id,
+                        }[group_by]
+                        group_label = f"{group_by}_id"
+                        group_filter = group_column.isnot(None)  # Only traces attributed to the grouping component
                     base_stmt = (
                         select(
-                            group_column.label(f"{group_by}_id"),
+                            group_column.label(group_label),
                             func.count(table.c.trace_id).label("total_traces"),
                             func.count(distinct(table.c.session_id)).label("total_sessions"),
                             func.avg(table.c.duration_ms).label("avg_duration_ms"),
@@ -3236,7 +3258,7 @@ class PostgresDb(BaseDb):
                             func.min(table.c.created_at).label("first_trace_at"),
                             func.max(table.c.created_at).label("last_trace_at"),
                         )
-                        .where(group_column.isnot(None))  # Only traces attributed to the grouping component
+                        .where(group_filter)
                         .group_by(group_column)
                     )
 
@@ -3308,7 +3330,7 @@ class PostgresDb(BaseDb):
                     else:
                         stats_list.append(
                             {
-                                f"{group_by}_id": getattr(row, f"{group_by}_id"),
+                                group_label: getattr(row, group_label),
                                 "total_traces": row.total_traces,
                                 "total_sessions": row.total_sessions,
                                 "avg_duration_ms": round(float(row.avg_duration_ms), 1)

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -1,6 +1,6 @@
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union, cast
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -54,6 +54,7 @@ try:
         UniqueConstraint,
         and_,
         case,
+        distinct,
         func,
         or_,
         select,
@@ -2049,6 +2050,9 @@ class PostgresDb(BaseDb):
     ) -> Tuple[List[dict], Optional[int]]:
         """Get all metrics matching the given date range.
 
+        Metrics for days not yet calculated are refreshed first, so results are
+        current even on deployments where nothing calls the refresh endpoint.
+
         Args:
             starting_date (Optional[date]): The starting date to filter metrics by.
             ending_date (Optional[date]): The ending date to filter metrics by.
@@ -2060,6 +2064,12 @@ class PostgresDb(BaseDb):
             Exception: If an error occurs during retrieval.
         """
         try:
+            # Refresh before reading. Dates with complete metrics are skipped, so this is cheap.
+            try:
+                self.calculate_metrics()
+            except Exception as e:
+                log_warning(f"Could not refresh metrics before reading them: {str(e)}")
+
             table = self._get_table(table_type="metrics", create_table_if_not_found=True)
             if table is None:
                 return [], None
@@ -3154,8 +3164,9 @@ class PostgresDb(BaseDb):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
-        """Get trace statistics grouped by session.
+        """Get trace statistics grouped by session or by component.
 
         Args:
             user_id: Filter by user ID.
@@ -3164,15 +3175,26 @@ class PostgresDb(BaseDb):
             workflow_id: Filter by workflow ID.
             start_time: Filter sessions with traces created after this datetime.
             end_time: Filter sessions with traces created before this datetime.
-            limit: Maximum number of sessions to return per page.
+            limit: Maximum number of groups to return per page.
             page: Page number (1-indexed).
             filter_expr: Advanced filter expression dict (from FilterExpr.to_dict()).
+            group_by: Grouping key. "session" (default) groups by session_id and keeps
+                the original output shape, ordered by last activity. "agent", "team" and
+                "workflow" group by the corresponding component id, add duration and
+                error aggregates, and are ordered by total_traces descending. Traces
+                without the grouping id are excluded.
 
         Returns:
-            tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
-                Each dict contains: session_id, user_id, agent_id, team_id, total_traces,
-                first_trace_at, last_trace_at.
+            tuple[List[Dict], int]: Tuple of (list of stats dicts, total count).
+                With group_by="session", each dict contains: session_id, user_id,
+                agent_id, team_id, workflow_id, total_traces, first_trace_at, last_trace_at.
+                With a component grouping, each dict contains: <group>_id, total_traces,
+                total_sessions, avg_duration_ms, p95_duration_ms, max_duration_ms,
+                error_traces (traces with status ERROR), first_trace_at, last_trace_at.
         """
+        if group_by not in ("session", "agent", "team", "workflow"):
+            raise ValueError(f"Invalid group_by value: {group_by!r}. Allowed: session, agent, team, workflow")
+
         try:
             table = self._get_table(table_type="traces")
             if table is None:
@@ -3180,21 +3202,43 @@ class PostgresDb(BaseDb):
                 return [], 0
 
             with self.Session() as sess:
-                # Build base query grouped by session_id
-                base_stmt = (
-                    select(
-                        table.c.session_id,
-                        func.max(table.c.user_id).label("user_id"),
-                        func.max(table.c.agent_id).label("agent_id"),
-                        func.max(table.c.team_id).label("team_id"),
-                        func.max(table.c.workflow_id).label("workflow_id"),
-                        func.count(table.c.trace_id).label("total_traces"),
-                        func.min(table.c.created_at).label("first_trace_at"),
-                        func.max(table.c.created_at).label("last_trace_at"),
+                if group_by == "session":
+                    # Build base query grouped by session_id
+                    base_stmt = (
+                        select(
+                            table.c.session_id,
+                            func.max(table.c.user_id).label("user_id"),
+                            func.max(table.c.agent_id).label("agent_id"),
+                            func.max(table.c.team_id).label("team_id"),
+                            func.max(table.c.workflow_id).label("workflow_id"),
+                            func.count(table.c.trace_id).label("total_traces"),
+                            func.min(table.c.created_at).label("first_trace_at"),
+                            func.max(table.c.created_at).label("last_trace_at"),
+                        )
+                        .where(table.c.session_id.isnot(None))  # Only sessions with session_id
+                        .group_by(table.c.session_id)
                     )
-                    .where(table.c.session_id.isnot(None))  # Only sessions with session_id
-                    .group_by(table.c.session_id)
-                )
+                else:
+                    group_column = {
+                        "agent": table.c.agent_id,
+                        "team": table.c.team_id,
+                        "workflow": table.c.workflow_id,
+                    }[group_by]
+                    base_stmt = (
+                        select(
+                            group_column.label(f"{group_by}_id"),
+                            func.count(table.c.trace_id).label("total_traces"),
+                            func.count(distinct(table.c.session_id)).label("total_sessions"),
+                            func.avg(table.c.duration_ms).label("avg_duration_ms"),
+                            func.percentile_cont(0.95).within_group(table.c.duration_ms).label("p95_duration_ms"),
+                            func.max(table.c.duration_ms).label("max_duration_ms"),
+                            func.sum(case((table.c.status == "ERROR", 1), else_=0)).label("error_traces"),
+                            func.min(table.c.created_at).label("first_trace_at"),
+                            func.max(table.c.created_at).label("last_trace_at"),
+                        )
+                        .where(group_column.isnot(None))  # Only traces attributed to the grouping component
+                        .group_by(group_column)
+                    )
 
                 # Apply filters
                 if user_id is not None:
@@ -3226,39 +3270,59 @@ class PostgresDb(BaseDb):
                     except (KeyError, TypeError) as e:
                         raise ValueError(f"Invalid filter expression: {e}") from e
 
-                # Get total count of sessions
+                # Get total count of groups
                 count_stmt = select(func.count()).select_from(base_stmt.alias())
                 total_count = sess.execute(count_stmt).scalar() or 0
 
                 # Apply pagination and ordering
                 offset = (page - 1) * limit if page and limit else 0
-                paginated_stmt = base_stmt.order_by(func.max(table.c.created_at).desc()).limit(limit).offset(offset)
+                order_by: List[Any] = (
+                    [func.max(table.c.created_at).desc()]
+                    if group_by == "session"
+                    else [func.count(table.c.trace_id).desc(), group_column]
+                )
+                paginated_stmt = base_stmt.order_by(*order_by).limit(limit).offset(offset)
 
                 results = sess.execute(paginated_stmt).fetchall()
 
                 # Convert to list of dicts with datetime objects
                 stats_list = []
                 for row in results:
-                    # Convert ISO strings to datetime objects
-                    first_trace_at_str = row.first_trace_at
-                    last_trace_at_str = row.last_trace_at
-
                     # Parse ISO format strings to datetime objects
-                    first_trace_at = datetime.fromisoformat(first_trace_at_str.replace("Z", "+00:00"))
-                    last_trace_at = datetime.fromisoformat(last_trace_at_str.replace("Z", "+00:00"))
+                    first_trace_at = datetime.fromisoformat(row.first_trace_at.replace("Z", "+00:00"))
+                    last_trace_at = datetime.fromisoformat(row.last_trace_at.replace("Z", "+00:00"))
 
-                    stats_list.append(
-                        {
-                            "session_id": row.session_id,
-                            "user_id": row.user_id,
-                            "agent_id": row.agent_id,
-                            "team_id": row.team_id,
-                            "workflow_id": row.workflow_id,
-                            "total_traces": row.total_traces,
-                            "first_trace_at": first_trace_at,
-                            "last_trace_at": last_trace_at,
-                        }
-                    )
+                    if group_by == "session":
+                        stats_list.append(
+                            {
+                                "session_id": row.session_id,
+                                "user_id": row.user_id,
+                                "agent_id": row.agent_id,
+                                "team_id": row.team_id,
+                                "workflow_id": row.workflow_id,
+                                "total_traces": row.total_traces,
+                                "first_trace_at": first_trace_at,
+                                "last_trace_at": last_trace_at,
+                            }
+                        )
+                    else:
+                        stats_list.append(
+                            {
+                                f"{group_by}_id": getattr(row, f"{group_by}_id"),
+                                "total_traces": row.total_traces,
+                                "total_sessions": row.total_sessions,
+                                "avg_duration_ms": round(float(row.avg_duration_ms), 1)
+                                if row.avg_duration_ms is not None
+                                else None,
+                                "p95_duration_ms": round(float(row.p95_duration_ms), 1)
+                                if row.p95_duration_ms is not None
+                                else None,
+                                "max_duration_ms": row.max_duration_ms,
+                                "error_traces": row.error_traces,
+                                "first_trace_at": first_trace_at,
+                                "last_trace_at": last_trace_at,
+                            }
+                        )
 
                 return stats_list, total_count
 
@@ -3391,6 +3455,150 @@ class PostgresDb(BaseDb):
         except Exception as e:
             log_error(f"Error getting spans: {str(e)}")
             return []
+
+    def get_span_stats(
+        self,
+        agent_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        name: Optional[str] = None,
+        span_type: Optional[str] = None,
+        limit: Optional[int] = 20,
+        page: Optional[int] = 1,
+        sort_by: str = "total_calls",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """Get span statistics aggregated SQL-side by span name and span type.
+
+        Only span names, durations and status are aggregated. The span attributes
+        payload, which can hold full conversation content, is never selected — the
+        single "openinference.span.kind" key is extracted in SQL as the span type.
+
+        Args:
+            agent_id: Only include spans belonging to traces of this agent.
+            team_id: Only include spans belonging to traces of this team.
+            workflow_id: Only include spans belonging to traces of this workflow.
+            start_time: Only include spans starting after this datetime.
+            end_time: Only include spans starting before this datetime.
+            name: Filter by exact span name.
+            span_type: Filter by span type (e.g. AGENT, LLM, TOOL, CHAIN).
+            limit: Maximum number of groups to return per page.
+            page: Page number (1-indexed).
+            sort_by: Aggregate to sort by: total_calls, avg_duration_ms,
+                p95_duration_ms, max_duration_ms, error_count or last_called_at.
+            sort_order: "asc" or "desc".
+
+        Returns:
+            Tuple[List[Dict], int]: Tuple of (list of stats dicts, total count of groups).
+                Each dict contains: name, span_type, total_calls, avg_duration_ms,
+                p95_duration_ms, max_duration_ms, error_count, last_called_at (datetime).
+        """
+        try:
+            table = self._get_table(table_type="spans")
+            if table is None:
+                log_debug("Spans table not found")
+                return [], 0
+
+            span_type_col = table.c.attributes["openinference.span.kind"].astext
+
+            total_calls_col = func.count(table.c.span_id)
+            avg_duration_col = func.avg(table.c.duration_ms)
+            p95_duration_col = func.percentile_cont(0.95).within_group(table.c.duration_ms)
+            max_duration_col = func.max(table.c.duration_ms)
+            error_count_col = func.sum(case((table.c.status_code == "ERROR", 1), else_=0))
+            last_called_at_col = func.max(table.c.start_time)
+
+            with self.Session() as sess:
+                stmt = select(
+                    table.c.name,
+                    span_type_col.label("span_type"),
+                    total_calls_col.label("total_calls"),
+                    avg_duration_col.label("avg_duration_ms"),
+                    p95_duration_col.label("p95_duration_ms"),
+                    max_duration_col.label("max_duration_ms"),
+                    error_count_col.label("error_count"),
+                    last_called_at_col.label("last_called_at"),
+                ).group_by(table.c.name, span_type_col)
+
+                # Component filters live on the traces table
+                if agent_id or team_id or workflow_id:
+                    traces_table = self._get_table(table_type="traces")
+                    if traces_table is None:
+                        log_debug("Traces table not found")
+                        return [], 0
+                    stmt = stmt.select_from(table.join(traces_table, table.c.trace_id == traces_table.c.trace_id))
+                    if agent_id:
+                        stmt = stmt.where(traces_table.c.agent_id == agent_id)
+                    if team_id:
+                        stmt = stmt.where(traces_table.c.team_id == team_id)
+                    if workflow_id:
+                        stmt = stmt.where(traces_table.c.workflow_id == workflow_id)
+
+                if start_time:
+                    # Convert datetime to ISO string for comparison
+                    stmt = stmt.where(table.c.start_time >= start_time.isoformat())
+                if end_time:
+                    # Convert datetime to ISO string for comparison
+                    stmt = stmt.where(table.c.start_time <= end_time.isoformat())
+                if name:
+                    stmt = stmt.where(table.c.name == name)
+                if span_type:
+                    stmt = stmt.where(span_type_col == span_type)
+
+                # Get total count of groups
+                count_stmt = select(func.count()).select_from(stmt.alias())
+                total_count = sess.execute(count_stmt).scalar() or 0
+
+                sort_columns = {
+                    "total_calls": total_calls_col,
+                    "avg_duration_ms": avg_duration_col,
+                    "p95_duration_ms": p95_duration_col,
+                    "max_duration_ms": max_duration_col,
+                    "error_count": error_count_col,
+                    "last_called_at": last_called_at_col,
+                }
+                sort_col = sort_columns.get(sort_by)
+                if sort_col is None:
+                    log_debug(f"Invalid sort field: '{sort_by}'. Sorting by total_calls.")
+                    sort_col = total_calls_col
+                order_by = sort_col.asc() if sort_order == "asc" else sort_col.desc()
+
+                offset = (page - 1) * limit if page and limit else 0
+                paginated_stmt = stmt.order_by(order_by, table.c.name).limit(limit).offset(offset)
+
+                results = sess.execute(paginated_stmt).fetchall()
+
+                stats_list = []
+                for row in results:
+                    last_called_at = (
+                        datetime.fromisoformat(row.last_called_at.replace("Z", "+00:00"))
+                        if row.last_called_at
+                        else None
+                    )
+                    stats_list.append(
+                        {
+                            "name": row.name,
+                            "span_type": row.span_type,
+                            "total_calls": row.total_calls,
+                            "avg_duration_ms": round(float(row.avg_duration_ms), 1)
+                            if row.avg_duration_ms is not None
+                            else None,
+                            "p95_duration_ms": round(float(row.p95_duration_ms), 1)
+                            if row.p95_duration_ms is not None
+                            else None,
+                            "max_duration_ms": row.max_duration_ms,
+                            "error_count": row.error_count,
+                            "last_called_at": last_called_at,
+                        }
+                    )
+
+                return stats_list, total_count
+
+        except Exception as e:
+            log_error(f"Error getting span stats: {str(e)}")
+            return [], 0
 
     # --- Components ---
     def get_component(

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -1980,7 +1980,7 @@ class RedisDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -1,6 +1,6 @@
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -1980,6 +1980,7 @@ class RedisDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 
@@ -1992,12 +1993,19 @@ class RedisDb(BaseDb):
             end_time: Filter sessions with traces created before this datetime.
             limit: Maximum number of sessions to return per page.
             page: Page number (1-indexed).
+            group_by: Only the default "session" grouping is supported by this backend.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
                 Each dict contains: session_id, user_id, agent_id, team_id, total_traces,
                 first_trace_at, last_trace_at.
         """
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
+
         try:
             log_debug(
                 f"get_trace_stats called with filters: user_id={user_id}, agent_id={agent_id}, "

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -2715,7 +2715,7 @@ class SingleStoreDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -1,7 +1,7 @@
 import json
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -2715,6 +2715,7 @@ class SingleStoreDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 
@@ -2727,12 +2728,19 @@ class SingleStoreDb(BaseDb):
             end_time: Filter sessions with traces created before this datetime.
             limit: Maximum number of sessions to return per page.
             page: Page number (1-indexed).
+            group_by: Only the default "session" grouping is supported by this backend.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
                 Each dict contains: session_id, user_id, agent_id, team_id, total_traces,
                 first_trace_at, last_trace_at.
         """
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
+
         try:
             log_debug(
                 f"get_trace_stats called with filters: user_id={user_id}, agent_id={agent_id}, "

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -151,6 +151,8 @@ class AsyncSqliteDb(AsyncBaseDb):
 
         # Initialize database session factory
         self.async_session_factory = async_sessionmaker(bind=self.db_engine, expire_on_commit=False)
+        # Zero means never refreshed; get_metrics uses this to refresh lazily, at most once per minute
+        self._metrics_refreshed_at: float = 0.0
 
     async def close(self) -> None:
         """Close database connections and dispose of the connection pool.
@@ -1749,6 +1751,9 @@ class AsyncSqliteDb(AsyncBaseDb):
             Exception: If an error occurs during metrics calculation.
         """
         try:
+            # Stamp first so failed runs are throttled too instead of retried on every read
+            self._metrics_refreshed_at = time.time()
+
             table = await self._get_table(table_type="metrics")
             if table is None:
                 return None
@@ -1817,6 +1822,9 @@ class AsyncSqliteDb(AsyncBaseDb):
     ) -> Tuple[List[dict], Optional[int]]:
         """Get all metrics matching the given date range.
 
+        Metrics are refreshed lazily, at most once per minute per process, so results
+        stay current even on deployments where nothing calls the refresh endpoint.
+
         Args:
             starting_date (Optional[date]): The starting date to filter metrics by.
             ending_date (Optional[date]): The ending date to filter metrics by.
@@ -1828,6 +1836,14 @@ class AsyncSqliteDb(AsyncBaseDb):
             Exception: If an error occurs during retrieval.
         """
         try:
+            # Refresh at most once per minute per process: recalculating the current
+            # day scans all of today's sessions, too costly for every read.
+            if time.time() - self._metrics_refreshed_at >= 60:
+                try:
+                    await self.calculate_metrics()
+                except Exception as e:
+                    log_warning(f"Could not refresh metrics before reading them: {str(e)}")
+
             table = await self._get_table(table_type="metrics")
             if table is None:
                 return [], None
@@ -2865,7 +2881,7 @@ class AsyncSqliteDb(AsyncBaseDb):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session or by component.
 
@@ -2882,8 +2898,10 @@ class AsyncSqliteDb(AsyncBaseDb):
             group_by: Grouping key. "session" (default) groups by session_id and keeps
                 the original output shape, ordered by last activity. "agent", "team" and
                 "workflow" group by the corresponding component id, add duration and
-                error aggregates, and are ordered by total_traces descending. Traces
-                without the grouping id are excluded. SQLite has no percentile function,
+                error aggregates, and are ordered by total_traces descending; traces
+                without the grouping id are excluded. "endpoint" groups traces that
+                carry no component id at all (HTTP/MCP entrypoint wrappers) by trace
+                name, with the same aggregates. SQLite has no percentile function,
                 so p95_duration_ms is always None.
 
         Returns:
@@ -2893,13 +2911,14 @@ class AsyncSqliteDb(AsyncBaseDb):
                 With a component grouping, each dict contains: <group>_id, total_traces,
                 total_sessions, avg_duration_ms, p95_duration_ms (always None),
                 max_duration_ms, error_traces (traces with status ERROR), first_trace_at,
-                last_trace_at.
+                last_trace_at. With group_by="endpoint", the grouping key is name
+                instead of <group>_id.
         """
-        if group_by not in ("session", "agent", "team", "workflow"):
-            raise ValueError(f"Invalid group_by value: {group_by!r}. Allowed: session, agent, team, workflow")
+        if group_by not in ("session", "agent", "team", "workflow", "endpoint"):
+            raise ValueError(f"Invalid group_by value: {group_by!r}. Allowed: session, agent, team, workflow, endpoint")
 
         try:
-            from sqlalchemy import case, distinct
+            from sqlalchemy import and_, case, distinct
 
             table = await self._get_table(table_type="traces")
             if table is None:
@@ -2924,14 +2943,26 @@ class AsyncSqliteDb(AsyncBaseDb):
                         .group_by(table.c.session_id)
                     )
                 else:
-                    group_column = {
-                        "agent": table.c.agent_id,
-                        "team": table.c.team_id,
-                        "workflow": table.c.workflow_id,
-                    }[group_by]
+                    if group_by == "endpoint":
+                        # Endpoint-level traces (HTTP/MCP entrypoint wrappers) carry no component ids
+                        group_column = table.c.name
+                        group_label = "name"
+                        group_filter = and_(
+                            table.c.agent_id.is_(None),
+                            table.c.team_id.is_(None),
+                            table.c.workflow_id.is_(None),
+                        )
+                    else:
+                        group_column = {
+                            "agent": table.c.agent_id,
+                            "team": table.c.team_id,
+                            "workflow": table.c.workflow_id,
+                        }[group_by]
+                        group_label = f"{group_by}_id"
+                        group_filter = group_column.isnot(None)  # Only traces attributed to the grouping component
                     base_stmt = (
                         select(
-                            group_column.label(f"{group_by}_id"),
+                            group_column.label(group_label),
                             func.count(table.c.trace_id).label("total_traces"),
                             func.count(distinct(table.c.session_id)).label("total_sessions"),
                             func.avg(table.c.duration_ms).label("avg_duration_ms"),
@@ -2940,7 +2971,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                             func.min(table.c.created_at).label("first_trace_at"),
                             func.max(table.c.created_at).label("last_trace_at"),
                         )
-                        .where(group_column.isnot(None))  # Only traces attributed to the grouping component
+                        .where(group_filter)
                         .group_by(group_column)
                     )
 
@@ -3013,7 +3044,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                     else:
                         stats_list.append(
                             {
-                                f"{group_by}_id": getattr(row, f"{group_by}_id"),
+                                group_label: getattr(row, group_label),
                                 "total_traces": row.total_traces,
                                 "total_sessions": row.total_sessions,
                                 "avg_duration_ms": round(float(row.avg_duration_ms), 1)

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -2,7 +2,7 @@ import json
 import time
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union, cast
 from uuid import uuid4
 
 from sqlalchemy import or_
@@ -2865,8 +2865,9 @@ class AsyncSqliteDb(AsyncBaseDb):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
-        """Get trace statistics grouped by session.
+        """Get trace statistics grouped by session or by component.
 
         Args:
             user_id: Filter by user ID.
@@ -2875,37 +2876,73 @@ class AsyncSqliteDb(AsyncBaseDb):
             workflow_id: Filter by workflow ID.
             start_time: Filter sessions with traces created after this datetime.
             end_time: Filter sessions with traces created before this datetime.
-            limit: Maximum number of sessions to return per page.
+            limit: Maximum number of groups to return per page.
             page: Page number (1-indexed).
             filter_expr: Advanced filter expression dict (from FilterExpr.to_dict()).
+            group_by: Grouping key. "session" (default) groups by session_id and keeps
+                the original output shape, ordered by last activity. "agent", "team" and
+                "workflow" group by the corresponding component id, add duration and
+                error aggregates, and are ordered by total_traces descending. Traces
+                without the grouping id are excluded. SQLite has no percentile function,
+                so p95_duration_ms is always None.
 
         Returns:
-            tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
-                Each dict contains: session_id, user_id, agent_id, team_id, total_traces,
-                workflow_id, first_trace_at, last_trace_at.
+            tuple[List[Dict], int]: Tuple of (list of stats dicts, total count).
+                With group_by="session", each dict contains: session_id, user_id,
+                agent_id, team_id, workflow_id, total_traces, first_trace_at, last_trace_at.
+                With a component grouping, each dict contains: <group>_id, total_traces,
+                total_sessions, avg_duration_ms, p95_duration_ms (always None),
+                max_duration_ms, error_traces (traces with status ERROR), first_trace_at,
+                last_trace_at.
         """
+        if group_by not in ("session", "agent", "team", "workflow"):
+            raise ValueError(f"Invalid group_by value: {group_by!r}. Allowed: session, agent, team, workflow")
+
         try:
+            from sqlalchemy import case, distinct
+
             table = await self._get_table(table_type="traces")
             if table is None:
                 log_debug("Traces table not found")
                 return [], 0
 
             async with self.async_session_factory() as sess:
-                # Build base query grouped by session_id
-                base_stmt = (
-                    select(
-                        table.c.session_id,
-                        func.max(table.c.user_id).label("user_id"),
-                        func.max(table.c.agent_id).label("agent_id"),
-                        func.max(table.c.team_id).label("team_id"),
-                        func.max(table.c.workflow_id).label("workflow_id"),
-                        func.count(table.c.trace_id).label("total_traces"),
-                        func.min(table.c.created_at).label("first_trace_at"),
-                        func.max(table.c.created_at).label("last_trace_at"),
+                if group_by == "session":
+                    # Build base query grouped by session_id
+                    base_stmt = (
+                        select(
+                            table.c.session_id,
+                            func.max(table.c.user_id).label("user_id"),
+                            func.max(table.c.agent_id).label("agent_id"),
+                            func.max(table.c.team_id).label("team_id"),
+                            func.max(table.c.workflow_id).label("workflow_id"),
+                            func.count(table.c.trace_id).label("total_traces"),
+                            func.min(table.c.created_at).label("first_trace_at"),
+                            func.max(table.c.created_at).label("last_trace_at"),
+                        )
+                        .where(table.c.session_id.isnot(None))  # Only sessions with session_id
+                        .group_by(table.c.session_id)
                     )
-                    .where(table.c.session_id.isnot(None))  # Only sessions with session_id
-                    .group_by(table.c.session_id)
-                )
+                else:
+                    group_column = {
+                        "agent": table.c.agent_id,
+                        "team": table.c.team_id,
+                        "workflow": table.c.workflow_id,
+                    }[group_by]
+                    base_stmt = (
+                        select(
+                            group_column.label(f"{group_by}_id"),
+                            func.count(table.c.trace_id).label("total_traces"),
+                            func.count(distinct(table.c.session_id)).label("total_sessions"),
+                            func.avg(table.c.duration_ms).label("avg_duration_ms"),
+                            func.max(table.c.duration_ms).label("max_duration_ms"),
+                            func.sum(case((table.c.status == "ERROR", 1), else_=0)).label("error_traces"),
+                            func.min(table.c.created_at).label("first_trace_at"),
+                            func.max(table.c.created_at).label("last_trace_at"),
+                        )
+                        .where(group_column.isnot(None))  # Only traces attributed to the grouping component
+                        .group_by(group_column)
+                    )
 
                 # Apply filters
                 if user_id is not None:
@@ -2937,13 +2974,18 @@ class AsyncSqliteDb(AsyncBaseDb):
                     except (KeyError, TypeError) as e:
                         raise ValueError(f"Invalid filter expression: {e}") from e
 
-                # Get total count of sessions
+                # Get total count of groups
                 count_stmt = select(func.count()).select_from(base_stmt.alias())
                 total_count = await sess.scalar(count_stmt) or 0
 
                 # Apply pagination and ordering
                 offset = (page - 1) * limit if page and limit else 0
-                paginated_stmt = base_stmt.order_by(func.max(table.c.created_at).desc()).limit(limit).offset(offset)
+                order_by: List[Any] = (
+                    [func.max(table.c.created_at).desc()]
+                    if group_by == "session"
+                    else [func.count(table.c.trace_id).desc(), group_column]
+                )
+                paginated_stmt = base_stmt.order_by(*order_by).limit(limit).offset(offset)
 
                 result = await sess.execute(paginated_stmt)
                 results = result.fetchall()
@@ -2951,26 +2993,39 @@ class AsyncSqliteDb(AsyncBaseDb):
                 # Convert to list of dicts with datetime objects
                 stats_list = []
                 for row in results:
-                    # Convert ISO strings to datetime objects
-                    first_trace_at_str = row.first_trace_at
-                    last_trace_at_str = row.last_trace_at
-
                     # Parse ISO format strings to datetime objects
-                    first_trace_at = datetime.fromisoformat(first_trace_at_str.replace("Z", "+00:00"))
-                    last_trace_at = datetime.fromisoformat(last_trace_at_str.replace("Z", "+00:00"))
+                    first_trace_at = datetime.fromisoformat(row.first_trace_at.replace("Z", "+00:00"))
+                    last_trace_at = datetime.fromisoformat(row.last_trace_at.replace("Z", "+00:00"))
 
-                    stats_list.append(
-                        {
-                            "session_id": row.session_id,
-                            "user_id": row.user_id,
-                            "agent_id": row.agent_id,
-                            "team_id": row.team_id,
-                            "workflow_id": row.workflow_id,
-                            "total_traces": row.total_traces,
-                            "first_trace_at": first_trace_at,
-                            "last_trace_at": last_trace_at,
-                        }
-                    )
+                    if group_by == "session":
+                        stats_list.append(
+                            {
+                                "session_id": row.session_id,
+                                "user_id": row.user_id,
+                                "agent_id": row.agent_id,
+                                "team_id": row.team_id,
+                                "workflow_id": row.workflow_id,
+                                "total_traces": row.total_traces,
+                                "first_trace_at": first_trace_at,
+                                "last_trace_at": last_trace_at,
+                            }
+                        )
+                    else:
+                        stats_list.append(
+                            {
+                                f"{group_by}_id": getattr(row, f"{group_by}_id"),
+                                "total_traces": row.total_traces,
+                                "total_sessions": row.total_sessions,
+                                "avg_duration_ms": round(float(row.avg_duration_ms), 1)
+                                if row.avg_duration_ms is not None
+                                else None,
+                                "p95_duration_ms": None,
+                                "max_duration_ms": row.max_duration_ms,
+                                "error_traces": row.error_traces,
+                                "first_trace_at": first_trace_at,
+                                "last_trace_at": last_trace_at,
+                            }
+                        )
 
                 return stats_list, total_count
 
@@ -3089,6 +3144,151 @@ class AsyncSqliteDb(AsyncBaseDb):
         except Exception as e:
             log_error(f"Error getting spans: {str(e)}")
             return []
+
+    async def get_span_stats(
+        self,
+        agent_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        name: Optional[str] = None,
+        span_type: Optional[str] = None,
+        limit: Optional[int] = 20,
+        page: Optional[int] = 1,
+        sort_by: str = "total_calls",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """Get span statistics aggregated SQL-side by span name and span type.
+
+        Only span names, durations and status are aggregated. The span attributes
+        payload, which can hold full conversation content, is never selected — the
+        single "openinference.span.kind" key is extracted in SQL as the span type.
+        SQLite has no percentile function, so p95_duration_ms is always None and
+        sorting by p95_duration_ms falls back to total_calls.
+
+        Args:
+            agent_id: Only include spans belonging to traces of this agent.
+            team_id: Only include spans belonging to traces of this team.
+            workflow_id: Only include spans belonging to traces of this workflow.
+            start_time: Only include spans starting after this datetime.
+            end_time: Only include spans starting before this datetime.
+            name: Filter by exact span name.
+            span_type: Filter by span type (e.g. AGENT, LLM, TOOL, CHAIN).
+            limit: Maximum number of groups to return per page.
+            page: Page number (1-indexed).
+            sort_by: Aggregate to sort by: total_calls, avg_duration_ms,
+                max_duration_ms, error_count or last_called_at.
+            sort_order: "asc" or "desc".
+
+        Returns:
+            Tuple[List[Dict], int]: Tuple of (list of stats dicts, total count of groups).
+                Each dict contains: name, span_type, total_calls, avg_duration_ms,
+                p95_duration_ms (always None), max_duration_ms, error_count,
+                last_called_at (datetime).
+        """
+        try:
+            from sqlalchemy import case
+
+            table = await self._get_table(table_type="spans")
+            if table is None:
+                log_debug("Spans table not found")
+                return [], 0
+
+            span_type_col = func.json_extract(table.c.attributes, '$."openinference.span.kind"')
+
+            total_calls_col = func.count(table.c.span_id)
+            avg_duration_col = func.avg(table.c.duration_ms)
+            max_duration_col = func.max(table.c.duration_ms)
+            error_count_col = func.sum(case((table.c.status_code == "ERROR", 1), else_=0))
+            last_called_at_col = func.max(table.c.start_time)
+
+            async with self.async_session_factory() as sess:
+                stmt = select(
+                    table.c.name,
+                    span_type_col.label("span_type"),
+                    total_calls_col.label("total_calls"),
+                    avg_duration_col.label("avg_duration_ms"),
+                    max_duration_col.label("max_duration_ms"),
+                    error_count_col.label("error_count"),
+                    last_called_at_col.label("last_called_at"),
+                ).group_by(table.c.name, span_type_col)
+
+                # Component filters live on the traces table
+                if agent_id or team_id or workflow_id:
+                    traces_table = await self._get_table(table_type="traces")
+                    if traces_table is None:
+                        log_debug("Traces table not found")
+                        return [], 0
+                    stmt = stmt.select_from(table.join(traces_table, table.c.trace_id == traces_table.c.trace_id))
+                    if agent_id:
+                        stmt = stmt.where(traces_table.c.agent_id == agent_id)
+                    if team_id:
+                        stmt = stmt.where(traces_table.c.team_id == team_id)
+                    if workflow_id:
+                        stmt = stmt.where(traces_table.c.workflow_id == workflow_id)
+
+                if start_time:
+                    # Convert datetime to ISO string for comparison
+                    stmt = stmt.where(table.c.start_time >= start_time.isoformat())
+                if end_time:
+                    # Convert datetime to ISO string for comparison
+                    stmt = stmt.where(table.c.start_time <= end_time.isoformat())
+                if name:
+                    stmt = stmt.where(table.c.name == name)
+                if span_type:
+                    stmt = stmt.where(span_type_col == span_type)
+
+                # Get total count of groups
+                count_stmt = select(func.count()).select_from(stmt.alias())
+                total_count = await sess.scalar(count_stmt) or 0
+
+                sort_columns = {
+                    "total_calls": total_calls_col,
+                    "avg_duration_ms": avg_duration_col,
+                    "max_duration_ms": max_duration_col,
+                    "error_count": error_count_col,
+                    "last_called_at": last_called_at_col,
+                }
+                sort_col = sort_columns.get(sort_by)
+                if sort_col is None:
+                    log_debug(f"Sort field '{sort_by}' not available on SQLite. Sorting by total_calls.")
+                    sort_col = total_calls_col
+                order_by = sort_col.asc() if sort_order == "asc" else sort_col.desc()
+
+                offset = (page - 1) * limit if page and limit else 0
+                paginated_stmt = stmt.order_by(order_by, table.c.name).limit(limit).offset(offset)
+
+                result = await sess.execute(paginated_stmt)
+                results = result.fetchall()
+
+                stats_list = []
+                for row in results:
+                    last_called_at = (
+                        datetime.fromisoformat(row.last_called_at.replace("Z", "+00:00"))
+                        if row.last_called_at
+                        else None
+                    )
+                    stats_list.append(
+                        {
+                            "name": row.name,
+                            "span_type": row.span_type,
+                            "total_calls": row.total_calls,
+                            "avg_duration_ms": round(float(row.avg_duration_ms), 1)
+                            if row.avg_duration_ms is not None
+                            else None,
+                            "p95_duration_ms": None,
+                            "max_duration_ms": row.max_duration_ms,
+                            "error_count": row.error_count,
+                            "last_called_at": last_called_at,
+                        }
+                    )
+
+                return stats_list, total_count
+
+        except Exception as e:
+            log_error(f"Error getting span stats: {str(e)}")
+            return [], 0
 
     # -- Learning methods --
     async def get_learning(

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -3288,7 +3288,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                 order_by = sort_col.asc() if sort_order == "asc" else sort_col.desc()
 
                 offset = (page - 1) * limit if page and limit else 0
-                paginated_stmt = stmt.order_by(order_by, table.c.name).limit(limit).offset(offset)
+                paginated_stmt = stmt.order_by(order_by, table.c.name, span_type_col).limit(limit).offset(offset)
 
                 result = await sess.execute(paginated_stmt)
                 results = result.fetchall()

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -3193,7 +3193,7 @@ class SqliteDb(BaseDb):
                 order_by = sort_col.asc() if sort_order == "asc" else sort_col.desc()
 
                 offset = (page - 1) * limit if page and limit else 0
-                paginated_stmt = stmt.order_by(order_by, table.c.name).limit(limit).offset(offset)
+                paginated_stmt = stmt.order_by(order_by, table.c.name, span_type_col).limit(limit).offset(offset)
 
                 results = sess.execute(paginated_stmt).fetchall()
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -2,7 +2,7 @@ import json
 import time
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union, cast
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -2775,8 +2775,9 @@ class SqliteDb(BaseDb):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
-        """Get trace statistics grouped by session.
+        """Get trace statistics grouped by session or by component.
 
         Args:
             user_id: Filter by user ID.
@@ -2785,15 +2786,30 @@ class SqliteDb(BaseDb):
             workflow_id: Filter by workflow ID.
             start_time: Filter sessions with traces created after this datetime.
             end_time: Filter sessions with traces created before this datetime.
-            limit: Maximum number of sessions to return per page.
+            limit: Maximum number of groups to return per page.
             page: Page number (1-indexed).
             filter_expr: Advanced filter expression dict (from FilterExpr.to_dict()).
+            group_by: Grouping key. "session" (default) groups by session_id and keeps
+                the original output shape, ordered by last activity. "agent", "team" and
+                "workflow" group by the corresponding component id, add duration and
+                error aggregates, and are ordered by total_traces descending. Traces
+                without the grouping id are excluded. SQLite has no percentile function,
+                so p95_duration_ms is always None.
 
         Returns:
-            tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
+            tuple[List[Dict], int]: Tuple of (list of stats dicts, total count).
+                With group_by="session", each dict contains: session_id, user_id,
+                agent_id, team_id, workflow_id, total_traces, first_trace_at, last_trace_at.
+                With a component grouping, each dict contains: <group>_id, total_traces,
+                total_sessions, avg_duration_ms, p95_duration_ms (always None),
+                max_duration_ms, error_traces (traces with status ERROR), first_trace_at,
+                last_trace_at.
         """
+        if group_by not in ("session", "agent", "team", "workflow"):
+            raise ValueError(f"Invalid group_by value: {group_by!r}. Allowed: session, agent, team, workflow")
+
         try:
-            from sqlalchemy import func
+            from sqlalchemy import case, distinct, func
 
             table = self._get_table(table_type="traces")
             if table is None:
@@ -2801,21 +2817,42 @@ class SqliteDb(BaseDb):
                 return [], 0
 
             with self.Session() as sess:
-                # Build base query grouped by session_id
-                base_stmt = (
-                    select(
-                        table.c.session_id,
-                        func.max(table.c.user_id).label("user_id"),
-                        func.max(table.c.agent_id).label("agent_id"),
-                        func.max(table.c.team_id).label("team_id"),
-                        func.max(table.c.workflow_id).label("workflow_id"),
-                        func.count(table.c.trace_id).label("total_traces"),
-                        func.min(table.c.created_at).label("first_trace_at"),
-                        func.max(table.c.created_at).label("last_trace_at"),
+                if group_by == "session":
+                    # Build base query grouped by session_id
+                    base_stmt = (
+                        select(
+                            table.c.session_id,
+                            func.max(table.c.user_id).label("user_id"),
+                            func.max(table.c.agent_id).label("agent_id"),
+                            func.max(table.c.team_id).label("team_id"),
+                            func.max(table.c.workflow_id).label("workflow_id"),
+                            func.count(table.c.trace_id).label("total_traces"),
+                            func.min(table.c.created_at).label("first_trace_at"),
+                            func.max(table.c.created_at).label("last_trace_at"),
+                        )
+                        .where(table.c.session_id.isnot(None))  # Only sessions with session_id
+                        .group_by(table.c.session_id)
                     )
-                    .where(table.c.session_id.isnot(None))  # Only sessions with session_id
-                    .group_by(table.c.session_id)
-                )
+                else:
+                    group_column = {
+                        "agent": table.c.agent_id,
+                        "team": table.c.team_id,
+                        "workflow": table.c.workflow_id,
+                    }[group_by]
+                    base_stmt = (
+                        select(
+                            group_column.label(f"{group_by}_id"),
+                            func.count(table.c.trace_id).label("total_traces"),
+                            func.count(distinct(table.c.session_id)).label("total_sessions"),
+                            func.avg(table.c.duration_ms).label("avg_duration_ms"),
+                            func.max(table.c.duration_ms).label("max_duration_ms"),
+                            func.sum(case((table.c.status == "ERROR", 1), else_=0)).label("error_traces"),
+                            func.min(table.c.created_at).label("first_trace_at"),
+                            func.max(table.c.created_at).label("last_trace_at"),
+                        )
+                        .where(group_column.isnot(None))  # Only traces attributed to the grouping component
+                        .group_by(group_column)
+                    )
 
                 # Apply filters
                 if user_id is not None:
@@ -2847,13 +2884,18 @@ class SqliteDb(BaseDb):
                     except (KeyError, TypeError) as e:
                         raise ValueError(f"Invalid filter expression: {e}") from e
 
-                # Get total count of sessions
+                # Get total count of groups
                 count_stmt = select(func.count()).select_from(base_stmt.alias())
                 total_count = sess.execute(count_stmt).scalar() or 0
 
                 # Apply pagination and ordering
                 offset = (page - 1) * limit if page and limit else 0
-                paginated_stmt = base_stmt.order_by(func.max(table.c.created_at).desc()).limit(limit).offset(offset)
+                order_by: List[Any] = (
+                    [func.max(table.c.created_at).desc()]
+                    if group_by == "session"
+                    else [func.count(table.c.trace_id).desc(), group_column]
+                )
+                paginated_stmt = base_stmt.order_by(*order_by).limit(limit).offset(offset)
 
                 results = sess.execute(paginated_stmt).fetchall()
 
@@ -2862,26 +2904,39 @@ class SqliteDb(BaseDb):
 
                 stats_list = []
                 for row in results:
-                    # Convert ISO strings to datetime objects
-                    first_trace_at_str = row.first_trace_at
-                    last_trace_at_str = row.last_trace_at
-
                     # Parse ISO format strings to datetime objects
-                    first_trace_at = datetime.fromisoformat(first_trace_at_str.replace("Z", "+00:00"))
-                    last_trace_at = datetime.fromisoformat(last_trace_at_str.replace("Z", "+00:00"))
+                    first_trace_at = datetime.fromisoformat(row.first_trace_at.replace("Z", "+00:00"))
+                    last_trace_at = datetime.fromisoformat(row.last_trace_at.replace("Z", "+00:00"))
 
-                    stats_list.append(
-                        {
-                            "session_id": row.session_id,
-                            "user_id": row.user_id,
-                            "agent_id": row.agent_id,
-                            "team_id": row.team_id,
-                            "workflow_id": row.workflow_id,
-                            "total_traces": row.total_traces,
-                            "first_trace_at": first_trace_at,
-                            "last_trace_at": last_trace_at,
-                        }
-                    )
+                    if group_by == "session":
+                        stats_list.append(
+                            {
+                                "session_id": row.session_id,
+                                "user_id": row.user_id,
+                                "agent_id": row.agent_id,
+                                "team_id": row.team_id,
+                                "workflow_id": row.workflow_id,
+                                "total_traces": row.total_traces,
+                                "first_trace_at": first_trace_at,
+                                "last_trace_at": last_trace_at,
+                            }
+                        )
+                    else:
+                        stats_list.append(
+                            {
+                                f"{group_by}_id": getattr(row, f"{group_by}_id"),
+                                "total_traces": row.total_traces,
+                                "total_sessions": row.total_sessions,
+                                "avg_duration_ms": round(float(row.avg_duration_ms), 1)
+                                if row.avg_duration_ms is not None
+                                else None,
+                                "p95_duration_ms": None,
+                                "max_duration_ms": row.max_duration_ms,
+                                "error_traces": row.error_traces,
+                                "first_trace_at": first_trace_at,
+                                "last_trace_at": last_trace_at,
+                            }
+                        )
 
                 return stats_list, total_count
 
@@ -2994,6 +3049,152 @@ class SqliteDb(BaseDb):
         except Exception as e:
             log_error(f"Error getting spans: {str(e)}")
             return []
+
+    def get_span_stats(
+        self,
+        agent_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        name: Optional[str] = None,
+        span_type: Optional[str] = None,
+        limit: Optional[int] = 20,
+        page: Optional[int] = 1,
+        sort_by: str = "total_calls",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """Get span statistics aggregated SQL-side by span name and span type.
+
+        Only span names, durations and status are aggregated. The span attributes
+        payload, which can hold full conversation content, is never selected — the
+        single "openinference.span.kind" key is extracted in SQL as the span type.
+        SQLite has no percentile function, so p95_duration_ms is always None and
+        sorting by p95_duration_ms falls back to total_calls.
+
+        Args:
+            agent_id: Only include spans belonging to traces of this agent.
+            team_id: Only include spans belonging to traces of this team.
+            workflow_id: Only include spans belonging to traces of this workflow.
+            start_time: Only include spans starting after this datetime.
+            end_time: Only include spans starting before this datetime.
+            name: Filter by exact span name.
+            span_type: Filter by span type (e.g. AGENT, LLM, TOOL, CHAIN).
+            limit: Maximum number of groups to return per page.
+            page: Page number (1-indexed).
+            sort_by: Aggregate to sort by: total_calls, avg_duration_ms,
+                max_duration_ms, error_count or last_called_at.
+            sort_order: "asc" or "desc".
+
+        Returns:
+            Tuple[List[Dict], int]: Tuple of (list of stats dicts, total count of groups).
+                Each dict contains: name, span_type, total_calls, avg_duration_ms,
+                p95_duration_ms (always None), max_duration_ms, error_count,
+                last_called_at (datetime).
+        """
+        try:
+            from sqlalchemy import case, func
+
+            table = self._get_table(table_type="spans")
+            if table is None:
+                log_debug("Spans table not found")
+                return [], 0
+
+            span_type_col = func.json_extract(table.c.attributes, '$."openinference.span.kind"')
+
+            total_calls_col = func.count(table.c.span_id)
+            avg_duration_col = func.avg(table.c.duration_ms)
+            max_duration_col = func.max(table.c.duration_ms)
+            error_count_col = func.sum(case((table.c.status_code == "ERROR", 1), else_=0))
+            last_called_at_col = func.max(table.c.start_time)
+
+            with self.Session() as sess:
+                stmt = select(
+                    table.c.name,
+                    span_type_col.label("span_type"),
+                    total_calls_col.label("total_calls"),
+                    avg_duration_col.label("avg_duration_ms"),
+                    max_duration_col.label("max_duration_ms"),
+                    error_count_col.label("error_count"),
+                    last_called_at_col.label("last_called_at"),
+                ).group_by(table.c.name, span_type_col)
+
+                # Component filters live on the traces table
+                if agent_id or team_id or workflow_id:
+                    traces_table = self._get_table(table_type="traces")
+                    if traces_table is None:
+                        log_debug("Traces table not found")
+                        return [], 0
+                    stmt = stmt.select_from(table.join(traces_table, table.c.trace_id == traces_table.c.trace_id))
+                    if agent_id:
+                        stmt = stmt.where(traces_table.c.agent_id == agent_id)
+                    if team_id:
+                        stmt = stmt.where(traces_table.c.team_id == team_id)
+                    if workflow_id:
+                        stmt = stmt.where(traces_table.c.workflow_id == workflow_id)
+
+                if start_time:
+                    # Convert datetime to ISO string for comparison
+                    stmt = stmt.where(table.c.start_time >= start_time.isoformat())
+                if end_time:
+                    # Convert datetime to ISO string for comparison
+                    stmt = stmt.where(table.c.start_time <= end_time.isoformat())
+                if name:
+                    stmt = stmt.where(table.c.name == name)
+                if span_type:
+                    stmt = stmt.where(span_type_col == span_type)
+
+                # Get total count of groups
+                count_stmt = select(func.count()).select_from(stmt.alias())
+                total_count = sess.execute(count_stmt).scalar() or 0
+
+                sort_columns = {
+                    "total_calls": total_calls_col,
+                    "avg_duration_ms": avg_duration_col,
+                    "max_duration_ms": max_duration_col,
+                    "error_count": error_count_col,
+                    "last_called_at": last_called_at_col,
+                }
+                sort_col = sort_columns.get(sort_by)
+                if sort_col is None:
+                    log_debug(f"Sort field '{sort_by}' not available on SQLite. Sorting by total_calls.")
+                    sort_col = total_calls_col
+                order_by = sort_col.asc() if sort_order == "asc" else sort_col.desc()
+
+                offset = (page - 1) * limit if page and limit else 0
+                paginated_stmt = stmt.order_by(order_by, table.c.name).limit(limit).offset(offset)
+
+                results = sess.execute(paginated_stmt).fetchall()
+
+                from datetime import datetime
+
+                stats_list = []
+                for row in results:
+                    last_called_at = (
+                        datetime.fromisoformat(row.last_called_at.replace("Z", "+00:00"))
+                        if row.last_called_at
+                        else None
+                    )
+                    stats_list.append(
+                        {
+                            "name": row.name,
+                            "span_type": row.span_type,
+                            "total_calls": row.total_calls,
+                            "avg_duration_ms": round(float(row.avg_duration_ms), 1)
+                            if row.avg_duration_ms is not None
+                            else None,
+                            "p95_duration_ms": None,
+                            "max_duration_ms": row.max_duration_ms,
+                            "error_count": row.error_count,
+                            "last_called_at": last_called_at,
+                        }
+                    )
+
+                return stats_list, total_count
+
+        except Exception as e:
+            log_error(f"Error getting span stats: {str(e)}")
+            return [], 0
 
     # -- Migrations --
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -184,6 +184,8 @@ class SqliteDb(BaseDb):
 
         # Initialize database session
         self.Session: scoped_session = scoped_session(sessionmaker(bind=self.db_engine))
+        # Zero means never refreshed; get_metrics uses this to refresh lazily, at most once per minute
+        self._metrics_refreshed_at: float = 0.0
 
     # -- Serialization methods --
     def to_dict(self) -> Dict[str, Any]:
@@ -1939,6 +1941,9 @@ class SqliteDb(BaseDb):
             Exception: If an error occurs during metrics calculation.
         """
         try:
+            # Stamp first so failed runs are throttled too instead of retried on every read
+            self._metrics_refreshed_at = time.time()
+
             table = self._get_table(table_type="metrics", create_table_if_not_found=True)
             if table is None:
                 return None
@@ -2007,6 +2012,9 @@ class SqliteDb(BaseDb):
     ) -> Tuple[List[dict], Optional[int]]:
         """Get all metrics matching the given date range.
 
+        Metrics are refreshed lazily, at most once per minute per process, so results
+        stay current even on deployments where nothing calls the refresh endpoint.
+
         Args:
             starting_date (Optional[date]): The starting date to filter metrics by.
             ending_date (Optional[date]): The ending date to filter metrics by.
@@ -2018,6 +2026,14 @@ class SqliteDb(BaseDb):
             Exception: If an error occurs during retrieval.
         """
         try:
+            # Refresh at most once per minute per process: recalculating the current
+            # day scans all of today's sessions, too costly for every read.
+            if time.time() - self._metrics_refreshed_at >= 60:
+                try:
+                    self.calculate_metrics()
+                except Exception as e:
+                    log_warning(f"Could not refresh metrics before reading them: {str(e)}")
+
             table = self._get_table(table_type="metrics", create_table_if_not_found=True)
             if table is None:
                 return [], None
@@ -2775,7 +2791,7 @@ class SqliteDb(BaseDb):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session or by component.
 
@@ -2792,8 +2808,10 @@ class SqliteDb(BaseDb):
             group_by: Grouping key. "session" (default) groups by session_id and keeps
                 the original output shape, ordered by last activity. "agent", "team" and
                 "workflow" group by the corresponding component id, add duration and
-                error aggregates, and are ordered by total_traces descending. Traces
-                without the grouping id are excluded. SQLite has no percentile function,
+                error aggregates, and are ordered by total_traces descending; traces
+                without the grouping id are excluded. "endpoint" groups traces that
+                carry no component id at all (HTTP/MCP entrypoint wrappers) by trace
+                name, with the same aggregates. SQLite has no percentile function,
                 so p95_duration_ms is always None.
 
         Returns:
@@ -2803,13 +2821,14 @@ class SqliteDb(BaseDb):
                 With a component grouping, each dict contains: <group>_id, total_traces,
                 total_sessions, avg_duration_ms, p95_duration_ms (always None),
                 max_duration_ms, error_traces (traces with status ERROR), first_trace_at,
-                last_trace_at.
+                last_trace_at. With group_by="endpoint", the grouping key is name
+                instead of <group>_id.
         """
-        if group_by not in ("session", "agent", "team", "workflow"):
-            raise ValueError(f"Invalid group_by value: {group_by!r}. Allowed: session, agent, team, workflow")
+        if group_by not in ("session", "agent", "team", "workflow", "endpoint"):
+            raise ValueError(f"Invalid group_by value: {group_by!r}. Allowed: session, agent, team, workflow, endpoint")
 
         try:
-            from sqlalchemy import case, distinct, func
+            from sqlalchemy import and_, case, distinct, func
 
             table = self._get_table(table_type="traces")
             if table is None:
@@ -2834,14 +2853,26 @@ class SqliteDb(BaseDb):
                         .group_by(table.c.session_id)
                     )
                 else:
-                    group_column = {
-                        "agent": table.c.agent_id,
-                        "team": table.c.team_id,
-                        "workflow": table.c.workflow_id,
-                    }[group_by]
+                    if group_by == "endpoint":
+                        # Endpoint-level traces (HTTP/MCP entrypoint wrappers) carry no component ids
+                        group_column = table.c.name
+                        group_label = "name"
+                        group_filter = and_(
+                            table.c.agent_id.is_(None),
+                            table.c.team_id.is_(None),
+                            table.c.workflow_id.is_(None),
+                        )
+                    else:
+                        group_column = {
+                            "agent": table.c.agent_id,
+                            "team": table.c.team_id,
+                            "workflow": table.c.workflow_id,
+                        }[group_by]
+                        group_label = f"{group_by}_id"
+                        group_filter = group_column.isnot(None)  # Only traces attributed to the grouping component
                     base_stmt = (
                         select(
-                            group_column.label(f"{group_by}_id"),
+                            group_column.label(group_label),
                             func.count(table.c.trace_id).label("total_traces"),
                             func.count(distinct(table.c.session_id)).label("total_sessions"),
                             func.avg(table.c.duration_ms).label("avg_duration_ms"),
@@ -2850,7 +2881,7 @@ class SqliteDb(BaseDb):
                             func.min(table.c.created_at).label("first_trace_at"),
                             func.max(table.c.created_at).label("last_trace_at"),
                         )
-                        .where(group_column.isnot(None))  # Only traces attributed to the grouping component
+                        .where(group_filter)
                         .group_by(group_column)
                     )
 
@@ -2924,7 +2955,7 @@ class SqliteDb(BaseDb):
                     else:
                         stats_list.append(
                             {
-                                f"{group_by}_id": getattr(row, f"{group_by}_id"),
+                                group_label: getattr(row, group_label),
                                 "total_traces": row.total_traces,
                                 "total_sessions": row.total_sessions,
                                 "avg_duration_ms": round(float(row.avg_duration_ms), 1)

--- a/libs/agno/agno/db/sqlite/utils.py
+++ b/libs/agno/agno/db/sqlite/utils.py
@@ -299,10 +299,10 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                         )
 
             # Parse session_data from JSON string
-            session_data = session.get("session_data", {})
+            session_data = session.get("session_data") or {}
             if isinstance(session_data, str):
                 session_data = json.loads(session_data)
-            session_metrics = session_data.get("session_metrics", {})
+            session_metrics = session_data.get("session_metrics") or {}
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/agno/db/surrealdb/surrealdb.py
+++ b/libs/agno/agno/db/surrealdb/surrealdb.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime, timedelta, timezone
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
 
 if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
@@ -1737,6 +1737,7 @@ class SurrealDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 
@@ -1749,12 +1750,19 @@ class SurrealDb(BaseDb):
             end_time: Filter sessions with traces created before this datetime.
             limit: Maximum number of sessions to return per page.
             page: Page number (1-indexed).
+            group_by: Only the default "session" grouping is supported by this backend.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
                 Each dict contains: session_id, user_id, agent_id, team_id, workflow_id, total_traces,
                 first_trace_at, last_trace_at.
         """
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
+
         try:
             table = self._get_table("traces", create_table_if_not_found=False)
 

--- a/libs/agno/agno/db/surrealdb/surrealdb.py
+++ b/libs/agno/agno/db/surrealdb/surrealdb.py
@@ -1737,7 +1737,7 @@ class SurrealDb(BaseDb):
         end_time: Optional[datetime] = None,
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 

--- a/libs/agno/agno/db/valkey/valkey.py
+++ b/libs/agno/agno/db/valkey/valkey.py
@@ -2323,7 +2323,7 @@ class ValkeyDb(BaseDb):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
-        group_by: Literal["session", "agent", "team", "workflow"] = "session",
+        group_by: Literal["session", "agent", "team", "workflow", "endpoint"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 

--- a/libs/agno/agno/db/valkey/valkey.py
+++ b/libs/agno/agno/db/valkey/valkey.py
@@ -1,6 +1,6 @@
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -2323,6 +2323,7 @@ class ValkeyDb(BaseDb):
         limit: Optional[int] = 20,
         page: Optional[int] = 1,
         filter_expr: Optional[Dict[str, Any]] = None,
+        group_by: Literal["session", "agent", "team", "workflow"] = "session",
     ) -> tuple[List[Dict[str, Any]], int]:
         """Get trace statistics grouped by session.
 
@@ -2336,12 +2337,19 @@ class ValkeyDb(BaseDb):
             limit: Maximum number of sessions to return per page.
             page: Page number (1-indexed).
             filter_expr: Serialized FilterExpr dict to apply on trace fields.
+            group_by: Only the default "session" grouping is supported by this backend.
 
         Returns:
             tuple[List[Dict], int]: Tuple of (list of session stats dicts, total count).
                 Each dict contains: session_id, user_id, agent_id, team_id, total_traces,
                 first_trace_at, last_trace_at.
         """
+        if group_by != "session":
+            raise NotImplementedError(
+                f"get_trace_stats with group_by={group_by!r} is not supported by {self.__class__.__name__}. "
+                "Only the default 'session' grouping is available."
+            )
+
         try:
             from agno.db.filter_converter import TRACE_COLUMNS
 

--- a/libs/agno/agno/tools/agentos.py
+++ b/libs/agno/agno/tools/agentos.py
@@ -1,0 +1,857 @@
+"""AgentOSTools -- give agents a read-only ops view of the AgentOS they run on.
+
+Answers questions about usage, cost, latency, failures, schedules, eval history
+and runtime-built components by reading directly from the AgentOS database.
+
+Typical use:
+    from agno.tools.agentos import AgentOSTools
+
+    ops_agent = Agent(
+        model=OpenAIResponses(id="gpt-5.5"),
+        tools=[AgentOSTools(db=db)],
+    )
+
+    ops_agent.print_response("Which agent is slowest, and which tools fail the most?")
+
+The toolkit takes the database, never the AgentOS instance: agents are constructed
+before the OS and passed into ``AgentOS(agents=[...])``, so an agent holding an OS
+reference would be a construction cycle. Every tool reads only from ``db``.
+
+Enable flags:
+    * All surfaces are enabled by default: metrics, traces, schedules, evals,
+      components and approvals.
+    * Pass e.g. ``schedules=False`` to hide a surface from the agent.
+    * ``components`` defaults to False for async databases, which do not support
+      ``list_components``. Passing ``components=True`` with an async database
+      raises at construction time.
+    * Surfaces not supported by the configured database (e.g. schedules on most
+      backends) return a clear error payload at call time.
+
+Read-only:
+    * No tool mutates anything. Schedule, approval and component management are
+      deliberately not exposed, so the toolkit is safe to reach from any frontend.
+    * Span attributes payloads, approval tool arguments and schedule run
+      input/output are never returned -- they can hold full conversation content.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union, cast
+
+from agno.tools.toolkit import Toolkit
+from agno.utils.log import log_warning, logger
+
+if TYPE_CHECKING:
+    from agno.db.base import AsyncBaseDb, BaseDb
+
+
+class AgentOSTools(Toolkit):
+    """Toolkit that lets an agent answer ops questions about its AgentOS.
+
+    Args:
+        db: The AgentOS database (sync ``BaseDb`` or ``AsyncBaseDb``). All tools
+            read only from this database.
+        metrics: Expose get_platform_metrics. Defaults to True.
+        traces: Expose get_run_activity and get_tool_activity. Defaults to True.
+        schedules: Expose list_schedules and get_schedule_history. Defaults to True.
+        evals: Expose get_eval_history. Defaults to True.
+        components: Expose list_platform_components. Defaults to True for sync
+            databases and False for async databases, which do not support
+            component listing. Explicit True with an async database raises.
+        approvals: Expose list_pending_approvals. Defaults to True.
+    """
+
+    def __init__(
+        self,
+        db: Union["BaseDb", "AsyncBaseDb"],
+        metrics: Optional[bool] = None,
+        traces: Optional[bool] = None,
+        schedules: Optional[bool] = None,
+        evals: Optional[bool] = None,
+        components: Optional[bool] = None,
+        approvals: Optional[bool] = None,
+        **kwargs: Any,
+    ):
+        from agno.db.base import AsyncBaseDb
+
+        if db is None:
+            raise ValueError("AgentOSTools requires a db")
+
+        self.db: Union["BaseDb", "AsyncBaseDb"] = db
+        self._db_is_async: bool = isinstance(db, AsyncBaseDb)
+
+        (
+            self.enable_metrics,
+            self.enable_traces,
+            self.enable_schedules,
+            self.enable_evals,
+            self.enable_components,
+            self.enable_approvals,
+        ) = _resolve_flags(
+            metrics=metrics,
+            traces=traces,
+            schedules=schedules,
+            evals=evals,
+            components=components,
+            approvals=approvals,
+            db_is_async=self._db_is_async,
+        )
+
+        tools: List[Callable] = []
+        async_tools: List[tuple[Callable[..., Any], str]] = []
+
+        if self.enable_metrics:
+            tools.append(self.get_platform_metrics)
+            async_tools.append((self.aget_platform_metrics, "get_platform_metrics"))
+        if self.enable_traces:
+            tools.extend([self.get_run_activity, self.get_tool_activity])
+            async_tools.extend(
+                [
+                    (self.aget_run_activity, "get_run_activity"),
+                    (self.aget_tool_activity, "get_tool_activity"),
+                ]
+            )
+        if self.enable_evals:
+            tools.append(self.get_eval_history)
+            async_tools.append((self.aget_eval_history, "get_eval_history"))
+        if self.enable_schedules:
+            tools.extend([self.list_schedules, self.get_schedule_history])
+            async_tools.extend(
+                [
+                    (self.alist_schedules, "list_schedules"),
+                    (self.aget_schedule_history, "get_schedule_history"),
+                ]
+            )
+        if self.enable_components:
+            tools.append(self.list_platform_components)
+            async_tools.append((self.alist_platform_components, "list_platform_components"))
+        if self.enable_approvals:
+            tools.append(self.list_pending_approvals)
+            async_tools.append((self.alist_pending_approvals, "list_pending_approvals"))
+
+        instruction_lines = [
+            "Answer operations questions about this AgentOS with the read-only platform tools.",
+            "Usage and cost: get_platform_metrics. Latency and errors per component: get_run_activity. "
+            "Slow or failing tools and model calls: get_tool_activity.",
+            "When a payload carries a truncation or sampling note, report it -- never present a sample "
+            "as the whole picture.",
+            "These tools are read-only. You cannot modify schedules, approvals or components.",
+        ]
+
+        # Toolkit instructions are only injected into the system message when
+        # add_instructions is set, so default it on.
+        kwargs.setdefault("add_instructions", True)
+        super().__init__(
+            name="agentos",
+            tools=tools,
+            async_tools=async_tools,
+            instructions="\n".join(instruction_lines),
+            **kwargs,
+        )
+
+    def _sync_db(self) -> "BaseDb":
+        return cast("BaseDb", self.db)
+
+    def _async_db(self) -> "AsyncBaseDb":
+        return cast("AsyncBaseDb", self.db)
+
+    # ------------------------------------------------------------------
+    # Platform metrics
+    # ------------------------------------------------------------------
+
+    def get_platform_metrics(self, days: int = 7) -> str:
+        """Get daily platform usage metrics: runs, sessions, users, tokens and model mix.
+
+        Args:
+            days (int): Number of days to include, counting back from today. Defaults to 7.
+
+        Returns:
+            str: JSON with {window_days, start_date, end_date, totals, model_mix, daily}.
+        """
+        if self._db_is_async:
+            return _async_db_error()
+        try:
+            start_date, end_date = _metrics_window(days)
+            try:
+                self._sync_db().calculate_metrics()
+            except NotImplementedError:
+                pass
+            except Exception as e:
+                log_warning(f"Could not refresh metrics: {e}")
+            rows, _ = self._sync_db().get_metrics(starting_date=start_date, ending_date=end_date)
+            return _format_platform_metrics(rows, days, start_date, end_date)
+        except Exception as e:
+            logger.exception("Failed to get platform metrics")
+            return json.dumps({"error": str(e)})
+
+    async def aget_platform_metrics(self, days: int = 7) -> str:
+        """Async variant of get_platform_metrics."""
+        if not self._db_is_async:
+            return await _run_sync(self.get_platform_metrics, days)
+        try:
+            start_date, end_date = _metrics_window(days)
+            try:
+                await self._async_db().calculate_metrics()
+            except NotImplementedError:
+                pass
+            except Exception as e:
+                log_warning(f"Could not refresh metrics: {e}")
+            rows, _ = await self._async_db().get_metrics(starting_date=start_date, ending_date=end_date)
+            return _format_platform_metrics(rows, days, start_date, end_date)
+        except Exception as e:
+            logger.exception("Failed to get platform metrics")
+            return json.dumps({"error": str(e)})
+
+    # ------------------------------------------------------------------
+    # Run activity (traces grouped by component)
+    # ------------------------------------------------------------------
+
+    def get_run_activity(self, days: int = 7) -> str:
+        """Get per-agent, per-team and per-workflow run activity: run counts, latency and errors.
+
+        Args:
+            days (int): Number of days to include, counting back from now. Defaults to 7.
+
+        Returns:
+            str: JSON with {window_days, agents, teams, workflows, unattributed_traces, notes}.
+                Each component row carries total_traces, total_sessions, avg/p95/max duration
+                in ms and error_traces. Unattributed traces are endpoint-level wrappers
+                (e.g. MCP calls) not tied to a component.
+        """
+        if self._db_is_async:
+            return _async_db_error()
+        try:
+            start_time = _window_start(days)
+            groupings: Dict[str, Tuple[List[Dict[str, Any]], int]] = {}
+            for group in ("agent", "team", "workflow"):
+                groupings[group] = self._sync_db().get_trace_stats(
+                    group_by=group, start_time=start_time, limit=_GROUP_LIMIT
+                )
+            _, window_total = self._sync_db().get_traces(start_time=start_time, limit=1)
+            return _format_run_activity(groupings, window_total, days)
+        except NotImplementedError as e:
+            return json.dumps({"error": f"Component-grouped trace stats are not supported by this database: {e}"})
+        except Exception as e:
+            logger.exception("Failed to get run activity")
+            return json.dumps({"error": str(e)})
+
+    async def aget_run_activity(self, days: int = 7) -> str:
+        """Async variant of get_run_activity."""
+        if not self._db_is_async:
+            return await _run_sync(self.get_run_activity, days)
+        try:
+            start_time = _window_start(days)
+            groupings: Dict[str, Tuple[List[Dict[str, Any]], int]] = {}
+            for group in ("agent", "team", "workflow"):
+                groupings[group] = await self._async_db().get_trace_stats(
+                    group_by=group, start_time=start_time, limit=_GROUP_LIMIT
+                )
+            _, window_total = await self._async_db().get_traces(start_time=start_time, limit=1)
+            return _format_run_activity(groupings, window_total, days)
+        except NotImplementedError as e:
+            return json.dumps({"error": f"Component-grouped trace stats are not supported by this database: {e}"})
+        except Exception as e:
+            logger.exception("Failed to get run activity")
+            return json.dumps({"error": str(e)})
+
+    # ------------------------------------------------------------------
+    # Tool activity (span aggregates)
+    # ------------------------------------------------------------------
+
+    def get_tool_activity(self, days: int = 7) -> str:
+        """Get tool and model call statistics: most-used and slowest tools, model call latency.
+
+        Aggregates span names, durations and status only -- never conversation content.
+
+        Args:
+            days (int): Number of days to include, counting back from now. Defaults to 7.
+
+        Returns:
+            str: JSON with {window_days, tools_most_used, tools_slowest, model_calls, notes}.
+                Each row carries total_calls, avg/p95/max duration in ms, error_count and
+                last_called_at. p95_duration_ms is null on backends without SQL percentiles.
+        """
+        if self._db_is_async:
+            return _async_db_error()
+        try:
+            start_time = _window_start(days)
+            tools_most_used, tools_total = self._sync_db().get_span_stats(
+                span_type="TOOL", start_time=start_time, sort_by="total_calls", limit=_SPAN_LIMIT
+            )
+            tools_slowest, _ = self._sync_db().get_span_stats(
+                span_type="TOOL", start_time=start_time, sort_by="avg_duration_ms", limit=_SPAN_LIMIT
+            )
+            model_calls, models_total = self._sync_db().get_span_stats(
+                span_type="LLM", start_time=start_time, sort_by="total_calls", limit=_SPAN_LIMIT
+            )
+            return _format_tool_activity(tools_most_used, tools_slowest, tools_total, model_calls, models_total, days)
+        except NotImplementedError:
+            return json.dumps({"error": "Span statistics are not supported by this database"})
+        except Exception as e:
+            logger.exception("Failed to get tool activity")
+            return json.dumps({"error": str(e)})
+
+    async def aget_tool_activity(self, days: int = 7) -> str:
+        """Async variant of get_tool_activity."""
+        if not self._db_is_async:
+            return await _run_sync(self.get_tool_activity, days)
+        try:
+            start_time = _window_start(days)
+            tools_most_used, tools_total = await self._async_db().get_span_stats(
+                span_type="TOOL", start_time=start_time, sort_by="total_calls", limit=_SPAN_LIMIT
+            )
+            tools_slowest, _ = await self._async_db().get_span_stats(
+                span_type="TOOL", start_time=start_time, sort_by="avg_duration_ms", limit=_SPAN_LIMIT
+            )
+            model_calls, models_total = await self._async_db().get_span_stats(
+                span_type="LLM", start_time=start_time, sort_by="total_calls", limit=_SPAN_LIMIT
+            )
+            return _format_tool_activity(tools_most_used, tools_slowest, tools_total, model_calls, models_total, days)
+        except NotImplementedError:
+            return json.dumps({"error": "Span statistics are not supported by this database"})
+        except Exception as e:
+            logger.exception("Failed to get tool activity")
+            return json.dumps({"error": str(e)})
+
+    # ------------------------------------------------------------------
+    # Eval history
+    # ------------------------------------------------------------------
+
+    def get_eval_history(self, limit: int = 20) -> str:
+        """Get recent eval runs normalized to PASS/FAIL, with the judge's reason on failures.
+
+        Args:
+            limit (int): Maximum number of eval runs to return, newest first. Defaults to 20.
+
+        Returns:
+            str: JSON with {eval_runs, count, total}. Accuracy evals report scores
+                (status SCORED), performance evals report run times (status MEASURED).
+        """
+        if self._db_is_async:
+            return _async_db_error()
+        try:
+            rows, total = cast(
+                Tuple[List[Dict[str, Any]], int],
+                self._sync_db().get_eval_runs(limit=limit, page=1, deserialize=False),
+            )
+            return _format_eval_history(rows, total)
+        except Exception as e:
+            logger.exception("Failed to get eval history")
+            return json.dumps({"error": str(e)})
+
+    async def aget_eval_history(self, limit: int = 20) -> str:
+        """Async variant of get_eval_history."""
+        if not self._db_is_async:
+            return await _run_sync(self.get_eval_history, limit)
+        try:
+            rows, total = cast(
+                Tuple[List[Dict[str, Any]], int],
+                await self._async_db().get_eval_runs(limit=limit, page=1, deserialize=False),
+            )
+            return _format_eval_history(rows, total)
+        except Exception as e:
+            logger.exception("Failed to get eval history")
+            return json.dumps({"error": str(e)})
+
+    # ------------------------------------------------------------------
+    # Schedules
+    # ------------------------------------------------------------------
+
+    def list_schedules(self, limit: int = 20) -> str:
+        """List schedules with their cron expression, enabled state and last run outcome.
+
+        Args:
+            limit (int): Maximum number of schedules to return, newest first. Defaults to 20.
+
+        Returns:
+            str: JSON with {schedules, count, total}. Each schedule carries its
+                last_run status, timestamp and error if any.
+        """
+        if self._db_is_async:
+            return _async_db_error()
+        try:
+            schedules, total = self._sync_db().get_schedules(limit=limit)
+            last_runs: Dict[str, Optional[Dict[str, Any]]] = {}
+            for schedule in schedules:
+                runs, _ = self._sync_db().get_schedule_runs(schedule["id"], limit=1)
+                last_runs[schedule["id"]] = runs[0] if runs else None
+            return _format_schedules(schedules, total, last_runs)
+        except NotImplementedError:
+            return json.dumps({"error": "The scheduler is not supported by this database"})
+        except Exception as e:
+            logger.exception("Failed to list schedules")
+            return json.dumps({"error": str(e)})
+
+    async def alist_schedules(self, limit: int = 20) -> str:
+        """Async variant of list_schedules."""
+        if not self._db_is_async:
+            return await _run_sync(self.list_schedules, limit)
+        try:
+            schedules, total = await self._async_db().get_schedules(limit=limit)
+            last_runs: Dict[str, Optional[Dict[str, Any]]] = {}
+            for schedule in schedules:
+                runs, _ = await self._async_db().get_schedule_runs(schedule["id"], limit=1)
+                last_runs[schedule["id"]] = runs[0] if runs else None
+            return _format_schedules(schedules, total, last_runs)
+        except NotImplementedError:
+            return json.dumps({"error": "The scheduler is not supported by this database"})
+        except Exception as e:
+            logger.exception("Failed to list schedules")
+            return json.dumps({"error": str(e)})
+
+    def get_schedule_history(self, schedule_id: str, limit: int = 20) -> str:
+        """Get the run history of one schedule: outcome trend, not just the last run.
+
+        Args:
+            schedule_id (str): The id of the schedule (see list_schedules).
+            limit (int): Maximum number of runs to return, newest first. Defaults to 20.
+
+        Returns:
+            str: JSON with {schedule_id, summary, runs, count, total}. The summary
+                counts runs by status and carries the most recent failure.
+        """
+        if self._db_is_async:
+            return _async_db_error()
+        try:
+            runs, total = self._sync_db().get_schedule_runs(schedule_id, limit=limit)
+            return _format_schedule_history(schedule_id, runs, total)
+        except NotImplementedError:
+            return json.dumps({"error": "The scheduler is not supported by this database"})
+        except Exception as e:
+            logger.exception("Failed to get schedule history")
+            return json.dumps({"error": str(e)})
+
+    async def aget_schedule_history(self, schedule_id: str, limit: int = 20) -> str:
+        """Async variant of get_schedule_history."""
+        if not self._db_is_async:
+            return await _run_sync(self.get_schedule_history, schedule_id, limit)
+        try:
+            runs, total = await self._async_db().get_schedule_runs(schedule_id, limit=limit)
+            return _format_schedule_history(schedule_id, runs, total)
+        except NotImplementedError:
+            return json.dumps({"error": "The scheduler is not supported by this database"})
+        except Exception as e:
+            logger.exception("Failed to get schedule history")
+            return json.dumps({"error": str(e)})
+
+    # ------------------------------------------------------------------
+    # Components
+    # ------------------------------------------------------------------
+
+    def list_platform_components(self, limit: int = 50) -> str:
+        """List runtime-built components (agents, teams, workflows) persisted in the database.
+
+        Args:
+            limit (int): Maximum number of components to return, newest first. Defaults to 50.
+
+        Returns:
+            str: JSON with {components, count, total}. Each component carries its
+                type, name, description and current version.
+        """
+        if self._db_is_async:
+            return json.dumps({"error": "Component listing is not supported by async databases"})
+        try:
+            components, total = self._sync_db().list_components(limit=limit)
+            return _format_components(components, total)
+        except NotImplementedError:
+            return json.dumps({"error": "Component listing is not supported by this database"})
+        except Exception as e:
+            logger.exception("Failed to list platform components")
+            return json.dumps({"error": str(e)})
+
+    async def alist_platform_components(self, limit: int = 50) -> str:
+        """Async variant of list_platform_components."""
+        if self._db_is_async:
+            return json.dumps({"error": "Component listing is not supported by async databases"})
+        return await _run_sync(self.list_platform_components, limit)
+
+    # ------------------------------------------------------------------
+    # Approvals
+    # ------------------------------------------------------------------
+
+    def list_pending_approvals(self) -> str:
+        """List human-in-the-loop approvals waiting on a human decision.
+
+        Tool arguments and approval context are not included -- they can hold
+        user conversation content.
+
+        Returns:
+            str: JSON with {approvals, count, total}. Each approval carries its
+                source, pause type, tool name, requester and expiry.
+        """
+        if self._db_is_async:
+            return _async_db_error()
+        try:
+            approvals, total = self._sync_db().get_approvals(status="pending", limit=_APPROVAL_LIMIT)
+            return _format_pending_approvals(approvals, total)
+        except NotImplementedError:
+            return json.dumps({"error": "Approvals are not supported by this database"})
+        except Exception as e:
+            logger.exception("Failed to list pending approvals")
+            return json.dumps({"error": str(e)})
+
+    async def alist_pending_approvals(self) -> str:
+        """Async variant of list_pending_approvals."""
+        if not self._db_is_async:
+            return await _run_sync(self.list_pending_approvals)
+        try:
+            approvals, total = await self._async_db().get_approvals(status="pending", limit=_APPROVAL_LIMIT)
+            return _format_pending_approvals(approvals, total)
+        except NotImplementedError:
+            return json.dumps({"error": "Approvals are not supported by this database"})
+        except Exception as e:
+            logger.exception("Failed to list pending approvals")
+            return json.dumps({"error": str(e)})
+
+
+# ----------------------------------------------------------------------
+# Module helpers
+# ----------------------------------------------------------------------
+
+_GROUP_LIMIT = 100
+_SPAN_LIMIT = 15
+_APPROVAL_LIMIT = 100
+
+
+def _resolve_flags(
+    metrics: Optional[bool],
+    traces: Optional[bool],
+    schedules: Optional[bool],
+    evals: Optional[bool],
+    components: Optional[bool],
+    approvals: Optional[bool],
+    db_is_async: bool,
+) -> tuple[bool, bool, bool, bool, bool, bool]:
+    """Resolve the enable flags for the six ops surfaces.
+
+    * Every surface is enabled by default.
+    * ``components`` defaults to False for async databases, which do not support
+      ``list_components``; explicit ``components=True`` with an async database
+      raises so the misconfiguration surfaces at construction time.
+    """
+    m = bool(metrics) if metrics is not None else True
+    t = bool(traces) if traces is not None else True
+    s = bool(schedules) if schedules is not None else True
+    e = bool(evals) if evals is not None else True
+    a = bool(approvals) if approvals is not None else True
+
+    if components is None:
+        c = not db_is_async
+    else:
+        c = bool(components)
+        if c and db_is_async:
+            raise ValueError(
+                "components=True requires a synchronous database (BaseDb). "
+                "Async databases do not support list_components."
+            )
+
+    return m, t, s, e, c, a
+
+
+async def _run_sync(function: Callable[..., str], *args: Any, **kwargs: Any) -> str:
+    import asyncio
+
+    return await asyncio.to_thread(function, *args, **kwargs)
+
+
+def _async_db_error() -> str:
+    return json.dumps(
+        {
+            "error": "This toolkit is configured with an async database. Run the agent through the "
+            "async execution path (arun / AgentOS server) so the async tool variants are used."
+        }
+    )
+
+
+def _window_start(days: int) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=max(int(days), 1))
+
+
+def _metrics_window(days: int) -> tuple[date, date]:
+    end_date = datetime.now(timezone.utc).date()
+    start_date = end_date - timedelta(days=max(int(days), 1) - 1)
+    return start_date, end_date
+
+
+def _epoch_to_iso(value: Optional[int]) -> Optional[str]:
+    if value is None:
+        return None
+    try:
+        return datetime.fromtimestamp(int(value), tz=timezone.utc).isoformat()
+    except (ValueError, OSError, TypeError):
+        return None
+
+
+def _format_platform_metrics(rows: List[Any], days: int, start_date: date, end_date: date) -> str:
+    daily = []
+    totals = {
+        "agent_runs": 0,
+        "team_runs": 0,
+        "workflow_runs": 0,
+        "agent_sessions": 0,
+        "team_sessions": 0,
+        "workflow_sessions": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+    }
+    model_mix: Dict[str, int] = {}
+
+    for row in sorted(rows, key=lambda r: str(r["date"])):
+        record = dict(row)
+        token_metrics = record.get("token_metrics") or {}
+        daily.append(
+            {
+                "date": str(record.get("date")),
+                "agent_runs": record.get("agent_runs_count", 0),
+                "team_runs": record.get("team_runs_count", 0),
+                "workflow_runs": record.get("workflow_runs_count", 0),
+                "agent_sessions": record.get("agent_sessions_count", 0),
+                "team_sessions": record.get("team_sessions_count", 0),
+                "workflow_sessions": record.get("workflow_sessions_count", 0),
+                "distinct_users": record.get("users_count", 0),
+                "total_tokens": token_metrics.get("total_tokens", 0),
+            }
+        )
+        totals["agent_runs"] += record.get("agent_runs_count", 0)
+        totals["team_runs"] += record.get("team_runs_count", 0)
+        totals["workflow_runs"] += record.get("workflow_runs_count", 0)
+        totals["agent_sessions"] += record.get("agent_sessions_count", 0)
+        totals["team_sessions"] += record.get("team_sessions_count", 0)
+        totals["workflow_sessions"] += record.get("workflow_sessions_count", 0)
+        totals["input_tokens"] += token_metrics.get("input_tokens", 0)
+        totals["output_tokens"] += token_metrics.get("output_tokens", 0)
+        totals["total_tokens"] += token_metrics.get("total_tokens", 0)
+        for model in record.get("model_metrics") or []:
+            key = f"{model.get('model_id')}:{model.get('model_provider')}"
+            model_mix[key] = model_mix.get(key, 0) + int(model.get("count", 0))
+
+    payload: Dict[str, Any] = {
+        "window_days": days,
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        "totals": totals,
+        "model_mix": [{"model": key, "runs": count} for key, count in sorted(model_mix.items(), key=lambda kv: -kv[1])],
+        "daily": daily,
+        "notes": ["distinct_users is per-day; summing it across days would overcount"],
+    }
+    if not daily:
+        payload["notes"].append("no metrics recorded for this window; the platform may have had no sessions")
+    return json.dumps(payload, default=str)
+
+
+def _format_run_activity(groupings: Dict[str, Tuple[List[Dict[str, Any]], int]], window_total: int, days: int) -> str:
+    notes: List[str] = []
+    payload: Dict[str, Any] = {"window_days": days, "total_traces": window_total}
+
+    attributed = 0
+    truncated = False
+    for group, plural in (("agent", "agents"), ("team", "teams"), ("workflow", "workflows")):
+        rows, total_groups = groupings[group]
+        payload[plural] = rows
+        attributed += sum(int(row.get("total_traces", 0)) for row in rows)
+        if total_groups > len(rows):
+            truncated = True
+            notes.append(f"only the top {len(rows)} of {total_groups} {plural} are shown")
+
+    if truncated:
+        payload["unattributed_traces"] = None
+        notes.append("unattributed_traces cannot be computed because component rows were truncated")
+    else:
+        payload["unattributed_traces"] = max(window_total - attributed, 0)
+        notes.append(
+            "unattributed_traces are endpoint-level wrappers (e.g. MCP or API calls) not tied to a "
+            "single component; component rows already count the runs they wrap"
+        )
+    payload["notes"] = notes
+    return json.dumps(payload, default=str)
+
+
+def _format_tool_activity(
+    tools_most_used: List[Dict[str, Any]],
+    tools_slowest: List[Dict[str, Any]],
+    tools_total: int,
+    model_calls: List[Dict[str, Any]],
+    models_total: int,
+    days: int,
+) -> str:
+    notes: List[str] = []
+    if tools_total > len(tools_most_used):
+        notes.append(f"only the top {len(tools_most_used)} of {tools_total} tools are shown per list")
+    if models_total > len(model_calls):
+        notes.append(f"only the top {len(model_calls)} of {models_total} model call groups are shown")
+    if any(row.get("p95_duration_ms") is None for row in tools_most_used + model_calls):
+        notes.append("p95_duration_ms is not available on this database backend")
+
+    payload = {
+        "window_days": days,
+        "tools_most_used": tools_most_used,
+        "tools_slowest": tools_slowest,
+        "model_calls": model_calls,
+        "notes": notes,
+    }
+    return json.dumps(payload, default=str)
+
+
+def _normalize_eval_run(record: Dict[str, Any]) -> Dict[str, Any]:
+    eval_type = record.get("eval_type")
+    eval_data = record.get("eval_data") or {}
+    if isinstance(eval_data, str):
+        try:
+            eval_data = json.loads(eval_data)
+        except (ValueError, TypeError):
+            eval_data = {}
+
+    normalized: Dict[str, Any] = {
+        "id": record.get("run_id"),
+        "name": record.get("name"),
+        "eval_type": eval_type,
+        "component": record.get("evaluated_component_name")
+        or record.get("agent_id")
+        or record.get("team_id")
+        or record.get("workflow_id"),
+        "model_id": record.get("model_id"),
+        "created_at": _epoch_to_iso(record.get("created_at")),
+    }
+
+    results = eval_data.get("results") or []
+    if eval_type == "reliability":
+        eval_status = str(eval_data.get("eval_status") or "")
+        normalized["status"] = {"PASSED": "PASS", "FAILED": "FAIL"}.get(eval_status, eval_status or None)
+        if normalized["status"] == "FAIL":
+            normalized["reason"] = {
+                "failed_tool_calls": eval_data.get("failed_tool_calls") or [],
+                "missing_tool_calls": eval_data.get("missing_tool_calls") or [],
+                "failed_argument_checks": eval_data.get("failed_argument_checks") or [],
+            }
+    elif eval_type == "agent_as_judge":
+        passed_flags = [bool(r.get("passed")) for r in results if isinstance(r, dict)]
+        normalized["status"] = "PASS" if passed_flags and all(passed_flags) else ("FAIL" if passed_flags else None)
+        normalized["pass_rate"] = eval_data.get("pass_rate")
+        if eval_data.get("avg_score") is not None:
+            normalized["avg_score"] = eval_data.get("avg_score")
+        if normalized["status"] == "FAIL":
+            reasons = [str(r.get("reason", "")) for r in results if isinstance(r, dict) and not r.get("passed")]
+            normalized["reason"] = "; ".join(reason for reason in reasons if reason)[:1000]
+    elif eval_type == "accuracy":
+        normalized["status"] = "SCORED"
+        normalized["avg_score"] = eval_data.get("avg_score")
+    elif eval_type == "performance":
+        normalized["status"] = "MEASURED"
+        normalized["avg_run_time"] = eval_data.get("avg_run_time")
+    else:
+        normalized["status"] = "UNKNOWN"
+
+    return {key: value for key, value in normalized.items() if value is not None}
+
+
+def _format_eval_history(rows: List[Any], total: int) -> str:
+    eval_runs = [_normalize_eval_run(dict(row)) for row in rows]
+    payload: Dict[str, Any] = {"eval_runs": eval_runs, "count": len(eval_runs), "total": total}
+    if total > len(eval_runs):
+        payload["notes"] = [f"only the {len(eval_runs)} most recent of {total} eval runs are shown"]
+    return json.dumps(payload, default=str)
+
+
+def _format_schedule_run(run: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "status": run.get("status"),
+        "attempt": run.get("attempt"),
+        "triggered_at": _epoch_to_iso(run.get("triggered_at")),
+        "completed_at": _epoch_to_iso(run.get("completed_at")),
+        "status_code": run.get("status_code"),
+        "error": run.get("error"),
+    }
+
+
+def _format_schedules(
+    schedules: List[Dict[str, Any]], total: int, last_runs: Dict[str, Optional[Dict[str, Any]]]
+) -> str:
+    rows = []
+    for schedule in schedules:
+        last_run = last_runs.get(schedule["id"])
+        rows.append(
+            {
+                "id": schedule.get("id"),
+                "name": schedule.get("name"),
+                "description": schedule.get("description"),
+                "cron_expr": schedule.get("cron_expr"),
+                "timezone": schedule.get("timezone"),
+                "enabled": schedule.get("enabled"),
+                "endpoint": schedule.get("endpoint"),
+                "next_run_at": _epoch_to_iso(schedule.get("next_run_at")),
+                "last_run": _format_schedule_run(last_run) if last_run else None,
+            }
+        )
+    payload: Dict[str, Any] = {"schedules": rows, "count": len(rows), "total": total}
+    if total > len(rows):
+        payload["notes"] = [f"only {len(rows)} of {total} schedules are shown"]
+    return json.dumps(payload, default=str)
+
+
+def _format_schedule_history(schedule_id: str, runs: List[Dict[str, Any]], total: int) -> str:
+    status_counts: Dict[str, int] = {}
+    last_failure: Optional[Dict[str, Any]] = None
+    for run in runs:
+        status = str(run.get("status"))
+        status_counts[status] = status_counts.get(status, 0) + 1
+        if last_failure is None and status in ("failed", "timeout"):
+            last_failure = _format_schedule_run(run)
+
+    payload: Dict[str, Any] = {
+        "schedule_id": schedule_id,
+        "summary": {"status_counts": status_counts, "last_failure": last_failure},
+        "runs": [_format_schedule_run(run) for run in runs],
+        "count": len(runs),
+        "total": total,
+    }
+    if total > len(runs):
+        payload["notes"] = [f"only the {len(runs)} most recent of {total} runs are shown"]
+    return json.dumps(payload, default=str)
+
+
+def _format_components(components: List[Dict[str, Any]], total: int) -> str:
+    rows = [
+        {
+            "component_id": component.get("component_id"),
+            "component_type": component.get("component_type"),
+            "name": component.get("name"),
+            "description": component.get("description"),
+            "current_version": component.get("current_version"),
+            "created_at": _epoch_to_iso(component.get("created_at")),
+            "updated_at": _epoch_to_iso(component.get("updated_at")),
+        }
+        for component in components
+    ]
+    payload: Dict[str, Any] = {"components": rows, "count": len(rows), "total": total}
+    if total > len(rows):
+        payload["notes"] = [f"only {len(rows)} of {total} components are shown"]
+    return json.dumps(payload, default=str)
+
+
+def _format_pending_approvals(approvals: List[Dict[str, Any]], total: int) -> str:
+    rows = []
+    for approval in approvals:
+        row = {
+            "id": approval.get("id"),
+            "run_id": approval.get("run_id"),
+            "session_id": approval.get("session_id"),
+            "source_type": approval.get("source_type"),
+            "source_name": approval.get("source_name"),
+            "approval_type": approval.get("approval_type"),
+            "pause_type": approval.get("pause_type"),
+            "tool_name": approval.get("tool_name"),
+            "agent_id": approval.get("agent_id"),
+            "team_id": approval.get("team_id"),
+            "workflow_id": approval.get("workflow_id"),
+            "user_id": approval.get("user_id"),
+            "created_at": _epoch_to_iso(approval.get("created_at")),
+            "expires_at": _epoch_to_iso(approval.get("expires_at")),
+        }
+        rows.append({key: value for key, value in row.items() if value is not None})
+    payload: Dict[str, Any] = {"approvals": rows, "count": len(rows), "total": total}
+    if total > len(rows):
+        payload["notes"] = [f"only {len(rows)} of {total} pending approvals are shown"]
+    return json.dumps(payload, default=str)

--- a/libs/agno/agno/tools/agentos.py
+++ b/libs/agno/agno/tools/agentos.py
@@ -28,10 +28,16 @@ Enable flags:
       backends) return a clear error payload at call time.
 
 Read-only:
-    * No tool mutates anything. Schedule, approval and component management are
-      deliberately not exposed, so the toolkit is safe to reach from any frontend.
+    * No tool mutates platform state. Schedule, approval and component management
+      are deliberately not exposed. The one write that does happen is the metrics
+      rollup refresh inside get_platform_metrics -- derived data, no user content.
     * Span attributes payloads, approval tool arguments and schedule run
       input/output are never returned -- they can hold full conversation content.
+    * The tools read the database directly, so AgentOS endpoint scopes do not
+      apply to them: anyone who can talk to the agent sees platform-wide
+      aggregates, and pending approvals include identifiers (user_id, tool_name,
+      session_id). Expose the agent carrying this toolkit to operators, and use
+      the enable flags to trim surfaces for wider audiences.
 """
 
 from __future__ import annotations
@@ -187,7 +193,14 @@ class AgentOSTools(Toolkit):
             return json.dumps({"error": str(e)})
 
     async def aget_platform_metrics(self, days: int = 7) -> str:
-        """Async variant of get_platform_metrics."""
+        """Get daily platform usage metrics: runs, sessions, users, tokens and model mix.
+
+        Args:
+            days (int): Number of days to include, counting back from today. Defaults to 7.
+
+        Returns:
+            str: JSON with {window_days, start_date, end_date, totals, model_mix, daily}.
+        """
         if not self._db_is_async:
             return await _run_sync(self.get_platform_metrics, days)
         try:
@@ -209,27 +222,27 @@ class AgentOSTools(Toolkit):
     # ------------------------------------------------------------------
 
     def get_run_activity(self, days: int = 7) -> str:
-        """Get per-agent, per-team and per-workflow run activity: run counts, latency and errors.
+        """Get per-agent, per-team, per-workflow and endpoint-level run activity: run counts, latency and errors.
 
         Args:
             days (int): Number of days to include, counting back from now. Defaults to 7.
 
         Returns:
-            str: JSON with {window_days, agents, teams, workflows, unattributed_traces, notes}.
-                Each component row carries total_traces, total_sessions, avg/p95/max duration
-                in ms and error_traces. Unattributed traces are endpoint-level wrappers
-                (e.g. MCP calls) not tied to a component.
+            str: JSON with {window_days, total_traces, agents, teams, workflows, endpoint_level, notes}.
+                Each row carries total_traces, total_sessions, avg/p95/max duration in ms
+                and error_traces. endpoint_level rows are traces with no component id
+                (HTTP/MCP entrypoint wrappers), grouped by trace name.
         """
         if self._db_is_async:
             return _async_db_error()
         try:
             start_time = _window_start(days)
             groupings: Dict[str, Tuple[List[Dict[str, Any]], int]] = {}
-            for group in ("agent", "team", "workflow"):
+            for group in ("agent", "team", "workflow", "endpoint"):
                 groupings[group] = self._sync_db().get_trace_stats(
                     group_by=group, start_time=start_time, limit=_GROUP_LIMIT
                 )
-            _, window_total = self._sync_db().get_traces(start_time=start_time, limit=1)
+            _, window_total = self._sync_db().get_traces(limit=1, filter_expr=_created_after_expr(start_time))
             return _format_run_activity(groupings, window_total, days)
         except NotImplementedError as e:
             return json.dumps({"error": f"Component-grouped trace stats are not supported by this database: {e}"})
@@ -238,17 +251,27 @@ class AgentOSTools(Toolkit):
             return json.dumps({"error": str(e)})
 
     async def aget_run_activity(self, days: int = 7) -> str:
-        """Async variant of get_run_activity."""
+        """Get per-agent, per-team, per-workflow and endpoint-level run activity: run counts, latency and errors.
+
+        Args:
+            days (int): Number of days to include, counting back from now. Defaults to 7.
+
+        Returns:
+            str: JSON with {window_days, total_traces, agents, teams, workflows, endpoint_level, notes}.
+                Each row carries total_traces, total_sessions, avg/p95/max duration in ms
+                and error_traces. endpoint_level rows are traces with no component id
+                (HTTP/MCP entrypoint wrappers), grouped by trace name.
+        """
         if not self._db_is_async:
             return await _run_sync(self.get_run_activity, days)
         try:
             start_time = _window_start(days)
             groupings: Dict[str, Tuple[List[Dict[str, Any]], int]] = {}
-            for group in ("agent", "team", "workflow"):
+            for group in ("agent", "team", "workflow", "endpoint"):
                 groupings[group] = await self._async_db().get_trace_stats(
                     group_by=group, start_time=start_time, limit=_GROUP_LIMIT
                 )
-            _, window_total = await self._async_db().get_traces(start_time=start_time, limit=1)
+            _, window_total = await self._async_db().get_traces(limit=1, filter_expr=_created_after_expr(start_time))
             return _format_run_activity(groupings, window_total, days)
         except NotImplementedError as e:
             return json.dumps({"error": f"Component-grouped trace stats are not supported by this database: {e}"})
@@ -294,7 +317,18 @@ class AgentOSTools(Toolkit):
             return json.dumps({"error": str(e)})
 
     async def aget_tool_activity(self, days: int = 7) -> str:
-        """Async variant of get_tool_activity."""
+        """Get tool and model call statistics: most-used and slowest tools, model call latency.
+
+        Aggregates span names, durations and status only -- never conversation content.
+
+        Args:
+            days (int): Number of days to include, counting back from now. Defaults to 7.
+
+        Returns:
+            str: JSON with {window_days, tools_most_used, tools_slowest, model_calls, notes}.
+                Each row carries total_calls, avg/p95/max duration in ms, error_count and
+                last_called_at. p95_duration_ms is null on backends without SQL percentiles.
+        """
         if not self._db_is_async:
             return await _run_sync(self.get_tool_activity, days)
         try:
@@ -334,7 +368,7 @@ class AgentOSTools(Toolkit):
         try:
             rows, total = cast(
                 Tuple[List[Dict[str, Any]], int],
-                self._sync_db().get_eval_runs(limit=limit, page=1, deserialize=False),
+                self._sync_db().get_eval_runs(limit=_clamp(limit, 1, 100), page=1, deserialize=False),
             )
             return _format_eval_history(rows, total)
         except Exception as e:
@@ -342,13 +376,21 @@ class AgentOSTools(Toolkit):
             return json.dumps({"error": str(e)})
 
     async def aget_eval_history(self, limit: int = 20) -> str:
-        """Async variant of get_eval_history."""
+        """Get recent eval runs normalized to PASS/FAIL, with the judge's reason on failures.
+
+        Args:
+            limit (int): Maximum number of eval runs to return, newest first. Defaults to 20.
+
+        Returns:
+            str: JSON with {eval_runs, count, total}. Accuracy evals report scores
+                (status SCORED), performance evals report run times (status MEASURED).
+        """
         if not self._db_is_async:
             return await _run_sync(self.get_eval_history, limit)
         try:
             rows, total = cast(
                 Tuple[List[Dict[str, Any]], int],
-                await self._async_db().get_eval_runs(limit=limit, page=1, deserialize=False),
+                await self._async_db().get_eval_runs(limit=_clamp(limit, 1, 100), page=1, deserialize=False),
             )
             return _format_eval_history(rows, total)
         except Exception as e:
@@ -372,7 +414,7 @@ class AgentOSTools(Toolkit):
         if self._db_is_async:
             return _async_db_error()
         try:
-            schedules, total = self._sync_db().get_schedules(limit=limit)
+            schedules, total = self._sync_db().get_schedules(limit=_clamp(limit, 1, 50))
             last_runs: Dict[str, Optional[Dict[str, Any]]] = {}
             for schedule in schedules:
                 runs, _ = self._sync_db().get_schedule_runs(schedule["id"], limit=1)
@@ -385,11 +427,19 @@ class AgentOSTools(Toolkit):
             return json.dumps({"error": str(e)})
 
     async def alist_schedules(self, limit: int = 20) -> str:
-        """Async variant of list_schedules."""
+        """List schedules with their cron expression, enabled state and last run outcome.
+
+        Args:
+            limit (int): Maximum number of schedules to return, newest first. Defaults to 20.
+
+        Returns:
+            str: JSON with {schedules, count, total}. Each schedule carries its
+                last_run status, timestamp and error if any.
+        """
         if not self._db_is_async:
             return await _run_sync(self.list_schedules, limit)
         try:
-            schedules, total = await self._async_db().get_schedules(limit=limit)
+            schedules, total = await self._async_db().get_schedules(limit=_clamp(limit, 1, 50))
             last_runs: Dict[str, Optional[Dict[str, Any]]] = {}
             for schedule in schedules:
                 runs, _ = await self._async_db().get_schedule_runs(schedule["id"], limit=1)
@@ -415,7 +465,7 @@ class AgentOSTools(Toolkit):
         if self._db_is_async:
             return _async_db_error()
         try:
-            runs, total = self._sync_db().get_schedule_runs(schedule_id, limit=limit)
+            runs, total = self._sync_db().get_schedule_runs(schedule_id, limit=_clamp(limit, 1, 100))
             return _format_schedule_history(schedule_id, runs, total)
         except NotImplementedError:
             return json.dumps({"error": "The scheduler is not supported by this database"})
@@ -424,11 +474,20 @@ class AgentOSTools(Toolkit):
             return json.dumps({"error": str(e)})
 
     async def aget_schedule_history(self, schedule_id: str, limit: int = 20) -> str:
-        """Async variant of get_schedule_history."""
+        """Get the run history of one schedule: outcome trend, not just the last run.
+
+        Args:
+            schedule_id (str): The id of the schedule (see list_schedules).
+            limit (int): Maximum number of runs to return, newest first. Defaults to 20.
+
+        Returns:
+            str: JSON with {schedule_id, summary, runs, count, total}. The summary
+                counts runs by status and carries the most recent failure.
+        """
         if not self._db_is_async:
             return await _run_sync(self.get_schedule_history, schedule_id, limit)
         try:
-            runs, total = await self._async_db().get_schedule_runs(schedule_id, limit=limit)
+            runs, total = await self._async_db().get_schedule_runs(schedule_id, limit=_clamp(limit, 1, 100))
             return _format_schedule_history(schedule_id, runs, total)
         except NotImplementedError:
             return json.dumps({"error": "The scheduler is not supported by this database"})
@@ -453,7 +512,7 @@ class AgentOSTools(Toolkit):
         if self._db_is_async:
             return json.dumps({"error": "Component listing is not supported by async databases"})
         try:
-            components, total = self._sync_db().list_components(limit=limit)
+            components, total = self._sync_db().list_components(limit=_clamp(limit, 1, 100))
             return _format_components(components, total)
         except NotImplementedError:
             return json.dumps({"error": "Component listing is not supported by this database"})
@@ -462,7 +521,15 @@ class AgentOSTools(Toolkit):
             return json.dumps({"error": str(e)})
 
     async def alist_platform_components(self, limit: int = 50) -> str:
-        """Async variant of list_platform_components."""
+        """List runtime-built components (agents, teams, workflows) persisted in the database.
+
+        Args:
+            limit (int): Maximum number of components to return, newest first. Defaults to 50.
+
+        Returns:
+            str: JSON with {components, count, total}. Each component carries its
+                type, name, description and current version.
+        """
         if self._db_is_async:
             return json.dumps({"error": "Component listing is not supported by async databases"})
         return await _run_sync(self.list_platform_components, limit)
@@ -493,7 +560,15 @@ class AgentOSTools(Toolkit):
             return json.dumps({"error": str(e)})
 
     async def alist_pending_approvals(self) -> str:
-        """Async variant of list_pending_approvals."""
+        """List human-in-the-loop approvals waiting on a human decision.
+
+        Tool arguments and approval context are not included -- they can hold
+        user conversation content.
+
+        Returns:
+            str: JSON with {approvals, count, total}. Each approval carries its
+                source, pause type, tool name, requester and expiry.
+        """
         if not self._db_is_async:
             return await _run_sync(self.list_pending_approvals)
         try:
@@ -565,13 +640,17 @@ def _async_db_error() -> str:
     )
 
 
+def _clamp(value: int, low: int, high: int) -> int:
+    return max(low, min(int(value), high))
+
+
 def _window_start(days: int) -> datetime:
-    return datetime.now(timezone.utc) - timedelta(days=max(int(days), 1))
+    return datetime.now(timezone.utc) - timedelta(days=_clamp(days, 1, 365))
 
 
 def _metrics_window(days: int) -> tuple[date, date]:
     end_date = datetime.now(timezone.utc).date()
-    start_date = end_date - timedelta(days=max(int(days), 1) - 1)
+    start_date = end_date - timedelta(days=_clamp(days, 1, 365) - 1)
     return start_date, end_date
 
 
@@ -642,29 +721,30 @@ def _format_platform_metrics(rows: List[Any], days: int, start_date: date, end_d
     return json.dumps(payload, default=str)
 
 
+def _created_after_expr(start_time: datetime) -> Dict[str, Any]:
+    return {"op": "GTE", "key": "created_at", "value": start_time.isoformat()}
+
+
 def _format_run_activity(groupings: Dict[str, Tuple[List[Dict[str, Any]], int]], window_total: int, days: int) -> str:
     notes: List[str] = []
     payload: Dict[str, Any] = {"window_days": days, "total_traces": window_total}
 
-    attributed = 0
-    truncated = False
-    for group, plural in (("agent", "agents"), ("team", "teams"), ("workflow", "workflows")):
+    for group, key in (
+        ("agent", "agents"),
+        ("team", "teams"),
+        ("workflow", "workflows"),
+        ("endpoint", "endpoint_level"),
+    ):
         rows, total_groups = groupings[group]
-        payload[plural] = rows
-        attributed += sum(int(row.get("total_traces", 0)) for row in rows)
+        payload[key] = rows
         if total_groups > len(rows):
-            truncated = True
-            notes.append(f"only the top {len(rows)} of {total_groups} {plural} are shown")
+            notes.append(f"only the top {len(rows)} of {total_groups} {key} groups are shown")
 
-    if truncated:
-        payload["unattributed_traces"] = None
-        notes.append("unattributed_traces cannot be computed because component rows were truncated")
-    else:
-        payload["unattributed_traces"] = max(window_total - attributed, 0)
-        notes.append(
-            "unattributed_traces are endpoint-level wrappers (e.g. MCP or API calls) not tied to a "
-            "single component; component rows already count the runs they wrap"
-        )
+    notes.append(
+        "endpoint_level rows are traces with no component id (HTTP/MCP entrypoint wrappers around "
+        "component runs); component tables exclude them, and a trace attributed to more than one "
+        "component appears under each, so the tables may not sum to total_traces"
+    )
     payload["notes"] = notes
     return json.dumps(payload, default=str)
 

--- a/libs/agno/agno/tools/agentos.py
+++ b/libs/agno/agno/tools/agentos.py
@@ -1,7 +1,10 @@
 """AgentOSTools -- give agents a read-only ops view of the AgentOS they run on.
 
-Answers questions about usage, cost, latency, failures, schedules, eval history
-and runtime-built components by reading directly from the AgentOS database.
+Answers questions about usage, latency, failures, schedules, eval history and
+runtime-built components by reading directly from the AgentOS database.
+
+Cost is not reported: agno only records provider-supplied cost, which almost no
+provider returns, and it is not aggregated into the daily metrics rollup.
 
 Typical use:
     from agno.tools.agentos import AgentOSTools
@@ -33,6 +36,10 @@ Read-only:
       rollup refresh inside get_platform_metrics -- derived data, no user content.
     * Span attributes payloads, approval tool arguments and schedule run
       input/output are never returned -- they can hold full conversation content.
+    * Schedule run errors are redacted: an error that came with an HTTP status
+      code is reduced to ``HTTP <code>`` (upstream response bodies echo run
+      input back, e.g. via a 422), and framework-generated messages are capped
+      at their first line, 200 characters.
     * The tools read the database directly, so AgentOS endpoint scopes do not
       apply to them: anyone who can talk to the agent sees platform-wide
       aggregates, and pending approvals include identifiers (user_id, tool_name,
@@ -139,8 +146,10 @@ class AgentOSTools(Toolkit):
 
         instruction_lines = [
             "Answer operations questions about this AgentOS with the read-only platform tools.",
-            "Usage and cost: get_platform_metrics. Latency and errors per component: get_run_activity. "
+            "Usage and token totals: get_platform_metrics. Latency and errors per component: get_run_activity. "
             "Slow or failing tools and model calls: get_tool_activity.",
+            "No tool reports cost. If asked what something cost, say the platform does not track it "
+            "and give token totals instead -- never estimate cost from tokens.",
             "When a payload carries a truncation or sampling note, report it -- never present a sample "
             "as the whole picture.",
             "These tools are read-only. You cannot modify schedules, approvals or components.",
@@ -409,7 +418,8 @@ class AgentOSTools(Toolkit):
 
         Returns:
             str: JSON with {schedules, count, total}. Each schedule carries its
-                last_run status, timestamp and error if any.
+                last_run status, timestamp and a redacted error summary if any
+                (an HTTP status line or a capped framework message).
         """
         if self._db_is_async:
             return _async_db_error()
@@ -434,7 +444,8 @@ class AgentOSTools(Toolkit):
 
         Returns:
             str: JSON with {schedules, count, total}. Each schedule carries its
-                last_run status, timestamp and error if any.
+                last_run status, timestamp and a redacted error summary if any
+                (an HTTP status line or a capped framework message).
         """
         if not self._db_is_async:
             return await _run_sync(self.list_schedules, limit)
@@ -459,8 +470,11 @@ class AgentOSTools(Toolkit):
             limit (int): Maximum number of runs to return, newest first. Defaults to 20.
 
         Returns:
-            str: JSON with {schedule_id, summary, runs, count, total}. The summary
-                counts runs by status and carries the most recent failure.
+            str: JSON with {schedule_id, page_summary, runs, count, total}. The
+                page_summary counts the returned runs by status and carries their
+                most recent failure; it covers only the runs returned, not the
+                schedule's full history. Errors are redacted to an HTTP status
+                line or a capped framework message.
         """
         if self._db_is_async:
             return _async_db_error()
@@ -481,8 +495,11 @@ class AgentOSTools(Toolkit):
             limit (int): Maximum number of runs to return, newest first. Defaults to 20.
 
         Returns:
-            str: JSON with {schedule_id, summary, runs, count, total}. The summary
-                counts runs by status and carries the most recent failure.
+            str: JSON with {schedule_id, page_summary, runs, count, total}. The
+                page_summary counts the returned runs by status and carries their
+                most recent failure; it covers only the runs returned, not the
+                schedule's full history. Errors are redacted to an HTTP status
+                line or a capped framework message.
         """
         if not self._db_is_async:
             return await _run_sync(self.get_schedule_history, schedule_id, limit)
@@ -588,6 +605,7 @@ class AgentOSTools(Toolkit):
 _GROUP_LIMIT = 100
 _SPAN_LIMIT = 15
 _APPROVAL_LIMIT = 100
+_ERROR_SUMMARY_LIMIT = 200
 
 
 def _resolve_flags(
@@ -820,7 +838,10 @@ def _normalize_eval_run(record: Dict[str, Any]) -> Dict[str, Any]:
         normalized["avg_score"] = eval_data.get("avg_score")
     elif eval_type == "performance":
         normalized["status"] = "MEASURED"
-        normalized["avg_run_time"] = eval_data.get("avg_run_time")
+        run_times = eval_data.get("result")
+        if not isinstance(run_times, dict):
+            run_times = eval_data  # older rows stored the numbers at the top level
+        normalized["avg_run_time"] = run_times.get("avg_run_time")
     else:
         normalized["status"] = "UNKNOWN"
 
@@ -835,6 +856,25 @@ def _format_eval_history(rows: List[Any], total: int) -> str:
     return json.dumps(payload, default=str)
 
 
+def _summarize_run_error(run: Dict[str, Any]) -> Optional[str]:
+    """Reduce a stored schedule run error to a safe, bounded summary.
+
+    Errors that came with an HTTP status code are raw upstream response bodies,
+    which can echo the run input back (e.g. a 422 validation error), so the
+    body is dropped and only ``HTTP <code>`` is returned. Errors without a
+    status code are framework-generated (timeouts, cancellations, transport
+    failures) and are kept, first line only, capped at 200 characters.
+    """
+    error = run.get("error")
+    if error is None:
+        return None
+    status_code = run.get("status_code")
+    if status_code is not None:
+        return f"HTTP {status_code}"
+    lines = str(error).strip().splitlines()
+    return lines[0][:_ERROR_SUMMARY_LIMIT] if lines else None
+
+
 def _format_schedule_run(run: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "status": run.get("status"),
@@ -842,7 +882,7 @@ def _format_schedule_run(run: Dict[str, Any]) -> Dict[str, Any]:
         "triggered_at": _epoch_to_iso(run.get("triggered_at")),
         "completed_at": _epoch_to_iso(run.get("completed_at")),
         "status_code": run.get("status_code"),
-        "error": run.get("error"),
+        "error": _summarize_run_error(run),
     }
 
 
@@ -882,13 +922,16 @@ def _format_schedule_history(schedule_id: str, runs: List[Dict[str, Any]], total
 
     payload: Dict[str, Any] = {
         "schedule_id": schedule_id,
-        "summary": {"status_counts": status_counts, "last_failure": last_failure},
+        "page_summary": {"status_counts": status_counts, "last_failure": last_failure},
         "runs": [_format_schedule_run(run) for run in runs],
         "count": len(runs),
         "total": total,
     }
     if total > len(runs):
-        payload["notes"] = [f"only the {len(runs)} most recent of {total} runs are shown"]
+        payload["notes"] = [
+            f"only the {len(runs)} most recent of {total} runs are shown",
+            f"page_summary covers only these {len(runs)} runs; older runs may hold failures it does not reflect",
+        ]
     return json.dumps(payload, default=str)
 
 

--- a/libs/agno/agno/tools/agentos.py
+++ b/libs/agno/agno/tools/agentos.py
@@ -197,9 +197,9 @@ class AgentOSTools(Toolkit):
                 log_warning(f"Could not refresh metrics: {e}")
             rows, _ = self._sync_db().get_metrics(starting_date=start_date, ending_date=end_date)
             return _format_platform_metrics(rows, days, start_date, end_date)
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get platform metrics")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get platform metrics")
 
     async def aget_platform_metrics(self, days: int = 7) -> str:
         """Get daily platform usage metrics: runs, sessions, users, tokens and model mix.
@@ -222,9 +222,9 @@ class AgentOSTools(Toolkit):
                 log_warning(f"Could not refresh metrics: {e}")
             rows, _ = await self._async_db().get_metrics(starting_date=start_date, ending_date=end_date)
             return _format_platform_metrics(rows, days, start_date, end_date)
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get platform metrics")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get platform metrics")
 
     # ------------------------------------------------------------------
     # Run activity (traces grouped by component)
@@ -255,9 +255,9 @@ class AgentOSTools(Toolkit):
             return _format_run_activity(groupings, window_total, days)
         except NotImplementedError as e:
             return json.dumps({"error": f"Component-grouped trace stats are not supported by this database: {e}"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get run activity")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get run activity")
 
     async def aget_run_activity(self, days: int = 7) -> str:
         """Get per-agent, per-team, per-workflow and endpoint-level run activity: run counts, latency and errors.
@@ -284,9 +284,9 @@ class AgentOSTools(Toolkit):
             return _format_run_activity(groupings, window_total, days)
         except NotImplementedError as e:
             return json.dumps({"error": f"Component-grouped trace stats are not supported by this database: {e}"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get run activity")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get run activity")
 
     # ------------------------------------------------------------------
     # Tool activity (span aggregates)
@@ -321,9 +321,9 @@ class AgentOSTools(Toolkit):
             return _format_tool_activity(tools_most_used, tools_slowest, tools_total, model_calls, models_total, days)
         except NotImplementedError:
             return json.dumps({"error": "Span statistics are not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get tool activity")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get tool activity")
 
     async def aget_tool_activity(self, days: int = 7) -> str:
         """Get tool and model call statistics: most-used and slowest tools, model call latency.
@@ -354,9 +354,9 @@ class AgentOSTools(Toolkit):
             return _format_tool_activity(tools_most_used, tools_slowest, tools_total, model_calls, models_total, days)
         except NotImplementedError:
             return json.dumps({"error": "Span statistics are not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get tool activity")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get tool activity")
 
     # ------------------------------------------------------------------
     # Eval history
@@ -380,9 +380,9 @@ class AgentOSTools(Toolkit):
                 self._sync_db().get_eval_runs(limit=_clamp(limit, 1, 100), page=1, deserialize=False),
             )
             return _format_eval_history(rows, total)
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get eval history")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get eval history")
 
     async def aget_eval_history(self, limit: int = 20) -> str:
         """Get recent eval runs normalized to PASS/FAIL, with the judge's reason on failures.
@@ -402,9 +402,9 @@ class AgentOSTools(Toolkit):
                 await self._async_db().get_eval_runs(limit=_clamp(limit, 1, 100), page=1, deserialize=False),
             )
             return _format_eval_history(rows, total)
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get eval history")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get eval history")
 
     # ------------------------------------------------------------------
     # Schedules
@@ -432,9 +432,9 @@ class AgentOSTools(Toolkit):
             return _format_schedules(schedules, total, last_runs)
         except NotImplementedError:
             return json.dumps({"error": "The scheduler is not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to list schedules")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to list schedules")
 
     async def alist_schedules(self, limit: int = 20) -> str:
         """List schedules with their cron expression, enabled state and last run outcome.
@@ -458,9 +458,9 @@ class AgentOSTools(Toolkit):
             return _format_schedules(schedules, total, last_runs)
         except NotImplementedError:
             return json.dumps({"error": "The scheduler is not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to list schedules")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to list schedules")
 
     def get_schedule_history(self, schedule_id: str, limit: int = 20) -> str:
         """Get the run history of one schedule: outcome trend, not just the last run.
@@ -483,9 +483,9 @@ class AgentOSTools(Toolkit):
             return _format_schedule_history(schedule_id, runs, total)
         except NotImplementedError:
             return json.dumps({"error": "The scheduler is not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get schedule history")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get schedule history")
 
     async def aget_schedule_history(self, schedule_id: str, limit: int = 20) -> str:
         """Get the run history of one schedule: outcome trend, not just the last run.
@@ -508,9 +508,9 @@ class AgentOSTools(Toolkit):
             return _format_schedule_history(schedule_id, runs, total)
         except NotImplementedError:
             return json.dumps({"error": "The scheduler is not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get schedule history")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get schedule history")
 
     # ------------------------------------------------------------------
     # Components
@@ -533,9 +533,9 @@ class AgentOSTools(Toolkit):
             return _format_components(components, total)
         except NotImplementedError:
             return json.dumps({"error": "Component listing is not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to list platform components")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to list platform components")
 
     async def alist_platform_components(self, limit: int = 50) -> str:
         """List runtime-built components (agents, teams, workflows) persisted in the database.
@@ -572,9 +572,9 @@ class AgentOSTools(Toolkit):
             return _format_pending_approvals(approvals, total)
         except NotImplementedError:
             return json.dumps({"error": "Approvals are not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to list pending approvals")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to list pending approvals")
 
     async def alist_pending_approvals(self) -> str:
         """List human-in-the-loop approvals waiting on a human decision.
@@ -593,9 +593,9 @@ class AgentOSTools(Toolkit):
             return _format_pending_approvals(approvals, total)
         except NotImplementedError:
             return json.dumps({"error": "Approvals are not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to list pending approvals")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to list pending approvals")
 
 
 # ----------------------------------------------------------------------
@@ -656,6 +656,17 @@ def _async_db_error() -> str:
             "async execution path (arun / AgentOS server) so the async tool variants are used."
         }
     )
+
+
+def _tool_error(context: str) -> str:
+    """Generic error payload for the agent.
+
+    The exception detail is logged (logger.exception) but never returned. These
+    tools read the database directly with no endpoint scopes, so raw exception
+    text -- SQL fragments, table or column names -- must not reach whoever talks
+    to the agent.
+    """
+    return json.dumps({"error": f"{context}. The error has been logged."})
 
 
 def _clamp(value: int, low: int, high: int) -> int:

--- a/libs/agno/tests/integration/db/async_postgres/test_trace_span_stats.py
+++ b/libs/agno/tests/integration/db/async_postgres/test_trace_span_stats.py
@@ -156,6 +156,27 @@ async def test_get_span_stats(stats_db: AsyncPostgresDb):
 
 
 @pytest.mark.asyncio
+async def test_get_span_stats_paging_with_tied_name_groups_is_lossless(stats_db: AsyncPostgresDb):
+    trace = _make_trace(agent_id="agent-1", session_id="s1")
+    await stats_db.upsert_trace(trace)
+    # 8 groups sharing one name, all tied on every aggregate: only the
+    # (name, span_type) ORDER BY tiebreak makes paging deterministic
+    await stats_db.create_spans([_make_span(trace.trace_id, name="dup", span_type=f"KIND{i:02d}") for i in range(20)])
+
+    seen = []
+    total = 0
+    for page in range(1, 24):
+        rows, total = await stats_db.get_span_stats(limit=3, page=page)
+        if not rows:
+            break
+        seen.extend((row["name"], row["span_type"]) for row in rows)
+
+    assert total == 20
+    assert len(seen) == 20
+    assert len(set(seen)) == 20
+
+
+@pytest.mark.asyncio
 async def test_get_metrics_refreshes_lazily_and_throttles(stats_db: AsyncPostgresDb):
     async def seed_session(user_id: str) -> None:
         now = int(time.time())

--- a/libs/agno/tests/integration/db/async_postgres/test_trace_span_stats.py
+++ b/libs/agno/tests/integration/db/async_postgres/test_trace_span_stats.py
@@ -1,0 +1,145 @@
+"""Integration tests for component-grouped trace stats, span stats and lazy metrics on AsyncPostgresDb"""
+
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+import pytest
+
+from agno.db.postgres import AsyncPostgresDb
+from agno.session.agent import AgentSession
+from agno.tracing.schemas import Span, Trace
+
+
+def _make_trace(
+    agent_id: Optional[str] = None,
+    session_id: Optional[str] = "session-1",
+    user_id: Optional[str] = "user-1",
+    duration_ms: int = 100,
+    status: str = "OK",
+    minutes_ago: int = 5,
+) -> Trace:
+    start = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+    return Trace(
+        trace_id=str(uuid.uuid4()),
+        name="Agent.run",
+        status=status,
+        start_time=start,
+        end_time=start + timedelta(milliseconds=duration_ms),
+        duration_ms=duration_ms,
+        total_spans=0,
+        error_count=1 if status == "ERROR" else 0,
+        run_id=None,
+        session_id=session_id,
+        user_id=user_id,
+        agent_id=agent_id,
+        team_id=None,
+        workflow_id=None,
+        created_at=start,
+    )
+
+
+def _make_span(
+    trace_id: str,
+    name: str = "my_tool",
+    span_type: Optional[str] = "TOOL",
+    duration_ms: int = 100,
+    status_code: str = "OK",
+) -> Span:
+    start = datetime.now(timezone.utc) - timedelta(minutes=5)
+    attributes: Dict[str, Any] = {"openinference.span.kind": span_type} if span_type else {}
+    return Span(
+        span_id=str(uuid.uuid4()),
+        trace_id=trace_id,
+        parent_span_id=None,
+        name=name,
+        span_kind="INTERNAL",
+        status_code=status_code,
+        status_message=None,
+        start_time=start,
+        end_time=start + timedelta(milliseconds=duration_ms),
+        duration_ms=duration_ms,
+        attributes=attributes,
+        created_at=start,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_trace_stats_group_by_agent(async_postgres_db_real: AsyncPostgresDb):
+    await async_postgres_db_real.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1", duration_ms=100))
+    await async_postgres_db_real.upsert_trace(
+        _make_trace(agent_id="agent-1", session_id="s2", duration_ms=300, status="ERROR")
+    )
+    await async_postgres_db_real.upsert_trace(_make_trace(session_id=None, user_id=None))
+
+    rows, total = await async_postgres_db_real.get_trace_stats(group_by="agent")
+
+    assert total == 1
+    top = rows[0]
+    assert top["agent_id"] == "agent-1"
+    assert top["total_traces"] == 2
+    assert top["avg_duration_ms"] == 200.0
+    assert top["p95_duration_ms"] == 290.0
+    assert top["error_traces"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_trace_stats_default_shape_unchanged(async_postgres_db_real: AsyncPostgresDb):
+    await async_postgres_db_real.upsert_trace(_make_trace(agent_id="agent-1", session_id="session-1"))
+
+    rows, total = await async_postgres_db_real.get_trace_stats()
+
+    assert total == 1
+    expected_keys = {
+        "session_id",
+        "user_id",
+        "agent_id",
+        "team_id",
+        "workflow_id",
+        "total_traces",
+        "first_trace_at",
+        "last_trace_at",
+    }
+    assert set(rows[0].keys()) == expected_keys
+
+
+@pytest.mark.asyncio
+async def test_get_span_stats(async_postgres_db_real: AsyncPostgresDb):
+    trace = _make_trace(agent_id="agent-1", session_id="s1")
+    await async_postgres_db_real.upsert_trace(trace)
+    await async_postgres_db_real.create_spans(
+        [
+            _make_span(trace.trace_id, name="slow_tool", duration_ms=900),
+            _make_span(trace.trace_id, name="slow_tool", duration_ms=1100),
+            _make_span(trace.trace_id, name="Model.invoke", span_type="LLM", duration_ms=500),
+        ]
+    )
+
+    rows, total = await async_postgres_db_real.get_span_stats(span_type="TOOL")
+
+    assert total == 1
+    assert rows[0]["name"] == "slow_tool"
+    assert rows[0]["total_calls"] == 2
+    assert rows[0]["avg_duration_ms"] == 1000.0
+    assert rows[0]["p95_duration_ms"] == 1090.0
+    assert "attributes" not in rows[0]
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_refreshes_lazily(async_postgres_db_real: AsyncPostgresDb):
+    now = int(time.time())
+    session = AgentSession(
+        session_id=str(uuid.uuid4()),
+        agent_id="agent-1",
+        user_id="user-1",
+        created_at=now,
+        updated_at=now,
+    )
+    await async_postgres_db_real.upsert_session(session)
+
+    # No calculate_metrics call: get_metrics must refresh on its own
+    rows, _ = await async_postgres_db_real.get_metrics()
+
+    assert len(rows) == 1
+    assert rows[0]["agent_sessions_count"] == 1

--- a/libs/agno/tests/integration/db/async_postgres/test_trace_span_stats.py
+++ b/libs/agno/tests/integration/db/async_postgres/test_trace_span_stats.py
@@ -1,4 +1,8 @@
-"""Integration tests for component-grouped trace stats, span stats and lazy metrics on AsyncPostgresDb"""
+"""Integration tests for component-grouped trace stats, span stats and lazy metrics on AsyncPostgresDb.
+
+Each test gets its own AsyncPostgresDb with a dedicated schema and engine, so it
+is immune to the shared test_schema teardown ordering issues.
+"""
 
 import time
 import uuid
@@ -6,10 +10,24 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
 import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
 
 from agno.db.postgres import AsyncPostgresDb
 from agno.session.agent import AgentSession
 from agno.tracing.schemas import Span, Trace
+
+
+@pytest_asyncio.fixture
+async def stats_db():
+    schema = f"agentos_stats_{uuid.uuid4().hex[:8]}"
+    engine = create_async_engine("postgresql+psycopg_async://ai:ai@localhost:5532/ai")
+    db = AsyncPostgresDb(db_engine=engine, db_schema=schema)
+    yield db
+    async with engine.begin() as conn:
+        await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+    await engine.dispose()
 
 
 def _make_trace(
@@ -19,11 +37,12 @@ def _make_trace(
     duration_ms: int = 100,
     status: str = "OK",
     minutes_ago: int = 5,
+    name: str = "Agent.run",
 ) -> Trace:
     start = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
     return Trace(
         trace_id=str(uuid.uuid4()),
-        name="Agent.run",
+        name=name,
         status=status,
         start_time=start,
         end_time=start + timedelta(milliseconds=duration_ms),
@@ -66,14 +85,12 @@ def _make_span(
 
 
 @pytest.mark.asyncio
-async def test_get_trace_stats_group_by_agent(async_postgres_db_real: AsyncPostgresDb):
-    await async_postgres_db_real.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1", duration_ms=100))
-    await async_postgres_db_real.upsert_trace(
-        _make_trace(agent_id="agent-1", session_id="s2", duration_ms=300, status="ERROR")
-    )
-    await async_postgres_db_real.upsert_trace(_make_trace(session_id=None, user_id=None))
+async def test_get_trace_stats_group_by_agent(stats_db: AsyncPostgresDb):
+    await stats_db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1", duration_ms=100))
+    await stats_db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s2", duration_ms=300, status="ERROR"))
+    await stats_db.upsert_trace(_make_trace(session_id=None, user_id=None))
 
-    rows, total = await async_postgres_db_real.get_trace_stats(group_by="agent")
+    rows, total = await stats_db.get_trace_stats(group_by="agent")
 
     assert total == 1
     top = rows[0]
@@ -85,10 +102,22 @@ async def test_get_trace_stats_group_by_agent(async_postgres_db_real: AsyncPostg
 
 
 @pytest.mark.asyncio
-async def test_get_trace_stats_default_shape_unchanged(async_postgres_db_real: AsyncPostgresDb):
-    await async_postgres_db_real.upsert_trace(_make_trace(agent_id="agent-1", session_id="session-1"))
+async def test_get_trace_stats_group_by_endpoint(stats_db: AsyncPostgresDb):
+    await stats_db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1"))
+    await stats_db.upsert_trace(_make_trace(session_id=None, user_id=None, name="tools/call run_agent"))
 
-    rows, total = await async_postgres_db_real.get_trace_stats()
+    rows, total = await stats_db.get_trace_stats(group_by="endpoint")
+
+    assert total == 1
+    assert rows[0]["name"] == "tools/call run_agent"
+    assert rows[0]["total_traces"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_trace_stats_default_shape_unchanged(stats_db: AsyncPostgresDb):
+    await stats_db.upsert_trace(_make_trace(agent_id="agent-1", session_id="session-1"))
+
+    rows, total = await stats_db.get_trace_stats()
 
     assert total == 1
     expected_keys = {
@@ -105,10 +134,10 @@ async def test_get_trace_stats_default_shape_unchanged(async_postgres_db_real: A
 
 
 @pytest.mark.asyncio
-async def test_get_span_stats(async_postgres_db_real: AsyncPostgresDb):
+async def test_get_span_stats(stats_db: AsyncPostgresDb):
     trace = _make_trace(agent_id="agent-1", session_id="s1")
-    await async_postgres_db_real.upsert_trace(trace)
-    await async_postgres_db_real.create_spans(
+    await stats_db.upsert_trace(trace)
+    await stats_db.create_spans(
         [
             _make_span(trace.trace_id, name="slow_tool", duration_ms=900),
             _make_span(trace.trace_id, name="slow_tool", duration_ms=1100),
@@ -116,7 +145,7 @@ async def test_get_span_stats(async_postgres_db_real: AsyncPostgresDb):
         ]
     )
 
-    rows, total = await async_postgres_db_real.get_span_stats(span_type="TOOL")
+    rows, total = await stats_db.get_span_stats(span_type="TOOL")
 
     assert total == 1
     assert rows[0]["name"] == "slow_tool"
@@ -127,19 +156,28 @@ async def test_get_span_stats(async_postgres_db_real: AsyncPostgresDb):
 
 
 @pytest.mark.asyncio
-async def test_get_metrics_refreshes_lazily(async_postgres_db_real: AsyncPostgresDb):
-    now = int(time.time())
-    session = AgentSession(
-        session_id=str(uuid.uuid4()),
-        agent_id="agent-1",
-        user_id="user-1",
-        created_at=now,
-        updated_at=now,
-    )
-    await async_postgres_db_real.upsert_session(session)
+async def test_get_metrics_refreshes_lazily_and_throttles(stats_db: AsyncPostgresDb):
+    async def seed_session(user_id: str) -> None:
+        now = int(time.time())
+        await stats_db.upsert_session(
+            AgentSession(
+                session_id=str(uuid.uuid4()), agent_id="agent-1", user_id=user_id, created_at=now, updated_at=now
+            )
+        )
+
+    await seed_session("user-1")
 
     # No calculate_metrics call: get_metrics must refresh on its own
-    rows, _ = await async_postgres_db_real.get_metrics()
-
+    rows, _ = await stats_db.get_metrics()
     assert len(rows) == 1
     assert rows[0]["agent_sessions_count"] == 1
+
+    # A second read within the throttle window must not recompute
+    await seed_session("user-2")
+    rows, _ = await stats_db.get_metrics()
+    assert rows[0]["agent_sessions_count"] == 1
+
+    # Expiring the throttle picks the new session up
+    stats_db._metrics_refreshed_at = 0.0
+    rows, _ = await stats_db.get_metrics()
+    assert rows[0]["agent_sessions_count"] == 2

--- a/libs/agno/tests/integration/db/postgres/test_trace_span_stats.py
+++ b/libs/agno/tests/integration/db/postgres/test_trace_span_stats.py
@@ -1,0 +1,193 @@
+"""Integration tests for component-grouped trace stats, span stats and lazy metrics on PostgresDb"""
+
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from agno.db.postgres.postgres import PostgresDb
+from agno.session.agent import AgentSession
+from agno.tracing.schemas import Span, Trace
+
+
+def _make_trace(
+    agent_id: Optional[str] = None,
+    team_id: Optional[str] = None,
+    workflow_id: Optional[str] = None,
+    session_id: Optional[str] = "session-1",
+    user_id: Optional[str] = "user-1",
+    duration_ms: int = 100,
+    status: str = "OK",
+    minutes_ago: int = 5,
+) -> Trace:
+    start = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+    return Trace(
+        trace_id=str(uuid.uuid4()),
+        name="Agent.run",
+        status=status,
+        start_time=start,
+        end_time=start + timedelta(milliseconds=duration_ms),
+        duration_ms=duration_ms,
+        total_spans=0,
+        error_count=1 if status == "ERROR" else 0,
+        run_id=None,
+        session_id=session_id,
+        user_id=user_id,
+        agent_id=agent_id,
+        team_id=team_id,
+        workflow_id=workflow_id,
+        created_at=start,
+    )
+
+
+def _make_span(
+    trace_id: str,
+    name: str = "my_tool",
+    span_type: Optional[str] = "TOOL",
+    duration_ms: int = 100,
+    status_code: str = "OK",
+    minutes_ago: int = 5,
+) -> Span:
+    start = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+    attributes: Dict[str, Any] = {"openinference.span.kind": span_type} if span_type else {}
+    return Span(
+        span_id=str(uuid.uuid4()),
+        trace_id=trace_id,
+        parent_span_id=None,
+        name=name,
+        span_kind="INTERNAL",
+        status_code=status_code,
+        status_message=None,
+        start_time=start,
+        end_time=start + timedelta(milliseconds=duration_ms),
+        duration_ms=duration_ms,
+        attributes=attributes,
+        created_at=start,
+    )
+
+
+def test_get_trace_stats_default_shape_unchanged(postgres_db_real: PostgresDb):
+    postgres_db_real.upsert_trace(_make_trace(agent_id="agent-1", session_id="session-1"))
+    postgres_db_real.upsert_trace(_make_trace(agent_id="agent-2", session_id="session-2"))
+
+    rows, total = postgres_db_real.get_trace_stats()
+
+    assert total == 2
+    expected_keys = {
+        "session_id",
+        "user_id",
+        "agent_id",
+        "team_id",
+        "workflow_id",
+        "total_traces",
+        "first_trace_at",
+        "last_trace_at",
+    }
+    for row in rows:
+        assert set(row.keys()) == expected_keys
+        assert isinstance(row["first_trace_at"], datetime)
+
+
+def test_get_trace_stats_group_by_agent(postgres_db_real: PostgresDb):
+    postgres_db_real.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1", duration_ms=100))
+    postgres_db_real.upsert_trace(_make_trace(agent_id="agent-1", session_id="s2", duration_ms=300, status="ERROR"))
+    postgres_db_real.upsert_trace(_make_trace(agent_id="agent-2", session_id="s3", duration_ms=50))
+    postgres_db_real.upsert_trace(_make_trace(session_id=None, user_id=None))  # endpoint-level, excluded
+
+    rows, total = postgres_db_real.get_trace_stats(group_by="agent")
+
+    assert total == 2
+    top = rows[0]
+    assert top["agent_id"] == "agent-1"
+    assert top["total_traces"] == 2
+    assert top["total_sessions"] == 2
+    assert top["avg_duration_ms"] == 200.0
+    # percentile_cont(0.95) over [100, 300] interpolates to 290
+    assert top["p95_duration_ms"] == 290.0
+    assert top["max_duration_ms"] == 300
+    assert top["error_traces"] == 1
+
+
+def test_get_trace_stats_group_by_team_and_workflow(postgres_db_real: PostgresDb):
+    postgres_db_real.upsert_trace(_make_trace(team_id="team-1", session_id="s1"))
+    postgres_db_real.upsert_trace(_make_trace(workflow_id="wf-1", session_id="s2"))
+
+    team_rows, team_total = postgres_db_real.get_trace_stats(group_by="team")
+    workflow_rows, workflow_total = postgres_db_real.get_trace_stats(group_by="workflow")
+
+    assert team_total == 1
+    assert team_rows[0]["team_id"] == "team-1"
+    assert workflow_total == 1
+    assert workflow_rows[0]["workflow_id"] == "wf-1"
+
+
+def test_get_span_stats_aggregates_and_extracts_span_type(postgres_db_real: PostgresDb):
+    trace = _make_trace(agent_id="agent-1", session_id="s1")
+    postgres_db_real.upsert_trace(trace)
+    postgres_db_real.create_spans(
+        [
+            _make_span(trace.trace_id, name="slow_tool", duration_ms=900),
+            _make_span(trace.trace_id, name="slow_tool", duration_ms=1100),
+            _make_span(trace.trace_id, name="fast_tool", duration_ms=10, status_code="ERROR"),
+            _make_span(trace.trace_id, name="Model.invoke", span_type="LLM", duration_ms=500),
+        ]
+    )
+
+    rows, total = postgres_db_real.get_span_stats()
+
+    assert total == 3
+    by_name = {row["name"]: row for row in rows}
+    assert by_name["slow_tool"]["total_calls"] == 2
+    assert by_name["slow_tool"]["avg_duration_ms"] == 1000.0
+    # percentile_cont(0.95) over [900, 1100] interpolates to 1090
+    assert by_name["slow_tool"]["p95_duration_ms"] == 1090.0
+    assert by_name["slow_tool"]["span_type"] == "TOOL"
+    assert by_name["fast_tool"]["error_count"] == 1
+    assert by_name["Model.invoke"]["span_type"] == "LLM"
+    for row in rows:
+        assert "attributes" not in row
+
+
+def test_get_span_stats_filters_and_sorting(postgres_db_real: PostgresDb):
+    trace = _make_trace(agent_id="agent-1", session_id="s1")
+    other = _make_trace(agent_id="agent-2", session_id="s2")
+    postgres_db_real.upsert_trace(trace)
+    postgres_db_real.upsert_trace(other)
+    postgres_db_real.create_spans(
+        [
+            _make_span(trace.trace_id, name="tool_a", duration_ms=1000),
+            _make_span(trace.trace_id, name="tool_b", duration_ms=10),
+            _make_span(other.trace_id, name="tool_c", duration_ms=10),
+            _make_span(trace.trace_id, name="Model.invoke", span_type="LLM", duration_ms=500),
+        ]
+    )
+
+    tool_rows, tool_total = postgres_db_real.get_span_stats(span_type="TOOL", sort_by="p95_duration_ms")
+    assert tool_total == 3
+    assert tool_rows[0]["name"] == "tool_a"
+
+    agent_rows, agent_total = postgres_db_real.get_span_stats(agent_id="agent-1")
+    assert agent_total == 3
+    assert "tool_c" not in {row["name"] for row in agent_rows}
+
+    start_time = datetime.now(timezone.utc) - timedelta(minutes=60)
+    windowed_rows, _ = postgres_db_real.get_span_stats(start_time=start_time)
+    assert {row["name"] for row in windowed_rows} == {"tool_a", "tool_b", "tool_c", "Model.invoke"}
+
+
+def test_get_metrics_refreshes_lazily(postgres_db_real: PostgresDb):
+    now = int(time.time())
+    session = AgentSession(
+        session_id=str(uuid.uuid4()),
+        agent_id="agent-1",
+        user_id="user-1",
+        created_at=now,
+        updated_at=now,
+    )
+    postgres_db_real.upsert_session(session)
+
+    # No calculate_metrics call: get_metrics must refresh on its own
+    rows, _ = postgres_db_real.get_metrics()
+
+    assert len(rows) == 1
+    assert rows[0]["agent_sessions_count"] == 1

--- a/libs/agno/tests/integration/db/postgres/test_trace_span_stats.py
+++ b/libs/agno/tests/integration/db/postgres/test_trace_span_stats.py
@@ -1,13 +1,32 @@
-"""Integration tests for component-grouped trace stats, span stats and lazy metrics on PostgresDb"""
+"""Integration tests for component-grouped trace stats, span stats and lazy metrics on PostgresDb.
+
+Each test gets its own PostgresDb with a dedicated schema and engine, so it is
+immune to the shared test_schema teardown ordering issues.
+"""
 
 import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
+import pytest
+from sqlalchemy import create_engine, text
+
 from agno.db.postgres.postgres import PostgresDb
 from agno.session.agent import AgentSession
 from agno.tracing.schemas import Span, Trace
+
+
+@pytest.fixture
+def stats_db():
+    schema = f"agentos_stats_{uuid.uuid4().hex[:8]}"
+    engine = create_engine("postgresql+psycopg://ai:ai@localhost:5532/ai")
+    db = PostgresDb(db_engine=engine, db_schema=schema)
+    yield db
+    with engine.connect() as conn:
+        conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        conn.commit()
+    engine.dispose()
 
 
 def _make_trace(
@@ -19,11 +38,12 @@ def _make_trace(
     duration_ms: int = 100,
     status: str = "OK",
     minutes_ago: int = 5,
+    name: str = "Agent.run",
 ) -> Trace:
     start = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
     return Trace(
         trace_id=str(uuid.uuid4()),
-        name="Agent.run",
+        name=name,
         status=status,
         start_time=start,
         end_time=start + timedelta(milliseconds=duration_ms),
@@ -66,11 +86,11 @@ def _make_span(
     )
 
 
-def test_get_trace_stats_default_shape_unchanged(postgres_db_real: PostgresDb):
-    postgres_db_real.upsert_trace(_make_trace(agent_id="agent-1", session_id="session-1"))
-    postgres_db_real.upsert_trace(_make_trace(agent_id="agent-2", session_id="session-2"))
+def test_get_trace_stats_default_shape_unchanged(stats_db: PostgresDb):
+    stats_db.upsert_trace(_make_trace(agent_id="agent-1", session_id="session-1"))
+    stats_db.upsert_trace(_make_trace(agent_id="agent-2", session_id="session-2"))
 
-    rows, total = postgres_db_real.get_trace_stats()
+    rows, total = stats_db.get_trace_stats()
 
     assert total == 2
     expected_keys = {
@@ -88,13 +108,13 @@ def test_get_trace_stats_default_shape_unchanged(postgres_db_real: PostgresDb):
         assert isinstance(row["first_trace_at"], datetime)
 
 
-def test_get_trace_stats_group_by_agent(postgres_db_real: PostgresDb):
-    postgres_db_real.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1", duration_ms=100))
-    postgres_db_real.upsert_trace(_make_trace(agent_id="agent-1", session_id="s2", duration_ms=300, status="ERROR"))
-    postgres_db_real.upsert_trace(_make_trace(agent_id="agent-2", session_id="s3", duration_ms=50))
-    postgres_db_real.upsert_trace(_make_trace(session_id=None, user_id=None))  # endpoint-level, excluded
+def test_get_trace_stats_group_by_agent(stats_db: PostgresDb):
+    stats_db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1", duration_ms=100))
+    stats_db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s2", duration_ms=300, status="ERROR"))
+    stats_db.upsert_trace(_make_trace(agent_id="agent-2", session_id="s3", duration_ms=50))
+    stats_db.upsert_trace(_make_trace(session_id=None, user_id=None))  # endpoint-level, excluded
 
-    rows, total = postgres_db_real.get_trace_stats(group_by="agent")
+    rows, total = stats_db.get_trace_stats(group_by="agent")
 
     assert total == 2
     top = rows[0]
@@ -108,23 +128,28 @@ def test_get_trace_stats_group_by_agent(postgres_db_real: PostgresDb):
     assert top["error_traces"] == 1
 
 
-def test_get_trace_stats_group_by_team_and_workflow(postgres_db_real: PostgresDb):
-    postgres_db_real.upsert_trace(_make_trace(team_id="team-1", session_id="s1"))
-    postgres_db_real.upsert_trace(_make_trace(workflow_id="wf-1", session_id="s2"))
+def test_get_trace_stats_group_by_team_workflow_endpoint(stats_db: PostgresDb):
+    stats_db.upsert_trace(_make_trace(team_id="team-1", session_id="s1"))
+    stats_db.upsert_trace(_make_trace(workflow_id="wf-1", session_id="s2"))
+    stats_db.upsert_trace(_make_trace(session_id=None, user_id=None, name="tools/call run_agent"))
 
-    team_rows, team_total = postgres_db_real.get_trace_stats(group_by="team")
-    workflow_rows, workflow_total = postgres_db_real.get_trace_stats(group_by="workflow")
+    team_rows, team_total = stats_db.get_trace_stats(group_by="team")
+    workflow_rows, workflow_total = stats_db.get_trace_stats(group_by="workflow")
+    endpoint_rows, endpoint_total = stats_db.get_trace_stats(group_by="endpoint")
 
     assert team_total == 1
     assert team_rows[0]["team_id"] == "team-1"
     assert workflow_total == 1
     assert workflow_rows[0]["workflow_id"] == "wf-1"
+    assert endpoint_total == 1
+    assert endpoint_rows[0]["name"] == "tools/call run_agent"
+    assert endpoint_rows[0]["total_traces"] == 1
 
 
-def test_get_span_stats_aggregates_and_extracts_span_type(postgres_db_real: PostgresDb):
+def test_get_span_stats_aggregates_and_extracts_span_type(stats_db: PostgresDb):
     trace = _make_trace(agent_id="agent-1", session_id="s1")
-    postgres_db_real.upsert_trace(trace)
-    postgres_db_real.create_spans(
+    stats_db.upsert_trace(trace)
+    stats_db.create_spans(
         [
             _make_span(trace.trace_id, name="slow_tool", duration_ms=900),
             _make_span(trace.trace_id, name="slow_tool", duration_ms=1100),
@@ -133,7 +158,7 @@ def test_get_span_stats_aggregates_and_extracts_span_type(postgres_db_real: Post
         ]
     )
 
-    rows, total = postgres_db_real.get_span_stats()
+    rows, total = stats_db.get_span_stats()
 
     assert total == 3
     by_name = {row["name"]: row for row in rows}
@@ -148,46 +173,64 @@ def test_get_span_stats_aggregates_and_extracts_span_type(postgres_db_real: Post
         assert "attributes" not in row
 
 
-def test_get_span_stats_filters_and_sorting(postgres_db_real: PostgresDb):
+def test_get_span_stats_filters_and_sorting(stats_db: PostgresDb):
     trace = _make_trace(agent_id="agent-1", session_id="s1")
     other = _make_trace(agent_id="agent-2", session_id="s2")
-    postgres_db_real.upsert_trace(trace)
-    postgres_db_real.upsert_trace(other)
-    postgres_db_real.create_spans(
+    stats_db.upsert_trace(trace)
+    stats_db.upsert_trace(other)
+    stats_db.create_spans(
         [
             _make_span(trace.trace_id, name="tool_a", duration_ms=1000),
             _make_span(trace.trace_id, name="tool_b", duration_ms=10),
             _make_span(other.trace_id, name="tool_c", duration_ms=10),
+            _make_span(trace.trace_id, name="old_tool", minutes_ago=120),
             _make_span(trace.trace_id, name="Model.invoke", span_type="LLM", duration_ms=500),
         ]
     )
 
-    tool_rows, tool_total = postgres_db_real.get_span_stats(span_type="TOOL", sort_by="p95_duration_ms")
-    assert tool_total == 3
+    tool_rows, tool_total = stats_db.get_span_stats(span_type="TOOL", sort_by="p95_duration_ms")
+    assert tool_total == 4
     assert tool_rows[0]["name"] == "tool_a"
 
-    agent_rows, agent_total = postgres_db_real.get_span_stats(agent_id="agent-1")
-    assert agent_total == 3
+    agent_rows, agent_total = stats_db.get_span_stats(agent_id="agent-1")
+    assert agent_total == 4
     assert "tool_c" not in {row["name"] for row in agent_rows}
 
+    # The span 120 minutes old must fall outside a 60-minute window
     start_time = datetime.now(timezone.utc) - timedelta(minutes=60)
-    windowed_rows, _ = postgres_db_real.get_span_stats(start_time=start_time)
-    assert {row["name"] for row in windowed_rows} == {"tool_a", "tool_b", "tool_c", "Model.invoke"}
+    windowed_rows, _ = stats_db.get_span_stats(start_time=start_time)
+    windowed_names = {row["name"] for row in windowed_rows}
+    assert "old_tool" not in windowed_names
+    assert windowed_names == {"tool_a", "tool_b", "tool_c", "Model.invoke"}
+
+    # And only it survives an end_time cap before the recent spans
+    end_time = datetime.now(timezone.utc) - timedelta(minutes=60)
+    capped_rows, _ = stats_db.get_span_stats(end_time=end_time)
+    assert {row["name"] for row in capped_rows} == {"old_tool"}
 
 
-def test_get_metrics_refreshes_lazily(postgres_db_real: PostgresDb):
-    now = int(time.time())
-    session = AgentSession(
-        session_id=str(uuid.uuid4()),
-        agent_id="agent-1",
-        user_id="user-1",
-        created_at=now,
-        updated_at=now,
-    )
-    postgres_db_real.upsert_session(session)
+def test_get_metrics_refreshes_lazily_and_throttles(stats_db: PostgresDb):
+    def seed_session(user_id: str) -> None:
+        now = int(time.time())
+        stats_db.upsert_session(
+            AgentSession(
+                session_id=str(uuid.uuid4()), agent_id="agent-1", user_id=user_id, created_at=now, updated_at=now
+            )
+        )
+
+    seed_session("user-1")
 
     # No calculate_metrics call: get_metrics must refresh on its own
-    rows, _ = postgres_db_real.get_metrics()
-
+    rows, _ = stats_db.get_metrics()
     assert len(rows) == 1
     assert rows[0]["agent_sessions_count"] == 1
+
+    # A second read within the throttle window must not recompute
+    seed_session("user-2")
+    rows, _ = stats_db.get_metrics()
+    assert rows[0]["agent_sessions_count"] == 1
+
+    # Expiring the throttle picks the new session up
+    stats_db._metrics_refreshed_at = 0.0
+    rows, _ = stats_db.get_metrics()
+    assert rows[0]["agent_sessions_count"] == 2

--- a/libs/agno/tests/integration/db/postgres/test_trace_span_stats.py
+++ b/libs/agno/tests/integration/db/postgres/test_trace_span_stats.py
@@ -209,6 +209,26 @@ def test_get_span_stats_filters_and_sorting(stats_db: PostgresDb):
     assert {row["name"] for row in capped_rows} == {"old_tool"}
 
 
+def test_get_span_stats_paging_with_tied_name_groups_is_lossless(stats_db: PostgresDb):
+    trace = _make_trace(agent_id="agent-1", session_id="s1")
+    stats_db.upsert_trace(trace)
+    # 8 groups sharing one name, all tied on every aggregate: only the
+    # (name, span_type) ORDER BY tiebreak makes paging deterministic
+    stats_db.create_spans([_make_span(trace.trace_id, name="dup", span_type=f"KIND{i:02d}") for i in range(20)])
+
+    seen = []
+    total = 0
+    for page in range(1, 24):
+        rows, total = stats_db.get_span_stats(limit=3, page=page)
+        if not rows:
+            break
+        seen.extend((row["name"], row["span_type"]) for row in rows)
+
+    assert total == 20
+    assert len(seen) == 20
+    assert len(set(seen)) == 20
+
+
 def test_get_metrics_refreshes_lazily_and_throttles(stats_db: PostgresDb):
     def seed_session(user_id: str) -> None:
         now = int(time.time())

--- a/libs/agno/tests/unit/tools/test_agentos.py
+++ b/libs/agno/tests/unit/tools/test_agentos.py
@@ -252,6 +252,23 @@ class TestTraceStatsGroupBy:
 
         assert rows[0]["total_traces"] == 1
 
+    def test_group_by_endpoint(self, db):
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1"))
+        endpoint_trace = _make_trace(session_id=None, user_id=None, duration_ms=40)
+        db.upsert_trace(endpoint_trace)
+        other_endpoint = _make_trace(session_id=None, user_id=None, duration_ms=60)
+        other_endpoint.name = "tools/list"
+        db.upsert_trace(other_endpoint)
+
+        rows, total = db.get_trace_stats(group_by="endpoint")
+
+        assert total == 2
+        by_name = {row["name"]: row for row in rows}
+        # Only traces with no component ids at all are endpoint-level
+        assert by_name["Agent.run"]["total_traces"] == 1
+        assert by_name["Agent.run"]["avg_duration_ms"] == 40.0
+        assert by_name["tools/list"]["total_traces"] == 1
+
 
 # ----------------------------------------------------------------------
 # Db layer: get_span_stats
@@ -350,7 +367,7 @@ class TestSpanStats:
 
 
 class TestGetRunActivity:
-    def test_reports_components_and_unattributed(self, db, toolkit):
+    def test_reports_components_and_endpoint_level(self, db, toolkit):
         db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1", duration_ms=100))
         db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s2", duration_ms=300))
         db.upsert_trace(_make_trace(team_id="team-1", session_id="s3"))
@@ -359,18 +376,30 @@ class TestGetRunActivity:
         out = _loads(toolkit.get_run_activity(days=7))
 
         assert out["total_traces"] == 4
-        assert out["unattributed_traces"] == 1
         assert [(r["agent_id"], r["total_traces"]) for r in out["agents"]] == [("agent-1", 2)]
         assert [(r["team_id"], r["total_traces"]) for r in out["teams"]] == [("team-1", 1)]
         assert out["workflows"] == []
-        assert any("endpoint-level" in note for note in out["notes"])
+        assert [(r["name"], r["total_traces"]) for r in out["endpoint_level"]] == [("Agent.run", 1)]
+        assert any("endpoint_level" in note for note in out["notes"])
 
     def test_empty_platform(self, toolkit):
         out = _loads(toolkit.get_run_activity())
 
         assert out["total_traces"] == 0
         assert out["agents"] == []
-        assert out["unattributed_traces"] == 0
+        assert out["endpoint_level"] == []
+
+    def test_truncation_note(self, db, toolkit, monkeypatch):
+        import agno.tools.agentos as agentos_module
+
+        monkeypatch.setattr(agentos_module, "_GROUP_LIMIT", 1)
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1"))
+        db.upsert_trace(_make_trace(agent_id="agent-2", session_id="s2"))
+
+        out = _loads(toolkit.get_run_activity())
+
+        assert len(out["agents"]) == 1
+        assert any("top 1 of 2 agents" in note for note in out["notes"])
 
 
 # ----------------------------------------------------------------------
@@ -398,6 +427,16 @@ class TestGetToolActivity:
         assert [r["name"] for r in out["model_calls"]] == ["Model.invoke"]
         # SQLite has no percentile support, the payload must say so
         assert any("p95" in note for note in out["notes"])
+
+    def test_truncation_note(self, db, toolkit):
+        trace = _make_trace(agent_id="agent-1", session_id="s1")
+        db.upsert_trace(trace)
+        db.create_spans([_make_span(trace.trace_id, name=f"tool_{i:02d}") for i in range(16)])
+
+        out = _loads(toolkit.get_tool_activity())
+
+        assert len(out["tools_most_used"]) == 15
+        assert any("top 15 of 16 tools" in note for note in out["notes"])
 
 
 # ----------------------------------------------------------------------
@@ -430,6 +469,49 @@ class TestGetPlatformMetrics:
 
         assert out["daily"] == []
         assert any("no metrics" in note for note in out["notes"])
+
+
+class TestLazyMetricsRefresh:
+    def _seed_session(self, db, agent_id="agent-1", user_id="user-1"):
+        from agno.session.agent import AgentSession
+
+        now = int(time.time())
+        db.upsert_session(
+            AgentSession(
+                session_id=str(uuid.uuid4()), agent_id=agent_id, user_id=user_id, created_at=now, updated_at=now
+            )
+        )
+
+    def test_get_metrics_refreshes_lazily(self, db):
+        self._seed_session(db)
+
+        # No calculate_metrics call: get_metrics must refresh on its own
+        rows, _ = db.get_metrics()
+
+        assert len(rows) == 1
+        assert rows[0]["agent_sessions_count"] == 1
+
+    def test_refresh_is_throttled(self, db):
+        self._seed_session(db)
+        rows, _ = db.get_metrics()
+        assert rows[0]["agent_sessions_count"] == 1
+
+        # A second read within the throttle window must not recompute
+        self._seed_session(db, user_id="user-2")
+        rows, _ = db.get_metrics()
+        assert rows[0]["agent_sessions_count"] == 1
+
+        # Expiring the throttle picks the new session up
+        db._metrics_refreshed_at = 0.0
+        rows, _ = db.get_metrics()
+        assert rows[0]["agent_sessions_count"] == 2
+
+    def test_explicit_calculate_stamps_the_throttle(self, db):
+        self._seed_session(db)
+
+        db.calculate_metrics()
+
+        assert db._metrics_refreshed_at > 0.0
 
 
 # ----------------------------------------------------------------------
@@ -682,6 +764,49 @@ class TestAsyncVariants:
 
         assert out["total_traces"] == 1
         assert out["agents"][0]["agent_id"] == "agent-1"
+
+    @pytest.mark.asyncio
+    async def test_async_trace_stats_aggregates(self, async_db):
+        await async_db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1", duration_ms=100))
+        await async_db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s2", duration_ms=300, status="ERROR"))
+        await async_db.upsert_trace(_make_trace(session_id=None, user_id=None))
+
+        rows, total = await async_db.get_trace_stats(group_by="agent")
+
+        assert total == 1
+        top = rows[0]
+        assert top["agent_id"] == "agent-1"
+        assert top["total_traces"] == 2
+        assert top["total_sessions"] == 2
+        assert top["avg_duration_ms"] == 200.0
+        assert top["max_duration_ms"] == 300
+        assert top["error_traces"] == 1
+        assert top["p95_duration_ms"] is None
+
+        endpoint_rows, endpoint_total = await async_db.get_trace_stats(group_by="endpoint")
+        assert endpoint_total == 1
+        assert endpoint_rows[0]["name"] == "Agent.run"
+
+    @pytest.mark.asyncio
+    async def test_async_span_stats_aggregates(self, async_db):
+        trace = _make_trace(agent_id="agent-1", session_id="s1")
+        await async_db.upsert_trace(trace)
+        await async_db.create_spans(
+            [
+                _make_span(trace.trace_id, name="my_tool", duration_ms=100),
+                _make_span(trace.trace_id, name="my_tool", duration_ms=300, status_code="ERROR"),
+            ]
+        )
+
+        rows, total = await async_db.get_span_stats()
+
+        assert total == 1
+        assert rows[0]["name"] == "my_tool"
+        assert rows[0]["total_calls"] == 2
+        assert rows[0]["avg_duration_ms"] == 200.0
+        assert rows[0]["max_duration_ms"] == 300
+        assert rows[0]["error_count"] == 1
+        assert rows[0]["span_type"] == "TOOL"
 
     @pytest.mark.asyncio
     async def test_async_span_stats_path(self, async_db):

--- a/libs/agno/tests/unit/tools/test_agentos.py
+++ b/libs/agno/tests/unit/tools/test_agentos.py
@@ -1,0 +1,711 @@
+"""Unit tests for AgentOSTools toolkit.
+
+Uses a real SqliteDb (and AsyncSqliteDb) backed by a pytest tmp_path so the
+full db read path is exercised, not mocked.
+"""
+
+import json
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+import pytest
+
+from agno.db.schemas.evals import EvalRunRecord, EvalType
+from agno.db.schemas.scheduler import Schedule, ScheduleRun
+from agno.db.sqlite import SqliteDb
+from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+from agno.tools.agentos import AgentOSTools
+from agno.tracing.schemas import Span, Trace
+
+# ----------------------------------------------------------------------
+# Fixtures and helpers
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SqliteDb(id="agentos-test-db", db_file=str(tmp_path / "agentos.db"))
+
+
+@pytest.fixture
+def async_db(tmp_path):
+    return AsyncSqliteDb(id="agentos-test-async-db", db_file=str(tmp_path / "agentos_async.db"))
+
+
+@pytest.fixture
+def toolkit(db):
+    return AgentOSTools(db=db)
+
+
+def _loads(s: str) -> Dict[str, Any]:
+    return json.loads(s)
+
+
+def _make_trace(
+    agent_id: Optional[str] = None,
+    team_id: Optional[str] = None,
+    workflow_id: Optional[str] = None,
+    session_id: Optional[str] = "session-1",
+    user_id: Optional[str] = "user-1",
+    duration_ms: int = 100,
+    status: str = "OK",
+    minutes_ago: int = 5,
+) -> Trace:
+    start = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+    return Trace(
+        trace_id=str(uuid.uuid4()),
+        name="Agent.run",
+        status=status,
+        start_time=start,
+        end_time=start + timedelta(milliseconds=duration_ms),
+        duration_ms=duration_ms,
+        total_spans=0,
+        error_count=1 if status == "ERROR" else 0,
+        run_id=None,
+        session_id=session_id,
+        user_id=user_id,
+        agent_id=agent_id,
+        team_id=team_id,
+        workflow_id=workflow_id,
+        created_at=start,
+    )
+
+
+def _make_span(
+    trace_id: str,
+    name: str = "my_tool",
+    span_type: Optional[str] = "TOOL",
+    duration_ms: int = 100,
+    status_code: str = "OK",
+    minutes_ago: int = 5,
+) -> Span:
+    start = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+    attributes: Dict[str, Any] = {"openinference.span.kind": span_type} if span_type else {}
+    return Span(
+        span_id=str(uuid.uuid4()),
+        trace_id=trace_id,
+        parent_span_id=None,
+        name=name,
+        span_kind="INTERNAL",
+        status_code=status_code,
+        status_message=None,
+        start_time=start,
+        end_time=start + timedelta(milliseconds=duration_ms),
+        duration_ms=duration_ms,
+        attributes=attributes,
+        created_at=start,
+    )
+
+
+ALL_TOOLS = {
+    "get_platform_metrics",
+    "get_run_activity",
+    "get_tool_activity",
+    "get_eval_history",
+    "list_schedules",
+    "get_schedule_history",
+    "list_platform_components",
+    "list_pending_approvals",
+}
+
+
+# ----------------------------------------------------------------------
+# Initialization and flags
+# ----------------------------------------------------------------------
+
+
+class TestInitialization:
+    def test_default_registers_all_tools(self, toolkit):
+        assert ALL_TOOLS == set(toolkit.functions.keys())
+
+    def test_async_variants_match_sync(self, toolkit):
+        assert set(toolkit.async_functions.keys()) == set(toolkit.functions.keys())
+
+    def test_flags_disable_surfaces(self, db):
+        toolkit = AgentOSTools(db=db, schedules=False, approvals=False, components=False)
+        expected = ALL_TOOLS - {
+            "list_schedules",
+            "get_schedule_history",
+            "list_pending_approvals",
+            "list_platform_components",
+        }
+        assert expected == set(toolkit.functions.keys())
+
+    def test_metrics_only(self, db):
+        toolkit = AgentOSTools(db=db, traces=False, schedules=False, evals=False, components=False, approvals=False)
+        assert {"get_platform_metrics"} == set(toolkit.functions.keys())
+
+    def test_add_instructions_defaults_on_and_respects_override(self, db):
+        assert AgentOSTools(db=db).add_instructions is True
+        assert AgentOSTools(db=db, add_instructions=False).add_instructions is False
+
+    def test_instructions_mention_read_only(self, toolkit):
+        assert "read-only" in toolkit.instructions
+
+    def test_requires_db(self):
+        with pytest.raises(ValueError):
+            AgentOSTools(db=None)  # type: ignore[arg-type]
+
+    def test_async_db_disables_components_by_default(self, async_db):
+        toolkit = AgentOSTools(db=async_db)
+        assert "list_platform_components" not in toolkit.functions
+        assert ALL_TOOLS - {"list_platform_components"} == set(toolkit.functions.keys())
+
+    def test_async_db_components_true_raises(self, async_db):
+        with pytest.raises(ValueError):
+            AgentOSTools(db=async_db, components=True)
+
+
+# ----------------------------------------------------------------------
+# Db layer: get_trace_stats default shape (backwards compatibility)
+# ----------------------------------------------------------------------
+
+
+class TestTraceStatsDefaultShape:
+    def test_default_output_shape_is_unchanged(self, db):
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="session-1", minutes_ago=10))
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="session-1", minutes_ago=9))
+        db.upsert_trace(_make_trace(agent_id="agent-2", session_id="session-2", minutes_ago=1))
+
+        rows, total = db.get_trace_stats()
+
+        assert total == 2
+        assert len(rows) == 2
+        expected_keys = {
+            "session_id",
+            "user_id",
+            "agent_id",
+            "team_id",
+            "workflow_id",
+            "total_traces",
+            "first_trace_at",
+            "last_trace_at",
+        }
+        for row in rows:
+            assert set(row.keys()) == expected_keys
+            assert isinstance(row["first_trace_at"], datetime)
+            assert isinstance(row["last_trace_at"], datetime)
+        # Ordered by last activity, most recent session first
+        assert rows[0]["session_id"] == "session-2"
+        assert rows[1]["total_traces"] == 2
+
+    def test_invalid_group_by_raises(self, db):
+        with pytest.raises(ValueError):
+            db.get_trace_stats(group_by="bogus")  # type: ignore[arg-type]
+
+
+# ----------------------------------------------------------------------
+# Db layer: get_trace_stats component groupings
+# ----------------------------------------------------------------------
+
+
+class TestTraceStatsGroupBy:
+    def test_group_by_agent_aggregates(self, db):
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1", duration_ms=100))
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s2", duration_ms=300, status="ERROR"))
+        db.upsert_trace(_make_trace(agent_id="agent-2", session_id="s3", duration_ms=50))
+        # Endpoint-level trace: no component ids, must be excluded from the grouping
+        db.upsert_trace(_make_trace(session_id=None, user_id=None))
+
+        rows, total = db.get_trace_stats(group_by="agent")
+
+        assert total == 2
+        assert len(rows) == 2
+        # Ordered by total_traces descending
+        top = rows[0]
+        assert top["agent_id"] == "agent-1"
+        assert top["total_traces"] == 2
+        assert top["total_sessions"] == 2
+        assert top["avg_duration_ms"] == 200.0
+        assert top["max_duration_ms"] == 300
+        assert top["error_traces"] == 1
+        assert top["p95_duration_ms"] is None  # SQLite has no percentile function
+        assert isinstance(top["first_trace_at"], datetime)
+        assert isinstance(top["last_trace_at"], datetime)
+
+    def test_group_by_workflow(self, db):
+        db.upsert_trace(_make_trace(workflow_id="wf-1", session_id="s1", duration_ms=1000))
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s2"))
+
+        rows, total = db.get_trace_stats(group_by="workflow")
+
+        assert total == 1
+        assert rows[0]["workflow_id"] == "wf-1"
+        assert rows[0]["total_traces"] == 1
+
+    def test_group_by_respects_filters(self, db):
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1", user_id="user-1"))
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s2", user_id="user-2"))
+
+        rows, _ = db.get_trace_stats(group_by="agent", user_id="user-2")
+
+        assert rows[0]["total_traces"] == 1
+
+    def test_group_by_respects_time_window(self, db):
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1", minutes_ago=120))
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s2", minutes_ago=5))
+
+        start_time = datetime.now(timezone.utc) - timedelta(minutes=60)
+        rows, _ = db.get_trace_stats(group_by="agent", start_time=start_time)
+
+        assert rows[0]["total_traces"] == 1
+
+
+# ----------------------------------------------------------------------
+# Db layer: get_span_stats
+# ----------------------------------------------------------------------
+
+
+class TestSpanStats:
+    def _seed(self, db):
+        trace = _make_trace(agent_id="agent-1", session_id="s1")
+        db.upsert_trace(trace)
+        db.create_spans(
+            [
+                _make_span(trace.trace_id, name="slow_tool", duration_ms=900),
+                _make_span(trace.trace_id, name="slow_tool", duration_ms=1100),
+                _make_span(trace.trace_id, name="fast_tool", duration_ms=10),
+                _make_span(trace.trace_id, name="fast_tool", duration_ms=20),
+                _make_span(trace.trace_id, name="fast_tool", duration_ms=30, status_code="ERROR"),
+                _make_span(trace.trace_id, name="Model.invoke", span_type="LLM", duration_ms=500),
+            ]
+        )
+        return trace
+
+    def test_aggregates_by_name(self, db):
+        self._seed(db)
+
+        rows, total = db.get_span_stats()
+
+        assert total == 3
+        by_name = {row["name"]: row for row in rows}
+        assert by_name["slow_tool"]["total_calls"] == 2
+        assert by_name["slow_tool"]["avg_duration_ms"] == 1000.0
+        assert by_name["slow_tool"]["max_duration_ms"] == 1100
+        assert by_name["slow_tool"]["span_type"] == "TOOL"
+        assert by_name["fast_tool"]["error_count"] == 1
+        assert by_name["Model.invoke"]["span_type"] == "LLM"
+        assert isinstance(by_name["slow_tool"]["last_called_at"], datetime)
+
+    def test_span_type_filter(self, db):
+        self._seed(db)
+
+        rows, total = db.get_span_stats(span_type="TOOL")
+
+        assert total == 2
+        assert {row["name"] for row in rows} == {"slow_tool", "fast_tool"}
+
+    def test_name_filter(self, db):
+        self._seed(db)
+
+        rows, total = db.get_span_stats(name="slow_tool")
+
+        assert total == 1
+        assert rows[0]["total_calls"] == 2
+
+    def test_sort_by_avg_duration(self, db):
+        self._seed(db)
+
+        rows, _ = db.get_span_stats(span_type="TOOL", sort_by="avg_duration_ms")
+
+        assert rows[0]["name"] == "slow_tool"
+
+    def test_component_filter_joins_traces(self, db):
+        self._seed(db)
+        other_trace = _make_trace(agent_id="agent-2", session_id="s2")
+        db.upsert_trace(other_trace)
+        db.create_span(_make_span(other_trace.trace_id, name="other_tool"))
+
+        rows, total = db.get_span_stats(agent_id="agent-1")
+
+        assert total == 3
+        assert "other_tool" not in {row["name"] for row in rows}
+
+    def test_time_window(self, db):
+        trace = _make_trace(agent_id="agent-1", session_id="s1")
+        db.upsert_trace(trace)
+        db.create_span(_make_span(trace.trace_id, name="old_tool", minutes_ago=120))
+        db.create_span(_make_span(trace.trace_id, name="new_tool", minutes_ago=5))
+
+        start_time = datetime.now(timezone.utc) - timedelta(minutes=60)
+        rows, total = db.get_span_stats(start_time=start_time)
+
+        assert total == 1
+        assert rows[0]["name"] == "new_tool"
+
+    def test_never_returns_attributes(self, db):
+        self._seed(db)
+
+        rows, _ = db.get_span_stats()
+
+        for row in rows:
+            assert "attributes" not in row
+
+
+# ----------------------------------------------------------------------
+# Toolkit: run activity
+# ----------------------------------------------------------------------
+
+
+class TestGetRunActivity:
+    def test_reports_components_and_unattributed(self, db, toolkit):
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1", duration_ms=100))
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s2", duration_ms=300))
+        db.upsert_trace(_make_trace(team_id="team-1", session_id="s3"))
+        db.upsert_trace(_make_trace(session_id=None, user_id=None))  # endpoint-level
+
+        out = _loads(toolkit.get_run_activity(days=7))
+
+        assert out["total_traces"] == 4
+        assert out["unattributed_traces"] == 1
+        assert [(r["agent_id"], r["total_traces"]) for r in out["agents"]] == [("agent-1", 2)]
+        assert [(r["team_id"], r["total_traces"]) for r in out["teams"]] == [("team-1", 1)]
+        assert out["workflows"] == []
+        assert any("endpoint-level" in note for note in out["notes"])
+
+    def test_empty_platform(self, toolkit):
+        out = _loads(toolkit.get_run_activity())
+
+        assert out["total_traces"] == 0
+        assert out["agents"] == []
+        assert out["unattributed_traces"] == 0
+
+
+# ----------------------------------------------------------------------
+# Toolkit: tool activity
+# ----------------------------------------------------------------------
+
+
+class TestGetToolActivity:
+    def test_reports_tools_and_model_calls(self, db, toolkit):
+        trace = _make_trace(agent_id="agent-1", session_id="s1")
+        db.upsert_trace(trace)
+        db.create_spans(
+            [
+                _make_span(trace.trace_id, name="busy_tool", duration_ms=10),
+                _make_span(trace.trace_id, name="busy_tool", duration_ms=20),
+                _make_span(trace.trace_id, name="slow_tool", duration_ms=2000),
+                _make_span(trace.trace_id, name="Model.invoke", span_type="LLM", duration_ms=500),
+            ]
+        )
+
+        out = _loads(toolkit.get_tool_activity(days=7))
+
+        assert out["tools_most_used"][0]["name"] == "busy_tool"
+        assert out["tools_slowest"][0]["name"] == "slow_tool"
+        assert [r["name"] for r in out["model_calls"]] == ["Model.invoke"]
+        # SQLite has no percentile support, the payload must say so
+        assert any("p95" in note for note in out["notes"])
+
+
+# ----------------------------------------------------------------------
+# Toolkit: platform metrics
+# ----------------------------------------------------------------------
+
+
+class TestGetPlatformMetrics:
+    def test_calculates_and_reports(self, db, toolkit):
+        from agno.session.agent import AgentSession
+
+        now = int(time.time())
+        session = AgentSession(
+            session_id=str(uuid.uuid4()),
+            agent_id="agent-1",
+            user_id="user-1",
+            created_at=now,
+            updated_at=now,
+        )
+        db.upsert_session(session)
+
+        out = _loads(toolkit.get_platform_metrics(days=7))
+
+        assert out["totals"]["agent_sessions"] == 1
+        assert len(out["daily"]) == 1
+        assert out["daily"][0]["distinct_users"] == 1
+
+    def test_empty_platform_notes_absence(self, toolkit):
+        out = _loads(toolkit.get_platform_metrics())
+
+        assert out["daily"] == []
+        assert any("no metrics" in note for note in out["notes"])
+
+
+# ----------------------------------------------------------------------
+# Toolkit: eval history
+# ----------------------------------------------------------------------
+
+
+class TestGetEvalHistory:
+    def test_normalizes_pass_fail_and_reasons(self, db, toolkit):
+        db.create_eval_run(
+            EvalRunRecord(
+                run_id="eval-1",
+                eval_type=EvalType.RELIABILITY,
+                eval_data={"eval_status": "PASSED", "failed_tool_calls": []},
+                agent_id="agent-1",
+                name="tool check",
+            )
+        )
+        db.create_eval_run(
+            EvalRunRecord(
+                run_id="eval-2",
+                eval_type=EvalType.RELIABILITY,
+                eval_data={"eval_status": "FAILED", "failed_tool_calls": ["web_search"], "missing_tool_calls": []},
+                agent_id="agent-1",
+                name="tool check",
+            )
+        )
+        db.create_eval_run(
+            EvalRunRecord(
+                run_id="eval-3",
+                eval_type=EvalType.AGENT_AS_JUDGE,
+                eval_data={
+                    "pass_rate": 0.0,
+                    "avg_score": 4.0,
+                    "results": [{"passed": False, "reason": "Answer missed the deadline constraint"}],
+                },
+                agent_id="agent-1",
+                name="judge check",
+            )
+        )
+        db.create_eval_run(
+            EvalRunRecord(
+                run_id="eval-4",
+                eval_type=EvalType.ACCURACY,
+                eval_data={"avg_score": 8.5},
+                agent_id="agent-1",
+                name="accuracy check",
+            )
+        )
+
+        out = _loads(toolkit.get_eval_history())
+
+        assert out["total"] == 4
+        by_id = {run["id"]: run for run in out["eval_runs"]}
+        assert by_id["eval-1"]["status"] == "PASS"
+        assert "reason" not in by_id["eval-1"]
+        assert by_id["eval-2"]["status"] == "FAIL"
+        assert by_id["eval-2"]["reason"]["failed_tool_calls"] == ["web_search"]
+        assert by_id["eval-3"]["status"] == "FAIL"
+        assert "deadline" in by_id["eval-3"]["reason"]
+        assert by_id["eval-4"]["status"] == "SCORED"
+        assert by_id["eval-4"]["avg_score"] == 8.5
+
+    def test_truncation_note(self, db, toolkit):
+        for i in range(3):
+            db.create_eval_run(
+                EvalRunRecord(
+                    run_id=f"eval-{i}",
+                    eval_type=EvalType.ACCURACY,
+                    eval_data={"avg_score": 5.0},
+                    agent_id="agent-1",
+                )
+            )
+
+        out = _loads(toolkit.get_eval_history(limit=2))
+
+        assert out["count"] == 2
+        assert out["total"] == 3
+        assert any("most recent" in note for note in out["notes"])
+
+
+# ----------------------------------------------------------------------
+# Toolkit: schedules
+# ----------------------------------------------------------------------
+
+
+class TestSchedules:
+    def _seed(self, db):
+        schedule = Schedule(
+            id="sched-1",
+            name="daily-report",
+            cron_expr="0 9 * * *",
+            endpoint="/agents/reporter/runs",
+        )
+        db.create_schedule(schedule.to_dict())
+        now = int(time.time())
+        db.create_schedule_run(
+            ScheduleRun(
+                id="run-1",
+                schedule_id="sched-1",
+                status="failed",
+                triggered_at=now - 120,
+                error="endpoint timed out",
+                created_at=now - 120,
+            ).to_dict()
+        )
+        db.create_schedule_run(
+            ScheduleRun(
+                id="run-2",
+                schedule_id="sched-1",
+                status="success",
+                triggered_at=now - 60,
+                completed_at=now - 30,
+                status_code=200,
+                created_at=now - 60,
+            ).to_dict()
+        )
+
+    def test_list_schedules_with_last_outcome(self, db, toolkit):
+        self._seed(db)
+
+        out = _loads(toolkit.list_schedules())
+
+        assert out["total"] == 1
+        schedule = out["schedules"][0]
+        assert schedule["name"] == "daily-report"
+        assert schedule["cron_expr"] == "0 9 * * *"
+        assert schedule["last_run"]["status"] == "success"
+
+    def test_schedule_history_summary(self, db, toolkit):
+        self._seed(db)
+
+        out = _loads(toolkit.get_schedule_history("sched-1"))
+
+        assert out["summary"]["status_counts"] == {"success": 1, "failed": 1}
+        assert out["summary"]["last_failure"]["error"] == "endpoint timed out"
+        # Run input/output can hold conversation content and must not be exposed
+        for run in out["runs"]:
+            assert "input" not in run
+            assert "output" not in run
+
+    def test_unsupported_backend_returns_clear_error(self, db, toolkit, monkeypatch):
+        def raise_not_implemented(*args: Any, **kwargs: Any):
+            raise NotImplementedError
+
+        monkeypatch.setattr(db, "get_schedules", raise_not_implemented)
+
+        out = _loads(toolkit.list_schedules())
+
+        assert "not supported" in out["error"]
+
+
+# ----------------------------------------------------------------------
+# Toolkit: components
+# ----------------------------------------------------------------------
+
+
+class TestComponents:
+    def test_lists_components(self, db, toolkit):
+        from agno.db.base import ComponentType
+
+        db.upsert_component(
+            component_id="news-scout",
+            component_type=ComponentType.AGENT,
+            name="News Scout",
+            description="Summarizes tech news",
+        )
+
+        out = _loads(toolkit.list_platform_components())
+
+        assert out["total"] == 1
+        component = out["components"][0]
+        assert component["component_id"] == "news-scout"
+        assert component["component_type"] == "agent"
+        assert component["name"] == "News Scout"
+        assert "current_version" in component
+
+
+# ----------------------------------------------------------------------
+# Toolkit: approvals
+# ----------------------------------------------------------------------
+
+
+class TestPendingApprovals:
+    def test_lists_only_pending_and_hides_tool_args(self, db, toolkit):
+        db.create_approval(
+            {
+                "id": "approval-1",
+                "run_id": "run-1",
+                "session_id": "s1",
+                "status": "pending",
+                "source_type": "agent",
+                "pause_type": "confirmation",
+                "tool_name": "send_email",
+                "tool_args": {"to": "someone@example.com", "body": "private content"},
+                "agent_id": "agent-1",
+                "user_id": "user-1",
+            }
+        )
+        db.create_approval(
+            {
+                "id": "approval-2",
+                "run_id": "run-2",
+                "session_id": "s2",
+                "status": "approved",
+                "source_type": "agent",
+                "pause_type": "confirmation",
+            }
+        )
+
+        out = _loads(toolkit.list_pending_approvals())
+
+        assert out["total"] == 1
+        approval = out["approvals"][0]
+        assert approval["id"] == "approval-1"
+        assert approval["tool_name"] == "send_email"
+        assert "tool_args" not in approval
+        assert "context" not in approval
+
+
+# ----------------------------------------------------------------------
+# Toolkit: error paths
+# ----------------------------------------------------------------------
+
+
+class TestErrorPaths:
+    def test_db_failure_returns_error_payload(self, db, toolkit, monkeypatch):
+        def fail(*args: Any, **kwargs: Any):
+            raise RuntimeError("db exploded")
+
+        monkeypatch.setattr(db, "get_eval_runs", fail)
+
+        out = _loads(toolkit.get_eval_history())
+
+        assert "db exploded" in out["error"]
+
+
+# ----------------------------------------------------------------------
+# Async variants
+# ----------------------------------------------------------------------
+
+
+class TestAsyncVariants:
+    @pytest.mark.asyncio
+    async def test_native_async_path(self, async_db):
+        await async_db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1", duration_ms=100))
+        toolkit = AgentOSTools(db=async_db)
+
+        out = _loads(await toolkit.aget_run_activity(days=7))
+
+        assert out["total_traces"] == 1
+        assert out["agents"][0]["agent_id"] == "agent-1"
+
+    @pytest.mark.asyncio
+    async def test_async_span_stats_path(self, async_db):
+        trace = _make_trace(agent_id="agent-1", session_id="s1")
+        await async_db.upsert_trace(trace)
+        await async_db.create_span(_make_span(trace.trace_id, name="my_tool", duration_ms=100))
+        toolkit = AgentOSTools(db=async_db)
+
+        out = _loads(await toolkit.aget_tool_activity(days=7))
+
+        assert out["tools_most_used"][0]["name"] == "my_tool"
+
+    def test_sync_tool_with_async_db_returns_clear_error(self, async_db):
+        toolkit = AgentOSTools(db=async_db)
+
+        out = _loads(toolkit.get_run_activity())
+
+        assert "async" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_async_wrapper_with_sync_db(self, db):
+        db.upsert_trace(_make_trace(agent_id="agent-1", session_id="s1"))
+        toolkit = AgentOSTools(db=db)
+
+        out = _loads(await toolkit.aget_run_activity())
+
+        assert out["agents"][0]["agent_id"] == "agent-1"

--- a/libs/agno/tests/unit/tools/test_agentos.py
+++ b/libs/agno/tests/unit/tools/test_agentos.py
@@ -352,6 +352,24 @@ class TestSpanStats:
         assert total == 1
         assert rows[0]["name"] == "new_tool"
 
+    def test_paging_with_tied_name_groups_is_lossless(self, db):
+        trace = _make_trace(agent_id="agent-1")
+        db.upsert_trace(trace)
+        for i in range(20):
+            db.create_spans([_make_span(trace.trace_id, name="dup", span_type=f"KIND{i:02d}")])
+
+        seen = []
+        total = 0
+        for page in range(1, 24):
+            rows, total = db.get_span_stats(limit=3, page=page)
+            if not rows:
+                break
+            seen.extend((row["name"], row["span_type"]) for row in rows)
+
+        assert total == 20
+        assert len(seen) == 20
+        assert len(set(seen)) == 20
+
     def test_never_returns_attributes(self, db):
         self._seed(db)
 
@@ -575,6 +593,42 @@ class TestGetEvalHistory:
         assert by_id["eval-4"]["status"] == "SCORED"
         assert by_id["eval-4"]["avg_score"] == 8.5
 
+    def test_performance_eval_reports_run_time(self, db, toolkit):
+        from agno.eval.performance import PerformanceEval, PerformanceResult
+
+        # Seed through the writer's own shape so this breaks if it changes again
+        perf = PerformanceEval(func=lambda: None)
+        perf.result = PerformanceResult(run_times=[1.0, 3.0])
+        db.create_eval_run(
+            EvalRunRecord(
+                run_id="eval-perf",
+                eval_type=EvalType.PERFORMANCE,
+                eval_data=perf._parse_eval_run_data(),
+                agent_id="agent-1",
+                name="perf check",
+            )
+        )
+
+        out = _loads(toolkit.get_eval_history())
+
+        run = out["eval_runs"][0]
+        assert run["status"] == "MEASURED"
+        assert run["avg_run_time"] == pytest.approx(2.0)
+
+    def test_performance_eval_tolerates_flat_rows(self, db, toolkit):
+        db.create_eval_run(
+            EvalRunRecord(
+                run_id="eval-perf-flat",
+                eval_type=EvalType.PERFORMANCE,
+                eval_data={"avg_run_time": 1.5},
+                agent_id="agent-1",
+            )
+        )
+
+        out = _loads(toolkit.get_eval_history())
+
+        assert out["eval_runs"][0]["avg_run_time"] == 1.5
+
     def test_truncation_note(self, db, toolkit):
         for i in range(3):
             db.create_eval_run(
@@ -641,17 +695,117 @@ class TestSchedules:
         assert schedule["cron_expr"] == "0 9 * * *"
         assert schedule["last_run"]["status"] == "success"
 
-    def test_schedule_history_summary(self, db, toolkit):
+    def test_schedule_history_page_summary(self, db, toolkit):
         self._seed(db)
 
         out = _loads(toolkit.get_schedule_history("sched-1"))
 
-        assert out["summary"]["status_counts"] == {"success": 1, "failed": 1}
-        assert out["summary"]["last_failure"]["error"] == "endpoint timed out"
+        assert out["page_summary"]["status_counts"] == {"success": 1, "failed": 1}
+        assert out["page_summary"]["last_failure"]["error"] == "endpoint timed out"
         # Run input/output can hold conversation content and must not be exposed
         for run in out["runs"]:
             assert "input" not in run
             assert "output" not in run
+
+    def test_page_summary_is_scoped_to_the_page_and_says_so(self, db, toolkit):
+        schedule = Schedule(id="sched-1", name="hourly-digest", cron_expr="0 * * * *", endpoint="/agents/d/runs")
+        db.create_schedule(schedule.to_dict())
+        now = int(time.time())
+        # The only failure is the oldest run, outside the default page below
+        db.create_schedule_run(
+            ScheduleRun(
+                id="run-fail",
+                schedule_id="sched-1",
+                status="failed",
+                triggered_at=now - 1000,
+                error="boom",
+                created_at=now - 1000,
+            ).to_dict()
+        )
+        for i in range(9):
+            db.create_schedule_run(
+                ScheduleRun(
+                    id=f"run-ok-{i}",
+                    schedule_id="sched-1",
+                    status="success",
+                    triggered_at=now - 900 + i * 100,
+                    completed_at=now - 890 + i * 100,
+                    status_code=200,
+                    created_at=now - 900 + i * 100,
+                ).to_dict()
+            )
+
+        out = _loads(toolkit.get_schedule_history("sched-1", limit=3))
+
+        assert "summary" not in out
+        assert out["page_summary"]["status_counts"] == {"success": 3}
+        assert out["page_summary"]["last_failure"] is None
+        assert out["total"] == 10
+        assert any("page_summary covers only these 3 runs" in note for note in out["notes"])
+
+    def test_error_bodies_are_redacted_and_bounded(self, db, toolkit):
+        marker = "SECRET_PAYLOAD_MARKER ssn=123-45-6789"
+        schedule = Schedule(id="sched-1", name="daily-report", cron_expr="0 9 * * *", endpoint="/agents/r/runs")
+        db.create_schedule(schedule.to_dict())
+        now = int(time.time())
+        # An upstream 422 echoes the run input back in the response body
+        body = json.dumps({"detail": [{"loc": ["body", "user_id"], "input": marker}]}) + "x" * 5000
+        db.create_schedule_run(
+            ScheduleRun(
+                id="run-1",
+                schedule_id="sched-1",
+                status="failed",
+                triggered_at=now - 60,
+                status_code=422,
+                error=body,
+                created_at=now - 60,
+            ).to_dict()
+        )
+
+        history = toolkit.get_schedule_history("sched-1")
+        schedules = toolkit.list_schedules()
+
+        assert marker not in history
+        assert marker not in schedules
+        out = _loads(history)
+        assert out["runs"][0]["error"] == "HTTP 422"
+        assert out["page_summary"]["last_failure"]["error"] == "HTTP 422"
+        assert _loads(schedules)["schedules"][0]["last_run"]["error"] == "HTTP 422"
+        for run in out["runs"]:
+            assert run["error"] is None or len(run["error"]) <= 200
+
+    def test_framework_errors_keep_a_capped_first_line(self, db, toolkit):
+        schedule = Schedule(id="sched-1", name="daily-report", cron_expr="0 9 * * *", endpoint="/agents/r/runs")
+        db.create_schedule(schedule.to_dict())
+        now = int(time.time())
+        db.create_schedule_run(
+            ScheduleRun(
+                id="run-1",
+                schedule_id="sched-1",
+                status="failed",
+                triggered_at=now - 120,
+                error="Polling timed out after 300s for run abc\n" + "Traceback (most recent call last):\n" * 50,
+                created_at=now - 120,
+            ).to_dict()
+        )
+        db.create_schedule_run(
+            ScheduleRun(
+                id="run-2",
+                schedule_id="sched-1",
+                status="failed",
+                triggered_at=now - 60,
+                error="y" * 5000,
+                created_at=now - 60,
+            ).to_dict()
+        )
+
+        out = _loads(toolkit.get_schedule_history("sched-1"))
+
+        by_error = [run["error"] for run in out["runs"]]
+        assert "Polling timed out after 300s for run abc" in by_error
+        assert "y" * 200 in by_error
+        for error in by_error:
+            assert len(error) <= 200
 
     def test_unsupported_backend_returns_clear_error(self, db, toolkit, monkeypatch):
         def raise_not_implemented(*args: Any, **kwargs: Any):

--- a/libs/agno/tests/unit/tools/test_agentos.py
+++ b/libs/agno/tests/unit/tools/test_agentos.py
@@ -892,15 +892,21 @@ class TestPendingApprovals:
 
 
 class TestErrorPaths:
-    def test_db_failure_returns_error_payload(self, db, toolkit, monkeypatch):
+    def test_db_failure_returns_generic_error_without_leaking_detail(self, db, toolkit, monkeypatch):
+        # Raw exception text can carry SQL fragments, table and column names. These
+        # tools read the db with no endpoint scopes, so the detail must not reach
+        # whoever talks to the agent -- it is logged instead.
         def fail(*args: Any, **kwargs: Any):
-            raise RuntimeError("db exploded")
+            raise RuntimeError("db exploded: SELECT secret_col FROM secret_table")
 
         monkeypatch.setattr(db, "get_eval_runs", fail)
 
         out = _loads(toolkit.get_eval_history())
 
-        assert "db exploded" in out["error"]
+        assert "error" in out
+        assert "secret_table" not in out["error"]
+        assert "db exploded" not in out["error"]
+        assert "Failed to get eval history" in out["error"]
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Ships **AgentOSTools** (`agno/tools/agentos.py`): a read-only ops toolkit so an agent can answer questions about the AgentOS it runs on — usage, latency, failures, tool statistics, schedules, eval history, pending approvals and runtime-built components. Proven downstream by the `agentos-railway` template, which hand-rolled six of these as local functions; it can now import this toolkit and delete its copies.

The toolkit is constructed as `AgentOSTools(db=...)` — never the `AgentOS` instance. Agents are built before the OS and passed into `AgentOS(agents=[...])`, so an agent holding an OS reference would be a construction cycle. Structure mirrors `StudioTools`: per-surface enable flags (`metrics`, `traces`, `schedules`, `evals`, `components`, `approvals`), sync + async variants for every tool registered under one tool name, compact JSON payloads with truncation/capability notes stated in the payload itself.

### Tools

| Tool | Backed by |
|---|---|
| `get_platform_metrics(days)` | `calculate_metrics()` + `get_metrics()` — daily runs, sessions, distinct users, token breakdown, model mix |
| `get_run_activity(days)` | new `get_trace_stats(group_by=...)` — per-agent/team/workflow latency and errors, plus endpoint-level wrappers |
| `get_tool_activity(days)` | new `get_span_stats()` — slowest and most-used tools, model call latency |
| `get_eval_history(limit)` | `get_eval_runs()` — normalized to PASS/FAIL with the judge's reason on failures |
| `list_schedules(limit)` | `get_schedules()` + `get_schedule_runs()` — each schedule's last outcome |
| `get_schedule_history(schedule_id)` | `get_schedule_runs()` — trend, not just last run |
| `list_platform_components(limit)` | `list_components()` — runtime-built components + versions |
| `list_pending_approvals()` | `get_approvals(status="pending")` — HITL gates waiting on a human |

No mutations are exposed (deliberate: an ops surface that only reads needs no confirmation gates). Sensitive payloads never leave the db: span `attributes` (full conversation content), approval `tool_args`/`context`, schedule run `input`/`output` are excluded from every formatter, and schedule run `error` values — raw upstream response bodies, which can echo run input back via a 422 — are redacted to `HTTP <code>` or a capped framework message.

### Db-layer foundation

- **`get_trace_stats` gains `group_by: Literal["session", "agent", "team", "workflow", "endpoint"]`.** The default `"session"` output is byte-identical to before (pinned by tests). Component groupings add `total_sessions`, `avg/p95/max(duration_ms)` and `error_traces` (indexed `status` column — no spans join), ordered by `total_traces` desc. `"endpoint"` groups traces with no component id at all (HTTP/MCP entrypoint wrappers) by trace name — this is how `get_run_activity` reports wrappers without double-counting. Implemented for Postgres and SQLite (sync + async); the other 14 backends accept the parameter and raise `NotImplementedError` for non-default groupings.
- **New optional `get_span_stats()`** on `BaseDb`/`AsyncBaseDb` (concrete raise, no abstractmethod — no backend breaks): SQL-side aggregation by span name and span type with count, avg/p95/max duration, error count, `last_called_at`; filterable by time window, component, name and type. The span type is the single scalar `attributes->>'openinference.span.kind'` extracted in SQL — the `attributes` payload (measured at ~7KB/span avg on a live platform) is never selected. This makes "which tools are slowest platform-wide" one indexed query instead of dragging every transcript through app memory.
- **Metrics are no longer silently empty on untouched deployments.** `get_metrics` on Postgres and SQLite (sync + async) refreshes lazily, throttled to at most once per minute per process — `calculate_metrics()` stamps the throttle, so explicit refreshes (including the toolkit's own) are not repeated. Verified on a live platform where 365 sessions had produced zero metrics rows.
- p95 uses `percentile_cont(0.95)` on Postgres; SQLite reports `p95_duration_ms: null` (no SQL percentile support) and the payload says so — never a max masquerading as a p95.
- Fixes a pre-existing SQLite bug: `calculate_date_metrics` crashed on sessions with NULL `session_data`.

### Review

Two independent review passes (one external, one 25-agent adversarial workflow) are already folded in: endpoint-level grouping replaced a subtraction-derived unattributed count (double-counting + mixed time columns), the refresh throttle replaced an O(sessions-today) recompute per read, async tool variants carry full docstrings (they are the LLM-facing schema on the served path), model-chosen `limit`/`days` are clamped, and the module docstring states the trust model honestly (metrics rollup refresh is a derived-data write; endpoint scopes do not apply to direct db reads; approvals expose identifiers — expose the ops agent to operators, trim surfaces with flags for wider audiences).

A third pass (independent adversarial review, every finding re-executed) landed four more fixes: the schedule-run `error` redaction above; a total-order `ORDER BY (sort_col, name, span_type)` so span-stats paging cannot drop or duplicate tied groups (lossiness reproduced on Postgres at 20 tied same-name groups, and the new paging tests fail against the unfixed ordering); performance evals read `avg_run_time` through the writer's nested `result` container (every performance eval previously returned `MEASURED` with nothing measured); and `get_schedule_history`'s summary is renamed `page_summary` with an explicit note when older runs fall outside the page, so an off-page failure can no longer read as "no failures". Cost is deliberately not reported anywhere: agno only records provider-supplied cost, which almost no provider returns, and the ops agent is instructed to give token totals rather than estimate spend.

### Verification

- 66 new tests: 53 unit (real SQLite/AsyncSqliteDb, no mocks, mirroring `test_studio.py` — includes a backwards-compat pin on the default `get_trace_stats` shape) + 13 integration (real Postgres, exact `percentile_cont` interpolation values, hermetic per-test schemas immune to the shared `test_schema` teardown issue).
- Live-verified against a running platform db: per-agent latency, `update_user_memory` at 3.6s avg over 35 calls vs 8ms tools, endpoint grouping naming the MCP methods exactly.
- Cookbook `cookbook/05_agent_os/25_agentos_tools/` ran live end-to-end (see its `TEST_LOG.md`).
- `./scripts/format.sh` and `./scripts/validate.sh` (ruff + mypy) clean.

Known pre-existing issues, out of scope: `SqliteDb.get_spans` missing the `limit` parameter vs the base signature; `test_metrics.py` integration date-boundary flakes near midnight UTC.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The `GET /metrics` route now returns data without anyone clicking the refresh button, on Postgres and SQLite. The traces router is unchanged — `group_by` and `get_span_stats` are not exposed over HTTP in this PR. Follow-up candidate: the `agentos-railway` template imports this toolkit and deletes its local copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

