### PR TITLE
fix: stop Azure Foundry Claude from dropping temperature/top_p/top_k of 0

### DIFF
--- a/libs/agno/agno/models/azure/claude.py
+++ b/libs/agno/agno/models/azure/claude.py
@@ -131,13 +131,13 @@ class Claude(AnthropicClaude):
             _request_params["thinking"] = self.thinking
         if self.output_config:
             _request_params["output_config"] = self.output_config
-        if self.temperature:
+        if self.temperature is not None:
             _request_params["temperature"] = self.temperature
         if self.stop_sequences:
             _request_params["stop_sequences"] = self.stop_sequences
-        if self.top_p:
+        if self.top_p is not None:
             _request_params["top_p"] = self.top_p
-        if self.top_k:
+        if self.top_k is not None:
             _request_params["top_k"] = self.top_k
         if self.timeout:
             _request_params["timeout"] = self.timeout

--- a/libs/agno/tests/unit/models/test_claude_request_params.py
+++ b/libs/agno/tests/unit/models/test_claude_request_params.py
@@ -364,3 +364,71 @@ def test_vertexai_temperature_none_excluded():
     model = VertexAIClaude()
     params = model.get_request_params()
     assert "temperature" not in params
+
+
+def test_azure_temperature_zero_included():
+    """Azure Foundry Claude: temperature=0.0 must appear in request params."""
+    from agno.models.azure.claude import Claude as AzureClaude
+
+    model = AzureClaude(temperature=0.0)
+    params = model.get_request_params()
+    assert "temperature" in params
+    assert params["temperature"] == 0.0
+
+
+def test_azure_top_p_zero_included():
+    """Azure Foundry Claude: top_p=0.0 must appear in request params."""
+    from agno.models.azure.claude import Claude as AzureClaude
+
+    model = AzureClaude(top_p=0.0)
+    params = model.get_request_params()
+    assert "top_p" in params
+    assert params["top_p"] == 0.0
+
+
+def test_azure_top_k_zero_included():
+    """Azure Foundry Claude: top_k=0 must appear in request params."""
+    from agno.models.azure.claude import Claude as AzureClaude
+
+    model = AzureClaude(top_k=0)
+    params = model.get_request_params()
+    assert "top_k" in params
+    assert params["top_k"] == 0
+
+
+def test_azure_temperature_none_excluded():
+    """Azure Foundry Claude: unset temperature must not appear in request params."""
+    from agno.models.azure.claude import Claude as AzureClaude
+
+    model = AzureClaude()
+    params = model.get_request_params()
+    assert "temperature" not in params
+    assert "top_p" not in params
+    assert "top_k" not in params
+
+
+def test_azure_positive_sampling_params_included():
+    """Azure Foundry Claude: ordinary non-zero values keep working."""
+    from agno.models.azure.claude import Claude as AzureClaude
+
+    model = AzureClaude(temperature=0.7, top_p=0.9, top_k=40)
+    params = model.get_request_params()
+    assert params["temperature"] == 0.7
+    assert params["top_p"] == 0.9
+    assert params["top_k"] == 40
+
+
+def test_azure_all_sampling_params_zero():
+    """Azure Foundry Claude: all three zeros must survive together.
+
+    Azure was the only Claude subclass still gating these on truthiness while
+    anthropic/, aws/ and vertexai/ used `is not None`, so the same explicit 0
+    behaved differently depending on which provider you routed through.
+    """
+    from agno.models.azure.claude import Claude as AzureClaude
+
+    model = AzureClaude(temperature=0.0, top_p=0.0, top_k=0)
+    params = model.get_request_params()
+    assert params["temperature"] == 0.0
+    assert params["top_p"] == 0.0
+    assert params["top_k"] == 0


### PR DESCRIPTION
Fixes #9249

## Summary

`AzureFoundryClaude.get_request_params` gates its sampling parameters on truthiness (`libs/agno/agno/models/azure/claude.py:134-141`):

```python
if self.temperature:
    _request_params["temperature"] = self.temperature
if self.top_p:
    _request_params["top_p"] = self.top_p
if self.top_k:
    _request_params["top_k"] = self.top_k
```

All three are inherited from `AnthropicClaude` as `Optional[...] = None`, so `None` already encodes "unset" and `0` is a legitimate value -- `temperature=0.0` is the single most common setting for deterministic output. A truthiness test cannot distinguish the two, so an explicit `0` is dropped from the request and the provider falls back to its own default (Anthropic's `temperature` default is `1.0`). The user asks for deterministic output and silently gets sampled output.

**Azure was the only Claude subclass still doing this.** The three siblings already use `is not None`:

| file | lines |
|---|---|
| `models/anthropic/claude.py` | 552, 556, 558 |
| `models/aws/claude.py` | 201, 205, 207 |
| `models/vertexai/claude.py` | 124, 128, 130 |
| `models/azure/claude.py` | **134, 138, 140 -- the outlier** |

So the same explicit `0` behaved differently depending on which provider a request was routed through. `_get_client_params` in this same file already uses `if self.timeout is not None:` (line 71).

## Reproduction

```python
from agno.models.azure.claude import Claude as AzureClaude

AzureClaude(temperature=0.0, top_p=0.0, top_k=0).get_request_params()
# actual:   {'max_tokens': 8192}
#            ^ all three sampling params gone
# expected: {'max_tokens': 8192, 'temperature': 0.0, 'top_p': 0.0, 'top_k': 0}
```

The same construction against `agno.models.anthropic.Claude`, `agno.models.aws.Claude` or `agno.models.vertexai.Claude` correctly returns all three.

## Tests

`libs/agno/tests/unit/models/test_claude_request_params.py` already has a section headed *"temperature / top_p / top_k: zero values must not be silently dropped"* with `test_anthropic_*`, `test_aws_*` and `test_vertexai_*` variants -- the Azure ones were simply missing. This adds them in the same shape, plus a negative test (unset must stay absent) and a positive one (ordinary non-zero values keep working).

```
libs/agno/tests/unit/models/test_claude_request_params.py    40 passed
```

Control experiment -- with only `models/azure/claude.py` reverted and the new tests kept:

```
4 failed, 2 passed

FAILED test_azure_temperature_zero_included
FAILED test_azure_top_p_zero_included
FAILED test_azure_top_k_zero_included
FAILED test_azure_all_sampling_params_zero
```

Exactly the four zero-value cases fail. `test_azure_temperature_none_excluded` and `test_azure_positive_sampling_params_included` stay green, so the tests pin this defect and nothing more.

`ruff format --check` and `ruff check` clean on both files.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Scoped deliberately to the three parameters the existing test section covers. `max_tokens`, `thinking`, `output_config`, `stop_sequences` and `timeout` in the same method are also truthiness-gated, but for those the falsy value is either meaningless (`max_tokens=0`, `stop_sequences=[]`, `timeout=0`) or the base class treats it the same way, so I left them to avoid mixing a broader refactor into a bug fix. Happy to widen it if you would prefer.

`temperature=None` still omits the parameter, so no working configuration changes -- only the previously unreachable `0` case is affected.

Closes #9249
