### PR TITLE
fix(anthropic): support server tools in count_tokens token accounting

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -89,6 +89,39 @@ class SystemPromptBlock(BaseModel):
     ttl: Optional[Literal["5m", "1h"]] = None
 
 
+# The count_tokens endpoint rejects provider-executed (server) tool types such as
+# web_search_* and code_execution_* with a 400 — only schema-bearing tools are
+# accepted. Their definitions are injected server-side and are not small (e.g.
+# web_search_20260209 adds ~6K input tokens), so instead of dropping them from the
+# count, their real overhead is measured once per (model, tool set) via two minimal
+# /v1/messages probes and cached for the process lifetime.
+_SERVER_TOOL_OVERHEAD_CACHE: Dict[Any, int] = {}
+_SERVER_TOOL_PROBE_MESSAGES: Any = [{"role": "user", "content": "hi"}]
+
+
+def _split_server_tools(
+    tools: Optional[List[Dict[str, Any]]],
+) -> tuple[Optional[List[Dict[str, Any]]], List[Dict[str, Any]]]:
+    """Split tools into (tools countable via count_tokens, server tools)."""
+    if not tools:
+        return None, []
+    countable = [t for t in tools if "input_schema" in t]
+    server = [t for t in tools if "input_schema" not in t]
+    return countable or None, server
+
+
+def _server_tool_cache_key(model_id: str, server_tools: List[Dict[str, Any]]) -> Any:
+    return (model_id, tuple(sorted(t.get("type", "") for t in server_tools)))
+
+
+def _total_input_tokens(usage: Any) -> int:
+    return (
+        (usage.input_tokens or 0)
+        + (getattr(usage, "cache_read_input_tokens", 0) or 0)
+        + (getattr(usage, "cache_creation_input_tokens", 0) or 0)
+    )
+
+
 @dataclass
 class Claude(Model):
     """
@@ -488,9 +521,10 @@ class Claude(Model):
             enable_citations=self.citations and not self._output_format_enabled(response_format),
         )
         anthropic_tools = None
+        server_tools: List[Dict[str, Any]] = []
         if tools:
             formatted_tools = self._format_tools(tools)
-            anthropic_tools = format_tools_for_model(formatted_tools)
+            anthropic_tools, server_tools = _split_server_tools(format_tools_for_model(formatted_tools))
 
         kwargs: Dict[str, Any] = {"messages": anthropic_messages, "model": self.id}
         system = self._build_system(system_prompt)
@@ -500,7 +534,39 @@ class Claude(Model):
             kwargs["tools"] = anthropic_tools
 
         response = self.get_client().messages.count_tokens(**kwargs)
-        return response.input_tokens + count_schema_tokens(response_format, self.id)
+        return (
+            response.input_tokens
+            + self._measure_server_tools_overhead(server_tools)
+            + count_schema_tokens(response_format, self.id)
+        )
+
+    def _measure_server_tools_overhead(self, server_tools: List[Dict[str, Any]]) -> int:
+        """Measured input-token overhead of server tool definitions.
+
+        The count_tokens endpoint rejects server tools, so their real size is
+        measured once per (model, tool set) with two minimal /v1/messages calls
+        and cached for the process lifetime.
+        """
+        if not server_tools:
+            return 0
+        key = _server_tool_cache_key(self.id, server_tools)
+        if key in _SERVER_TOOL_OVERHEAD_CACHE:
+            return _SERVER_TOOL_OVERHEAD_CACHE[key]
+        try:
+            client = self.get_client()
+            base = client.messages.create(model=self.id, max_tokens=1, messages=_SERVER_TOOL_PROBE_MESSAGES)
+            with_tools = client.messages.create(
+                model=self.id,
+                max_tokens=1,
+                messages=_SERVER_TOOL_PROBE_MESSAGES,
+                tools=server_tools,  # type: ignore[arg-type]
+            )
+            overhead = max(0, _total_input_tokens(with_tools.usage) - _total_input_tokens(base.usage))
+        except Exception as e:
+            log_warning(f"Failed to measure server tool token overhead, counting them as 0: {e}")
+            return 0
+        _SERVER_TOOL_OVERHEAD_CACHE[key] = overhead
+        return overhead
 
     async def acount_tokens(
         self,
@@ -516,9 +582,10 @@ class Claude(Model):
             enable_citations=self.citations and not self._output_format_enabled(response_format),
         )
         anthropic_tools = None
+        server_tools: List[Dict[str, Any]] = []
         if tools:
             formatted_tools = self._format_tools(tools)
-            anthropic_tools = format_tools_for_model(formatted_tools)
+            anthropic_tools, server_tools = _split_server_tools(format_tools_for_model(formatted_tools))
 
         kwargs: Dict[str, Any] = {"messages": anthropic_messages, "model": self.id}
         system = self._build_system(system_prompt)
@@ -528,7 +595,34 @@ class Claude(Model):
             kwargs["tools"] = anthropic_tools
 
         response = await self.get_async_client().messages.count_tokens(**kwargs)
-        return response.input_tokens + count_schema_tokens(response_format, self.id)
+        return (
+            response.input_tokens
+            + await self._ameasure_server_tools_overhead(server_tools)
+            + count_schema_tokens(response_format, self.id)
+        )
+
+    async def _ameasure_server_tools_overhead(self, server_tools: List[Dict[str, Any]]) -> int:
+        """Async variant of _measure_server_tools_overhead."""
+        if not server_tools:
+            return 0
+        key = _server_tool_cache_key(self.id, server_tools)
+        if key in _SERVER_TOOL_OVERHEAD_CACHE:
+            return _SERVER_TOOL_OVERHEAD_CACHE[key]
+        try:
+            client = self.get_async_client()
+            base = await client.messages.create(model=self.id, max_tokens=1, messages=_SERVER_TOOL_PROBE_MESSAGES)
+            with_tools = await client.messages.create(
+                model=self.id,
+                max_tokens=1,
+                messages=_SERVER_TOOL_PROBE_MESSAGES,
+                tools=server_tools,  # type: ignore[arg-type]
+            )
+            overhead = max(0, _total_input_tokens(with_tools.usage) - _total_input_tokens(base.usage))
+        except Exception as e:
+            log_warning(f"Failed to measure server tool token overhead, counting them as 0: {e}")
+            return 0
+        _SERVER_TOOL_OVERHEAD_CACHE[key] = overhead
+        return overhead
 
     def get_request_params(
         self,


### PR DESCRIPTION
Fixes #9189

## Summary

Anthropic's `count_tokens` endpoint rejects provider-executed (server) tool types (`web_search_*`, `code_execution_*`) with a `400`, so any agent carrying a server tool failed during context-size accounting. `Claude.count_tokens()` forwarded the full tool list to that endpoint unchanged, and the error propagated out of the unguarded call site in `CompressionManager.should_compress_tool_results()` (`libs/agno/agno/compression/manager.py:89`, and `:193` on the async path) — killing the run before the model was ever invoked.

Schema-bearing tools are still counted via the endpoint. Server tools are excluded from that request and their real definition overhead is measured once per `(model, tool set)` with two minimal `/v1/messages` probes; the diff is cached for the process lifetime and added to the returned count (`web_search_20260209` measures ~5.9K tokens on `claude-sonnet-5`). On probe failure the overhead counts as 0 with a warning instead of failing the run.

**Why measure instead of skip:** simply dropping server tools from the count avoids the 400 but under-reports by ~6K tokens per tool, which defeats a token threshold — compression fires late or never, and the run can still overflow the context window.

### Changes

All in `libs/agno/agno/models/anthropic/claude.py` (+98 / −4), no public API change:

| Symbol | Purpose |
|---|---|
| `_split_server_tools()` | Partitions the formatted tool list on the presence of `input_schema` — client tools are countable, server tools are not. |
| `_server_tool_cache_key()` | Cache key of `(model_id, sorted tool types)`, so the overhead is measured once per model per tool set. |
| `_total_input_tokens()` | Sums `input_tokens` plus both cache-read and cache-creation input tokens, so the probe delta is correct even when prompt caching is active. |
| `_measure_server_tools_overhead()` | Two `max_tokens=1` probes — one bare, one with the server tools — clamped with `max(0, ...)`, cached in `_SERVER_TOOL_OVERHEAD_CACHE`. |
| `_ameasure_server_tools_overhead()` | Async twin of the above. |

`count_tokens()` and `acount_tokens()` now return `endpoint count + measured server-tool overhead + schema tokens`.

Issue number: [#9189](https://github.com/agno-agi/agno/issues/9189) — full reproduction, root cause, and the reasoning behind measuring rather than skipping are written up there.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach

This PR is the fix for [#9189](https://github.com/agno-agi/agno/issues/9189), which I opened.
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Blast radius.** The probes only run when a server tool is actually present *and* `count_tokens` is called — i.e. token-threshold compression on an Anthropic agent using native web search or code execution. Agents without server tools take a `server_tools == []` early return and are completely unaffected; the existing `count_tokens` behaviour is byte-for-byte unchanged for them.

**Cost of the approach.** Two extra `max_tokens=1` requests per `(model, tool set)`, once per process. That is the deliberate trade-off, and the alternatives were worse:

- *Hardcode a per-tool-type token table* — accurate today, silently wrong the next time Anthropic revs a tool version (`web_search_20250305` → `web_search_20260209`) or tweaks the injected definition.
- *Drop server tools from the count* — the pre-existing under-count this PR set out to fix.
- *Ask the count endpoint* — not possible; rejecting these tools is exactly the bug.

Measuring keeps the number correct across tool-version bumps with no table to maintain.

**Failure mode is a soft one.** Any exception during probing is caught, logged via `log_warning`, and counted as `0` overhead. The result is deliberately *not* cached on the failure path, so a transient error (rate limit, blip) is retried on the next call rather than poisoning the cache for the process lifetime.

**Cache lifetime.** `_SERVER_TOOL_OVERHEAD_CACHE` is a module-level dict, unbounded but keyed on `(model_id, tool types)` — cardinality is tied to distinct model/tool-set combinations in a process, so growth is negligible in practice. Happy to move it behind an explicit cache utility if maintainers prefer.

**Prompt caching.** The probe delta sums `input_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` so the measurement stays correct when cache-control blocks are in play and part of the input is billed as cached.

**Open question for reviewers.** Should the probe be opt-out via a `Claude(...)` flag for users who would rather eat the under-count than the two extra requests? Easy to add if wanted — left out to keep the fix minimal.
