### PR TITLE
Fix HITL user input schema isolation

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1,6 +1,7 @@
 import asyncio
 import collections.abc
 import json
+from copy import deepcopy
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from hashlib import md5
@@ -2351,7 +2352,7 @@ class Model(ABC):
 
             # The function requires user input (HITL)
             if fc.function.requires_user_input:
-                user_input_schema = fc.function.user_input_schema
+                user_input_schema = deepcopy(fc.function.user_input_schema)
                 if fc.arguments and user_input_schema:
                     for name, value in fc.arguments.items():
                         for user_input_field in user_input_schema:
@@ -2552,7 +2553,7 @@ class Model(ABC):
                 )
             # If the function requires user input, we yield a message to the user
             if fc.function.requires_user_input and not skip_pause_check:
-                user_input_schema = fc.function.user_input_schema
+                user_input_schema = deepcopy(fc.function.user_input_schema)
                 if fc.arguments and user_input_schema:
                     for name, value in fc.arguments.items():
                         for user_input_field in user_input_schema:

--- a/libs/agno/tests/unit/models/test_hitl_tool_pause_schema_copy.py
+++ b/libs/agno/tests/unit/models/test_hitl_tool_pause_schema_copy.py
@@ -1,0 +1,87 @@
+"""Regression tests for HITL tool pause schema isolation."""
+
+import pytest
+
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ModelResponseEvent
+from agno.tools.function import Function, FunctionCall, UserInputField
+
+
+class _PausedHitlModel(Model):
+    def __init__(self) -> None:
+        super().__init__(id="paused-hitl", name="paused-hitl", provider="test")
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return ModelResponse()
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return ModelResponse()
+
+    def invoke_stream(self, *args, **kwargs):
+        yield ModelResponse()
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        yield ModelResponse()
+
+    def _parse_provider_response(self, response, **kwargs) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response) -> ModelResponse:
+        return response
+
+
+def _make_function() -> Function:
+    return Function(
+        name="submit_comment",
+        requires_user_input=True,
+        user_input_schema=[UserInputField(name="content", field_type=str, description="Comment content")],
+    )
+
+
+def _make_function_call(function: Function, call_id: str, content: str) -> FunctionCall:
+    return FunctionCall(function=function, arguments={"content": content}, call_id=call_id)
+
+
+def _assert_tool_pause_schema_isolation(responses):
+    assert len(responses) == 2
+    assert all(response.event == ModelResponseEvent.tool_call_paused.value for response in responses)
+
+    first_schema = responses[0].tool_executions[0].user_input_schema
+    second_schema = responses[1].tool_executions[0].user_input_schema
+
+    assert first_schema is not None
+    assert second_schema is not None
+    assert first_schema is not second_schema
+    assert [field.value for field in first_schema] == ["1"]
+    assert [field.value for field in second_schema] == ["2"]
+
+
+def test_sync_tool_pause_copies_user_input_schema():
+    model = _PausedHitlModel()
+    function = _make_function()
+    function_calls = [
+        _make_function_call(function, "call-1", "1"),
+        _make_function_call(function, "call-2", "2"),
+    ]
+
+    responses = list(model.run_function_calls(function_calls, []))
+
+    _assert_tool_pause_schema_isolation(responses)
+    assert function.user_input_schema is not None
+    assert [field.value for field in function.user_input_schema] == [None]
+
+
+@pytest.mark.asyncio
+async def test_async_tool_pause_copies_user_input_schema():
+    model = _PausedHitlModel()
+    function = _make_function()
+    function_calls = [
+        _make_function_call(function, "call-1", "1"),
+        _make_function_call(function, "call-2", "2"),
+    ]
+
+    responses = [response async for response in model.arun_function_calls(function_calls, [])]
+
+    _assert_tool_pause_schema_isolation(responses)
+    assert function.user_input_schema is not None
+    assert [field.value for field in function.user_input_schema] == [None]


### PR DESCRIPTION
## Summary
- deep-copy HITL user_input_schema before filling tool-call argument values
- keep the registered Function schema immutable across parallel calls
- add sync and async regression coverage for parallel paused tool calls

Fixes #8546

## Tests
- PYTHONPATH=/Users/even/Documents/GitHub/personal/agno/libs/agno /Users/even/Documents/GitHub/personal/agno/libs/agno/.venv/bin/pytest tests/unit/models/test_hitl_tool_pause_schema_copy.py tests/unit/team/test_continue_run_requirements.py -q
- PYTHONPATH=/Users/even/Documents/GitHub/personal/agno/libs/agno /Users/even/Documents/GitHub/personal/agno/libs/agno/.venv/bin/ruff check agno/models/base.py tests/unit/models/test_hitl_tool_pause_schema_copy.py