### PR TITLE
fix: run metrics refresh in background to avoid blocking workers

### DIFF
--- a/libs/agno/agno/client/os.py
+++ b/libs/agno/agno/client/os.py
@@ -34,7 +34,7 @@ from agno.os.routers.memory.schemas import (
     UserMemorySchema,
     UserStatsSchema,
 )
-from agno.os.routers.metrics.schemas import MetricsRefreshResponse, MetricsResponse
+from agno.os.routers.metrics.schemas import DayAggregatedMetrics, MetricsRefreshResponse, MetricsResponse
 from agno.os.routers.teams.schema import TeamResponse
 from agno.os.routers.traces.schemas import (
     TraceDetail,
@@ -2967,30 +2967,37 @@ class AgentOSClient:
         self,
         db_id: Optional[str] = None,
         table: Optional[str] = None,
+        background: bool = False,
         headers: Optional[Dict[str, str]] = None,
-    ) -> MetricsRefreshResponse:
+    ) -> Union[List[DayAggregatedMetrics], MetricsRefreshResponse]:
         """Manually trigger recalculation of system metrics from raw data.
 
         This operation analyzes system activity logs and regenerates aggregated metrics.
         Useful for ensuring metrics are up-to-date or after system maintenance.
-        Returns immediately with 202 Accepted; refresh runs in background.
+        By default the refresh runs synchronously and returns the refreshed metrics.
+        With background=True the server returns 202 immediately and runs the refresh
+        in the background; poll get_metrics for results. Servers that predate
+        background support ignore the flag and refresh synchronously.
 
         Args:
             db_id: Optional database ID to use
             table: Optional database table to use
+            background: Run the refresh in the background and return immediately
             headers: HTTP headers to include in the request (optional)
 
         Returns:
-            MetricsRefreshResponse: Status of the refresh request
+            List[DayAggregatedMetrics]: The refreshed daily aggregated metrics (synchronous refresh)
+            MetricsRefreshResponse: Status of the refresh request (background refresh)
 
         Raises:
             HTTPStatusError: On HTTP errors
         """
         params: Dict[str, Any] = {"db_id": db_id, "table": table}
         params = {k: v for k, v in params.items() if v is not None}
+        if background:
+            params["background"] = True
 
         data = await self._apost("/metrics/refresh", params=params, headers=headers)
         if isinstance(data, list):
-            # Servers older than the 202 contract compute synchronously and return the refreshed metrics
-            return MetricsRefreshResponse(status="completed", message="Metrics refresh completed")
+            return [DayAggregatedMetrics.model_validate(m) for m in data]
         return MetricsRefreshResponse.model_validate(data)

--- a/libs/agno/agno/client/os.py
+++ b/libs/agno/agno/client/os.py
@@ -34,7 +34,7 @@ from agno.os.routers.memory.schemas import (
     UserMemorySchema,
     UserStatsSchema,
 )
