### PR TITLE
[fix] Fail closed on unresolved component databases

### DIFF
--- a/libs/agno/agno/os/routers/components/components.py
+++ b/libs/agno/agno/os/routers/components/components.py
@@ -40,14 +40,13 @@ def _resolve_db_in_config(
     """
     Resolve db reference in config by looking up in registry or OS db.
 
-    If config contains a db dict with an id, this function will:
-    1. Check if the id matches the OS db
-    2. Check if the id exists in the registry
-    3. Merge the resolved db's connection details with the caller-provided
-       fields, with caller-provided fields (e.g. custom table names) taking
-       precedence. This preserves user-specified overrides like
-       ``session_table`` / ``memory_table`` while still reusing the resolved
-       db's connection configuration.
+    If config contains a db dict, this function will:
+    1. Resolve its id against the OS db or registry, if provided
+    2. Fall back to the OS db when the id is missing or cannot be resolved
+    3. Merge the resolved db's connection details with caller-provided
+       table-name overrides. This preserves user-specified values like
+       ``session_table`` / ``memory_table`` without trusting caller-provided
+       connection configuration.
 
     Args:
         config: The config dict that may contain a db reference
@@ -60,8 +59,8 @@ def _resolve_db_in_config(
     component_db = config.get("db")
     if component_db is not None and isinstance(component_db, dict):
         component_db_id = component_db.get("id")
+        resolved_db = None
         if component_db_id is not None:
-            resolved_db = None
             # First check if it matches the OS db
             if component_db_id == os_db.id:
                 resolved_db = os_db
@@ -69,17 +68,21 @@ def _resolve_db_in_config(
             elif registry is not None:
                 resolved_db = registry.get_db(component_db_id)
 
-            # Merge resolved db with caller-provided table-name overrides.
-            # Connection-defining fields (type, db_url, db_file, db_schema,
-            # id, ...) always come from the resolved db so the caller can't
-            # redirect a referenced db to a different backend. Only the
-            # whitelisted table-name keys are taken from the caller.
-            if resolved_db is not None:
-                resolved_dict = resolved_db.to_dict()
-                table_overrides = {key: component_db[key] for key in DB_TABLE_NAME_KEYS if key in component_db}
-                config["db"] = {**resolved_dict, **table_overrides}
+        if resolved_db is None:
+            resolved_db = os_db
+            if component_db_id is None:
+                log_warning("Component db config is missing an id; using the OS db")
             else:
-                log_error(f"Could not resolve db with id: {component_db_id}")
+                log_error(f"Could not resolve db with id: {component_db_id}; using the OS db")
+
+        # Merge resolved db with caller-provided table-name overrides.
+        # Connection-defining fields (type, db_url, db_file, db_schema,
+        # id, ...) always come from the resolved db so the caller can't
+        # redirect a component to a different backend. Only the whitelisted
+        # table-name keys are taken from the caller.
+        resolved_dict = resolved_db.to_dict()
+        table_overrides = {key: component_db[key] for key in DB_TABLE_NAME_KEYS if key in component_db}
+        config["db"] = {**resolved_dict, **table_overrides}
     elif component_db is None and "db" in config:
         # Explicitly set to None, remove the key
         config.pop("db", None)

--- a/libs/agno/tests/unit/os/routers/test_components_router.py
+++ b/libs/agno/tests/unit/os/routers/test_components_router.py
@@ -686,15 +686,47 @@ class TestResolveDbInConfig:
 
         assert "db" not in out
 
-    def test_db_without_id_is_passed_through(self, tmp_path):
+    def test_db_without_id_uses_os_db_and_rejects_connection_fields(self, tmp_path):
         from agno.os.routers.components.components import _resolve_db_in_config
 
         os_db = self._make_os_db(tmp_path)
-        payload = {"db": {"type": "sqlite", "session_table": "custom"}}
+        payload = {
+            "db": {
+                "type": "postgres",
+                "db_url": "postgresql://attacker/evil",
+                "db_file": str(tmp_path / "attacker" / "evil.db"),
+                "session_table": "custom_sessions",
+            }
+        }
 
         out = _resolve_db_in_config(dict(payload), os_db, None)
 
-        assert out["db"] == payload["db"]
+        assert out["db"]["id"] == os_db.id
+        assert out["db"]["type"] == "sqlite"
+        assert out["db"]["db_file"] == os_db.db_file
+        assert out["db"].get("db_url") == os_db.db_url
+        assert out["db"]["session_table"] == "custom_sessions"
+
+    def test_unknown_db_id_uses_os_db_and_rejects_connection_fields(self, tmp_path):
+        from agno.os.routers.components.components import _resolve_db_in_config
+
+        os_db = self._make_os_db(tmp_path)
+        payload = {
+            "db": {
+                "id": "unknown-db",
+                "type": "postgres",
+                "db_url": "postgresql://attacker/evil",
+                "session_table": "custom_sessions",
+            }
+        }
+
+        out = _resolve_db_in_config(dict(payload), os_db, None)
+
+        assert out["db"]["id"] == os_db.id
+        assert out["db"]["type"] == "sqlite"
+        assert out["db"]["db_file"] == os_db.db_file
+        assert out["db"].get("db_url") == os_db.db_url
+        assert out["db"]["session_table"] == "custom_sessions"
 
     def test_matching_id_merges_table_overrides_onto_resolved_db(self, tmp_path):
         """The reported bug: table-name overrides in the payload were being


### PR DESCRIPTION
## Summary

Fixes #8702.

Component configurations with a missing or unresolved database ID could retain caller-provided connection fields. This change makes database resolution fail closed:

- fall back to the registered AgentOS database when the component database ID is missing or unresolved
- source all connection-defining fields from that trusted database
- preserve only the existing `DB_TABLE_NAME_KEYS` table-name overrides
- cover both id-less and unknown-ID payloads with regression tests

This keeps custom table names working while preventing component configs from redirecting database access to an unregistered backend.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

AI assistance disclosure: the investigation, implementation, tests, and PR text were produced with Codex assistance. The final diff and validation outputs were self-reviewed in the contribution workflow before submission.

Validation:

- `python -m pytest libs/agno/tests/unit/os/routers/test_components_router.py -q` — 40 passed
- `uvx --from ruff==0.15.20 ruff check ...` — passed
- `uvx --from ruff==0.15.20 ruff format --check ...` — passed
- focused mypy check with skipped imports — passed
- `git diff --check` — passed

The repository-wide format and validation scripts were not run because they operate beyond the two-file scope; the repository-pinned Ruff version and the complete affected router test module were run directly.
