### PR TITLE
feat: add You.com knowledge readers

### DIFF
--- a/cookbook/07_knowledge/05_integrations/readers/04_youcom.py
+++ b/cookbook/07_knowledge/05_integrations/readers/04_youcom.py
@@ -1,0 +1,58 @@
+"""
+You.com Knowledge Readers
+==========================
+Search, contents, research, and finance readers for RAG ingestion.
+"""
+
+import asyncio
+import os
+
+from agno.knowledge.reader.youcom.contents_reader import YouContentsReader
+from agno.knowledge.reader.youcom.finance_reader import YouFinanceResearchReader
+from agno.knowledge.reader.youcom.research_reader import YouResearchReader
+from agno.knowledge.reader.youcom.search_reader import YouSearchReader
+
+
+API_KEY = os.getenv("YDC_API_KEY")
+
+
+async def main() -> None:
+    search_reader = YouSearchReader(api_key=API_KEY, chunk=False, count=3)
+    search_docs = await search_reader.async_read("agno rag readers")
+    print("SEARCH")
+    for doc in search_docs[:2]:
+        print(doc.name)
+        print(doc.meta_data)
+        print(doc.content[:400])
+        print()
+
+    contents_reader = YouContentsReader(api_key=API_KEY, chunk=False)
+    content_docs = await contents_reader.async_read(["https://you.com/docs/api-reference/contents"])
+    print("CONTENTS")
+    for doc in content_docs[:1]:
+        print(doc.name)
+        print(doc.meta_data)
+        print(doc.content[:400])
+        print()
+
+    research_reader = YouResearchReader(api_key=API_KEY, chunk=False, include_source_documents=True)
+    research_docs = await research_reader.async_read("How does Agno use knowledge readers?")
+    print("RESEARCH")
+    for doc in research_docs[:2]:
+        print(doc.name)
+        print(doc.meta_data)
+        print(doc.content[:400])
+        print()
+
+    finance_reader = YouFinanceResearchReader(api_key=API_KEY, chunk=False, include_source_documents=True)
+    finance_docs = await finance_reader.async_read("What drove NVIDIA revenue growth in fiscal 2025?")
+    print("FINANCE")
+    for doc in finance_docs[:2]:
+        print(doc.name)
+        print(doc.meta_data)
+        print(doc.content[:400])
+        print()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/libs/agno/agno/knowledge/reader/reader_factory.py
+++ b/libs/agno/agno/knowledge/reader/reader_factory.py
@@ -60,6 +60,22 @@ class ReaderFactory:
             "name": "TavilyReader",
             "description": "Extracts content from URLs using Tavily's Extract API with markdown or text output",
         },
