### PR TITLE
fix: wf agent durable run flow

### DIFF
--- a/libs/agno/agno/workflow/agent.py
+++ b/libs/agno/agno/workflow/agent.py
@@ -125,8 +125,14 @@ Guidelines:
             else:
                 log_debug(f"Reloaded session before tool execution: {len(session_from_db.runs or [])} runs")
 
-            # Create a new run ID for this execution
-            run_id = str(uuid4())
+            # Reuse the caller's run id so the workflow execution IS the run the
+            # client polls, rather than a second one. The background path no
+            # longer pre-persists an empty outer run for the workflow-agent case
+            # (see Workflow._arun_background), so there is no placeholder row to
+            # merge with — this avoids both the "0 out of 4 steps done" duplicate
+            # and workflow_agent_run cross-contamination. Falls back to a fresh
+            # id when there is no run context (e.g. direct library use).
+            run_id = run_context.run_id or str(uuid4())
 
             workflow_run_response = WorkflowRunOutput(
                 run_id=run_id,
@@ -240,8 +246,14 @@ Guidelines:
             else:
                 log_debug(f"Reloaded session before async tool execution: {len(session_from_db.runs or [])} runs")
 
-            # Create a new run ID for this execution
-            run_id = str(uuid4())
+            # Reuse the caller's run id so the workflow execution IS the run the
+            # client polls, rather than a second one. The background path no
+            # longer pre-persists an empty outer run for the workflow-agent case
+            # (see Workflow._arun_background), so there is no placeholder row to
+            # merge with — this avoids both the "0 out of 4 steps done" duplicate
+            # and workflow_agent_run cross-contamination. Falls back to a fresh
+            # id when there is no run context (e.g. direct library use).
+            run_id = run_context.run_id or str(uuid4())
 
             workflow_run_response = WorkflowRunOutput(
                 run_id=run_id,

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -4120,12 +4120,16 @@ class Workflow:
         workflow_run_response.metrics = WorkflowMetrics(steps={})
         workflow_run_response.metrics.start_timer()
 
-        # Store PENDING response immediately
-        workflow_session.upsert_run(run=workflow_run_response)
-        if self._has_async_db():
-            await self.asave_session(session=workflow_session)
-        else:
-            self.save_session(session=workflow_session)
+        # Store PENDING response immediately. Skip for the workflow-agent case:
+        # _aexecute_workflow_agent persists the real run (reusing this run id),
+        # so pre-persisting an empty outer run here would leave a duplicate the
+        # UI renders as "0 out of 4 steps done".
+        if self.agent is None:
+            workflow_session.upsert_run(run=workflow_run_response)
+            if self._has_async_db():
+                await self.asave_session(session=workflow_session)
+            else:
+                self.save_session(session=workflow_session)
 
         # Prepare execution input
         inputs = WorkflowExecutionInput(
@@ -4146,31 +4150,27 @@ class Workflow:
 
             try:
                 async with background_run_slot(run_id=workflow_run_response.run_id):
-                    # Update status to RUNNING and save (atomic helper: row-locked
-                    # patch when the DB supports it, fresh-read + save otherwise)
-                    workflow_run_response.status = RunStatus.running
-                    await apersist_run_transition(self, "workflow", session_id, workflow_run_response, user_id=user_id)
-
                     if self.agent is not None:
-                        agent_result = await self._aexecute_workflow_agent(
+                        # WorkflowAgent case: _aexecute_workflow_agent owns the
+                        # run rows and reuses this run id, so there is no empty
+                        # outer run to transition or finalize. Delegating cleanly
+                        # (no pre-persist, no safety-net upsert) yields a single
+                        # run per turn instead of an extra "0 out of 4 steps done".
+                        await self._aexecute_workflow_agent(
                             user_input=input,  # type: ignore
                             execution_input=inputs,
                             run_context=run_context,
                             stream=False,
                             **kwargs,
                         )
-                        # Safety net: the polled 202 run_id must reach a
-                        # terminal state even if an internal path persisted the
-                        # answer under a different run id
-                        if getattr(agent_result, "run_id", None) != workflow_run_response.run_id:
-                            workflow_run_response.status = getattr(agent_result, "status", None) or RunStatus.completed
-                            workflow_run_response.content = getattr(agent_result, "content", None)
-                            workflow_session.upsert_run(run=workflow_run_response)
-                            if self._has_async_db():
-                                await self.asave_session(session=workflow_session)
-                            else:
-                                self.save_session(session=workflow_session)
                     else:
+                        # Update status to RUNNING and save (atomic helper:
+                        # row-locked patch when the DB supports it, fresh-read +
+                        # save otherwise)
+                        workflow_run_response.status = RunStatus.running
+                        await apersist_run_transition(
+                            self, "workflow", session_id, workflow_run_response, user_id=user_id
+                        )
                         await self._aexecute(
                             session_id=session_id,
                             user_id=user_id,
@@ -4869,8 +4869,11 @@ class Workflow:
 
         log_debug(f"Executing workflow agent with streaming - input: {agent_input}...")
 
-        # Create a workflow run response upfront for potential direct answer (will be used only if workflow is not executed)
-        run_id = str(uuid4())
+        # Create a workflow run response upfront for potential direct answer (will be used only if workflow is not executed).
+        # Reuse the caller's run id so a direct answer IS the polled run (the
+        # background path no longer pre-persists an empty outer run for the
+        # workflow-agent case, so there is no placeholder to merge with).
+        run_id = run_context.run_id or str(uuid4())
         direct_reply_run_response = WorkflowRunOutput(
             run_id=run_id,
             input=execution_input.input,
@@ -5259,8 +5262,11 @@ class Workflow:
 
         log_debug(f"Executing async workflow agent with streaming - input: {agent_input}...")
 
-        # Create a workflow run response upfront for potential direct answer (will be used only if workflow is not executed)
-        run_id = str(uuid4())
+        # Create a workflow run response upfront for potential direct answer (will be used only if workflow is not executed).
+        # Reuse the caller's run id so a direct answer IS the polled run (the
+        # background path no longer pre-persists an empty outer run for the
+        # workflow-agent case, so there is no placeholder to merge with).
+        run_id = run_context.run_id or str(uuid4())
         direct_reply_run_response = WorkflowRunOutput(
             run_id=run_id,
             input=execution_input.input,


### PR DESCRIPTION
## Summary

Background `WorkflowAgent` runs persisted two runs per turn: the real workflow run (with steps/content) plus an empty outer run — no `step_results`, null content — which the UI renders as "0 out of 4 steps done" next to the real result.

Root cause: the durable-queue background scaffolding pre-persists an outer `workflow_run_response` (`PENDING → RUNNING → safety-net finalize`) for all workflow background runs. But for a `WorkflowAgent`, that outer run is not what executes — `_aexecute_workflow_agent` runs the actual workflow (via the `run_workflow` tool) or produces a direct answer under a different run id. So the outer run is committed but never receives steps/content, leaving an empty duplicate.

This PR makes the WorkflowAgent background path persist exactly one run per turn by:

- Reusing the caller's run id in the WorkflowAgent execution instead of minting a fresh uuid4(), so the workflow run (or direct answer) is the run the client polls — not a second one. Applied at all four sites: the sync + async run_workflow tool factories (workflow/agent.py) and the sync + async streaming direct-answer paths (workflow/workflow.py).
- Skipping the outer-run pre-persist and RUNNING/safety-net finalize for the WorkflowAgent case only in `_arun_background`. Because there is no empty placeholder row, there is nothing to merge with — which also avoids a workflow_agent_run cross-contamination bug (turn N picking up turn N-1's nested agent run).
Scope is limited to self.agent is not None. Non-agent workflows are unchanged (they keep Store PENDING, the RUNNING transition, and apersist_run_transition in the else branch).

### Behavior
Before (2 turns → 4 runs, 2 ghosts):

```
run[0] COMPLETED steps=0 content=None   ← "0 out of 4 steps done" ghost
run[1] COMPLETED steps=4 content=<story>
run[2] COMPLETED steps=0 content=None   ← ghost
run[3] COMPLETED steps=0 content=<answer>
```

### After (2 turns → 2 runs):

```
run[0] COMPLETED steps=4 content=<story>   workflow_agent_run.input=<turn-1>
run[1] COMPLETED steps=0 content=<answer>  workflow_agent_run.input=<turn-2>
```

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
