### PR TITLE
Update Cerebras defaults and cookbook models

### DIFF
--- a/cookbook/90_models/cerebras/basic.py
+++ b/cookbook/90_models/cerebras/basic.py
@@ -15,7 +15,7 @@ from agno.models.cerebras import Cerebras
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Cerebras(id="llama-3.3-70b"),
+    model=Cerebras(id="gpt-oss-120b"),
     markdown=True,
 )
 

--- a/cookbook/90_models/cerebras/db.py
+++ b/cookbook/90_models/cerebras/db.py
@@ -14,7 +14,7 @@ db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 db = PostgresDb(db_url=db_url)
 
 agent = Agent(
-    model=Cerebras(id="llama-3.3-70b"),
+    model=Cerebras(id="gpt-oss-120b"),
     db=db,
     tools=[WebSearchTools()],
     add_history_to_context=True,

--- a/cookbook/90_models/cerebras/knowledge.py
+++ b/cookbook/90_models/cerebras/knowledge.py
@@ -17,7 +17,7 @@ knowledge = Knowledge(
 # Add content to the knowledge
 knowledge.insert(url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf")
 
-agent = Agent(model=Cerebras(id="llama-3.3-70b"), knowledge=knowledge)
+agent = Agent(model=Cerebras(id="gpt-oss-120b"), knowledge=knowledge)
 agent.print_response("How to make Thai curry?", markdown=True)
 
 # ---------------------------------------------------------------------------

--- a/cookbook/90_models/cerebras/structured_output.py
+++ b/cookbook/90_models/cerebras/structured_output.py
@@ -38,14 +38,14 @@ class MovieScript(BaseModel):
 
 # Agent that uses structured outputs with strict_output=True (default)
 structured_output_agent = Agent(
-    model=Cerebras(id="zai-glm-4.7"),
+    model=Cerebras(id="gpt-oss-120b"),
     description="You write movie scripts.",
     output_schema=MovieScript,
 )
 
 # Agent with strict_output=False (guided mode)
 guided_output_agent = Agent(
-    model=Cerebras(id="zai-glm-4.7", strict_output=False),
+    model=Cerebras(id="gpt-oss-120b", strict_output=False),
     description="You write movie scripts.",
     output_schema=MovieScript,
 )

--- a/cookbook/90_models/cerebras/structured_output.py
+++ b/cookbook/90_models/cerebras/structured_output.py
@@ -38,14 +38,14 @@ class MovieScript(BaseModel):
 
 # Agent that uses structured outputs with strict_output=True (default)
 structured_output_agent = Agent(
-    model=Cerebras(id="qwen-3-32b"),
+    model=Cerebras(id="zai-glm-4.7"),
     description="You write movie scripts.",
     output_schema=MovieScript,
 )
 
 # Agent with strict_output=False (guided mode)
 guided_output_agent = Agent(
-    model=Cerebras(id="qwen-3-32b", strict_output=False),
+    model=Cerebras(id="zai-glm-4.7", strict_output=False),
     description="You write movie scripts.",
     output_schema=MovieScript,
 )

--- a/cookbook/90_models/cerebras/tool_use.py
+++ b/cookbook/90_models/cerebras/tool_use.py
@@ -16,7 +16,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Cerebras(id="llama-3.3-70b"),
+    model=Cerebras(id="gpt-oss-120b"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/libs/agno/agno/models/cerebras/cerebras.py
+++ b/libs/agno/agno/models/cerebras/cerebras.py
@@ -37,7 +37,7 @@ class Cerebras(Model):
     A class for interacting with models using the Cerebras API.
     """
 
-    id: str = "llama-4-scout-17b-16e-instruct"
+    id: str = "gpt-oss-120b"
     name: str = "Cerebras"
     provider: str = "Cerebras"
 

--- a/libs/agno/agno/models/cerebras/cerebras_openai.py
+++ b/libs/agno/agno/models/cerebras/cerebras_openai.py
@@ -13,7 +13,7 @@ from agno.utils.log import log_debug
 
 @dataclass
 class CerebrasOpenAI(OpenAILike):
-    id: str = "llama-4-scout-17b-16e-instruct"
+    id: str = "gpt-oss-120b"
     name: str = "CerebrasOpenAI"
     provider: str = "CerebrasOpenAI"
 

--- a/libs/agno/tests/integration/models/cerebras/cerebras_openai/test_basic.py
+++ b/libs/agno/tests/integration/models/cerebras/cerebras_openai/test_basic.py
@@ -6,6 +6,10 @@ from agno.db.sqlite import SqliteDb
 from agno.models.cerebras import CerebrasOpenAI
 
 
+def test_default_model_id():
+    assert CerebrasOpenAI().id == "gpt-oss-120b"
+
+
 def _assert_metrics(response: RunOutput):
     assert response.metrics is not None
     input_tokens = response.metrics.input_tokens

--- a/libs/agno/tests/integration/models/cerebras/test_basic.py
+++ b/libs/agno/tests/integration/models/cerebras/test_basic.py
@@ -6,6 +6,10 @@ from agno.db.sqlite import SqliteDb
 from agno.models.cerebras import Cerebras
 
 
+def test_default_model_id():
+    assert Cerebras().id == "gpt-oss-120b"
+
+
 @pytest.fixture(scope="module")
 def cerebras_model():
     """Fixture that provides a Cerebras model and reuses it across all tests in the module."""


### PR DESCRIPTION
## Summary

- Changes both Cerebras model defaults to `gpt-oss-120b`.
- Updates cookbook examples to current `gpt-oss-120b` and `zai-glm-4.7` IDs.
- Adds regression tests for the `Cerebras` and `CerebrasOpenAI` defaults.

## Why

The previous default model was retired, which could cause model-not-found errors for users relying on the default constructor.

Closes #9245

## Validation

- `uv run --no-project --with pytest --with pytest-asyncio --with sqlalchemy --with aiosqlite --with openai --with-editable libs/agno[cerebras] pytest --import-mode=importlib -q libs/agno/tests/integration/models/cerebras/test_basic.py::test_default_model_id libs/agno/tests/integration/models/cerebras/cerebras_openai/test_basic.py::test_default_model_id`
- Result: 2 passed.
- Python syntax parsing and `git diff --check`.
- Source of truth: https://api.cerebras.ai/public/v1/models