+        "youcom_search": {
+            "name": "YouSearchReader",
+            "description": "Reads unified You.com search results into chunked documents for RAG workflows",
+        },
+        "youcom_contents": {
+            "name": "YouContentsReader",
+            "description": "Reads You.com page contents and metadata for direct URL ingestion",
+        },
+        "youcom_research": {
+            "name": "YouResearchReader",
+            "description": "Reads You.com research answers with inline citations and optional source documents",
+        },
+        "youcom_finance": {
+            "name": "YouFinanceResearchReader",
+            "description": "Reads You.com finance research answers with inline citations and optional source documents",
+        },
         "youtube": {
             "name": "YouTubeReader",
             "description": "Extracts transcripts and metadata from YouTube videos and playlists",
@@ -236,6 +252,54 @@ class ReaderFactory:
         return TavilyReader(**config)
 
     @classmethod
+    def _get_youcom_search_reader(cls, **kwargs) -> Reader:
+        """Get You.com search reader instance."""
+        from agno.knowledge.reader.youcom.search_reader import YouSearchReader
+
+        config: Dict[str, Any] = {
+            "name": "You.com Search Reader",
+            "description": "Reads unified You.com search results into chunked documents for RAG workflows",
+        }
+        config.update(kwargs)
+        return YouSearchReader(**config)
+
+    @classmethod
+    def _get_youcom_contents_reader(cls, **kwargs) -> Reader:
+        """Get You.com contents reader instance."""
+        from agno.knowledge.reader.youcom.contents_reader import YouContentsReader
+
+        config: Dict[str, Any] = {
+            "name": "You.com Contents Reader",
+            "description": "Reads You.com page contents and metadata for direct URL ingestion",
+        }
+        config.update(kwargs)
+        return YouContentsReader(**config)
+
+    @classmethod
+    def _get_youcom_research_reader(cls, **kwargs) -> Reader:
+        """Get You.com research reader instance."""
+        from agno.knowledge.reader.youcom.research_reader import YouResearchReader
+
+        config: Dict[str, Any] = {
+            "name": "You.com Research Reader",
+            "description": "Reads You.com research answers with inline citations and optional source documents",
+        }
+        config.update(kwargs)
+        return YouResearchReader(**config)
+
+    @classmethod
+    def _get_youcom_finance_reader(cls, **kwargs) -> Reader:
+        """Get You.com finance research reader instance."""
+        from agno.knowledge.reader.youcom.finance_reader import YouFinanceResearchReader
+
+        config: Dict[str, Any] = {
+            "name": "You.com Finance Research Reader",
+            "description": "Reads You.com finance research answers with inline citations and optional source documents",
+        }
+        config.update(kwargs)
+        return YouFinanceResearchReader(**config)
+
+    @classmethod
     def _get_youtube_reader(cls, **kwargs) -> Reader:
         """Get YouTube reader instance."""
         from agno.knowledge.reader.youtube_reader import YouTubeReader
@@ -346,6 +410,10 @@ class ReaderFactory:
             "website": ("agno.knowledge.reader.website_reader", "WebsiteReader"),
             "firecrawl": ("agno.knowledge.reader.firecrawl_reader", "FirecrawlReader"),
             "tavily": ("agno.knowledge.reader.tavily_reader", "TavilyReader"),
+            "youcom_search": ("agno.knowledge.reader.youcom.search_reader", "YouSearchReader"),
+            "youcom_contents": ("agno.knowledge.reader.youcom.contents_reader", "YouContentsReader"),
+            "youcom_research": ("agno.knowledge.reader.youcom.research_reader", "YouResearchReader"),
+            "youcom_finance": ("agno.knowledge.reader.youcom.finance_reader", "YouFinanceResearchReader"),
             "youtube": ("agno.knowledge.reader.youtube_reader", "YouTubeReader"),
             "arxiv": ("agno.knowledge.reader.arxiv_reader", "ArxivReader"),
             "wikipedia": ("agno.knowledge.reader.wikipedia_reader", "WikipediaReader"),

--- a/libs/agno/agno/knowledge/reader/youcom/__init__.py
+++ b/libs/agno/agno/knowledge/reader/youcom/__init__.py
@@ -1,13 +1,9 @@
-from agno.knowledge.reader.base import Reader
-from agno.knowledge.reader.reader_factory import ReaderFactory
 from agno.knowledge.reader.youcom.contents_reader import YouContentsReader
 from agno.knowledge.reader.youcom.finance_reader import YouFinanceResearchReader
 from agno.knowledge.reader.youcom.research_reader import YouResearchReader
 from agno.knowledge.reader.youcom.search_reader import YouSearchReader
 
 __all__ = [
-    "Reader",
-    "ReaderFactory",
     "YouContentsReader",
     "YouFinanceResearchReader",
     "YouResearchReader",

--- a/libs/agno/agno/knowledge/reader/youcom/base.py
+++ b/libs/agno/agno/knowledge/reader/youcom/base.py
@@ -1,0 +1,128 @@
+import hashlib
+import json
+from dataclasses import dataclass
+from os import getenv
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+import httpx
+
+from agno.knowledge.chunking.semantic import SemanticChunking
+from agno.knowledge.chunking.strategy import ChunkingStrategy
+from agno.knowledge.document.base import Document
+from agno.knowledge.reader.base import Reader
+from agno.utils.log import log_error, log_warning, logger
+
+DEFAULT_BASE_URL = "https://ydc-index.io"
+DEFAULT_REQUEST_TIMEOUT = 30
+DEFAULT_CRAWL_TIMEOUT_PAD = 10
+
+
+def _normalize_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, indent=2)
+    return str(value)
+
+
+def _join_non_empty(parts: Sequence[str]) -> str:
+    return "\n\n".join(part for part in parts if part)
+
+
+def _slug(value: str) -> str:
+    return hashlib.sha1(value.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class YouComReaderBase(Reader):
+    api_key: Optional[str] = None
+    base_url: str = DEFAULT_BASE_URL
+    request_timeout: Optional[float] = None
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        request_timeout: Optional[float] = None,
+        chunk: bool = True,
+        chunk_size: int = 5000,
+        chunking_strategy: Optional[ChunkingStrategy] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        if chunking_strategy is None:
+            try:
+                chunking_strategy = SemanticChunking(chunk_size=chunk_size)
+            except Exception:
+                chunking_strategy = None
+
+        super().__init__(chunk=chunk, chunk_size=chunk_size, chunking_strategy=chunking_strategy, name=name, description=description)
+
+        self.api_key = api_key or getenv("YDC_API_KEY")
+        if not self.api_key:
+            log_error("YDC_API_KEY not set. Please set the YDC_API_KEY environment variable.")
+        self.base_url = (base_url or getenv("YDC_BASE_URL") or DEFAULT_BASE_URL).rstrip("/")
+        self.request_timeout = request_timeout
+
+    def _headers(self) -> Dict[str, str]:
+        return {"X-API-Key": self.api_key or "", "Accept": "application/json"}
+
+    def _chunk_document(self, document: Document) -> List[Document]:
+        if self.chunk:
+            return self.chunk_document(document)
+        return [document]
+
+    def _maybe_chunk_document(self, document: Document) -> List[Document]:
+        if document.content and self.chunk:
+            return self.chunk_document(document)
+        return [document]
+
+    def _request_timeout_or_default(self, crawl_timeout: int, pad: int = DEFAULT_CRAWL_TIMEOUT_PAD) -> Optional[float]:
+        if self.request_timeout is not None:
+            return self.request_timeout
+        return max(DEFAULT_REQUEST_TIMEOUT, crawl_timeout + pad)
+
+    def _ensure_query(self, query: str) -> str:
+        if not query or not query.strip():
+            raise ValueError("Query cannot be empty")
+        return query.strip()
+
+    def _normalize_urls(self, urls: str | Iterable[str]) -> List[str]:
+        if isinstance(urls, str):
+            normalized = [urls]
+        else:
+            normalized = [url for url in urls if url]
+        if not normalized:
+            raise ValueError("At least one URL is required")
+        return normalized
+
+    def _json_request(self, method: str, path: str, *, params: Optional[Dict[str, Any]] = None, json_body: Optional[Dict[str, Any]] = None) -> Any:
+        url = f"{self.base_url}{path}"
+        with httpx.Client(timeout=self.request_timeout) as client:
+            response = client.request(method, url, headers=self._headers(), params=params, json=json_body)
+        response.raise_for_status()
+        return response.json()
+
+    async def _async_json_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_body: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        url = f"{self.base_url}{path}"
+        async with httpx.AsyncClient(timeout=self.request_timeout) as client:
+            response = await client.request(method, url, headers=self._headers(), params=params, json=json_body)
+        response.raise_for_status()
+        return response.json()
+
+    def _document_from_text(self, *, doc_id: str, name: str, content: str, meta_data: Dict[str, Any]) -> List[Document]:
+        document = Document(id=doc_id, name=name, content=content, meta_data=meta_data)
+        return self._maybe_chunk_document(document)
+
+    def _log_request_error(self, prefix: str, error: Exception) -> None:
+        log_warning(f"{prefix}: {error}")
+        logger.exception(prefix)

--- a/libs/agno/agno/knowledge/reader/youcom/contents_reader.py
+++ b/libs/agno/agno/knowledge/reader/youcom/contents_reader.py
@@ -1,0 +1,113 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.document.base import Document
+from agno.knowledge.reader.youcom.base import DEFAULT_CRAWL_TIMEOUT_PAD, YouComReaderBase, _join_non_empty, _normalize_text
+from agno.knowledge.types import ContentType
+
+
+@dataclass
+class YouContentsReader(YouComReaderBase):
+    formats: Sequence[str] = ("markdown", "metadata")
+    crawl_timeout: int = 10
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        formats: Sequence[str] = ("markdown", "metadata"),
+        crawl_timeout: int = 10,
+        request_timeout: Optional[float] = None,
+        chunk: bool = True,
+        chunk_size: int = 5000,
+        chunking_strategy: Optional[ChunkingStrategy] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            api_key=api_key,
+            base_url=base_url,
+            request_timeout=request_timeout,
+            chunk=chunk,
+            chunk_size=chunk_size,
+            chunking_strategy=chunking_strategy,
+            name=name,
+            description=description,
+        )
+        if not 1 <= crawl_timeout <= 60:
+            raise ValueError("crawl_timeout must be between 1 and 60 seconds")
+        if isinstance(formats, str):
+            self.formats = tuple(part.strip() for part in formats.split(",") if part.strip())
+        else:
+            self.formats = tuple(formats)
+        self.crawl_timeout = crawl_timeout
+
+    @classmethod
+    def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:
+        return [
+            ChunkingStrategyType.CODE_CHUNKER,
+            ChunkingStrategyType.SEMANTIC_CHUNKER,
+            ChunkingStrategyType.FIXED_SIZE_CHUNKER,
+            ChunkingStrategyType.AGENTIC_CHUNKER,
+            ChunkingStrategyType.DOCUMENT_CHUNKER,
+            ChunkingStrategyType.RECURSIVE_CHUNKER,
+        ]
+
+    @classmethod
+    def get_supported_content_types(cls) -> List[ContentType]:
+        return [ContentType.URL]
+
+    def _build_payload(self, urls: Iterable[str]) -> Dict[str, Any]:
+        return {"urls": list(urls), "formats": list(self.formats)}
+
+    def _documents_from_response(self, urls: List[str], data: Any) -> List[Document]:
+        if not isinstance(data, list):
+            return []
+        documents: List[Document] = []
+        for index, page in enumerate(data):
+            if not isinstance(page, dict):
+                continue
+            url = page.get("url") or urls[min(index, len(urls) - 1)]
+            title = page.get("title") or url
+            content = _normalize_text(page.get("markdown") or page.get("html") or page.get("text"))
+            if not content:
+                content = ""
+            meta_data = {
+                "source": "youcom_contents",
+                "url": url,
+                "title": title,
+            }
+            if page.get("metadata") is not None:
+                meta_data["metadata"] = page["metadata"]
+            documents.extend(
+                self._document_from_text(
+                    doc_id=url or title,
+                    name=title,
+                    content=_join_non_empty([f"# {title}", f"Source: {url}" if url else "", content]),
+                    meta_data=meta_data,
+                )
+            )
+        return documents
+
+    def read(self, urls: str | Iterable[str], name: Optional[str] = None) -> List[Document]:
+        normalized_urls = self._normalize_urls(urls)
+        try:
+            request_timeout = self._request_timeout_or_default(self.crawl_timeout, DEFAULT_CRAWL_TIMEOUT_PAD)
+            self.request_timeout = request_timeout
+            data = self._json_request("POST", "/v1/contents", json_body=self._build_payload(normalized_urls))
+            return self._documents_from_response(normalized_urls, data)
+        except Exception as error:
+            self._log_request_error("You.com contents request failed", error)
+            return []
+
+    async def async_read(self, urls: str | Iterable[str], name: Optional[str] = None) -> List[Document]:
+        normalized_urls = self._normalize_urls(urls)
+        try:
+            request_timeout = self._request_timeout_or_default(self.crawl_timeout, DEFAULT_CRAWL_TIMEOUT_PAD)
+            self.request_timeout = request_timeout
+            data = await self._async_json_request("POST", "/v1/contents", json_body=self._build_payload(normalized_urls))
+            return self._documents_from_response(normalized_urls, data)
+        except Exception as error:
+            self._log_request_error("You.com contents request failed", error)
+            return []

--- a/libs/agno/agno/knowledge/reader/youcom/finance_reader.py
+++ b/libs/agno/agno/knowledge/reader/youcom/finance_reader.py
@@ -1,0 +1,135 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.document.base import Document
+from agno.knowledge.reader.youcom.base import YouComReaderBase, _join_non_empty, _normalize_text, _slug
+from agno.knowledge.types import ContentType
+
+
+@dataclass
+class YouFinanceResearchReader(YouComReaderBase):
+    research_effort: str = "deep"
+    include_source_documents: bool = False
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        research_effort: str = "deep",
+        include_source_documents: bool = False,
+        request_timeout: Optional[float] = None,
+        chunk: bool = True,
+        chunk_size: int = 5000,
+        chunking_strategy: Optional[ChunkingStrategy] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            api_key=api_key,
+            base_url=base_url,
+            request_timeout=request_timeout,
+            chunk=chunk,
+            chunk_size=chunk_size,
+            chunking_strategy=chunking_strategy,
+            name=name,
+            description=description,
+        )
+        if not research_effort:
+            raise ValueError("research_effort cannot be empty")
+        self.research_effort = research_effort
+        self.include_source_documents = include_source_documents
+
+    @classmethod
+    def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:
+        return [
+            ChunkingStrategyType.CODE_CHUNKER,
+            ChunkingStrategyType.SEMANTIC_CHUNKER,
+            ChunkingStrategyType.FIXED_SIZE_CHUNKER,
+            ChunkingStrategyType.AGENTIC_CHUNKER,
+            ChunkingStrategyType.DOCUMENT_CHUNKER,
+            ChunkingStrategyType.RECURSIVE_CHUNKER,
+        ]
+
+    @classmethod
+    def get_supported_content_types(cls) -> List[ContentType]:
+        return [ContentType.TOPIC]
+
+    def _build_payload(self, query: str) -> Dict[str, Any]:
+        return {
+            "input": query,
+            "research_effort": self.research_effort,
+        }
+
+    def _documents_from_response(self, query: str, data: Any) -> List[Document]:
+        if not isinstance(data, dict):
+            return []
+        output = data.get("output") if isinstance(data.get("output"), dict) else data
+        if not isinstance(output, dict):
+            return []
+        content = output.get("content")
+        if content is None:
+            return []
+        content_text = _normalize_text(content)
+        sources = output.get("sources") or []
+        documents = self._document_from_text(
+            doc_id=f"youcom:finance:{_slug(query)}",
+            name=query,
+            content=content_text,
+            meta_data={
+                "source": "youcom_finance_research",
+                "input": query,
+                "research_effort": self.research_effort,
+                "content_type": output.get("content_type", "text"),
+                "source_count": len(sources) if isinstance(sources, list) else 0,
+            },
+        )
+        if not self.include_source_documents or not isinstance(sources, list):
+            return documents
+        for index, source in enumerate(sources):
+            if not isinstance(source, dict):
+                continue
+            url = source.get("url", "")
+            title = source.get("title") or url or f"Source {index + 1}"
+            source_content = _join_non_empty(
+                [
+                    f"# {title}",
+                    f"Source: {url}" if url else "",
+                    _normalize_text(source.get("description")),
+                    _normalize_text(source.get("snippet") or source.get("content") or source.get("markdown") or source.get("text")),
+                ]
+            )
+            documents.extend(
+                self._document_from_text(
+                    doc_id=url or f"youcom:finance:{_slug(query)}:source:{index}",
+                    name=title,
+                    content=source_content,
+                    meta_data={
+                        "source": "youcom_finance_research_source",
+                        "input": query,
+                        "research_effort": self.research_effort,
+                        "source_index": index,
+                        "url": url,
+                        "title": title,
+                    },
+                )
+            )
+        return documents
+
+    def read(self, query: str, name: Optional[str] = None) -> List[Document]:
+        query = self._ensure_query(query)
+        try:
+            data = self._json_request("POST", "/v1/finance_research", json_body=self._build_payload(query))
+            return self._documents_from_response(query, data)
+        except Exception as error:
+            self._log_request_error("You.com finance research request failed", error)
+            return []
+
+    async def async_read(self, query: str, name: Optional[str] = None) -> List[Document]:
+        query = self._ensure_query(query)
+        try:
+            data = await self._async_json_request("POST", "/v1/finance_research", json_body=self._build_payload(query))
+            return self._documents_from_response(query, data)
+        except Exception as error:
+            self._log_request_error("You.com finance research request failed", error)
+            return []

