### PR TITLE
[fix] recover from stale previous_response_id in OpenAIResponses

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -1076,6 +1076,8 @@ class OpenAIResponses(Model):
 
             assistant_message.metrics.start_timer()
 
+            # Relies on the SDK establishing the connection inside create(), so a stale
+            # previous_response_id surfaces as a 400 here rather than during iteration.
             try:
                 stream = self.get_client().responses.create(
                     model=self.id,
@@ -1196,6 +1198,8 @@ class OpenAIResponses(Model):
 
             assistant_message.metrics.start_timer()
 
+            # Relies on the SDK establishing the connection inside create(), so a stale
+            # previous_response_id surfaces as a 400 here rather than during iteration.
             try:
                 async_stream = await self.get_async_client().responses.create(
                     model=self.id,

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -254,9 +254,14 @@ class OpenAIResponses(Model):
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
+        use_previous_response_id: bool = True,
     ) -> Dict[str, Any]:
         """
         Returns keyword arguments for API requests.
+
+        Args:
+            use_previous_response_id: When False, skip chaining via previous_response_id
+                (used to recover when a stored response id is no longer valid).
 
         Returns:
             Dict[str, Any]: A dictionary of keyword arguments for API requests.
@@ -369,24 +374,30 @@ class OpenAIResponses(Model):
                 request_params["store"] = True
 
                 # Check if the last assistant message has a previous_response_id to continue from
-                previous_response_id = None
-                for msg in reversed(messages):
-                    if (
-                        msg.role == "assistant"
-                        and hasattr(msg, "provider_data")
-                        and msg.provider_data
-                        and "response_id" in msg.provider_data
-                    ):
-                        previous_response_id = msg.provider_data["response_id"]
-                        log_debug(f"Using previous_response_id: {previous_response_id}")
-                        break
+                if use_previous_response_id:
+                    previous_response_id = None
+                    for msg in reversed(messages):
+                        if (
+                            msg.role == "assistant"
+                            and hasattr(msg, "provider_data")
+                            and msg.provider_data
+                            and "response_id" in msg.provider_data
+                        ):
+                            previous_response_id = msg.provider_data["response_id"]
+                            log_debug(f"Using previous_response_id: {previous_response_id}")
+                            break
 
-                if previous_response_id:
-                    request_params["previous_response_id"] = previous_response_id
+                    if previous_response_id:
+                        request_params["previous_response_id"] = previous_response_id
 
         # Add additional request params if provided
         if self.request_params:
             request_params.update(self.request_params)
+
+        # When recovering from a stale previous_response_id, make sure a user-supplied
+        # request_params entry cannot re-introduce it and defeat the retry.
+        if not use_previous_response_id:
+            request_params.pop("previous_response_id", None)
 
         if request_params:
             log_debug(f"Calling {self.provider} with request parameters: {request_params}", log_level=2)
@@ -582,11 +593,28 @@ class OpenAIResponses(Model):
                         fc_id_to_call_id[fc_id] = call_id
         return fc_id_to_call_id
 
+    @staticmethod
+    def _is_previous_response_not_found_error(exc: APIStatusError) -> bool:
+        """Return True for the specific 400 when a chained previous_response_id is missing."""
+        if exc.status_code != 400:
+            return False
+        # The detail can live on the exception message or only in the response body,
+        # depending on how the SDK surfaces the error; check both.
+        parts = [getattr(exc, "message", None) or "", str(exc)]
+        try:
+            error_body = exc.response.json().get("error", {})
+        except Exception:
+            error_body = getattr(exc.response, "text", "") if exc.response is not None else ""
+        parts.append(error_body.get("message", "") if isinstance(error_body, dict) else str(error_body))
+        text = " ".join(parts).lower()
+        return "previous response" in text and "not found" in text
+
     def _format_messages(
         self,
         messages: List[Message],
         compress_tool_results: bool = False,
         tools: Optional[List[Union[Function, Dict[str, Any]]]] = None,
+        use_previous_response_id: bool = True,
     ) -> List[Union[Dict[str, Any], ResponseReasoningItem]]:
         """
         Format a message into the format expected by OpenAI.
@@ -595,6 +623,8 @@ class OpenAIResponses(Model):
             messages (List[Message]): The message to format.
             compress_tool_results: Whether to compress tool results.
             tools: The tools list, used to detect if file_search is present.
+            use_previous_response_id: When False, send full history (no trim / no skip of
+                prior function_call items). Used to recover when a stored response id is invalid.
 
         Returns:
             Dict[str, Any]: The formatted message.
@@ -611,7 +641,7 @@ class OpenAIResponses(Model):
         messages_to_format = messages
         previous_response_id: Optional[str] = None
 
-        if self._using_reasoning_model() and self.store is not False:
+        if use_previous_response_id and self._using_reasoning_model() and self.store is not False:
             # Detect whether we're chaining via previous_response_id. If so, we should NOT
             # re-send prior function_call items; the Responses API already has the state and
             # expects only the corresponding function_call_output items.
@@ -774,14 +804,41 @@ class OpenAIResponses(Model):
             request_params = self.get_request_params(
                 messages=messages, response_format=response_format, tools=tools, tool_choice=tool_choice
             )
+            formatted_input = self._format_messages(messages, compress_tool_results, tools=tools)  # type: ignore[arg-type]
 
             assistant_message.metrics.start_timer()
 
-            provider_response = self.get_client().responses.create(
-                model=self.id,
-                input=self._format_messages(messages, compress_tool_results, tools=tools),  # type: ignore
-                **request_params,
-            )
+            try:
+                provider_response = self.get_client().responses.create(
+                    model=self.id,
+                    input=formatted_input,  # type: ignore
+                    **request_params,
+                )
+            except APIStatusError as create_exc:
+                if request_params.get("previous_response_id") and self._is_previous_response_not_found_error(
+                    create_exc
+                ):
+                    log_warning("previous_response_id not found; retrying without previous_response_id")
+                    request_params = self.get_request_params(
+                        messages=messages,
+                        response_format=response_format,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        use_previous_response_id=False,
+                    )
+                    formatted_input = self._format_messages(
+                        messages,
+                        compress_tool_results,
+                        tools=tools,  # type: ignore[arg-type]
+                        use_previous_response_id=False,
+                    )
+                    provider_response = self.get_client().responses.create(
+                        model=self.id,
+                        input=formatted_input,  # type: ignore
+                        **request_params,
+                    )
+                else:
+                    raise
 
             # Stop the timer before polling so wall-clock polling wait is not counted as inference time.
             # For background mode, the initial create() measures submission latency; the polling loop
@@ -879,14 +936,41 @@ class OpenAIResponses(Model):
             request_params = self.get_request_params(
                 messages=messages, response_format=response_format, tools=tools, tool_choice=tool_choice
             )
+            formatted_input = self._format_messages(messages, compress_tool_results, tools=tools)  # type: ignore[arg-type]
 
             assistant_message.metrics.start_timer()
 
-            provider_response = await self.get_async_client().responses.create(
-                model=self.id,
-                input=self._format_messages(messages, compress_tool_results, tools=tools),  # type: ignore
-                **request_params,
-            )
+            try:
+                provider_response = await self.get_async_client().responses.create(
+                    model=self.id,
+                    input=formatted_input,  # type: ignore
+                    **request_params,
+                )
+            except APIStatusError as create_exc:
+                if request_params.get("previous_response_id") and self._is_previous_response_not_found_error(
+                    create_exc
+                ):
+                    log_warning("previous_response_id not found; retrying without previous_response_id")
+                    request_params = self.get_request_params(
+                        messages=messages,
+                        response_format=response_format,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        use_previous_response_id=False,
+                    )
+                    formatted_input = self._format_messages(
+                        messages,
+                        compress_tool_results,
+                        tools=tools,  # type: ignore[arg-type]
+                        use_previous_response_id=False,
+                    )
+                    provider_response = await self.get_async_client().responses.create(
+                        model=self.id,
+                        input=formatted_input,  # type: ignore
+                        **request_params,
+                    )
+                else:
+                    raise
 
             # Stop the timer before polling so wall-clock polling wait is not counted as inference time.
             # For background mode, the initial create() measures submission latency; the polling loop
@@ -987,16 +1071,47 @@ class OpenAIResponses(Model):
             # Background mode is not supported for streaming. Strip the flag and warn.
             if request_params.pop("background", None):
                 log_warning("Background mode is not supported for streaming requests. Ignoring `background=True`.")
+            formatted_input = self._format_messages(messages, compress_tool_results, tools=tools)  # type: ignore[arg-type]
             tool_use: Dict[str, Any] = {}
 
             assistant_message.metrics.start_timer()
 
-            for chunk in self.get_client().responses.create(
-                model=self.id,
-                input=self._format_messages(messages, compress_tool_results, tools=tools),  # type: ignore
-                stream=True,
-                **request_params,
-            ):
+            try:
+                stream = self.get_client().responses.create(
+                    model=self.id,
+                    input=formatted_input,  # type: ignore
+                    stream=True,
+                    **request_params,
+                )
+            except APIStatusError as create_exc:
+                if request_params.get("previous_response_id") and self._is_previous_response_not_found_error(
+                    create_exc
+                ):
+                    log_warning("previous_response_id not found; retrying without previous_response_id")
+                    request_params = self.get_request_params(
+                        messages=messages,
+                        response_format=response_format,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        use_previous_response_id=False,
+                    )
+                    request_params.pop("background", None)
+                    formatted_input = self._format_messages(
+                        messages,
+                        compress_tool_results,
+                        tools=tools,  # type: ignore[arg-type]
+                        use_previous_response_id=False,
+                    )
+                    stream = self.get_client().responses.create(
+                        model=self.id,
+                        input=formatted_input,  # type: ignore
+                        stream=True,
+                        **request_params,
+                    )
+                else:
+                    raise
+
+            for chunk in stream:
                 model_response, tool_use = self._parse_provider_response_delta(
                     stream_event=chunk,  # type: ignore
                     assistant_message=assistant_message,
@@ -1076,16 +1191,46 @@ class OpenAIResponses(Model):
             # Background mode is not supported for streaming. Strip the flag and warn.
             if request_params.pop("background", None):
                 log_warning("Background mode is not supported for streaming requests. Ignoring `background=True`.")
+            formatted_input = self._format_messages(messages, compress_tool_results, tools=tools)  # type: ignore[arg-type]
             tool_use: Dict[str, Any] = {}
 
             assistant_message.metrics.start_timer()
 
-            async_stream = await self.get_async_client().responses.create(
-                model=self.id,
-                input=self._format_messages(messages, compress_tool_results, tools=tools),  # type: ignore
-                stream=True,
-                **request_params,
-            )
+            try:
+                async_stream = await self.get_async_client().responses.create(
+                    model=self.id,
+                    input=formatted_input,  # type: ignore
+                    stream=True,
+                    **request_params,
+                )
+            except APIStatusError as create_exc:
+                if request_params.get("previous_response_id") and self._is_previous_response_not_found_error(
+                    create_exc
+                ):
+                    log_warning("previous_response_id not found; retrying without previous_response_id")
+                    request_params = self.get_request_params(
+                        messages=messages,
+                        response_format=response_format,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        use_previous_response_id=False,
+                    )
+                    request_params.pop("background", None)
+                    formatted_input = self._format_messages(
+                        messages,
+                        compress_tool_results,
+                        tools=tools,  # type: ignore[arg-type]
+                        use_previous_response_id=False,
+                    )
+                    async_stream = await self.get_async_client().responses.create(
+                        model=self.id,
+                        input=formatted_input,  # type: ignore
+                        stream=True,
+                        **request_params,
+                    )
+                else:
+                    raise
+
             async for chunk in async_stream:  # type: ignore
                 model_response, tool_use = self._parse_provider_response_delta(chunk, assistant_message, tool_use)  # type: ignore
                 yield model_response

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -264,9 +264,14 @@ class OpenAIResponses(Model):
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         run_response: Optional[RunOutput] = None,
+        use_previous_response_id: bool = True,
     ) -> Dict[str, Any]:
         """
         Returns keyword arguments for API requests.
+
+        Args:
+            use_previous_response_id: When False, skip chaining via previous_response_id
+                (used to recover when a stored response id is no longer valid).
 
         Returns:
             Dict[str, Any]: A dictionary of keyword arguments for API requests.
@@ -379,24 +384,30 @@ class OpenAIResponses(Model):
                 request_params["store"] = True
 
                 # Check if the last assistant message has a previous_response_id to continue from
-                previous_response_id = None
-                for msg in reversed(messages):
-                    if (
-                        msg.role == "assistant"
-                        and hasattr(msg, "provider_data")
-                        and msg.provider_data
-                        and "response_id" in msg.provider_data
-                    ):
-                        previous_response_id = msg.provider_data["response_id"]
-                        log_debug(f"Using previous_response_id: {previous_response_id}")
-                        break
+                if use_previous_response_id:
+                    previous_response_id = None
+                    for msg in reversed(messages):
+                        if (
+                            msg.role == "assistant"
+                            and hasattr(msg, "provider_data")
+                            and msg.provider_data
+                            and "response_id" in msg.provider_data
+                        ):
+                            previous_response_id = msg.provider_data["response_id"]
+                            log_debug(f"Using previous_response_id: {previous_response_id}")
+                            break
 
-                if previous_response_id:
-                    request_params["previous_response_id"] = previous_response_id
+                    if previous_response_id:
+                        request_params["previous_response_id"] = previous_response_id
 
         # Add additional request params if provided
         if self.request_params:
             request_params.update(self.request_params)
+
+        # When recovering from a stale previous_response_id, make sure a user-supplied
+        # request_params entry cannot re-introduce it and defeat the retry.
+        if not use_previous_response_id:
+            request_params.pop("previous_response_id", None)
 
         if request_params:
             log_debug(f"Calling {self.provider} with request parameters: {request_params}", log_level=2)
@@ -592,11 +603,28 @@ class OpenAIResponses(Model):
                         fc_id_to_call_id[fc_id] = call_id
         return fc_id_to_call_id
 
+    @staticmethod
+    def _is_previous_response_not_found_error(exc: APIStatusError) -> bool:
+        """Return True for the specific 400 when a chained previous_response_id is missing."""
+        if exc.status_code != 400:
+            return False
+        # The detail can live on the exception message or only in the response body,
+        # depending on how the SDK surfaces the error; check both.
+        parts = [getattr(exc, "message", None) or "", str(exc)]
+        try:
+            error_body = exc.response.json().get("error", {})
+        except Exception:
+            error_body = getattr(exc.response, "text", "") if exc.response is not None else ""
+        parts.append(error_body.get("message", "") if isinstance(error_body, dict) else str(error_body))
+        text = " ".join(parts).lower()
+        return "previous response" in text and "not found" in text
+
     def _format_messages(
         self,
         messages: List[Message],
         compress_tool_results: bool = False,
         tools: Optional[List[Union[Function, Dict[str, Any]]]] = None,
+        use_previous_response_id: bool = True,
     ) -> List[Union[Dict[str, Any], ResponseReasoningItem]]:
         """
         Format a message into the format expected by OpenAI.
@@ -605,6 +633,8 @@ class OpenAIResponses(Model):
             messages (List[Message]): The message to format.
             compress_tool_results: Whether to compress tool results.
             tools: The tools list, used to detect if file_search is present.
+            use_previous_response_id: When False, send full history (no trim / no skip of
+                prior function_call items). Used to recover when a stored response id is invalid.
 
         Returns:
             Dict[str, Any]: The formatted message.
@@ -621,7 +651,7 @@ class OpenAIResponses(Model):
         messages_to_format = messages
         previous_response_id: Optional[str] = None
 
-        if self._using_reasoning_model() and self.store is not False:
+        if use_previous_response_id and self._using_reasoning_model() and self.store is not False:
             # Detect whether we're chaining via previous_response_id. If so, we should NOT
             # re-send prior function_call items; the Responses API already has the state and
             # expects only the corresponding function_call_output items.
@@ -788,14 +818,42 @@ class OpenAIResponses(Model):
                 tool_choice=tool_choice,
                 run_response=run_response,
             )
