### PR TITLE
fix: preserve HITL rejection across callable tool changes

### DIFF
--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -742,14 +742,25 @@ def run_tool(
 def reject_tool_call(
     agent: Agent, run_messages: RunMessages, tool: ToolExecution, functions: Optional[Dict[str, Function]] = None
 ):
+    """Append a rejection result for the exact persisted HITL proposal.
+
+    Rejection is a terminal control decision and does not execute the function.
+    Callable tool factories may expose a different surface when a paused run
+    resumes, so the result must come from the stored ToolExecution rather than
+    the current function registry.
+    """
     agent.model = cast(Model, agent.model)
-    function_call = agent.model.get_function_call_to_run_from_tool_execution(tool, functions)
-    function_call.error = tool.confirmation_note or "Function call was rejected by the user"
-    function_call_result = agent.model.create_function_call_result(
-        function_call=function_call,
-        success=False,
+    run_messages.messages.append(
+        Message(
+            role=agent.model.tool_message_role,
+            content=tool.confirmation_note or "Function call was rejected by the user",
+            tool_call_id=tool.tool_call_id,
+            tool_name=tool.tool_name,
+            tool_args=tool.tool_args,
+            tool_call_error=True,
+            stop_after_tool_call=tool.stop_after_tool_call,
+        )
     )
-    run_messages.messages.append(function_call_result)
 
 
 async def arun_tool(
@@ -861,7 +872,11 @@ def handle_tool_call_updates(
 
     for _t in run_response.tools or []:
         # Case 1: Handle confirmed tools and execute them
-        if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
+        if (
+            _t.requires_confirmation is not None
+            and _t.requires_confirmation is True
+            and (_functions or _t.confirmed is False)
+        ):
             # Tool is confirmed and hasn't been run before
             if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
                 # Consume the generator without yielding
@@ -913,7 +928,11 @@ def handle_tool_call_updates_stream(
 
     for _t in run_response.tools or []:
         # Case 1: Handle confirmed tools and execute them
-        if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
+        if (
+            _t.requires_confirmation is not None
+            and _t.requires_confirmation is True
+            and (_functions or _t.confirmed is False)
+        ):
             # Tool is confirmed and hasn't been run before
             if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
                 yield from run_tool(
@@ -963,7 +982,11 @@ async def ahandle_tool_call_updates(
 
     for _t in run_response.tools or []:
         # Case 1: Handle confirmed tools and execute them
-        if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
+        if (
+            _t.requires_confirmation is not None
+            and _t.requires_confirmation is True
+            and (_functions or _t.confirmed is False)
+        ):
             # Tool is confirmed and hasn't been run before
             if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
                 async for _ in arun_tool(agent, run_response, run_messages, _t, functions=_functions):
@@ -1014,7 +1037,11 @@ async def ahandle_tool_call_updates_stream(
 
     for _t in run_response.tools or []:
         # Case 1: Handle confirmed tools and execute them
-        if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
+        if (
+            _t.requires_confirmation is not None
+            and _t.requires_confirmation is True
+            and (_functions or _t.confirmed is False)
+        ):
             # Tool is confirmed and hasn't been run before
             if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
                 async for event in arun_tool(

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5021,7 +5021,11 @@ def _handle_team_tool_call_updates(
 
     for _t in run_response.tools or []:
         # Case 1: Handle confirmed tools and execute them
-        if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
+        if (
+            _t.requires_confirmation is not None
+            and _t.requires_confirmation is True
+            and (_functions or _t.confirmed is False)
+        ):
             if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
                 deque(run_tool(team, run_response, run_messages, _t, functions=_functions, team_mode=True), maxlen=0)  # type: ignore
             else:
@@ -5081,7 +5085,11 @@ def _handle_team_tool_call_updates_stream(
 
     for _t in run_response.tools or []:
         # Case 1: Handle confirmed tools and execute them
-        if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
+        if (
+            _t.requires_confirmation is not None
+            and _t.requires_confirmation is True
+            and (_functions or _t.confirmed is False)
+        ):
             if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
                 yield from run_tool(
                     team,  # type: ignore[arg-type]
@@ -5154,7 +5162,11 @@ async def _ahandle_team_tool_call_updates(
     _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)}
 
     for _t in run_response.tools or []:
-        if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
+        if (
+            _t.requires_confirmation is not None
+            and _t.requires_confirmation is True
+            and (_functions or _t.confirmed is False)
+        ):
             if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
                 async for _ in arun_tool(team, run_response, run_messages, _t, functions=_functions, team_mode=True):  # type: ignore
                     pass
@@ -5214,7 +5226,11 @@ async def _ahandle_team_tool_call_updates_stream(
 
     for _t in run_response.tools or []:
         # Case 1: Handle confirmed tools and execute them
-        if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
+        if (
+            _t.requires_confirmation is not None
+            and _t.requires_confirmation is True
+            and (_functions or _t.confirmed is False)
+        ):
             if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
                 async for event in arun_tool(
                     team,  # type: ignore[arg-type]

--- a/libs/agno/tests/unit/agent/test_continue_rejected_dynamic_tools.py
+++ b/libs/agno/tests/unit/agent/test_continue_rejected_dynamic_tools.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+
+from agno.agent import Agent
+from agno.models.base import Model
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.tools.decorator import tool
+
+
+class _ScriptedCaptureModel(Model):
+    """Provider double that proposes one HITL call, then observes its rejection."""
+
+    def __init__(self) -> None:
+        super().__init__(id="dynamic-hitl", name="dynamic-hitl", provider="test")
+        self.calls = 0
+        self.contexts: list[list[Message]] = []
+        self.provider_tool_names: list[list[str]] = []
+
+    def _next_response(self, **kwargs: Any) -> ModelResponse:
+        self.calls += 1
+        self.contexts.append([message.model_copy(deep=True) for message in kwargs["messages"]])
+        self.provider_tool_names.append(
+            [item["function"]["name"] for item in kwargs.get("tools") or [] if item.get("type") == "function"]
+        )
+        if self.calls == 1:
+            return ModelResponse(
+                tool_calls=[
+                    {
+                        "id": "proposal-1",
+                        "type": "function",
+                        "function": {
+                            "name": "present_for_review",
+                            "arguments": '{"artifact": "draft-v1"}',
+                        },
+                    }
+                ]
+            )
+        return ModelResponse(content="rejection received")
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next_response(**kwargs)
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next_response(**kwargs)
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield self._next_response(**kwargs)
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        yield self._next_response(**kwargs)
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+
+def _dynamic_agent() -> tuple[Agent, _ScriptedCaptureModel, dict[str, str], list[str]]:
+    phase = {"name": "present"}
+    executions: list[str] = []
+
+    @tool(requires_confirmation=True)
+    def present_for_review(artifact: str) -> str:
+        executions.append(f"present:{artifact}")
+        return "presented"
+
+    def inspect_current() -> str:
+        executions.append("inspect")
+        return "inspected"
+
+    def phase_tools() -> list[Any]:
+        if phase["name"] == "present":
+            return [present_for_review]
+        if phase["name"] == "inspect":
+            return [inspect_current]
+        return []
+
+    model = _ScriptedCaptureModel()
+    agent = Agent(
+        model=model,
+        tools=phase_tools,
+        cache_callables=False,
+        telemetry=False,
+    )
+    return agent, model, phase, executions
+
+
+def _reject_paused_proposal(paused: RunOutput, note: str) -> RunOutput:
+    persisted = RunOutput.from_dict(paused.to_dict())
+    assert persisted.status == RunStatus.paused
+    assert persisted.tools and len(persisted.tools) == 1
+    persisted.tools[0].confirmed = False
+    persisted.tools[0].confirmation_note = note
+    return persisted
+
+
+def _assert_rejection_trajectory(
+    result: RunOutput,
+    model: _ScriptedCaptureModel,
+    executions: list[str],
+    note: str,
+    current_tool_names: list[str],
+) -> None:
+    assert result.status == RunStatus.completed
+    assert result.content == "rejection received"
+    assert model.calls == 2
+    assert executions == []
+    assert model.provider_tool_names == [["present_for_review"], current_tool_names]
+
+    rejection = next(
+        message for message in model.contexts[1] if message.role == "tool" and message.tool_call_id == "proposal-1"
+    )
+    assert rejection.content == note
+    assert rejection.tool_name == "present_for_review"
+    assert rejection.tool_args == {"artifact": "draft-v1"}
+    assert rejection.tool_call_error is True
+
+
+@pytest.mark.parametrize(
+    ("next_phase", "current_tool_names"),
+    [("inspect", ["inspect_current"]), ("empty", [])],
+)
+@pytest.mark.parametrize("stream", [False, True])
+def test_sync_rejection_survives_changed_callable_tool_surface(
+    stream: bool,
+    next_phase: str,
+    current_tool_names: list[str],
+) -> None:
+    agent, model, phase, executions = _dynamic_agent()
+    paused = agent.run("Prepare the artifact for review.")
+    note = "Keep the same owner and revise the comparative."
+    persisted = _reject_paused_proposal(paused, note)
+
+    phase["name"] = next_phase
+    if stream:
+        events = list(
+            agent.continue_run(
+                persisted,
+                stream=True,
+                stream_events=True,
+                yield_run_output=True,
+            )
+        )
+        result = next(event for event in events if isinstance(event, RunOutput))
+    else:
+        result = agent.continue_run(persisted)
+
+    _assert_rejection_trajectory(result, model, executions, note, current_tool_names)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("next_phase", "current_tool_names"),
+    [("inspect", ["inspect_current"]), ("empty", [])],
+)
+@pytest.mark.parametrize("stream", [False, True])
+async def test_async_rejection_survives_changed_callable_tool_surface(
+    stream: bool,
+    next_phase: str,
+    current_tool_names: list[str],
+) -> None:
+    agent, model, phase, executions = _dynamic_agent()
+    paused = await agent.arun("Prepare the artifact for review.")
+    note = "Keep the same owner and revise the comparative."
+    persisted = _reject_paused_proposal(paused, note)
+
+    phase["name"] = next_phase
+    if stream:
+        events = [
+            event
+            async for event in agent.acontinue_run(
+                persisted,
+                stream=True,
+                stream_events=True,
+                yield_run_output=True,
+            )
+        ]
+        result = next(event for event in events if isinstance(event, RunOutput))
+    else:
+        result = await agent.acontinue_run(persisted)
+
+    _assert_rejection_trajectory(result, model, executions, note, current_tool_names)

--- a/libs/agno/tests/unit/team/test_continue_rejected_dynamic_tools.py
+++ b/libs/agno/tests/unit/team/test_continue_rejected_dynamic_tools.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+import pytest
+
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ToolExecution
+from agno.run.messages import RunMessages
+from agno.run.team import TeamRunOutput
+from agno.team import Team
+from agno.team._run import (
+    _ahandle_team_tool_call_updates,
+    _ahandle_team_tool_call_updates_stream,
+    _handle_team_tool_call_updates,
+    _handle_team_tool_call_updates_stream,
+)
+
+
+class _TeamModel(Model):
+    def __init__(self) -> None:
+        super().__init__(id="team-hitl", name="team-hitl", provider="test")
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        raise AssertionError("provider should not be called by the update handler")
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        raise AssertionError("provider should not be called by the update handler")
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        raise AssertionError("provider should not be called by the update handler")
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        raise AssertionError("provider should not be called by the update handler")
+        yield
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+
+def _rejected_update() -> tuple[Team, TeamRunOutput, RunMessages, ToolExecution]:
+    tool = ToolExecution(
+        tool_call_id="proposal-1",
+        tool_name="present_for_review",
+        tool_args={"artifact": "draft-v1"},
+        requires_confirmation=True,
+        confirmed=False,
+        confirmation_note="Revise the comparative.",
+    )
+    return (
+        Team(model=_TeamModel(), members=[]),
+        TeamRunOutput(run_id="team-run", tools=[tool]),
+        RunMessages(),
+        tool,
+    )
+
+
+def _assert_rejected(run_messages: RunMessages, tool: ToolExecution) -> None:
+    assert tool.requires_confirmation is False
+    assert tool.confirmed is False
+    assert tool.tool_call_error is True
+    assert len(run_messages.messages) == 1
+    result = run_messages.messages[0]
+    assert result.tool_call_id == "proposal-1"
+    assert result.tool_name == "present_for_review"
+    assert result.tool_args == {"artifact": "draft-v1"}
+    assert result.content == "Revise the comparative."
+    assert result.tool_call_error is True
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_sync_team_rejection_survives_empty_tool_surface(stream: bool) -> None:
+    team, run_response, run_messages, tool = _rejected_update()
+
+    if stream:
+        list(_handle_team_tool_call_updates_stream(team, run_response, run_messages, tools=[]))
+    else:
+        _handle_team_tool_call_updates(team, run_response, run_messages, tools=[])
+
+    _assert_rejected(run_messages, tool)
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.asyncio
+async def test_async_team_rejection_survives_empty_tool_surface(stream: bool) -> None:
+    team, run_response, run_messages, tool = _rejected_update()
+
+    if stream:
+        async for _ in _ahandle_team_tool_call_updates_stream(team, run_response, run_messages, tools=[]):
+            pass
+    else:
+        await _ahandle_team_tool_call_updates(team, run_response, run_messages, tools=[])
+
+    _assert_rejected(run_messages, tool)


### PR DESCRIPTION
Fixes #9197.

## What changed

- Build a rejected tool result from the persisted `ToolExecution` instead of resolving its name against the current function registry.
- Allow explicit rejection to be consumed when a callable factory now exposes a different or empty tool surface.
- Preserve the original call ID, name, arguments, note, error status, and stop-after metadata.

## Why

Rejection is a terminal user decision and does not execute the function. Requiring the old function to remain present makes persisted HITL continuation depend on an unrelated current capability surface.

## Verification

- 8 focused cases: sync/async × streaming/non-streaming × changed/empty surfaces.
- Every case serializes and reloads the paused `RunOutput` before rejection.
- 95 adjacent continuation tests passed in final review.

Related but not duplicate: #7621 and #8979.