### PR TITLE
fix: read and write agnoctl client config files as UTF-8

### DIFF
--- a/libs/agnoctl/agnoctl/clients/base.py
+++ b/libs/agnoctl/agnoctl/clients/base.py
@@ -75,8 +75,8 @@ def read_json_lenient(path: Path) -> Optional[Dict[str, Any]]:
     if not path.exists():
         return None
     try:
-        parsed = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None
     return parsed if isinstance(parsed, dict) else None
 
@@ -86,7 +86,12 @@ def read_json_strict(path: Path) -> Dict[str, Any]:
     if not path.exists():
         return {}
     try:
-        parsed = json.loads(path.read_text())
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except UnicodeDecodeError as e:
+        raise CLIError(
+            "Refusing to modify " + str(path) + ": the file is not valid UTF-8 (" + str(e) + ").",
+            hint="JSON must be UTF-8. Re-save the file as UTF-8, then re-run.",
+        )
     except (OSError, json.JSONDecodeError) as e:
         raise CLIError(
             "Refusing to modify " + str(path) + ": the existing file is not valid JSON (" + str(e) + ").",
@@ -127,7 +132,7 @@ def atomic_write_text(path: Path, text: str, *, secure: bool) -> None:
     fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix="." + path.name + ".", suffix=".tmp")
     tmp = Path(tmp_name)
     try:
-        with os.fdopen(fd, "w") as handle:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())

