### PR TITLE
fix: normalize the DNS trailing dot on both sides of allowed_hosts

### DIFF
--- a/libs/agno/agno/knowledge/reader/utils/url_validation.py
+++ b/libs/agno/agno/knowledge/reader/utils/url_validation.py
@@ -2,6 +2,18 @@ from typing import Any, Callable, List, Optional
 from urllib.parse import urlparse
 
 
+def _normalize_host(host: str) -> str:
+    """Reduce a hostname to the form the allowlist compares on.
+
+    Two spellings of the same host must normalize to one string, or an exact-match
+    allowlist admits one and rejects the other. Case is one such spelling; the
+    trailing dot is the other. ``docs.example.com.`` names the root label
+    explicitly, which DNS resolves identically to ``docs.example.com`` -- but
+    ``urlparse`` keeps the dot, so the two are not ``==``.
+    """
+    return host.rstrip(".").lower()
+
+
 def validate_allowed_hosts(allowed_hosts: Optional[List[str]]) -> Optional[List[str]]:
     """Validate an ``allowed_hosts`` argument and raise ``TypeError`` if a single string is passed."""
     if allowed_hosts is None:
@@ -11,7 +23,7 @@ def validate_allowed_hosts(allowed_hosts: Optional[List[str]]) -> Optional[List[
             "allowed_hosts must be a list of hostnames, not a single string. "
             f"Did you mean allowed_hosts=[{allowed_hosts!r}]?"
         )
-    return [host.lower() for host in allowed_hosts]
+    return [_normalize_host(host) for host in allowed_hosts]
 
 
 def is_host_allowed(url: str, allowed_hosts: Optional[List[str]]) -> bool:
@@ -20,6 +32,14 @@ def is_host_allowed(url: str, allowed_hosts: Optional[List[str]]) -> bool:
     When ``allowed_hosts`` is ``None``, all hosts are allowed.
     When set, only URLs whose hostname matches an entry are allowed
     matching is case-insensitive and exact (no implicit subdomains).
+
+    Both sides are normalized with :func:`_normalize_host` so that the two DNS
+    spellings of one host cannot disagree: without it a URL written
+    ``https://docs.example.com./x`` was refused by an allowlist naming
+    ``docs.example.com``, and -- the direction that matters for a guard -- an
+    allowlist entry copied from a zone file as ``docs.example.com.`` admitted
+    only the dotted spelling. The dot survives an httpx redirect hop, so the
+    same asymmetry reached :func:`make_redirect_guard`.
 
     Args:
         url: The URL to check.
@@ -34,8 +54,11 @@ def is_host_allowed(url: str, allowed_hosts: Optional[List[str]]) -> bool:
     host = urlparse(url).hostname
     if not host:
         return False
-    host_lower = host.lower()
-    return any(host_lower == entry.lower() for entry in allowed_hosts)
+    # ``.`` alone is a hostname of only root labels, which names no host.
+    host_normalized = _normalize_host(host)
+    if not host_normalized:
+        return False
+    return any(host_normalized == _normalize_host(entry) for entry in allowed_hosts)
 
 
 def make_redirect_guard(allowed_hosts: Optional[List[str]]) -> Optional[Callable[[Any], None]]:

--- a/libs/agno/tests/unit/tools/test_llms_txt.py
+++ b/libs/agno/tests/unit/tools/test_llms_txt.py
@@ -568,6 +568,34 @@ def test_reader_allowed_hosts_ignores_port_and_userinfo():
     assert is_host_allowed("http://docs.agno.com@evil.example/x", reader.allowed_hosts) is False
 
 
+def test_reader_allowed_hosts_normalizes_trailing_dot_in_url():
+    """``docs.agno.com.`` names the root label explicitly and resolves the same."""
+    reader = LLMsTxtReader(allowed_hosts=["docs.agno.com"])
+    assert is_host_allowed("https://docs.agno.com./x", reader.allowed_hosts) is True
+    assert is_host_allowed("https://docs.agno.com/x", reader.allowed_hosts) is True
+
+
+def test_reader_allowed_hosts_normalizes_trailing_dot_in_entry():
+    """The direction that matters for a guard: an entry copied from a zone file.
+
+    Written with the dot, the allowlist used to admit only the dotted spelling --
+    so every ordinary URL for the host the operator meant to permit was refused.
+    """
+    reader = LLMsTxtReader(allowed_hosts=["docs.agno.com."])
+    assert is_host_allowed("https://docs.agno.com/x", reader.allowed_hosts) is True
+    assert is_host_allowed("https://docs.agno.com./x", reader.allowed_hosts) is True
+    assert is_host_allowed("https://other.example/x", reader.allowed_hosts) is False
+
+
+def test_reader_allowed_hosts_trailing_dot_is_not_a_suffix_bypass():
+    """Normalizing the dot must not turn exact matching into suffix matching."""
+    reader = LLMsTxtReader(allowed_hosts=["docs.agno.com"])
+    assert is_host_allowed("https://docs.agno.com.evil.example/x", reader.allowed_hosts) is False
+    assert is_host_allowed("https://evil.example/docs.agno.com./x", reader.allowed_hosts) is False
+    # A hostname of nothing but root labels names no host, so it matches nothing.
+    assert is_host_allowed("https://./x", reader.allowed_hosts) is False
+
+
 def test_reader_allowed_hosts_blocks_localhost_and_metadata():
     reader = LLMsTxtReader(allowed_hosts=["docs.agno.com"])
     assert is_host_allowed("http://127.0.0.1:8000/admin", reader.allowed_hosts) is False


### PR DESCRIPTION
## Summary

`docs.example.com.` names the DNS root label explicitly. Resolvers treat it as the
same host as `docs.example.com`, but `urlparse` keeps the dot, so the two spellings
are not `==`. `is_host_allowed` matches exactly, so an `allowed_hosts` allowlist
admitted one spelling and refused the other — **in both directions**:

```python
from agno.knowledge.reader.utils.url_validation import is_host_allowed, validate_allowed_hosts

# the URL carries the dot
allowed = validate_allowed_hosts(["docs.example.com"])
is_host_allowed("https://docs.example.com/x",  allowed)   # True
is_host_allowed("https://docs.example.com./x", allowed)   # False   <- same host

# the allowlist entry carries the dot (e.g. copied from a zone file)
allowed = validate_allowed_hosts(["docs.example.com."])
is_host_allowed("https://docs.example.com/x",  allowed)   # False   <- same host
is_host_allowed("https://docs.example.com./x", allowed)   # True
```

The second direction is the one that bites an operator. In DNS the trailing dot is
the normal way to write a fully-qualified name, so an entry copied from a zone file
or an `dig` output silently permits *only* the dotted spelling — and every ordinary
URL for the host they meant to allow gets refused, with the message
`Host not in allowed_hosts`.

The dot also survives a redirect hop, so this reached `make_redirect_guard` /
`make_async_redirect_guard`, which re-validate each redirect target:

```python
httpx.URL("https://docs.example.com/start").join("//docs.example.com./x").host
# 'docs.example.com.'
```

### The fix

One helper, `_normalize_host`, applied to **both** sides — the allowlist in
`validate_allowed_hosts` and the URL host in `is_host_allowed` — so the two cannot
disagree. Case folding moves into the same helper, because it is the same kind of
rule (one host, two spellings) for the same reason.

Normalizing does **not** widen matching:

| input | result | why |
|---|---|---|
| `docs.example.com.evil.example` | rejected | only *trailing* dots are stripped; comparison stays exact |
| `evil.example/docs.example.com./x` | rejected | the path is not the host |
| `http://docs.example.com@evil.example/x` | rejected | userinfo is not the host (already covered) |
| `https://./x` | rejected | normalizes to `""`, which matches nothing rather than an empty entry |

This is the same normalization other SSRF-facing code applies for exactly this
reason — e.g. `pydantic_ai._ssrf.extract_host_and_port` strips it with the note
that *"leaving it in would bypass exact-match domain allow/blocklists"*.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format --check` and `ruff check` both clean on
      the two changed files; `mypy` reports 0 errors in the changed source file — the 406
      errors it reports across 69 other files are pre-existing on `main`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides — not applicable, no API change
- [x] Tested in clean environment
- [x] Tests added/updated

**Test evidence.** 3 cases added next to the existing case/port/userinfo
normalization tests, which this is the missing member of.

Control experiment — the new assertions **fail without the source change**:

```
$ git stash push -- libs/agno/agno/knowledge/reader/utils/url_validation.py
$ pytest libs/agno/tests/unit/tools/test_llms_txt.py -k allowed_hosts
test_llms_txt.py:574: AssertionError: assert False is True   # URL-side dot
test_llms_txt.py:585: AssertionError: assert False is True   # entry-side dot
2 failed, 8 passed
```

The third new test (`..._is_not_a_suffix_bypass`) passes either way by design — it
guards that the fix does not turn exact matching into suffix matching.

With the fix:

```
$ pytest libs/agno/tests/unit/tools/test_llms_txt.py
67 passed

$ pytest libs/agno/tests/unit/reader/ libs/agno/tests/unit/tools/test_llms_txt.py
295 passed, 2 failed, 1 skipped
```

The 2 failures are `test_text_reader.py::test_unicode_content` and
`::test_async_unicode_content`, which fail identically on a clean `main` and do not
reference `allowed_hosts` or `url_validation` (`grep -c` → 0). 5 files in
`tests/unit/reader/` fail to collect on `main` for missing optional deps
(`arxiv`, `docling`, `chonkie`) and are excluded from that run.

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests
- [x] **A related PR exists and is disclosed here.** #7944 ("security: fix SSRF in
      `WebTools.expand_url` and `url_validation`") touches this same file, so I checked
      it before opening this. It is **orthogonal**: it adds IP-range blocking
      (RFC 1918 / loopback / link-local / metadata) and makes the guards unconditional.
      It does no hostname normalization at all — `rstrip` does not appear in its diff —
      so it neither fixes nor conflicts with this. If #7944 lands first, this still
      applies; if this lands first, #7944's changes are additive. Happy to rebase on
      whichever merges first.
- [ ] Not entirely AI-generated.

---

## Additional Notes

The helper is deliberately `_`-private and takes a single host string rather than
being folded inline, so that any future caller that needs to compare a hostname
against this allowlist has one place to get the same normalization. The two existing
callers were the whole point — the bug was that only one side was normalized.
