### PR TITLE
fix: don't let an oversize read_file satisfy require_read_before_write

### DIFF
--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -429,8 +429,10 @@ class Workspace(Toolkit):
             if not file_path.is_file():
                 return f"Error: file not found: {path}"
             contents = file_path.read_text(encoding=encoding)
-            self._read_paths.add(file_path)
             if start_line is None and end_line is None:
+                # The size guards return no contents at all, so the agent has learned nothing
+                # about the file. Recording the read before them would satisfy
+                # require_read_before_write on the strength of an error message.
                 if len(contents) > self.max_file_length:
                     return (
                         f"Error: file too long ({len(contents)} chars > {self.max_file_length}). "
@@ -444,6 +446,7 @@ class Workspace(Toolkit):
                         "Use start_line/end_line to read a chunk, "
                         "or use search_content to find specific text first."
                     )
+                self._read_paths.add(file_path)
                 return _format_with_line_numbers(contents, start_line=1)
             lines = contents.split("\n")
             start = start_line if start_line is not None else 1
@@ -451,6 +454,10 @@ class Workspace(Toolkit):
             start_idx = max(0, start - 1)
             end_idx = min(len(lines), end)
             chunk = "\n".join(lines[start_idx:end_idx])
+            if start_idx < end_idx:
+                # A range past the end of the file returns nothing, which is no more a read
+                # than the size-guard errors above.
+                self._read_paths.add(file_path)
             return _format_with_line_numbers(chunk, start_line=start)
         except Exception as e:
             log_error(f"read_file failed: {e}")

--- a/libs/agno/tests/unit/tools/test_workspace.py
+++ b/libs/agno/tests/unit/tools/test_workspace.py
@@ -709,6 +709,57 @@ def test_require_read_before_write_blocks_unread_edit():
         assert (Path(tmp_dir) / "doc.md").read_text() == "Hello, world."
 
 
