### PR TITLE
fix: stop AgentOSTools leaking raw exception text to the agent

### DIFF
--- a/libs/agno/agno/tools/agentos.py
+++ b/libs/agno/agno/tools/agentos.py
@@ -197,9 +197,9 @@ class AgentOSTools(Toolkit):
                 log_warning(f"Could not refresh metrics: {e}")
             rows, _ = self._sync_db().get_metrics(starting_date=start_date, ending_date=end_date)
             return _format_platform_metrics(rows, days, start_date, end_date)
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get platform metrics")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get platform metrics")
 
     async def aget_platform_metrics(self, days: int = 7) -> str:
         """Get daily platform usage metrics: runs, sessions, users, tokens and model mix.
@@ -222,9 +222,9 @@ class AgentOSTools(Toolkit):
                 log_warning(f"Could not refresh metrics: {e}")
             rows, _ = await self._async_db().get_metrics(starting_date=start_date, ending_date=end_date)
             return _format_platform_metrics(rows, days, start_date, end_date)
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get platform metrics")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get platform metrics")
 
     # ------------------------------------------------------------------
     # Run activity (traces grouped by component)
@@ -255,9 +255,9 @@ class AgentOSTools(Toolkit):
             return _format_run_activity(groupings, window_total, days)
         except NotImplementedError as e:
             return json.dumps({"error": f"Component-grouped trace stats are not supported by this database: {e}"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get run activity")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get run activity")
 
     async def aget_run_activity(self, days: int = 7) -> str:
         """Get per-agent, per-team, per-workflow and endpoint-level run activity: run counts, latency and errors.
@@ -284,9 +284,9 @@ class AgentOSTools(Toolkit):
             return _format_run_activity(groupings, window_total, days)
         except NotImplementedError as e:
             return json.dumps({"error": f"Component-grouped trace stats are not supported by this database: {e}"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get run activity")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get run activity")
 
     # ------------------------------------------------------------------
     # Tool activity (span aggregates)
@@ -321,9 +321,9 @@ class AgentOSTools(Toolkit):
             return _format_tool_activity(tools_most_used, tools_slowest, tools_total, model_calls, models_total, days)
         except NotImplementedError:
             return json.dumps({"error": "Span statistics are not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get tool activity")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get tool activity")
 
     async def aget_tool_activity(self, days: int = 7) -> str:
         """Get tool and model call statistics: most-used and slowest tools, model call latency.
@@ -354,9 +354,9 @@ class AgentOSTools(Toolkit):
             return _format_tool_activity(tools_most_used, tools_slowest, tools_total, model_calls, models_total, days)
         except NotImplementedError:
             return json.dumps({"error": "Span statistics are not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get tool activity")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get tool activity")
 
     # ------------------------------------------------------------------
     # Eval history
@@ -380,9 +380,9 @@ class AgentOSTools(Toolkit):
                 self._sync_db().get_eval_runs(limit=_clamp(limit, 1, 100), page=1, deserialize=False),
             )
             return _format_eval_history(rows, total)
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get eval history")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get eval history")
 
     async def aget_eval_history(self, limit: int = 20) -> str:
         """Get recent eval runs normalized to PASS/FAIL, with the judge's reason on failures.
@@ -402,9 +402,9 @@ class AgentOSTools(Toolkit):
                 await self._async_db().get_eval_runs(limit=_clamp(limit, 1, 100), page=1, deserialize=False),
             )
             return _format_eval_history(rows, total)
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get eval history")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get eval history")
 
     # ------------------------------------------------------------------
     # Schedules
