### PR TITLE
fix(team): do not complete on empty/None member after transfer

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -740,13 +740,17 @@ def _get_delegate_task_function(
             yield f"Member '{member_agent.name}' requires human input before continuing."
             return
 
-        if not stream:
+        # Surface empty/None member responses for BOTH stream and non-stream paths.
+        # Previously only the non-stream branch reported emptiness; streaming
+        # members could leave the team with silent early-stop (#5278).
+        from agno.team._member_response import empty_member_response_message, member_run_is_empty
+
+        if member_run_is_empty(member_agent_run_response):
+            member_label = member_agent.name or member_agent.id or member_id
+            yield empty_member_response_message(str(member_label))
+        elif not stream:
             try:
-                if member_agent_run_response.content is None and (  # type: ignore
-                    member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0  # type: ignore
-                ):
-                    yield "No response from the member agent."
-                elif isinstance(member_agent_run_response.content, str):  # type: ignore
+                if isinstance(member_agent_run_response.content, str):  # type: ignore
                     content = member_agent_run_response.content.strip()  # type: ignore
                     if len(content) > 0:
                         yield content
@@ -926,13 +930,14 @@ def _get_delegate_task_function(
             yield f"Member '{member_agent.name}' requires human input before continuing."
             return
 
-        if not stream:
+        from agno.team._member_response import empty_member_response_message, member_run_is_empty
+
+        if member_run_is_empty(member_agent_run_response):
+            member_label = member_agent.name or member_agent.id or member_id
+            yield empty_member_response_message(str(member_label))
+        elif not stream:
             try:
-                if member_agent_run_response.content is None and (  # type: ignore
-                    member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0  # type: ignore
-                ):
-                    yield "No response from the member agent."
-                elif isinstance(member_agent_run_response.content, str):  # type: ignore
+                if isinstance(member_agent_run_response.content, str):  # type: ignore
                     if len(member_agent_run_response.content.strip()) > 0:  # type: ignore
                         yield member_agent_run_response.content  # type: ignore
 

--- a/libs/agno/agno/team/_member_response.py
+++ b/libs/agno/agno/team/_member_response.py
@@ -1,0 +1,39 @@
+"""Helpers for evaluating team-member run outcomes (#5278).
+
+When a member model returns None/empty content (seen with some Gemini versions),
+Team delegation must surface a hard incomplete signal instead of silently finishing.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def member_run_is_empty(member_agent_run_response: Optional[Any]) -> bool:
+    """Return True when a member run produced no usable content or tool results.
+
+    Empty/None model responses are a known multi-agent failure mode: the team
+    leader may stop after "I transferred the task..." without further work.
+    """
+    if member_agent_run_response is None:
+        return True
+    content = getattr(member_agent_run_response, "content", None)
+    tools = getattr(member_agent_run_response, "tools", None)
+    has_tools = tools is not None and len(tools) > 0
+    if content is None:
+        return not has_tools
+    if isinstance(content, str) and not content.strip():
+        return not has_tools
+    return False
+
+
+def empty_member_response_message(member_name: Optional[str] = None) -> str:
+    """User/leader-visible message when a member returns nothing usable."""
+    label = member_name or "member"
+    return (
+        f"No usable response from team member '{label}' "
+        f"(empty or None content; possible model/provider early stop). "
+        f"The delegated task was NOT completed. "
+        f"Retry the delegation, disable member streaming if the team is streaming, "
+        f"or switch models."
+    )

--- a/libs/agno/tests/unit/team/test_member_response_empty.py
+++ b/libs/agno/tests/unit/team/test_member_response_empty.py
@@ -1,0 +1,30 @@
+"""#5278: empty member responses must be detected for team early-stop prevention."""
+from types import SimpleNamespace
+
+from agno.team._member_response import empty_member_response_message, member_run_is_empty
+
+
+def test_none_response_is_empty():
+    assert member_run_is_empty(None) is True
+
+
+def test_none_content_without_tools_is_empty():
+    assert member_run_is_empty(SimpleNamespace(content=None, tools=None)) is True
+    assert member_run_is_empty(SimpleNamespace(content=None, tools=[])) is True
+
+
+def test_empty_string_content_is_empty():
+    assert member_run_is_empty(SimpleNamespace(content="   ", tools=None)) is True
+
+
+def test_content_or_tools_not_empty():
+    assert member_run_is_empty(SimpleNamespace(content="done", tools=None)) is False
+    assert member_run_is_empty(
+        SimpleNamespace(content=None, tools=[SimpleNamespace(result="x")])
+    ) is False
+
+
+def test_empty_message_mentions_not_completed():
+    msg = empty_member_response_message("researcher")
+    assert "researcher" in msg
+    assert "NOT completed" in msg


### PR DESCRIPTION
## Summary
- Detect empty/None member runs after transfer (`member_run_is_empty`)
- Do **not** treat empty member responses as successful completion (stream + non-stream transfer paths)
- Surface an explicit incomplete message instead of silent stop

Fixes #5278

## Problem
Multi-agent Team runs can stop after “transferred… waiting for response” when a member returns `None`/empty content (reported especially with Gemini + streaming), leaving workflows silently incomplete.

## Test plan
- [x] `libs/agno/tests/unit/team/test_member_response_empty.py` (5 tests)
- [ ] CI suite on this PR

## Residual risk
- Unit coverage on empty policy; full live Gemini dual-stream matrix still recommended for maintainers with that stack.