--- a/libs/agno/agno/knowledge/reader/youcom/research_reader.py
+++ b/libs/agno/agno/knowledge/reader/youcom/research_reader.py
@@ -1,0 +1,161 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.document.base import Document
+from agno.knowledge.reader.youcom.base import YouComReaderBase, _join_non_empty, _normalize_text, _slug
+from agno.knowledge.types import ContentType
+
+
+@dataclass
+class YouResearchReader(YouComReaderBase):
+    research_effort: str = "deep"
+    source_control: Optional[Dict[str, Any]] = None
+    output_schema: Optional[Dict[str, Any]] = None
+    include_source_documents: bool = False
+    background: bool = False
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        research_effort: str = "deep",
+        source_control: Optional[Dict[str, Any]] = None,
+        output_schema: Optional[Dict[str, Any]] = None,
+        include_source_documents: bool = False,
+        background: bool = False,
+        request_timeout: Optional[float] = None,
+        chunk: bool = True,
+        chunk_size: int = 5000,
+        chunking_strategy: Optional[ChunkingStrategy] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            api_key=api_key,
+            base_url=base_url,
+            request_timeout=request_timeout,
+            chunk=chunk,
+            chunk_size=chunk_size,
+            chunking_strategy=chunking_strategy,
+            name=name,
+            description=description,
+        )
+        if not research_effort:
+            raise ValueError("research_effort cannot be empty")
+        self.research_effort = research_effort
+        self.source_control = source_control
+        self.output_schema = output_schema
+        self.include_source_documents = include_source_documents
+        self.background = background
+
+    @classmethod
+    def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:
+        return [
+            ChunkingStrategyType.CODE_CHUNKER,
+            ChunkingStrategyType.SEMANTIC_CHUNKER,
+            ChunkingStrategyType.FIXED_SIZE_CHUNKER,
+            ChunkingStrategyType.AGENTIC_CHUNKER,
+            ChunkingStrategyType.DOCUMENT_CHUNKER,
+            ChunkingStrategyType.RECURSIVE_CHUNKER,
+        ]
+
+    @classmethod
+    def get_supported_content_types(cls) -> List[ContentType]:
+        return [ContentType.TOPIC]
+
+    def _build_payload(self, query: str) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "input": query,
+            "research_effort": self.research_effort,
+        }
+        if self.source_control:
+            payload["source_control"] = self.source_control
+        if self.output_schema:
+            payload["output_schema"] = self.output_schema
+        if self.background:
+            payload["background"] = True
+        return payload
+
+    def _documents_from_response(self, query: str, data: Any) -> List[Document]:
+        if not isinstance(data, dict):
+            return []
+        output = data.get("output") if isinstance(data.get("output"), dict) else data
+        if not isinstance(output, dict):
+            return []
+        content = output.get("content")
+        if content is None:
+            return []
+        content_text = _normalize_text(content)
+        content_type = output.get("content_type", "text")
+        sources = output.get("sources") or []
+        documents = self._document_from_text(
+            doc_id=f"youcom:research:{_slug(query)}",
+            name=query,
+            content=content_text,
+            meta_data={
+                "source": "youcom_research",
+                "input": query,
+                "research_effort": self.research_effort,
+                "content_type": content_type,
+                "source_count": len(sources) if isinstance(sources, list) else 0,
+            },
+        )
+        if not self.include_source_documents or not isinstance(sources, list):
+            return documents
+
+        for index, source in enumerate(sources):
+            if not isinstance(source, dict):
+                continue
+            url = source.get("url", "")
+            title = source.get("title") or url or f"Source {index + 1}"
+            source_content = _join_non_empty(
+                [
+                    f"# {title}",
+                    f"Source: {url}" if url else "",
+                    _normalize_text(source.get("description")),
+                    _normalize_text(source.get("snippet") or source.get("content") or source.get("markdown") or source.get("text")),
+                ]
+            )
+            documents.extend(
+                self._document_from_text(
+                    doc_id=url or f"youcom:research:{_slug(query)}:source:{index}",
+                    name=title,
+                    content=source_content,
+                    meta_data={
+                        "source": "youcom_research_source",
+                        "input": query,
+                        "research_effort": self.research_effort,
+                        "source_index": index,
+                        "url": url,
+                        "title": title,
+                    },
+                )
+            )
+        return documents
+
+    def _validate_frontier(self) -> None:
+        if self.background:
+            return
+        if self.research_effort == "frontier":
+            raise ValueError("research_effort='frontier' requires background=True")
+
+    def read(self, query: str, name: Optional[str] = None) -> List[Document]:
+        query = self._ensure_query(query)
+        self._validate_frontier()
+        try:
+            data = self._json_request("POST", "/v1/research", json_body=self._build_payload(query))
+            return self._documents_from_response(query, data)
+        except Exception as error:
+            self._log_request_error("You.com research request failed", error)
+            return []
+
+    async def async_read(self, query: str, name: Optional[str] = None) -> List[Document]:
+        query = self._ensure_query(query)
+        self._validate_frontier()
+        try:
+            data = await self._async_json_request("POST", "/v1/research", json_body=self._build_payload(query))
+            return self._documents_from_response(query, data)
+        except Exception as error:
+            self._log_request_error("You.com research request failed", error)
+            return []

