### PR TITLE
feat: surface team member activity in AG-UI via ACTIVITY_SNAPSHOT

### DIFF
--- a/cookbook/05_agent_os/interfaces/agui/TEST_LOG.md
+++ b/cookbook/05_agent_os/interfaces/agui/TEST_LOG.md
@@ -54,9 +54,11 @@
 
 ### research_team.py
 
-**Status:** PENDING
+**Status:** PASS
 
-**Description:** Research Team.
+**Description:** Research Team - two members (researcher + writer) coordinated by a team leader, exposed over AG-UI. Demonstrates team member visibility via AG-UI Activity events.
+
+**Result:** Verified end-to-end against the real AG-UI pipeline (run_entity -> event translation). Each member's progress is emitted as ACTIVITY_SNAPSHOT events (activity_type "agno.team_member") with a stable per-member message_id, agentId/agentName, status transitions (running -> tool_calling -> completed), and accumulated member text. Member text is NOT folded into the leader's TEXT_MESSAGE_* stream, which carries only the leader's own output. Validated with both a mocked-model harness and a real OpenAI-compatible model run; member tool calls produce tool_calling snapshots and the leader's final summary appears only in the leader message. Note: the model id was corrected to gpt-5.5 (the file previously referenced a non-existent gpt-5.4).
 
 ---
 

--- a/cookbook/05_agent_os/interfaces/agui/research_team.py
+++ b/cookbook/05_agent_os/interfaces/agui/research_team.py
@@ -2,7 +2,13 @@
 Research Team
 =============
 
