### PR TITLE
Fix /metrics/refresh blocking the event loop

### DIFF
--- a/libs/agno/agno/os/routers/metrics/metrics.py
+++ b/libs/agno/agno/os/routers/metrics/metrics.py
@@ -3,6 +3,7 @@ from datetime import date
 from typing import List, Optional, Union, cast
 
 from fastapi import Depends, HTTPException, Query, Request
+from fastapi.concurrency import run_in_threadpool
 from fastapi.routing import APIRouter
 
 from agno.db.base import AsyncBaseDb, BaseDb
@@ -117,7 +118,9 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 db = cast(AsyncBaseDb, db)
                 metrics, latest_updated_at = await db.get_metrics(starting_date=starting_date, ending_date=ending_date)
             else:
-                metrics, latest_updated_at = db.get_metrics(starting_date=starting_date, ending_date=ending_date)
+                metrics, latest_updated_at = await run_in_threadpool(
+                    db.get_metrics, starting_date=starting_date, ending_date=ending_date
+                )
 
             return MetricsResponse(
                 metrics=[DayAggregatedMetrics.from_dict(metric) for metric in metrics],
@@ -193,7 +196,7 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 db = cast(AsyncBaseDb, db)
                 result = await db.calculate_metrics()
             else:
-                result = db.calculate_metrics()
+                result = await run_in_threadpool(db.calculate_metrics)
             if result is None:
                 return []
 

--- a/libs/agno/tests/unit/os/routers/test_metrics_router.py
+++ b/libs/agno/tests/unit/os/routers/test_metrics_router.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import APIRouter
+
+from agno.os.routers.metrics import metrics as metrics_router
+from agno.os.routers.metrics.metrics import attach_routes
+
+
+def _route_endpoint(path: str):
+    router = attach_routes(APIRouter(), dbs={})
+    route = next(route for route in router.routes if getattr(route, "path", None) == path)
+    return route.endpoint
+
+
+@pytest.mark.asyncio
+async def test_refresh_metrics_runs_sync_db_in_threadpool(monkeypatch):
+    sync_db = SimpleNamespace(calculate_metrics=Mock(return_value=[]))
+    get_db = AsyncMock(return_value=sync_db)
+    run_in_threadpool = AsyncMock(side_effect=lambda fn, *args, **kwargs: fn(*args, **kwargs))
+
+    monkeypatch.setattr(metrics_router, "get_db", get_db)
+    monkeypatch.setattr(metrics_router, "run_in_threadpool", run_in_threadpool)
+
+    endpoint = _route_endpoint("/metrics/refresh")
+    request = Mock()
+    request.state = SimpleNamespace()
+
+    result = await endpoint(request=request, db_id="db-1", table=None)
+
+    assert result == []
+    get_db.assert_awaited_once_with({}, "db-1", None)
+    run_in_threadpool.assert_awaited_once()
+    sync_db.calculate_metrics.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_runs_sync_db_in_threadpool(monkeypatch):
+    sync_db = SimpleNamespace(get_metrics=Mock(return_value=([], None)))
+    get_db = AsyncMock(return_value=sync_db)
+    run_in_threadpool = AsyncMock(side_effect=lambda fn, *args, **kwargs: fn(*args, **kwargs))
+
+    monkeypatch.setattr(metrics_router, "get_db", get_db)
+    monkeypatch.setattr(metrics_router, "run_in_threadpool", run_in_threadpool)
+
+    endpoint = _route_endpoint("/metrics")
+    request = Mock()
+    request.state = SimpleNamespace()
+
+    result = await endpoint(request=request, starting_date=None, ending_date=None, db_id="db-1", table=None)
+
+    assert result.metrics == []
+    get_db.assert_awaited_once_with({}, "db-1", None)
+    run_in_threadpool.assert_awaited_once()
+    sync_db.get_metrics.assert_called_once_with(starting_date=None, ending_date=None)


### PR DESCRIPTION
Fixes #9091.

- Offload sync DB metrics reads and recalculation to `run_in_threadpool` in the metrics router.
- Keeps async DB and remote DB paths unchanged.
- Adds unit coverage for both `/metrics` and `/metrics/refresh` sync-db paths.

Validation:
- `pytest libs/agno/tests/unit/os/routers/test_metrics_router.py -q`
- `ruff check libs/agno/agno/os/routers/metrics/metrics.py libs/agno/tests/unit/os/routers/test_metrics_router.py`
