### PR TITLE
fix(website_reader): add label-boundary check to crawl scope

### DIFF
--- a/libs/agno/agno/knowledge/reader/website_reader.py
+++ b/libs/agno/agno/knowledge/reader/website_reader.py
@@ -106,6 +106,21 @@ class WebsiteReader(Reader):
         # Return primary domain (excluding subdomains)
         return ".".join(domain_parts[-2:])
 
+    def _is_in_scope(self, netloc: str, primary_domain: str) -> bool:
+        """
+        Check whether *netloc* belongs to *primary_domain* or a subdomain of it.
+
+        Uses a label-boundary check so that look-alike domains such as
+        ``evilexample.com`` are **not** considered in-scope for ``example.com``.
+
+        :param netloc: The netloc (host[:port]) from a URL.
+        :param primary_domain: The primary domain to check against.
+        :return: True if netloc is the primary domain or a subdomain of it.
+        """
+        # Strip port if present for comparison
+        host = netloc.split(":")[0] if ":" in netloc else netloc
+        return host == primary_domain or host.endswith("." + primary_domain)
+
     def _extract_main_content(self, soup: BeautifulSoup) -> str:
         """
         Extracts the main content from a BeautifulSoup object.
@@ -195,7 +210,7 @@ class WebsiteReader(Reader):
             # - host is not in allowed_hosts (when configured)
             if (
                 current_url in self._visited
-                or not urlparse(current_url).netloc.endswith(primary_domain)
+                or not self._is_in_scope(urlparse(current_url).netloc, primary_domain)
                 or (current_depth > self.max_depth and current_url != url)
                 or num_links >= self.max_links
                 or not is_host_allowed(current_url, self.allowed_hosts)
@@ -245,7 +260,7 @@ class WebsiteReader(Reader):
                         continue
 
                     parsed_url = urlparse(full_url)
-                    if parsed_url.netloc.endswith(primary_domain) and not any(
+                    if self._is_in_scope(parsed_url.netloc, primary_domain) and not any(
                         parsed_url.path.endswith(ext) for ext in [".pdf", ".jpg", ".png"]
                     ):
                         full_url_str = str(full_url)
@@ -323,7 +338,7 @@ class WebsiteReader(Reader):
 
                 if (
                     current_url in self._visited
-                    or not urlparse(current_url).netloc.endswith(primary_domain)
+                    or not self._is_in_scope(urlparse(current_url).netloc, primary_domain)
                     or current_depth > self.max_depth
                     or num_links >= self.max_links
                     or not is_host_allowed(current_url, self.allowed_hosts)
@@ -360,7 +375,7 @@ class WebsiteReader(Reader):
                             continue
 
                         parsed_url = urlparse(full_url)
-                        if parsed_url.netloc.endswith(primary_domain) and not any(
+                        if self._is_in_scope(parsed_url.netloc, primary_domain) and not any(
                             parsed_url.path.endswith(ext) for ext in [".pdf", ".jpg", ".png"]
                         ):
                             full_url_str = str(full_url)

--- a/libs/agno/tests/unit/reader/test_website_reader.py
+++ b/libs/agno/tests/unit/reader/test_website_reader.py
@@ -452,3 +452,92 @@ def test_crawl_real_network_failure_still_raises():
     ):
         with pytest.raises(httpx.RequestError):
             reader.crawl("https://example.com")
+
+
+# ---------------------------------------------------------------------------
+# Crawl scope label-boundary check (CVE-style: look-alike domain spoofing)
+# ---------------------------------------------------------------------------
+
+
+def test_is_in_scope_exact_domain():
+    """The exact primary domain must be in scope."""
+    reader = WebsiteReader()
+    assert reader._is_in_scope("example.com", "example.com") is True
+
+
+def test_is_in_scope_subdomain():
+    """Subdomains of the primary domain must be in scope."""
+    reader = WebsiteReader()
+    assert reader._is_in_scope("docs.example.com", "example.com") is True
+    assert reader._is_in_scope("api.example.com", "example.com") is True
+
+
+def test_is_in_scope_lookalike_domain_rejected():
+    """Look-alike domains that merely *end with* the primary domain string
+    must NOT be treated as in-scope.
+
+    Regression test for the bare ``endswith`` bug where
+    ``"evilexample.com".endswith("example.com")`` returned ``True``."""
+    reader = WebsiteReader()
+    assert reader._is_in_scope("evilexample.com", "example.com") is False
+    assert reader._is_in_scope("notexample.com", "example.com") is False
+    assert reader._is_in_scope("attackerexample.com", "example.com") is False
+
+
+def test_is_in_scope_with_port():
+    """Ports must be stripped before comparison."""
+    reader = WebsiteReader()
+    assert reader._is_in_scope("example.com:443", "example.com") is True
+    assert reader._is_in_scope("docs.example.com:8080", "example.com") is True
+    assert reader._is_in_scope("evilexample.com:443", "example.com") is False
+
+
+def test_crawl_rejects_lookalike_domain():
+    """Integration-level test: a page linking to a look-alike domain must
+    NOT crawl the look-alike.
+
+    Uses httpx.MockTransport to serve controlled responses and verify which
+    hosts are actually fetched."""
+    pages = {
+        "https://docs.example.com/guide": (
+            "<html><body><main>Guide</main>"
+            '<a href="https://evilexample.com/steal">Looks internal</a>'
+            '<a href="https://api.example.com/real">Real subdomain</a>'
+            '<a href="https://unrelated.org/x">External</a>'
+            "</body></html>"
+        ),
+        "https://api.example.com/real": "<html><body><main>API</main></body></html>",
+    }
+
+    fetched_hosts: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        host = request.url.host
+        fetched_hosts.append(host)
+        content = pages.get(str(request.url))
+        if content is not None:
+            return httpx.Response(200, content=content.encode())
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    reader = WebsiteReader(max_depth=2, max_links=10)
+
+    with patch("agno.knowledge.reader.website_reader.httpx.get") as mock_get:
+        # Wire each call through the mock transport
+        def fake_get(url, **kwargs):
+            with httpx.Client(transport=transport) as client:
+                resp = client.get(url, **kwargs)
+                resp.raise_for_status()
+                return resp
+
+        mock_get.side_effect = fake_get
+        reader.crawl("https://docs.example.com/guide")
+
+    # evilexample.com must NOT have been fetched
+    assert "evilexample.com" not in fetched_hosts, (
+        f"evilexample.com was crawled — look-alike domain boundary failed! "
+        f"Hosts fetched: {fetched_hosts}"
+    )
+    assert "unrelated.org" not in fetched_hosts
+    # Real subdomain should be fetched
+    assert "api.example.com" in fetched_hosts


### PR DESCRIPTION
## Summary

The `WebsiteReader` crawl scope check used a bare `endswith` on the netloc, so a look-alike domain such as `evilexample.com` was treated as in-scope for `example.com` and got crawled/ingested.

`"evilexample.com".endswith("example.com")` → `True` ❌

## Fix

Introduce `_is_in_scope()` which checks that the host either:
- equals the primary domain exactly, or
- ends with `.` + primary_domain (proper DNS label boundary)

Ports are stripped before comparison.

### Affected call sites (4 locations, sync + async)
| Line | Role | Path |
|------|------|------|
| ~213 | sync: skip out-of-scope URLs in queue | `crawl()` |
| ~263 | sync: enqueue discovered links | `crawl()` |
| ~341 | async: skip out-of-scope URLs in queue | `async_crawl()` |
| ~378 | async: enqueue discovered links | `async_crawl()` |

## Tests

- `test_is_in_scope_exact_domain` — exact match passes
- `test_is_in_scope_subdomain` — real subdomains pass
- `test_is_in_scope_lookalike_domain_rejected` — `evilexample.com` rejected for `example.com`
- `test_is_in_scope_with_port` — port stripping works correctly
- `test_crawl_rejects_lookalike_domain` — integration test with `httpx.MockTransport` verifying `evilexample.com` is NOT fetched when crawling `docs.example.com`

## Reproduction (from #9275)

```python
PAGES = {
    "docs.example.com": '''<html><body><main>Docs home</main>
        <a href="https://evilexample.com/steal">Looks internal</a>
        <a href="https://api.example.com/real">Real subdomain</a>
        <a href="https://unrelated.org/x">Clearly external</a>
    </body></html>''',
}

reader = WebsiteReader(max_depth=2, max_links=10)
result = reader.crawl("https://docs.example.com/guide")
```

**Before fix:** `evilexample.com` crawled ❌
**After fix:** `evilexample.com` rejected ✅

Fixes #9275