+            formatted_input = self._format_messages(messages, compress_tool_results, tools=tools)  # type: ignore[arg-type]
 
             assistant_message.metrics.start_timer()
 
-            provider_response = self.get_client().responses.create(
-                **self._get_model_request_kwargs(),
-                input=self._format_messages(messages, compress_tool_results, tools=tools),  # type: ignore
-                **request_params,
-            )
+            try:
+                provider_response = self.get_client().responses.create(
+                    **self._get_model_request_kwargs(),
+                    input=formatted_input,  # type: ignore
+                    **request_params,
+                )
+            except APIStatusError as create_exc:
+                if request_params.get("previous_response_id") and self._is_previous_response_not_found_error(
+                    create_exc
+                ):
+                    log_warning("previous_response_id not found; retrying without previous_response_id")
+                    request_params = self.get_request_params(
+                        messages=messages,
+                        response_format=response_format,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        run_response=run_response,
+                        use_previous_response_id=False,
+                    )
+                    formatted_input = self._format_messages(
+                        messages,
+                        compress_tool_results,
+                        tools=tools,  # type: ignore[arg-type]
+                        use_previous_response_id=False,
+                    )
+                    provider_response = self.get_client().responses.create(
+                        **self._get_model_request_kwargs(),
+                        input=formatted_input,  # type: ignore
+                        **request_params,
+                    )
+                else:
+                    raise
 
             # Stop the timer before polling so wall-clock polling wait is not counted as inference time.
             # For background mode, the initial create() measures submission latency; the polling loop