--- a/libs/agnoctl/agnoctl/clients/codex.py
+++ b/libs/agnoctl/agnoctl/clients/codex.py
@@ -167,7 +167,15 @@ class CodexAdapter(ClientAdapter):
         (shared by the write and remove paths so their refusal behavior cannot drift)."""
         if not self.config_path.exists():
             return "", {}
-        text = self.config_path.read_text()
+        # TOML is UTF-8 by spec; a file that is not decodable is as unusable as one that
+        # does not parse, so it refuses through the same path rather than as a traceback.
+        try:
+            text = self.config_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as e:
+            raise CLIError(
+                "Refusing to modify " + str(self.config_path) + ": the file is not valid UTF-8 (" + str(e) + ").",
+                hint="TOML must be UTF-8. Re-save the file as UTF-8, then re-run.",
+            )
         try:
             return text, tomllib.loads(text)
         except tomllib.TOMLDecodeError as e:
@@ -188,8 +196,8 @@ class CodexAdapter(ClientAdapter):
         if not self.config_path.exists():
             return None
         try:
-            return tomllib.loads(self.config_path.read_text())
-        except (OSError, tomllib.TOMLDecodeError):
+            return tomllib.loads(self.config_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
             return None
 
     @staticmethod

--- a/libs/agnoctl/tests/test_adapters.py
+++ b/libs/agnoctl/tests/test_adapters.py
@@ -809,3 +809,115 @@ def test_configured_sources_collects_and_labels(tmp_path):
         {"cursor": CursorAdapter(home=tmp_path, cwd=tmp_path), "codex": CodexAdapter(home=tmp_path)}
     )
     assert sources == [("https://prod.example.com", "client-config", "Cursor, Codex")]
+
+
+# -- Config file encoding ----------------------------------------------------------
+#
+# Client config files are UTF-8: JSON by definition (RFC 8259 8.1) and TOML by spec.
+# Reading or writing them without an explicit encoding= uses the host's locale codec,
+# which on a non-UTF-8 Windows code page either raises UnicodeDecodeError or silently
+# mojibakes the server names and filesystem paths -- and since the write paths are
+# read-modify-write, a mojibake read corrupts the user's whole config on save.
+#
+# `narrow_locale` forces that situation on every platform so these tests are not silent
+# no-ops on UTF-8 CI runners.
+
+NON_ASCII_PATH = "D:/资料/客户文档"
+
+
+@pytest.fixture
+def narrow_locale(monkeypatch, tmp_path):
+    """Give text opens that do not name an encoding a narrow one, as a narrow locale would.
+
+    Patches ``io.open`` rather than ``builtins.open`` because that is the entry point
+    ``pathlib.Path.read_text`` actually reaches -- patching only ``builtins.open`` would
+    leave it untouched and make these tests pass vacuously. ``Path.read_text`` resolves an
+    absent encoding to the sentinel ``"locale"`` before it gets here, so that spelling
+    counts as absent too. ``os.fdopen`` is wrapped separately since it is handed a file
+    descriptor, which carries no path to scope on.
+
+    Scoped to ``tmp_path`` so nothing else the test process reads is affected.
+    """
+    import io
+
+    real_open = io.open
+    real_fdopen = os.fdopen
+
+    def narrow(mode, encoding):
+        return "b" not in mode and encoding in (None, "locale")
+
+    def open_with_narrow_locale(file, mode="r", buffering=-1, encoding=None, *args, **kwargs):
+        if narrow(mode, encoding) and isinstance(file, (str, os.PathLike)) and str(file).startswith(str(tmp_path)):
+            encoding = "ascii"
+        return real_open(file, mode, buffering, encoding, *args, **kwargs)
+
+    def fdopen_with_narrow_locale(fd, mode="r", buffering=-1, encoding=None, *args, **kwargs):
+        if narrow(mode, encoding):
+            encoding = "ascii"
+        return real_fdopen(fd, mode, buffering, encoding, *args, **kwargs)
+
+    monkeypatch.setattr(io, "open", open_with_narrow_locale)
+    monkeypatch.setattr(os, "fdopen", fdopen_with_narrow_locale)
+
+
+def test_read_json_preserves_non_ascii(tmp_path: Path, narrow_locale):
+    """Both JSON readers must decode as UTF-8 regardless of the host locale."""
+    from agnoctl.clients.base import read_json_lenient, read_json_strict
+
+    path = tmp_path / "mcp.json"
+    config = {"mcpServers": {"文件系统": {"command": "npx", "args": ["-y", NON_ASCII_PATH]}}}
+    path.write_text(json.dumps(config, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    assert read_json_lenient(path) == config
+    assert read_json_strict(path) == config
+
+
+def test_atomic_write_text_writes_utf8(tmp_path: Path, narrow_locale):
+    """Written bytes must be UTF-8 so the next reader -- ours or the client's -- can parse them."""
+    path = tmp_path / "config.toml"
+    text = 'root = "' + NON_ASCII_PATH + '"\n'
+
+    atomic_write_text(path, text, secure=False)
+
+    # Compare decoded text, not raw bytes: the newline translation is platform-dependent,
+    # the encoding is what this asserts.
+    assert path.read_text(encoding="utf-8") == text
+    assert NON_ASCII_PATH.encode("utf-8") in path.read_bytes()
+
+
+def test_codex_write_preserves_non_ascii_config(tmp_path: Path, narrow_locale):
+    """Codex writes are read-modify-write, so unrelated non-ASCII entries must survive."""
+    (tmp_path / ".codex").mkdir()
+    config_path = tmp_path / ".codex" / "config.toml"
+    original = (
+        'model = "gpt-5"\n\n'
+        "[mcp_servers.filesystem]\n"
+        'command = "npx"\n'
+        'args = ["-y", "' + NON_ASCII_PATH + '"]\n\n'
+        '[projects."' + NON_ASCII_PATH + '"]\n'
+        'trust_level = "trusted"\n'
+    )
+    config_path.write_text(original, encoding="utf-8")
+
+    result = CodexAdapter(home=tmp_path).write("agno", "http://localhost:7777/mcp", None)
+
+    assert result.method == "file"
+    parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    # The entry we added, plus every pre-existing one, byte-for-byte.
+    assert parsed["mcp_servers"]["agno"]["url"] == "http://localhost:7777/mcp"
+    assert parsed["mcp_servers"]["filesystem"]["args"][-1] == NON_ASCII_PATH
+    assert NON_ASCII_PATH in parsed["projects"]
+
+
+def test_codex_read_of_undecodable_config_does_not_crash(tmp_path: Path):
+    """A config that is not valid UTF-8 is a bad file, not a traceback."""
+    (tmp_path / ".codex").mkdir()
+    config_path = tmp_path / ".codex" / "config.toml"
+    # Latin-1 bytes that are not legal UTF-8.
+    config_path.write_bytes(b'[mcp_servers.x]\nurl = "http://h/mcp"  # caf\xe9\n')
+
+    adapter = CodexAdapter(home=tmp_path)
+
+    assert adapter.list_entries() == {}
+    with pytest.raises(CLIError):
+        adapter.write("agno", "http://localhost:7777/mcp", None)


### PR DESCRIPTION
## Summary

