### PR TITLE
fix: A2A stream client drops Task-level metadata by breaking on status-update

### DIFF
--- a/libs/agno/agno/client/a2a/utils.py
+++ b/libs/agno/agno/client/a2a/utils.py
@@ -155,8 +155,32 @@ async def map_stream_events_to_run_events(
                 agent_id=agent_id,
             )
 
+        elif event.event_type == "completed" and event.is_final:
+            # A "status-update" reporting completion arrives before the "task" event
+            # that carries the final message parts and Task-level metadata - do not
+            # stop the loop here, or that metadata is silently dropped. Failed/canceled
+            # status-updates fall through to the is_final branch below and still break
+            # immediately, since agno's own server always follows them with a "task"
+            # event too, but other A2A servers may not guarantee that for failures.
+            continue
+
+        elif event.event_type == "task":
+            # The authoritative terminal event per the A2A spec - carries the final
+            # message parts and any Task-level metadata (see continue branch above).
+            final_content = event.content if event.content else accumulated_content
+            yield RunCompletedEvent(
+                content=final_content,
+                metadata=event.metadata,
+                run_id=run_id,
+                session_id=session_id,
+                agent_id=agent_id,
+            )
+            break  # Stream complete
+
         elif event.is_final:
-            # Use content from final event or accumulated content
+            # Reached for failed/canceled status-updates (or non-agno servers that
+            # never send a "task" event) - preserve the original behaviour of
+            # stopping immediately rather than waiting indefinitely for one.
             final_content = event.content if event.content else accumulated_content
             yield RunCompletedEvent(
                 content=final_content,
@@ -265,8 +289,28 @@ async def map_stream_events_to_team_run_events(
                 team_id=team_id,
             )
 
+        elif event.event_type == "completed" and event.is_final:
+            # See matching comment in map_stream_events_to_run_events - do not stop
+            # the loop on a completed status-update, or Task-level metadata carried
+            # by the following "task" event is silently dropped.
+            continue
+
+        elif event.event_type == "task":
+            # The authoritative terminal event per the A2A spec - carries the final
+            # message parts and any Task-level metadata (see continue branch above).
+            final_content = event.content if event.content else accumulated_content
+            yield TeamRunCompletedEvent(
+                content=final_content,
+                metadata=event.metadata,
+                run_id=run_id,
+                session_id=session_id,
+                team_id=team_id,
+            )
+            break  # Stream complete
+
         elif event.is_final:
-            # Use content from final event or accumulated content
+            # Failed/canceled status-updates, or non-agno servers that never send
+            # a "task" event - preserve original behaviour of stopping immediately.
             final_content = event.content if event.content else accumulated_content
             yield TeamRunCompletedEvent(
                 content=final_content,

--- a/libs/agno/agno/client/a2a/utils.py
+++ b/libs/agno/agno/client/a2a/utils.py
@@ -155,35 +155,13 @@ async def map_stream_events_to_run_events(
                 agent_id=agent_id,
             )
 
-        elif event.event_type == "completed" and event.is_final:
-            # A "status-update" reporting completion arrives before the "task" event
-            # that carries the final message parts and Task-level metadata - do not
-            # stop the loop here, or that metadata is silently dropped. Failed/canceled
-            # status-updates fall through to the is_final branch below and still break
-            # immediately, since agno's own server always follows them with a "task"
-            # event too, but other A2A servers may not guarantee that for failures.
-            continue
-
-        elif event.event_type == "task":
-            # The authoritative terminal event per the A2A spec - carries the final
-            # message parts and any Task-level metadata (see continue branch above).
+        elif event.is_final:
+            # Terminal event per the A2A spec; forward any metadata the server
+            # attached to it onto the completed event.
             final_content = event.content if event.content else accumulated_content
             yield RunCompletedEvent(
                 content=final_content,
                 metadata=event.metadata,
-                run_id=run_id,
-                session_id=session_id,
-                agent_id=agent_id,
-            )
-            break  # Stream complete
-
-        elif event.is_final:
-            # Reached for failed/canceled status-updates (or non-agno servers that
-            # never send a "task" event) - preserve the original behaviour of
-            # stopping immediately rather than waiting indefinitely for one.
-            final_content = event.content if event.content else accumulated_content
-            yield RunCompletedEvent(
-                content=final_content,
                 run_id=run_id,
                 session_id=session_id,
                 agent_id=agent_id,
@@ -289,31 +267,13 @@ async def map_stream_events_to_team_run_events(
                 team_id=team_id,
             )
 
-        elif event.event_type == "completed" and event.is_final:
-            # See matching comment in map_stream_events_to_run_events - do not stop
-            # the loop on a completed status-update, or Task-level metadata carried
-            # by the following "task" event is silently dropped.
-            continue
-
-        elif event.event_type == "task":
-            # The authoritative terminal event per the A2A spec - carries the final
-            # message parts and any Task-level metadata (see continue branch above).
+        elif event.is_final:
+            # Terminal event per the A2A spec; forward any metadata the server
+            # attached to it onto the completed event.
             final_content = event.content if event.content else accumulated_content
             yield TeamRunCompletedEvent(
                 content=final_content,
                 metadata=event.metadata,
-                run_id=run_id,
-                session_id=session_id,
-                team_id=team_id,
-            )
-            break  # Stream complete
-
-        elif event.is_final:
-            # Failed/canceled status-updates, or non-agno servers that never send
-            # a "task" event - preserve original behaviour of stopping immediately.
-            final_content = event.content if event.content else accumulated_content
-            yield TeamRunCompletedEvent(
-                content=final_content,
                 run_id=run_id,
                 session_id=session_id,
                 team_id=team_id,

--- a/libs/agno/agno/client/a2a/utils.py
+++ b/libs/agno/agno/client/a2a/utils.py
@@ -156,8 +156,8 @@ async def map_stream_events_to_run_events(
             )
 
         elif event.is_final:
-            # Terminal event per the A2A spec; forward any metadata the server
-            # attached to it onto the completed event.
+            # final=true marks the end of the stream; forward any metadata the
+            # server attached to it onto the completed event.
             final_content = event.content if event.content else accumulated_content
             yield RunCompletedEvent(
                 content=final_content,
@@ -268,8 +268,8 @@ async def map_stream_events_to_team_run_events(
             )
 
         elif event.is_final:
-            # Terminal event per the A2A spec; forward any metadata the server
-            # attached to it onto the completed event.
+            # final=true marks the end of the stream; forward any metadata the
+            # server attached to it onto the completed event.
             final_content = event.content if event.content else accumulated_content
             yield TeamRunCompletedEvent(
                 content=final_content,
@@ -380,10 +380,12 @@ async def map_stream_events_to_workflow_run_events(
             )
 
         elif event.is_final:
-            # Use content from final event or accumulated content
+            # final=true marks the end of the stream; forward any metadata the
+            # server attached to it onto the completed event.
             final_content = event.content if event.content else accumulated_content
             yield WorkflowCompletedEvent(
                 content=final_content,
+                metadata=event.metadata,
                 run_id=run_id,
                 session_id=session_id,
                 workflow_id=workflow_id,

--- a/libs/agno/agno/os/interfaces/a2a/utils.py
+++ b/libs/agno/agno/os/interfaces/a2a/utils.py
@@ -809,6 +809,7 @@ async def stream_a2a_response(
         return
 
     # Build from completion_event if available, otherwise use accumulated content
+    final_metadata: Optional[Dict[str, Any]] = None
     if completion_event:
         final_content = completion_event.content if completion_event.content else accumulated_content
 
@@ -872,7 +873,7 @@ async def stream_a2a_response(
             )
 
         # Handle all other data as Message metadata
-        final_metadata: Dict[str, Any] = {}
+        final_metadata = {}
         if hasattr(completion_event, "metrics") and completion_event.metrics:  # type: ignore
             final_metadata["metrics"] = completion_event.metrics.to_dict()  # type: ignore
         if hasattr(completion_event, "metadata") and completion_event.metadata:
@@ -905,6 +906,7 @@ async def stream_a2a_response(
         status=TaskStatus(state=TaskState.completed),
         history=[final_message],
         artifacts=artifacts if artifacts else None,
+        metadata=final_metadata if final_metadata else None,
     )
     response = SendStreamingMessageSuccessResponse(id=request_id, result=task)
     yield f"event: Task\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"

--- a/libs/agno/agno/os/interfaces/a2a/utils.py
+++ b/libs/agno/agno/os/interfaces/a2a/utils.py
@@ -757,8 +757,10 @@ async def stream_a2a_response(
     # delivery. Metrics are excluded - they already flow via .metrics / the history
     # message, so including them here would duplicate the blob.
     status_metadata: Optional[Dict[str, Any]] = None
-    if completion_event and getattr(completion_event, "metadata", None):
-        status_metadata = dict(completion_event.metadata)
+    if completion_event:
+        completion_metadata = getattr(completion_event, "metadata", None)
+        if completion_metadata:
+            status_metadata = dict(completion_metadata)
 
     # 3. Send final status event
     # If cancelled, send canceled status; otherwise send completed

--- a/libs/agno/agno/os/interfaces/a2a/utils.py
+++ b/libs/agno/agno/os/interfaces/a2a/utils.py
@@ -753,15 +753,12 @@ async def stream_a2a_response(
         elif isinstance(event, (RunCancelledEvent, TeamRunCancelledEvent, WorkflowCancelledEvent)):
             cancelled_event = event
 
-    # Collect metadata (metrics + caller-stamped RunCompletedEvent.metadata) so it
-    # can ride the terminal status-update below - the client reads metadata there.
-    final_metadata: Optional[Dict[str, Any]] = None
-    if completion_event:
-        final_metadata = {}
-        if hasattr(completion_event, "metrics") and completion_event.metrics:  # type: ignore
-            final_metadata["metrics"] = completion_event.metrics.to_dict()  # type: ignore
-        if hasattr(completion_event, "metadata") and completion_event.metadata:
-            final_metadata.update(completion_event.metadata)
+    # Caller-stamped metadata rides the terminal status-update for out-of-band
+    # delivery. Metrics are excluded - they already flow via .metrics / the history
+    # message, so including them here would duplicate the blob.
+    status_metadata: Optional[Dict[str, Any]] = None
+    if completion_event and getattr(completion_event, "metadata", None):
+        status_metadata = dict(completion_event.metadata)
 
     # 3. Send final status event
     # If cancelled, send canceled status; otherwise send completed
@@ -783,7 +780,7 @@ async def stream_a2a_response(
             context_id=context_id,
             status=TaskStatus(state=TaskState.completed),
             final=True,
-            metadata=final_metadata if final_metadata else None,
+            metadata=status_metadata if status_metadata else None,
         )
     response = SendStreamingMessageSuccessResponse(id=request_id, result=final_status_event)
     yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
@@ -882,8 +879,13 @@ async def stream_a2a_response(
                 )
             )
 
-        # Metadata is delivered on the terminal status-update above; kept on the
-        # message here too to preserve existing message-level metadata behaviour.
+        # Handle all other data as Message metadata
+        final_metadata: Dict[str, Any] = {}
+        if hasattr(completion_event, "metrics") and completion_event.metrics:  # type: ignore
+            final_metadata["metrics"] = completion_event.metrics.to_dict()  # type: ignore
+        if hasattr(completion_event, "metadata") and completion_event.metadata:
+            final_metadata.update(completion_event.metadata)
+
         final_message = A2AMessage(
             message_id=message_id,
             role=Role.agent,

--- a/libs/agno/agno/os/interfaces/a2a/utils.py
+++ b/libs/agno/agno/os/interfaces/a2a/utils.py
@@ -753,6 +753,16 @@ async def stream_a2a_response(
         elif isinstance(event, (RunCancelledEvent, TeamRunCancelledEvent, WorkflowCancelledEvent)):
             cancelled_event = event
 
+    # Collect metadata (metrics + caller-stamped RunCompletedEvent.metadata) so it
+    # can ride the terminal status-update below - the client reads metadata there.
+    final_metadata: Optional[Dict[str, Any]] = None
+    if completion_event:
+        final_metadata = {}
+        if hasattr(completion_event, "metrics") and completion_event.metrics:  # type: ignore
+            final_metadata["metrics"] = completion_event.metrics.to_dict()  # type: ignore
+        if hasattr(completion_event, "metadata") and completion_event.metadata:
+            final_metadata.update(completion_event.metadata)
+
     # 3. Send final status event
     # If cancelled, send canceled status; otherwise send completed
     if cancelled_event:
@@ -773,6 +783,7 @@ async def stream_a2a_response(
             context_id=context_id,
             status=TaskStatus(state=TaskState.completed),
             final=True,
+            metadata=final_metadata if final_metadata else None,
         )
     response = SendStreamingMessageSuccessResponse(id=request_id, result=final_status_event)
     yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
@@ -809,7 +820,6 @@ async def stream_a2a_response(
         return
 
     # Build from completion_event if available, otherwise use accumulated content
-    final_metadata: Optional[Dict[str, Any]] = None
     if completion_event:
         final_content = completion_event.content if completion_event.content else accumulated_content
 
@@ -872,13 +882,8 @@ async def stream_a2a_response(
                 )
             )
 
-        # Handle all other data as Message metadata
-        final_metadata = {}
-        if hasattr(completion_event, "metrics") and completion_event.metrics:  # type: ignore
-            final_metadata["metrics"] = completion_event.metrics.to_dict()  # type: ignore
-        if hasattr(completion_event, "metadata") and completion_event.metadata:
-            final_metadata.update(completion_event.metadata)
-
+        # Metadata is delivered on the terminal status-update above; kept on the
+        # message here too to preserve existing message-level metadata behaviour.
         final_message = A2AMessage(
             message_id=message_id,
             role=Role.agent,
@@ -906,7 +911,6 @@ async def stream_a2a_response(
         status=TaskStatus(state=TaskState.completed),
         history=[final_message],
         artifacts=artifacts if artifacts else None,
-        metadata=final_metadata if final_metadata else None,
     )
     response = SendStreamingMessageSuccessResponse(id=request_id, result=task)
     yield f"event: Task\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"

--- a/libs/agno/tests/unit/a2a/test_client.py
+++ b/libs/agno/tests/unit/a2a/test_client.py
@@ -1,5 +1,6 @@
 """Unit tests for A2AClient."""
 
+from typing import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,7 +11,9 @@ from agno.client.a2a import (
     StreamEvent,
     TaskResult,
 )
+from agno.client.a2a.utils import map_stream_events_to_run_events
 from agno.exceptions import RemoteServerUnavailableError
+from agno.run.agent import RunCompletedEvent, RunContentEvent, RunStartedEvent
 
 
 class TestA2AClientInit:
@@ -402,6 +405,60 @@ class TestStreamMessage:
             assert len(content_events) == 2
             assert content_events[0].content == "Hello"
             assert content_events[1].content == " World"
+
+    @pytest.mark.asyncio
+    async def test_stream_message_task_metadata_survives_completed_status_update(self):
+        """Regression test: a "status-update" reporting completion (final=True)
+        arrives before the authoritative "task" event that carries the final
+        message parts and any Task-level metadata. map_stream_events_to_run_events
+        must not stop on the status-update, or that metadata is silently dropped."""
+        with patch("agno.client.a2a.client.get_default_async_client") as mock_get_client:
+
+            async def mock_aiter_lines():
+                lines = [
+                    '{"result": {"kind": "status-update", "taskId": "task-123", "status": {"state": "working"}}}',
+                    '{"result": {"kind": "message", "messageId": "m1", "parts": [{"kind": "text", "text": "Hello"}]}}',
+                    '{"result": {"kind": "status-update", "taskId": "task-123", "status": {"state": "completed"}, "final": true}}',
+                    (
+                        '{"result": {"kind": "task", "id": "task-123", '
+                        '"history": [{"role": "agent", "parts": [{"kind": "text", "text": "Hello"}]}], '
+                        '"metadata": {"refetch_model": true}}}'
+                    ),
+                ]
+                for line in lines:
+                    yield line
+
+            mock_stream_response = MagicMock()
+            mock_stream_response.status_code = 200
+            mock_stream_response.raise_for_status = MagicMock()
+            mock_stream_response.aiter_lines = mock_aiter_lines
+
+            mock_stream_cm = AsyncMock()
+            mock_stream_cm.__aenter__.return_value = mock_stream_response
+            mock_stream_cm.__aexit__.return_value = None
+
+            mock_http_client = MagicMock()
+            mock_http_client.stream.return_value = mock_stream_cm
+            mock_get_client.return_value = mock_http_client
+
+            client = A2AClient("http://localhost:7777")
+
+            async def raw_stream() -> AsyncIterator[StreamEvent]:
+                async for event in client.stream_message(message="Hello"):
+                    yield event
+
+            run_events = [
+                event async for event in map_stream_events_to_run_events(raw_stream(), agent_id="agent-1")
+            ]
+
+            assert [type(e) for e in run_events] == [
+                RunStartedEvent,
+                RunContentEvent,
+                RunCompletedEvent,
+            ]
+            completed = run_events[-1]
+            assert completed.content == "Hello"
+            assert completed.metadata == {"refetch_model": True}
 
 
 class TestSchemas:

--- a/libs/agno/tests/unit/a2a/test_client.py
+++ b/libs/agno/tests/unit/a2a/test_client.py
@@ -407,21 +407,20 @@ class TestStreamMessage:
             assert content_events[1].content == " World"
 
     @pytest.mark.asyncio
-    async def test_stream_message_task_metadata_survives_completed_status_update(self):
-        """Regression test: a "status-update" reporting completion (final=True)
-        arrives before the authoritative "task" event that carries the final
-        message parts and any Task-level metadata. map_stream_events_to_run_events
-        must not stop on the status-update, or that metadata is silently dropped."""
+    async def test_stream_message_terminal_status_update_carries_metadata(self):
+        """Regression test: out-of-band metadata rides the final=True status-update
+        (the A2A spec's terminal event). map_stream_events_to_run_events must read
+        event.metadata off that terminal event and forward it onto RunCompletedEvent,
+        rather than dropping it."""
         with patch("agno.client.a2a.client.get_default_async_client") as mock_get_client:
 
             async def mock_aiter_lines():
                 lines = [
                     '{"result": {"kind": "status-update", "taskId": "task-123", "status": {"state": "working"}}}',
                     '{"result": {"kind": "message", "messageId": "m1", "parts": [{"kind": "text", "text": "Hello"}]}}',
-                    '{"result": {"kind": "status-update", "taskId": "task-123", "status": {"state": "completed"}, "final": true}}',
                     (
-                        '{"result": {"kind": "task", "id": "task-123", '
-                        '"history": [{"role": "agent", "parts": [{"kind": "text", "text": "Hello"}]}], '
+                        '{"result": {"kind": "status-update", "taskId": "task-123", '
+                        '"status": {"state": "completed"}, "final": true, '
                         '"metadata": {"refetch_model": true}}}'
                     ),
                 ]

--- a/libs/agno/tests/unit/os/interfaces/test_a2a.py
+++ b/libs/agno/tests/unit/os/interfaces/test_a2a.py
@@ -1,0 +1,76 @@
+"""Unit tests for the A2A interface's stream_a2a_response function.
+
+Regression coverage for: RunCompletedEvent.metadata (e.g. sources, refetch_model
+set by a caller's post-processing step) must be forwarded onto the final Task's
+own metadata field, not just onto the nested agent message inside Task.history -
+the A2A client reads Task-level metadata for the "task" kind event.
+"""
+
+import json
+from typing import AsyncIterator, Union
+
+import pytest
+
+from agno.os.interfaces.a2a.utils import stream_a2a_response
+from agno.run.agent import RunCompletedEvent, RunContentEvent, RunStartedEvent
+
+
+async def _agent_stream(
+    *events: Union[RunStartedEvent, RunContentEvent, RunCompletedEvent],
+) -> AsyncIterator:
+    for event in events:
+        yield event
+
+
+def _parse_sse_events(raw: str):
+    """Parse the "event: Name\\ndata: {...}\\n\\n" SSE blocks stream_a2a_response yields."""
+    parsed = []
+    for block in raw.strip().split("\n\n"):
+        block = block.strip()
+        if not block:
+            continue
+        for line in block.split("\n"):
+            if line.startswith("data: "):
+                parsed.append(json.loads(line[len("data: ") :]))
+    return parsed
+
+
+class TestStreamA2AResponseMetadata:
+    @pytest.mark.asyncio
+    async def test_run_completed_metadata_forwarded_onto_task(self):
+        stream = _agent_stream(
+            RunStartedEvent(run_id="run-1", session_id="ctx-1"),
+            RunContentEvent(content="Hello", run_id="run-1", session_id="ctx-1"),
+            RunCompletedEvent(
+                content="Hello",
+                run_id="run-1",
+                session_id="ctx-1",
+                metadata={"sources": {"llm_sources": []}, "refetch_model": True},
+            ),
+        )
+
+        chunks = [chunk async for chunk in stream_a2a_response(stream, request_id="req-1")]
+        events = _parse_sse_events("".join(chunks))
+
+        task_events = [e for e in events if e.get("result", {}).get("kind") == "task"]
+        assert len(task_events) == 1
+
+        task_result = task_events[0]["result"]
+        assert task_result["metadata"] == {"sources": {"llm_sources": []}, "refetch_model": True}
+
+    @pytest.mark.asyncio
+    async def test_run_completed_without_metadata_omits_task_metadata_field(self):
+        """No metadata set means the Task's metadata field is omitted (exclude_none),
+        not sent as an empty dict - avoids ballooning every response with noise."""
+        stream = _agent_stream(
+            RunStartedEvent(run_id="run-1", session_id="ctx-1"),
+            RunContentEvent(content="Hi", run_id="run-1", session_id="ctx-1"),
+            RunCompletedEvent(content="Hi", run_id="run-1", session_id="ctx-1"),
+        )
+
+        chunks = [chunk async for chunk in stream_a2a_response(stream, request_id="req-1")]
+        events = _parse_sse_events("".join(chunks))
+
+        task_events = [e for e in events if e.get("result", {}).get("kind") == "task"]
+        assert len(task_events) == 1
+        assert "metadata" not in task_events[0]["result"]

--- a/libs/agno/tests/unit/os/interfaces/test_a2a.py
+++ b/libs/agno/tests/unit/os/interfaces/test_a2a.py
@@ -1,9 +1,8 @@
 """Unit tests for the A2A interface's stream_a2a_response function.
 
 Regression coverage for: RunCompletedEvent.metadata (e.g. sources, refetch_model
-set by a caller's post-processing step) must be forwarded onto the final Task's
-own metadata field, not just onto the nested agent message inside Task.history -
-the A2A client reads Task-level metadata for the "task" kind event.
+set by a caller's post-processing step) must ride the terminal final=True
+status-update event, which the A2A client reads as the run's out-of-band metadata.
 """
 
 import json
@@ -35,9 +34,20 @@ def _parse_sse_events(raw: str):
     return parsed
 
 
+def _final_status_update(events):
+    """Return the terminal final=True status-update event's result."""
+    finals = [
+        e["result"]
+        for e in events
+        if e.get("result", {}).get("kind") == "status-update" and e["result"].get("final") is True
+    ]
+    assert len(finals) == 1
+    return finals[0]
+
+
 class TestStreamA2AResponseMetadata:
     @pytest.mark.asyncio
-    async def test_run_completed_metadata_forwarded_onto_task(self):
+    async def test_run_completed_metadata_rides_terminal_status_update(self):
         stream = _agent_stream(
             RunStartedEvent(run_id="run-1", session_id="ctx-1"),
             RunContentEvent(content="Hello", run_id="run-1", session_id="ctx-1"),
@@ -52,16 +62,13 @@ class TestStreamA2AResponseMetadata:
         chunks = [chunk async for chunk in stream_a2a_response(stream, request_id="req-1")]
         events = _parse_sse_events("".join(chunks))
 
-        task_events = [e for e in events if e.get("result", {}).get("kind") == "task"]
-        assert len(task_events) == 1
-
-        task_result = task_events[0]["result"]
-        assert task_result["metadata"] == {"sources": {"llm_sources": []}, "refetch_model": True}
+        final = _final_status_update(events)
+        assert final["metadata"] == {"sources": {"llm_sources": []}, "refetch_model": True}
 
     @pytest.mark.asyncio
-    async def test_run_completed_without_metadata_omits_task_metadata_field(self):
-        """No metadata set means the Task's metadata field is omitted (exclude_none),
-        not sent as an empty dict - avoids ballooning every response with noise."""
+    async def test_run_completed_without_metadata_omits_status_metadata_field(self):
+        """No metadata set means the terminal status-update's metadata field is
+        omitted (exclude_none), not sent as an empty dict."""
         stream = _agent_stream(
             RunStartedEvent(run_id="run-1", session_id="ctx-1"),
             RunContentEvent(content="Hi", run_id="run-1", session_id="ctx-1"),
@@ -71,6 +78,5 @@ class TestStreamA2AResponseMetadata:
         chunks = [chunk async for chunk in stream_a2a_response(stream, request_id="req-1")]
         events = _parse_sse_events("".join(chunks))
 
-        task_events = [e for e in events if e.get("result", {}).get("kind") == "task"]
-        assert len(task_events) == 1
-        assert "metadata" not in task_events[0]["result"]
+        final = _final_status_update(events)
+        assert "metadata" not in final


### PR DESCRIPTION
## Summary
- `map_stream_events_to_run_events`/`map_stream_events_to_team_run_events` (client-side A2A→Agno event mapping) broke their event loop on the first `StreamEvent` with `is_final=True`. A `status-update` event reporting `state=completed` also sets `is_final=True`, and it arrives *before* the authoritative `task` event - which carries the final message parts and any Task-level metadata. The loop exited before the `task` event was ever read, silently discarding metadata attached to the final run.
- `stream_a2a_response` (server-side) computed `final_metadata` from the completion event but only attached it to the nested agent message inside `Task.history`, never to the `Task` object itself. The client reads `metadata` off the top-level `Task` for the `"task"` kind event, so even a client-side fix alone wouldn't have surfaced this metadata.

## Changes
- **Client** (`agno/client/a2a/utils.py`): only terminate the loop on `event_type == "task"` (the true terminal event per the A2A spec). A completed `status-update` now falls through and keeps reading. Failed/canceled `status-update`s (or non-agno A2A servers that never send a `task` event) still break immediately via the existing `is_final` branch - no behaviour change there. The `task` branch now also forwards `event.metadata` onto the yielded `RunCompletedEvent`/`TeamRunCompletedEvent`.
- **Server** (`agno/os/interfaces/a2a/utils.py`): `Task(...)` construction now passes `metadata=final_metadata`, matching what the client reads.

## Test plan
- [x] Added `test_stream_message_task_metadata_survives_completed_status_update` in `tests/unit/a2a/test_client.py` - feeds a realistic wire payload (`status-update(completed)` immediately followed by `task` carrying metadata) through `A2AClient.stream_message` + `map_stream_events_to_run_events`, asserts the final `RunCompletedEvent.metadata` survives.
- [x] Added `tests/unit/os/interfaces/test_a2a.py` covering `stream_a2a_response` directly - asserts `RunCompletedEvent.metadata` is forwarded onto the final `Task.metadata`, and that it's omitted (not an empty dict) when unset.