@@ -897,14 +955,42 @@ class OpenAIResponses(Model):
                 tool_choice=tool_choice,
                 run_response=run_response,
             )
+            formatted_input = self._format_messages(messages, compress_tool_results, tools=tools)  # type: ignore[arg-type]
 
             assistant_message.metrics.start_timer()
 
-            provider_response = await self.get_async_client().responses.create(
-                **self._get_model_request_kwargs(),
-                input=self._format_messages(messages, compress_tool_results, tools=tools),  # type: ignore
-                **request_params,
-            )
+            try:
+                provider_response = await self.get_async_client().responses.create(
+                    **self._get_model_request_kwargs(),
+                    input=formatted_input,  # type: ignore
+                    **request_params,
+                )
+            except APIStatusError as create_exc:
+                if request_params.get("previous_response_id") and self._is_previous_response_not_found_error(
+                    create_exc
+                ):
+                    log_warning("previous_response_id not found; retrying without previous_response_id")
+                    request_params = self.get_request_params(
+                        messages=messages,
+                        response_format=response_format,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        run_response=run_response,
+                        use_previous_response_id=False,
+                    )
+                    formatted_input = self._format_messages(
+                        messages,
+                        compress_tool_results,
+                        tools=tools,  # type: ignore[arg-type]
+                        use_previous_response_id=False,
+                    )
+                    provider_response = await self.get_async_client().responses.create(
+                        **self._get_model_request_kwargs(),
+                        input=formatted_input,  # type: ignore
+                        **request_params,
+                    )
+                else:
+                    raise
 
             # Stop the timer before polling so wall-clock polling wait is not counted as inference time.
             # For background mode, the initial create() measures submission latency; the polling loop
