### PR TITLE
[cookbook] Add Provenrail tamper-evident audit trail example

### DIFF
--- a/cookbook/observability/README.md
+++ b/cookbook/observability/README.md
@@ -20,6 +20,7 @@ Observability examples for tracing and monitoring Agno agents, teams, and workfl
 - `mlflow_via_openinference.py`
 - `maxim_ops.py`
 - `opik_via_openinference.py`
+- `provenrail_op.py`
 - `the_context_company.py`
 - `trace_to_database.py`
 - `traceloop_op.py`

--- a/cookbook/observability/provenrail_op.py
+++ b/cookbook/observability/provenrail_op.py
@@ -1,0 +1,98 @@
+"""
+Provenrail Integration
+======================
+
+Demonstrates recording every Agno tool call into a tamper-evident, independently
+verifiable audit trail using a tool hook.
+
+Tracing answers "what did we observe and log?". This answers a different question:
+"what can we still prove happened, to someone who does not trust us?". Each tool call is
+Ed25519-signed by the agent's own key and hash-chained to its predecessor, so a later
+edit, deletion, or reordering of the record is detectable by anyone, with an open-source
+verifier and no account.
+
+Key concepts:
+- A tool hook is middleware: it receives the tool name, the callable and the arguments,
+  invokes the callable, and records the outcome.
+- Failures are recorded as evidence too, then re-raised unchanged, so Agno's own error
+  handling is untouched.
+- Capture never breaks the agent: a recording failure is swallowed rather than raised
+  into the tool path.
+
+Honest scope: this proves that whatever was recorded has not been altered. It does not,
+and cannot, prove completeness: an agent that never invokes the tool cannot be recorded
+by a hook. Provenrail is evidence tooling, not legal advice or a compliance certification.
+
+Setup:
+    pip install agno provenrail openai
+    export OPENAI_API_KEY=...
+    pr quickstart          # writes .provenrail.json (local sink, no account needed)
+
+Verify the result afterwards, trusting neither the agent nor the sink:
+    pr verify bundle.json
+"""
+
+import provenrail as fr
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from provenrail.integrations.agno import provenrail_tool_hook
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+# Reads .provenrail.json, written once by `pr quickstart`. Records are pushed off-box to
+# an append-only sink as they happen, so the process that produced them cannot rewrite
+# them afterwards.
+fr.configure()
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+def transfer_funds(account: str, amount: int) -> str:
+    """Transfer an amount to an account.
+
+    Args:
+        account: The destination account identifier.
+        amount: The amount to transfer.
+    """
+    return f"Transferred {amount} to {account}"
+
+
+def check_balance(account: str) -> str:
+    """Return the balance of an account.
+
+    Args:
+        account: The account identifier.
+    """
+    return f"Account {account} balance: 10000"
+
+
+# ---------------------------------------------------------------------------
+# Agent Instructions
+# ---------------------------------------------------------------------------
+instructions = """
+You are a treasury assistant. Check the balance before moving any funds, and never
+transfer more than the available balance.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Run the Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # Everything inside the `record` block is captured into one signed, sealed session.
+    with fr.record("treasury-agent") as recorder:
+        agent = Agent(
+            model=OpenAIChat(id="gpt-4o"),
+            instructions=instructions,
+            tools=[check_balance, transfer_funds],
+            tool_hooks=[provenrail_tool_hook(recorder)],
+            markdown=True,
+        )
+        agent.print_response("Move 500 to account LT12, but check the balance first.")
+
+    # On exit the session is sealed and flushed off-box. Export it and check it with the
+    # standalone verifier, or open the bundle at provenrail.com/verify, which runs a
+    # second, independent verifier implementation entirely in your browser.
+    print("\nRecorded. Export and verify with:  pr export && pr verify bundle.json")


### PR DESCRIPTION
## Summary

Adds a cookbook example showing how to record every Agno tool call into a tamper-evident,
independently verifiable audit trail using a tool hook.

Tracing answers "what did we observe and log?". This addresses a different question that
came up in #7518: "what can we still prove happened, to a party who does not trust us?".
Each tool call is Ed25519-signed and hash-chained to its predecessor, so a later edit,
deletion, or reordering is detectable by anyone with an open-source verifier and no account.

Issue number: #7518

The example lives in `cookbook/observability/`, alongside the other third-party
integrations (`weave_op.py`, `langfuse_via_openinference.py`, `maxim_ops.py`, and so on),
and adds one line to that directory's README.

**Implementation note.** The hook is middleware in the shape Agno already defines: it
receives `function_name`, `function_call` and `arguments`, invokes the callable, and
records the outcome. Failures are recorded as evidence and then re-raised unchanged, so
Agno's own error handling is untouched, and a recording failure is swallowed rather than
raised into the tool path, so capture can never break an agent.

Nothing in `libs/agno` changes. The integration itself lives in the `provenrail` package
(`pip install provenrail`, MIT-licensed client and verifier), so this PR adds no dependency
to Agno.

**Honest scope**, stated in the example itself: this proves that whatever was recorded has
not been altered. It does not prove completeness, since an agent that never invokes a tool
cannot be recorded by a hook. That limit is written into the example rather than glossed over.

## Type of change

- [x] Other: cookbook example

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format` and `ruff check` against
      `cookbook/observability/provenrail_op.py`; the repo-wide scripts require the full
      dev venv, so the added file was formatted and linted with the same rules)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**AI disclosure.** Per the contributing guidelines: this PR was written with Claude Code.
It has been reviewed and verified by the author rather than submitted unread. The
verification is concrete:

- The hook was executed against **real Agno 2.8.5** (not a mock): `Function.from_callable`
  plus `FunctionCall(...).execute()`, on both a succeeding and a raising tool. Agno reported
  `status="success"` and `status="failure"` respectively, and both calls appeared in the
  signed record.
- The resulting bundle was verified end to end with the standalone verifier, which recomputes
  every hash and signature from scratch: `RESULT: VERIFIED`.
- The hook parameter names were checked against Agno's actual source rather than the docs.
  `FunctionCall._build_hook_args` resolves hooks by parameter name and invokes them
  keyword-only, so `function_name` / `function_call` / `arguments` are load-bearing. There is
  a regression test asserting Agno still supplies exactly those three names, so a rename on
  either side fails loudly instead of silently dropping capture.
- 13 tests cover the integration in the provenrail repo (success, failure, async, non-dict
  arguments, idempotent instrumentation, and a capture-failure path proving the tool's
  return value still reaches the agent when the sink is down).
- The cookbook file itself was imported and executed against a real `Agent` with its
  `tool_hooks` wired as written, confirming both tools are captured in order.

Happy to adjust the placement, trim the docstring, or drop the README line if you would
rather keep that list manual.
