### PR TITLE
fix: keep sync callable factories off the event loop

### DIFF
--- a/libs/agno/agno/utils/asyncio.py
+++ b/libs/agno/agno/utils/asyncio.py
@@ -1,0 +1,48 @@
+"""Async boundaries for synchronous framework work."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
+from functools import partial
+from typing import Any, Callable
+
+_BLOCKING_EXECUTOR = ThreadPoolExecutor(thread_name_prefix="agno-blocking")
+
+
+async def run_blocking(
+    function: Callable[..., Any],
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Run synchronous work with context propagation and settled cancellation."""
+
+    loop = asyncio.get_running_loop()
+    context = copy_context()
+    future = loop.run_in_executor(
+        _BLOCKING_EXECUTOR,
+        partial(context.run, partial(function, *args, **kwargs)),
+    )
+    cancellation: asyncio.CancelledError | None = None
+    while not future.done():
+        try:
+            # Polling also covers runtimes that can miss the cross-thread
+            # wakeup after a worker completes in a short-lived event loop.
+            await asyncio.wait_for(asyncio.shield(future), timeout=0.01)
+        except TimeoutError:
+            continue
+        except asyncio.CancelledError as exc:
+            if future.cancelled():
+                raise
+            if cancellation is None:
+                cancellation = exc
+
+    result = future.result()
+    if cancellation is not None:
+        raise cancellation
+    return result
+
+
+__all__ = ["run_blocking"]

