### PR TITLE
fix: normalize empty OpenAI-compatible tool arguments

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from os import getenv
@@ -328,7 +329,7 @@ class OpenAIChat(Model):
             "content": tool_result,
             "name": message.name,
             "tool_call_id": message.tool_call_id,
-            "tool_calls": message.tool_calls,
+            "tool_calls": self._format_tool_calls(message.tool_calls) if message.tool_calls is not None else None,
         }
         message_dict = {k: v for k, v in message_dict.items() if v is not None}
 
@@ -376,6 +377,23 @@ class OpenAIChat(Model):
         if message.content is None:
             message_dict["content"] = ""
         return message_dict
+
+    @staticmethod
+    def _format_tool_calls(tool_calls: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        formatted_tool_calls: List[Dict[str, Any]] = []
+        for tool_call in tool_calls:
+            formatted_tool_call = dict(tool_call)
+            function = formatted_tool_call.get("function")
+            if isinstance(function, dict):
+                formatted_function = dict(function)
+                arguments = formatted_function.get("arguments")
+                if arguments is None or arguments == "":
+                    formatted_function["arguments"] = "{}"
+                elif isinstance(arguments, (dict, list)):
+                    formatted_function["arguments"] = json.dumps(arguments)
+                formatted_tool_call["function"] = formatted_function
+            formatted_tool_calls.append(formatted_tool_call)
+        return formatted_tool_calls
 
     def _format_all_messages(
         self, messages: List[Message], compress_tool_results: bool = False
@@ -783,6 +801,10 @@ class OpenAIChat(Model):
                     tool_call_entry["id"] = _tool_call_id
                 if _tool_call_type:
                     tool_call_entry["type"] = _tool_call_type
+        for tool_call in tool_calls:
+            function = tool_call.get("function")
+            if isinstance(function, dict) and not function.get("arguments"):
+                function["arguments"] = "{}"
         return tool_calls
 
     def _should_collect_metrics(self, response: ChatCompletionChunk) -> bool:

--- a/libs/agno/tests/unit/models/openai/test_parse_tool_calls.py
+++ b/libs/agno/tests/unit/models/openai/test_parse_tool_calls.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from agno.models.message import Message
 from agno.models.openai.chat import OpenAIChat
 
 
@@ -69,6 +70,37 @@ def test_parse_tool_calls_multiple_tools_independent():
     assert result[0]["function"]["name"] == "tool_a"
     assert result[1]["function"]["name"] == "tool_b"
     assert result[0] is not result[1]
+
+
+def test_parse_tool_calls_defaults_empty_arguments_to_json_object():
+    """Zero-argument streamed tool calls must round-trip as valid JSON."""
+    deltas = [
+        _FakeChoiceDeltaToolCall(index=0, tool_id="call_1", tool_type="function", func_name="api_schema_inspect"),
+    ]
+    result = OpenAIChat.parse_tool_calls(deltas)
+
+    assert result[0]["function"]["arguments"] == "{}"
+
+
+def test_format_message_defaults_empty_tool_call_arguments_without_mutating_message():
+    """OpenAI-compatible providers reject empty-string tool call arguments on the next turn."""
+    model = OpenAIChat(id="gpt-4o-mini")
+    message = Message(
+        role="assistant",
+        content=None,
+        tool_calls=[
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "api_schema_inspect", "arguments": ""},
+            }
+        ],
+    )
+
+    formatted = model._format_message(message)
+
+    assert formatted["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert message.tool_calls[0]["function"]["arguments"] == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #8312.

OpenAI-compatible providers can return zero-argument tool calls with an empty `function.arguments` string. Agno could execute that call because its tool parser treats empty args as `{}`, but the persisted assistant `tool_calls` were sent back unchanged on the next chat completion turn. Providers such as Databricks-hosted Claude reject that empty string because `arguments` must be a valid JSON string.

This normalizes empty tool call arguments to `"{}"` when formatting OpenAI chat messages, and also finalizes streamed zero-argument tool calls with `"{}"` after all chunks are parsed. Existing message objects are not mutated.

## Validation

- `.venv-min/bin/python -m pytest libs/agno/tests/unit/models/openai/test_parse_tool_calls.py -q`
- `.venv-min/bin/ruff check --select I libs/agno/agno/models/openai/chat.py libs/agno/tests/unit/models/openai/test_parse_tool_calls.py`
- `.venv-min/bin/ruff check --select E4,E7,E9,F --line-length 120 libs/agno/agno/models/openai/chat.py libs/agno/tests/unit/models/openai/test_parse_tool_calls.py`
- `.venv-min/bin/ruff format --check --line-length 120 libs/agno/agno/models/openai/chat.py libs/agno/tests/unit/models/openai/test_parse_tool_calls.py`

## Duplicate check

Before implementing, I confirmed #8312 is still open, has no assignees, and `gh pr list --repo agno-agi/agno --state open --search "8312 OpenAILike zero-argument tool"` returned no open PRs directly covering this issue. I skipped other candidates that already had open PR coverage, including #7962 and #7851.