`agnoctl` reads and writes the coding-agent config files (`~/.claude.json`, `~/.codex/config.toml`, `~/.cursor/mcp.json`) in text mode with no `encoding=` argument, so Python decodes and encodes them with the **host locale** codec. JSON is UTF-8 by definition (RFC 8259 §8.1) and TOML is UTF-8 by spec, so on any host whose locale is not UTF-8 these files go through the wrong codec.

Five sites, three files:

| file | site | direction |
|---|---|---|
| `clients/base.py` | `read_json_lenient()` | read |
| `clients/base.py` | `read_json_strict()` | read |
| `clients/base.py` | `atomic_write_text()` | write |
| `clients/codex.py` | `_read_strict()` | read |
| `clients/codex.py` | `_parse_config()` | read |

This matters more here than at a typical `open()` site because these paths are **read-modify-write**: `connect`/`disconnect` parse the user's *entire* config, add or drop one `mcpServers` entry, and write the whole thing back. So a mis-decoded read is not a local misread — it gets committed to disk over the user's real config.

Three concrete failure modes, all reproduced below on `cp936`:

1. **Silent mojibake on read.** The UTF-8 bytes happen to be legal in the locale codec, so the decode "succeeds" into wrong text. Server names and the filesystem paths in `args` are corrupted with no warning at all.
2. **Uncaught `UnicodeDecodeError`.** When the bytes are *not* legal in the locale codec, `CodexAdapter.list_entries()` and `.write()` raise `UnicodeDecodeError` straight out of `pathlib` — a raw traceback, not a CLI error message. `_parse_config` even has an `except (OSError, tomllib.TOMLDecodeError)` intended to make an unusable file a clean no-op, but `UnicodeDecodeError` slips past it.
3. **The write side re-encodes the file.** This is why `atomic_write_text` is in the diff and not only the readers. With the reads fixed but the write left on the locale codec, the correctly-decoded config is written back out in the *locale* encoding — so a UTF-8 `config.toml` silently becomes a GBK one (Codex then cannot read it), or the write dies outright when the text has no locale representation.

`clients/discovery.py:135` already reads with an explicit encoding (`utf-8-sig`), so this brings the rest of `agnoctl` in line with the module's own convention.

Beyond the encoding itself, the two strict/refusal paths now name the actual problem: an undecodable file gets *"the file is not valid UTF-8"* with a "re-save as UTF-8" hint, rather than being reported as invalid JSON/TOML — which it may well parse as, once decoded correctly.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — n/a, internal CLI behavior with no cookbook surface
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

**On the similar PR:** #7984 ("add explicit `encoding="utf-8"` to text-mode `open()` calls", open since 2026-05-19) makes the same *kind* of change but has **zero file overlap** — it touches 5 files under `libs/agno/` (`models/base.py`, `os/utils.py`, `tools/function.py`, `db/json/json_db.py`, `utils/functions.py`) and none under `libs/agnoctl/`. The two are complementary and will not conflict. This one is narrower in intent and carries reproduction evidence plus regression tests rather than being a blanket sweep.

---

## Additional Notes

### Reproduction, before the fix

Windows 11, Python 3.12.10, `locale.getpreferredencoding(False) == 'cp936'`, through the real adapter code paths:

```
locale.getpreferredencoding(False) = cp936
1) read_json_lenient  name='鏂囦欢绯荤粺' ok=False
2) list_entries       UnicodeDecodeError: 'gbk' codec can't decode byte 0xe9 in position 43: illegal multibyte sequence
3) write              UnicodeDecodeError: 'gbk' codec can't decode byte 0xe9 in position 43: illegal multibyte sequence
```

(`'文'` is U+6587; it comes back as U+93C2. I compared codepoints rather than trusting the printed text, because GBK↔UTF-8 mojibake can look like a clean round-trip in a cp936 terminal.)

After the fix, same script:

```
1) read_json_lenient  name='文件系统' ok=True
2) list_entries       {}
3) write              CLIError: Refusing to modify ...\.codex\config.toml: the file is not valid UTF-8 (...)
```

### Why `atomic_write_text` is in the diff

With the readers fixed but `atomic_write_text` left on the locale codec, `CodexAdapter.write()` against a pre-existing UTF-8 `config.toml`:

