### PR TITLE
[fix] Default to descending sort order in Redis, Valkey, DynamoDB and Firestore

### DIFF
--- a/libs/agno/agno/db/dynamo/utils.py
+++ b/libs/agno/agno/db/dynamo/utils.py
@@ -194,7 +194,7 @@ def apply_sorting(
     if sort_by is None:
         sort_by = "created_at"
 
-    is_descending = sort_order == "desc"
+    is_descending = sort_order != "asc" if sort_order else True
 
     # Sort using the helper function that handles updated_at -> created_at fallback
     sorted_records = sorted(

--- a/libs/agno/agno/db/firestore/utils.py
+++ b/libs/agno/agno/db/firestore/utils.py
@@ -144,7 +144,7 @@ def apply_sorting_to_records(
         return records
 
     try:
-        is_descending = sort_order == "desc"
+        is_descending = sort_order != "asc" if sort_order else True
 
         # Sort using the helper function that handles updated_at -> created_at fallback
         sorted_records = sorted(

--- a/libs/agno/agno/db/redis/utils.py
+++ b/libs/agno/agno/db/redis/utils.py
@@ -98,7 +98,7 @@ def apply_sorting(
         return records
 
     try:
-        is_descending = sort_order == "desc"
+        is_descending = sort_order != "asc" if sort_order else True
 
         # Sort using the helper function that handles updated_at -> created_at fallback
         sorted_records = sorted(

--- a/libs/agno/agno/db/valkey/utils.py
+++ b/libs/agno/agno/db/valkey/utils.py
@@ -140,7 +140,7 @@ def apply_sorting(
         return records
 
     try:
-        is_descending = sort_order == "desc"
+        is_descending = sort_order != "asc" if sort_order else True
 
         # Sort using the helper function that handles updated_at -> created_at fallback
         sorted_records = sorted(

--- a/libs/agno/tests/unit/db/test_apply_sorting_defaults.py
+++ b/libs/agno/tests/unit/db/test_apply_sorting_defaults.py
@@ -1,0 +1,112 @@
+"""Every DB backend must default to descending order when sort_order is omitted.
+
+tests/unit/os/routers/test_sort_order_default.py fixes the intended default at the
+router layer: an omitted sort_order reaches the DB as SortOrder.DESC. The DB classes
+are also public API and are called directly, where sort_order is simply None. These
+tests hold every backend's apply_sorting to the same default so a "most recent first"
+listing does not silently invert when the backend changes.
+
+Backends whose client library is not part of the [dev] extra are skipped rather than
+stubbed, matching how the rest of this directory handles optional dependencies.
+"""
+
+from typing import Any, Dict, List
+
+import pytest
+
+# Ordered oldest to newest, so natural insertion order is the ascending order.
+RECORDS: List[Dict[str, Any]] = [
+    {"session_id": "oldest", "created_at": 100, "updated_at": 100},
+    {"session_id": "middle", "created_at": 200, "updated_at": 200},
+    {"session_id": "newest", "created_at": 300, "updated_at": 300},
+]
+
+NEWEST_FIRST = ["newest", "middle", "oldest"]
+OLDEST_FIRST = ["oldest", "middle", "newest"]
+
+# Backends that sort an already-materialized list of records in Python.
+LIST_SORTERS = [
+    ("in_memory", "agno.db.in_memory.utils", "apply_sorting"),
+    ("json", "agno.db.json.utils", "apply_sorting"),
+    ("gcs_json", "agno.db.gcs_json.utils", "apply_sorting"),
+    ("redis", "agno.db.redis.utils", "apply_sorting"),
+    ("valkey", "agno.db.valkey.utils", "apply_sorting"),
+    ("dynamo", "agno.db.dynamo.utils", "apply_sorting"),
+    ("firestore", "agno.db.firestore.utils", "apply_sorting_to_records"),
+]
+
+# Backends that push ORDER BY down to SQLAlchemy.
+SQL_BACKENDS = ["sqlite", "postgres", "mysql", "singlestore"]
+
+
+def _sorter(module: str, func: str):
+    return getattr(pytest.importorskip(module), func)
+
+
+def _ids(records: List[Dict[str, Any]]) -> List[str]:
+    return [record["session_id"] for record in records]
+
+
+@pytest.mark.parametrize("name,module,func", LIST_SORTERS)
+def test_omitted_sort_order_is_descending(name: str, module: str, func: str):
+    """An omitted sort_order must mean newest first, as it does at the router layer."""
+    apply_sorting = _sorter(module, func)
+
+    assert _ids(apply_sorting(list(RECORDS), sort_by="created_at", sort_order=None)) == NEWEST_FIRST
+
+
+@pytest.mark.parametrize("name,module,func", LIST_SORTERS)
+def test_explicit_sort_order_is_unchanged(name: str, module: str, func: str):
+    """The explicit directions keep working; only the omitted case moves."""
+    apply_sorting = _sorter(module, func)
+
+    assert _ids(apply_sorting(list(RECORDS), sort_by="created_at", sort_order="desc")) == NEWEST_FIRST
+    assert _ids(apply_sorting(list(RECORDS), sort_by="created_at", sort_order="asc")) == OLDEST_FIRST
+
+
+@pytest.mark.parametrize("name,module,func", LIST_SORTERS)
+def test_updated_at_falls_back_to_created_at(name: str, module: str, func: str):
+    """The documented pre-2.0 fallback still holds under the default direction."""
+    apply_sorting = _sorter(module, func)
+    records = [
+        {"session_id": "oldest", "created_at": 100, "updated_at": None},
+        {"session_id": "newest", "created_at": 300, "updated_at": None},
+    ]
+
+    # Both rows resolve to their created_at, so the newer creation time leads.
+    assert _ids(apply_sorting(records, sort_by="updated_at", sort_order=None))[0] == "newest"
+
+
+def test_dynamo_defaults_to_created_at_descending():
+    """Dynamo substitutes created_at for a missing sort_by, so it always sorts."""
+    apply_sorting = _sorter("agno.db.dynamo.utils", "apply_sorting")
+
+    assert _ids(apply_sorting(list(RECORDS), sort_by=None, sort_order=None)) == NEWEST_FIRST
+
+
+@pytest.mark.parametrize("backend", SQL_BACKENDS)
+def test_sql_backends_order_by_desc_when_sort_order_omitted(backend: str):
+    """The SQL backends already default to DESC; hold them there."""
+    sqlalchemy = pytest.importorskip("sqlalchemy")
+    apply_sorting = _sorter(f"agno.db.{backend}.utils", "apply_sorting")
+
+    metadata = sqlalchemy.MetaData()
+    table = sqlalchemy.Table(
+        "sessions",
+        metadata,
+        sqlalchemy.Column("session_id", sqlalchemy.String),
+        sqlalchemy.Column("created_at", sqlalchemy.Integer),
+        sqlalchemy.Column("updated_at", sqlalchemy.Integer),
+    )
+
+    statement = str(apply_sorting(sqlalchemy.select(table), table, sort_by="created_at", sort_order=None))
+
+    assert "ORDER BY" in statement.upper()
+    assert "DESC" in statement.upper()
+
+
+def test_mongo_sort_spec_is_descending_when_sort_order_omitted():
+    """Mongo pushes sorting to the driver; -1 is descending."""
+    apply_sorting = _sorter("agno.db.mongo.utils", "apply_sorting")
+
+    assert apply_sorting({}, sort_by="created_at", sort_order=None) == [("created_at", -1)]


### PR DESCRIPTION
## Summary

`get_sessions()`, `get_user_memories()` and the other paginated reads accept `sort_order`. When it is omitted, **eight DB backends return newest first and four return oldest first**, so the same call returns opposite ends of the table depending on which backend is configured.

The intended default is already settled in this repo. `tests/unit/os/routers/test_sort_order_default.py` states it in its own docstring — *"Validates that sort_order query parameter defaults to SortOrder.DESC"* — and asserts `call_kwargs["sort_order"] is SortOrder.DESC`. The DB classes are public API and are also called directly, where `sort_order` is simply `None`, and that is the path that diverges.

**Root cause.** Four implementations resolve the direction with `sort_order == "desc"`, which evaluates to `False` when `sort_order` is `None`, making the omitted case *ascending*:

| Backend | Expression | Default with `sort_order=None` |
|---|---|---|
| `in_memory`, `json`, `gcs_json` | `sort_order != "asc" if sort_order else True` | descending |
| `sqlite`, `postgres`, `mysql`, `singlestore` | `if sort_order and sort_order == "asc": … else: .desc()` | descending |
| `mongo` | `1 if sort_order == "asc" else -1` | descending |
| `firestore` (query path) | `if sort_order == "asc": ASCENDING else: DESCENDING` | descending |
| **`redis`** | `sort_order == "desc"` | **ascending** |
| **`valkey`** | `sort_order == "desc"` | **ascending** |
| **`dynamo`** | `sort_order == "desc"` | **ascending** |
| **`firestore`** (`apply_sorting_to_records`) | `sort_order == "desc"` | **ascending** |

Two details make this a defect rather than an intentional per-backend choice:

- **`firestore/utils.py` contradicts itself.** `apply_sorting` (query path, line 102) defaults to `DESCENDING`; `apply_sorting_to_records` (line 127) defaults to ascending. One file, one collection, two answers.
- **`dynamo` always sorts.** It substitutes `created_at` when `sort_by` is `None`, so a plain `get_sessions()` with no sort arguments at all returns the *oldest* sessions first, where every SQL backend returns them unsorted and the router-declared default is newest first.

**User-visible effect.** A "recent sessions" list built on `RedisDb`, `ValkeyDb`, `DynamoDb` or `FirestoreDb` shows the oldest rows, and with `limit` set the newest rows never appear at all. Nothing raises. Moving a working app from Postgres to Redis silently reverses the order of every listing.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — n/a, no public API or example behaviour changes
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach — no similar PR exists; the only open PR matching `sort_order` is #5331 (`feat: context manager`), which is unrelated
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — see the disclosure under Additional Notes

---

## Additional Notes

**The fix.** One line in each of the four files, using the exact expression the correct backends already use:

```python
is_descending = sort_order != "asc" if sort_order else True
```

No new semantics and no new abstraction — the explicit `"asc"` and `"desc"` paths are byte-for-byte unchanged in behaviour. Only the omitted case moves, and it moves to the value the router layer already declares.

**Tests.** `libs/agno/tests/unit/db/test_apply_sorting_defaults.py` parametrizes across *all* backends, not just the four repaired, so the eight that are already correct are held there too. It also covers the documented pre-2.0 `updated_at → created_at` fallback under the new default, and Dynamo's implicit `sort_by="created_at"`.

Backends whose client library is not in the `[dev]` extra are `importorskip`-ed rather than stubbed, matching how this directory already handles optional dependencies. In CI that leaves `redis` (one of the four repaired) plus the SQL backends, `in_memory` and `json` running; the remaining three were verified locally with the extras installed.

**Verified by running the new tests against unpatched code first:**

```
# before the fix
9 failed, 18 passed
# the 9 are exactly redis / valkey / dynamo / firestore; the 18 already-correct cases pass

# after the fix
27 passed
```

Full `tests/unit/db` and the sort-order router tests were run before and after: **identical results, no test newly failing.** The pre-existing failures in that range (7 `aiosqlite` collection errors in `test_auth_tokens*.py`, 3 `test_valkey.py::TestTrace` failures) reproduce unchanged with this branch stashed.

`ruff format`, `ruff check` and `mypy` are clean on all five files. The one `mypy` error in the wider run is `firestore/firestore.py:115` (`"Client" has no attribute "list_collections"`), which is pre-existing and in a file this PR does not touch.

**Scope, deliberately.** `surrealdb` has the same defect through a different mechanism — `queries.py` builds `ORDER BY {sort_by} {sort_order or ''}`, so an omitted `sort_order` emits no direction and SurrealDB's own default (ascending) applies. It is left out because it is a query-string change rather than this one-line comparison, and it wants a live SurrealDB to verify rather than a unit test. Happy to send it as a follow-up.

Also left alone: `mongo` and Firestore's query path do not apply the `updated_at → created_at` fallback that every Python-side backend gets from `get_sort_value`, because they push sorting to the database. That is a real parity gap but a separate behaviour question needing `$ifNull`-style query changes, and folding it in would turn a one-line fix into a design change.

**AI disclosure.** This PR was written with AI assistance (Claude Code). I found and confirmed the divergence, chose the scope, ran the verification above — including running the new tests against unpatched code to prove they fail — and I understand and stand behind every line. Flagging it because CONTRIBUTING asks.
