### PR TITLE
docs: fix broken links in cookbook READMEs and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Make sure all tests pass before submitting your pull request. If you add new fea
    - Import your `VectorDb` Class in `libs/agno/agno/vectordb/<your_db>/__init__.py`.
    - Checkout the [`libs/agno/agno/vectordb/pgvector/pgvector`](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/vectordb/pgvector/pgvector.py) file for an example.
 4. Add a recipe for using your `VectorDb` under `cookbook/07_knowledge/vector_db/<your_db>`.
-   - Checkout [`cookbook/07_knowledge/vector_db/pgvector/pgvector_db`](https://github.com/agno-agi/agno/blob/main/cookbook/07_knowledge/vector_db/pgvector/pgvector_db.py) for an example.
+   - Checkout [`cookbook/07_knowledge/09_archive/vector_dbs/pgvector_db`](https://github.com/agno-agi/agno/blob/main/cookbook/07_knowledge/09_archive/vector_dbs/pgvector_db.py) for an example.
 5. Important: Format and validate your code by running `./scripts/format.sh` and `./scripts/validate.sh`.
 6. Submit a pull request.
 
@@ -132,7 +132,7 @@ Make sure all tests pass before submitting your pull request. If you add new fea
    - Your Class will be in `libs/agno/agno/tools/<your_tool>.py`.
    - Make sure to register all functions in your class via a flag.
    - Checkout the [`agno/tools/youtube.py`](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/youtube.py) file for an example.
-   - If your tool requires an API key, checkout the [`agno/tools/serpapi_tools.py`](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/serpapi_tools.py) as well.
+   - If your tool requires an API key, checkout the [`agno/tools/serpapi.py`](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/tools/serpapi.py) as well.
 4. Add a recipe for using your Tool under `cookbook/tools/<your_tool>`.
    - Checkout [`agno/cookbook/91_tools/youtube_tools`](https://github.com/agno-agi/agno/blob/main/cookbook/91_tools/youtube_tools.py) for an example.
 5. Important: Format and validate your code by running `./scripts/format.sh` and `./scripts/validate.sh`.

--- a/cookbook/07_knowledge/02_building_blocks/README.md
+++ b/cookbook/07_knowledge/02_building_blocks/README.md
@@ -28,6 +28,6 @@ Core components you can configure to customize knowledge behavior.
 ## Further Reading
 
 - [Knowledge Overview](https://docs.agno.com/knowledge/overview)
-- [Chunking Strategies](https://docs.agno.com/knowledge/chunking)
-- [Embedders](https://docs.agno.com/knowledge/embedders)
-- [Vector Databases](https://docs.agno.com/vectordb)
+- [Chunking Strategies](https://docs.agno.com/knowledge/concepts/chunking/overview)
+- [Embedders](https://docs.agno.com/knowledge/concepts/embedder/overview)
+- [Vector Databases](https://docs.agno.com/knowledge/concepts/vector-db)

--- a/cookbook/07_knowledge/05_integrations/README.md
+++ b/cookbook/07_knowledge/05_integrations/README.md
@@ -45,5 +45,5 @@ Specific reader, cloud storage, and vector database integrations.
 ## Further Reading
 
 - [Knowledge Overview](https://docs.agno.com/knowledge/overview)
-- [Readers](https://docs.agno.com/knowledge/readers)
-- [Vector Databases](https://docs.agno.com/vectordb)
+- [Readers](https://docs.agno.com/knowledge/concepts/readers/overview)
+- [Vector Databases](https://docs.agno.com/knowledge/concepts/vector-db)


### PR DESCRIPTION
Fixes #9223

## Summary

Fixes six broken links in the cookbook documentation. All targets were verified with `curl` — the four `docs.agno.com` links currently 404 (the docs site reorganized these pages under `/knowledge/concepts/`), and the two GitHub `blob` links in `CONTRIBUTING.md` point at file paths that were renamed or moved inside the repo.

### Links repointed

| File | Old | New | Verified |
| --- | --- | --- | --- |
| `cookbook/07_knowledge/02_building_blocks/README.md` | `/knowledge/chunking` | `/knowledge/concepts/chunking/overview` | 200 |
| `cookbook/07_knowledge/02_building_blocks/README.md` | `/knowledge/embedders` | `/knowledge/concepts/embedder/overview` | 200 |
| `cookbook/07_knowledge/02_building_blocks/README.md` | `/vectordb` | `/knowledge/concepts/vector-db` | 200 |
| `cookbook/07_knowledge/05_integrations/README.md` | `/knowledge/readers` | `/knowledge/concepts/readers/overview` | 200 |
| `cookbook/07_knowledge/05_integrations/README.md` | `/vectordb` | `/knowledge/concepts/vector-db` | 200 |
| `CONTRIBUTING.md` (Vector DB section) | `cookbook/07_knowledge/vector_db/pgvector/pgvector_db.py` | `cookbook/07_knowledge/09_archive/vector_dbs/pgvector_db.py` | file exists |
| `CONTRIBUTING.md` (Tools section) | `libs/agno/agno/tools/serpapi_tools.py` | `libs/agno/agno/tools/serpapi.py` | file exists |

### Note on the vector-db CONTRIBUTING reference

The `pgvector_db.py` file is now inside `09_archive/`. This PR just unbreaks the link — whether that section of `CONTRIBUTING.md` should point at a non-archived example is a separate call for the maintainers.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — **N/A, docs-only changes; no Python touched**
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — this PR *is* the doc update
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — N/A
- [x] Tested in clean environment — curl-verified all replacement URLs against `docs.agno.com` from a fresh terminal
- [ ] Tests added/updated (if applicable) — N/A, no code changed

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed no other PR addresses this
- [ ] If a similar PR exists, I have explained below why this PR is a better approach — no similar PR found
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — assisted (Claude Code); every change hand-verified against the live `docs.agno.com` sitemap and the repo tree before commit

## Additional Notes

- All destination URLs on `docs.agno.com` were confirmed 200 OK
- All destination file paths inside the repo exist
- Diff is 7 lines across 3 files, no logic touched