### PR TITLE
fix: skip structured parsing after stop-after tool

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -923,6 +923,9 @@ def get_response_format(
 def convert_response_to_structured_format(
     agent: Agent, run_response: Union[RunOutput, ModelResponse], run_context: Optional[RunContext] = None
 ):
+    if _response_stopped_after_tool_call(run_response):
+        return
+
     # Get output_schema from run_context
     output_schema = run_context.output_schema if run_context else None
 
@@ -955,6 +958,11 @@ def convert_response_to_structured_format(
                     log_warning(f"Failed to convert response to output model: {str(e)}")
             else:
                 log_warning("Something went wrong. Run response content is not a string")
+
+
+def _response_stopped_after_tool_call(run_response: Union[RunOutput, ModelResponse]) -> bool:
+    tool_executions = getattr(run_response, "tools", None) or getattr(run_response, "tool_executions", None) or []
+    return any(getattr(tool_execution, "stop_after_tool_call", False) for tool_execution in tool_executions)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/tests/unit/agent/test_stop_after_output_schema.py
+++ b/libs/agno/tests/unit/agent/test_stop_after_output_schema.py
@@ -1,0 +1,114 @@
+import json
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+from pydantic import BaseModel
+
+from agno.agent import _response
+from agno.agent.agent import Agent
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.tools.decorator import tool
+
+
+class StructuredResponse(BaseModel):
+    message: str
+
+
+class ToolCallingModel(Model):
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self._mock_response = ModelResponse(
+            role="assistant",
+            response_usage=MessageMetrics(),
+            tool_calls=[
+                {
+                    "id": "call-load-config",
+                    "type": "function",
+                    "function": {
+                        "name": "load_config",
+                        "arguments": json.dumps({"name": "config"}),
+                    },
+                }
+            ],
+        )
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._mock_response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._mock_response
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._mock_response
+
+
+@tool(stop_after_tool_call=True)
+def load_config(name: str) -> str:
+    return f"Loaded: {name}"
+
+
+def test_run_skips_output_schema_conversion_after_stop_after_tool_call(monkeypatch: pytest.MonkeyPatch):
+    called = False
+
+    def fail_if_parsed(*args, **kwargs):
+        nonlocal called
+        called = True
+        return None
+
+    monkeypatch.setattr(_response, "parse_response_model_str", fail_if_parsed)
+
+    agent = Agent(model=ToolCallingModel(), tools=[load_config], output_schema=StructuredResponse)
+
+    response = agent.run("load the config")
+
+    assert called is False
+    assert response.content == "Loaded: config"
+    assert response.tools is not None
+    assert response.tools[0].stop_after_tool_call is True
+
+
+@pytest.mark.asyncio
+async def test_arun_skips_output_schema_conversion_after_stop_after_tool_call(monkeypatch: pytest.MonkeyPatch):
+    called = False
+
+    def fail_if_parsed(*args, **kwargs):
+        nonlocal called
+        called = True
+        return None
+
+    monkeypatch.setattr(_response, "parse_response_model_str", fail_if_parsed)
+
+    agent = Agent(model=ToolCallingModel(), tools=[load_config], output_schema=StructuredResponse)
+
+    response = await agent.arun("load the config")
+
+    assert called is False
+    assert response.content == "Loaded: config"
+    assert response.tools is not None
+    assert response.tools[0].stop_after_tool_call is True


### PR DESCRIPTION
Fixes #6298.

## What changed

- Skip output_schema conversion when the run has intentionally terminated on a `stop_after_tool_call` tool execution.
- Keep `stop_after_tool_call` separate from HITL pause semantics.
- Add focused sync and async regression coverage with an offline model.

## Why

A stop-after tool can be the terminal response for a run. When `output_schema` is configured, the agent still attempted to parse that terminal tool result as structured model JSON, producing warnings/errors instead of returning the tool result as-is.

## Duplicate check

I checked #9205 and #9206 before opening this. They cover stop-after after HITL confirmation and stop-after boundaries inside a tool-call batch, but not this `output_schema` finalization path from #6298.

## Verification

- `PYTHONPATH=/Users/even/Documents/GitHub/personal/agno-stop-after-6298/libs/agno /Users/even/Documents/GitHub/personal/agno/libs/agno/.venv/bin/pytest tests/unit/agent/test_stop_after_output_schema.py -q`
- `PYTHONPATH=/Users/even/Documents/GitHub/personal/agno-stop-after-6298/libs/agno /Users/even/Documents/GitHub/personal/agno/libs/agno/.venv/bin/pytest tests/unit/agent/test_stop_after_output_schema.py tests/unit/agent/test_run_regressions.py -q`
- `PYTHONPATH=/Users/even/Documents/GitHub/personal/agno-stop-after-6298/libs/agno /Users/even/Documents/GitHub/personal/agno/libs/agno/.venv/bin/ruff check agno/agent/_response.py tests/unit/agent/test_stop_after_output_schema.py`