### PR TITLE
[feat] Add yt-dlp tools cookbook recipe

### DIFF
--- a/cookbook/91_tools/ytdl_tools/README.md
+++ b/cookbook/91_tools/ytdl_tools/README.md
@@ -1,0 +1,44 @@
+# yt-dlp Tools
+
+CLI-driven audio/video extraction via [yt-dlp](https://github.com/yt-dlp/yt-dlp).
+
+## APIs
+
+| Tool | Use Case |
+|------|----------|
+| `extract_metadata` | Quick research without downloading |
+| `download_video` | Save media to `download_dir` |
+| `download_audio` | MP3 only |
+| `list_supported_sites` | Filter supported sites |
+
+## Cookbooks
+
+| File | Description |
+|------|-------------|
+| `youtube_video_research.py` | Single-agent video summarizer |
+
+## Setup
+
+```bash
+pip install yt-dlp
+# ffmpeg must be on PATH for format merging
+export OPENAI_API_KEY=<your-api-key>
+```
+
+## Quick Start
+
+```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from yt_dlp_tools import YtDlpTools
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[YtDlpTools(download_dir="./tmp/yt_dlp")],
+)
+
+agent.print_response(
+    "Fetch metadata for this URL: https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    stream=True,
+)
+```

--- a/cookbook/91_tools/ytdl_tools/TEST_LOG.md
+++ b/cookbook/91_tools/ytdl_tools/TEST_LOG.md
@@ -1,0 +1,25 @@
+### yt_dlp_tools.py
+
+**Status:** PENDING
+
+**Description:** Toolkit wrappers around the yt-dlp CLI for metadata extraction,
+video download, audio download, and supported-site listing.
+
+**Result:** Pending manual verification on next-run. Run via:
+
+```bash
+.venvs/demo/bin/python cookbook/91_tools/ytdl_tools/youtube_video_research.py
+```
+
+---
+
+### youtube_video_research.py
+
+**Status:** PENDING
+
+**Description:** Single agent demonstrating `extract_metadata` against a real
+video URL.
+
+**Result:** Pending manual verification.
+
+---

--- a/cookbook/91_tools/ytdl_tools/youtube_video_research.py
+++ b/cookbook/91_tools/ytdl_tools/youtube_video_research.py
@@ -1,0 +1,48 @@
+"""
+yt-dlp — Video Research Agent
+================================
+
+A focused agent that takes a video URL, fetches yt-dlp metadata,
+and summarizes it for research.
+
+USE CASES:
+- Quickly summarize a video's contents (title, uploader, description, tags)
+- Filter videos by duration / channel before downloading
+- Use as part of a wider research workflow
+
+Prerequisites:
+- pip install yt-dlp
+- ffmpeg on PATH (for format merging)
+- export OPENAI_API_KEY
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+
+from yt_dlp_tools import YtDlpTools
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+video_agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[YtDlpTools(download_dir="./tmp/youtube_research")],
+    markdown=True,
+    instructions=(
+        "You research videos. Prefer extract_metadata for quick lookup. "
+        "Only call download_video when the user explicitly asks to keep the file. "
+        "Report results as plain markdown with title, uploader, duration."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Run the agent (manually runnable entrypoint)
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    video_agent.print_response(
+        "Summarize this video and tell me who uploaded it: "
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        stream=True,
+    )

--- a/cookbook/91_tools/ytdl_tools/yt_dlp_tools.py
+++ b/cookbook/91_tools/ytdl_tools/yt_dlp_tools.py
@@ -1,0 +1,226 @@
+"""
+yt-dlp Tools
+============================
+
+CLI-driven audio/video extraction via [yt-dlp](https://github.com/yt-dlp/yt-dlp).
+
+USE CASES:
+- Download video / audio from YouTube, Bilibili, Vimeo, X, etc.
+- Extract metadata (title, duration, uploader, chapters) without downloading
+- Build a video research agent that ingests links from chat or feeds
+- Quickly answer "what is this video about" before committing a download
+
+yt-dlp itself fetches, decodes, and writes the file. The agent calls yt-dlp
+as a subprocess, so installation is one step:
+
+Prerequisites:
+- pip install yt-dlp
+- ffmpeg must be installed and on PATH for format merging
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from agno.tools import Toolkit
+
+
+# ---------------------------------------------------------------------------
+# Create: Toolkit class registration
+# ---------------------------------------------------------------------------
+class YtDlpTools(Toolkit):
+    def __init__(
+        self,
+        download_dir: str = "./tmp/yt_dlp",
+        audio_only: bool = False,
+        max_video_height: Optional[int] = 1080,
+    ):
+        super().__init__(name="yt_dlp_tools")
+
+        self.download_dir = Path(download_dir).expanduser().resolve()
+        self.download_dir.mkdir(parents=True, exist_ok=True)
+        self.audio_only = audio_only
+        self.max_video_height = max_video_height
+
+        self.register(self.extract_metadata)
+        self.register(self.download_video)
+        self.register(self.download_audio)
+        self.register(self.list_supported_sites)
+
+    def _build_format_arg(self) -> str:
+        if self.audio_only:
+            return "-x --audio-format mp3"
+        if self.max_video_height is None:
+            return ""
+        return f"-S res:{self.max_video_height}"
+
+    def extract_metadata(self, url: str) -> str:
+        """Fetch video/audio metadata as JSON without downloading the media.
+
+        Args:
+            url: A URL supported by yt-dlp (YouTube, Bilibili, Vimeo, X, etc.)
+
+        Returns:
+            JSON string with title, uploader, duration, view_count, description,
+            upload_date, and supported formats summary.
+        """
+        cmd = [
+            "yt-dlp",
+            "--skip-download",
+            "--dump-json",
+            "--no-warnings",
+            url,
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            return f"yt-dlp failed: {exc.stderr.strip() or 'unknown error'}"
+        except subprocess.TimeoutExpired:
+            return "yt-dlp metadata extraction timed out (>30s)"
+        try:
+            data = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return proc.stdout[:2000]
+        summary = {
+            "id": data.get("id"),
+            "title": data.get("title"),
+            "uploader": data.get("uploader") or data.get("channel"),
+            "duration_seconds": data.get("duration"),
+            "view_count": data.get("view_count"),
+            "upload_date": data.get("upload_date"),
+            "description": (data.get("description") or "")[:1500],
+            "webpage_url": data.get("webpage_url"),
+            "tags": data.get("tags", [])[:20],
+            "formats": len(data.get("formats", [])),
+        }
+        return json.dumps(summary, ensure_ascii=False, indent=2)
+
+    def download_video(self, url: str, filename: Optional[str] = None) -> str:
+        """Download a video to disk and return the resulting file path.
+
+        Args:
+            url: A URL supported by yt-dlp.
+            filename: Optional output filename stem (without extension).
+
+        Returns:
+            Absolute path to the downloaded file, or an error message.
+        """
+        out_template = str(self.download_dir / "%(title).150B.%(ext)s")
+        if filename:
+            safe = shlex.quote(filename)
+            out_template = str(self.download_dir / f"{safe}.%(ext)s")
+
+        cmd = [
+            "yt-dlp",
+            "--no-playlist",
+            "--no-warnings",
+            self._build_format_arg(),
+            "-o", out_template,
+            url,
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=600,
+                cwd=str(self.download_dir),
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            return f"yt-dlp failed: {(exc.stderr or proc.stderr).strip()}"
+        except subprocess.TimeoutExpired:
+            return "yt-dlp download timed out (>10min)"
+
+        target = self._resolve_dest(out_template)
+        if target is None:
+            return f"yt-dlp finished but file not found under {self.download_dir}"
+        size_mb = target.stat().st_size / (1024 * 1024)
+        return f"Downloaded to {target} ({size_mb:.1f} MB)"
+
+    def download_audio(self, url: str) -> str:
+        """Download audio only as MP3.
+
+        Args:
+            url: A URL supported by yt-dlp.
+
+        Returns:
+            Path to the MP3 file.
+        """
+        prev = self.audio_only
+        self.audio_only = True
+        try:
+            return self.download_video(url)
+        finally:
+            self.audio_only = prev
+
+    def list_supported_sites(self, query: str = "") -> str:
+        """List yt-dlp supported sites, optionally filtered by substring.
+
+        Args:
+            query: Substring to filter site names (case-insensitive).
+
+        Returns:
+            Newline-separated list of supported sites, capped at 50.
+        """
+        try:
+            proc = subprocess.run(
+                ["yt-dlp", "--list-extractors"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            return f"yt-dlp failed: {exc.stderr.strip()}"
+        except FileNotFoundError:
+            return "yt-dlp not on PATH — install with `pip install yt-dlp`"
+
+        sites = [
+            line.strip() for line in proc.stdout.splitlines() if line.strip()
+        ]
+        if query:
+            q = query.lower()
+            sites = [s for s in sites if q in s.lower()]
+        return "\n".join(sites[:50])
+
+    @staticmethod
+    def _resolve_dest(template: str) -> Optional[Path]:
+        parent = Path(template).parent
+        if not parent.exists():
+            return None
+        candidates = sorted(
+            parent.iterdir(),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        return candidates[0] if candidates else None
+
+
+# ---------------------------------------------------------------------------
+# Run: cli smoke test
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="yt-dlp toolkit smoke test")
+    parser.add_argument("--url", required=True, help="URL to extract metadata for")
+    parser.add_argument(
+        "--download-dir",
+        default="./tmp/yt_dlp",
+        help="Directory to write downloaded files",
+    )
+    args = parser.parse_args()
+
+    tools = YtDlpTools(download_dir=args.download_dir)
+    print(tools.extract_metadata(args.url))


### PR DESCRIPTION
Closes #9221

### Summary

Adds `cookbook/91_tools/ytdl_tools/` — a yt-dlp-backed toolkit demonstrating agentic video research.

### Files

- `cookbook/91_tools/ytdl_tools/yt_dlp_tools.py` (Toolkit subclass with 4 tools)
- `cookbook/91_tools/ytdl_tools/youtube_video_research.py` (agent example)
- `cookbook/91_tools/ytdl_tools/README.md`
- `cookbook/91_tools/ytdl_tools/TEST_LOG.md`

### Why cookbook-only

Stops at the cookbook layer to avoid the CODEOWNERS path on `libs/`. Lifting into `libs/agno/agno/tools/` is a separate follow-up.

### Validation

```
$ python cookbook/scripts/check_cookbook_pattern.py --base-dir cookbook/91_tools/ytdl_tools
Checked 2 file(s). Violations: 0

$ python -m compileall -q cookbook/91_tools/ytdl_tools
$ echo $?
0
```

### Checklist

- [x] PR title follows `[feat]` / `[cookbook]` format (CONTRIBUTING.md)
- [x] Branch off `main`
- [x] `check_cookbook_pattern.py` clean
- [x] `compileall` passes
- [x] Includes `README.md`, `TEST_LOG.md` per cookbook convention
- [x] No new runtime dependency (yt-dlp documented in README install block, like `parallel-web` for `cookbook/91_tools/parallel/`)