@@ -1009,16 +1095,48 @@ class OpenAIResponses(Model):
             # Background mode is not supported for streaming. Strip the flag and warn.
             if request_params.pop("background", None):
                 log_warning("Background mode is not supported for streaming requests. Ignoring `background=True`.")
+            formatted_input = self._format_messages(messages, compress_tool_results, tools=tools)  # type: ignore[arg-type]
             tool_use: Dict[str, Any] = {}
 
             assistant_message.metrics.start_timer()
 
-            for chunk in self.get_client().responses.create(
-                **self._get_model_request_kwargs(),
-                input=self._format_messages(messages, compress_tool_results, tools=tools),  # type: ignore
-                stream=True,
-                **request_params,
-            ):
+            try:
+                stream = self.get_client().responses.create(
+                    **self._get_model_request_kwargs(),
+                    input=formatted_input,  # type: ignore
+                    stream=True,
+                    **request_params,
+                )
+            except APIStatusError as create_exc:
+                if request_params.get("previous_response_id") and self._is_previous_response_not_found_error(
+                    create_exc
+                ):
+                    log_warning("previous_response_id not found; retrying without previous_response_id")
+                    request_params = self.get_request_params(
+                        messages=messages,
+                        response_format=response_format,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        run_response=run_response,
+                        use_previous_response_id=False,
+                    )
+                    request_params.pop("background", None)
+                    formatted_input = self._format_messages(
+                        messages,
+                        compress_tool_results,
+                        tools=tools,  # type: ignore[arg-type]
+                        use_previous_response_id=False,
+                    )
+                    stream = self.get_client().responses.create(
+                        **self._get_model_request_kwargs(),
+                        input=formatted_input,  # type: ignore
+                        stream=True,
+                        **request_params,
+                    )
+                else:
+                    raise
+
+            for chunk in stream:
                 model_response, tool_use = self._parse_provider_response_delta(
                     stream_event=chunk,  # type: ignore
                     assistant_message=assistant_message,
@@ -1102,16 +1220,46 @@ class OpenAIResponses(Model):
             # Background mode is not supported for streaming. Strip the flag and warn.
             if request_params.pop("background", None):
                 log_warning("Background mode is not supported for streaming requests. Ignoring `background=True`.")
+            formatted_input = self._format_messages(messages, compress_tool_results, tools=tools)  # type: ignore[arg-type]
             tool_use: Dict[str, Any] = {}
 
             assistant_message.metrics.start_timer()
 
-            async_stream = await self.get_async_client().responses.create(
-                **self._get_model_request_kwargs(),
-                input=self._format_messages(messages, compress_tool_results, tools=tools),  # type: ignore
-                stream=True,
-                **request_params,
-            )
+            try:
+                async_stream = await self.get_async_client().responses.create(
+                    **self._get_model_request_kwargs(),
+                    input=formatted_input,  # type: ignore
+                    stream=True,
+                    **request_params,
+                )
+            except APIStatusError as create_exc:
+                if request_params.get("previous_response_id") and self._is_previous_response_not_found_error(
+                    create_exc
+                ):
+                    log_warning("previous_response_id not found; retrying without previous_response_id")
+                    request_params = self.get_request_params(
+                        messages=messages,
+                        response_format=response_format,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        run_response=run_response,
+                        use_previous_response_id=False,
+                    )
+                    request_params.pop("background", None)
+                    formatted_input = self._format_messages(
+                        messages,
+                        compress_tool_results,
+                        tools=tools,  # type: ignore[arg-type]
+                        use_previous_response_id=False,
+                    )
+                    async_stream = await self.get_async_client().responses.create(
+                        **self._get_model_request_kwargs(),
+                        input=formatted_input,  # type: ignore
+                        stream=True,
+                        **request_params,
+                    )
+                else:
+                    raise
             async for chunk in async_stream:  # type: ignore
                 model_response, tool_use = self._parse_provider_response_delta(chunk, assistant_message, tool_use)  # type: ignore
                 yield model_response

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -1100,6 +1100,8 @@ class OpenAIResponses(Model):
 
             assistant_message.metrics.start_timer()
 
+            # Relies on the SDK establishing the connection inside create(), so a stale
+            # previous_response_id surfaces as a 400 here rather than during iteration.
             try:
                 stream = self.get_client().responses.create(
                     **self._get_model_request_kwargs(),
@@ -1225,6 +1227,8 @@ class OpenAIResponses(Model):
 
             assistant_message.metrics.start_timer()
 
+            # Relies on the SDK establishing the connection inside create(), so a stale
+            # previous_response_id surfaces as a 400 here rather than during iteration.
             try:
                 async_stream = await self.get_async_client().responses.create(
                     **self._get_model_request_kwargs(),

--- a/libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py
@@ -1,5 +1,11 @@
 from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock
 
+import httpx
+import pytest
+from openai import APIStatusError
+
+from agno.exceptions import ModelProviderError
 from agno.models.message import Message
 from agno.models.openai.responses import OpenAIResponses
 from agno.models.response import ModelResponse
@@ -188,3 +194,335 @@ def test_reasoning_previous_response_skips_prior_function_call_items(monkeypatch
 
     # Expect no re-sent function_call when previous_response_id is present for reasoning models
     assert all(x.get("type") != "function_call" for x in fm)
+
+
+def test_format_messages_without_previous_response_id_sends_full_history(monkeypatch):
+    model = OpenAIResponses(id="o4-mini")
+    monkeypatch.setattr(model, "_using_reasoning_model", lambda: True)
+
+    assistant_with_prev = Message(role="assistant", content="prior")
+    assistant_with_prev.provider_data = {"response_id": "resp_123"}  # type: ignore[attr-defined]
+    assistant_with_tool_call = Message(
+        role="assistant",
+        tool_calls=[
+            {
+                "id": "fc_abc123",
+                "call_id": "call_def456",
+                "type": "function",
+                "function": {"name": "execute_shell_command", "arguments": "{}"},
+            }
+        ],
+    )
+    messages = [
+        Message(role="system", content="s"),
+        Message(role="user", content="u"),
+        assistant_with_prev,
+        assistant_with_tool_call,
+    ]
+
+    fm = model._format_messages(messages=messages, use_previous_response_id=False)
+
+    # system -> developer via role_map
+    assert any(x.get("role") == "developer" for x in fm)
+    assert any(x.get("type") == "function_call" for x in fm)
+
+
+# ---------------------------------------------------------------------------
+# previous_response_id recovery on "not found" 400
+# ---------------------------------------------------------------------------
+
+
+class _InvokeFakeResponse:
+    def __init__(self, *, _id: str = "resp_ok", output_text: str = "ok"):
+        self.id = _id
+        self.status = "completed"
+        self.output: List[Any] = []
+        self.output_text = output_text
+        self.usage = None
+        self.error = None
+
+
+def _make_fake_client() -> MagicMock:
+    client = MagicMock()
+    client.is_closed.return_value = False
+    return client
+
+
+def _previous_response_not_found_error(response_id: str = "resp_missing") -> APIStatusError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/responses")
+    response = httpx.Response(400, request=request)
+    message = f"Previous response with id '{response_id}' not found."
+    return APIStatusError(message=message, response=response, body={"error": {"message": message}})
+
+
+def _history_with_previous_response_id() -> List[Message]:
+    assistant_with_prev = Message(role="assistant", content="prior answer")
+    assistant_with_prev.provider_data = {"response_id": "resp_stale"}  # type: ignore[attr-defined]
+    return [
+        Message(role="system", content="be helpful"),
+        Message(role="user", content="first question"),
+        assistant_with_prev,
+        Message(role="user", content="follow up"),
+    ]
+
+
+def test_invoke_valid_previous_response_id_no_retry():
+    model = OpenAIResponses(id="o4-mini")
+    fake_client = _make_fake_client()
+    fake_client.responses.create.return_value = _InvokeFakeResponse(_id="resp_new")
+    model.client = fake_client
+
+    result = model.invoke(
+        messages=_history_with_previous_response_id(),
+        assistant_message=Message(role="assistant"),
+    )
+
+    assert result is not None
+    assert fake_client.responses.create.call_count == 1
+    _, kwargs = fake_client.responses.create.call_args
+    assert kwargs.get("previous_response_id") == "resp_stale"
+
+
+def test_invoke_invalid_previous_response_id_retries_with_full_history():
+    model = OpenAIResponses(id="o4-mini")
+    fake_client = _make_fake_client()
+    fake_client.responses.create.side_effect = [
+        _previous_response_not_found_error("resp_stale"),
+        _InvokeFakeResponse(_id="resp_recovered", output_text="recovered"),
+    ]
+    model.client = fake_client
+
+    result = model.invoke(
+        messages=_history_with_previous_response_id(),
+        assistant_message=Message(role="assistant"),
+    )
+
+    assert result is not None
+    assert result.provider_data is not None
+    assert result.provider_data.get("response_id") == "resp_recovered"
+    assert fake_client.responses.create.call_count == 2
+
+    first_kwargs = fake_client.responses.create.call_args_list[0].kwargs
+    second_kwargs = fake_client.responses.create.call_args_list[1].kwargs
+    assert first_kwargs.get("previous_response_id") == "resp_stale"
+    assert "previous_response_id" not in second_kwargs
+
+    second_input = second_kwargs.get("input") or []
+    # Full history (system mapped to developer), not the trimmed previous_response_id slice
+    assert any(isinstance(item, dict) and item.get("role") == "developer" for item in second_input)
+    assert any(
+        isinstance(item, dict) and item.get("role") == "user" and item.get("content") == "first question"
+        for item in second_input
+    )
+    assert any(
+        isinstance(item, dict) and item.get("role") == "user" and item.get("content") == "follow up"
+        for item in second_input
+    )
+
+
+def test_invoke_non_reasoning_model_never_retries_on_previous_response_error():
+    model = OpenAIResponses(id="gpt-4.1-mini")
+    fake_client = _make_fake_client()
+    fake_client.responses.create.side_effect = _previous_response_not_found_error("resp_stale")
+    model.client = fake_client
+
+    with pytest.raises(ModelProviderError):
+        model.invoke(
+            messages=_history_with_previous_response_id(),
+            assistant_message=Message(role="assistant"),
+        )
+
+    assert fake_client.responses.create.call_count == 1
+    _, kwargs = fake_client.responses.create.call_args
+    assert "previous_response_id" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_valid_previous_response_id_no_retry():
+    model = OpenAIResponses(id="o4-mini")
+    fake_client = _make_fake_client()
+    fake_client.responses.create = AsyncMock(return_value=_InvokeFakeResponse(_id="resp_new"))
+    model.async_client = fake_client
+
+    result = await model.ainvoke(
+        messages=_history_with_previous_response_id(),
+        assistant_message=Message(role="assistant"),
+    )
+
+    assert result is not None
+    assert fake_client.responses.create.call_count == 1
+    _, kwargs = fake_client.responses.create.call_args
+    assert kwargs.get("previous_response_id") == "resp_stale"
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_invalid_previous_response_id_retries_with_full_history():
+    model = OpenAIResponses(id="o4-mini")
+    fake_client = _make_fake_client()
+    fake_client.responses.create = AsyncMock(
+        side_effect=[
+            _previous_response_not_found_error("resp_stale"),
+            _InvokeFakeResponse(_id="resp_recovered", output_text="recovered"),
+        ]
+    )
+    model.async_client = fake_client
+
+    result = await model.ainvoke(
+        messages=_history_with_previous_response_id(),
+        assistant_message=Message(role="assistant"),
+    )
+
+    assert result is not None
+    assert result.provider_data is not None
+    assert result.provider_data.get("response_id") == "resp_recovered"
+    assert fake_client.responses.create.call_count == 2
+
+    first_kwargs = fake_client.responses.create.call_args_list[0].kwargs
+    second_kwargs = fake_client.responses.create.call_args_list[1].kwargs
+    assert first_kwargs.get("previous_response_id") == "resp_stale"
+    assert "previous_response_id" not in second_kwargs
+
+    second_input = second_kwargs.get("input") or []
+    assert any(isinstance(item, dict) and item.get("role") == "developer" for item in second_input)
+    assert any(
+        isinstance(item, dict) and item.get("role") == "user" and item.get("content") == "first question"
+        for item in second_input
+    )
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_non_reasoning_model_never_retries_on_previous_response_error():
+    model = OpenAIResponses(id="gpt-4.1-mini")
+    fake_client = _make_fake_client()
+    fake_client.responses.create = AsyncMock(side_effect=_previous_response_not_found_error("resp_stale"))
+    model.async_client = fake_client
+
+    with pytest.raises(ModelProviderError):
+        await model.ainvoke(
+            messages=_history_with_previous_response_id(),
+            assistant_message=Message(role="assistant"),
+        )
+
+    assert fake_client.responses.create.call_count == 1
+    _, kwargs = fake_client.responses.create.call_args
+    assert "previous_response_id" not in kwargs
+
+
+def _history_with_tool_call_and_previous_response_id() -> List[Message]:
+    tool_call_msg = Message(
+        role="assistant",
+        tool_calls=[
+            {
+                "id": "fc_abc",
+                "call_id": "call_abc",
+                "type": "function",
+                "function": {"name": "do_it", "arguments": "{}"},
+            }
+        ],
+    )
+    prev = Message(role="assistant", content="prior")
+    prev.provider_data = {"response_id": "resp_stale"}  # type: ignore[attr-defined]
+    return [
+        Message(role="user", content="q1"),
+        tool_call_msg,
+        Message(role="tool", tool_call_id="fc_abc", content="result"),
+        prev,
+        Message(role="user", content="q2"),
+    ]
+
+
+class _AsyncEmptyStream:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+def test_invoke_stale_id_resends_function_call_items():
+    model = OpenAIResponses(id="gpt-5.4-mini")
+    fake_client = _make_fake_client()
+    fake_client.responses.create.side_effect = [
+        _previous_response_not_found_error("resp_stale"),
+        _InvokeFakeResponse(_id="resp_recovered"),
+    ]
+    model.client = fake_client
+
+    model.invoke(
+        messages=_history_with_tool_call_and_previous_response_id(),
+        assistant_message=Message(role="assistant"),
+    )
+
+    assert fake_client.responses.create.call_count == 2
+    second_input = fake_client.responses.create.call_args_list[1].kwargs.get("input") or []
+    fc_items = [x for x in second_input if isinstance(x, dict) and x.get("type") == "function_call"]
+    assert len(fc_items) == 1
+    assert fc_items[0]["id"] == "fc_abc"
+
+
+def test_invoke_stream_stale_id_retries_without_previous_response_id():
+    model = OpenAIResponses(id="gpt-5.4-mini")
+    fake_client = _make_fake_client()
+    fake_client.responses.create.side_effect = [
+        _previous_response_not_found_error("resp_stale"),
+        iter([]),
+    ]
+    model.client = fake_client
+
+    list(
+        model.invoke_stream(
+            messages=_history_with_previous_response_id(),
+            assistant_message=Message(role="assistant"),
+        )
+    )
+
+    assert fake_client.responses.create.call_count == 2
+    first_kwargs = fake_client.responses.create.call_args_list[0].kwargs
+    second_kwargs = fake_client.responses.create.call_args_list[1].kwargs
+    assert first_kwargs.get("previous_response_id") == "resp_stale"
+    assert "previous_response_id" not in second_kwargs
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_stream_stale_id_retries_without_previous_response_id():
+    model = OpenAIResponses(id="gpt-5.4-mini")
+    fake_client = _make_fake_client()
+    fake_client.responses.create = AsyncMock(
+        side_effect=[
+            _previous_response_not_found_error("resp_stale"),
+            _AsyncEmptyStream(),
+        ]
+    )
+    model.async_client = fake_client
+
+    chunks = [
+        chunk
+        async for chunk in model.ainvoke_stream(
+            messages=_history_with_previous_response_id(),
+            assistant_message=Message(role="assistant"),
+        )
+    ]
+
+    assert chunks == []
+    assert fake_client.responses.create.call_count == 2
+    second_kwargs = fake_client.responses.create.call_args_list[1].kwargs
+    assert "previous_response_id" not in second_kwargs
+
+
+def test_detector_matches_error_carried_only_in_response_body():
+    request = httpx.Request("POST", "https://api.openai.com/v1/responses")
+    # Empty exception message; the detail lives only in the JSON body.
+    response = httpx.Response(
+        400, json={"error": {"message": "Previous response with id 'resp_x' not found."}}, request=request
+    )
+    exc = APIStatusError("", response=response, body=None)
+    assert OpenAIResponses._is_previous_response_not_found_error(exc) is True
+
+
+def test_recovery_drops_user_supplied_previous_response_id():
+    model = OpenAIResponses(id="gpt-5.4-mini", request_params={"previous_response_id": "resp_user"})
+    params = model.get_request_params(
+        messages=_history_with_previous_response_id(),
+        use_previous_response_id=False,
+    )
+    assert "previous_response_id" not in params


### PR DESCRIPTION
## Summary

Fixes #9240.

When `OpenAIResponses` chains turns with `previous_response_id`, a stale, expired,
or cross-account id makes the API reject the request with a 400
"Previous response with id ... not found". The whole call fails even though the
conversation history is intact and the request could just be sent without the
chain pointer.

This adds a one-time retry on that specific 400. On the retry the model drops
`previous_response_id`, sends the full history instead, and re-sends the
function_call items so tool state is preserved. Applies to all four entry points:
invoke, ainvoke, invoke_stream, ainvoke_stream.

The detector reads both the exception message and the JSON error body, since the
"not found" text is not always on the top-level message. The retry path also
strips any user-supplied previous_response_id out of request_params so it cannot
be re-introduced and defeat the recovery.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Tests: 16 cases in test_openai_responses_id_handling.py cover sync/async invoke
and stream recovery, function_call re-send, body-only error detection, and the
request_params drop. Full openai unit suite passes (84), ruff format/check clean.