+def test_require_read_before_write_not_satisfied_by_line_limit_error():
+    """A read rejected by max_file_lines returned no contents, so it isn't a read."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir, require_read_before_write=True, max_file_lines=3)
+        (Path(tmp_dir) / "big.txt").write_text("line\n" * 10)
+        assert "too long" in ws.read_file("big.txt")
+        result = ws.write_file("big.txt", "tampered")
+        assert "require_read_before_write" in result
+        assert (Path(tmp_dir) / "big.txt").read_text() == "line\n" * 10
+
+
+def test_require_read_before_write_not_satisfied_by_char_limit_error():
+    """Same for the max_file_length guard, which returns before the contents too."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir, require_read_before_write=True, max_file_length=5)
+        (Path(tmp_dir) / "big.txt").write_text("Hello, world.")
+        assert "too long" in ws.read_file("big.txt")
+        assert "require_read_before_write" in ws.edit_file("big.txt", old_str="world", new_str="Agno")
+        assert "require_read_before_write" in ws.delete_file("big.txt")
+        assert (Path(tmp_dir) / "big.txt").read_text() == "Hello, world."
+
+
+def test_require_read_before_write_satisfied_by_chunk_read_of_long_file():
+    """The escape hatch the error message points at still works: read a chunk, then write."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir, require_read_before_write=True, max_file_lines=3)
+        (Path(tmp_dir) / "big.txt").write_text("line\n" * 10)
+        assert "too long" in ws.read_file("big.txt")
+        assert ws.read_file("big.txt", start_line=1, end_line=3).startswith("     1\tline")
+        assert "Wrote" in ws.write_file("big.txt", "updated")
+
+
+def test_require_read_before_write_not_satisfied_by_out_of_range_chunk():
+    """A range past the end of the file yields an empty string — nothing was learned."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir, require_read_before_write=True)
+        (Path(tmp_dir) / "doc.md").write_text("one\ntwo\nthree\n")
+        assert ws.read_file("doc.md", start_line=9999, end_line=10000) == ""
+        assert "require_read_before_write" in ws.edit_file("doc.md", old_str="two", new_str="TWO")
+        assert (Path(tmp_dir) / "doc.md").read_text() == "one\ntwo\nthree\n"
+
+
+def test_require_read_before_write_satisfied_by_reading_empty_file():
+    """An empty file renders as an empty string, but the read was real and complete."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir, require_read_before_write=True)
+        (Path(tmp_dir) / "empty.txt").write_text("")
+        assert ws.read_file("empty.txt") == ""
+        assert "Wrote" in ws.write_file("empty.txt", "now has content")
+
+
 def test_require_read_before_write_blocks_unread_delete():
     with tempfile.TemporaryDirectory() as tmp_dir:
         ws = Workspace(tmp_dir, require_read_before_write=True)


### PR DESCRIPTION
## Summary

`Workspace(require_read_before_write=True)` could be satisfied by a `read_file` call that returned no file contents — only an error string.

`read_file` recorded the path in `self._read_paths` immediately after `read_text()`, before the `max_file_length` and `max_file_lines` guards. When a guard fired, the agent received `"Error: file too long (…)"` and zero bytes of the file, but the path was already marked as read, so the next `write_file` / `edit_file` / `move_file` / `delete_file` passed `_check_read_before_write` and wrote over a file the agent had never seen. The same held for a chunk read whose range fell past the end of the file: `read_file(path, start_line=9999, end_line=10000)` returns `""` and still marked the file as read.

Issue number: #9273

Before, on `main` @ `7c68873`:

```python
ws = Workspace(root=root, require_read_before_write=True, max_file_lines=10)
ws.read_file("big.txt")            # 'Error: file too long (501 lines > 10). …'
ws.write_file("big.txt", "CLOBBERED")   # 'Wrote 9 chars to big.txt'   <-- guard bypassed
ws.delete_file("big.txt")               # 'Deleted big.txt'
```

Control, same workspace, a file within the limits that was never read — the guard itself works, the failed oversize read is the only difference:

```python
ws2.edit_file("small.txt", "y", "Z")
# 'Error: require_read_before_write is enabled and small.txt hasn't been read this session. …'
```

## The fix

`self._read_paths.add(file_path)` moves past the size guards, onto the two paths that actually return contents.

The chunk path checks `start_idx < end_idx` rather than testing whether the rendered string is empty. That distinction matters: reading a genuinely empty file also renders as `""`, and that *is* a complete read — the agent now knows the file is empty. Two of the new tests pin exactly this, so the fix can't regress into refusing legitimate reads.

`require_read_before_write` defaults to `False`, so nothing changes for callers who don't opt in. For those who do, the error message already tells the agent what to do instead — read a chunk with `start_line`/`end_line`, or use `search_content` — and that route still works.

## Type of change

- [x] Bug fix

---

## Test plan

Five tests added to the existing `require_read_before_write` section of `libs/agno/tests/unit/tools/test_workspace.py`, three negative and two positive:

| test | pins |
|---|---|
| `…not_satisfied_by_line_limit_error` | `max_file_lines` error doesn't count as a read |
| `…not_satisfied_by_char_limit_error` | `max_file_length` error doesn't either, across edit + delete |
| `…not_satisfied_by_out_of_range_chunk` | a range past EOF doesn't either |
| `…satisfied_by_chunk_read_of_long_file` | the documented escape hatch still works |
| `…satisfied_by_reading_empty_file` | an empty file still counts as read |

**Control experiment** — with only `workspace.py` reverted and the tests kept, exactly the three negative tests fail and both positive tests pass:

```
test_require_read_before_write_not_satisfied_by_char_limit_error      FAILED
test_require_read_before_write_not_satisfied_by_line_limit_error      FAILED
test_require_read_before_write_not_satisfied_by_out_of_range_chunk    FAILED
test_require_read_before_write_satisfied_by_chunk_read_of_long_file   PASSED
test_require_read_before_write_satisfied_by_reading_empty_file        PASSED
3 failed, 7 passed
```

**Regression check** — `pytest libs/agno/tests/unit/ -k "workspace or fs or toolkit"`:

| | failed | passed |
|---|---|---|
| clean `origin/main` | 5 | 620 |
| this branch | 5 | 625 |

Identical failure count; the +5 are the new tests. The 5 pre-existing failures are Windows-specific and unrelated to the changed file (`fs/test_local.py` file-mode bits, and `test_run_command_runs_in_root` comparing `pwd` output against a Windows path). The 72 collection errors are missing optional dependencies (`weaviate-client`, `slack-sdk`, …) and are present on `main` too.

`ruff format --check` → "2 files already formatted". `ruff check` and import-sort → "All checks passed!". `mypy` reports no errors in `workspace.py`.

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — this is a Windows checkout with no `bash` script runner wired up, so I ran the commands they invoke directly: `ruff format`, `ruff check`, `ruff check --select I`, `mypy`
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — two comments explaining why the ordering matters, so the `add()` calls don't drift back up
- [ ] Examples and guides: no cookbook change — this is a guard-ordering fix with no new surface
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue — searched `require_read_before_write`, `read_before_write`, `max_file_lines`, and `workspace.py`; the only prior hits are the two PRs that introduced the toolkit (#7683, #7698), both closed
- [x] If a similar PR exists, I have explained below why this PR is a better approach — n/a, none exists
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — written with AI assistance; the bug was found by reading the guard's call sites, and every claim above was reproduced and measured locally, including the control experiment

---

## Additional Notes

Security-adjacent but not a sandbox escape: `_check_path` still contains everything to the workspace root, and `require_read_before_write` is an agent-correctness guard rather than a permission boundary. The impact is data loss on files the agent couldn't see, in the configuration where the operator explicitly asked for that not to happen.
