### PR TITLE
[fix] Cache Pydantic version lookup during tool wrapping

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from functools import partial, wraps
+from functools import lru_cache, partial, wraps
 from importlib.metadata import version
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Type, TypeVar, get_type_hints
 
@@ -13,6 +13,11 @@ from agno.run import RunContext
 from agno.utils.log import log_debug, log_exception, log_warning
 
 T = TypeVar("T")
+
+
+@lru_cache(maxsize=1)
+def _get_pydantic_version() -> Version:
+    return Version(version("pydantic"))
 
 
 def get_entrypoint_docstring(entrypoint: Callable) -> str:
@@ -563,7 +568,7 @@ class Function(BaseModel):
         """Wrap a callable with Pydantic's validate_call decorator, if relevant"""
         from inspect import isasyncgenfunction, iscoroutinefunction, signature
 
-        pydantic_version = Version(version("pydantic"))
+        pydantic_version = _get_pydantic_version()
 
         # Async generators need special handling: validate_call turns an `async def ... yield`
         # into a plain function that returns an async_generator, which makes

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Optional
 import pytest
 from pydantic import BaseModel, ValidationError
 
+import agno.tools.function as function_module
 from agno.models.message import Message
 from agno.run.base import RunContext
 from agno.tools.decorator import tool
@@ -143,6 +144,20 @@ def test_wrap_callable():
     with pytest.raises(ValidationError):
         test_func.entrypoint(param1="test")
     assert test_func.entrypoint._wrapped_for_validation is True
+
+
+def test_wrap_callable_caches_pydantic_version_lookup(mocker):
+    """Pydantic package metadata should only be read once across many tool wraps."""
+    function_module._get_pydantic_version.cache_clear()
+    version_spy = mocker.spy(function_module, "version")
+
+    def test_func(value: str) -> str:
+        return value
+
+    for _ in range(100):
+        Function._wrap_callable(test_func)
+
+    assert version_spy.call_count == 1
 
 
 def test_function_from_callable_strict():


### PR DESCRIPTION
## Summary

`Function._wrap_callable()` reads Pydantic package metadata for every tool wrap. In [MindRoom](https://github.com/mindroom-ai/mindroom), repeated wraps through `src/mindroom/tool_system/output_files.py` make this I/O a hot path; on a network-backed Python install it caused multi-second event-loop stalls and made Agno tool handling very slow.

This caches the parsed Pydantic version once per process. Tool wrapping and schemas are unchanged.

100-wrap local benchmark: 65.94 ms -> 11.01 ms; metadata lookups: 100 -> 1.

Fixes #9211.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (not applicable)
- [ ] Examples and guides updated (not applicable)
- [x] Tested in a clean worktree
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I searched existing open pull requests and found no duplicate
- [ ] A similar PR exists (not applicable)
- [x] This PR was entirely AI-generated with Codex and reviewed by the submitter

---

## Additional Notes

One regression test was added. The focused 55-test file and scoped Ruff checks pass. Full unit collection in the local dev environment is blocked by optional provider dependencies not installed by the repository setup script.