### PR TITLE
[fix] Display StopAgentRun agent messages

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -91,10 +91,13 @@ def _log_messages(messages: List[Message]) -> None:
         m.log(metrics=False)
 
 
-def _handle_agent_exception(a_exc: AgentRunException, additional_input: Optional[List[Message]] = None) -> None:
-    """Handle AgentRunException and collect additional messages."""
+def _handle_agent_exception(
+    a_exc: AgentRunException, additional_input: Optional[List[Message]] = None
+) -> Optional[str]:
+    """Handle AgentRunException, collect additional messages, and return stopping agent content."""
     if additional_input is None:
         additional_input = []
+    stop_agent_message_content = None
     if a_exc.user_message is not None:
         msg = (
             Message(role="user", content=a_exc.user_message)
@@ -110,6 +113,8 @@ def _handle_agent_exception(a_exc: AgentRunException, additional_input: Optional
             else a_exc.agent_message
         )
         additional_input.append(msg)
+        if a_exc.stop_execution:
+            stop_agent_message_content = msg.get_content_string()
 
     if a_exc.messages:
         for m in a_exc.messages:
@@ -124,6 +129,8 @@ def _handle_agent_exception(a_exc: AgentRunException, additional_input: Optional
     if a_exc.stop_execution:
         for m in additional_input:
             m.stop_after_tool_call = True
+
+    return stop_agent_message_content
 
 
 @dataclass
@@ -2155,11 +2162,12 @@ class Model(ABC):
         # Run function calls sequentially
         function_execution_result: FunctionExecutionResult = FunctionExecutionResult(status="failure")
         stop_after_tool_call_from_exception = False
+        stop_agent_message_content = None
         try:
             function_execution_result = function_call.execute()
         except AgentRunException as a_exc:
             # Update additional messages from function call
-            _handle_agent_exception(a_exc, additional_input)
+            stop_agent_message_content = _handle_agent_exception(a_exc, additional_input)
             # If stop_execution is True, mark that we should stop after this tool call
             if a_exc.stop_execution:
                 stop_after_tool_call_from_exception = True
@@ -2309,6 +2317,8 @@ class Model(ABC):
 
         # Add function call to function call results
         function_call_results.append(function_call_result)
+        if stop_agent_message_content is not None:
+            yield ModelResponse(content=stop_agent_message_content)
 
     def run_function_calls(
         self,
@@ -2844,10 +2854,11 @@ class Model(ABC):
 
             # Handle AgentRunException
             stop_after_tool_call_from_exception = False
+            stop_agent_message_content = None
             if isinstance(function_call_success, AgentRunException):
                 a_exc = function_call_success
                 # Update additional messages from function call
-                _handle_agent_exception(a_exc, additional_input)
+                stop_agent_message_content = _handle_agent_exception(a_exc, additional_input)
                 # If stop_execution is True, mark that we should stop after this tool call
                 if a_exc.stop_execution:
                     stop_after_tool_call_from_exception = True
@@ -2989,6 +3000,8 @@ class Model(ABC):
 
             # Add function call result to function call results
             function_call_results.append(function_call_result)
+            if stop_agent_message_content is not None:
+                yield ModelResponse(content=stop_agent_message_content)
 
         # Add any additional messages at the end
         if additional_input:

--- a/libs/agno/tests/unit/agent/test_stop_agent_run.py
+++ b/libs/agno/tests/unit/agent/test_stop_agent_run.py
@@ -1,61 +1,92 @@
-from typing import Any, AsyncIterator, Iterator
+from typing import Any, AsyncIterator, Callable, Iterator, Optional
 
 import pytest
 
 from agno.agent.agent import Agent
-from agno.exceptions import StopAgentRun
+from agno.exceptions import RetryAgentRun, StopAgentRun
 from agno.models.base import Model
 from agno.models.message import MessageMetrics
 from agno.models.response import ModelResponse
 from agno.run.agent import RunContentEvent
 
 AGENT_MESSAGE = "Value 200 exceeds the threshold. Stopping tool execution."
+RETRY_GUIDANCE = "Try the tool call again with corrected input."
+SECOND_TURN = "The retry completed successfully."
 TOOL_ERROR = "Value 200 exceeds the threshold."
 
 
 class ToolCallModel(Model):
-    """Offline model that always requests the tool which stops the run."""
+    """Offline model that requests a configured tool, then optionally returns text."""
 
-    def __init__(self):
+    def __init__(
+        self,
+        tool_name: str = "check_threshold",
+        arguments: str = '{"value": 200}',
+        second_turn_content: Optional[str] = None,
+    ) -> None:
         super().__init__(id="test-model", name="test-model", provider="test")
-        self._response = ModelResponse(
+        self.call_count = 0
+        self._tool_response = ModelResponse(
             content="",
             role="assistant",
             tool_calls=[
                 {
                     "id": "call-1",
                     "type": "function",
-                    "function": {"name": "check_threshold", "arguments": '{"value": 200}'},
+                    "function": {"name": tool_name, "arguments": arguments},
                 }
             ],
             response_usage=MessageMetrics(),
         )
+        self._second_turn_content = second_turn_content
+
+    def _next_response(self) -> ModelResponse:
+        self.call_count += 1
+        if self.call_count > 1 and self._second_turn_content is not None:
+            return ModelResponse(
+                content=self._second_turn_content,
+                role="assistant",
+                response_usage=MessageMetrics(),
+            )
+        return self._tool_response
 
     def invoke(self, *args, **kwargs) -> ModelResponse:
-        return self._response
+        return self._next_response()
 
     async def ainvoke(self, *args, **kwargs) -> ModelResponse:
-        return self._response
+        return self._next_response()
 
     def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
-        yield self._response
+        yield self._next_response()
 
     async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
-        yield self._response
+        yield self._next_response()
 
     def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
-        return self._response
+        return self._tool_response
 
     def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
-        return self._response
+        return self._tool_response
 
 
 def check_threshold(value: int) -> str:
     raise StopAgentRun(TOOL_ERROR, agent_message=AGENT_MESSAGE)
 
 
-def make_agent() -> Agent:
-    return Agent(model=ToolCallModel(), tools=[check_threshold])
+def stop_without_message() -> str:
+    raise StopAgentRun("Stopping without a caller-facing message.")
+
+
+def stop_with_user_message_only() -> str:
+    raise StopAgentRun("Stopping with model input only.", user_message="USER-MESSAGE")
+
+
+def retry_with_message() -> str:
+    raise RetryAgentRun("Retrying the tool call.", agent_message=RETRY_GUIDANCE)
+
+
+def make_agent(tool: Callable[..., str] = check_threshold, model: Optional[ToolCallModel] = None) -> Agent:
+    return Agent(model=model or ToolCallModel(), tools=[tool])
 
 
 def test_stop_agent_run_agent_message_is_returned():
@@ -93,3 +124,35 @@ async def test_stop_agent_run_agent_message_is_streamed_async():
 
     content = [event.content for event in events if isinstance(event, RunContentEvent) and event.content]
     assert content == [AGENT_MESSAGE]
+
+
+def test_stop_agent_run_without_agent_message_adds_no_content():
+    model = ToolCallModel(tool_name="stop_without_message", arguments="{}")
+
+    response = make_agent(stop_without_message, model).run("Stop")
+
+    assert not response.content
+    assert model.call_count == 1
+
+
+def test_stop_agent_run_user_message_is_not_run_content():
+    model = ToolCallModel(tool_name="stop_with_user_message_only", arguments="{}")
+
+    response = make_agent(stop_with_user_message_only, model).run("Stop")
+
+    assert not response.content
+    assert model.call_count == 1
+
+
+def test_retry_agent_run_agent_message_stays_internal():
+    model = ToolCallModel(
+        tool_name="retry_with_message",
+        arguments="{}",
+        second_turn_content=SECOND_TURN,
+    )
+
+    response = make_agent(retry_with_message, model).run("Retry")
+
+    assert response.content == SECOND_TURN
+    assert RETRY_GUIDANCE not in str(response.content)
+    assert model.call_count == 2

--- a/libs/agno/tests/unit/agent/test_stop_agent_run.py
+++ b/libs/agno/tests/unit/agent/test_stop_agent_run.py
@@ -1,0 +1,95 @@
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.exceptions import StopAgentRun
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run.agent import RunContentEvent
+
+AGENT_MESSAGE = "Value 200 exceeds the threshold. Stopping tool execution."
+TOOL_ERROR = "Value 200 exceeds the threshold."
+
+
+class ToolCallModel(Model):
+    """Offline model that always requests the tool which stops the run."""
+
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self._response = ModelResponse(
+            content="",
+            role="assistant",
+            tool_calls=[
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "check_threshold", "arguments": '{"value": 200}'},
+                }
+            ],
+            response_usage=MessageMetrics(),
+        )
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._response
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._response
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._response
+
+
+def check_threshold(value: int) -> str:
+    raise StopAgentRun(TOOL_ERROR, agent_message=AGENT_MESSAGE)
+
+
+def make_agent() -> Agent:
+    return Agent(model=ToolCallModel(), tools=[check_threshold])
+
+
+def test_stop_agent_run_agent_message_is_returned():
+    response = make_agent().run("Check 200")
+
+    assert response.content == AGENT_MESSAGE
+
+    assert response.messages is not None
+    tool_messages = [message for message in response.messages if message.role == "tool"]
+    assistant_messages = [message for message in response.messages if message.role == "assistant"]
+
+    assert tool_messages[-1].content == TOOL_ERROR
+    assert tool_messages[-1].stop_after_tool_call is True
+    assert assistant_messages[-1].content == AGENT_MESSAGE
+    assert assistant_messages[-1].stop_after_tool_call is True
+
+
+@pytest.mark.asyncio
+async def test_stop_agent_run_agent_message_is_returned_async():
+    response = await make_agent().arun("Check 200")
+
+    assert response.content == AGENT_MESSAGE
+
+
+def test_stop_agent_run_agent_message_is_streamed():
+    events = list(make_agent().run("Check 200", stream=True))
+
+    content = [event.content for event in events if isinstance(event, RunContentEvent) and event.content]
+    assert content == [AGENT_MESSAGE]
+
+
+@pytest.mark.asyncio
+async def test_stop_agent_run_agent_message_is_streamed_async():
+    events = [event async for event in make_agent().arun("Check 200", stream=True)]
+
+    content = [event.content for event in events if isinstance(event, RunContentEvent) and event.content]
+    assert content == [AGENT_MESSAGE]


### PR DESCRIPTION
## Summary

`StopAgentRun.agent_message` was added to the conversation history but never propagated to the model response, leaving `RunOutput.content` and `print_response()` empty.

This change:

- returns the stopping assistant message from the existing exception handler
- emits it as normal model content after the tool-call completion event
- preserves the existing tool error, stop flag, and assistant history message
- applies the same behavior to sync/async and streaming/non-streaming runs

Fixes #9251

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation:

- `521 passed` for `libs/agno/tests/unit/agent`
- repository format script passed across Agno, agno_infra, and cookbook
- Ruff format and lint passed across all 1,999 files under `libs/agno`
- focused mypy passed for `agno/models/base.py`
- `git diff --check` passed

The repository-wide validation script currently reaches pre-existing mypy errors in the Azure Blob loader and Anthropic/AWS Claude model files; none are in the changed files.

This is an AI-assisted contribution. The implementation was reviewed against both tool-call execution paths and validated with deterministic offline regression tests covering all four public execution modes.
