### PR TITLE
feat: support .zip and .eml file uploads in AgentOS

### DIFF
--- a/libs/agno/agno/media.py
+++ b/libs/agno/agno/media.py
@@ -439,6 +439,8 @@ class File(BaseModel):
             "application/vnd.ms-powerpoint",  # .ppt
             "application/vnd.ms-excel",  # .xls
             "application/vnd.ms-outlook",  # .msg
+            "application/zip",  # .zip
+            "message/rfc822",  # .eml
             "text/javascript",
             "application/x-python",
             "text/x-python",

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -593,6 +593,8 @@ DOCUMENT_MIME_TYPES = {
     "application/vnd.ms-powerpoint",  # .ppt
     "application/vnd.ms-excel",  # .xls
     "application/vnd.ms-outlook",  # .msg
+    "application/zip",  # .zip
+    "message/rfc822",  # .eml
     "text/javascript",
     "application/x-python",
     "text/x-python",
@@ -620,6 +622,8 @@ EXTENSION_CATEGORY: Dict[str, str] = {
     "xlsx": "document",
     "xls": "document",
     "msg": "document",
+    "zip": "document",
+    "eml": "document",
     "py": "document",
     "txt": "document",
     "html": "document",
@@ -724,6 +728,8 @@ _DOCUMENT_EXTENSION_MIME: Dict[str, str] = {
     "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "xls": "application/vnd.ms-excel",
     "msg": "application/vnd.ms-outlook",
+    "zip": "application/zip",
+    "eml": "message/rfc822",
     "py": "text/x-python",
     "txt": "text/plain",
     "html": "text/html",

--- a/libs/agno/tests/unit/os/routers/test_slack_router.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_router.py
@@ -401,7 +401,7 @@ class TestNonStreamingRoutes:
     async def test_mixed_files_categorized_correctly(self):
         agent_mock = make_agent_mock()
         mock_slack = make_slack_mock(token="xoxb-test")
-        mock_httpx = make_httpx_mock([b"csv-data", b"img-data", b"zip-data"])
+        mock_httpx = make_httpx_mock([b"csv-data", b"img-data", b"mystery-data"])
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
@@ -417,7 +417,7 @@ class TestNonStreamingRoutes:
                 [
                     {"id": "F5", "name": "data.csv", "mimetype": "text/csv"},
                     {"id": "F6", "name": "pic.jpg", "mimetype": "image/jpeg"},
-                    {"id": "F7", "name": "bundle.zip", "mimetype": "application/zip"},
+                    {"id": "F7", "name": "mystery.xyz", "mimetype": "application/x-mystery"},
                 ]
             )
             resp = make_signed_request(client, body)
@@ -435,7 +435,7 @@ class TestNonStreamingRoutes:
     async def test_non_whitelisted_mime_type_passes_none(self):
         agent_mock = make_agent_mock()
         mock_slack = make_slack_mock(token="xoxb-test")
-        mock_httpx = make_httpx_mock(b"zipdata")
+        mock_httpx = make_httpx_mock(b"mysterydata")
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
@@ -447,14 +447,14 @@ class TestNonStreamingRoutes:
             from fastapi.testclient import TestClient
 
             client = TestClient(app)
-            body = slack_event_with_files([{"id": "F1", "name": "archive.zip", "mimetype": "application/zip"}])
+            body = slack_event_with_files([{"id": "F1", "name": "mystery.xyz", "mimetype": "application/x-mystery"}])
             resp = make_signed_request(client, body)
 
         assert resp.status_code == 200
         await wait_for_call(agent_mock.arun)
         uploaded_file = agent_mock.arun.call_args.kwargs["files"][0]
         assert uploaded_file.mime_type is None
-        assert uploaded_file.content == b"zipdata"
+        assert uploaded_file.content == b"mysterydata"
 
     @pytest.mark.asyncio
     async def test_non_streaming_clears_status_after_response(self):

--- a/libs/agno/tests/unit/os/test_utils.py
+++ b/libs/agno/tests/unit/os/test_utils.py
@@ -121,6 +121,8 @@ DOCUMENT_FORMATS = [
     ("sheet.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
     ("sheet.xls", "application/vnd.ms-excel"),
     ("email.msg", "application/vnd.ms-outlook"),
+    ("archive.zip", "application/zip"),
+    ("email.eml", "message/rfc822"),
     ("module.py", "text/x-python"),
     ("readme.txt", "text/plain"),
     ("page.html", "text/html"),
@@ -162,7 +164,6 @@ class TestClassifyUploadFile:
 
     def test_unsupported_type_returns_none(self):
         """Genuinely unsupported files must still be rejected (router raises 400)."""
-        assert classify_upload_file(_make_upload_file("archive.zip", "application/zip")) is None
         assert classify_upload_file(_make_upload_file("mystery.xyz", "application/octet-stream")) is None
         assert classify_upload_file(_make_upload_file("noext", "application/octet-stream")) is None
 


### PR DESCRIPTION
## Summary

Adds `.zip` and `.eml` to the set of file types AgentOS upload routers accept. Previously these were rejected with "Unsupported file type" (HTTP 400) because neither MIME type was present in `DOCUMENT_MIME_TYPES`/`_DOCUMENT_EXTENSION_MIME` (`libs/agno/agno/os/utils.py`) or `FileMedia.valid_mime_types()` (`libs/agno/agno/media.py`).

- `.eml` (`message/rfc822`) is a standard email format, same use case as the already-supported `.msg`.
- `.zip` (`application/zip`) is accepted as an opaque binary attachment only — no server-side extraction or inspection of its contents. Unpacking is left to the caller's own `pre_hooks`/workflow logic, consistent with how other binary formats (`.doc`, `.ppt`, `.msg`) are already passed through without being parsed by Agno itself.

Also updated `EXTENSION_CATEGORY` and `_DOCUMENT_EXTENSION_MIME` so uploads with a missing/generic `content_type` (`application/octet-stream` or empty) still resolve to the correct MIME type from the filename extension, following the existing fallback pattern used for `.md`/`.pptx`.

Closes #9191

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated 

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

**This PR was generated with the assistance of Claude Code.** The change was reviewed and understood by the author before submission.
---

## Additional Notes

Not all model providers can process `.zip`/`.eml` content directly (e.g. Anthropic/Gemini reject arbitrary binary/container formats) — such uploads succeed at the router but fail later with a provider-level error, consistent with existing behavior for other binary Office formats (`.doc`, `.ppt`, `.xls`).

Related: #7330, #7329, #8064