```
locale: cp936
chinese  write ok, file still UTF-8? False  bytes=b'args = ["-y", "D:/\xd7\xca\xc1\xcf/\xbf\xcd\xbb\xa7\xce\xc4\xb5\xb5"]'
emoji    UnicodeEncodeError: 'gbk' codec can't encode character '\U0001f4c1' in position 61: illegal multibyte sequence
korean   UnicodeEncodeError: 'gbk' codec can't encode character '\ubb38' in position 61: illegal multibyte sequence
```

The file is rewritten as GBK, or the write fails outright. With the full fix all three leave the config byte-identical UTF-8.

### Not limited to Chinese locales

Decoding UTF-8 bytes with a narrow codec, comparing the decoded string against the original:

```
string     codec    result
chinese    cp1252   silent mojibake
accented   cp1252   silent mojibake     # C:/Users/José
accented   cp932    silent mojibake
accented   cp949    silent mojibake
emoji      cp1252   UnicodeDecodeError
japanese   cp932    UnicodeDecodeError  # C:/ドキュメント on a Japanese Windows install
korean     cp949    silent mojibake
cyrillic   cp1252   silent mojibake
```

`cp1252` — the default on a stock English-locale Windows — silently mojibakes an accented username path, so this is not a CJK-only concern.

### Tests

Four tests in `libs/agnoctl/tests/test_adapters.py`:

- `test_read_json_preserves_non_ascii` — both JSON readers
- `test_atomic_write_text_writes_utf8` — the bytes on disk are UTF-8
- `test_codex_write_preserves_non_ascii_config` — read-modify-write survival: an unrelated `[projects."D:/资料/客户文档"]` table and a `filesystem` server's non-ASCII `args` are still intact after `write()`
- `test_codex_read_of_undecodable_config_does_not_crash` — a non-UTF-8 file yields `{}` from `list_entries()` and a `CLIError` (not a traceback) from `write()`

The `narrow_locale` fixture patches `io.open` and `os.fdopen` to inject a narrow codec when the caller omits `encoding=`, scoped to `tmp_path`. That makes these tests fail on UTF-8 CI runners too, instead of being silent no-ops there. Two notes from getting it right:

- `builtins.open` is the wrong hook: `pathlib.Path.read_text()` goes through `io.open` and `atomic_write_text` through `os.fdopen`, so a `builtins.open` patch leaves both untouched. My first draft of these tests passed against the *unfixed* code for exactly that reason.
- `Path.read_text()` resolves an absent encoding to the sentinel string `"locale"` before the call, so the fixture treats that spelling as absent too.

**Control experiment** — revert only the two source files, keep the tests:

```
$ git checkout HEAD~1 -- libs/agnoctl/agnoctl/clients/base.py libs/agnoctl/agnoctl/clients/codex.py
$ pytest tests/test_adapters.py -k "non_ascii or utf8 or undecodable" -q
FAILED test_read_json_preserves_non_ascii - UnicodeDecodeError
FAILED test_atomic_write_text_writes_utf8 - UnicodeEncodeError
FAILED test_codex_write_preserves_non_ascii_config - UnicodeDecodeError
FAILED test_codex_read_of_undecodable_config_does_not_crash
4 failed
```

All four fail without the fix and pass with it, so none of them passes vacuously.

### Suite and lint

```
$ pytest libs/agnoctl/tests/ -q
16 failed, 306 passed
```

Baseline on unmodified `main` (`git stash push -u -- libs/agnoctl`) is `16 failed, 302 passed` — the same 16 failures, with exactly my 4 new tests added. Those 16 pre-existing failures are POSIX file-mode assertions (`0600`/umask) and symlink-rejection tests that cannot hold on Windows; they are unrelated to this change.

```
$ ruff check libs/agnoctl              # ruff 0.15.20, the version pinned in libs/agnoctl/pyproject.toml
All checks passed!
$ ruff format --check <the 3 changed files>
3 files already formatted
$ mypy libs/agnoctl/agnoctl --config-file libs/agnoctl/pyproject.toml
Success: no issues found in 21 source files
```

Those are the exact two `agnoctl` steps from `scripts/validate.sh:70-71`, run directly since `dev_setup.sh` builds a POSIX `.venv`.

---

*AI disclosure: I used an AI coding assistant (Claude Code) while investigating and preparing this change. I reviewed the diff line by line, and every output quoted above is real output from my machine that I verified — including the control experiment, which is what caught a genuine bug in my own first draft of the tests.*