@@ -432,9 +432,9 @@ class AgentOSTools(Toolkit):
             return _format_schedules(schedules, total, last_runs)
         except NotImplementedError:
             return json.dumps({"error": "The scheduler is not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to list schedules")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to list schedules")
 
     async def alist_schedules(self, limit: int = 20) -> str:
         """List schedules with their cron expression, enabled state and last run outcome.
@@ -458,9 +458,9 @@ class AgentOSTools(Toolkit):
             return _format_schedules(schedules, total, last_runs)
         except NotImplementedError:
             return json.dumps({"error": "The scheduler is not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to list schedules")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to list schedules")
 
     def get_schedule_history(self, schedule_id: str, limit: int = 20) -> str:
         """Get the run history of one schedule: outcome trend, not just the last run.
@@ -483,9 +483,9 @@ class AgentOSTools(Toolkit):
             return _format_schedule_history(schedule_id, runs, total)
         except NotImplementedError:
             return json.dumps({"error": "The scheduler is not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get schedule history")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get schedule history")
 
     async def aget_schedule_history(self, schedule_id: str, limit: int = 20) -> str:
         """Get the run history of one schedule: outcome trend, not just the last run.
@@ -508,9 +508,9 @@ class AgentOSTools(Toolkit):
             return _format_schedule_history(schedule_id, runs, total)
         except NotImplementedError:
             return json.dumps({"error": "The scheduler is not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to get schedule history")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to get schedule history")
 
     # ------------------------------------------------------------------
     # Components
@@ -533,9 +533,9 @@ class AgentOSTools(Toolkit):
             return _format_components(components, total)
         except NotImplementedError:
             return json.dumps({"error": "Component listing is not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to list platform components")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to list platform components")
 
     async def alist_platform_components(self, limit: int = 50) -> str:
         """List runtime-built components (agents, teams, workflows) persisted in the database.
@@ -572,9 +572,9 @@ class AgentOSTools(Toolkit):
             return _format_pending_approvals(approvals, total)
         except NotImplementedError:
             return json.dumps({"error": "Approvals are not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to list pending approvals")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to list pending approvals")
 
     async def alist_pending_approvals(self) -> str:
         """List human-in-the-loop approvals waiting on a human decision.
@@ -593,9 +593,9 @@ class AgentOSTools(Toolkit):
             return _format_pending_approvals(approvals, total)
         except NotImplementedError:
             return json.dumps({"error": "Approvals are not supported by this database"})
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to list pending approvals")
-            return json.dumps({"error": str(e)})
+            return _tool_error("Failed to list pending approvals")
 
 
 # ----------------------------------------------------------------------
@@ -656,6 +656,17 @@ def _async_db_error() -> str:
             "async execution path (arun / AgentOS server) so the async tool variants are used."
         }
     )
+
+
+def _tool_error(context: str) -> str:
+    """Generic error payload for the agent.
+
+    The exception detail is logged (logger.exception) but never returned. These
+    tools read the database directly with no endpoint scopes, so raw exception
+    text -- SQL fragments, table or column names -- must not reach whoever talks
+    to the agent.
+    """
+    return json.dumps({"error": f"{context}. The error has been logged."})
 
 
 def _clamp(value: int, low: int, high: int) -> int:

--- a/libs/agno/tests/unit/tools/test_agentos.py
+++ b/libs/agno/tests/unit/tools/test_agentos.py
@@ -892,15 +892,21 @@ class TestPendingApprovals:
 
 
 class TestErrorPaths:
-    def test_db_failure_returns_error_payload(self, db, toolkit, monkeypatch):
+    def test_db_failure_returns_generic_error_without_leaking_detail(self, db, toolkit, monkeypatch):
+        # Raw exception text can carry SQL fragments, table and column names. These
+        # tools read the db with no endpoint scopes, so the detail must not reach
+        # whoever talks to the agent -- it is logged instead.
         def fail(*args: Any, **kwargs: Any):
-            raise RuntimeError("db exploded")
+            raise RuntimeError("db exploded: SELECT secret_col FROM secret_table")
 
         monkeypatch.setattr(db, "get_eval_runs", fail)
 
         out = _loads(toolkit.get_eval_history())
 
-        assert "db exploded" in out["error"]
+        assert "error" in out
+        assert "secret_table" not in out["error"]
+        assert "db exploded" not in out["error"]
+        assert "Failed to get eval history" in out["error"]
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Stacks on #9185. The `AgentOSTools` module goes to real trouble to redact schedule-run errors (upstream 422 bodies can echo run input back), but every tool's generic `except` fell back to `return json.dumps({"error": str(e)})`.

These tools read the database directly with **no endpoint scopes** (the module docstring states this explicitly), so anyone who can talk to the agent can induce a failure and read back raw exception text -- SQL fragments, table and column names. That is the one place the file contradicts its own stated posture.

This routes the exception detail to `logger.exception` (already called on every path) and returns a generic, bounded message to the agent via a new `_tool_error` helper. All 15 generic `except` blocks across the 8 sync/async tool pairs are updated; the `NotImplementedError` handlers (which surface framework-authored, non-sensitive messages) are left as-is.

The error-path unit test previously asserted the exception text appeared in the payload -- it now asserts the detail is **not** leaked to the agent. The captured test log confirms the full traceback is still logged server-side.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: N/A
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

## Additional Notes

`./scripts/format.sh` and `./scripts/validate.sh` (ruff + mypy) clean. `test_agentos.py`: 53 passed.