### PR TITLE
chore: release 2.8.6

### DIFF
--- a/libs/agno/agno/client/os.py
+++ b/libs/agno/agno/client/os.py
@@ -34,7 +34,12 @@ from agno.os.routers.memory.schemas import (
     UserMemorySchema,
     UserStatsSchema,
 )
-from agno.os.routers.metrics.schemas import DayAggregatedMetrics, MetricsRefreshResponse, MetricsResponse
+from agno.os.routers.metrics.schemas import (
+    DayAggregatedMetrics,
+    MetricsRefreshResponse,
+    MetricsRefreshStatusResponse,
+    MetricsResponse,
+)
 from agno.os.routers.teams.schema import TeamResponse
 from agno.os.routers.traces.schemas import (
     TraceDetail,
@@ -3001,3 +3006,34 @@ class AgentOSClient:
         if isinstance(data, list):
             return [DayAggregatedMetrics.model_validate(m) for m in data]
         return MetricsRefreshResponse.model_validate(data)
+
+    async def get_metrics_refresh_status(
+        self,
+        db_id: Optional[str] = None,
+        table: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> MetricsRefreshStatusResponse:
+        """Get the status of the most recent metrics refresh for the target database.
+
+        Returns 'running' while a refresh is in progress, then 'completed' or 'failed'
+        with the finish timestamp. The state updates even when a refresh completes
+        without writing new data. Returns 'idle' if no refresh has been triggered
+        since the server process started. Intended for polling after starting a
+        background refresh via refresh_metrics(background=True).
+
+        Args:
+            db_id: Optional database ID to use
+            table: Optional database table to use
+            headers: HTTP headers to include in the request (optional)
+
+        Returns:
+            MetricsRefreshStatusResponse: Status of the most recent refresh
+
+        Raises:
+            HTTPStatusError: On HTTP errors
+        """
+        params: Dict[str, Any] = {"db_id": db_id, "table": table}
+        params = {k: v for k, v in params.items() if v is not None}
+
+        data = await self._aget("/metrics/refresh/status", params=params, headers=headers)
+        return MetricsRefreshStatusResponse.model_validate(data)

--- a/libs/agno/agno/os/routers/metrics/metrics.py
+++ b/libs/agno/agno/os/routers/metrics/metrics.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import date
+from datetime import date, datetime, timezone
 from typing import List, Optional, Union
 
 from fastapi import BackgroundTasks, Depends, HTTPException, Query, Request, Response
@@ -8,7 +8,12 @@ from starlette.concurrency import run_in_threadpool
 
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
-from agno.os.routers.metrics.schemas import DayAggregatedMetrics, MetricsRefreshResponse, MetricsResponse
+from agno.os.routers.metrics.schemas import (
+    DayAggregatedMetrics,
+    MetricsRefreshResponse,
+    MetricsRefreshStatusResponse,
+    MetricsResponse,
+)
 from agno.os.schema import (
     BadRequestResponse,
     InternalServerErrorResponse,
@@ -129,9 +134,10 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Error getting metrics: {str(e)}")
 
-    # Databases with a refresh currently in flight, keyed by db id. Only mutated on the
-    # event loop (the sync calculation itself runs in the threadpool), so no lock is needed.
-    refreshes_in_flight: set[str] = set()
+    # Most recent refresh state per db id, doubling as the in-flight guard ('running').
+    # Only mutated on the event loop (the sync calculation itself runs in the threadpool),
+    # so no lock is needed. Per-process: each worker tracks the refreshes it started.
+    refresh_states: dict[str, MetricsRefreshStatusResponse] = {}
 
     async def _do_refresh(
         db: Union[BaseDb, AsyncBaseDb, RemoteDb],
@@ -139,6 +145,10 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
         table: Optional[str],
         headers: Optional[dict],
     ) -> None:
+        refresh_key = str(db.id)
+        current_state = refresh_states.get(refresh_key)
+        started_at = current_state.started_at if current_state else None
+        final_state = MetricsRefreshStatusResponse(status="completed", started_at=started_at)
         try:
             if isinstance(db, RemoteDb):
                 await db.refresh_metrics(db_id=db_id, table=table, headers=headers, background=True)
@@ -148,8 +158,10 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 await run_in_threadpool(db.calculate_metrics)
         except Exception as e:
             logger.error(f"Metrics refresh failed: {e}")
+            final_state = MetricsRefreshStatusResponse(status="failed", started_at=started_at, error=str(e))
         finally:
-            refreshes_in_flight.discard(str(db.id))
+            final_state.finished_at = datetime.now(timezone.utc)
+            refresh_states[refresh_key] = final_state
 
     @router.post(
         "/metrics/refresh",
@@ -228,12 +240,15 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
             if background:
                 response.status_code = 202
                 refresh_key = str(db.id)
-                if refresh_key in refreshes_in_flight:
+                current_state = refresh_states.get(refresh_key)
+                if current_state is not None and current_state.status == "running":
                     return MetricsRefreshResponse(
                         status="already_running", message="A metrics refresh is already in progress for this database"
                     )
 
-                refreshes_in_flight.add(refresh_key)
+                refresh_states[refresh_key] = MetricsRefreshStatusResponse(
+                    status="running", started_at=datetime.now(timezone.utc)
+                )
                 background_tasks.add_task(_do_refresh, db, db_id, table, headers)
 
                 return MetricsRefreshResponse(status="started", message="Metrics refresh started in background")
@@ -252,5 +267,61 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
 
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Error refreshing metrics: {str(e)}")
+
+    @router.get(
+        "/metrics/refresh/status",
+        response_model=MetricsRefreshStatusResponse,
+        status_code=200,
+        operation_id="get_metrics_refresh_status",
+        summary="Get Metrics Refresh Status",
+        description=(
+            "Get the status of the most recent metrics refresh for the target database. "
+            "Returns 'running' while a refresh is in progress, then 'completed' or 'failed' with "
+            "the finish timestamp — the state updates even when a refresh completes without "
+            "writing new data. Returns 'idle' if no refresh has been triggered since this server "
+            "process started. For remote databases the status is fetched from the remote AgentOS. "
+            "Intended for polling after starting a background refresh via POST /metrics/refresh?background=true."
+        ),
+        responses={
+            200: {
+                "description": "Current refresh status",
+                "content": {
+                    "application/json": {
+                        "example": {
+                            "status": "completed",
+                            "started_at": "2025-08-12T08:01:47Z",
+                            "finished_at": "2025-08-12T08:01:49Z",
+                            "error": None,
+                        }
+                    }
+                },
+            },
+            400: {"description": "Invalid request", "model": BadRequestResponse},
+            404: {"description": "Database not found", "model": NotFoundResponse},
+            500: {"description": "Failed to get refresh status", "model": InternalServerErrorResponse},
+        },
+    )
+    async def get_metrics_refresh_status(
+        request: Request,
+        db_id: Optional[str] = Query(default=None, description="Database ID to get the refresh status for"),
+        table: Optional[str] = Query(default=None, description="Table to get the refresh status for"),
+    ) -> MetricsRefreshStatusResponse:
+        try:
+            db = await get_db(dbs, db_id, table)
+
+            if isinstance(db, RemoteDb):
+                auth_token = get_auth_token_from_request(request)
+                headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else None
+                return await db.get_metrics_refresh_status(db_id=db_id, table=table, headers=headers)
+
+            state = refresh_states.get(str(db.id))
+            if state is None:
+                return MetricsRefreshStatusResponse(status="idle")
+            return state
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Error getting metrics refresh status: {str(e)}")
 
     return router

--- a/libs/agno/agno/os/routers/metrics/schemas.py
+++ b/libs/agno/agno/os/routers/metrics/schemas.py
@@ -54,3 +54,10 @@ class MetricsResponse(BaseModel):
 class MetricsRefreshResponse(BaseModel):
     status: str = Field(..., description="Status of the refresh request")
     message: Optional[str] = Field(None, description="Additional details")
+
+
+class MetricsRefreshStatusResponse(BaseModel):
+    status: str = Field(..., description="Refresh status: 'idle', 'running', 'completed' or 'failed'")
+    started_at: Optional[datetime] = Field(None, description="When the most recent refresh started")
+    finished_at: Optional[datetime] = Field(None, description="When the most recent refresh finished")
+    error: Optional[str] = Field(None, description="Error message if the most recent refresh failed")

--- a/libs/agno/agno/remote/base.py
+++ b/libs/agno/agno/remote/base.py
@@ -28,7 +28,12 @@ if TYPE_CHECKING:
         VectorSearchResult,
     )
     from agno.os.routers.memory.schemas import OptimizeMemoriesResponse, UserMemorySchema, UserStatsSchema
-    from agno.os.routers.metrics.schemas import DayAggregatedMetrics, MetricsRefreshResponse, MetricsResponse
+    from agno.os.routers.metrics.schemas import (
+        DayAggregatedMetrics,
+        MetricsRefreshResponse,
+        MetricsRefreshStatusResponse,
+        MetricsResponse,
+    )
     from agno.os.routers.traces.schemas import TraceDetail, TraceNode, TraceSessionStats, TraceSummary
     from agno.os.schema import (
         AgentSessionDetailSchema,
@@ -249,6 +254,9 @@ class RemoteDb:
 
     async def refresh_metrics(self, **kwargs: Any) -> Union[List["DayAggregatedMetrics"], "MetricsRefreshResponse"]:
         return await self.client.refresh_metrics(**kwargs)
+
+    async def get_metrics_refresh_status(self, **kwargs: Any) -> "MetricsRefreshStatusResponse":
+        return await self.client.get_metrics_refresh_status(**kwargs)
 
     # OTHER
     async def migrate_database(self, target_version: Optional[str] = None) -> None:

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
 
 # AgentOS server bundle
 os = ["fastapi", "python-multipart>=0.0.18", "uvicorn", "websockets", "sqlalchemy", "PyJWT", "opentelemetry-sdk", "openinference-instrumentation-agno", "agno[scheduler]"]
-mcp = ["mcp>=1.9.2", "fastmcp>=3.4.3,<4"]
+mcp = ["mcp>=1.9.2,<2", "fastmcp>=3.4.3,<4"]
 scheduler = ["croniter>=1.3", "pytz>=2023.3"]
 
 # Dependencies for Telemetry

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "2.8.5"
+version = "2.8.6"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"

--- a/libs/agno/tests/system/Dockerfile.gateway
+++ b/libs/agno/tests/system/Dockerfile.gateway
@@ -34,7 +34,7 @@ RUN pip install --no-cache-dir \
     opentelemetry-sdk \
     openinference-instrumentation-agno \
     PyJWT \
-    mcp \
+    "mcp<2" \
     fastmcp \
     "a2a-sdk>=0.3.0,<1.0" \
     agui \

--- a/libs/agno/tests/system/Dockerfile.remote
+++ b/libs/agno/tests/system/Dockerfile.remote
@@ -34,7 +34,7 @@ RUN pip install --no-cache-dir \
     opentelemetry-sdk \
     openinference-instrumentation-agno \
     PyJWT \
-    mcp \
+    "mcp<2" \
     fastmcp \
     "a2a-sdk>=0.3.0,<1.0" \
     agui \

--- a/libs/agno/tests/system/requirements.txt
+++ b/libs/agno/tests/system/requirements.txt
@@ -8,7 +8,7 @@ httpx>=0.27.0
 httpx[http2]>=0.27.0
 python-dotenv>=1.0.0
 PyJWT>=2.8.0
-mcp>=1.0.0
+mcp>=1.0.0,<2
 fastmcp>=2.0.0
 sqlalchemy
 psycopg-binary

--- a/libs/agno/tests/system/tests/test_metrics_routes.py
+++ b/libs/agno/tests/system/tests/test_metrics_routes.py
@@ -4,6 +4,7 @@ System Tests for AgentOS Metrics Routes.
 Run with: pytest test_metrics_routes.py -v --tb=short
 """
 
+import time
 import uuid
 
 import httpx
@@ -136,6 +137,29 @@ class TestLocalMetricsRoutes:
         assert data["status"] in ("started", "already_running")
         assert "message" in data
 
+    def test_refresh_metrics_background_status_reaches_completed(
+        self, client: httpx.Client, generate_metrics_data: dict
+    ):
+        """Test GET /metrics/refresh/status reports completion after a background refresh for local db."""
+        response = client.post(f"/metrics/refresh?db_id={self.DB_ID}&background=true")
+        assert response.status_code == 202
+
+        data = {}
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            status_response = client.get(f"/metrics/refresh/status?db_id={self.DB_ID}")
+            assert status_response.status_code == 200
+            data = status_response.json()
+            assert data["status"] in ("running", "completed", "failed")
+            if data["status"] != "running":
+                break
+            time.sleep(0.5)
+
+        assert data["status"] == "completed"
+        assert data["started_at"] is not None
+        assert data["finished_at"] is not None
+        assert data["error"] is None
+
 
 class TestRemoteMetricsRoutes:
     """Test metrics routes with remote database (remote-db)."""
@@ -239,3 +263,26 @@ class TestRemoteMetricsRoutes:
 
         assert data["status"] in ("started", "already_running")
         assert "message" in data
+
+    def test_refresh_metrics_background_status_reaches_completed(
+        self, client: httpx.Client, generate_metrics_data: dict
+    ):
+        """Test GET /metrics/refresh/status reports completion after a background refresh for remote db."""
+        response = client.post(f"/metrics/refresh?db_id={self.DB_ID}&background=true")
+        assert response.status_code == 202
+
+        data = {}
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            status_response = client.get(f"/metrics/refresh/status?db_id={self.DB_ID}")
+            assert status_response.status_code == 200
+            data = status_response.json()
+            assert data["status"] in ("running", "completed", "failed")
+            if data["status"] != "running":
+                break
+            time.sleep(0.5)
+
+        assert data["status"] == "completed"
+        assert data["started_at"] is not None
+        assert data["finished_at"] is not None
+        assert data["error"] is None


### PR DESCRIPTION
## New Features

- **Smallest AI**: Added `SmallestTools`, a text-to-speech toolkit for Smallest AI with `text_to_speech` (returns audio as a `ToolResult` artifact, optionally saved to disk) and `get_voices`. Supports the `lightning_v3.1` and `lightning_v3.1_pro` models.
- **AgentOS**: Added `GET /metrics/refresh/status` to observe background metrics refreshes:
    - Reports `idle`, `running`, `completed` or `failed` with `started_at`, `finished_at` and `error`, so clients can poll for completion instead of timing out silently. The state updates even when a refresh finishes without writing new data.
    - Available on the client as `AgentOSClient.get_metrics_refresh_status()`
- **OpenSearch**: Added `OpenSearch` vector database support (`agno.vectordb.opensearch`) with vector, keyword and hybrid search in both sync and async variants, installable via the `agno[opensearch]` extra. Includes cookbook examples and a `run_opensearch.sh` script for local setup.

## Improvements

- **Tools**: Cached the Pydantic version lookup during tool wrapping. The package metadata was re-read on every wrap, which made repeated tool wrapping a hot path (100-wrap benchmark: 65.9 ms to 11.0 ms).

## Bug Fixes

- **AgentOS**: `POST /metrics/refresh` no longer blocks uvicorn workers on large datasets:
    - The sync `calculate_metrics()` call now runs in the threadpool, so other requests keep flowing during a refresh. Same 200 + metrics list response as before.
    - New opt-in `?background=true` query param returns 202 immediately and runs the refresh as a background task. Background refreshes are single-flight per database.
    - `GET /metrics` with a sync `BaseDb` also moves its lazy refresh to the threadpool.
- **Encoding**: Text-mode `open()` calls now pass explicit `encoding="utf-8"`, so JSON cache and config files written on one platform stay readable on another (Windows defaults to `cp1252`).