--- a/libs/agno/agno/utils/asyncio.py
+++ b/libs/agno/agno/utils/asyncio.py
@@ -31,7 +31,7 @@ async def run_blocking(
             # Polling also covers runtimes that can miss the cross-thread
             # wakeup after a worker completes in a short-lived event loop.
             await asyncio.wait_for(asyncio.shield(future), timeout=0.01)
-        except TimeoutError:
+        except asyncio.TimeoutError:
             continue
         except asyncio.CancelledError as exc:
             if future.cancelled():

--- a/libs/agno/agno/utils/callables.py
+++ b/libs/agno/agno/utils/callables.py
@@ -22,6 +22,7 @@ from typing import (
 if TYPE_CHECKING:
     from agno.run import RunContext
 
+from agno.utils.asyncio import run_blocking
 from agno.utils.log import log_debug, log_warning
 
 
@@ -122,9 +123,12 @@ async def ainvoke_callable_factory(
     if "session_state" in sig.parameters:
         kwargs["session_state"] = run_context.session_state if run_context.session_state is not None else {}
 
-    result = factory(**kwargs)
+    if asyncio.iscoroutinefunction(factory):
+        result = factory(**kwargs)
+    else:
+        result = await run_blocking(factory, **kwargs)
 
-    if asyncio.iscoroutine(result):
+    if asyncio.isfuture(result) or asyncio.iscoroutine(result):
         result = await result
 
     return result
@@ -193,8 +197,11 @@ async def _acompute_cache_key(
         if "team" in sig.parameters:
             kwargs["team"] = entity
 
-        result = custom_key_fn(**kwargs)
-        if asyncio.iscoroutine(result):
+        if asyncio.iscoroutinefunction(custom_key_fn):
+            result = custom_key_fn(**kwargs)
+        else:
+            result = await run_blocking(custom_key_fn, **kwargs)
+        if asyncio.isfuture(result) or asyncio.iscoroutine(result):
             result = await result
         return result
 

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -97,6 +97,7 @@ from agno.run.workflow import (
 from agno.session.workflow import WorkflowChatInteraction, WorkflowSession
 from agno.team.team import Team
 from agno.utils.agent import validate_input
+from agno.utils.asyncio import run_blocking
 from agno.utils.log import (
     log_debug,
     log_error,
@@ -1434,8 +1435,7 @@ class Workflow:
             if self._has_async_db():
                 result = await self._aupsert_session(session=session)  # type: ignore
             else:
-                # Offload the sync DB call so it doesn't block the event loop.
-                result = await asyncio.to_thread(self._upsert_session, session=session)
+                result = await run_blocking(self._upsert_session, session=session)
             if result is None:
                 log_warning(f"WorkflowSession not persisted (ownership mismatch): {session.session_id}")
             else:

--- a/libs/agno/tests/unit/agent/test_callable_resources.py
+++ b/libs/agno/tests/unit/agent/test_callable_resources.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
+import time
+from contextvars import ContextVar
 from typing import Any, Dict, Optional
 from unittest.mock import MagicMock
 
@@ -207,9 +211,51 @@ class TestAinvokeCallableFactory:
         assert result == [_dummy_tool]
 
     @pytest.mark.asyncio
+    async def test_sync_factory_does_not_block_event_loop_and_preserves_context(self):
+        started = threading.Event()
+        release = threading.Event()
+        marker: ContextVar[str] = ContextVar("marker", default="missing")
+
+        def factory():
+            assert marker.get() == "request-context"
+            started.set()
+            release.wait(timeout=1)
+            return [_dummy_tool]
+
+        agent = Agent(name="test")
+        rc = _make_run_context()
+        marker.set("request-context")
+        task = asyncio.create_task(ainvoke_callable_factory(factory, agent, rc))
+        try:
+            deadline = time.monotonic() + 0.5
+            while not started.is_set() and time.monotonic() < deadline:
+                await asyncio.sleep(0)
+            assert started.is_set()
+            before = time.monotonic()
+            await asyncio.sleep(0.01)
+            assert time.monotonic() - before < 0.2
+            assert not task.done()
+        finally:
+            release.set()
+        assert await task == [_dummy_tool]
+
+    @pytest.mark.asyncio
     async def test_async_factory_awaited(self):
         async def factory(agent):
             return [_dummy_tool]
+
+        agent = Agent(name="test")
+        rc = _make_run_context()
+        result = await ainvoke_callable_factory(factory, agent, rc)
+        assert result == [_dummy_tool]
+
+    @pytest.mark.asyncio
+    async def test_sync_factory_returned_awaitable_is_awaited(self):
+        async def resolve():
+            return [_dummy_tool]
+
+        def factory():
+            return resolve()
 
         agent = Agent(name="test")
         rc = _make_run_context()
@@ -459,6 +505,38 @@ class TestAresolveCallableTools:
         agent = Agent(name="test", tools=factory)
         rc = _make_run_context(user_id="u1")
         await aresolve_callable_tools(agent, rc)
+        assert rc.tools == [_dummy_tool]
+
+    @pytest.mark.asyncio
+    async def test_sync_cache_key_does_not_block_event_loop(self):
+        started = threading.Event()
+        release = threading.Event()
+
+        def cache_key(run_context):
+            started.set()
+            release.wait(timeout=1)
+            return run_context.user_id
+
+        agent = Agent(
+            name="test",
+            tools=lambda: [_dummy_tool],
+            callable_tools_cache_key=cache_key,
+        )
+        rc = _make_run_context(user_id="u1")
+        task = asyncio.create_task(aresolve_callable_tools(agent, rc))
+        try:
+            deadline = time.monotonic() + 0.5
+            while not started.is_set() and time.monotonic() < deadline:
+                await asyncio.sleep(0)
+            assert started.is_set()
+            before = time.monotonic()
+            await asyncio.sleep(0.01)
+            assert time.monotonic() - before < 0.2
+            assert not task.done()
+        finally:
+            release.set()
+
+        await task
         assert rc.tools == [_dummy_tool]
 
 

--- a/libs/agno/tests/unit/utils/test_asyncio.py
+++ b/libs/agno/tests/unit/utils/test_asyncio.py
@@ -1,0 +1,54 @@
+import asyncio
+import time
+from contextvars import ContextVar
+from threading import Event
+
+import pytest
+
+from agno.utils.asyncio import run_blocking
+
+
+def test_run_blocking_preserves_context_in_a_short_lived_loop():
+    marker: ContextVar[str] = ContextVar("marker", default="missing")
+    marker.set("bound-run")
+
+    async def invoke():
+        return await run_blocking(marker.get)
+
+    assert asyncio.run(invoke()) == "bound-run"
+
+
+def test_run_blocking_wakes_short_lived_loop_after_delayed_worker():
+    def work() -> str:
+        time.sleep(0.05)
+        return "finished"
+
+    async def invoke() -> str:
+        return await asyncio.wait_for(run_blocking(work), timeout=0.5)
+
+    assert asyncio.run(invoke()) == "finished"
+
+
+def test_run_blocking_settles_worker_before_propagating_cancellation():
+    entered = Event()
+    release = Event()
+    completed = Event()
+
+    def work() -> None:
+        entered.set()
+        release.wait(timeout=2)
+        completed.set()
+
+    async def invoke() -> None:
+        task = asyncio.create_task(run_blocking(work))
+        while not entered.is_set():
+            await asyncio.sleep(0.01)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(invoke())
+    assert completed.is_set()

--- a/libs/agno/tests/unit/workflow/test_workflow_sync_persistence_cancellation.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_sync_persistence_cancellation.py
@@ -1,0 +1,54 @@
+import asyncio
+from contextvars import ContextVar
+from threading import Event
+from unittest.mock import Mock
+
+import pytest
+
+from agno.session.workflow import WorkflowSession
+from agno.workflow.workflow import Workflow
+
+
+def test_asave_session_settles_sync_persistence_before_cancellation(monkeypatch):
+    entered = Event()
+    release = Event()
+    completed = Event()
+    marker: ContextVar[str] = ContextVar("marker", default="missing")
+    observed_context: list[str] = []
+
+    workflow = Workflow(id="sync-persistence", db=Mock(), session_id="session-1")
+    session = WorkflowSession(
+        session_id="session-1",
+        workflow_id="sync-persistence",
+        session_data={},
+    )
+
+    monkeypatch.setattr(workflow, "_has_async_db", lambda: False)
+
+    def blocking_upsert(*, session: WorkflowSession) -> WorkflowSession:
+        observed_context.append(marker.get())
+        entered.set()
+        release.wait(timeout=2)
+        completed.set()
+        return session
+
+    monkeypatch.setattr(workflow, "_upsert_session", blocking_upsert)
+
+    async def invoke() -> None:
+        marker.set("request-context")
+        task = asyncio.create_task(workflow.asave_session(session))
+        while not entered.is_set():
+            await asyncio.sleep(0.01)
+
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(invoke())
+
+    assert completed.is_set()
+    assert observed_context == ["request-context"]


### PR DESCRIPTION
Fixes #9203.

> [!NOTE]
> Depends on #9209 and is intentionally stacked on that shared `run_blocking()` boundary. Until the prerequisite merges, this PR's compare includes both commits; after it lands, this branch will be rebased and the diff will shrink to callable resolution only.

## What changed

- Offload synchronous callable resource factories from async Agent and Team resolution.
- Offload synchronous custom cache-key functions through the same boundary.
- Leave native async callables on the event loop.
- Await coroutine or Future values returned by synchronous factories.

## Verification

- Event-loop responsiveness and ContextVar propagation.
- Returned-awaitable behavior.
- Synchronous custom cache-key responsiveness.
- 116 Agent, Team, blocking-boundary, and Workflow tests passed.

Related but not duplicate: #7621, #8628, and #8648.