### PR TITLE
fix: keep every repeated topics query parameter in GET /memories

### DIFF
--- a/libs/agno/agno/os/routers/memory/memory.py
+++ b/libs/agno/agno/os/routers/memory/memory.py
@@ -785,12 +785,20 @@ def parse_topics(
         examples=["preferences,technical,communication_style"],
     ),
 ) -> Optional[List[str]]:
-    """Parse comma-separated topics into a list for filtering memories by topic."""
+    """Parse comma-separated topics into a list for filtering memories by topic.
+
+    The parameter is declared ``List[str]``, so FastAPI collects a repeated query
+    parameter into one element per occurrence: ``?topics=a&topics=b`` arrives as
+    ``["a", "b"]``. Every element is split, not just the first -- reading only
+    ``topics[0]`` silently narrowed the filter to the first occurrence and
+    discarded the rest, returning a result set the caller did not ask for with no
+    error to indicate it. Both spellings, and a mix of them, are accepted.
+    """
     if not topics:
         return None
 
     try:
-        return [topic.strip() for topic in topics[0].split(",") if topic.strip()]
+        return [topic.strip() for value in topics for topic in value.split(",") if topic.strip()]
 
     except Exception as e:
         raise HTTPException(status_code=422, detail=f"Invalid topics format: {e}")