--- a/libs/agno/agno/knowledge/reader/youcom/search_reader.py
+++ b/libs/agno/agno/knowledge/reader/youcom/search_reader.py
@@ -1,0 +1,207 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal, Optional, Sequence
+
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.document.base import Document
+from agno.knowledge.reader.youcom.base import YouComReaderBase, _join_non_empty, _normalize_text, _slug
+from agno.knowledge.types import ContentType
+
+
+@dataclass
+class YouSearchReader(YouComReaderBase):
+    count: int = 5
+    livecrawl: Optional[Literal["web", "news", "all"]] = None
+    livecrawl_formats: Sequence[str] = ("markdown",)
+    include_domains: Optional[List[str]] = None
+    exclude_domains: Optional[List[str]] = None
+    boost_domains: Optional[List[str]] = None
+    country: Optional[str] = None
+    freshness: Optional[str] = None
+    language: Optional[str] = None
+    safesearch: Optional[str] = None
+    offset: Optional[int] = None
+    crawl_timeout: int = 10
+    search_params: Optional[Dict[str, Any]] = None
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        count: int = 5,
+        livecrawl: Optional[Literal["web", "news", "all"]] = None,
+        livecrawl_formats: Sequence[str] = ("markdown",),
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        boost_domains: Optional[List[str]] = None,
+        country: Optional[str] = None,
+        freshness: Optional[str] = None,
+        language: Optional[str] = None,
+        safesearch: Optional[str] = None,
+        offset: Optional[int] = None,
+        crawl_timeout: int = 10,
+        search_params: Optional[Dict[str, Any]] = None,
+        request_timeout: Optional[float] = None,
+        chunk: bool = True,
+        chunk_size: int = 5000,
+        chunking_strategy: Optional[ChunkingStrategy] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            api_key=api_key,
+            base_url=base_url,
+            request_timeout=request_timeout,
+            chunk=chunk,
+            chunk_size=chunk_size,
+            chunking_strategy=chunking_strategy,
+            name=name,
+            description=description,
+        )
+        if count <= 0:
+            raise ValueError("count must be positive")
+        if not 1 <= crawl_timeout <= 60:
+            raise ValueError("crawl_timeout must be between 1 and 60 seconds")
+        if offset is not None and not 0 <= offset <= 9:
+            raise ValueError("offset must be between 0 and 9")
+        if include_domains and (exclude_domains or boost_domains):
+            raise ValueError("include_domains cannot be combined with exclude_domains or boost_domains")
+
+        self.count = count
+        self.livecrawl = livecrawl
+        if isinstance(livecrawl_formats, str):
+            self.livecrawl_formats = tuple(part.strip() for part in livecrawl_formats.split(",") if part.strip())
+        else:
+            self.livecrawl_formats = tuple(livecrawl_formats)
+        self.include_domains = include_domains
+        self.exclude_domains = exclude_domains
+        self.boost_domains = boost_domains
+        self.country = country
+        self.freshness = freshness
+        self.language = language
+        self.safesearch = safesearch
+        self.offset = offset
+        self.crawl_timeout = crawl_timeout
+        self.search_params = search_params
+
+    @classmethod
+    def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:
+        return [
+            ChunkingStrategyType.CODE_CHUNKER,
+            ChunkingStrategyType.SEMANTIC_CHUNKER,
+            ChunkingStrategyType.FIXED_SIZE_CHUNKER,
+            ChunkingStrategyType.AGENTIC_CHUNKER,
+            ChunkingStrategyType.DOCUMENT_CHUNKER,
+            ChunkingStrategyType.RECURSIVE_CHUNKER,
+        ]
+
+    @classmethod
+    def get_supported_content_types(cls) -> List[ContentType]:
+        return [ContentType.TOPIC]
+
+    def _build_params(self, query: str) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"query": query, "count": self.count}
+        if self.livecrawl:
+            params["livecrawl"] = self.livecrawl
+            params["crawl_timeout"] = self.crawl_timeout
+            params["livecrawl_formats"] = list(self.livecrawl_formats)
+        if self.include_domains:
+            params["include_domains"] = ",".join(self.include_domains)
+        if self.exclude_domains:
+            params["exclude_domains"] = ",".join(self.exclude_domains)
+        if self.boost_domains:
+            params["boost_domains"] = ",".join(self.boost_domains)
+        if self.country:
+            params["country"] = self.country
+        if self.freshness:
+            params["freshness"] = self.freshness
+        if self.language:
+            params["language"] = self.language
+        if self.safesearch:
+            params["safesearch"] = self.safesearch
+        if self.offset is not None:
+            params["offset"] = self.offset
+        if self.search_params:
+            params.update(self.search_params)
+        return params
+
+    def _parse_result(self, query: str, result: Dict[str, Any], section: str, index: int) -> List[Document]:
+        url = result.get("url", "")
+        title = result.get("title") or url or f"Result {index + 1}"
+        description = _normalize_text(result.get("description"))
+        snippets = result.get("snippets")
+        snippet_text = ""
+        if isinstance(snippets, list):
+            snippet_text = "\n".join(snippet for snippet in snippets if isinstance(snippet, str))
+        contents = result.get("contents")
+        content_text = ""
+        if isinstance(contents, dict):
+            content_text = _normalize_text(contents.get("markdown") or contents.get("text") or contents.get("html") or contents.get("content"))
+        content = _join_non_empty(
+            [
+                f"# {title}",
+                f"Source: {url}" if url else "",
+                description,
+                snippet_text,
+                content_text,
+            ]
+        )
+        meta_data = {
+            "query": query,
+            "source": "youcom_search",
+            "section": section,
+            "result_index": index,
+            "url": url,
+            "title": title,
+        }
+        if result.get("page_age"):
+            meta_data["page_age"] = result["page_age"]
+        if result.get("published_date"):
+            meta_data["published_date"] = result["published_date"]
+        if result.get("favicon_url"):
+            meta_data["favicon_url"] = result["favicon_url"]
+        return self._document_from_text(
+            doc_id=url or f"youcom:search:{_slug(query)}:{section}:{index}",
+            name=title,
+            content=content,
+            meta_data=meta_data,
+        )
+
+    def _documents_from_response(self, query: str, data: Any) -> List[Document]:
+        if not isinstance(data, dict):
+            return []
+        results = data.get("results")
+        if not results:
+            return []
+        documents: List[Document] = []
+        if isinstance(results, dict):
+            for section, items in results.items():
+                if not isinstance(items, list):
+                    continue
+                for index, result in enumerate(items):
+                    if isinstance(result, dict):
+                        documents.extend(self._parse_result(query, result, section, index))
+        elif isinstance(results, list):
+            for index, result in enumerate(results):
+                if isinstance(result, dict):
+                    documents.extend(self._parse_result(query, result, "web", index))
+        return documents
+
+    def read(self, query: str, name: Optional[str] = None) -> List[Document]:
+        query = self._ensure_query(query)
+        try:
+            self.request_timeout = self._request_timeout_or_default(self.crawl_timeout)
+            data = self._json_request("GET", "/v1/search", params=self._build_params(query))
+            return self._documents_from_response(query, data)
+        except Exception as error:
+            self._log_request_error("You.com search request failed", error)
+            return []
+
+    async def async_read(self, query: str, name: Optional[str] = None) -> List[Document]:
+        query = self._ensure_query(query)
+        try:
+            self.request_timeout = self._request_timeout_or_default(self.crawl_timeout)
+            data = await self._async_json_request("GET", "/v1/search", params=self._build_params(query))
+            return self._documents_from_response(query, data)
+        except Exception as error:
+            self._log_request_error("You.com search request failed", error)
+            return []

