### PR TITLE
fix: preserve AG-UI run lineage and text surface

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -38,6 +38,36 @@ from agno.run.team import TeamRunEvent
 from agno.utils.message import get_text_from_message
 
 EventHandler = Callable[[BaseRunOutputEvent, StreamState], List[BaseEvent]]
+_RUN_LINEAGE_FIELDS = ("agent_id", "team_id", "run_id", "parent_run_id")
+
+
+def _add_run_lineage(events: list[BaseEvent], chunk: BaseRunOutputEvent, state: StreamState) -> list[BaseEvent]:
+    """Preserve Agno run lineage on translated AG-UI events."""
+    lineage = {field: getattr(chunk, field, None) for field in _RUN_LINEAGE_FIELDS}
+    lineage["team_id"] = lineage["team_id"] or state.team_id
+
+    for event in events:
+        for field, value in lineage.items():
+            existing_value = getattr(event, field, None)
+            is_protocol_field = field in event.__class__.model_fields
+            if value not in (None, "") and not (is_protocol_field and existing_value not in (None, "")):
+                setattr(event, field, value)
+    return events
+
+
+def _add_text_surface(events: list[BaseEvent], chunk: BaseRunOutputEvent, state: StreamState) -> list[BaseEvent]:
+    """Mark whether translated text is user-facing or orchestration trace."""
+    parent_run_id = getattr(chunk, "parent_run_id", None)
+    surface = "user" if not parent_run_id or state.team_mode == "route" else "trace"
+
+    for event in events:
+        if event.type in {
+            EventType.TEXT_MESSAGE_START,
+            EventType.TEXT_MESSAGE_CONTENT,
+            EventType.TEXT_MESSAGE_END,
+        }:
+            setattr(event, "surface", surface)
+    return events
 
 
 def _extract_response_chunk_content(response: RunContentEvent) -> str:
@@ -458,11 +488,14 @@ def process_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEve
 
     handler = HANDLERS.get(normalized)
     if handler:
-        return handler(chunk, state)
+        events = handler(chunk, state)
+        if normalized == RunEvent.run_content.value:
+            events = _add_text_surface(events, chunk, state)
+        return _add_run_lineage(events, chunk, state)
 