--- a/libs/agno/tests/unit/os/routers/test_memory_topics_filter.py
+++ b/libs/agno/tests/unit/os/routers/test_memory_topics_filter.py
@@ -1,0 +1,100 @@
+"""
+Unit tests for the ``topics`` query parameter in GET /memories.
+
+``parse_topics`` declares ``Optional[List[str]]``, so FastAPI collects a repeated
+query parameter into one element per occurrence. Reading only ``topics[0]``
+silently dropped every occurrence after the first, narrowing the filter without
+any error -- the caller got a result set they did not ask for.
+
+Uses FastAPI TestClient to exercise the real ASGI stack end-to-end, and asserts
+on the value handed to the DB layer rather than on the response body.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _make_async_db():
+    """Create an AsyncBaseDb mock that passes isinstance checks."""
+    from agno.db.base import AsyncBaseDb
+
+    mock = MagicMock(spec=AsyncBaseDb)
+    mock.id = "test-db"
+    # get_user_memories returns (list[dict], int)
+    mock.get_user_memories = AsyncMock(return_value=([], 0))
+    return mock
+
+
+def _build_app_with_memory_router(db):
+    from agno.os.routers.memory import get_memory_router
+    from agno.os.settings import AgnoAPISettings
+
+    app = FastAPI()
+    router = get_memory_router(dbs={"test-db": [db]}, settings=AgnoAPISettings())
+    app.include_router(router)
+    return app
+
+
+class TestMemoryTopicsFilter:
+    """Test the topics parameter in GET /memories."""
+
+    @pytest.fixture
+    def db(self):
+        return _make_async_db()
+
+    @pytest.fixture
+    def client(self, db):
+        return TestClient(_build_app_with_memory_router(db))
+
+    def _topics_passed_to_db(self, client, db, query):
+        response = client.get(f"/memories?db_id=test-db{query}")
+        assert response.status_code == 200, response.text
+        db.get_user_memories.assert_called_once()
+        return db.get_user_memories.call_args.kwargs["topics"]
+
+    def test_repeated_query_parameter_keeps_every_occurrence(self, client, db):
+        """``?topics=a&topics=b`` is the standard spelling for a list parameter.
+
+        Only the first occurrence used to survive, so a caller filtering on three
+        topics silently got a filter on one.
+        """
+        assert self._topics_passed_to_db(client, db, "&topics=preferences&topics=technical") == [
+            "preferences",
+            "technical",
+        ]
+
+    def test_three_repeated_occurrences(self, client, db):
+        assert self._topics_passed_to_db(client, db, "&topics=a&topics=b&topics=c") == ["a", "b", "c"]
+
+    def test_comma_separated_value_still_works(self, client, db):
+        """The documented spelling is unchanged."""
+        assert self._topics_passed_to_db(client, db, "&topics=preferences,technical") == [
+            "preferences",
+            "technical",
+        ]
+
+    def test_mixed_comma_and_repeated_spellings(self, client, db):
+        """Nothing forces a caller to pick one spelling, so both compose."""
+        assert self._topics_passed_to_db(client, db, "&topics=a,b&topics=c") == ["a", "b", "c"]
+
+    def test_whitespace_is_stripped_in_every_occurrence(self, client, db):
+        """Stripping applied to the first occurrence only; now it applies to all."""
+        assert self._topics_passed_to_db(client, db, "&topics=%20a%20,%20b%20&topics=%20c%20") == ["a", "b", "c"]
+
+    def test_omitted_topics_is_none(self, client, db):
+        """No filter at all must stay ``None``, not an empty list."""
+        assert self._topics_passed_to_db(client, db, "") is None
+
+    def test_empty_value_yields_empty_list(self, client, db):
+        """``?topics=`` names no topic. Pre-existing behaviour, kept deliberately."""
+        assert self._topics_passed_to_db(client, db, "&topics=") == []
+
+    def test_bare_comma_yields_empty_list(self, client, db):
+        """``?topics=,`` splits into two empty strings, both dropped."""
+        assert self._topics_passed_to_db(client, db, "&topics=,") == []
+
+    def test_empty_occurrence_among_real_ones_is_dropped(self, client, db):
+        assert self._topics_passed_to_db(client, db, "&topics=a&topics=") == ["a"]


### PR DESCRIPTION
## Summary

`parse_topics` in `libs/agno/agno/os/routers/memory/memory.py` declares its parameter as `Optional[List[str]] = Query(...)`, so FastAPI collects a repeated query parameter into **one element per occurrence** — `?topics=a&topics=b` arrives as `["a", "b"]`. The body read only `topics[0]`:

```python
return [topic.strip() for topic in topics[0].split(",") if topic.strip()]
```

Every occurrence after the first was silently discarded. No error is raised, so a caller filtering `GET /memories` on three topics gets a filter on one and a result set they never asked for.

Measured against the current `main` (`7c68873`) with a FastAPI `TestClient`:

| Query string | Before | After |
| --- | --- | --- |
| *(omitted)* | `None` | `None` |
| `?topics=a,b` | `['a', 'b']` | `['a', 'b']` |
| `?topics=a&topics=b` | `['a']` — `b` dropped | `['a', 'b']` |
| `?topics=a&topics=b&topics=c` | `['a']` — `b`, `c` dropped | `['a', 'b', 'c']` |
| `?topics=a,b&topics=c` | `['a', 'b']` — `c` dropped | `['a', 'b', 'c']` |
| `?topics=` | `[]` | `[]` |
| `?topics=,` | `[]` | `[]` |

The value is not sanity-checked anywhere downstream: the sole caller is `get_memories` at `memory.py:265` (`topics: Optional[List[str]] = Depends(parse_topics)`), which forwards `topics=topics` verbatim into both the `RemoteDb` branch and `local_kwargs`, so the narrowed filter reaches the DB layer on either path.

### Why this is a bug and not the intended contract

`parse_eval_types_filter` in `libs/agno/agno/os/routers/evals/evals.py:515` is the correctly typed contrast:

```python
def parse_eval_types_filter(eval_types: Optional[str] = Query(default=None, ...)):
    return [EvalType(item.strip()) for item in eval_types.split(",")]
```

It declares `Optional[str]` — a single value — so splitting one string is right there. In `parse_topics` the declaration says multi-valued while the implementation read one element: the type annotation and the body disagreed about arity. Fixing the body rather than the annotation keeps the documented comma spelling working and makes the standard list spelling work too.

## The change

One line plus a docstring:

```python
return [topic.strip() for value in topics for topic in value.split(",") if topic.strip()]
```

Deliberately minimal: iterating over every element instead of `topics[0]` leaves all three pre-existing spellings **byte-identical** (`?topics=a,b` → `['a','b']`, `?topics=` → `[]`, `?topics=,` → `[]`), so the diff carries exactly one behavioural change and nothing that currently works changes shape. I considered also mapping the empty-list case to `None` and rejected it to keep the diff single-purpose.

## Tests

Adds `libs/agno/tests/unit/os/routers/test_memory_topics_filter.py` — 9 tests modelled on the existing `test_sort_order_default.py` (a `MagicMock(spec=AsyncBaseDb)`, a real ASGI `TestClient`, assertions on `db.get_user_memories.call_args.kwargs["topics"]` rather than on the response body, so they pin the value actually handed to the DB layer).

**Control experiment** — the new assertions must fail on unfixed source, and the old-behaviour guards must pass either way:

```
$ git stash push -- libs/agno/agno/os/routers/memory/memory.py
$ pytest libs/agno/tests/unit/os/routers/test_memory_topics_filter.py -q
  test_repeated_query_parameter_keeps_every_occurrence   AssertionError
  test_three_repeated_occurrences                        AssertionError
  test_mixed_comma_and_repeated_spellings                AssertionError
  test_whitespace_is_stripped_in_every_occurrence        AssertionError
  4 failed, 5 passed

$ git stash pop
$ pytest libs/agno/tests/unit/os/routers/test_memory_topics_filter.py -q
  9 passed
```

The 5 that pass either way are the deliberate guards: the comma spelling, omitted → `None`, `?topics=` → `[]`, `?topics=,` → `[]`, and an empty occurrence among real ones being dropped.

Full router suite, same command on this branch:

```
$ pytest libs/agno/tests/unit/os/routers/ -q --ignore-glob='*slack*'
  326 passed
```

(The 5 `*slack*` modules are excluded only because `agno[slack]` is not installed in my environment; they fail to import identically on clean `main`.)

`ruff format --check` and `ruff check` are clean on both changed files.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format --check` and `ruff check` on both changed files — clean; `mypy` reports no new errors in the changed file)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — n/a, no cookbook covers this query parameter
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

**Search performed:** `repo:agno-agi/agno is:pr is:open parse_topics` → 0 results. `repo:agno-agi/agno is:pr is:open topics in:title` → 1 result, #3976, an unrelated Kafka tool. Open PRs #7784 and #6554 touch the memories area but neither goes near `parse_topics` or the `topics` query parameter, so there is no conflict. This is the only `[0].split(` of this shape anywhere in `agno/os/routers/`.

## Additional Notes

No API surface change: the parameter name, type, description and example in the OpenAPI schema are untouched, and every request shape that works today returns the same value. Requests that previously returned a silently truncated filter now return the full one — the only observable difference, and the point of the fix.