-from agno.os.routers.metrics.schemas import DayAggregatedMetrics, MetricsResponse
+from agno.os.routers.metrics.schemas import MetricsRefreshResponse, MetricsResponse
 from agno.os.routers.teams.schema import TeamResponse
 from agno.os.routers.traces.schemas import (
     TraceDetail,
@@ -2968,11 +2968,12 @@ class AgentOSClient:
         db_id: Optional[str] = None,
         table: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
-    ) -> List[DayAggregatedMetrics]:
+    ) -> MetricsRefreshResponse:
         """Manually trigger recalculation of system metrics from raw data.
 
         This operation analyzes system activity logs and regenerates aggregated metrics.
         Useful for ensuring metrics are up-to-date or after system maintenance.
+        Returns immediately with 202 Accepted; refresh runs in background.
 
         Args:
             db_id: Optional database ID to use
@@ -2980,7 +2981,7 @@ class AgentOSClient:
             headers: HTTP headers to include in the request (optional)
 
         Returns:
-            List[DayAggregatedMetrics]: List of refreshed daily aggregated metrics
+            MetricsRefreshResponse: Status of the refresh request
 
         Raises:
             HTTPStatusError: On HTTP errors
@@ -2989,4 +2990,4 @@ class AgentOSClient:
         params = {k: v for k, v in params.items() if v is not None}
 
         data = await self._apost("/metrics/refresh", params=params, headers=headers)
-        return [DayAggregatedMetrics.model_validate(m) for m in data]
+        return MetricsRefreshResponse.model_validate(data)

--- a/libs/agno/agno/client/os.py
+++ b/libs/agno/agno/client/os.py
@@ -2990,4 +2990,7 @@ class AgentOSClient:
         params = {k: v for k, v in params.items() if v is not None}
 
         data = await self._apost("/metrics/refresh", params=params, headers=headers)
+        if isinstance(data, list):
+            # Servers older than the 202 contract compute synchronously and return the refreshed metrics
+            return MetricsRefreshResponse(status="completed", message="Metrics refresh completed")
         return MetricsRefreshResponse.model_validate(data)

--- a/libs/agno/agno/os/routers/metrics/metrics.py
+++ b/libs/agno/agno/os/routers/metrics/metrics.py
@@ -1,13 +1,14 @@
 import logging
 from datetime import date
-from typing import List, Optional, Union, cast
+from typing import Optional, Union
 
-from fastapi import Depends, HTTPException, Query, Request
+from fastapi import BackgroundTasks, Depends, HTTPException, Query, Request
 from fastapi.routing import APIRouter
+from starlette.concurrency import run_in_threadpool
 
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
-from agno.os.routers.metrics.schemas import DayAggregatedMetrics, MetricsResponse
+from agno.os.routers.metrics.schemas import DayAggregatedMetrics, MetricsRefreshResponse, MetricsResponse
 from agno.os.schema import (
     BadRequestResponse,
     InternalServerErrorResponse,
@@ -114,10 +115,11 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 )
 
             if isinstance(db, AsyncBaseDb):
-                db = cast(AsyncBaseDb, db)
                 metrics, latest_updated_at = await db.get_metrics(starting_date=starting_date, ending_date=ending_date)
             else:
-                metrics, latest_updated_at = db.get_metrics(starting_date=starting_date, ending_date=ending_date)
+                metrics, latest_updated_at = await run_in_threadpool(
+                    lambda: db.get_metrics(starting_date=starting_date, ending_date=ending_date)
+                )
 
             return MetricsResponse(
                 metrics=[DayAggregatedMetrics.from_dict(metric) for metric in metrics],
@@ -127,79 +129,65 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Error getting metrics: {str(e)}")
 
+    async def _do_refresh(
+        db: Union[BaseDb, AsyncBaseDb, RemoteDb],
+        db_id: Optional[str],
+        table: Optional[str],
+        headers: Optional[dict],
+    ) -> None:
+        try:
+            if isinstance(db, RemoteDb):
+                await db.refresh_metrics(db_id=db_id, table=table, headers=headers)
+            elif isinstance(db, AsyncBaseDb):
+                await db.calculate_metrics()
+            else:
+                await run_in_threadpool(db.calculate_metrics)
+        except Exception as e:
+            logger.error(f"Metrics refresh failed: {e}")
+
     @router.post(
         "/metrics/refresh",
-        response_model=List[DayAggregatedMetrics],
-        status_code=200,
+        response_model=MetricsRefreshResponse,
+        status_code=202,
         operation_id="refresh_metrics",
         summary="Refresh Metrics",
         description=(
             "Manually trigger recalculation of system metrics from raw data. "
             "This operation analyzes system activity logs and regenerates aggregated metrics. "
-            "Useful for ensuring metrics are up-to-date or after system maintenance."
+            "Useful for ensuring metrics are up-to-date or after system maintenance. "
+            "Returns immediately with 202 Accepted. Poll GET /metrics for results."
         ),
         responses={
-            200: {
-                "description": "Metrics refreshed successfully",
+            202: {
+                "description": "Refresh started",
                 "content": {
                     "application/json": {
-                        "example": [
-                            {
-                                "id": "e77c9531-818b-47a5-99cd-59fed61e5403",
-                                "agent_runs_count": 2,
-                                "agent_sessions_count": 2,
-                                "team_runs_count": 0,
-                                "team_sessions_count": 0,
-                                "workflow_runs_count": 0,
-                                "workflow_sessions_count": 0,
-                                "users_count": 1,
-                                "token_metrics": {
-                                    "input_tokens": 256,
-                                    "output_tokens": 441,
-                                    "total_tokens": 697,
-                                    "audio_total_tokens": 0,
-                                    "audio_input_tokens": 0,
-                                    "audio_output_tokens": 0,
-                                    "cache_read_tokens": 0,
-                                    "cache_write_tokens": 0,
-                                    "reasoning_tokens": 0,
-                                },
-                                "model_metrics": [{"model_id": "gpt-4o", "model_provider": "OpenAI", "count": 2}],
-                                "date": "2025-08-12T00:00:00Z",
-                                "created_at": "2025-08-12T08:01:47Z",
-                                "updated_at": "2025-08-12T08:01:47Z",
-                            }
-                        ]
+                        "example": {"status": "started", "message": "Metrics refresh started in background"}
                     }
                 },
             },
-            500: {"description": "Failed to refresh metrics", "model": InternalServerErrorResponse},
+            500: {"description": "Failed to start metrics refresh", "model": InternalServerErrorResponse},
         },
     )
     async def calculate_metrics(
         request: Request,
+        background_tasks: BackgroundTasks,
         db_id: Optional[str] = Query(default=None, description="Database ID to use for metrics calculation"),
         table: Optional[str] = Query(default=None, description="Table to use for metrics calculation"),
-    ) -> List[DayAggregatedMetrics]:
+    ) -> MetricsRefreshResponse:
         try:
             db = await get_db(dbs, db_id, table)
 
+            headers = None
             if isinstance(db, RemoteDb):
                 auth_token = get_auth_token_from_request(request)
                 headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else None
-                return await db.refresh_metrics(db_id=db_id, table=table, headers=headers)
 
-            if isinstance(db, AsyncBaseDb):
-                db = cast(AsyncBaseDb, db)
-                result = await db.calculate_metrics()
-            else:
-                result = db.calculate_metrics()
-            if result is None:
-                return []
+            background_tasks.add_task(_do_refresh, db, db_id, table, headers)
 
-            return [DayAggregatedMetrics.from_dict(metric) for metric in result]
+            return MetricsRefreshResponse(status="started", message="Metrics refresh started in background")
 
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Error refreshing metrics: {str(e)}")
+            raise HTTPException(status_code=500, detail=f"Error starting metrics refresh: {str(e)}")
 
     return router

--- a/libs/agno/agno/os/routers/metrics/metrics.py
+++ b/libs/agno/agno/os/routers/metrics/metrics.py
@@ -1,8 +1,8 @@
 import logging
 from datetime import date
-from typing import Optional, Union
+from typing import List, Optional, Union
 
-from fastapi import BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import BackgroundTasks, Depends, HTTPException, Query, Request, Response
 from fastapi.routing import APIRouter
 from starlette.concurrency import run_in_threadpool
 
@@ -141,7 +141,7 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
     ) -> None:
         try:
             if isinstance(db, RemoteDb):
-                await db.refresh_metrics(db_id=db_id, table=table, headers=headers)
+                await db.refresh_metrics(db_id=db_id, table=table, headers=headers, background=True)
             elif isinstance(db, AsyncBaseDb):
                 await db.calculate_metrics()
             else:
@@ -153,36 +153,70 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
 
     @router.post(
         "/metrics/refresh",
-        response_model=MetricsRefreshResponse,
-        status_code=202,
+        response_model=Union[List[DayAggregatedMetrics], MetricsRefreshResponse],
+        status_code=200,
         operation_id="refresh_metrics",
         summary="Refresh Metrics",
         description=(
             "Manually trigger recalculation of system metrics from raw data. "
             "This operation analyzes system activity logs and regenerates aggregated metrics. "
             "Useful for ensuring metrics are up-to-date or after system maintenance. "
-            "Returns immediately with 202 Accepted. Poll GET /metrics for results. "
-            "If a refresh is already in progress for the target database, "
+            "By default the refresh runs synchronously and returns the refreshed metrics. "
+            "Pass background=true to run the refresh in the background instead: the endpoint "
+            "returns 202 Accepted immediately and GET /metrics can be polled for results. "
+            "If a background refresh is already in progress for the target database, "
             "returns status 'already_running' without starting a new one."
         ),
         responses={
+            200: {
+                "description": "Metrics refreshed successfully",
+                "content": {
+                    "application/json": {
+                        "example": [
+                            {
+                                "id": "e77c9531-818b-47a5-99cd-59fed61e5403",
+                                "agent_runs_count": 2,
+                                "agent_sessions_count": 2,
+                                "team_runs_count": 0,
+                                "team_sessions_count": 0,
+                                "workflow_runs_count": 0,
+                                "workflow_sessions_count": 0,
+                                "users_count": 1,
+                                "token_metrics": {
+                                    "input_tokens": 256,
+                                    "output_tokens": 441,
+                                    "total_tokens": 697,
+                                },
+                                "model_metrics": [{"model_id": "gpt-5.5", "model_provider": "OpenAI", "count": 2}],
+                                "date": "2025-08-12T00:00:00Z",
+                                "created_at": "2025-08-12T08:01:47Z",
+                                "updated_at": "2025-08-12T08:01:47Z",
+                            }
+                        ]
+                    }
+                },
+            },
             202: {
-                "description": "Refresh started",
+                "description": "Background refresh started",
                 "content": {
                     "application/json": {
                         "example": {"status": "started", "message": "Metrics refresh started in background"}
                     }
                 },
             },
-            500: {"description": "Failed to start metrics refresh", "model": InternalServerErrorResponse},
+            500: {"description": "Failed to refresh metrics", "model": InternalServerErrorResponse},
         },
     )
     async def calculate_metrics(
         request: Request,
+        response: Response,
         background_tasks: BackgroundTasks,
         db_id: Optional[str] = Query(default=None, description="Database ID to use for metrics calculation"),
         table: Optional[str] = Query(default=None, description="Table to use for metrics calculation"),
-    ) -> MetricsRefreshResponse:
+        background: bool = Query(
+            default=False, description="Run the refresh in the background and return 202 immediately"
+        ),
+    ) -> Union[List[DayAggregatedMetrics], MetricsRefreshResponse]:
         try:
             db = await get_db(dbs, db_id, table)
 
@@ -191,18 +225,32 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 auth_token = get_auth_token_from_request(request)
                 headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else None
 
-            refresh_key = str(db.id)
-            if refresh_key in refreshes_in_flight:
-                return MetricsRefreshResponse(
-                    status="already_running", message="A metrics refresh is already in progress for this database"
-                )
+            if background:
+                response.status_code = 202
+                refresh_key = str(db.id)
+                if refresh_key in refreshes_in_flight:
+                    return MetricsRefreshResponse(
+                        status="already_running", message="A metrics refresh is already in progress for this database"
+                    )
 
-            refreshes_in_flight.add(refresh_key)
-            background_tasks.add_task(_do_refresh, db, db_id, table, headers)
+                refreshes_in_flight.add(refresh_key)
+                background_tasks.add_task(_do_refresh, db, db_id, table, headers)
 
-            return MetricsRefreshResponse(status="started", message="Metrics refresh started in background")
+                return MetricsRefreshResponse(status="started", message="Metrics refresh started in background")
+
+            if isinstance(db, RemoteDb):
+                return await db.refresh_metrics(db_id=db_id, table=table, headers=headers)
+
+            if isinstance(db, AsyncBaseDb):
+                result = await db.calculate_metrics()
+            else:
+                result = await run_in_threadpool(db.calculate_metrics)
+            if result is None:
+                return []
+
+            return [DayAggregatedMetrics.from_dict(metric) for metric in result]
 
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Error starting metrics refresh: {str(e)}")
+            raise HTTPException(status_code=500, detail=f"Error refreshing metrics: {str(e)}")
 
     return router

--- a/libs/agno/agno/os/routers/metrics/metrics.py
+++ b/libs/agno/agno/os/routers/metrics/metrics.py
@@ -118,7 +118,7 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 metrics, latest_updated_at = await db.get_metrics(starting_date=starting_date, ending_date=ending_date)
             else:
                 metrics, latest_updated_at = await run_in_threadpool(
-                    lambda: db.get_metrics(starting_date=starting_date, ending_date=ending_date)
+                    db.get_metrics, starting_date=starting_date, ending_date=ending_date
                 )
 
             return MetricsResponse(
@@ -128,6 +128,10 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
 
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Error getting metrics: {str(e)}")
+
+    # Databases with a refresh currently in flight, keyed by db id. Only mutated on the
+    # event loop (the sync calculation itself runs in the threadpool), so no lock is needed.
+    refreshes_in_flight: set[str] = set()
 
     async def _do_refresh(
         db: Union[BaseDb, AsyncBaseDb, RemoteDb],
@@ -144,6 +148,8 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 await run_in_threadpool(db.calculate_metrics)
         except Exception as e:
             logger.error(f"Metrics refresh failed: {e}")
+        finally:
+            refreshes_in_flight.discard(str(db.id))
 
     @router.post(
         "/metrics/refresh",
@@ -155,7 +161,9 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
             "Manually trigger recalculation of system metrics from raw data. "
             "This operation analyzes system activity logs and regenerates aggregated metrics. "
             "Useful for ensuring metrics are up-to-date or after system maintenance. "
-            "Returns immediately with 202 Accepted. Poll GET /metrics for results."
+            "Returns immediately with 202 Accepted. Poll GET /metrics for results. "
+            "If a refresh is already in progress for the target database, "
+            "returns status 'already_running' without starting a new one."
         ),
         responses={
             202: {
@@ -183,6 +191,13 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 auth_token = get_auth_token_from_request(request)
                 headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else None
 
+            refresh_key = str(db.id)
+            if refresh_key in refreshes_in_flight:
+                return MetricsRefreshResponse(
+                    status="already_running", message="A metrics refresh is already in progress for this database"
+                )
+
+            refreshes_in_flight.add(refresh_key)
             background_tasks.add_task(_do_refresh, db, db_id, table, headers)
 
             return MetricsRefreshResponse(status="started", message="Metrics refresh started in background")

--- a/libs/agno/agno/os/routers/metrics/schemas.py
+++ b/libs/agno/agno/os/routers/metrics/schemas.py
@@ -32,7 +32,7 @@ class DayAggregatedMetrics(BaseModel):
         return cls(
             agent_runs_count=metrics_dict.get("agent_runs_count", 0),
             agent_sessions_count=metrics_dict.get("agent_sessions_count", 0),
-            date=metrics_dict.get("date", datetime.now(timezone.utc)),
+            date=to_utc_datetime(metrics_dict.get("date")) or datetime.now(timezone.utc),
             id=metrics_dict.get("id", ""),
             model_metrics=metrics_dict.get("model_metrics", {}),
             team_runs_count=metrics_dict.get("team_runs_count", 0),
@@ -49,3 +49,8 @@ class DayAggregatedMetrics(BaseModel):
 class MetricsResponse(BaseModel):
     metrics: List[DayAggregatedMetrics] = Field(..., description="List of daily aggregated metrics")
     updated_at: Optional[datetime] = Field(None, description="Timestamp of the most recent metrics update")
+
+
+class MetricsRefreshResponse(BaseModel):
+    status: str = Field(..., description="Status of the refresh request")
+    message: Optional[str] = Field(None, description="Additional details")

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -1,5 +1,5 @@
 import json
-from datetime import date, datetime, timezone
+from datetime import date, datetime, time, timezone
 from os import getenv
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, Union
 
@@ -45,9 +45,9 @@ def to_utc_datetime(value: Optional[Union[str, int, float, date, datetime]]) -> 
             return value.replace(tzinfo=timezone.utc)
         return value
 
-    # Checked after datetime, since datetime is a subclass of date
+    # datetime is a subclass of date, so this must come after the datetime check
     if isinstance(value, date):
-        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+        return datetime.combine(value, time.min, tzinfo=timezone.utc)
 
     if isinstance(value, str):
         try:

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from os import getenv
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, Union
 
@@ -34,8 +34,8 @@ from agno.utils.log import log_debug, log_warning, logger
 from agno.workflow import RemoteWorkflow, Workflow, WorkflowFactory
 
 
-def to_utc_datetime(value: Optional[Union[str, int, float, datetime]]) -> Optional[datetime]:
-    """Convert a timestamp, ISO 8601 string, or datetime to a UTC datetime."""
+def to_utc_datetime(value: Optional[Union[str, int, float, date, datetime]]) -> Optional[datetime]:
+    """Convert a timestamp, ISO 8601 string, date, or datetime to a UTC datetime."""
     if value is None:
         return None
 
@@ -44,6 +44,10 @@ def to_utc_datetime(value: Optional[Union[str, int, float, datetime]]) -> Option
         if value.tzinfo is None:
             return value.replace(tzinfo=timezone.utc)
         return value
+
+    # Checked after datetime, since datetime is a subclass of date
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
 
     if isinstance(value, str):
         try:

--- a/libs/agno/agno/remote/base.py
+++ b/libs/agno/agno/remote/base.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
         VectorSearchResult,
     )
     from agno.os.routers.memory.schemas import OptimizeMemoriesResponse, UserMemorySchema, UserStatsSchema
-    from agno.os.routers.metrics.schemas import MetricsRefreshResponse, MetricsResponse
+    from agno.os.routers.metrics.schemas import DayAggregatedMetrics, MetricsRefreshResponse, MetricsResponse
     from agno.os.routers.traces.schemas import TraceDetail, TraceNode, TraceSessionStats, TraceSummary
     from agno.os.schema import (
         AgentSessionDetailSchema,
@@ -247,7 +247,7 @@ class RemoteDb:
     ) -> "MetricsResponse":
         return await self.client.get_metrics(starting_date=starting_date, ending_date=ending_date, **kwargs)
 
-    async def refresh_metrics(self, **kwargs: Any) -> "MetricsRefreshResponse":
+    async def refresh_metrics(self, **kwargs: Any) -> Union[List["DayAggregatedMetrics"], "MetricsRefreshResponse"]:
         return await self.client.refresh_metrics(**kwargs)
 
     # OTHER

--- a/libs/agno/agno/remote/base.py
+++ b/libs/agno/agno/remote/base.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
         VectorSearchResult,
     )
     from agno.os.routers.memory.schemas import OptimizeMemoriesResponse, UserMemorySchema, UserStatsSchema
-    from agno.os.routers.metrics.schemas import DayAggregatedMetrics, MetricsResponse
+    from agno.os.routers.metrics.schemas import MetricsRefreshResponse, MetricsResponse
     from agno.os.routers.traces.schemas import TraceDetail, TraceNode, TraceSessionStats, TraceSummary
     from agno.os.schema import (
         AgentSessionDetailSchema,
@@ -247,7 +247,7 @@ class RemoteDb:
     ) -> "MetricsResponse":
         return await self.client.get_metrics(starting_date=starting_date, ending_date=ending_date, **kwargs)
 
-    async def refresh_metrics(self, **kwargs: Any) -> List["DayAggregatedMetrics"]:
+    async def refresh_metrics(self, **kwargs: Any) -> "MetricsRefreshResponse":
         return await self.client.refresh_metrics(**kwargs)
 
     # OTHER

--- a/libs/agno/tests/system/tests/test_metrics_routes.py
+++ b/libs/agno/tests/system/tests/test_metrics_routes.py
@@ -105,27 +105,24 @@ class TestLocalMetricsRoutes:
             assert "created_at" in metric
             assert "updated_at" in metric
 
-    def test_refresh_metrics_returns_list(self, client: httpx.Client, generate_metrics_data: dict):
-        """Test POST /metrics/refresh recalculates and returns metrics for local db."""
+    def test_refresh_metrics_returns_accepted(self, client: httpx.Client, generate_metrics_data: dict):
+        """Test POST /metrics/refresh returns 202 with a refresh status for local db."""
         response = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
-        assert response.status_code == 200
+        assert response.status_code == 202
         data = response.json()
 
-        assert isinstance(data, list)
+        assert data["status"] in ("started", "already_running")
+        assert "message" in data
 
-    def test_refresh_metrics_contains_expected_fields(self, client: httpx.Client, generate_metrics_data: dict):
-        """Test POST /metrics/refresh returns metrics with expected fields for local db."""
-        response = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
-        assert response.status_code == 200
-        data = response.json()
+    def test_refresh_metrics_repeated_calls_accepted(self, client: httpx.Client, generate_metrics_data: dict):
+        """Test repeated POST /metrics/refresh calls return 202 without stacking refreshes for local db."""
+        first = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
+        second = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
+        assert first.status_code == 202
+        assert second.status_code == 202
 
-        if len(data) > 0:
-            metric = data[0]
-            assert "id" in metric
-            assert "agent_runs_count" in metric
-            assert "token_metrics" in metric
-            assert "model_metrics" in metric
-            assert "date" in metric
+        assert first.json()["status"] in ("started", "already_running")
+        assert second.json()["status"] in ("started", "already_running")
 
 
 class TestRemoteMetricsRoutes:
@@ -200,24 +197,21 @@ class TestRemoteMetricsRoutes:
             assert "created_at" in metric
             assert "updated_at" in metric
 
-    def test_refresh_metrics_returns_list(self, client: httpx.Client, generate_metrics_data: dict):
-        """Test POST /metrics/refresh recalculates and returns metrics for remote db."""
+    def test_refresh_metrics_returns_accepted(self, client: httpx.Client, generate_metrics_data: dict):
+        """Test POST /metrics/refresh returns 202 with a refresh status for remote db."""
         response = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
-        assert response.status_code == 200
+        assert response.status_code == 202
         data = response.json()
 
-        assert isinstance(data, list)
+        assert data["status"] in ("started", "already_running")
+        assert "message" in data
 
-    def test_refresh_metrics_contains_expected_fields(self, client: httpx.Client, generate_metrics_data: dict):
-        """Test POST /metrics/refresh returns metrics with expected fields for remote db."""
-        response = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
-        assert response.status_code == 200
-        data = response.json()
+    def test_refresh_metrics_repeated_calls_accepted(self, client: httpx.Client, generate_metrics_data: dict):
+        """Test repeated POST /metrics/refresh calls return 202 without stacking refreshes for remote db."""
+        first = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
+        second = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
+        assert first.status_code == 202
+        assert second.status_code == 202
 
-        if len(data) > 0:
-            metric = data[0]
-            assert "id" in metric
-            assert "agent_runs_count" in metric
-            assert "token_metrics" in metric
-            assert "model_metrics" in metric
-            assert "date" in metric
+        assert first.json()["status"] in ("started", "already_running")
+        assert second.json()["status"] in ("started", "already_running")

--- a/libs/agno/tests/system/tests/test_metrics_routes.py
+++ b/libs/agno/tests/system/tests/test_metrics_routes.py
@@ -105,24 +105,36 @@ class TestLocalMetricsRoutes:
             assert "created_at" in metric
             assert "updated_at" in metric
 
-    def test_refresh_metrics_returns_accepted(self, client: httpx.Client, generate_metrics_data: dict):
-        """Test POST /metrics/refresh returns 202 with a refresh status for local db."""
+    def test_refresh_metrics_returns_list(self, client: httpx.Client, generate_metrics_data: dict):
+        """Test POST /metrics/refresh recalculates and returns metrics for local db."""
         response = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert isinstance(data, list)
+
+    def test_refresh_metrics_contains_expected_fields(self, client: httpx.Client, generate_metrics_data: dict):
+        """Test POST /metrics/refresh returns metrics with expected fields for local db."""
+        response = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
+        assert response.status_code == 200
+        data = response.json()
+
+        if len(data) > 0:
+            metric = data[0]
+            assert "id" in metric
+            assert "agent_runs_count" in metric
+            assert "token_metrics" in metric
+            assert "model_metrics" in metric
+            assert "date" in metric
+
+    def test_refresh_metrics_background_returns_accepted(self, client: httpx.Client, generate_metrics_data: dict):
+        """Test POST /metrics/refresh?background=true returns 202 with a refresh status for local db."""
+        response = client.post(f"/metrics/refresh?db_id={self.DB_ID}&background=true")
         assert response.status_code == 202
         data = response.json()
 
         assert data["status"] in ("started", "already_running")
         assert "message" in data
-
-    def test_refresh_metrics_repeated_calls_accepted(self, client: httpx.Client, generate_metrics_data: dict):
-        """Test repeated POST /metrics/refresh calls return 202 without stacking refreshes for local db."""
-        first = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
-        second = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
-        assert first.status_code == 202
-        assert second.status_code == 202
-
-        assert first.json()["status"] in ("started", "already_running")
-        assert second.json()["status"] in ("started", "already_running")
 
 
 class TestRemoteMetricsRoutes:
@@ -197,21 +209,33 @@ class TestRemoteMetricsRoutes:
             assert "created_at" in metric
             assert "updated_at" in metric
 
-    def test_refresh_metrics_returns_accepted(self, client: httpx.Client, generate_metrics_data: dict):
-        """Test POST /metrics/refresh returns 202 with a refresh status for remote db."""
+    def test_refresh_metrics_returns_list(self, client: httpx.Client, generate_metrics_data: dict):
+        """Test POST /metrics/refresh recalculates and returns metrics for remote db."""
         response = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert isinstance(data, list)
+
+    def test_refresh_metrics_contains_expected_fields(self, client: httpx.Client, generate_metrics_data: dict):
+        """Test POST /metrics/refresh returns metrics with expected fields for remote db."""
+        response = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
+        assert response.status_code == 200
+        data = response.json()
+
+        if len(data) > 0:
+            metric = data[0]
+            assert "id" in metric
+            assert "agent_runs_count" in metric
+            assert "token_metrics" in metric
+            assert "model_metrics" in metric
+            assert "date" in metric
+
+    def test_refresh_metrics_background_returns_accepted(self, client: httpx.Client, generate_metrics_data: dict):
+        """Test POST /metrics/refresh?background=true returns 202 with a refresh status for remote db."""
+        response = client.post(f"/metrics/refresh?db_id={self.DB_ID}&background=true")
         assert response.status_code == 202
         data = response.json()
 
         assert data["status"] in ("started", "already_running")
         assert "message" in data
-
-    def test_refresh_metrics_repeated_calls_accepted(self, client: httpx.Client, generate_metrics_data: dict):
-        """Test repeated POST /metrics/refresh calls return 202 without stacking refreshes for remote db."""
-        first = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
-        second = client.post(f"/metrics/refresh?db_id={self.DB_ID}")
-        assert first.status_code == 202
-        assert second.status_code == 202
-
-        assert first.json()["status"] in ("started", "already_running")
-        assert second.json()["status"] in ("started", "already_running")


### PR DESCRIPTION
## Summary

`POST /metrics/refresh` was blocking uvicorn workers for 60+ seconds with large datasets (NIA reported 59k sessions). The sync `db.calculate_metrics()` call ran directly on the event loop, so one refresh froze the entire worker: all requests on it stalled, nginx timed out, and the worker was marked unhealthy and restarted.

This PR fixes the blocking without breaking the API contract:

- `POST /metrics/refresh` keeps its existing behavior by default: 200 with the refreshed `List[DayAggregatedMetrics]`. The sync `calculate_metrics()` call now runs in the threadpool (via `run_in_threadpool`), so the event loop is never blocked and other requests keep flowing while a refresh runs.
- New opt-in `?background=true` query param: returns 202 immediately with `{"status": "started", ...}` and runs the refresh as a background task. Useful for very large datasets where even a threadpooled refresh would exceed proxy timeouts for the caller. Poll `GET /metrics` for results.
- Background refreshes are single-flight per database: if one is already running, the endpoint returns 202 with `{"status": "already_running"}` instead of stacking another full recalculation. This prevents a retrying frontend from piling up concurrent 60-second scans.
- `GET /metrics` with a sync `BaseDb` also moves to `run_in_threadpool` (its lazy once-per-minute refresh could block the loop the same way).
- `to_utc_datetime()` now handles `datetime.date` values. SQL adapters return `date` objects for the metrics `date` column, and the previous code raised `TypeError` on them. The `date` check is placed after the `datetime` check since `datetime` subclasses `date`.

### Compatibility

No breaking changes:

- Existing callers of `POST /metrics/refresh` (scripts, old SDKs, the frontend) see the same 200 + list response as before.
- FastAPI ignores unknown query params, so a new client can always send `background=true`: old servers refresh synchronously and return the list, new servers return 202 with a status object. The SDK client branches on the response shape, so every client/server version combination works.
- When a gateway proxies a background refresh to a downstream server (`RemoteDb`), it forwards `background=true` so new downstreams return immediately instead of tying up the gateway's background task.

### Changes by file

| File | Change |
|------|--------|
| `os/routers/metrics/metrics.py` | Threadpool for sync db calls in both endpoints; `background` query param; `_do_refresh` background helper; per-db single-flight guard |
| `os/routers/metrics/schemas.py` | New `MetricsRefreshResponse` schema; `date` field normalized via `to_utc_datetime()` |
| `os/utils.py` | `to_utc_datetime()` handles `datetime.date` inputs |
| `client/os.py` | `refresh_metrics()` gains `background` flag; returns metrics list (sync) or `MetricsRefreshResponse` (background) |
| `remote/base.py` | `RemoteDb.refresh_metrics()` return type updated to the union |
| `tests/system/tests/test_metrics_routes.py` | Sync contract tests restored; new background-mode tests for local and remote dbs |

## Type of change

- [x] Bug fix
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Verified end-to-end against a live FastAPI app with a slow `calculate_metrics` stub:

- Default POST returns 200 with the refreshed metrics list, computed in the threadpool.
- `background=true` returns 202 in milliseconds; a concurrent second call gets `already_running` and exactly one calculation runs; the guard clears once the refresh completes.
- `GET /metrics` no longer 500s on SQL-backed dbs (the `datetime.date` regression from an earlier revision of this branch is fixed and covered by the `to_utc_datetime` change).

Remaining repo-wide `validate.sh` mypy failures are the 11 pre-existing errors in `models/` (gemini, claude), unrelated to this PR.