-    return on_unknown_event(chunk, state)
+    return _add_run_lineage(on_unknown_event(chunk, state), chunk, state)
 
 
 def process_completion(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
     """Process completion event (run_completed/run_paused) and return cleanup events."""
-    return on_run_completed(chunk, state)
+    return _add_run_lineage(on_run_completed(chunk, state), chunk, state)

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -116,6 +116,8 @@ async def run_entity(
             thread_id=run_input.thread_id,
             run_id=run_id,
             run_state=session_state,
+            team_id=entity.id if isinstance(entity, (Team, RemoteTeam)) else None,
+            team_mode=entity.mode.value if isinstance(entity, Team) and entity.mode else None,
         ):
             yield event
 

--- a/libs/agno/agno/os/interfaces/agui/state.py
+++ b/libs/agno/agno/os/interfaces/agui/state.py
@@ -40,6 +40,8 @@ class StreamState:
     # Run context
     thread_id: str = ""
     run_id: str = ""
+    team_id: Optional[str] = None
+    team_mode: Optional[str] = None
     run_state: Optional[Dict[str, Any]] = None
 
     def open_text_message(self) -> str:

--- a/libs/agno/agno/os/interfaces/agui/stream.py
+++ b/libs/agno/agno/os/interfaces/agui/stream.py
@@ -14,9 +14,17 @@ def stream_agno_response_as_agui_events(
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
+    team_id: Optional[str] = None,
+    team_mode: Optional[str] = None,
 ) -> Iterator[BaseEvent]:
     """Map the Agno response stream to AG-UI format."""
-    state = StreamState(thread_id=thread_id, run_id=run_id, run_state=run_state)
+    state = StreamState(
+        thread_id=thread_id,
+        run_id=run_id,
+        team_id=team_id,
+        team_mode=team_mode,
+        run_state=run_state,
+    )
 
     if run_state is not None:
         state.set_state_snapshot(run_state)
@@ -41,9 +49,17 @@ async def async_stream_agno_response_as_agui_events(
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
+    team_id: Optional[str] = None,
+    team_mode: Optional[str] = None,
 ) -> AsyncIterator[BaseEvent]:
     """Map the Agno response stream to AG-UI format."""
-    state = StreamState(thread_id=thread_id, run_id=run_id, run_state=run_state)
+    state = StreamState(
+        thread_id=thread_id,
+        run_id=run_id,
+        team_id=team_id,
+        team_mode=team_mode,
+        run_state=run_state,
+    )
 
     if run_state is not None:
         state.set_state_snapshot(run_state)

--- a/libs/agno/tests/unit/os/interfaces/test_agui_lineage.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_lineage.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Iterator
+
+import pytest
+from ag_ui.core import EventType
+from ag_ui.encoder import EventEncoder
+
+from agno.models.response import ToolExecution
+from agno.os.interfaces.agui.stream import (
+    async_stream_agno_response_as_agui_events,
+    stream_agno_response_as_agui_events,
+)
+from agno.run.agent import RunCompletedEvent, RunContentEvent, RunOutputEvent, ToolCallStartedEvent
+from agno.run.team import RunContentEvent as TeamRunContentEvent
+from agno.run.team import TeamRunOutputEvent
+
+
+def _assert_lineage(event, *, agent_id=None, team_id=None, run_id=None, parent_run_id=None):
+    assert getattr(event, "agent_id", None) == agent_id
+    assert getattr(event, "team_id", None) == team_id
+    assert getattr(event, "run_id", None) == run_id
+    assert getattr(event, "parent_run_id", None) == parent_run_id
+
+
+def _agent_stream() -> Iterator[RunOutputEvent | TeamRunOutputEvent]:
+    yield RunContentEvent(
+        content="member response",
+        agent_id="member-agent",
+        run_id="member-run",
+        parent_run_id="team-run",
+    )
+    yield RunCompletedEvent(
+        agent_id="member-agent",
+        run_id="member-run",
+        parent_run_id="team-run",
+    )
+
+
+async def _team_stream() -> AsyncIterator[RunOutputEvent | TeamRunOutputEvent]:
+    yield TeamRunContentEvent(
+        content="leader response",
+        team_id="research-team",
+        run_id="team-run",
+    )
+    yield RunCompletedEvent(run_id="team-run")
+
+
+def test_sync_stream_preserves_agent_run_lineage():
+    events = list(
+        stream_agno_response_as_agui_events(
+            _agent_stream(),
+            "thread-1",
+            "request-run",
+            team_id="research-team",
+            team_mode="coordinate",
+        )
+    )
+
+    start = next(event for event in events if event.type == EventType.TEXT_MESSAGE_START)
+    content = next(event for event in events if event.type == EventType.TEXT_MESSAGE_CONTENT)
+    finished = next(event for event in events if event.type == EventType.RUN_FINISHED)
+
+    _assert_lineage(
+        start,
+        agent_id="member-agent",
+        team_id="research-team",
+        run_id="member-run",
+        parent_run_id="team-run",
+    )
+    _assert_lineage(
+        content,
+        agent_id="member-agent",
+        team_id="research-team",
+        run_id="member-run",
+        parent_run_id="team-run",
+    )
+    encoded = EventEncoder().encode(content)
+    serialized = json.loads(encoded.removeprefix("data: ").strip())
+    assert {field: serialized[field] for field in ("agent_id", "team_id", "run_id", "parent_run_id")} == {
+        "agent_id": "member-agent",
+        "team_id": "research-team",
+        "run_id": "member-run",
+        "parent_run_id": "team-run",
+    }
+    assert serialized["surface"] == "trace"
+    _assert_lineage(
+        finished,
+        agent_id="member-agent",
+        team_id="research-team",
+        run_id="request-run",
+        parent_run_id="team-run",
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_stream_preserves_team_run_lineage():
+    events = [
+        event
+        async for event in async_stream_agno_response_as_agui_events(
+            _team_stream(),
+            "thread-1",
+            "request-run",
+        )
+    ]
+
+    start = next(event for event in events if event.type == EventType.TEXT_MESSAGE_START)
+    content = next(event for event in events if event.type == EventType.TEXT_MESSAGE_CONTENT)
+
+    _assert_lineage(start, team_id="research-team", run_id="team-run")
+    _assert_lineage(content, team_id="research-team", run_id="team-run")
+    assert getattr(start, "surface", None) == "user"
+    assert getattr(content, "surface", None) == "user"
+
+
+def test_coordinate_and_route_member_text_have_different_surfaces():
+    coordinate_events = list(
+        stream_agno_response_as_agui_events(
+            iter(
+                [
+                    RunContentEvent(
+                        content="member trace",
+                        agent_id="member-agent",
+                        run_id="member-run",
+                        parent_run_id="team-run",
+                    ),
+                    TeamRunContentEvent(
+                        content="leader answer",
+                        team_id="research-team",
+                        run_id="team-run",
+                    ),
+                    RunCompletedEvent(run_id="team-run"),
+                ]
+            ),
+            "thread-1",
+            "request-run",
+            team_id="research-team",
+            team_mode="coordinate",
+        )
+    )
+    coordinate_content = [event for event in coordinate_events if event.type == EventType.TEXT_MESSAGE_CONTENT]
+
+    assert [event.delta for event in coordinate_content] == ["member trace", "leader answer"]
+    assert [getattr(event, "surface", None) for event in coordinate_content] == ["trace", "user"]
+
+    route_events = list(
+        stream_agno_response_as_agui_events(
+            iter(
+                [
+                    RunContentEvent(
+                        content="member final answer",
+                        agent_id="member-agent",
+                        run_id="member-run",
+                        parent_run_id="team-run",
+                    ),
+                    RunCompletedEvent(run_id="team-run"),
+                ]
+            ),
+            "thread-1",
+            "request-run",
+            team_id="research-team",
+            team_mode="route",
+        )
+    )
+    route_content = next(event for event in route_events if event.type == EventType.TEXT_MESSAGE_CONTENT)
+
+    assert route_content.delta == "member final answer"
+    assert getattr(route_content, "surface", None) == "user"
+
+
+def test_missing_lineage_fields_remain_absent():
+    events = list(
+        stream_agno_response_as_agui_events(
+            iter([RunContentEvent(content="hello"), RunCompletedEvent()]),
+            "thread-1",
+            "request-run",
+        )
+    )
+
+    content = next(event for event in events if event.type == EventType.TEXT_MESSAGE_CONTENT)
+    serialized = content.model_dump(exclude_none=True)
+
+    for field in ("agent_id", "team_id", "run_id", "parent_run_id"):
+        assert field not in serialized
+
+
+def test_tool_events_preserve_member_lineage():
+    tool_event = ToolCallStartedEvent(
+        agent_id="member-agent",
+        run_id="member-run",
+        parent_run_id="team-run",
+        tool=ToolExecution(
+            tool_call_id="tool-1",
+            tool_name="search",
+            tool_args={"query": "agno"},
+        ),
+    )
+
+    events = list(
+        stream_agno_response_as_agui_events(
+            iter([tool_event, RunCompletedEvent(run_id="team-run")]),
+            "thread-1",
+            "request-run",
+            team_id="research-team",
+        )
+    )
+
+    tool_events = [event for event in events if event.type in (EventType.TOOL_CALL_START, EventType.TOOL_CALL_ARGS)]
+    assert len(tool_events) == 2
+    for event in tool_events:
+        _assert_lineage(
+            event,
+            agent_id="member-agent",
+            team_id="research-team",
+            run_id="member-run",
+            parent_run_id="team-run",
+        )


### PR DESCRIPTION
## What changed

This keeps Agno run lineage when native run events are translated into AG-UI events. The translated events now retain `agent_id`, `team_id`, `run_id`, and `parent_run_id` when those values are available.

Text events also include a small presentation hint:

- leader text uses `surface="user"`
- member text in coordinate mode uses `surface="trace"`
- member text in route mode uses `surface="user"`

Tool and HITL events are still forwarded normally and keep their lineage metadata.

## Why

With `stream_member_events=True`, member and leader text currently become indistinguishable `TEXT_MESSAGE_*` events. In coordinate mode this can put the member response and the leader's follow-up into the same live assistant message. Filtering every event with a `parent_run_id` is not enough, because route mode uses the member response as the final user-facing answer.

The lineage fields tell clients where an event came from, while `surface` tells them how the text is intended to be presented.

I used `surface="user" | "trace"` based on the discussion in #9090. The field is kept in one small translation helper, so it is easy to rename to `final_response` if that fits the public event contract better.

## Tests

- Added sync and async lineage coverage
- Added coordinate and route surface coverage
- Covered tool-event lineage and missing optional fields
- Full AG-UI unit group: 152 passed
- Ruff check and format check passed
- Targeted MyPy check passed

Closes #9090