--- a/libs/agno/tests/unit/reader/test_youcom_readers.py
+++ b/libs/agno/tests/unit/reader/test_youcom_readers.py
@@ -1,0 +1,230 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from agno.knowledge.reader.reader_factory import ReaderFactory
+from agno.knowledge.reader.youcom.contents_reader import YouContentsReader
+from agno.knowledge.reader.youcom.finance_reader import YouFinanceResearchReader
+from agno.knowledge.reader.youcom.research_reader import YouResearchReader
+from agno.knowledge.reader.youcom.search_reader import YouSearchReader
+
+
+def _mock_response(payload):
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = payload
+    return response
+
+
+def test_search_reader_builds_documents_and_pads_timeout():
+    payload = {
+        "results": {
+            "web": [
+                {
+                    "url": "https://example.com/article",
+                    "title": "Example Title",
+                    "description": "Example description",
+                    "snippets": ["Snippet one", "Snippet two"],
+                    "contents": {"markdown": "Live crawled body"},
+                    "page_age": "2d",
+                }
+            ]
+        }
+    }
+
+    with patch("agno.knowledge.reader.youcom.base.httpx.Client") as mock_client_cls:
+        mock_client = mock_client_cls.return_value.__enter__.return_value
+        mock_client.request.return_value = _mock_response(payload)
+
+        reader = YouSearchReader(chunk=False, crawl_timeout=45, livecrawl="all", livecrawl_formats=("markdown", "html"))
+        documents = reader.read("agno knowledge readers")
+
+    assert len(documents) == 1
+    document = documents[0]
+    assert document.name == "Example Title"
+    assert document.meta_data["source"] == "youcom_search"
+    assert document.meta_data["section"] == "web"
+    assert document.meta_data["page_age"] == "2d"
+    assert "Example description" in document.content
+    assert "Snippet one" in document.content
+    assert "Live crawled body" in document.content
+
+    mock_client_cls.assert_called_once_with(timeout=55)
+    _, kwargs = mock_client.request.call_args
+    assert kwargs["params"]["query"] == "agno knowledge readers"
+    assert kwargs["params"]["crawl_timeout"] == 45
+    assert kwargs["params"]["livecrawl_formats"] == ["markdown", "html"]
+
+
+@pytest.mark.asyncio
+async def test_search_reader_async_uses_async_client():
+    payload = {
+        "results": {
+            "web": [
+                {
+                    "url": "https://example.com/article",
+                    "title": "Async Example",
+                    "description": "Async description",
+                    "snippets": ["Async snippet"],
+                }
+            ]
+        }
+    }
+
+    with patch("agno.knowledge.reader.youcom.base.httpx.AsyncClient") as mock_client_cls:
+        mock_client = mock_client_cls.return_value.__aenter__.return_value
+        mock_client.request = AsyncMock(return_value=_mock_response(payload))
+
+        reader = YouSearchReader(chunk=False)
+        documents = await reader.async_read("agno async search")
+
+    assert len(documents) == 1
+    assert documents[0].name == "Async Example"
+    mock_client_cls.assert_called_once_with(timeout=30)
+    assert mock_client.request.await_count == 1
+
+
+def test_contents_reader_builds_documents_and_metadata():
+    payload = [
+        {
+            "url": "https://docs.agno.com",
+            "title": "Agno Docs",
+            "markdown": "# Agno\nDocs body",
+            "metadata": {"json_ld": {"@type": "WebPage"}},
+        }
+    ]
+
+    with patch("agno.knowledge.reader.youcom.base.httpx.Client") as mock_client_cls:
+        mock_client = mock_client_cls.return_value.__enter__.return_value
+        mock_client.request.return_value = _mock_response(payload)
+
+        reader = YouContentsReader(chunk=False, crawl_timeout=40)
+        documents = reader.read("https://docs.agno.com")
+
+    assert len(documents) == 1
+    document = documents[0]
+    assert document.name == "Agno Docs"
+    assert document.meta_data["url"] == "https://docs.agno.com"
+    assert document.meta_data["metadata"] == {"json_ld": {"@type": "WebPage"}}
+    assert "Docs body" in document.content
+    mock_client_cls.assert_called_once_with(timeout=50)
+    _, kwargs = mock_client.request.call_args
+    assert kwargs["json"]["urls"] == ["https://docs.agno.com"]
+    assert kwargs["json"]["formats"] == ["markdown", "metadata"]
+
+
+@pytest.mark.asyncio
+async def test_research_reader_async_uses_none_timeout():
+    payload = {
+        "output": {
+            "content": "Answer with citations [[1]]",
+            "content_type": "text",
+            "sources": [{"url": "https://example.com", "title": "Example source"}],
+        }
+    }
+
+    with patch("agno.knowledge.reader.youcom.base.httpx.AsyncClient") as mock_client_cls:
+        mock_client = mock_client_cls.return_value.__aenter__.return_value
+        mock_client.request = AsyncMock(return_value=_mock_response(payload))
+
+        reader = YouResearchReader(chunk=False, include_source_documents=True)
+        documents = await reader.async_read("What is Agno?")
+
+    assert len(documents) == 2
+    assert documents[0].meta_data["source"] == "youcom_research"
+    assert documents[0].meta_data["source_count"] == 1
+    assert documents[1].meta_data["source"] == "youcom_research_source"
+    mock_client_cls.assert_called_once_with(timeout=None)
+    _, kwargs = mock_client.request.call_args
+    assert kwargs["json"]["input"] == "What is Agno?"
+    assert kwargs["json"]["research_effort"] == "deep"
+
+
+def test_research_reader_builds_primary_and_source_documents():
+    payload = {
+        "output": {
+            "content": "Finance answer",
+            "content_type": "text",
+            "sources": [
+                {
+                    "url": "https://sec.gov/1",
+                    "title": "SEC filing",
+                    "description": "Filing description",
+                    "snippet": "Snippet from filing",
+                }
+            ],
+        }
+    }
+
+    with patch("agno.knowledge.reader.youcom.base.httpx.Client") as mock_client_cls:
+        mock_client = mock_client_cls.return_value.__enter__.return_value
+        mock_client.request.return_value = _mock_response(payload)
+
+        reader = YouResearchReader(chunk=False, research_effort="exhaustive", include_source_documents=True)
+        documents = reader.read("NVIDIA fiscal 2025 drivers")
+
+    assert len(documents) == 2
+    assert documents[0].content == "Finance answer"
+    assert documents[0].meta_data["research_effort"] == "exhaustive"
+    assert documents[1].name == "SEC filing"
+    assert "Snippet from filing" in documents[1].content
+    mock_client_cls.assert_called_once_with(timeout=None)
+    _, kwargs = mock_client.request.call_args
+    assert kwargs["json"]["research_effort"] == "exhaustive"
+
+
+def test_finance_reader_builds_documents():
+    payload = {
+        "output": {
+            "content": "Finance answer with citations",
+            "content_type": "text",
+            "sources": [{"url": "https://sec.gov/2", "title": "10-K"}],
+        }
+    }
+
+    with patch("agno.knowledge.reader.youcom.base.httpx.Client") as mock_client_cls:
+        mock_client = mock_client_cls.return_value.__enter__.return_value
+        mock_client.request.return_value = _mock_response(payload)
+
+        reader = YouFinanceResearchReader(chunk=False)
+        documents = reader.read("What drove revenue?")
+
+    assert len(documents) == 1
+    assert documents[0].name == "What drove revenue?"
+    assert documents[0].meta_data["source_count"] == 1
+    mock_client_cls.assert_called_once_with(timeout=None)
+    _, kwargs = mock_client.request.call_args
+    assert kwargs["json"]["input"] == "What drove revenue?"
+    assert kwargs["json"]["research_effort"] == "deep"
+
+
+def test_search_reader_returns_empty_list_on_request_error():
+    with patch("agno.knowledge.reader.youcom.base.httpx.Client") as mock_client_cls:
+        mock_client = mock_client_cls.return_value.__enter__.return_value
+        mock_client.request.side_effect = httpx.TimeoutException("timed out")
+
+        reader = YouSearchReader(chunk=False)
+        documents = reader.read("agno")
+
+    assert documents == []
+
+
+def test_research_frontier_requires_background():
+    reader = YouResearchReader(chunk=False, research_effort="frontier")
+    with pytest.raises(ValueError, match="requires background=True"):
+        reader.read("deep research")
+
+
+def test_reader_factory_exposes_youcom_readers():
+    ReaderFactory.clear_cache()
+
+    assert "youcom_search" in ReaderFactory.get_all_reader_keys()
+    assert "youcom_contents" in ReaderFactory.get_all_reader_keys()
+    assert "youcom_research" in ReaderFactory.get_all_reader_keys()
+    assert "youcom_finance" in ReaderFactory.get_all_reader_keys()
+
+    assert isinstance(ReaderFactory.create_reader("youcom_search", api_key="test"), YouSearchReader)
+    assert isinstance(ReaderFactory.create_reader("youcom_contents", api_key="test"), YouContentsReader)
+    assert isinstance(ReaderFactory.create_reader("youcom_research", api_key="test"), YouResearchReader)
+    assert isinstance(ReaderFactory.create_reader("youcom_finance", api_key="test"), YouFinanceResearchReader)


### PR DESCRIPTION
Closes #9131

Adds `agno.knowledge.reader.youcom` with Search, Contents, Research, and Finance readers, wired into ReaderFactory and covered by unit tests. This is distinct from the open You.com tools PRs (#8958, #9020, #9031), which wrap API tools rather than Knowledge readers.