### PR TITLE
fix: enforce declared stop-after boundaries within tool batches

### DIFF
--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -638,6 +638,46 @@ async def _amaybe_create_audit_approval(
         )
 
 
+def _insert_tool_results_in_call_order(run_messages: RunMessages, function_call_results: List[Message]) -> None:
+    """Insert resumed tool results in their original assistant-call order."""
+
+    for result in function_call_results:
+        if result.tool_call_id is None:
+            run_messages.messages.append(result)
+            continue
+
+        assistant_index: Optional[int] = None
+        call_ids: List[str] = []
+        for index in range(len(run_messages.messages) - 1, -1, -1):
+            message = run_messages.messages[index]
+            if message.role != "assistant" or not message.tool_calls:
+                continue
+            candidate_ids = [
+                tool_call.get("id")
+                for tool_call in message.tool_calls
+                if isinstance(tool_call, dict) and tool_call.get("id") is not None
+            ]
+            if result.tool_call_id in candidate_ids:
+                assistant_index = index
+                call_ids = candidate_ids
+                break
+
+        if assistant_index is None:
+            run_messages.messages.append(result)
+            continue
+
+        result_order = call_ids.index(result.tool_call_id)
+        insert_at = assistant_index + 1
+        while insert_at < len(run_messages.messages):
+            existing = run_messages.messages[insert_at]
+            if existing.role != "tool" or existing.tool_call_id not in call_ids:
+                break
+            if call_ids.index(existing.tool_call_id) > result_order:
+                break
+            insert_at += 1
+        run_messages.messages.insert(insert_at, result)
+
+
 def run_tool(
     agent: Agent,
     run_response: RunOutput,
@@ -736,7 +776,7 @@ def run_tool(
                 yield call_result  # type: ignore
 
     if len(function_call_results) > 0:
-        run_messages.messages.extend(function_call_results)
+        _insert_tool_results_in_call_order(run_messages, function_call_results)
 
 
 def reject_tool_call(
@@ -850,7 +890,7 @@ async def arun_tool(
                 yield call_result  # type: ignore
 
     if len(function_call_results) > 0:
-        run_messages.messages.extend(function_call_results)
+        _insert_tool_results_in_call_order(run_messages, function_call_results)
 
 
 def handle_tool_call_updates(

--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -652,11 +652,11 @@ def _insert_tool_results_in_call_order(run_messages: RunMessages, function_call_
             message = run_messages.messages[index]
             if message.role != "assistant" or not message.tool_calls:
                 continue
-            candidate_ids = [
-                tool_call.get("id")
-                for tool_call in message.tool_calls
-                if isinstance(tool_call, dict) and tool_call.get("id") is not None
-            ]
+            candidate_ids: List[str] = []
+            for tool_call in message.tool_calls:
+                tool_call_id = tool_call.get("id")
+                if isinstance(tool_call_id, str):
+                    candidate_ids.append(tool_call_id)
             if result.tool_call_id in candidate_ids:
                 assistant_index = index
                 call_ids = candidate_ids

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2130,6 +2130,27 @@ class Model(ABC):
             tool_call_error=True,
         )
 
+    def create_deferred_function_call_result(
+        self,
+        function_call: FunctionCall,
+        *,
+        boundary_tool_name: str,
+    ) -> Message:
+        """Settle a later call without executing it across a stop-after boundary."""
+
+        return Message(
+            role=self.tool_message_role,
+            content=(
+                f"Tool call {function_call.function.name} was not executed because "
+                f"{boundary_tool_name} is a stop-after boundary. Reissue it after "
+                "that result only if it is still needed."
+            ),
+            tool_call_id=function_call.call_id,
+            tool_name=function_call.function.name,
+            tool_args=function_call.arguments,
+            tool_call_error=True,
+        )
+
     def run_function_call(
         self,
         function_call: FunctionCall,
@@ -2322,7 +2343,7 @@ class Model(ABC):
         if additional_input is None:
             additional_input = []
 
-        for fc in function_calls:
+        for index, fc in enumerate(function_calls):
             if function_call_limit is not None:
                 current_function_call_count += 1
                 # We have reached the function call limit, so we add an error result to the function call results
@@ -2454,12 +2475,30 @@ class Model(ABC):
                     tool_executions=paused_tool_executions,
                     event=ModelResponseEvent.tool_call_paused.value,
                 )
+                if fc.function.stop_after_tool_call:
+                    function_call_results.extend(
+                        self.create_deferred_function_call_result(
+                            later_call,
+                            boundary_tool_name=fc.function.name,
+                        )
+                        for later_call in function_calls[index + 1 :]
+                    )
+                    break
                 # We don't execute the function calls here
                 continue
 
             yield from self.run_function_call(
                 function_call=fc, function_call_results=function_call_results, additional_input=additional_input
             )
+            if function_call_results and function_call_results[-1].stop_after_tool_call:
+                function_call_results.extend(
+                    self.create_deferred_function_call_result(
+                        later_call,
+                        boundary_tool_name=fc.function.name,
+                    )
+                    for later_call in function_calls[index + 1 :]
+                )
+                break
 
         # Add any additional messages at the end
         if additional_input:
@@ -2534,6 +2573,15 @@ class Model(ABC):
                     # Skip this function call
                     continue
             function_calls_to_run.append(fc)
+
+        deferred_function_calls: List[FunctionCall] = []
+        boundary_tool_name: Optional[str] = None
+        for index, fc in enumerate(function_calls_to_run):
+            if fc.function.stop_after_tool_call:
+                boundary_tool_name = fc.function.name
+                deferred_function_calls = function_calls_to_run[index + 1 :]
+                function_calls_to_run = function_calls_to_run[: index + 1]
+                break
 
         # Yield tool_call_started events for all function calls or pause them
         for fc in function_calls_to_run:
@@ -2989,6 +3037,15 @@ class Model(ABC):
 
             # Add function call result to function call results
             function_call_results.append(function_call_result)
+
+        if deferred_function_calls and boundary_tool_name is not None:
+            function_call_results.extend(
+                self.create_deferred_function_call_result(
+                    function_call,
+                    boundary_tool_name=boundary_tool_name,
+                )
+                for function_call in deferred_function_calls
+            )
 
         # Add any additional messages at the end
         if additional_input:

--- a/libs/agno/tests/unit/models/test_tool_stop_after_batch_boundary.py
+++ b/libs/agno/tests/unit/models/test_tool_stop_after_batch_boundary.py
@@ -4,9 +4,13 @@ from typing import Any, AsyncIterator, Iterator
 
 import pytest
 
+from agno.agent import Agent
 from agno.models.base import Model
 from agno.models.message import Message
-from agno.models.response import ModelResponse
+from agno.models.response import ModelResponse, ToolExecution
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.requirement import RunRequirement
 from agno.tools.function import Function
 
 
@@ -62,6 +66,33 @@ class _BatchModel(Model):
         return response
 
 
+class _ContinuationOrderingModel(_BatchModel):
+    def __init__(self) -> None:
+        super().__init__([])
+
+    def _ordered_response(self, messages: list[Message]) -> ModelResponse:
+        self.calls += 1
+        tool_call_ids = [message.tool_call_id for message in messages if message.role == "tool"]
+        assert tool_call_ids[-2:] == ["present-call", "edit-call"]
+        return ModelResponse(content="ordered")
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._ordered_response(kwargs["messages"])
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._ordered_response(kwargs["messages"])
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield self._ordered_response(kwargs["messages"])
+
+    async def ainvoke_stream(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> AsyncIterator[ModelResponse]:
+        yield self._ordered_response(kwargs["messages"])
+
+
 def _functions(executions: list[str]) -> list[Function]:
     def present() -> str:
         executions.append("present")
@@ -95,6 +126,50 @@ def _confirmation_functions(executions: list[str]) -> list[Function]:
     for function in functions:
         function.requires_confirmation = True
     return functions
+
+
+def _paused_boundary_run() -> RunOutput:
+    execution = ToolExecution(
+        tool_call_id="present-call",
+        tool_name="present",
+        tool_args={},
+        requires_confirmation=True,
+        confirmed=True,
+        stop_after_tool_call=True,
+    )
+    run = RunOutput(
+        run_id="ordered-boundary-run",
+        session_id="ordered-boundary-session",
+        status=RunStatus.paused,
+        tools=[execution],
+        requirements=[RunRequirement(tool_execution=execution)],
+        messages=[
+            Message(role="user", content="Present, then edit."),
+            Message(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "present-call",
+                        "type": "function",
+                        "function": {"name": "present", "arguments": "{}"},
+                    },
+                    {
+                        "id": "edit-call",
+                        "type": "function",
+                        "function": {"name": "edit", "arguments": "{}"},
+                    },
+                ],
+            ),
+            Message(
+                role="tool",
+                tool_call_id="edit-call",
+                tool_name="edit",
+                content="Skipped because present is a stop-after boundary.",
+                tool_call_error=True,
+            ),
+        ],
+    )
+    return RunOutput.from_dict(run.to_dict())
 
 
 def _assert_boundary_result(
@@ -245,3 +320,40 @@ async def test_async_multiple_confirmation_proposals_remain_pending(
     assert executions == []
     assert paused_names == ["confirm_a", "confirm_b"]
     assert not any(message.role == "tool" for message in messages)
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_sync_resumed_boundary_result_precedes_deferred_sibling(stream: bool) -> None:
+    model = _ContinuationOrderingModel()
+    executions: list[str] = []
+    agent = Agent(model=model, tools=_functions(executions), telemetry=False)
+    paused = _paused_boundary_run()
+
+    if stream:
+        events = list(agent.continue_run(paused, stream=True, yield_run_output=True))
+        result = next(event for event in events if isinstance(event, RunOutput))
+    else:
+        result = agent.continue_run(paused)
+
+    assert result.status == RunStatus.completed
+    assert model.calls == 1
+    assert executions == ["present"]
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.asyncio
+async def test_async_resumed_boundary_result_precedes_deferred_sibling(stream: bool) -> None:
+    model = _ContinuationOrderingModel()
+    executions: list[str] = []
+    agent = Agent(model=model, tools=_functions(executions), telemetry=False)
+    paused = _paused_boundary_run()
+
+    if stream:
+        events = [event async for event in agent.acontinue_run(paused, stream=True, yield_run_output=True)]
+        result = next(event for event in events if isinstance(event, RunOutput))
+    else:
+        result = await agent.acontinue_run(paused)
+
+    assert result.status == RunStatus.completed
+    assert model.calls == 1
+    assert executions == ["present"]

--- a/libs/agno/tests/unit/models/test_tool_stop_after_batch_boundary.py
+++ b/libs/agno/tests/unit/models/test_tool_stop_after_batch_boundary.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+
+from agno.models.base import Model
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+from agno.tools.function import Function
+
+
+class _BatchModel(Model):
+    def __init__(self, tool_names: list[str]) -> None:
+        super().__init__(
+            id="tool-stop-boundary-test",
+            name="tool-stop-boundary-test",
+            provider="test",
+        )
+        self.tool_names = tool_names
+        self.calls = 0
+
+    def _next_response(self) -> ModelResponse:
+        self.calls += 1
+        if self.calls > 1:
+            raise AssertionError("provider was called after a stop-after boundary")
+        return ModelResponse(
+            tool_calls=[
+                {
+                    "id": f"{name}-call",
+                    "type": "function",
+                    "function": {"name": name, "arguments": "{}"},
+                }
+                for name in self.tool_names
+            ]
+        )
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next_response()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next_response()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield self._next_response()
+
+    async def ainvoke_stream(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> AsyncIterator[ModelResponse]:
+        yield self._next_response()
+
+    def _parse_provider_response(
+        self,
+        response: Any,
+        **kwargs: Any,
+    ) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+
+def _functions(executions: list[str]) -> list[Function]:
+    def present() -> str:
+        executions.append("present")
+        return "presented"
+
+    def edit() -> str:
+        executions.append("edit")
+        return "edited"
+
+    present_function = Function.from_callable(present)
+    present_function.requires_confirmation = True
+    present_function.stop_after_tool_call = True
+    edit_function = Function.from_callable(edit)
+    edit_function.stop_after_tool_call = True
+    return [present_function, edit_function]
+
+
+def _confirmation_functions(executions: list[str]) -> list[Function]:
+    def confirm_a() -> str:
+        executions.append("confirm_a")
+        return "a"
+
+    def confirm_b() -> str:
+        executions.append("confirm_b")
+        return "b"
+
+    functions = [
+        Function.from_callable(confirm_a),
+        Function.from_callable(confirm_b),
+    ]
+    for function in functions:
+        function.requires_confirmation = True
+    return functions
+
+
+def _assert_boundary_result(
+    *,
+    model: _BatchModel,
+    messages: list[Message],
+    executions: list[str],
+    first_tool: str,
+) -> None:
+    assert model.calls == 1
+    expected_executions = [] if first_tool == "present" else ["edit"]
+    assert executions == expected_executions
+
+    tool_messages = [message for message in messages if message.role == "tool"]
+    deferred_name = "edit" if first_tool == "present" else "present"
+    deferred = next(message for message in tool_messages if message.tool_name == deferred_name)
+    assert deferred.tool_call_id == f"{deferred_name}-call"
+    assert deferred.tool_call_error is True
+    assert deferred.stop_after_tool_call is False
+    assert f"{first_tool} is a stop-after boundary" in str(deferred.content)
+
+    if first_tool == "present":
+        assert not any(message.tool_name == "present" for message in tool_messages)
+    else:
+        edit_result = next(message for message in tool_messages if message.tool_name == "edit")
+        assert edit_result.content == "edited"
+        assert edit_result.stop_after_tool_call is True
+
+
+@pytest.mark.parametrize("first_tool", ["present", "edit"])
+@pytest.mark.parametrize("stream", [False, True])
+def test_sync_later_calls_do_not_cross_stop_after_boundary(
+    first_tool: str,
+    stream: bool,
+) -> None:
+    later_tool = "edit" if first_tool == "present" else "present"
+    model = _BatchModel([first_tool, later_tool])
+    executions: list[str] = []
+    messages = [Message(role="user", content="Review and update the artifact.")]
+    kwargs = {
+        "messages": messages,
+        "tools": _functions(executions),
+        "tool_call_limit": 8,
+    }
+
+    if stream:
+        list(model.response_stream(**kwargs))
+    else:
+        model.response(**kwargs)
+
+    _assert_boundary_result(
+        model=model,
+        messages=messages,
+        executions=executions,
+        first_tool=first_tool,
+    )
+
+
+@pytest.mark.parametrize("first_tool", ["present", "edit"])
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.asyncio
+async def test_async_later_calls_do_not_cross_stop_after_boundary(
+    first_tool: str,
+    stream: bool,
+) -> None:
+    later_tool = "edit" if first_tool == "present" else "present"
+    model = _BatchModel([first_tool, later_tool])
+    executions: list[str] = []
+    messages = [Message(role="user", content="Review and update the artifact.")]
+    kwargs = {
+        "messages": messages,
+        "tools": _functions(executions),
+        "tool_call_limit": 8,
+    }
+
+    if stream:
+        async for _ in model.aresponse_stream(**kwargs):
+            pass
+    else:
+        await model.aresponse(**kwargs)
+
+    _assert_boundary_result(
+        model=model,
+        messages=messages,
+        executions=executions,
+        first_tool=first_tool,
+    )
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_sync_multiple_confirmation_proposals_remain_pending(stream: bool) -> None:
+    model = _BatchModel(["confirm_a", "confirm_b"])
+    executions: list[str] = []
+    messages = [Message(role="user", content="Propose both actions.")]
+    kwargs = {
+        "messages": messages,
+        "tools": _confirmation_functions(executions),
+    }
+
+    if stream:
+        events = list(model.response_stream(**kwargs))
+        paused_names = [
+            execution.tool_name
+            for event in events
+            for execution in (getattr(event, "tool_executions", None) or [])
+            if execution.requires_confirmation
+        ]
+    else:
+        response = model.response(**kwargs)
+        paused_names = [
+            execution.tool_name for execution in (response.tool_executions or []) if execution.requires_confirmation
+        ]
+
+    assert model.calls == 1
+    assert executions == []
+    assert paused_names == ["confirm_a", "confirm_b"]
+    assert not any(message.role == "tool" for message in messages)
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.asyncio
+async def test_async_multiple_confirmation_proposals_remain_pending(
+    stream: bool,
+) -> None:
+    model = _BatchModel(["confirm_a", "confirm_b"])
+    executions: list[str] = []
+    messages = [Message(role="user", content="Propose both actions.")]
+    kwargs = {
+        "messages": messages,
+        "tools": _confirmation_functions(executions),
+    }
+
+    if stream:
+        events = [event async for event in model.aresponse_stream(**kwargs)]
+        paused_names = [
+            execution.tool_name
+            for event in events
+            for execution in (getattr(event, "tool_executions", None) or [])
+            if execution.requires_confirmation
+        ]
+    else:
+        response = await model.aresponse(**kwargs)
+        paused_names = [
+            execution.tool_name for execution in (response.tool_executions or []) if execution.requires_confirmation
+        ]
+
+    assert model.calls == 1
+    assert executions == []
+    assert paused_names == ["confirm_a", "confirm_b"]
+    assert not any(message.role == "tool" for message in messages)


### PR DESCRIPTION
Fixes #9201.

## What changed

- Treat declared `Function.stop_after_tool_call` as a boundary inside a provider tool-call batch.
- Stop synchronous execution after the boundary call.
- Truncate async scheduling before later calls are launched.
- Emit a terminal tool-role error for every deferred proposal, preserving original call IDs, names, arguments, and source order.
- Cover confirmation tools that also declare stop-after without changing ordinary multi-confirmation behavior.

## Scope

This patch intentionally covers declared Function metadata only. It does not claim to solve generic HITL pause boundaries (#9202) or dynamically raised `AgentRunException(stop_execution=True)` after async work has already been scheduled.

## Verification

12 focused cases cover sync/async, streaming/non-streaming, executing and paused stop boundaries, plus ordinary multi-confirmation controls.