-Demonstrates research team.
+Demonstrates a research team exposed over AG-UI.
+
+Each member's live progress is surfaced as AG-UI ACTIVITY_SNAPSHOT events
+(activity_type "agno.team_member"), keyed by a per-member message_id, so the
+frontend can render which member is working and what it has produced. The
+leader's own text continues to stream as TEXT_MESSAGE_*; member text is NOT
+folded into the leader's message.
 """
 
 from agno.agent.agent import Agent
@@ -19,7 +25,7 @@ from agno.tools.websearch import WebSearchTools
 researcher = Agent(
     name="researcher",
     role="Research Assistant",
-    model=OpenAIResponses(id="gpt-5.4"),
+    model=OpenAIResponses(id="gpt-5.5"),
     instructions="You are a research assistant. Find information and provide detailed analysis.",
     tools=[WebSearchTools()],
     markdown=True,
@@ -28,7 +34,7 @@ researcher = Agent(
 writer = Agent(
     name="writer",
     role="Content Writer",
-    model=OpenAIResponses(id="gpt-5.4"),
+    model=OpenAIResponses(id="gpt-5.5"),
     instructions="You are a content writer. Create well-structured content based on research.",
     tools=[WebSearchTools()],
     markdown=True,

--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -4,6 +4,7 @@ import uuid
 from typing import Any, Callable, Dict, List, Optional
 
 from ag_ui.core import (
+    ActivitySnapshotEvent,
     BaseEvent,
     CustomEvent,
     EventType,
@@ -27,13 +28,16 @@ from ag_ui.core import (
 
 from agno.os.interfaces.agui.state import StreamState
 from agno.reasoning.step import ReasoningStep
-from agno.run.agent import RunContentEvent, RunEvent
+from agno.run.agent import BaseAgentRunEvent, RunContentEvent, RunEvent
 from agno.run.base import BaseRunOutputEvent
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import TeamRunEvent
 from agno.utils.message import get_text_from_message
 
 EventHandler = Callable[[BaseRunOutputEvent, StreamState], List[BaseEvent]]
+
+# activity_type identifying an Agno team member's live state to AG-UI frontends.
+TEAM_MEMBER_ACTIVITY_TYPE = "agno.team_member"
 
 
 def _extract_response_chunk_content(response: RunContentEvent) -> str:
@@ -47,21 +51,55 @@ def _extract_response_chunk_content(response: RunContentEvent) -> str:
 
 
 def _extract_team_response_chunk_content(response: TeamRunContentEvent) -> str:
-    # Team responses nest member outputs — fold them into one text delta
-    members_content = []
-    if hasattr(response, "member_responses") and response.member_responses:  # type: ignore
-        for member_resp in response.member_responses:  # type: ignore
-            if isinstance(member_resp, RunContentEvent):
-                member_content = _extract_response_chunk_content(member_resp)
-                if member_content:
-                    members_content.append(f"Team member: {member_content}")
-            elif isinstance(member_resp, TeamRunContentEvent):
-                member_content = _extract_team_response_chunk_content(member_resp)
-                if member_content:
-                    members_content.append(f"Team member: {member_content}")
-    members_response = "\n".join(members_content) if members_content else ""
-    main_content = get_text_from_message(response.content) if response.content is not None else ""
-    return main_content + members_response
+    # Team-leader chunks carry only the leader's own token in .content. Member
+    # output is NOT folded in here — member chunks stream separately as agent
+    # RunContentEvents and are surfaced via Activity snapshots (see on_run_content).
+    return get_text_from_message(response.content) if response.content is not None else ""
+
+
+def _is_member_chunk(chunk: BaseRunOutputEvent) -> bool:
+    """True when this chunk comes from a team member (not the team leader).
+
+    Member events are agent-level events whose parent_run_id was set to the team
+    run_id when delegated (see team/_default_tools.py). The team leader emits
+    BaseTeamRunEvent instead, so agent-level events with a parent are members.
+    """
+    return isinstance(chunk, BaseAgentRunEvent) and getattr(chunk, "parent_run_id", None) is not None
+
+
+def _member_key(chunk: BaseRunOutputEvent) -> str:
+    """Stable per-member key for the run: member run_id, falling back to agent_id."""
+    run_id = getattr(chunk, "run_id", None)
+    agent_id = getattr(chunk, "agent_id", None)
+    return run_id or agent_id or "member"
+
+
+def _member_activity_snapshot(chunk: BaseRunOutputEvent, state: StreamState) -> ActivitySnapshotEvent:
+    """Build the ACTIVITY_SNAPSHOT for a member chunk, updating its live state."""
+    key = _member_key(chunk)
+    message_id, content = state.get_or_create_member(key)
+    # Identity fields are filled in once known; chunks always carry them but we
+    # only overwrite when present so a later sparse chunk can't blank them out.
+    agent_id = getattr(chunk, "agent_id", None)
+    agent_name = getattr(chunk, "agent_name", None)
+    parent_run_id = getattr(chunk, "parent_run_id", None)
+    run_id = getattr(chunk, "run_id", None)
+    if agent_id:
+        content["agentId"] = agent_id
+    if agent_name:
+        content["agentName"] = agent_name
+    if run_id:
+        content["runId"] = run_id
+    if parent_run_id:
+        content["parentRunId"] = parent_run_id
+    content["updatedAt"] = getattr(chunk, "created_at", None)
+    return ActivitySnapshotEvent(
+        type=EventType.ACTIVITY_SNAPSHOT,
+        message_id=message_id,
+        activity_type=TEAM_MEMBER_ACTIVITY_TYPE,
+        content=dict(content),
+        replace=True,
+    )
 
 
 def _format_reasoning_step(step: Optional[ReasoningStep], step_number: int = 0) -> str:
@@ -96,15 +134,21 @@ def _emit_state_delta(state: StreamState) -> List[BaseEvent]:
 
 
 def on_run_content(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    # Team member chunks are surfaced as Activity snapshots, not folded into the
+    # leader's text message. This preserves which member produced the content.
+    if _is_member_chunk(chunk):
+        _, content = state.get_or_create_member(_member_key(chunk))
+        content["text"] += _extract_response_chunk_content(chunk)  # type: ignore
+        content["status"] = "running"
+        return [_member_activity_snapshot(chunk, state)]
+
     events: List[BaseEvent] = []
 
     event = getattr(chunk, "event", None)
-    if event == RunEvent.run_content:
-        content = _extract_response_chunk_content(chunk)  # type: ignore
-    elif event == TeamRunEvent.run_content:
-        content = _extract_team_response_chunk_content(chunk)  # type: ignore
+    if event == TeamRunEvent.run_content:
+        content_str = _extract_team_response_chunk_content(chunk)  # type: ignore
     else:
-        content = ""
+        content_str = _extract_response_chunk_content(chunk)  # type: ignore
 
     if not state.text_message_open:
         message_id = state.open_text_message()
@@ -117,12 +161,12 @@ def on_run_content(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEv
             )
         )
 
-    if content:
+    if content_str:
         events.append(
             TextMessageContentEvent(
                 type=EventType.TEXT_MESSAGE_CONTENT,
                 message_id=state.text_message_id,
-                delta=content,
+                delta=content_str,
             )
         )
 
@@ -134,6 +178,14 @@ def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[
     tool = getattr(chunk, "tool", None)
     if tool is None:
         return events
+
+    # Member tool call: reflect it on the member's Activity and skip the
+    # leader-oriented text-message bookkeeping below.
+    if _is_member_chunk(chunk):
+        _, content = state.get_or_create_member(_member_key(chunk))
+        content["status"] = "tool_calling"
+        content["currentTool"] = tool.tool_name
+        return [_member_activity_snapshot(chunk, state)]
 
     # Close open text message before tool call
     if state.text_message_open:
@@ -182,6 +234,12 @@ def on_tool_call_completed(chunk: BaseRunOutputEvent, state: StreamState) -> Lis
     tool = getattr(chunk, "tool", None)
     if tool is None:
         return events
+
+    if _is_member_chunk(chunk):
+        _, content = state.get_or_create_member(_member_key(chunk))
+        content["status"] = "running"
+        content["currentTool"] = None
+        return [_member_activity_snapshot(chunk, state)]
 
     if tool.tool_call_id in state.ended_tool_call_ids:
         return events
@@ -284,6 +342,16 @@ def on_reasoning_completed(chunk: BaseRunOutputEvent, state: StreamState) -> Lis
         state.end_reasoning()
 
     return events
+
+
+def on_member_content_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    """Member finished producing content: mark its Activity completed."""
+    if not _is_member_chunk(chunk):
+        return []
+    _, content = state.get_or_create_member(_member_key(chunk))
+    content["status"] = "completed"
+    content["currentTool"] = None
+    return [_member_activity_snapshot(chunk, state)]
 
 
 def on_custom_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
@@ -404,6 +472,7 @@ HANDLERS: Dict[str, EventHandler] = {
     RunEvent.reasoning_content_delta.value: on_reasoning_content_delta,
     RunEvent.reasoning_step.value: on_reasoning_step,
     RunEvent.reasoning_completed.value: on_reasoning_completed,
+    RunEvent.run_content_completed.value: on_member_content_completed,
     RunEvent.custom_event.value: on_custom_event,
 }
 

--- a/libs/agno/agno/os/interfaces/agui/state.py
+++ b/libs/agno/agno/os/interfaces/agui/state.py
@@ -34,6 +34,12 @@ class StreamState:
     reasoning_message_id: Optional[str] = None
     reasoning_step_count: int = 0
 
+    # Team member activity tracking (per-member AG-UI Activity snapshots).
+    # Keyed by member run_id (falls back to agent_id). Each member gets its own
+    # AG-UI message_id so the frontend can render a stable, addressable Activity.
+    member_message_ids: Dict[str, str] = field(default_factory=dict)
+    member_states: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
     # State delta tracking
     _last_snapshot: Optional[Dict[str, Any]] = field(default=None, repr=False)
 
@@ -88,6 +94,18 @@ class StreamState:
     def end_reasoning(self) -> None:
         self.reasoning_message_id = None
         self.reasoning_step_count = 0
+
+    def get_or_create_member(self, key: str) -> Tuple[str, Dict[str, Any]]:
+        """Return the AG-UI message_id and mutable snapshot content for a team member.
+
+        Creates the entry on first use. The returned content dict is shared by
+        reference so handlers can mutate it (append text, set status) and then
+        re-emit it as an ACTIVITY_SNAPSHOT.
+        """
+        if key not in self.member_message_ids:
+            self.member_message_ids[key] = str(uuid.uuid4())
+            self.member_states[key] = {"text": "", "status": "running", "currentTool": None}
+        return self.member_message_ids[key], self.member_states[key]
 
     def set_state_snapshot(self, state: Dict[str, Any]) -> None:
         self._last_snapshot = copy.deepcopy(state)

--- a/libs/agno/tests/unit/os/interfaces/test_agui_member_activity.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_member_activity.py
@@ -1,0 +1,150 @@
+"""Unit tests for team member visibility via AG-UI Activity snapshots.
+
+Verifies that member chunks are surfaced as ACTIVITY_SNAPSHOT events (not folded
+into the leader's text message), while the team leader keeps using TEXT_MESSAGE_*.
+"""
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import EventType
+
+from agno.os.interfaces.agui.handlers import process_event
+from agno.os.interfaces.agui.state import StreamState
+from agno.run.agent import RunContentCompletedEvent as AgentRunContentCompletedEvent
+from agno.run.agent import RunContentEvent as AgentRunContentEvent
+from agno.run.agent import ToolCallCompletedEvent, ToolCallStartedEvent
+from agno.run.team import RunContentEvent as TeamRunContentEvent
+
+
+def _state() -> StreamState:
+    return StreamState(thread_id="thread-1", run_id="run-1")
+
+
+def _member_chunk(text: str, run_id: str = "member-run-1", agent_id: str = "research-agent") -> AgentRunContentEvent:
+    return AgentRunContentEvent(
+        content=text,
+        agent_id=agent_id,
+        agent_name="Research Agent",
+        run_id=run_id,
+        parent_run_id="run-1",  # set by team delegation -> marks this as a member chunk
+    )
+
+
+def _leader_chunk(text: str) -> TeamRunContentEvent:
+    return TeamRunContentEvent(content=text, team_id="team-1", team_name="Team", run_id="run-1")
+
+
+def test_member_chunk_emits_activity_snapshot_not_text_message():
+    state = _state()
+    events = process_event(_member_chunk("searching..."), state)
+
+    types = [e.type for e in events]
+    assert EventType.ACTIVITY_SNAPSHOT in types
+    assert EventType.TEXT_MESSAGE_START not in types
+    assert EventType.TEXT_MESSAGE_CONTENT not in types
+
+    snapshot = next(e for e in events if e.type == EventType.ACTIVITY_SNAPSHOT)
+    assert snapshot.activity_type == "agno.team_member"
+    assert snapshot.content["agentId"] == "research-agent"
+    assert snapshot.content["agentName"] == "Research Agent"
+    assert snapshot.content["parentRunId"] == "run-1"
+    assert snapshot.content["status"] == "running"
+    assert "searching..." in snapshot.content["text"]
+
+
+def test_member_chunks_reuse_message_id_and_accumulate_text():
+    state = _state()
+    e1 = process_event(_member_chunk("hello "), state)
+    e2 = process_event(_member_chunk("world"), state)
+
+    snap1 = next(e for e in e1 if e.type == EventType.ACTIVITY_SNAPSHOT)
+    snap2 = next(e for e in e2 if e.type == EventType.ACTIVITY_SNAPSHOT)
+
+    assert snap1.message_id == snap2.message_id
+    assert snap2.content["text"] == "hello world"
+
+
+def test_distinct_members_get_distinct_message_ids():
+    state = _state()
+    e1 = process_event(_member_chunk("a", run_id="member-run-1", agent_id="agent-a"), state)
+    e2 = process_event(_member_chunk("b", run_id="member-run-2", agent_id="agent-b"), state)
+
+    snap1 = next(e for e in e1 if e.type == EventType.ACTIVITY_SNAPSHOT)
+    snap2 = next(e for e in e2 if e.type == EventType.ACTIVITY_SNAPSHOT)
+
+    assert snap1.message_id != snap2.message_id
+    assert snap1.content["agentId"] == "agent-a"
+    assert snap2.content["agentId"] == "agent-b"
+
+
+def test_leader_chunk_uses_text_message_only():
+    state = _state()
+    events = process_event(_leader_chunk("final answer"), state)
+
+    types = [e.type for e in events]
+    assert EventType.TEXT_MESSAGE_START in types
+    assert EventType.TEXT_MESSAGE_CONTENT in types
+    assert EventType.ACTIVITY_SNAPSHOT not in types
+
+    content = next(e for e in events if e.type == EventType.TEXT_MESSAGE_CONTENT)
+    assert content.delta == "final answer"
+
+
+def test_member_tool_call_updates_activity_status():
+    state = _state()
+
+    started = ToolCallStartedEvent(
+        agent_id="research-agent",
+        agent_name="Research Agent",
+        run_id="member-run-1",
+        parent_run_id="run-1",
+    )
+    started.tool = type("T", (), {"tool_call_id": "tc-1", "tool_name": "web_search", "tool_args": {}})()
+
+    events = process_event(started, state)
+    snapshot = next(e for e in events if e.type == EventType.ACTIVITY_SNAPSHOT)
+    assert snapshot.content["status"] == "tool_calling"
+    assert snapshot.content["currentTool"] == "web_search"
+
+    completed = ToolCallCompletedEvent(
+        agent_id="research-agent",
+        agent_name="Research Agent",
+        run_id="member-run-1",
+        parent_run_id="run-1",
+    )
+    completed.tool = type("T", (), {"tool_call_id": "tc-1", "tool_name": "web_search", "result": "ok"})()
+
+    events = process_event(completed, state)
+    snapshot = next(e for e in events if e.type == EventType.ACTIVITY_SNAPSHOT)
+    assert snapshot.content["status"] == "running"
+    assert snapshot.content["currentTool"] is None
+
+
+def test_member_content_completed_marks_completed():
+    state = _state()
+    process_event(_member_chunk("done"), state)
+
+    done = AgentRunContentCompletedEvent(
+        agent_id="research-agent",
+        agent_name="Research Agent",
+        run_id="member-run-1",
+        parent_run_id="run-1",
+    )
+    events = process_event(done, state)
+    snapshot = next(e for e in events if e.type == EventType.ACTIVITY_SNAPSHOT)
+    assert snapshot.content["status"] == "completed"
+    assert snapshot.content["currentTool"] is None
+
+
+def test_single_agent_chunk_without_parent_is_not_member():
+    # A plain agent run (no team) has parent_run_id=None, so it must NOT be
+    # treated as a member — it stays on the normal TEXT_MESSAGE_* path.
+    state = _state()
+    chunk = AgentRunContentEvent(content="hi", agent_id="solo", agent_name="Solo", run_id="run-1")
+    events = process_event(chunk, state)
+
+    types = [e.type for e in events]
+    assert EventType.TEXT_MESSAGE_CONTENT in types
+    assert EventType.ACTIVITY_SNAPSHOT not in types


### PR DESCRIPTION
## Summary

Team runs streamed through AG-UI previously folded every member's output into a single assistant message (with a `"Team member: "` prefix), so clients could not tell which member produced which content — see #9243.

This change surfaces each team member's live progress through AG-UI's native Activity channel instead of flattening:

- Member chunks emit `ACTIVITY_SNAPSHOT` events (`activity_type: "agno.team_member"`), keyed by a stable per-member `message_id`.
- Each snapshot carries `agentId`, `agentName`, `runId`, `parentRunId`, a status lifecycle (`running → tool_calling → completed`), `currentTool`, and the member's accumulated text.
- The leader's own output continues to stream as `TEXT_MESSAGE_*`; member text is no longer folded into the leader's message.
- No new config: member activity is emitted whenever member events are present (`stream_member_events=True`). Hiding member output is still controlled upstream via `stream_member_events=False`.

Fixes #9243

### Why Activity instead of separate text messages
AG-UI's `ACTIVITY_*` events are the protocol-native mechanism for "what each agent is doing" as a side-channel, decoupled from the main chat bubbles. Each member gets an addressable `message_id`, so interleaved/parallel member execution (nested teams) can't corrupt a single shared message — the failure mode a "one text message per member" approach has on frontends that assume a single active text bubble.

### Implementation
- `StreamState`: per-member `message_id` + mutable snapshot content tracking (`get_or_create_member`).
- `handlers`: `_is_member_chunk()` discriminator (agent-level event with non-None `parent_run_id`, set by team delegation); member `run_content` / `tool_call_started` / `tool_call_completed` / `run_content_completed` → `ACTIVITY_SNAPSHOT`; leader path unchanged.
- Removed the `member_responses` folding and the `"Team member: "` prefix from `_extract_team_response_chunk_content`.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (research_team.py + TEST_LOG.md)
- [x] Tested in clean environment
- [x] Tests added/updated (test_agui_member_activity.py — 7 tests)

---

## Additional Notes

**Validation performed:**
- 7 new unit tests + full existing AG-UI suite (70 tests) pass.
- End-to-end through the real pipeline (`run_entity` → event translation): member chunks produce per-member `ACTIVITY_SNAPSHOT`s reaching `status="completed"`; member text never appears in leader `TEXT_MESSAGE_CONTENT`; leader final summary appears only in the leader message. Confirmed with both a mocked model and a real model, including a member that calls a tool (observed `tool_calling` snapshots).

**Follow-up (not in this PR):** each member token currently emits a full `ACTIVITY_SNAPSHOT` (replace semantics, so it's correct but chatty). A future optimization could throttle snapshots or use `ACTIVITY_DELTA` for the text field.
