### PR TITLE
fix: require a label boundary when checking crawl scope in WebsiteReader

### DIFF
--- a/libs/agno/agno/knowledge/reader/website_reader.py
+++ b/libs/agno/agno/knowledge/reader/website_reader.py
@@ -106,6 +106,21 @@ class WebsiteReader(Reader):
         # Return primary domain (excluding subdomains)
         return ".".join(domain_parts[-2:])
 
+    def _is_same_domain(self, url: str, primary_domain: str) -> bool:
+        """True when ``url``'s host is ``primary_domain`` itself or a subdomain of it.
+
+        A plain ``endswith`` on the netloc has no label boundary, so an unrelated
+        registered domain that merely ends with the same characters reads as in-scope:
+        ``evilexample.com`` matches a primary domain of ``example.com``. Comparing the
+        hostname label-wise fixes that, and using ``hostname`` rather than ``netloc``
+        keeps a port or userinfo from hiding an otherwise legitimate match.
+        """
+        host = (urlparse(url).hostname or "").lower()
+        domain = primary_domain.lower()
+        if not host or not domain:
+            return False
+        return host == domain or host.endswith(f".{domain}")
+
     def _extract_main_content(self, soup: BeautifulSoup) -> str:
         """
         Extracts the main content from a BeautifulSoup object.
@@ -195,7 +210,7 @@ class WebsiteReader(Reader):
             # - host is not in allowed_hosts (when configured)
             if (
                 current_url in self._visited
-                or not urlparse(current_url).netloc.endswith(primary_domain)
+                or not self._is_same_domain(current_url, primary_domain)
                 or (current_depth > self.max_depth and current_url != url)
                 or num_links >= self.max_links
                 or not is_host_allowed(current_url, self.allowed_hosts)
@@ -245,7 +260,7 @@ class WebsiteReader(Reader):
                         continue
 
                     parsed_url = urlparse(full_url)
-                    if parsed_url.netloc.endswith(primary_domain) and not any(
+                    if self._is_same_domain(full_url, primary_domain) and not any(
                         parsed_url.path.endswith(ext) for ext in [".pdf", ".jpg", ".png"]
                     ):
                         full_url_str = str(full_url)
@@ -323,7 +338,7 @@ class WebsiteReader(Reader):
 
                 if (
                     current_url in self._visited
-                    or not urlparse(current_url).netloc.endswith(primary_domain)
+                    or not self._is_same_domain(current_url, primary_domain)
                     or current_depth > self.max_depth
                     or num_links >= self.max_links
                     or not is_host_allowed(current_url, self.allowed_hosts)
@@ -360,7 +375,7 @@ class WebsiteReader(Reader):
                             continue
 
                         parsed_url = urlparse(full_url)
-                        if parsed_url.netloc.endswith(primary_domain) and not any(
+                        if self._is_same_domain(full_url, primary_domain) and not any(
                             parsed_url.path.endswith(ext) for ext in [".pdf", ".jpg", ".png"]
                         ):
                             full_url_str = str(full_url)

--- a/libs/agno/tests/unit/reader/test_website_reader.py
+++ b/libs/agno/tests/unit/reader/test_website_reader.py
@@ -1,3 +1,4 @@
+from typing import Dict, List
 from unittest.mock import patch
 
 import httpx
@@ -452,3 +453,111 @@ def test_crawl_real_network_failure_still_raises():
     ):
         with pytest.raises(httpx.RequestError):
             reader.crawl("https://example.com")
+
+
+def test_is_same_domain_requires_a_label_boundary():
+    """An unrelated registered domain must not read as in-scope.
+
+    `netloc.endswith(primary_domain)` has no label boundary, so `evilexample.com`
+    satisfies a primary domain of `example.com`. Anyone able to put a link on a
+    crawled page could then steer the crawl onto a host they control.
+    """
+    reader = WebsiteReader()
+    primary_domain = reader._get_primary_domain("https://docs.example.com/guide")
+
+    # In scope: the domain itself and any subdomain of it.
+    assert reader._is_same_domain("https://example.com/x", primary_domain)
+    assert reader._is_same_domain("https://api.example.com/x", primary_domain)
+    assert reader._is_same_domain("https://deep.nested.example.com/x", primary_domain)
+
+    # Out of scope: shares a suffix but is a different registration.
+    assert not reader._is_same_domain("https://evilexample.com/x", primary_domain)
+    assert not reader._is_same_domain("https://not-example.com/x", primary_domain)
+
+    # Out of scope: the domain appears as a prefix, not a suffix.
+    assert not reader._is_same_domain("https://example.com.attacker.net/x", primary_domain)
+
+    # Hostnames are case-insensitive, and a port must not defeat a real match.
+    assert reader._is_same_domain("https://ExAmPlE.CoM/x", primary_domain)
+    assert reader._is_same_domain("https://api.example.com:8443/x", primary_domain)
+
+    # Nothing to compare against is not a match.
+    assert not reader._is_same_domain("not a url", primary_domain)
+    assert not reader._is_same_domain("https://example.com/x", "")
+
+
+def _page_handler(fetched: List[str], pages: Dict[str, str]):
+    """An httpx handler recording every host fetched and serving canned HTML."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        fetched.append(request.url.host)
+        return httpx.Response(200, text=pages.get(request.url.host, "<html><body><main>x</main></body></html>"))
+
+    return handler
+
+
+LOOKALIKE_PAGES = {
+    "docs.example.com": """<html><body><main>Docs home</main>
+        <a href="https://evilexample.com/steal">Looks internal</a>
+        <a href="https://api.example.com/real">Real subdomain</a>
+        <a href="https://unrelated.org/x">Clearly external</a>
+        </body></html>""",
+    "evilexample.com": "<html><body><main>attacker content</main></body></html>",
+    "api.example.com": "<html><body><main>legitimate subdomain content</main></body></html>",
+}
+
+
+def test_crawl_does_not_follow_a_lookalike_domain(monkeypatch):
+    """A link to a suffix-matching domain must not be crawled or ingested.
+
+    `unrelated.org` in the same page is the control: it proves the scope check is
+    doing its job, so a passing test cannot be explained by the crawl stopping early.
+    """
+    fetched: List[str] = []
+    transport = httpx.MockTransport(_page_handler(fetched, LOOKALIKE_PAGES))
+
+    monkeypatch.setattr(
+        "agno.knowledge.reader.website_reader.httpx.get",
+        lambda url, **kwargs: httpx.Client(transport=transport).get(url, follow_redirects=True),
+    )
+
+    reader = WebsiteReader(max_depth=2, max_links=10)
+    monkeypatch.setattr(reader, "delay", lambda *args, **kwargs: None)
+    result = reader.crawl("https://docs.example.com/guide")
+
+    assert "evilexample.com" not in fetched, "crawl escaped onto a lookalike domain"
+    assert not any("evilexample.com" in url for url in result)
+    assert "unrelated.org" not in fetched
+
+    # The legitimate subdomain must still be reached: the fix narrows the scope
+    # rather than disabling subdomain crawling.
+    assert "api.example.com" in fetched
+    assert "https://api.example.com/real" in result
+
+
+@pytest.mark.asyncio
+async def test_async_crawl_does_not_follow_a_lookalike_domain(monkeypatch):
+    """The async crawl shares the scope check and must behave identically."""
+    fetched: List[str] = []
+    transport = httpx.MockTransport(_page_handler(fetched, LOOKALIKE_PAGES))
+    original_async_client = httpx.AsyncClient
+
+    def _async_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        kwargs.pop("proxy", None)
+        return original_async_client(*args, **kwargs)
+
+    async def _no_delay(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("agno.knowledge.reader.website_reader.httpx.AsyncClient", _async_client)
+
+    reader = WebsiteReader(max_depth=2, max_links=10)
+    monkeypatch.setattr(reader, "async_delay", _no_delay)
+    result = await reader.async_crawl("https://docs.example.com/guide")
+
+    assert "evilexample.com" not in fetched, "async crawl escaped onto a lookalike domain"
+    assert not any("evilexample.com" in url for url in result)
+    assert "unrelated.org" not in fetched
+    assert "api.example.com" in fetched
+    assert "https://api.example.com/real" in result


### PR DESCRIPTION
## Summary

Fixes #9275.

`WebsiteReader` confines a crawl to the start URL's primary domain, but the check is a bare
`endswith` on the netloc, which has no label boundary:

```python
or not urlparse(current_url).netloc.endswith(primary_domain)
```

`"evilexample.com".endswith("example.com")` is `True`, so an unrelated registered domain that
merely shares a suffix reads as in-scope and gets crawled and ingested.

The expression appears four times — the crawl-queue filter and the link-discovery step, on
the sync path and the async one (`website_reader.py:198`, `:248`, `:326`, `:363`). All four
are replaced with one helper:

```python
def _is_same_domain(self, url: str, primary_domain: str) -> bool:
    host = (urlparse(url).hostname or "").lower()
    domain = primary_domain.lower()
    if not host or not domain:
        return False
    return host == domain or host.endswith(f".{domain}")
```

Reading `hostname` instead of `netloc` also drops the port, which fixes a second, milder
problem in the same line: `"example.com:8443".endswith("example.com")` is `False`, so a site
served on a non-default port was silently excluded from its own crawl.

`_get_primary_domain` is deliberately untouched. Its two-label result (`example.co.uk` yields
`co.uk`) is pinned by the existing `test_get_primary_domain`; narrowing that needs a
public-suffix list and is a separate discussion.

### Why this is worth fixing

`allowed_hosts` defaults to `None`, so this comparison is the only containment a default crawl
has. The trigger is a link on a crawled page — a user comment, a wiki edit, a forum post — so
it is frequently not under the operator's control, and registering a look-alike domain is
cheap. The fetched content becomes `Document`s attributed to a URL the operator believes is
in-scope, gets embedded, and is retrieved as trusted agent context. Nothing warns, because as
far as the crawler is concerned the host was in scope.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — n/a, no API change
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

Searched issues and PRs for `primary_domain`, `endswith`, `WebsiteReader crawl domain` and
`website reader subdomain` — no existing report or PR. The diagnosis, the probe and the tests
were developed with AI assistance; every claim below was verified by running it.

---

## Evidence

`docs.example.com` serves a page with three links — a look-alike domain, a real subdomain,
and a clearly external site — behind an `httpx.MockTransport` that records each host fetched.

| link on the page | before | after |
| --- | --- | --- |
| `https://api.example.com/real` (in-scope subdomain) | fetched | fetched |
| `https://evilexample.com/steal` (look-alike) | **fetched and ingested** | refused |
| `https://unrelated.org/x` (external) | refused | refused |

Before, on `main`:

```
hosts fetched : ['docs.example.com', 'evilexample.com', 'api.example.com']
crawled urls  : ['https://api.example.com/real',
                 'https://docs.example.com/guide',
                 'https://evilexample.com/steal']
```

After:

```
hosts fetched : ['docs.example.com', 'api.example.com']
crawled urls  : ['https://api.example.com/real', 'https://docs.example.com/guide']
```

`unrelated.org` being refused on both sides matters: it shows the scope check was working all
along and only the boundary was wrong, so the fix is a narrowing rather than a repair of
something inert.

## Tests

Three tests appended to `libs/agno/tests/unit/reader/test_website_reader.py`, alongside the
existing `allowed_hosts` security tests. No network — `httpx.MockTransport` serves everything.

| test | role |
| --- | --- |
| `test_is_same_domain_requires_a_label_boundary` | the boundary table: in-scope (`example.com`, `api.example.com`, `deep.nested.example.com`, mixed case, `:8443`) vs out (`evilexample.com`, `not-example.com`, `example.com.attacker.net`, empty inputs) |
| `test_crawl_does_not_follow_a_lookalike_domain` | the regression, end to end on the sync path, asserting both that the look-alike is not fetched **and** that the real subdomain still is |
| `test_async_crawl_does_not_follow_a_lookalike_domain` | the same for `async_crawl`, which carries its own copy of the check |

Both crawl tests assert `api.example.com` **is** reached. Without that, a fix that simply
stopped crawling subdomains would pass.

### Control experiment

Reverting `website_reader.py` and keeping the tests:

```
3 failed, 29 passed

FAILED test_is_same_domain_requires_a_label_boundary  - AttributeError: 'WebsiteReader' object has no attribute '_is_same_domain'
FAILED test_crawl_does_not_follow_a_lookalike_domain
  AssertionError: crawl escaped onto a lookalike domain
  assert 'evilexample.com' not in ['docs.example.com', 'evilexample.com', 'api.example.com']
FAILED test_async_crawl_does_not_follow_a_lookalike_domain
  AssertionError: async crawl escaped onto a lookalike domain
  assert 'evilexample.com' not in ['docs.example.com', 'evilexample.com', 'api.example.com']
```

Exactly the three new tests fail; all 29 pre-existing tests in the file pass unchanged.

### Suite runs

- `libs/agno/tests/unit/reader/test_website_reader.py` — **32 passed**
- `libs/agno/tests/unit/reader/` — 231 passed, 2 failed, 1 skipped

The 2 failures are `test_text_reader.py::test_unicode_content` and
`::test_async_unicode_content`, which fail identically on unmodified `main` (verified by
stashing) — a local encoding artifact, unrelated to this change. Five files in that directory
fail to collect on my machine for missing optional deps (`docling`, `chonkie`, `arxiv`,
`tavily`); those were excluded from the run and are likewise unrelated.

- `ruff format --check` — `2 files already formatted`
- `ruff check` — `All checks passed!`
- `mypy` on `website_reader.py` — no findings in this file (the 399 errors reported are all
  pre-existing, in other modules)

## Additional Notes

Security-relevant but not a privilege boundary: no authentication is bypassed. The impact is
that content from an attacker-registered host enters the knowledge base labelled as in-scope,
and that the crawler issues requests to a host the operator never listed — which is why the
same code path also matters for the `allowed_hosts` SSRF work. With `allowed_hosts` set, the
allowlist already blocked this; the fix closes it for the default configuration too.
