### PR TITLE
fix: settle sync workflow persistence cancellation

### DIFF
--- a/libs/agno/agno/utils/asyncio.py
+++ b/libs/agno/agno/utils/asyncio.py
@@ -1,0 +1,48 @@
+"""Async boundaries for synchronous framework work."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
+from functools import partial
+from typing import Any, Callable
+
+_BLOCKING_EXECUTOR = ThreadPoolExecutor(thread_name_prefix="agno-blocking")
+
+
+async def run_blocking(
+    function: Callable[..., Any],
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Run synchronous work with context propagation and settled cancellation."""
+
+    loop = asyncio.get_running_loop()
+    context = copy_context()
+    future = loop.run_in_executor(
+        _BLOCKING_EXECUTOR,
+        partial(context.run, partial(function, *args, **kwargs)),
+    )
+    cancellation: asyncio.CancelledError | None = None
+    while not future.done():
+        try:
+            # Polling also covers runtimes that can miss the cross-thread
+            # wakeup after a worker completes in a short-lived event loop.
+            await asyncio.wait_for(asyncio.shield(future), timeout=0.01)
+        except TimeoutError:
+            continue
+        except asyncio.CancelledError as exc:
+            if future.cancelled():
+                raise
+            if cancellation is None:
+                cancellation = exc
+
+    result = future.result()
+    if cancellation is not None:
+        raise cancellation
+    return result
+
+
+__all__ = ["run_blocking"]

--- a/libs/agno/agno/utils/asyncio.py
+++ b/libs/agno/agno/utils/asyncio.py
@@ -31,7 +31,7 @@ async def run_blocking(
             # Polling also covers runtimes that can miss the cross-thread
             # wakeup after a worker completes in a short-lived event loop.
             await asyncio.wait_for(asyncio.shield(future), timeout=0.01)
-        except TimeoutError:
+        except asyncio.TimeoutError:
             continue
         except asyncio.CancelledError as exc:
             if future.cancelled():

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -97,6 +97,7 @@ from agno.run.workflow import (
 from agno.session.workflow import WorkflowChatInteraction, WorkflowSession
 from agno.team.team import Team
 from agno.utils.agent import validate_input
+from agno.utils.asyncio import run_blocking
 from agno.utils.log import (
     log_debug,
     log_error,
@@ -1434,8 +1435,7 @@ class Workflow:
             if self._has_async_db():
                 result = await self._aupsert_session(session=session)  # type: ignore
             else:
-                # Offload the sync DB call so it doesn't block the event loop.
-                result = await asyncio.to_thread(self._upsert_session, session=session)
+                result = await run_blocking(self._upsert_session, session=session)
             if result is None:
                 log_warning(f"WorkflowSession not persisted (ownership mismatch): {session.session_id}")
             else:

--- a/libs/agno/tests/unit/utils/test_asyncio.py
+++ b/libs/agno/tests/unit/utils/test_asyncio.py
@@ -1,0 +1,54 @@
+import asyncio
+import time
+from contextvars import ContextVar
+from threading import Event
+
+import pytest
+
+from agno.utils.asyncio import run_blocking
+
+
+def test_run_blocking_preserves_context_in_a_short_lived_loop():
+    marker: ContextVar[str] = ContextVar("marker", default="missing")
+    marker.set("bound-run")
+
+    async def invoke():
+        return await run_blocking(marker.get)
+
+    assert asyncio.run(invoke()) == "bound-run"
+
+
+def test_run_blocking_wakes_short_lived_loop_after_delayed_worker():
+    def work() -> str:
+        time.sleep(0.05)
+        return "finished"
+
+    async def invoke() -> str:
+        return await asyncio.wait_for(run_blocking(work), timeout=0.5)
+
+    assert asyncio.run(invoke()) == "finished"
+
+
+def test_run_blocking_settles_worker_before_propagating_cancellation():
+    entered = Event()
+    release = Event()
+    completed = Event()
+
+    def work() -> None:
+        entered.set()
+        release.wait(timeout=2)
+        completed.set()
+
+    async def invoke() -> None:
+        task = asyncio.create_task(run_blocking(work))
+        while not entered.is_set():
+            await asyncio.sleep(0.01)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(invoke())
+    assert completed.is_set()

--- a/libs/agno/tests/unit/workflow/test_workflow_sync_persistence_cancellation.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_sync_persistence_cancellation.py
@@ -1,0 +1,54 @@
+import asyncio
+from contextvars import ContextVar
+from threading import Event
+from unittest.mock import Mock
+
+import pytest
+
+from agno.session.workflow import WorkflowSession
+from agno.workflow.workflow import Workflow
+
+
+def test_asave_session_settles_sync_persistence_before_cancellation(monkeypatch):
+    entered = Event()
+    release = Event()
+    completed = Event()
+    marker: ContextVar[str] = ContextVar("marker", default="missing")
+    observed_context: list[str] = []
+
+    workflow = Workflow(id="sync-persistence", db=Mock(), session_id="session-1")
+    session = WorkflowSession(
+        session_id="session-1",
+        workflow_id="sync-persistence",
+        session_data={},
+    )
+
+    monkeypatch.setattr(workflow, "_has_async_db", lambda: False)
+
+    def blocking_upsert(*, session: WorkflowSession) -> WorkflowSession:
+        observed_context.append(marker.get())
+        entered.set()
+        release.wait(timeout=2)
+        completed.set()
+        return session
+
+    monkeypatch.setattr(workflow, "_upsert_session", blocking_upsert)
+
+    async def invoke() -> None:
+        marker.set("request-context")
+        task = asyncio.create_task(workflow.asave_session(session))
+        while not entered.is_set():
+            await asyncio.sleep(0.01)
+
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(invoke())
+
+    assert completed.is_set()
+    assert observed_context == ["request-context"]


### PR DESCRIPTION
Fixes #9199.

Supersedes #9207, which the duplicate bot closed because the stacked callable PR mentioned this issue while disclosing its dependency. That incidental issue reference has been removed; the patches have distinct scopes.

## What changed

- Add a private context-preserving blocking boundary backed by a dedicated executor.
- Shield and settle synchronous work before propagating task cancellation.
- Poll the future to remain reliable when a short-lived loop misses a cross-thread wake-up.
- Route Workflow's synchronous `asave_session()` fallback through the boundary.

## Why

`asyncio.to_thread()` lets cancellation escape while the framework-owned database write is still active, so terminal cancellation can race persistence.

## Verification

Tests cover:

- ContextVar propagation in a short-lived loop.
- Delayed non-cancelled worker completion guarded by `asyncio.wait_for()`.
- Cancellation settlement before `CancelledError` escapes.
- The real Workflow synchronous persistence fallback.

Related but not duplicate: #6990.