### PR TITLE
[cookbook] Add OSOP workflow example for Agno agent patterns

### DIFF
--- a/cookbook/05_agent_os/26_osop_workflow/README.md
+++ b/cookbook/05_agent_os/26_osop_workflow/README.md
@@ -6,7 +6,7 @@ same workflow with Agno.
 
 ## What is OSOP?
 
-**OSOP** (Open Standard for Orchestration Protocols) is a YAML-based format for
+**OSOP** (Open Standard Operating Process) is a YAML-based format for
 describing multi-step workflows in a tool-agnostic way. Think of it as the
 *OpenAPI of workflows*: a single `.osop` file says what your agent does, so
 teams can share, review, and port agent workflows across frameworks (Agno,

--- a/cookbook/05_agent_os/26_osop_workflow/README.md
+++ b/cookbook/05_agent_os/26_osop_workflow/README.md
@@ -48,7 +48,7 @@ ordered `Step`s inside a `Workflow`; the whole graph is served by `AgentOS`.
 export OPENAI_API_KEY=sk-...
 
 # 2. Install dependencies
-pip install agno duckduckgo-search
+pip install agno duckduckgo-search openai sqlalchemy fastapi python-multipart
 
 # 3. Run
 python cookbook/05_agent_os/26_osop_workflow/research_workflow.py

--- a/cookbook/05_agent_os/26_osop_workflow/README.md
+++ b/cookbook/05_agent_os/26_osop_workflow/README.md
@@ -1,54 +1,69 @@
-# Research Agent Workflow — OSOP Example
+# Research Agent Workflow in OSOP Format
+# OSOP = Open Standard Operating Process
+# Spec: https://github.com/Archie0125/osop-spec
+#
+# This is the PORTABLE definition of the workflow. It describes WHAT should
+# happen, step by step, in a tool-agnostic way. The same .osop file can be
+# understood by any compatible runtime (Agno, LangChain, CrewAI, ...).
+# The runnable Agno implementation lives in research_workflow.py.
 
-This folder shows how to express an **Agno agent pattern** as a portable
-[OSOP](https://github.com/Archie0125/osop-spec) workflow, and how to run the
-same workflow with Agno.
+osop_version: "1.0"
+id: agno-research-agent
+name: Agno Research Agent Workflow
+description: A multi-step research agent — web search, analysis, and report generation — expressed as a portable OSOP workflow.
+tags: [agno, agent, research, web-search, osop]
 
-## What is OSOP?
+nodes:
+  - id: user-request
+    type: human
+    name: User Request
+    description: User provides a research topic or question.
 
-**OSOP** (Open Standard Operating Process) is a YAML-based format for
-describing multi-step workflows in a tool-agnostic way. Think of it as the
-*OpenAPI of workflows*: a single `.osop` file says what your agent does, so
-teams can share, review, and port agent workflows across frameworks (Agno,
-LangChain, CrewAI, …).
+  - id: web-search
+    type: agent
+    name: Web Search Agent
+    description: Search the web for relevant, up-to-date information on the topic.
+    runtime:
+      provider: openai
+      model: gpt-4o
+      config:
+        tools: [duckduckgo_search]
 
-An OSOP file has two parts:
+  - id: analyze
+    type: agent
+    name: Analysis Agent
+    description: Analyze the search results and extract the key insights.
+    runtime:
+      provider: openai
+      model: gpt-4o
+      config:
+        temperature: 0.2
 
-- **`nodes`** — the steps. Core node types: `agent`, `api`, `cli`, `human`.
-- **`edges`** — the connections. Core edge modes: `sequential`,
-  `conditional`, `parallel`, `fallback`.
+  - id: generate-report
+    type: agent
+    name: Report Generator
+    description: Compile the findings into a structured research report.
+    runtime:
+      provider: openai
+      model: gpt-4o
+      config:
+        temperature: 0.5
 
-## What's in this folder
+  - id: deliver
+    type: api
+    name: Deliver Report
+    description: Return the final report to the user.
 
-| File | Purpose |
-|------|---------|
-| `research_workflow.osop` | The portable OSOP definition of a research agent. |
-| `research_workflow.py` | The runnable Agno implementation of the same workflow. |
-
-## The workflow
-
-User Request → Web Search Agent → Analysis Agent → Report Generator → Deliver
-
-
-| OSOP Node | OSOP Type | Agno Equivalent |
-|-----------|-----------|-----------------|
-| user-request | `human` | The message you type in the UI/API |
-| web-search | `agent` | `Agent(tools=[DuckDuckGoTools()])` |
-| analyze | `agent` | `Agent` with analysis instructions |
-| generate-report | `agent` | `Agent` with report instructions |
-| deliver | `api` | Output returned to the user |
-
-Each OSOP `agent` node becomes an `Agent`; the `sequential` edges become
-ordered `Step`s inside a `Workflow`; the whole graph is served by `AgentOS`.
-
-## Run the Agno version
-
-```bash
-# 1. Set your key
-export OPENAI_API_KEY=sk-...
-
-# 2. Install dependencies
-pip install agno duckduckgo-search openai sqlalchemy fastapi python-multipart
-
-# 3. Run
-python cookbook/05_agent_os/26_osop_workflow/research_workflow.py
+edges:
+  - from: user-request
+    to: web-search
+    mode: sequential
+  - from: web-search
+    to: analyze
+    mode: sequential
+  - from: analyze
+    to: generate-report
+    mode: sequential
+  - from: generate-report
+    to: deliver
+    mode: sequential

--- a/cookbook/05_agent_os/26_osop_workflow/README.md
+++ b/cookbook/05_agent_os/26_osop_workflow/README.md
@@ -1,69 +1,51 @@
-# Research Agent Workflow in OSOP Format
-# OSOP = Open Standard Operating Process
-# Spec: https://github.com/Archie0125/osop-spec
-#
-# This is the PORTABLE definition of the workflow. It describes WHAT should
-# happen, step by step, in a tool-agnostic way. The same .osop file can be
-# understood by any compatible runtime (Agno, LangChain, CrewAI, ...).
-# The runnable Agno implementation lives in research_workflow.py.
+# Research Agent Workflow — OSOP Example
 
-osop_version: "1.0"
-id: agno-research-agent
-name: Agno Research Agent Workflow
-description: A multi-step research agent — web search, analysis, and report generation — expressed as a portable OSOP workflow.
-tags: [agno, agent, research, web-search, osop]
+This folder shows how to express an **Agno agent pattern** as a portable
+[OSOP](https://github.com/Archie0125/osop-spec) workflow, and how to run the
+same workflow with Agno.
 
-nodes:
-  - id: user-request
-    type: human
-    name: User Request
-    description: User provides a research topic or question.
+## What is OSOP?
 
-  - id: web-search
-    type: agent
-    name: Web Search Agent
-    description: Search the web for relevant, up-to-date information on the topic.
-    runtime:
-      provider: openai
-      model: gpt-4o
-      config:
-        tools: [duckduckgo_search]
+**OSOP** (Open Standard Operating Process) is a YAML-based format for
+describing multi-step workflows in a tool-agnostic way. Think of it as the
+*OpenAPI of workflows*: a single `.osop` file says what your agent does, so
+teams can share, review, and port agent workflows across frameworks (Agno,
+LangChain, CrewAI, …).
 
-  - id: analyze
-    type: agent
-    name: Analysis Agent
-    description: Analyze the search results and extract the key insights.
-    runtime:
-      provider: openai
-      model: gpt-4o
-      config:
-        temperature: 0.2
+An OSOP file has two parts:
 
-  - id: generate-report
-    type: agent
-    name: Report Generator
-    description: Compile the findings into a structured research report.
-    runtime:
-      provider: openai
-      model: gpt-4o
-      config:
-        temperature: 0.5
+- **`nodes`** — the steps. Core node types: `agent`, `api`, `cli`, `human`.
+- **`edges`** — the connections. Core edge modes: `sequential`,
+  `conditional`, `parallel`, `fallback`.
 
-  - id: deliver
-    type: api
-    name: Deliver Report
-    description: Return the final report to the user.
+## What's in this folder
 
-edges:
-  - from: user-request
-    to: web-search
-    mode: sequential
-  - from: web-search
-    to: analyze
-    mode: sequential
-  - from: analyze
-    to: generate-report
-    mode: sequential
-  - from: generate-report
-    to: deliver
-    mode: sequential
+| File | Purpose |
+|------|---------|
+| `research_workflow.osop` | The portable OSOP definition of a research agent. |
+| `research_workflow.py` | The runnable Agno implementation of the same workflow. |
+
+## The workflow
+
+| OSOP Node | OSOP Type | Agno Equivalent |
+|-----------|-----------|-----------------|
+| user-request | `human` | The message you type in the UI/API |
+| web-search | `agent` | `Agent(tools=[DuckDuckGoTools()])` |
+| analyze | `agent` | `Agent` with analysis instructions |
+| generate-report | `agent` | `Agent` with report instructions |
+| deliver | `api` | Output returned to the user |
+
+Each OSOP `agent` node becomes an `Agent`; the `sequential` edges become
+ordered `Step`s inside a `Workflow`; the whole graph is served by `AgentOS`.
+
+## Run the Agno version
+
+```bash
+# 1. Set your key
+export OPENAI_API_KEY=sk-...
+
+# 2. Install dependencies
+pip install agno duckduckgo-search openai sqlalchemy fastapi python-multipart
+
+# 3. Run
+python cookbook/05_agent_os/26_osop_workflow/research_workflow.py

--- a/cookbook/05_agent_os/26_osop_workflow/README.md
+++ b/cookbook/05_agent_os/26_osop_workflow/README.md
@@ -1,0 +1,54 @@
+# Research Agent Workflow — OSOP Example
+
+This folder shows how to express an **Agno agent pattern** as a portable
+[OSOP](https://github.com/Archie0125/osop-spec) workflow, and how to run the
+same workflow with Agno.
+
+## What is OSOP?
+
+**OSOP** (Open Standard for Orchestration Protocols) is a YAML-based format for
+describing multi-step workflows in a tool-agnostic way. Think of it as the
+*OpenAPI of workflows*: a single `.osop` file says what your agent does, so
+teams can share, review, and port agent workflows across frameworks (Agno,
+LangChain, CrewAI, …).
+
+An OSOP file has two parts:
+
+- **`nodes`** — the steps. Core node types: `agent`, `api`, `cli`, `human`.
+- **`edges`** — the connections. Core edge modes: `sequential`,
+  `conditional`, `parallel`, `fallback`.
+
+## What's in this folder
+
+| File | Purpose |
+|------|---------|
+| `research_workflow.osop` | The portable OSOP definition of a research agent. |
+| `research_workflow.py` | The runnable Agno implementation of the same workflow. |
+
+## The workflow
+
+User Request → Web Search Agent → Analysis Agent → Report Generator → Deliver
+
+
+| OSOP Node | OSOP Type | Agno Equivalent |
+|-----------|-----------|-----------------|
+| user-request | `human` | The message you type in the UI/API |
+| web-search | `agent` | `Agent(tools=[DuckDuckGoTools()])` |
+| analyze | `agent` | `Agent` with analysis instructions |
+| generate-report | `agent` | `Agent` with report instructions |
+| deliver | `api` | Output returned to the user |
+
+Each OSOP `agent` node becomes an `Agent`; the `sequential` edges become
+ordered `Step`s inside a `Workflow`; the whole graph is served by `AgentOS`.
+
+## Run the Agno version
+
+```bash
+# 1. Set your key
+export OPENAI_API_KEY=sk-...
+
+# 2. Install dependencies
+pip install agno duckduckgo-search
+
+# 3. Run
+python cookbook/05_agent_os/26_osop_workflow/research_workflow.py

--- a/cookbook/05_agent_os/26_osop_workflow/research_workflow.osop
+++ b/cookbook/05_agent_os/26_osop_workflow/research_workflow.osop
@@ -1,5 +1,5 @@
 # Research Agent Workflow in OSOP Format
-# OSOP = Open Standard for Orchestration Protocols
+# OSOP = Open Standard Operating Process
 # Spec: https://github.com/Archie0125/osop-spec
 #
 # This is the PORTABLE definition of the workflow. It describes WHAT should

--- a/cookbook/05_agent_os/26_osop_workflow/research_workflow.osop
+++ b/cookbook/05_agent_os/26_osop_workflow/research_workflow.osop
@@ -1,0 +1,138 @@
+"""
+OSOP Workflow Example — Research Agent (Agno implementation)
+=============================================================
+
+This file is the RUNNABLE Agno equivalent of ``research_workflow.osop``.
+
+It shows how an OSOP workflow (a portable YAML description) maps onto Agno
+agent patterns:
+
+* every OSOP ``agent`` node  -> an ``agno.agent.Agent``
+* every OSOP ``sequential`` edge -> an ordered ``agno.workflow.Step``
+* the whole graph            -> an ``agno.workflow.Workflow`` served by ``AgentOS``
+
+Prerequisites
+-------------
+    export OPENAI_API_KEY=sk-...
+
+Run
+---
+    python cookbook/05_agent_os/26_osop_workflow/research_workflow.py
+
+Then open the AgentOS UI at http://localhost:7777 and type your research
+question — that is the OSOP ``human`` node (user-request).
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.tools.duckduckgo import DuckDuckGoTools
+from agno.workflow import Step, Workflow
+
+# ---------------------------------------------------------------------------
+# Database — persists session history for the workflow
+# ---------------------------------------------------------------------------
+db = SqliteDb(
+    id="osop-research-db",
+    db_file="tmp/osop_research.db",
+)
+
+# ---------------------------------------------------------------------------
+# Agents — one per OSOP `agent` node
+# ---------------------------------------------------------------------------
+web_search_agent = Agent(
+    id="web-search-agent",
+    name="Web Search Agent",
+    model=OpenAIResponses(id="gpt-4o"),
+    tools=[DuckDuckGoTools()],
+    instructions=(
+        "You are a web research agent. Given a research topic, search the web "
+        "and return the most relevant, up-to-date facts together with their sources."
+    ),
+    markdown=True,
+)
+
+analysis_agent = Agent(
+    id="analysis-agent",
+    name="Analysis Agent",
+    model=OpenAIResponses(id="gpt-4o"),
+    instructions=(
+        "You are an analysis agent. Given raw search results, extract the key "
+        "insights, note agreements and disagreements, and summarize what matters."
+    ),
+    markdown=True,
+)
+
+report_agent = Agent(
+    id="report-agent",
+    name="Report Generator",
+    model=OpenAIResponses(id="gpt-4o"),
+    instructions=(
+        "You are a report writer. Given the analyzed insights, produce a clear, "
+        "structured research report with a heading and a few short sections."
+    ),
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Workflow — OSOP `sequential` edges become ordered Steps
+# ---------------------------------------------------------------------------
+research_workflow = Workflow(
+    id="osop-research-workflow",
+    name="Research Agent Workflow",
+    description="Web search -> analysis -> report generation.",
+    db=db,
+    steps=[
+        Step(name="Web Search", agent=web_search_agent),
+        Step(name="Analysis", agent=analysis_agent),
+        Step(name="Generate Report", agent=report_agent),
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# AgentOS — serves the workflow over HTTP (discovery, streaming, UI)
+# ---------------------------------------------------------------------------
+agent_os = AgentOS(
+    id="osop-research-os",
+    description="AgentOS serving the OSOP research workflow.",
+    db=db,
+    workflows=[research_workflow],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    # The `human` node (user-request) is simply the message you type in the UI/API.
+    agent_os.serve(app=app)
+点 Commit changes → 再点 Commit changes
+
+同样方法，再建一个文件，文件名 README.md，粘贴这段：
+
+# Research Agent Workflow — OSOP Example
+
+This folder shows how to express an **Agno agent pattern** as a portable
+[OSOP](https://github.com/Archie0125/osop-spec) workflow, and how to run the
+same workflow with Agno.
+
+## What is OSOP?
+
+**OSOP** (Open Standard for Orchestration Protocols) is a YAML-based format for
+describing multi-step workflows in a tool-agnostic way. Think of it as the
+*OpenAPI of workflows*: a single `.osop` file says what your agent does, so
+teams can share, review, and port agent workflows across frameworks (Agno,
+LangChain, CrewAI, …).
+
+An OSOP file has two parts:
+
+- **`nodes`** — the steps. Core node types: `agent`, `api`, `cli`, `human`.
+- **`edges`** — the connections. Core edge modes: `sequential`,
+  `conditional`, `parallel`, `fallback`.
+
+## What's in this folder
+
+| File | Purpose |
+|------|---------|
+| `research_workflow.osop` | The portable OSOP definition of a research agent. |
+| `research_workflow.py` | The runnable Agno implementation of the same workflow. |
+
+## The workflow

--- a/cookbook/05_agent_os/26_osop_workflow/research_workflow.osop
+++ b/cookbook/05_agent_os/26_osop_workflow/research_workflow.osop
@@ -1,138 +1,69 @@
-"""
-OSOP Workflow Example — Research Agent (Agno implementation)
-=============================================================
+# Research Agent Workflow in OSOP Format
+# OSOP = Open Standard for Orchestration Protocols
+# Spec: https://github.com/Archie0125/osop-spec
+#
+# This is the PORTABLE definition of the workflow. It describes WHAT should
+# happen, step by step, in a tool-agnostic way. The same .osop file can be
+# understood by any compatible runtime (Agno, LangChain, CrewAI, ...).
+# The runnable Agno implementation lives in research_workflow.py.
 
-This file is the RUNNABLE Agno equivalent of ``research_workflow.osop``.
+osop_version: "1.0"
+id: agno-research-agent
+name: Agno Research Agent Workflow
+description: A multi-step research agent — web search, analysis, and report generation — expressed as a portable OSOP workflow.
+tags: [agno, agent, research, web-search, osop]
 
-It shows how an OSOP workflow (a portable YAML description) maps onto Agno
-agent patterns:
+nodes:
+  - id: user-request
+    type: human
+    name: User Request
+    description: User provides a research topic or question.
 
-* every OSOP ``agent`` node  -> an ``agno.agent.Agent``
-* every OSOP ``sequential`` edge -> an ordered ``agno.workflow.Step``
-* the whole graph            -> an ``agno.workflow.Workflow`` served by ``AgentOS``
+  - id: web-search
+    type: agent
+    name: Web Search Agent
+    description: Search the web for relevant, up-to-date information on the topic.
+    runtime:
+      provider: openai
+      model: gpt-4o
+      config:
+        tools: [duckduckgo_search]
 
-Prerequisites
--------------
-    export OPENAI_API_KEY=sk-...
+  - id: analyze
+    type: agent
+    name: Analysis Agent
+    description: Analyze the search results and extract the key insights.
+    runtime:
+      provider: openai
+      model: gpt-4o
+      config:
+        temperature: 0.2
 
-Run
----
-    python cookbook/05_agent_os/26_osop_workflow/research_workflow.py
+  - id: generate-report
+    type: agent
+    name: Report Generator
+    description: Compile the findings into a structured research report.
+    runtime:
+      provider: openai
+      model: gpt-4o
+      config:
+        temperature: 0.5
 
-Then open the AgentOS UI at http://localhost:7777 and type your research
-question — that is the OSOP ``human`` node (user-request).
-"""
+  - id: deliver
+    type: api
+    name: Deliver Report
+    description: Return the final report to the user.
 
-from agno.agent import Agent
-from agno.db.sqlite import SqliteDb
-from agno.models.openai import OpenAIResponses
-from agno.os import AgentOS
-from agno.tools.duckduckgo import DuckDuckGoTools
-from agno.workflow import Step, Workflow
-
-# ---------------------------------------------------------------------------
-# Database — persists session history for the workflow
-# ---------------------------------------------------------------------------
-db = SqliteDb(
-    id="osop-research-db",
-    db_file="tmp/osop_research.db",
-)
-
-# ---------------------------------------------------------------------------
-# Agents — one per OSOP `agent` node
-# ---------------------------------------------------------------------------
-web_search_agent = Agent(
-    id="web-search-agent",
-    name="Web Search Agent",
-    model=OpenAIResponses(id="gpt-4o"),
-    tools=[DuckDuckGoTools()],
-    instructions=(
-        "You are a web research agent. Given a research topic, search the web "
-        "and return the most relevant, up-to-date facts together with their sources."
-    ),
-    markdown=True,
-)
-
-analysis_agent = Agent(
-    id="analysis-agent",
-    name="Analysis Agent",
-    model=OpenAIResponses(id="gpt-4o"),
-    instructions=(
-        "You are an analysis agent. Given raw search results, extract the key "
-        "insights, note agreements and disagreements, and summarize what matters."
-    ),
-    markdown=True,
-)
-
-report_agent = Agent(
-    id="report-agent",
-    name="Report Generator",
-    model=OpenAIResponses(id="gpt-4o"),
-    instructions=(
-        "You are a report writer. Given the analyzed insights, produce a clear, "
-        "structured research report with a heading and a few short sections."
-    ),
-    markdown=True,
-)
-
-# ---------------------------------------------------------------------------
-# Workflow — OSOP `sequential` edges become ordered Steps
-# ---------------------------------------------------------------------------
-research_workflow = Workflow(
-    id="osop-research-workflow",
-    name="Research Agent Workflow",
-    description="Web search -> analysis -> report generation.",
-    db=db,
-    steps=[
-        Step(name="Web Search", agent=web_search_agent),
-        Step(name="Analysis", agent=analysis_agent),
-        Step(name="Generate Report", agent=report_agent),
-    ],
-)
-
-# ---------------------------------------------------------------------------
-# AgentOS — serves the workflow over HTTP (discovery, streaming, UI)
-# ---------------------------------------------------------------------------
-agent_os = AgentOS(
-    id="osop-research-os",
-    description="AgentOS serving the OSOP research workflow.",
-    db=db,
-    workflows=[research_workflow],
-)
-app = agent_os.get_app()
-
-if __name__ == "__main__":
-    # The `human` node (user-request) is simply the message you type in the UI/API.
-    agent_os.serve(app=app)
-点 Commit changes → 再点 Commit changes
-
-同样方法，再建一个文件，文件名 README.md，粘贴这段：
-
-# Research Agent Workflow — OSOP Example
-
-This folder shows how to express an **Agno agent pattern** as a portable
-[OSOP](https://github.com/Archie0125/osop-spec) workflow, and how to run the
-same workflow with Agno.
-
-## What is OSOP?
-
-**OSOP** (Open Standard for Orchestration Protocols) is a YAML-based format for
-describing multi-step workflows in a tool-agnostic way. Think of it as the
-*OpenAPI of workflows*: a single `.osop` file says what your agent does, so
-teams can share, review, and port agent workflows across frameworks (Agno,
-LangChain, CrewAI, …).
-
-An OSOP file has two parts:
-
-- **`nodes`** — the steps. Core node types: `agent`, `api`, `cli`, `human`.
-- **`edges`** — the connections. Core edge modes: `sequential`,
-  `conditional`, `parallel`, `fallback`.
-
-## What's in this folder
-
-| File | Purpose |
-|------|---------|
-| `research_workflow.osop` | The portable OSOP definition of a research agent. |
-| `research_workflow.py` | The runnable Agno implementation of the same workflow. |
-
-## The workflow
+edges:
+  - from: user-request
+    to: web-search
+    mode: sequential
+  - from: web-search
+    to: analyze
+    mode: sequential
+  - from: analyze
+    to: generate-report
+    mode: sequential
+  - from: generate-report
+    to: deliver
+    mode: sequential

--- a/cookbook/05_agent_os/26_osop_workflow/research_workflow.py
+++ b/cookbook/05_agent_os/26_osop_workflow/research_workflow.py
@@ -1,0 +1,106 @@
+"""
+OSOP Workflow Example — Research Agent (Agno implementation)
+=============================================================
+
+This file is the RUNNABLE Agno equivalent of ``research_workflow.osop``.
+
+It shows how an OSOP workflow (a portable YAML description) maps onto Agno
+agent patterns:
+
+* every OSOP ``agent`` node  -> an ``agno.agent.Agent``
+* every OSOP ``sequential`` edge -> an ordered ``agno.workflow.Step``
+* the whole graph            -> an ``agno.workflow.Workflow`` served by ``AgentOS``
+
+Prerequisites
+-------------
+    export OPENAI_API_KEY=sk-...
+
+Run
+---
+    python cookbook/05_agent_os/26_osop_workflow/research_workflow.py
+
+Then open the AgentOS UI at http://localhost:7777 and type your research
+question — that is the OSOP ``human`` node (user-request).
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.tools.duckduckgo import DuckDuckGoTools
+from agno.workflow import Step, Workflow
+
+# ---------------------------------------------------------------------------
+# Database — persists session history for the workflow
+# ---------------------------------------------------------------------------
+db = SqliteDb(
+    id="osop-research-db",
+    db_file="tmp/osop_research.db",
+)
+
+# ---------------------------------------------------------------------------
+# Agents — one per OSOP `agent` node
+# ---------------------------------------------------------------------------
+web_search_agent = Agent(
+    id="web-search-agent",
+    name="Web Search Agent",
+    model=OpenAIResponses(id="gpt-4o"),
+    tools=[DuckDuckGoTools()],
+    instructions=(
+        "You are a web research agent. Given a research topic, search the web "
+        "and return the most relevant, up-to-date facts together with their sources."
+    ),
+    markdown=True,
+)
+
+analysis_agent = Agent(
+    id="analysis-agent",
+    name="Analysis Agent",
+    model=OpenAIResponses(id="gpt-4o"),
+    instructions=(
+        "You are an analysis agent. Given raw search results, extract the key "
+        "insights, note agreements and disagreements, and summarize what matters."
+    ),
+    markdown=True,
+)
+
+report_agent = Agent(
+    id="report-agent",
+    name="Report Generator",
+    model=OpenAIResponses(id="gpt-4o"),
+    instructions=(
+        "You are a report writer. Given the analyzed insights, produce a clear, "
+        "structured research report with a heading and a few short sections."
+    ),
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Workflow — OSOP `sequential` edges become ordered Steps
+# ---------------------------------------------------------------------------
+research_workflow = Workflow(
+    id="osop-research-workflow",
+    name="Research Agent Workflow",
+    description="Web search -> analysis -> report generation.",
+    db=db,
+    steps=[
+        Step(name="Web Search", agent=web_search_agent),
+        Step(name="Analysis", agent=analysis_agent),
+        Step(name="Generate Report", agent=report_agent),
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# AgentOS — serves the workflow over HTTP (discovery, streaming, UI)
+# ---------------------------------------------------------------------------
+agent_os = AgentOS(
+    id="osop-research-os",
+    description="AgentOS serving the OSOP research workflow.",
+    db=db,
+    workflows=[research_workflow],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    # The `human` node (user-request) is simply the message you type in the UI/API.
+    agent_os.serve(app=app)


### PR DESCRIPTION
fixes #7293

Adds an OSOP workflow example demonstrating Agno agent patterns:

- research_workflow.osop: portable OSOP definition (5 nodes + sequential edges)
- research_workflow.py: runnable Agno implementation (3 Agents + Workflow + AgentOS)
- README.md: OSOP explainer and node-to-Agno mapping table

Unlike the earlier stalled PRs (#7290 / #7777), this adds the runnable Agno
Python implementation rather than only the YAML + description.