### PR TITLE
feat: context compaction for long-running agents and teams

### DIFF
--- a/cookbook/14_context_compaction/01_quickstart.py
+++ b/cookbook/14_context_compaction/01_quickstart.py
@@ -1,0 +1,79 @@
+"""
+Context Compaction Quickstart
+=============================
+
+Long conversations exceed model context windows. Context compaction solves this
+by summarizing old assistant/tool messages while preserving user messages
+(intent, corrections, preferences) verbatim.
+
+When context approaches the limit, older messages are replaced with a summary.
+The model sees: [system] + [summary] + [preserved users] + [recent messages].
+"""
+
+from agno.agent import Agent
+from agno.compression import CompactionManager
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+# CompactionManager needs a model for token counting
+# keep_recent=2 means only 2 recent messages stay uncompacted (rest get summarized)
+compaction_manager = CompactionManager(
+    model=OpenAIChat(id="gpt-4.1-mini"),
+    compact_context=True,
+    compact_context_message_limit=6,
+    compact_context_keep_recent=2,
+)
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4.1-mini"),
+    db=SqliteDb(db_file="tmp/quickstart_compaction.db"),
+    session_id="quickstart-demo",
+    add_history_to_context=True,
+    compaction_manager=compaction_manager,
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print("Starting multi-turn conversation...")
+
+    responses = [
+        agent.run(
+            "What is Python? Give a detailed explanation with history and use cases."
+        ),
+        agent.run("Now explain JavaScript in the same level of detail."),
+        agent.run("Compare Python and JavaScript for web development."),
+        agent.run("What about TypeScript? How does it relate to JavaScript?"),
+        agent.run("Can you summarize the key differences between all three languages?"),
+    ]
+
+    for i, response in enumerate(responses, 1):
+        print(f"\n--- Turn {i} ---")
+        print(
+            response.content[:200] + "..."
+            if len(response.content) > 200
+            else response.content
+        )
+
+        if (
+            response.compaction_state
+            and response.compaction_state.total_compactions > 0
+        ):
+            print(
+                f"  [Compaction #{response.compaction_state.total_compactions}] {response.compaction_state.total_tokens_saved} tokens saved"
+            )
+
+    # Final state
+    last = responses[-1]
+    if last.compaction_state and last.compaction_state.total_compactions > 0:
+        state = last.compaction_state
+        print(
+            f"\nFinal: {state.total_compactions} compactions, {state.total_tokens_saved} tokens saved"
+        )

--- a/cookbook/14_context_compaction/02_custom_model.py
+++ b/cookbook/14_context_compaction/02_custom_model.py
@@ -1,0 +1,54 @@
+"""
+Custom Compaction Model
+=======================
+
+Use a cheaper model for generating compaction summaries while keeping the main
+agent on a more capable model. The compaction model only generates summaries,
+so it can be smaller and faster.
+
+This is useful when:
+- Your main agent uses an expensive model (GPT-4, Claude Opus)
+- You want to minimize compaction costs
+- Summary quality doesn't need to match response quality
+"""
+
+from agno.agent import Agent
+from agno.compression import CompactionManager
+from agno.models.openai import OpenAIChat
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+# Cheap model for summaries
+compaction_manager = CompactionManager(
+    model=OpenAIChat(id="gpt-4.1-mini"),  # Cheap model for summaries
+    compact_context=True,
+    compact_context_message_limit=6,
+    compact_context_keep_recent=2,
+    compact_context_preserve_user_budget=10000,
+)
+
+# More capable model for responses
+agent = Agent(
+    model=OpenAIChat(id="gpt-4.1"),
+    compaction_manager=compaction_manager,
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print("Agent configured with:")
+    print("  Main model: gpt-4.1")
+    print("  Compaction model: gpt-4.1-mini")
+    print(f"  Message limit: {compaction_manager.compact_context_message_limit}")
+    print(f"  Keep recent: {compaction_manager.compact_context_keep_recent}")
+    print()
+
+    response = agent.run(
+        "Explain the benefits of using separate models for compression."
+    )
+    print(response.content)

--- a/cookbook/14_context_compaction/03_with_tools.py
+++ b/cookbook/14_context_compaction/03_with_tools.py
@@ -1,0 +1,64 @@
+"""
+Context Compaction with Tools
+
+Demonstrates compaction with tool-heavy workflows where tool results
+consume significant context. User messages are preserved while tool
+outputs are summarized.
+
+Run: .venvs/demo/bin/python cookbook/14_context_compaction/03_with_tools.py
+"""
+
+from agno.agent import Agent
+from agno.compression import CompactionManager
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.tools.duckduckgo import DuckDuckGoTools
+
+# Create compaction manager
+compaction_manager = CompactionManager(
+    model=OpenAIChat(id="gpt-4.1-mini"),
+    compact_context=True,
+    compact_context_message_limit=6,
+    compact_context_keep_recent=2,
+)
+
+# Agent with web search tools - tool results can be large
+agent = Agent(
+    model=OpenAIChat(id="gpt-4.1-mini"),
+    tools=[DuckDuckGoTools()],
+    db=SqliteDb(db_file="tmp/tools_compaction.db"),
+    session_id="tools-demo",
+    add_history_to_context=True,
+    compaction_manager=compaction_manager,
+    markdown=True,
+)
+
+print("Running tool-heavy research session...")
+print(
+    "Context compaction will summarize tool results while preserving your questions.\n"
+)
+
+# Multi-turn research that generates large tool outputs
+queries = [
+    "Search for the latest news about Python 3.13 features",
+    "Now search for TypeScript 5.0 new features",
+    "Compare what you found - which has more impactful changes?",
+]
+
+for query in queries:
+    print(f"User: {query}")
+    response = agent.run(query)
+    print(f"Assistant: {response.content[:300]}...")
+
+    if response.compaction_state and response.compaction_state.total_compactions > 0:
+        print(
+            f"  [Compaction] {response.compaction_state.total_tokens_saved} tokens saved"
+        )
+    print()
+
+# Show final compaction stats
+if response.compaction_state and response.compaction_state.total_compactions > 0:
+    state = response.compaction_state
+    print("Final stats:")
+    print(f"  Total compactions: {state.total_compactions}")
+    print(f"  Tokens saved: {state.total_tokens_saved}")

--- a/cookbook/14_context_compaction/04_with_session.py
+++ b/cookbook/14_context_compaction/04_with_session.py
@@ -1,0 +1,66 @@
+"""
+Context Compaction with Session Persistence
+
+Compaction state is stored in session_data, allowing it to persist
+across session reloads. This enables long-running conversations that
+span multiple process restarts.
+
+Run: .venvs/demo/bin/python cookbook/14_context_compaction/04_with_session.py
+"""
+
+from agno.agent import Agent
+from agno.compression import CompactionManager
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+
+# Use SQLite for session persistence
+db = SqliteDb(db_file="tmp/compaction_demo.db")
+
+# Create compaction manager
+compaction_manager = CompactionManager(
+    model=OpenAIChat(id="gpt-4.1-mini"),
+    compact_context=True,
+    compact_context_message_limit=4,
+    compact_context_keep_recent=2,
+)
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4.1-mini"),
+    session_id="compaction-demo-session",
+    db=db,
+    add_history_to_context=True,
+    compaction_manager=compaction_manager,
+    markdown=True,
+)
+
+print("Session-persistent context compaction demo")
+print(f"Session ID: {agent.session_id}")
+print("-" * 50)
+
+# Run multiple turns
+responses = [
+    agent.run("Remember: my favorite color is blue and I work as a data scientist."),
+    agent.run("What programming languages should I learn for my job?"),
+    agent.run("Tell me more about Python libraries for data science."),
+    agent.run(
+        "What was my favorite color again?"
+    ),  # Tests if user preference survives compaction
+]
+
+for i, r in enumerate(responses, 1):
+    print(f"\nTurn {i}: {r.content[:150]}...")
+    if r.compaction_state and r.compaction_state.total_compactions > 0:
+        print(
+            f"  [Compaction #{r.compaction_state.total_compactions}] {r.compaction_state.total_tokens_saved} tokens saved"
+        )
+
+# Check compaction state from last response
+last_response = responses[-1]
+state = last_response.compaction_state
+if state and state.total_compactions > 0:
+    print("\nFinal compaction state:")
+    print(f"  Total compactions: {state.total_compactions}")
+    print(f"  Messages compacted: {state.compacted_count}")
+    print(f"  Tokens saved: {state.total_tokens_saved}")
+else:
+    print("\nNo compaction occurred (context stayed under limit)")

--- a/cookbook/14_context_compaction/05_force_compaction.py
+++ b/cookbook/14_context_compaction/05_force_compaction.py
@@ -1,0 +1,79 @@
+"""
+Force Context Compaction Test
+
+Uses a very low token limit to force compaction to trigger.
+This verifies the full compaction flow works end-to-end.
+
+Run: .venvs/demo/bin/python cookbook/14_context_compaction/05_force_compaction.py
+"""
+
+from agno.agent import Agent
+from agno.compression import CompactionManager
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+
+# Low message limit to force compaction
+MESSAGE_LIMIT = 4
+
+db = SqliteDb(db_file="tmp/force_compaction_test.db")
+
+# Create compaction manager with low limits to force compaction
+# Model is required for token counting
+compaction_manager = CompactionManager(
+    model=OpenAIChat(id="gpt-4.1-mini"),
+    compact_context=True,
+    compact_context_message_limit=4,  # Trigger after 4 messages
+    compact_context_keep_recent=2,  # Only keep 2 recent messages
+)
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4.1-mini"),
+    session_id="force-compaction-test",
+    db=db,
+    add_history_to_context=True,  # Include previous turns in context
+    compaction_manager=compaction_manager,
+    markdown=True,
+    debug_mode=False,
+)
+
+print(f"Testing context compaction with {MESSAGE_LIMIT} message limit")
+print("=" * 60)
+
+# These prompts will generate long responses that exceed the token limit
+prompts = [
+    "My name is Alice and I'm a software engineer working on distributed systems. Remember this.",
+    "Explain the CAP theorem in detail with examples of systems that prioritize each property.",
+    "Now explain the PACELC theorem and how it extends CAP.",
+    "What are the trade-offs between consistency and availability in my distributed system design?",
+    "Based on our conversation, what would you recommend for a system that needs high availability?",
+    "What was my name and profession again?",  # Test if user info survives compaction
+]
+
+last_response = None
+for i, prompt in enumerate(prompts, 1):
+    print(f"\n--- Turn {i} ---")
+    print(f"User: {prompt[:60]}...")
+
+    response = agent.run(prompt)
+    last_response = response
+
+    # Check compaction state after each turn
+    state = response.compaction_state
+    if state and state.total_compactions > 0:
+        print(
+            f"[COMPACTION #{state.total_compactions}] {state.total_tokens_saved} tokens saved"
+        )
+
+    print(f"Assistant: {response.content[:150]}...")
+
+print("\n" + "=" * 60)
+print("Final compaction state:")
+if last_response and last_response.compaction_state:
+    state = last_response.compaction_state
+    print(f"  Total compactions: {state.total_compactions}")
+    print(f"  Messages compacted: {state.compacted_count}")
+    print(f"  Total tokens saved: {state.total_tokens_saved}")
+    print("\nSummary preview:")
+    print(state.summary[:500] + "..." if len(state.summary) > 500 else state.summary)
+else:
+    print("  No compaction occurred")

--- a/cookbook/14_context_compaction/06_preference_survival.py
+++ b/cookbook/14_context_compaction/06_preference_survival.py
@@ -1,0 +1,129 @@
+"""
+Preference Survival Test
+
+Tests if user preferences stated early in conversation survive compaction.
+This is a critical test - compaction should preserve user intent.
+
+Run: .venvs/demo/bin/python cookbook/14_context_compaction/06_preference_survival.py
+"""
+
+from agno.agent import Agent
+from agno.compression import CompactionManager
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+
+db = SqliteDb(db_file="tmp/preference_survival_test.db")
+
+# Create compaction manager with aggressive settings to force compaction
+compaction_manager = CompactionManager(
+    model=OpenAIChat(id="gpt-4.1-mini"),
+    compact_context=True,
+    compact_context_message_limit=4,
+    compact_context_keep_recent=2,
+)
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4.1-mini"),
+    session_id="preference-survival-test",
+    db=db,
+    add_history_to_context=True,
+    compaction_manager=compaction_manager,
+    markdown=True,
+)
+
+print("Preference Survival Test")
+print("=" * 60)
+print()
+
+# Turn 1: State preferences clearly
+preferences = """
+IMPORTANT - Remember these preferences for our entire conversation:
+- My name is Marcus and I'm a backend engineer
+- I prefer Python with type hints everywhere
+- I use pytest for testing, NOT unittest
+- I prefer composition over inheritance
+- Always use dataclasses, not regular classes
+- Logging with structlog, not print statements
+- I hate abbreviations - use full variable names
+"""
+
+print("Turn 1: Setting preferences...")
+response = agent.run(preferences)
+print(f"Response: {response.content[:100]}...")
+
+# Turn 2-4: Generate content to push toward compaction
+filler_prompts = [
+    "Explain the singleton pattern with a detailed Python example including all the edge cases.",
+    "Now explain the factory pattern with multiple examples of when to use abstract factories vs simple factories.",
+    "Describe the observer pattern with a complete implementation including async support.",
+]
+
+for i, prompt in enumerate(filler_prompts, 2):
+    print(f"\nTurn {i}: {prompt[:50]}...")
+    response = agent.run(prompt)
+
+    # Check if compaction happened
+    state = response.compaction_state
+    if state and state.total_compactions > 0:
+        print(
+            f"  [COMPACTION #{state.total_compactions}] {state.total_tokens_saved} tokens saved"
+        )
+
+# Turn 5: Test if preferences survived
+print("\n" + "=" * 60)
+print("VERIFICATION: Testing if preferences survived compaction")
+print("=" * 60)
+
+test_prompt = """
+Create a simple logging utility class for me.
+What's my name again, and what testing framework should you use?
+"""
+
+print(f"\nTest prompt: {test_prompt.strip()}")
+response = agent.run(test_prompt)
+print(f"\nResponse:\n{response.content}")
+
+# Analyze response for preference violations
+print("\n" + "=" * 60)
+print("ANALYSIS")
+print("=" * 60)
+
+response_lower = response.content.lower()
+
+checks = [
+    ("Name Marcus remembered", "marcus" in response_lower),
+    (
+        "Uses pytest (not unittest)",
+        "pytest" in response_lower or "unittest" not in response_lower,
+    ),
+    (
+        "Uses structlog (not print)",
+        "structlog" in response_lower or "print(" not in response.content,
+    ),
+    (
+        "Uses dataclass",
+        "dataclass" in response_lower or "@dataclass" in response.content,
+    ),
+    (
+        "Type hints present",
+        ": str" in response.content
+        or ": int" in response.content
+        or "-> " in response.content,
+    ),
+]
+
+passed = 0
+for check_name, check_result in checks:
+    status = "PASS" if check_result else "FAIL"
+    print(f"  {status}: {check_name}")
+    if check_result:
+        passed += 1
+
+print(f"\nScore: {passed}/{len(checks)} preferences preserved")
+
+# Show compaction state from the last response
+state = response.compaction_state
+if state and state.summary:
+    print("\nCompaction summary preview:")
+    print("-" * 40)
+    print(state.summary[:800] if state.summary else "(no summary)")

--- a/cookbook/14_context_compaction/07_comprehensive_test.py
+++ b/cookbook/14_context_compaction/07_comprehensive_test.py
@@ -1,0 +1,288 @@
+"""
+Comprehensive Context Compaction Test Suite
+
+Tests all aspects of context compaction:
+1. Basic compaction works
+2. User preferences survive compaction
+3. Works across multiple runs
+4. Async compaction works
+
+Run: .venvs/demo/bin/python cookbook/14_context_compaction/07_comprehensive_test.py
+"""
+
+import asyncio
+import os
+
+from agno.agent import Agent
+from agno.compression import CompactionManager
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+
+
+def test_basic_compaction():
+    """Test 1: Verify basic compaction triggers and works."""
+    print("\n" + "=" * 60)
+    print("TEST 1: Basic Compaction")
+    print("=" * 60)
+
+    db_path = "tmp/basic_compaction_test.db"
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    db = SqliteDb(db_file=db_path)
+
+    compaction_manager = CompactionManager(
+        model=OpenAIChat(id="gpt-4.1-mini"),
+        compact_context=True,
+        compact_context_message_limit=4,
+        compact_context_keep_recent=2,
+    )
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4.1-mini"),
+        session_id="basic-compaction-test",
+        db=db,
+        add_history_to_context=True,
+        compaction_manager=compaction_manager,
+    )
+
+    prompts = [
+        "Explain Python decorators with detailed examples.",
+        "Now explain context managers in Python.",
+        "How do decorators and context managers compare?",
+    ]
+
+    compaction_occurred = False
+    for i, prompt in enumerate(prompts, 1):
+        print(f"Turn {i}: {prompt[:40]}...")
+        response = agent.run(prompt)
+        print(f"  Response: {response.content[:60]}...")
+
+        state = response.compaction_state
+        if state and state.total_compactions > 0:
+            print(
+                f"  Compaction #{state.total_compactions} - {state.total_tokens_saved} tokens saved"
+            )
+            compaction_occurred = True
+
+    os.remove(db_path)
+
+    if compaction_occurred:
+        print("\nPASS: Basic compaction triggered")
+    else:
+        print("\nNOTE: Compaction may not have triggered (depends on response length)")
+
+    return True
+
+
+def test_preference_survival():
+    """Test 2: Verify user preferences survive compaction."""
+    print("\n" + "=" * 60)
+    print("TEST 2: Preference Survival")
+    print("=" * 60)
+
+    db_path = "tmp/preference_test.db"
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    db = SqliteDb(db_file=db_path)
+
+    compaction_manager = CompactionManager(
+        model=OpenAIChat(id="gpt-4.1-mini"),
+        compact_context=True,
+        compact_context_message_limit=4,
+        compact_context_keep_recent=2,
+    )
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4.1-mini"),
+        session_id="preference-test",
+        db=db,
+        add_history_to_context=True,
+        compaction_manager=compaction_manager,
+    )
+
+    # Set preferences
+    print("Setting preferences...")
+    r1 = agent.run("My name is CompactionTestUser and I prefer Python over JavaScript.")
+    print(f"  Response: {r1.content[:60]}...")
+
+    # Add filler content to trigger compaction
+    print("Adding content to trigger compaction...")
+    r2 = agent.run("Explain the decorator pattern in detail with multiple examples.")
+    print(f"  Response: {r2.content[:60]}...")
+
+    state = r2.compaction_state
+    if state and state.total_compactions > 0:
+        print(f"  Compaction #{state.total_compactions} occurred")
+
+    # Test if preferences survived
+    print("Testing preference survival...")
+    r3 = agent.run("What's my name and what language do I prefer?")
+    print(f"  Response: {r3.content[:150]}...")
+
+    name_found = "compactiontestuser" in r3.content.lower()
+    python_found = "python" in r3.content.lower()
+
+    os.remove(db_path)
+
+    print(f"\nName preserved: {'YES' if name_found else 'NO'}")
+    print(f"Language preference preserved: {'YES' if python_found else 'NO'}")
+
+    if name_found and python_found:
+        print("PASS: Preferences survived compaction")
+    else:
+        print("WARNING: Some preferences may have been lost")
+
+    return True
+
+
+def test_multi_run_persistence():
+    """Test 3: Verify compaction state persists across runs."""
+    print("\n" + "=" * 60)
+    print("TEST 3: Multi-Run State Persistence")
+    print("=" * 60)
+
+    db_path = "tmp/multi_run_test.db"
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    db = SqliteDb(db_file=db_path)
+
+    compaction_manager = CompactionManager(
+        model=OpenAIChat(id="gpt-4.1-mini"),
+        compact_context=True,
+        compact_context_message_limit=4,
+        compact_context_keep_recent=2,
+    )
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4.1-mini"),
+        session_id="multi-run-test",
+        db=db,
+        add_history_to_context=True,
+        compaction_manager=compaction_manager,
+    )
+
+    # Run 1: Set context
+    print("Run 1: Setting preferences...")
+    r1 = agent.run("My name is TestUser and I prefer Python.")
+    print(f"  Response: {r1.content[:60]}...")
+
+    # Run 2: Add more content
+    print("Run 2: Adding content...")
+    r2 = agent.run("Explain the decorator pattern in detail with multiple examples.")
+    print(f"  Response: {r2.content[:60]}...")
+
+    state = r2.compaction_state
+    if state and state.total_compactions > 0:
+        print(f"  Compaction #{state.total_compactions} occurred")
+
+    # Run 3: More content
+    print("Run 3: Adding more content...")
+    r3 = agent.run("Now explain the strategy pattern with examples.")
+    print(f"  Response: {r3.content[:60]}...")
+
+    state = r3.compaction_state
+    if state and state.total_compactions > 0:
+        print(f"  Compaction #{state.total_compactions} occurred")
+        print(f"  Total tokens saved: {state.total_tokens_saved}")
+
+    # Run 4: Test if preferences survived
+    print("Run 4: Testing preference survival...")
+    r4 = agent.run("What's my name?")
+    print(f"  Response: {r4.content[:100]}...")
+
+    name_found = "testuser" in r4.content.lower()
+    print(f"\nName preserved: {'YES' if name_found else 'NO'}")
+
+    os.remove(db_path)
+
+    print("PASS: Multi-run test completed")
+    return True
+
+
+async def test_async_compaction():
+    """Test 4: Verify async compaction works."""
+    print("\n" + "=" * 60)
+    print("TEST 4: Async Compaction")
+    print("=" * 60)
+
+    db_path = "tmp/async_test.db"
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    db = SqliteDb(db_file=db_path)
+
+    compaction_manager = CompactionManager(
+        model=OpenAIChat(id="gpt-4.1-mini"),
+        compact_context=True,
+        compact_context_message_limit=4,
+        compact_context_keep_recent=2,
+    )
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4.1-mini"),
+        session_id="async-test",
+        db=db,
+        add_history_to_context=True,
+        compaction_manager=compaction_manager,
+    )
+
+    prompts = [
+        "My name is AsyncUser. Remember this.",
+        "Explain coroutines in Python with detailed examples.",
+        "What's my name?",
+    ]
+
+    for i, prompt in enumerate(prompts, 1):
+        print(f"Async Turn {i}: {prompt[:40]}...")
+        response = await agent.arun(prompt)
+        print(f"  Response: {response.content[:60]}...")
+
+        state = response.compaction_state
+        if state and state.total_compactions > 0:
+            print(
+                f"  Compaction #{state.total_compactions}: {state.total_tokens_saved} tokens saved"
+            )
+
+    os.remove(db_path)
+
+    print("\nPASS: Async compaction works")
+    return True
+
+
+def run_all_tests():
+    """Run all tests."""
+    print("=" * 60)
+    print("COMPREHENSIVE CONTEXT COMPACTION TEST SUITE")
+    print("=" * 60)
+
+    results = []
+
+    # Integration tests
+    results.append(("Basic Compaction", test_basic_compaction()))
+    results.append(("Preference Survival", test_preference_survival()))
+    results.append(("Multi-Run Persistence", test_multi_run_persistence()))
+    results.append(("Async Compaction", asyncio.run(test_async_compaction())))
+
+    # Summary
+    print("\n" + "=" * 60)
+    print("TEST SUMMARY")
+    print("=" * 60)
+
+    passed = sum(1 for _, r in results if r)
+    total = len(results)
+
+    for name, result in results:
+        status = "PASS" if result else "FAIL"
+        print(f"  {status}: {name}")
+
+    print(f"\nTotal: {passed}/{total} tests passed")
+
+    return passed == total
+
+
+if __name__ == "__main__":
+    success = run_all_tests()
+    exit(0 if success else 1)

--- a/cookbook/14_context_compaction/08_streaming_test.py
+++ b/cookbook/14_context_compaction/08_streaming_test.py
@@ -1,0 +1,182 @@
+"""
+Streaming Context Compaction Test
+
+Tests that compaction works correctly with streaming responses.
+
+Run: .venvs/demo/bin/python cookbook/14_context_compaction/08_streaming_test.py
+"""
+
+import os
+
+from agno.agent import Agent
+from agno.compression import CompactionManager
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+
+
+def test_sync_streaming():
+    """Test compaction with sync streaming."""
+    print("=" * 60)
+    print("TEST: Sync Streaming Compaction")
+    print("=" * 60)
+
+    db_path = "tmp/streaming_test.db"
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    db = SqliteDb(db_file=db_path)
+
+    compaction_manager = CompactionManager(
+        model=OpenAIChat(id="gpt-4.1-mini"),
+        compact_context=True,
+        compact_context_message_limit=4,
+        compact_context_keep_recent=2,
+    )
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4.1-mini"),
+        session_id="streaming-test",
+        db=db,
+        add_history_to_context=True,
+        compaction_manager=compaction_manager,
+    )
+
+    prompts = [
+        "My name is StreamUser and I work on distributed systems.",
+        "Explain the Raft consensus algorithm with detailed examples.",
+        "What's my name and what do I work on?",
+    ]
+
+    for i, prompt in enumerate(prompts, 1):
+        print(f"\nTurn {i}: {prompt[:50]}...")
+        print("  Streaming: ", end="", flush=True)
+
+        full_response = ""
+        for chunk in agent.run(prompt, stream=True):
+            if hasattr(chunk, "content") and chunk.content:
+                print(".", end="", flush=True)
+                full_response += chunk.content
+
+        print()
+        print(f"  Response: {full_response[:80]}...")
+
+        # Get compaction state from the last run output
+        run_output = agent.get_last_run_output(session_id="streaming-test")
+        if run_output and run_output.compaction_state:
+            state = run_output.compaction_state
+            if state.total_compactions > 0:
+                print(
+                    f"  [Compaction #{state.total_compactions}] {state.total_tokens_saved} tokens saved"
+                )
+
+    # Verify name survived
+    name_found = "streamuser" in full_response.lower()
+    distributed_found = "distributed" in full_response.lower()
+
+    print(f"\nName preserved: {'YES' if name_found else 'NO'}")
+    print(f"Work context preserved: {'YES' if distributed_found else 'NO'}")
+
+    os.remove(db_path)
+
+    return name_found
+
+
+async def test_async_streaming():
+    """Test compaction with async streaming."""
+    print("\n" + "=" * 60)
+    print("TEST: Async Streaming Compaction")
+    print("=" * 60)
+
+    db_path = "tmp/async_streaming_test.db"
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    db = SqliteDb(db_file=db_path)
+
+    compaction_manager = CompactionManager(
+        model=OpenAIChat(id="gpt-4.1-mini"),
+        compact_context=True,
+        compact_context_message_limit=4,
+        compact_context_keep_recent=2,
+    )
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4.1-mini"),
+        session_id="async-streaming-test",
+        db=db,
+        add_history_to_context=True,
+        compaction_manager=compaction_manager,
+    )
+
+    prompts = [
+        "My name is AsyncStreamUser and I build ML pipelines.",
+        "Explain gradient descent optimization with mathematical details.",
+        "What's my name and what do I build?",
+    ]
+
+    for i, prompt in enumerate(prompts, 1):
+        print(f"\nTurn {i}: {prompt[:50]}...")
+        print("  Streaming: ", end="", flush=True)
+
+        full_response = ""
+        async for chunk in agent.arun(prompt, stream=True):
+            if hasattr(chunk, "content") and chunk.content:
+                print(".", end="", flush=True)
+                full_response += chunk.content
+
+        print()
+        print(f"  Response: {full_response[:80]}...")
+
+        # Get compaction state from the last run output
+        run_output = agent.get_last_run_output(session_id="async-streaming-test")
+        if run_output and run_output.compaction_state:
+            state = run_output.compaction_state
+            if state.total_compactions > 0:
+                print(
+                    f"  [Compaction #{state.total_compactions}] {state.total_tokens_saved} tokens saved"
+                )
+
+    # Verify name survived
+    name_found = "asyncstreamuser" in full_response.lower()
+    ml_found = "ml" in full_response.lower() or "pipeline" in full_response.lower()
+
+    print(f"\nName preserved: {'YES' if name_found else 'NO'}")
+    print(f"Work context preserved: {'YES' if ml_found else 'NO'}")
+
+    os.remove(db_path)
+
+    return name_found
+
+
+def main():
+    import asyncio
+
+    print("STREAMING COMPACTION TESTS")
+    print("=" * 60)
+
+    results = []
+
+    # Sync streaming
+    results.append(("Sync Streaming", test_sync_streaming()))
+
+    # Async streaming
+    results.append(("Async Streaming", asyncio.run(test_async_streaming())))
+
+    # Summary
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+
+    for name, passed in results:
+        status = "PASS" if passed else "FAIL"
+        print(f"  {status}: {name}")
+
+    all_passed = all(r for _, r in results)
+    print(f"\nTotal: {sum(1 for _, r in results if r)}/{len(results)} tests passed")
+
+    return all_passed
+
+
+if __name__ == "__main__":
+    success = main()
+    exit(0 if success else 1)

--- a/cookbook/14_context_compaction/09_multi_model_test.py
+++ b/cookbook/14_context_compaction/09_multi_model_test.py
@@ -1,0 +1,171 @@
+"""
+Multi-Model Context Compaction Test
+
+Tests compaction with different model combinations:
+1. Agent model = OpenAI, Compaction model = OpenAI (default)
+2. Agent model = OpenAI, Compaction model = Claude
+3. Agent model = Claude, Compaction model = GPT-4.1-mini
+4. Agent model = Gemini, Compaction model = OpenAI
+
+Run: .venvs/demo/bin/python cookbook/14_context_compaction/09_multi_model_test.py
+"""
+
+import os
+import tempfile
+from typing import Optional
+
+from agno.agent import Agent
+from agno.compression import CompactionManager
+from agno.db.sqlite import SqliteDb
+from agno.models.anthropic import Claude
+from agno.models.base import Model
+from agno.models.google import Gemini
+from agno.models.openai import OpenAIChat
+
+
+def run_compaction_test(
+    name: str,
+    agent_model: Model,
+    compaction_model: Optional[Model] = None,
+) -> bool:
+    """Run a compaction test with specified models."""
+    print("=" * 60)
+    print(f"TEST: {name}")
+    print("=" * 60)
+    print(f"  Agent model: {agent_model.id}")
+    if compaction_model:
+        print(f"  Compaction model: {compaction_model.id}")
+    else:
+        print("  Compaction model: (same as agent)")
+
+    # Use temp file for database
+    db_file = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    db_path = db_file.name
+    db_file.close()
+
+    db = SqliteDb(db_file=db_path)
+
+    # Create compaction manager - use compaction_model if provided, else agent_model
+    compaction_manager = CompactionManager(
+        model=compaction_model or agent_model,
+        compact_context=True,
+        compact_context_message_limit=4,
+        compact_context_keep_recent=2,
+    )
+
+    agent = Agent(
+        model=agent_model,
+        compaction_manager=compaction_manager,
+        session_id=f"test-{name.lower().replace(' ', '-')}",
+        db=db,
+        add_history_to_context=True,
+    )
+
+    prompts = [
+        "My name is MultiModelUser and I work on quantum computing research.",
+        "Explain quantum entanglement with detailed mathematical examples.",
+        "What's my name and what do I research?",
+    ]
+
+    last_response = None
+    for i, prompt in enumerate(prompts, 1):
+        print(f"\n  Turn {i}: {prompt[:50]}...")
+        try:
+            response = agent.run(prompt)
+            last_response = response
+            print(f"    Response: {response.content[:60]}...")
+
+            state = response.compaction_state
+            if state and state.total_compactions > 0:
+                print(
+                    f"    [Compaction #{state.total_compactions}] {state.total_tokens_saved} tokens saved"
+                )
+        except Exception as e:
+            print(f"    ERROR: {e}")
+            os.remove(db_path)
+            return False
+
+    # Verify name survived
+    name_found = last_response and "multimodeluser" in last_response.content.lower()
+    quantum_found = last_response and "quantum" in last_response.content.lower()
+
+    print(f"\n  Name preserved: {'YES' if name_found else 'NO'}")
+    print(f"  Context preserved: {'YES' if quantum_found else 'NO'}")
+
+    os.remove(db_path)
+
+    return name_found
+
+
+def main():
+    print("MULTI-MODEL CONTEXT COMPACTION TESTS")
+    print("=" * 60)
+    print()
+
+    results = []
+
+    # Test 1: OpenAI agent with default compaction (same model)
+    results.append(
+        (
+            "OpenAI Default",
+            run_compaction_test(
+                name="OpenAI Default",
+                agent_model=OpenAIChat(id="gpt-4.1-mini"),
+            ),
+        )
+    )
+
+    # Test 2: OpenAI agent with Claude as compaction model
+    results.append(
+        (
+            "OpenAI + Claude Compactor",
+            run_compaction_test(
+                name="OpenAI + Claude Compactor",
+                agent_model=OpenAIChat(id="gpt-4.1-mini"),
+                compaction_model=Claude(id="claude-sonnet-4-5-20250929"),
+            ),
+        )
+    )
+
+    # Test 3: Claude agent with GPT-4.1-mini as compaction model
+    results.append(
+        (
+            "Claude + GPT Compactor",
+            run_compaction_test(
+                name="Claude + GPT Compactor",
+                agent_model=Claude(id="claude-sonnet-4-5-20250929"),
+                compaction_model=OpenAIChat(id="gpt-4.1-mini"),
+            ),
+        )
+    )
+
+    # Test 4: Gemini agent with OpenAI compaction
+    results.append(
+        (
+            "Gemini + OpenAI Compactor",
+            run_compaction_test(
+                name="Gemini + OpenAI Compactor",
+                agent_model=Gemini(id="gemini-2.5-flash"),
+                compaction_model=OpenAIChat(id="gpt-4.1-mini"),
+            ),
+        )
+    )
+
+    # Summary
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+
+    for name, passed in results:
+        status = "PASS" if passed else "FAIL"
+        print(f"  {status}: {name}")
+
+    passed_count = sum(1 for _, r in results if r)
+    print(f"\nTotal: {passed_count}/{len(results)} tests passed")
+
+    return passed_count == len(results)
+
+
+if __name__ == "__main__":
+    success = main()
+    exit(0 if success else 1)

--- a/cookbook/14_context_compaction/README.md
+++ b/cookbook/14_context_compaction/README.md
@@ -1,0 +1,120 @@
+# Context Compaction
+
+Automatic context compression for long conversations. When context approaches limits, older assistant/tool messages are summarized while user messages are preserved verbatim.
+
+## Why Context Compaction?
+
+Long conversations exceed model context windows. Traditional solutions have drawbacks:
+- **Truncation** loses important early context
+- **Session summaries** are additive (summary + full history)
+- **Tool compression** only handles tool outputs
+
+Context compaction solves this by:
+1. Preserving user messages (intent, corrections, preferences)
+2. Summarizing assistant/tool messages (work done, results)
+3. Persisting state across session reloads
+
+## Quick Start
+
+```python
+from agno.agent import Agent
+from agno.compression import CompactionManager
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+
+# Create compaction manager with settings
+compaction_manager = CompactionManager(
+    model=OpenAIChat(id="gpt-4.1-mini"),  # Model for token counting and summaries
+    compact_context=True,
+    compact_context_message_limit=6,      # Trigger after 6 messages
+    compact_context_keep_recent=2,        # Keep 2 recent messages uncompacted
+)
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4.1-mini"),
+    db=SqliteDb(db_file="tmp/demo.db"),
+    session_id="demo",
+    add_history_to_context=True,
+    compaction_manager=compaction_manager,
+)
+
+# Long conversations automatically compress when needed
+for question in many_questions:
+    response = agent.run(question)
+    if response.compaction_state:
+        print(f"Compacted: {response.compaction_state.total_tokens_saved} tokens saved")
+```
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `compaction_manager` | None | CompactionManager instance with settings |
+
+### CompactionManager Options
+
+```python
+from agno.compression import CompactionManager
+
+cm = CompactionManager(
+    model=OpenAIChat(id="gpt-4.1-mini"),  # Required for token counting
+    compact_context=True,                  # Enable context compaction
+    compact_context_message_limit=6,       # Trigger after N messages
+    compact_context_token_limit=10000,     # OR trigger after N tokens
+    compact_context_keep_recent=2,         # Messages to keep uncompacted
+    compact_context_preserve_user_budget=20000,  # Max user tokens to preserve
+    compact_context_instructions="...",    # Custom summary prompt
+)
+```
+
+**Key settings:**
+- `model` - Required for token counting. Can be a cheap model like gpt-4.1-mini.
+- `compact_context_keep_recent` - Default is 10. Set lower (2-4) for demos.
+- `compact_context_message_limit` - Trigger based on message count.
+- `compact_context_token_limit` - Trigger based on token count.
+
+## Examples
+
+| File | Description |
+|------|-------------|
+| `01_quickstart.py` | Basic usage with automatic compaction |
+| `02_custom_model.py` | Use a cheap model for summaries |
+| `03_with_tools.py` | Tool-heavy workflows |
+| `04_with_session.py` | Persistent sessions with compaction state |
+| `05_force_compaction.py` | Force compaction with low limits |
+| `06_preference_survival.py` | Test that user preferences survive |
+| `07_comprehensive_test.py` | Full test suite |
+| `08_streaming_test.py` | Streaming responses |
+| `09_multi_model_test.py` | Multi-provider configurations |
+
+## How It Works
+
+When context exceeds the limit:
+
+1. **Split messages** into system, old, preserved users, and recent
+2. **Keep recent** messages uncompacted (controlled by `keep_recent`)
+3. **Summarize** old assistant/tool messages
+4. **Rebuild context**: `[system] + [summary] + [preserved users] + [recent]`
+5. **Store state** in `response.compaction_state`
+
+The summary includes a prefix telling the model it's continuing from a compacted context.
+
+## Accessing Compaction State
+
+```python
+response = agent.run("...")
+
+if response.compaction_state:
+    state = response.compaction_state
+    print(f"Total compactions: {state.total_compactions}")
+    print(f"Messages compacted: {state.compacted_count}")
+    print(f"Tokens saved: {state.total_tokens_saved}")
+    print(f"Summary: {state.summary[:200]}")
+```
+
+## Tips
+
+1. **Use OpenAIChat** for demos - OpenAIResponses uses server-side context and won't trigger local compaction.
+2. **Set `keep_recent` low** for testing - default 10 means you need many messages to see compaction.
+3. **Add a model** to CompactionManager - required for token counting.
+4. **Use `add_history_to_context=True`** - needed for messages to accumulate.

--- a/cookbook/14_context_compaction/TEST_LOG.md
+++ b/cookbook/14_context_compaction/TEST_LOG.md
@@ -10,9 +10,9 @@ Cookbook examples demonstrating context compaction for long-running conversation
 
 **Status:** PASS
 
-**Description:** Basic context compaction demonstration.
+**Description:** Basic multi-turn context compaction demo (5 turns: Python, JavaScript, TypeScript comparisons) with `compact_context_message_limit=6`, `keep_recent=2`.
 
-**Result:** 8 compactions, 4639 tokens saved across 5 turns. Multi-turn conversation successfully compacted while preserving context continuity.
+**Result:** 3 compactions triggered, 2053 tokens saved net across 5 turns. Compaction fired automatically once the message limit was crossed (turns 3-5), and the conversation stayed coherent throughout (each summary built on the previous one).
 
 ---
 
@@ -20,9 +20,9 @@ Cookbook examples demonstrating context compaction for long-running conversation
 
 **Status:** PASS
 
-**Description:** Using a separate model for compaction summaries.
+**Description:** Verifies a cheaper model (gpt-4.1-mini) can be configured for compaction summaries while a stronger model (gpt-4.1) handles the main responses. Single-turn script with no session/db.
 
-**Result:** Configuration verified. Agent uses gpt-4.1 for responses, gpt-4.1-mini for compaction summaries.
+**Result:** Configuration printed correctly (main=gpt-4.1, compactor=gpt-4.1-mini, message_limit=6, keep_recent=2). No compaction occurred — expected, since this file only demonstrates configuration wiring (single turn, no persisted history) rather than triggering compaction. Minor content-quality note: the model answered about generic "data compression" (arithmetic coding, PAQ) rather than "context compaction for agents," since the prompt is ambiguous without a clarifying system message — not a functional bug.
 
 ---
 
@@ -30,9 +30,9 @@ Cookbook examples demonstrating context compaction for long-running conversation
 
 **Status:** PASS
 
-**Description:** Context compaction with tool-heavy workflows.
+**Description:** Tests compaction in a tool-heavy workflow using `DuckDuckGoTools` (now a thin wrapper around `WebSearchTools`/`ddgs`) across 3 research turns.
 
-**Result:** 2 compactions, 956 tokens saved. Tool results (WebSearchTools) properly included in compaction.
+**Result:** 2 compactions triggered, 1065 tokens saved. `search_news` calls failed both times with `ddgs.exceptions.DDGSException: No results found` — an external DuckDuckGo news-backend issue, unrelated to agno. Agno's tool-error-relay handled this gracefully (error text returned to the model, which then answered from its own knowledge), and compaction itself worked correctly even with tool-error messages present in context.
 
 ---
 
@@ -40,9 +40,9 @@ Cookbook examples demonstrating context compaction for long-running conversation
 
 **Status:** PASS
 
-**Description:** Session persistence with compaction state.
+**Description:** Tests that compaction state persists via `SqliteDb` session storage, and that a user preference (favorite color) stated in turn 1 survives 3 compactions (`message_limit=4`).
 
-**Result:** 4 compactions, 2483 tokens saved. User preferences (favorite color: blue, role: data scientist) preserved across session.
+**Result:** 3 compactions triggered; "favorite color: blue" correctly recalled in turn 4 despite compaction. Notable: compactions #1 and #2 showed **negative** tokens saved (-94, -6) — confirmed via source (`libs/agno/agno/compression/_context.py:206`, `tokens_saved = tokens_before - tokens_after`) that this happens when the LLM-generated summary is larger than the small early message set it replaces. Compaction #3 saved 165, netting a positive cumulative total (65 tokens saved overall). Not a bug — see cross-cutting observations below.
 
 ---
 
@@ -50,9 +50,9 @@ Cookbook examples demonstrating context compaction for long-running conversation
 
 **Status:** PASS
 
-**Description:** Force compaction with low message limit (4 messages).
+**Description:** Forces frequent compaction via a low `message_limit=4` across 6 turns, testing whether user identity (name + profession) survives 5 rounds of compaction.
 
-**Result:** 10+ compactions, 4639+ tokens saved. Compaction triggered reliably after each turn.
+**Result:** 5 compactions triggered reliably (13 messages compacted total), 2118 tokens saved net. Final turn correctly recalled "Alice, software engineer specializing in distributed systems" after 5 compactions — strong evidence compaction preserves user identity through repeated summarization cycles.
 
 ---
 
@@ -60,17 +60,19 @@ Cookbook examples demonstrating context compaction for long-running conversation
 
 **Status:** PASS
 
-**Description:** Test that user preferences survive compaction.
+**Description:** Tests survival of 5 distinct stated preferences (name, pytest over unittest, structlog over print, dataclasses, type hints) through 3 rounds of aggressive compaction (`message_limit=4`).
 
-**Result:** 4/5 preferences preserved. Name (Marcus), pytest, structlog, type hints all survived compaction.
+**Result:** 5/5 preferences preserved (previous logged run scored 4/5 — this run scored perfectly, consistent with expected LLM response non-determinism). All checks passed: name "Marcus" remembered, pytest used, structlog used, dataclass used, type hints present in generated code.
 
 ---
 
 ### 07_comprehensive_test.py
 
-**Status:** PENDING
+**Status:** PASS
 
-**Description:** Comprehensive test suite for compaction.
+**Description:** Full test suite covering basic compaction, preference survival, multi-run persistence, and async compaction (4 sub-tests). Run with `timeout 180` as specified.
+
+**Result:** 4/4 sub-tests passed, exit code 0. Same negative-tokens-saved pattern observed on early small compactions in sub-tests 2-4, consistent with 04/05/06 findings — confirms this is systematic behavior of the compaction algorithm, not incidental.
 
 ---
 
@@ -78,9 +80,9 @@ Cookbook examples demonstrating context compaction for long-running conversation
 
 **Status:** PASS
 
-**Description:** Streaming responses with compaction.
+**Description:** Tests that compaction works correctly with both sync (`agent.run(stream=True)`) and async (`agent.arun(stream=True)`) streaming, verifying user name/context recall via `get_last_run_output()`.
 
-**Result:** 2/2 tests passed. Both sync and async streaming work correctly with compaction. User names preserved in both cases.
+**Result:** 2/2 passed — sync and async streaming both preserved user name and work context correctly after compaction (1 compaction triggered in each). One intermittent, non-reproducible `RuntimeError: generator didn't stop after athrow()` traceback appeared from httpcore2's async connection pool during async-generator cleanup, right at the compaction trigger point in the async test; it did not affect the final response or test outcome, and did not reproduce on an isolated re-run of the identical scenario. Flagged as a flaky async-cleanup warning (Python 3.12 / httpcore2 interaction), not a compaction defect.
 
 ---
 
@@ -88,14 +90,18 @@ Cookbook examples demonstrating context compaction for long-running conversation
 
 **Status:** PASS
 
-**Description:** Multi-model compaction configurations.
+**Description:** Tests 4 agent/compactor model combinations: OpenAI/OpenAI (default), OpenAI agent + Claude compactor, Claude agent + GPT compactor, Gemini agent + OpenAI compactor. 3 turns each.
 
-**Result:** 4/4 tests passed. All model combinations work:
-- OpenAI agent + OpenAI compactor
-- OpenAI agent + Claude compactor  
-- Claude agent + GPT compactor
-- Gemini agent + OpenAI compactor
-
-User context (name, research area) preserved in all cases.
+**Result:** 4/4 combinations passed — name ("MultiModelUser") and research-area context ("quantum computing") correctly preserved in all cases, no exceptions across providers. Two things worth flagging:
+1. **Timeout**: An initial run with `timeout 180` and buffered stdout (piped to a file) reported exit code 124 (timeout) after only reaching test 3/4 — this was a false alarm caused by Python fully buffering stdout when not attached to a TTY, not a real hang (confirmed by testing Gemini in isolation, which responded in 0.7s). Re-running with `python -u` (unbuffered) and `timeout 300` completed cleanly with exit code 0. **Recommend `timeout 300` for this file**, not the standard 120s, since it sequentially exercises 3 providers x 4 configs x 3 turns.
+2. **Model-dependent summary size**: Compaction summary length varies significantly by compactor model — Claude Sonnet 4.5 produced summaries in the 215-336 token range vs GPT-4.1-mini's typical 150-207 tokens for the same content, and in one run hit as high as 2035 tokens (against the `DEFAULT_COMPACTION_PROMPT`'s stated "maximum 2000 tokens" ceiling), producing the largest negative tokens-saved value observed across all 9 files (-1952 in that run). Verified via `libs/agno/agno/compression/_context.py:23-55` — the prompt gives a flat 2000-token ceiling with no dynamic/proportional sizing based on how much is actually being summarized. This is a real, model-dependent cost characteristic worth knowing about, not a bug.
 
 ---
+
+## Cross-Cutting Observations
+
+- **Compaction triggers correctly** in every file that exercises multiple turns (01, 03, 04, 05, 06, 07, 08, 09) — message-limit-based triggering fires reliably and message/token counts in the `[COMPACTION]` log line always reconcile with `response.compaction_state`.
+- **User preferences and identity reliably survive compaction** across all preference-survival-focused tests (04, 05, 06, 07, 08, 09), including through 5 consecutive compactions (05) and across sync/async/streaming/multi-provider variants.
+- **Streaming variants work** (08) for both sync and async, with one flaky (non-reproducible) async-generator cleanup warning that did not affect correctness.
+- **Multi-model combinations work** (09) across OpenAI, Anthropic, and Google as both agent model and compactor model, in all 4 tested pairings.
+- **Negative "tokens saved" on small/early compactions is expected, systematic behavior**, not a bug — confirmed at the source level (`_context.py:206`). It occurs when `old_messages` being replaced are smaller than the LLM-generated summary that replaces them. It appeared in 04, 06, 07, 08, and 09, and is most pronounced with more verbose compactor models (Claude > GPT-4.1-mini). Since `total_tokens_saved` accumulates per-compaction deltas across a session, early negative compactions are typically offset by later ones once there's more substantial content to compact — but the metric can mislead if read at a single point mid-conversation. Worth considering whether the default compaction prompt should scale its "maximum tokens" ceiling proportionally to the size of what's being compacted, rather than a flat 2000-token cap, to avoid this pattern on small/early compactions.

--- a/cookbook/14_context_compaction/TEST_LOG.md
+++ b/cookbook/14_context_compaction/TEST_LOG.md
@@ -1,0 +1,101 @@
+# Test Log - Context Compaction
+
+## Overview
+
+Cookbook examples demonstrating context compaction for long-running conversations.
+
+## Tests
+
+### 01_quickstart.py
+
+**Status:** PASS
+
+**Description:** Basic context compaction demonstration.
+
+**Result:** 8 compactions, 4639 tokens saved across 5 turns. Multi-turn conversation successfully compacted while preserving context continuity.
+
+---
+
+### 02_custom_model.py
+
+**Status:** PASS
+
+**Description:** Using a separate model for compaction summaries.
+
+**Result:** Configuration verified. Agent uses gpt-4.1 for responses, gpt-4.1-mini for compaction summaries.
+
+---
+
+### 03_with_tools.py
+
+**Status:** PASS
+
+**Description:** Context compaction with tool-heavy workflows.
+
+**Result:** 2 compactions, 956 tokens saved. Tool results (WebSearchTools) properly included in compaction.
+
+---
+
+### 04_with_session.py
+
+**Status:** PASS
+
+**Description:** Session persistence with compaction state.
+
+**Result:** 4 compactions, 2483 tokens saved. User preferences (favorite color: blue, role: data scientist) preserved across session.
+
+---
+
+### 05_force_compaction.py
+
+**Status:** PASS
+
+**Description:** Force compaction with low message limit (4 messages).
+
+**Result:** 10+ compactions, 4639+ tokens saved. Compaction triggered reliably after each turn.
+
+---
+
+### 06_preference_survival.py
+
+**Status:** PASS
+
+**Description:** Test that user preferences survive compaction.
+
+**Result:** 4/5 preferences preserved. Name (Marcus), pytest, structlog, type hints all survived compaction.
+
+---
+
+### 07_comprehensive_test.py
+
+**Status:** PENDING
+
+**Description:** Comprehensive test suite for compaction.
+
+---
+
+### 08_streaming_test.py
+
+**Status:** PASS
+
+**Description:** Streaming responses with compaction.
+
+**Result:** 2/2 tests passed. Both sync and async streaming work correctly with compaction. User names preserved in both cases.
+
+---
+
+### 09_multi_model_test.py
+
+**Status:** PASS
+
+**Description:** Multi-model compaction configurations.
+
+**Result:** 4/4 tests passed. All model combinations work:
+- OpenAI agent + OpenAI compactor
+- OpenAI agent + Claude compactor  
+- Claude agent + GPT compactor
+- Gemini agent + OpenAI compactor
+
+User context (name, research area) preserved in all cases.
+
+---

--- a/libs/agno/agno/agent/_init.py
+++ b/libs/agno/agno/agent/_init.py
@@ -18,7 +18,7 @@ from typing import (
 if TYPE_CHECKING:
     from agno.agent.agent import Agent
 
-from agno.compression.manager import CompressionManager
+from agno.compression.manager import CompactionManager
 from agno.db.base import AsyncBaseDb
 from agno.memory import MemoryManager
 from agno.models.utils import get_model
@@ -178,18 +178,26 @@ def set_session_summary_manager(agent: Agent) -> None:
         )
 
 
-def set_compression_manager(agent: Agent) -> None:
-    if agent.compress_tool_results and agent.compression_manager is None:
-        agent.compression_manager = CompressionManager(
+def set_compaction_manager(agent: Agent) -> None:
+    """Initialize compaction_manager for tool and/or history compaction."""
+    # Auto-create if either compaction flag is set
+    if (agent.compact_tools or agent.compact_context) and agent.compaction_manager is None:
+        agent.compaction_manager = CompactionManager(
             model=agent.model,
+            compact_tools=agent.compact_tools,
+            compact_context=agent.compact_context,
         )
 
-    if agent.compression_manager is not None and agent.compression_manager.model is None:
-        agent.compression_manager.model = agent.model
+    # If manager exists, sync the compact_context flag
+    if agent.compaction_manager is not None and agent.compact_context:
+        agent.compaction_manager.compact_context = True
 
-    # Check compression flag on the compression manager
-    if agent.compression_manager is not None and agent.compression_manager.compress_tool_results:
-        agent.compress_tool_results = True
+    if agent.compaction_manager is not None and agent.compaction_manager.model is None:
+        agent.compaction_manager.model = agent.model
+
+    # Sync compact_tools flag from manager back to agent
+    if agent.compaction_manager is not None and agent.compaction_manager.compact_tools:
+        agent.compact_tools = True
 
 
 def set_result_store(agent: Agent) -> None:
@@ -203,10 +211,10 @@ def set_result_store(agent: Agent) -> None:
     # stored-result envelope with text whose result id may be gone, while the
     # payload it pointed at lives on unreferenced. Refuse the combination
     # loudly instead of silently favouring one of them.
-    if agent.compress_tool_results and (agent.offload_tool_results or agent._result_store is not None):
+    if agent.compact_tools and (agent.offload_tool_results or agent._result_store is not None):
         raise ValueError(
-            "offload_tool_results and compress_tool_results cannot be enabled together: "
-            "compression rewrites the tool messages that hold stored-result envelopes. "
+            "offload_tool_results and compact_tools cannot be enabled together: "
+            "compaction rewrites the tool messages that hold stored-result envelopes. "
             "Disable one of the two."
         )
     # A store handed down by a team is the team's to manage.
@@ -280,8 +288,8 @@ def get_models(agent: Agent) -> None:
     if agent.fallback_config is not None:
         agent.fallback_config.resolve_models()
 
-    if agent.compression_manager is not None and agent.compression_manager.model is None:
-        agent.compression_manager.model = agent.model
+    if agent.compaction_manager is not None and agent.compaction_manager.model is None:
+        agent.compaction_manager.model = agent.model
 
 
 def initialize_agent(agent: Agent, debug_mode: Optional[bool] = None) -> None:
@@ -294,8 +302,8 @@ def initialize_agent(agent: Agent, debug_mode: Optional[bool] = None) -> None:
         set_memory_manager(agent)
     if agent.enable_session_summaries or agent.session_summary_manager is not None:
         set_session_summary_manager(agent)
-    if agent.compress_tool_results or agent.compression_manager is not None:
-        set_compression_manager(agent)
+    if agent.compact_tools or agent.compact_context or agent.compaction_manager is not None:
+        set_compaction_manager(agent)
     # Resolved when a setting is present or when a store exists.
     if agent.offload_tool_results or agent._result_store is not None:
         set_result_store(agent)

--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -1175,6 +1175,21 @@ def get_run_messages(
 
     # 3. Add history to run_messages
     if add_history_to_context:
+        from copy import deepcopy
+
+        # Find applicable compaction state from previous runs
+        compaction_state = session.get_compaction_state()
+
+        # Inject compaction summary before history (replaces compacted messages)
+        if compaction_state is not None:
+            log_debug(
+                f"[MESSAGES] Injecting compaction summary: total={compaction_state.total_compactions}, "
+                f"ids={len(compaction_state.compacted_message_ids)}"
+            )
+            run_messages.messages.append(compaction_state.get_summary_message())
+            # Seed run_response.compaction_state for mid-loop compaction to build on
+            run_response.compaction_state = deepcopy(compaction_state)
+
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
         # to preserve conversation continuity.
@@ -1187,6 +1202,7 @@ def get_run_messages(
             limit=agent.num_history_messages,
             skip_roles=[skip_role] if skip_role else None,
             agent_id=agent.id if agent.team_id is not None else None,
+            compacted_message_ids=compaction_state.compacted_message_ids if compaction_state else None,
         )
 
         if len(history) > 0:
@@ -1196,7 +1212,7 @@ def get_run_messages(
             if agent.max_tool_calls_from_history is not None:
                 filter_tool_calls(history_copy, agent.max_tool_calls_from_history)
 
-            log_debug(f"Adding {len(history_copy)} messages from history")
+            log_debug(f"[MESSAGES] Adding {len(history_copy)} messages from history")
 
             run_messages.messages += history_copy
 
@@ -1381,6 +1397,21 @@ async def aget_run_messages(
 
     # 3. Add history to run_messages
     if add_history_to_context:
+        from copy import deepcopy
+
+        # Find applicable compaction state from previous runs
+        compaction_state = session.get_compaction_state()
+
+        # Inject compaction summary before history (replaces compacted messages)
+        if compaction_state is not None:
+            log_debug(
+                f"[MESSAGES] Injecting compaction summary: total={compaction_state.total_compactions}, "
+                f"ids={len(compaction_state.compacted_message_ids)}"
+            )
+            run_messages.messages.append(compaction_state.get_summary_message())
+            # Seed run_response.compaction_state for mid-loop compaction to build on
+            run_response.compaction_state = deepcopy(compaction_state)
+
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
         # to preserve conversation continuity.
@@ -1393,6 +1424,7 @@ async def aget_run_messages(
             limit=agent.num_history_messages,
             skip_roles=[skip_role] if skip_role else None,
             agent_id=agent.id if agent.team_id is not None else None,
+            compacted_message_ids=compaction_state.compacted_message_ids if compaction_state else None,
         )
 
         if len(history) > 0:
@@ -1402,7 +1434,7 @@ async def aget_run_messages(
             if agent.max_tool_calls_from_history is not None:
                 filter_tool_calls(history_copy, agent.max_tool_calls_from_history)
 
-            log_debug(f"Adding {len(history_copy)} messages from history")
+            log_debug(f"[MESSAGES] Adding {len(history_copy)} messages from history")
 
             run_messages.messages += history_copy
 
@@ -1506,6 +1538,7 @@ def _build_continue_run_messages(
     session: Optional[AgentSession] = None,
     add_history_to_context: Optional[bool] = None,
     run_context: Optional[RunContext] = None,
+    run_response: Optional[RunOutput] = None,
 ) -> RunMessages:
     """This function returns a RunMessages object with the following attributes:
         - system_message: The system message for this run
@@ -1553,6 +1586,27 @@ def _build_continue_run_messages(
 
     # 2. Add history messages if not already present in input
     if add_history_to_context and session is not None and not input_has_history:
+        from copy import deepcopy
+
+        # Get compaction state for point-in-time filtering (time-travel for continue_run)
+        compaction_state = None
+        if run_response is not None:
+            compaction_state = run_response.compaction_state
+            if compaction_state is None:
+                lookup_id = run_response.forked_from_run_id or run_response.run_id
+                compaction_state = session.get_compaction_state(run_id=lookup_id)
+                # Seed run_response so mid-loop compaction can merge with prior state
+                if compaction_state is not None:
+                    run_response.compaction_state = deepcopy(compaction_state)
+
+        # Inject compaction summary before history (replaces compacted messages)
+        if compaction_state is not None:
+            log_debug(
+                f"[MESSAGES] continue_run: injecting compaction summary: "
+                f"total={compaction_state.total_compactions}, ids={len(compaction_state.compacted_message_ids)}"
+            )
+            run_messages.messages.append(compaction_state.get_summary_message())
+
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
         # to preserve conversation continuity.
@@ -1565,6 +1619,7 @@ def _build_continue_run_messages(
             limit=agent.num_history_messages,
             skip_roles=[skip_role] if skip_role else None,
             agent_id=agent.id if agent.team_id is not None else None,
+            compacted_message_ids=compaction_state.compacted_message_ids if compaction_state else None,
         )
 
         if len(history) > 0:
@@ -1574,7 +1629,7 @@ def _build_continue_run_messages(
             if agent.max_tool_calls_from_history is not None:
                 filter_tool_calls(history_copy, agent.max_tool_calls_from_history)
 
-            log_debug(f"Adding {len(history_copy)} messages from history")
+            log_debug(f"[MESSAGES] Adding {len(history_copy)} messages from history")
             run_messages.messages += history_copy
 
     # 3. Add the remaining input messages (skip the system message to avoid duplication)
@@ -1595,12 +1650,15 @@ def get_continue_run_messages(
     session: Optional[AgentSession] = None,
     add_history_to_context: Optional[bool] = None,
     run_context: Optional[RunContext] = None,
+    run_response: Optional[RunOutput] = None,
 ) -> RunMessages:
     """Build the messages that resume a paused run, reading offloaded media back first.
 
     The paused run's own messages come off the database carrying a reference and no bytes.
     """
-    run_messages = _build_continue_run_messages(agent, input, session, add_history_to_context, run_context)
+    run_messages = _build_continue_run_messages(
+        agent, input, session, add_history_to_context, run_context, run_response
+    )
     media_storage = _resolve_media_storage(agent)
     if media_storage is not None:
         from agno.utils.media_offload import refresh_messages_media
@@ -1615,9 +1673,12 @@ async def aget_continue_run_messages(
     session: Optional[AgentSession] = None,
     add_history_to_context: Optional[bool] = None,
     run_context: Optional[RunContext] = None,
+    run_response: Optional[RunOutput] = None,
 ) -> RunMessages:
     """Async variant of :func:`get_continue_run_messages`."""
-    run_messages = _build_continue_run_messages(agent, input, session, add_history_to_context, run_context)
+    run_messages = _build_continue_run_messages(
+        agent, input, session, add_history_to_context, run_context, run_response
+    )
     media_storage = _resolve_media_storage(agent)
     if media_storage is not None:
         from agno.utils.media_offload import arefresh_messages_media

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1066,7 +1066,7 @@ def handle_model_response_stream(
         stream_model_response=stream_model_response,
         run_response=run_response,
         send_media_to_model=agent.send_media_to_model,
-        compression_manager=agent.compression_manager if agent.compress_tool_results else None,
+        compression_manager=agent.compaction_manager if agent.compact_tools else None,
         **result_store_kwargs(agent),
         after_tool_results=build_after_tool_results_callback(
             agent,
@@ -1227,7 +1227,7 @@ async def ahandle_model_response_stream(
         stream_model_response=stream_model_response,
         run_response=run_response,
         send_media_to_model=agent.send_media_to_model,
-        compression_manager=agent.compression_manager if agent.compress_tool_results else None,
+        compression_manager=agent.compaction_manager if agent.compact_tools else None,
         **result_store_kwargs(agent),
         after_tool_results=abuild_after_tool_results_callback(
             agent,

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1053,7 +1053,21 @@ def handle_model_response_stream(
         log_debug("Response model set, model response is not streamed.")
         stream_model_response = False
 
-    from agno.agent._run import build_after_tool_results_callback
+    from agno.agent._run import build_after_tool_results_callback, build_compaction_callback
+
+    # Pre-loop compaction: compress history BEFORE first model call
+    if agent.compaction_manager is not None and agent.compaction_manager.compact_context:
+        log_debug(f"[STREAM-SYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+        compaction_result = agent.compaction_manager.compact(
+            run_messages.messages,
+            run_response=run_response,
+            run_metrics=run_response.metrics,
+        )
+        if compaction_result.summary:
+            run_messages.compacted_messages = compaction_result.compacted_messages
+            log_debug(
+                f"[STREAM-SYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+            )
 
     for model_response_event in call_model_stream_with_fallback(
         agent.model,
@@ -1066,7 +1080,9 @@ def handle_model_response_stream(
         stream_model_response=stream_model_response,
         run_response=run_response,
         send_media_to_model=agent.send_media_to_model,
-        compression_manager=agent.compaction_manager if agent.compact_tools else None,
+        compaction_manager=agent.compaction_manager if agent.compact_tools else None,
+        compacted_messages=run_messages.compacted_messages,
+        compaction_callback=build_compaction_callback(agent, run_messages, run_response),
         **result_store_kwargs(agent),
         after_tool_results=build_after_tool_results_callback(
             agent,
@@ -1214,7 +1230,21 @@ async def ahandle_model_response_stream(
         log_debug("Response model set, model response is not streamed.")
         stream_model_response = False
 
-    from agno.agent._run import abuild_after_tool_results_callback
+    from agno.agent._run import abuild_after_tool_results_callback, abuild_compaction_callback
+
+    # Pre-loop compaction: compress history BEFORE first model call
+    if agent.compaction_manager is not None and agent.compaction_manager.compact_context:
+        log_debug(f"[STREAM-ASYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+        compaction_result = await agent.compaction_manager.acompact(
+            run_messages.messages,
+            run_response=run_response,
+            run_metrics=run_response.metrics,
+        )
+        if compaction_result.summary:
+            run_messages.compacted_messages = compaction_result.compacted_messages
+            log_debug(
+                f"[STREAM-ASYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+            )
 
     model_response_stream = acall_model_stream_with_fallback(
         agent.model,
@@ -1227,7 +1257,9 @@ async def ahandle_model_response_stream(
         stream_model_response=stream_model_response,
         run_response=run_response,
         send_media_to_model=agent.send_media_to_model,
-        compression_manager=agent.compaction_manager if agent.compact_tools else None,
+        compaction_manager=agent.compaction_manager if agent.compact_tools else None,
+        compacted_messages=run_messages.compacted_messages,
+        compaction_callback=await abuild_compaction_callback(agent, run_messages, run_response),
         **result_store_kwargs(agent),
         after_tool_results=abuild_after_tool_results_callback(
             agent,

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -11,6 +11,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
+    Awaitable,
+    Callable,
     Dict,
     Iterator,
     List,
@@ -526,7 +528,24 @@ def _run(
                 # Check for cancellation before model call
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # 9. Generate a response from the Model (includes running function calls)
+                # 9. Pre-loop compaction: compress history BEFORE first model call
+                # Two-list architecture: messages for DB, compacted_messages for model
+                if agent.compaction_manager is not None and agent.compaction_manager.compact_context:
+                    log_debug(f"[RUN-SYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+                    compaction_result = agent.compaction_manager.compact(
+                        run_messages.messages,
+                        run_response=run_response,
+                        run_metrics=run_response.metrics,
+                    )
+                    if compaction_result.summary:
+                        run_messages.compacted_messages = compaction_result.compacted_messages
+                        log_debug(
+                            f"[RUN-SYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+                        )
+                    else:
+                        log_debug("[RUN-SYNC] Pre-loop compaction: no compaction needed")
+
+                # 10. Generate a response from the Model (includes running function calls)
                 agent.model = cast(Model, agent.model)
 
                 model_response: ModelResponse = call_model_with_fallback(
@@ -539,7 +558,9 @@ def _run(
                     response_format=response_format,
                     run_response=run_response,
                     send_media_to_model=agent.send_media_to_model,
-                    compression_manager=agent.compaction_manager if agent.compact_tools else None,
+                    compaction_manager=agent.compaction_manager if agent.compact_tools else None,
+                    compacted_messages=run_messages.compacted_messages,
+                    compaction_callback=build_compaction_callback(agent, run_messages, run_response),
                     **result_store_kwargs(agent),
                     after_tool_results=build_after_tool_results_callback(
                         agent,
@@ -1656,7 +1677,24 @@ async def _arun(
                 # Check for cancellation before model call
                 await araise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # 9. Generate a response from the Model (includes running function calls)
+                # 9. Pre-loop compaction: compress history BEFORE first model call
+                # Two-list architecture: messages for DB, compacted_messages for model
+                if agent.compaction_manager is not None and agent.compaction_manager.compact_context:
+                    log_debug(f"[RUN-ASYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+                    compaction_result = await agent.compaction_manager.acompact(
+                        run_messages.messages,
+                        run_response=run_response,
+                        run_metrics=run_response.metrics,
+                    )
+                    if compaction_result.summary:
+                        run_messages.compacted_messages = compaction_result.compacted_messages
+                        log_debug(
+                            f"[RUN-ASYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+                        )
+                    else:
+                        log_debug("[RUN-ASYNC] Pre-loop compaction: no compaction needed")
+
+                # 10. Generate a response from the Model (includes running function calls)
                 model_response: ModelResponse = await acall_model_with_fallback(
                     agent.model,
                     agent.fallback_config,
@@ -1667,7 +1705,9 @@ async def _arun(
                     response_format=response_format,
                     send_media_to_model=agent.send_media_to_model,
                     run_response=run_response,
-                    compression_manager=agent.compaction_manager if agent.compact_tools else None,
+                    compaction_manager=agent.compaction_manager if agent.compact_tools else None,
+                    compacted_messages=run_messages.compacted_messages,
+                    compaction_callback=await abuild_compaction_callback(agent, run_messages, run_response),
                     **result_store_kwargs(agent),
                     after_tool_results=abuild_after_tool_results_callback(
                         agent,
@@ -3641,6 +3681,7 @@ def continue_run_dispatch(
         session=agent_session,
         add_history_to_context=agent.add_history_to_context,
         run_context=run_context,
+        run_response=run_response,
     )
 
     # Reset the run state
@@ -4928,6 +4969,8 @@ async def _acontinue_run(
                     input=input_messages,
                     session=agent_session,
                     add_history_to_context=agent.add_history_to_context,
+                    run_context=run_context,
+                    run_response=run_response,
                 )
 
                 # Reset the run state
@@ -5428,6 +5471,8 @@ async def _acontinue_run_stream(
                     input=input_messages,
                     session=agent_session,
                     add_history_to_context=agent.add_history_to_context,
+                    run_context=run_context,
+                    run_response=run_response,
                 )
 
                 # Reset the run state
@@ -6347,6 +6392,69 @@ async def acheckpoint_run(
     run_response.last_checkpoint_at_message_index = len(run_response.messages or [])
     _mark_checkpoint_message(run_response)
     await apersist_run_in_session(agent, run_response, session, run_context)
+
+
+def build_compaction_callback(
+    agent: Agent,
+    run_messages: RunMessages,
+    run_response: RunOutput,
+) -> Optional[Callable[[], Optional[List[Message]]]]:
+    """Build the sync mid-loop compaction callback.
+
+    Returns ``None`` when context compaction is not enabled.
+
+    Called by the model loop after each tool batch to check if context exceeds
+    the threshold. If compaction triggers, returns the new shorter message list;
+    the model loop rebinds its local variable from the return value.
+    """
+    compaction_manager = agent.compaction_manager
+    if compaction_manager is None:
+        return None
+
+    def _callback() -> Optional[List[Message]]:
+        # Compact the smaller list if pre-loop compaction already ran
+        messages_to_compact = (
+            run_messages.compacted_messages if run_messages.compacted_messages else run_messages.messages
+        )
+        result = compaction_manager.compact(
+            messages_to_compact,
+            run_response=run_response,
+            run_metrics=run_response.metrics,
+        )
+        if result.summary:
+            run_messages.compacted_messages = result.compacted_messages
+            return result.compacted_messages
+        return None
+
+    return _callback
+
+
+async def abuild_compaction_callback(
+    agent: Agent,
+    run_messages: RunMessages,
+    run_response: RunOutput,
+) -> Optional[Callable[[], Awaitable[Optional[List[Message]]]]]:
+    """Async variant of :func:`build_compaction_callback`."""
+    compaction_manager = agent.compaction_manager
+    if compaction_manager is None:
+        return None
+
+    async def _callback() -> Optional[List[Message]]:
+        # Compact the smaller list if pre-loop compaction already ran
+        messages_to_compact = (
+            run_messages.compacted_messages if run_messages.compacted_messages else run_messages.messages
+        )
+        result = await compaction_manager.acompact(
+            messages_to_compact,
+            run_response=run_response,
+            run_metrics=run_response.metrics,
+        )
+        if result.summary:
+            run_messages.compacted_messages = result.compacted_messages
+            return result.compacted_messages
+        return None
+
+    return _callback
 
 
 def build_after_tool_results_callback(

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3785,7 +3785,7 @@ def _continue_run(
                     tool_call_limit=agent.tool_call_limit,
                     run_response=run_response,
                     send_media_to_model=agent.send_media_to_model,
-                    compression_manager=agent.compaction_manager if agent.compact_tools else None,
+                    compaction_manager=agent.compaction_manager if agent.compact_tools else None,
                     **result_store_kwargs(agent),
                     after_tool_results=build_after_tool_results_callback(
                         agent,
@@ -4995,7 +4995,7 @@ async def _acontinue_run(
                     tool_call_limit=agent.tool_call_limit,
                     run_response=run_response,
                     send_media_to_model=agent.send_media_to_model,
-                    compression_manager=agent.compaction_manager if agent.compact_tools else None,
+                    compaction_manager=agent.compaction_manager if agent.compact_tools else None,
                     **result_store_kwargs(agent),
                     after_tool_results=abuild_after_tool_results_callback(
                         agent,

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -539,7 +539,7 @@ def _run(
                     response_format=response_format,
                     run_response=run_response,
                     send_media_to_model=agent.send_media_to_model,
-                    compression_manager=agent.compression_manager if agent.compress_tool_results else None,
+                    compression_manager=agent.compaction_manager if agent.compact_tools else None,
                     **result_store_kwargs(agent),
                     after_tool_results=build_after_tool_results_callback(
                         agent,
@@ -1667,7 +1667,7 @@ async def _arun(
                     response_format=response_format,
                     send_media_to_model=agent.send_media_to_model,
                     run_response=run_response,
-                    compression_manager=agent.compression_manager if agent.compress_tool_results else None,
+                    compression_manager=agent.compaction_manager if agent.compact_tools else None,
                     **result_store_kwargs(agent),
                     after_tool_results=abuild_after_tool_results_callback(
                         agent,
@@ -3744,7 +3744,7 @@ def _continue_run(
                     tool_call_limit=agent.tool_call_limit,
                     run_response=run_response,
                     send_media_to_model=agent.send_media_to_model,
-                    compression_manager=agent.compression_manager if agent.compress_tool_results else None,
+                    compression_manager=agent.compaction_manager if agent.compact_tools else None,
                     **result_store_kwargs(agent),
                     after_tool_results=build_after_tool_results_callback(
                         agent,
@@ -4952,7 +4952,7 @@ async def _acontinue_run(
                     tool_call_limit=agent.tool_call_limit,
                     run_response=run_response,
                     send_media_to_model=agent.send_media_to_model,
-                    compression_manager=agent.compression_manager if agent.compress_tool_results else None,
+                    compression_manager=agent.compaction_manager if agent.compact_tools else None,
                     **result_store_kwargs(agent),
                     after_tool_results=abuild_after_tool_results_callback(
                         agent,

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3766,6 +3766,20 @@ def _continue_run(
     # 1. Handle the updated tools
     handle_tool_call_updates(agent, run_response=run_response, run_messages=run_messages, tools=tools)
 
+    # Pre-loop compaction: compress history BEFORE model call
+    if agent.compaction_manager is not None and agent.compaction_manager.compact_context:
+        log_debug(f"[AGENT-CONTINUE-SYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+        compaction_result = agent.compaction_manager.compact(
+            run_messages.messages,
+            run_response=run_response,
+            run_metrics=run_response.metrics,
+        )
+        if compaction_result.summary:
+            run_messages.compacted_messages = compaction_result.compacted_messages
+            log_debug(
+                f"[AGENT-CONTINUE-SYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+            )
+
     try:
         num_attempts = agent.retries + 1
         for attempt in range(num_attempts):
@@ -3786,6 +3800,8 @@ def _continue_run(
                     run_response=run_response,
                     send_media_to_model=agent.send_media_to_model,
                     compaction_manager=agent.compaction_manager if agent.compact_tools else None,
+                    compacted_messages=run_messages.compacted_messages,
+                    compaction_callback=build_compaction_callback(agent, run_messages, run_response),
                     **result_store_kwargs(agent),
                     after_tool_results=build_after_tool_results_callback(
                         agent,
@@ -4984,6 +5000,20 @@ async def _acontinue_run(
                     agent, run_response=run_response, run_messages=run_messages, tools=_tools
                 )
 
+                # Pre-loop compaction: compress history BEFORE model call
+                if agent.compaction_manager is not None and agent.compaction_manager.compact_context:
+                    log_debug(f"[AGENT-CONTINUE-ASYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+                    compaction_result = await agent.compaction_manager.acompact(
+                        run_messages.messages,
+                        run_response=run_response,
+                        run_metrics=run_response.metrics,
+                    )
+                    if compaction_result.summary:
+                        run_messages.compacted_messages = compaction_result.compacted_messages
+                        log_debug(
+                            f"[AGENT-CONTINUE-ASYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+                        )
+
                 # 8. Get model response
                 model_response: ModelResponse = await acall_model_with_fallback(
                     agent.model,
@@ -4996,6 +5026,8 @@ async def _acontinue_run(
                     run_response=run_response,
                     send_media_to_model=agent.send_media_to_model,
                     compaction_manager=agent.compaction_manager if agent.compact_tools else None,
+                    compacted_messages=run_messages.compacted_messages,
+                    compaction_callback=await abuild_compaction_callback(agent, run_messages, run_response),
                     **result_store_kwargs(agent),
                     after_tool_results=abuild_after_tool_results_callback(
                         agent,

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -1144,16 +1144,18 @@ def to_dict(agent: Agent) -> Dict[str, Any]:
     if agent.metadata is not None:
         config["metadata"] = agent.metadata
 
-    # --- Context compression settings ---
-    if agent.compress_tool_results:
-        config["compress_tool_results"] = agent.compress_tool_results
+    # --- Context compaction settings ---
+    if agent.compact_tools:
+        config["compact_tools"] = agent.compact_tools
+    if agent.compact_context:
+        config["compact_context"] = agent.compact_context
 
     # --- Result offloading settings ---
     if agent.offload_tool_results is not None:
         config["offload_tool_results"] = _offload_to_config(agent.offload_tool_results)
-    # TODO: implement compression manager serialization
-    # if agent.compression_manager is not None:
-    #     config["compression_manager"] = agent.compression_manager.to_dict()
+    # TODO: implement compaction manager serialization
+    # if agent.compaction_manager is not None:
+    #     config["compaction_manager"] = agent.compaction_manager.to_dict()
 
     # --- Callable factory settings ---
     if not agent.cache_callables:
@@ -1461,9 +1463,10 @@ def from_dict(
         role=config.get("role"),
         # --- Metadata ---
         metadata=strip_reserved_run_metadata(config.get("metadata")),
-        # --- Compression settings ---
-        compress_tool_results=config.get("compress_tool_results", False),
-        # compression_manager=config.get("compression_manager"),  # TODO
+        # --- Compaction settings (with backward compat for old config keys) ---
+        compact_tools=config.get("compact_tools") or config.get("compress_tool_results", False),
+        compact_context=config.get("compact_context", False),
+        # compaction_manager=config.get("compaction_manager"),  # TODO
         # --- Result offloading settings ---
         offload_tool_results=_offload_from_config(config.get("offload_tool_results")),
         # --- Debug and telemetry settings ---

--- a/libs/agno/agno/agent/_utils.py
+++ b/libs/agno/agno/agent/_utils.py
@@ -122,7 +122,7 @@ SHARED_BY_REFERENCE_FIELDS = (
     "parser_model",
     "output_model",
     "session_summary_manager",
-    "compression_manager",
+    "compaction_manager",
     "learning",
     "skills",
 )

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -32,7 +32,7 @@ from agno.agent import (
     _tools,
     _utils,
 )
-from agno.compression.manager import CompressionManager
+from agno.compression.manager import CompactionManager
 from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, UserMemory
 from agno.eval.base import BaseEval
 from agno.filters import FilterExpr
@@ -350,11 +350,13 @@ class Agent:
     # Metadata stored with this agent
     metadata: Optional[Dict[str, Any]] = None
 
-    # --- Context Compression ---
-    # If True, compress tool call results to save context
-    compress_tool_results: bool = False
-    # Compression manager for compressing tool call results
-    compression_manager: Optional[CompressionManager] = None
+    # --- Context Compaction ---
+    # If True, compact tool call results to save context
+    compact_tools: bool = False
+    # If True, compact conversation history to save context
+    compact_context: bool = False
+    # Compaction manager for tool results and/or conversation history
+    compaction_manager: Optional[CompactionManager] = None
 
     # --- Result Offloading ---
     # Store tool results longer than a threshold as files and leave a short
@@ -411,8 +413,12 @@ class Agent:
         enable_session_summaries: bool = False,
         add_session_summary_to_context: Optional[bool] = None,
         session_summary_manager: Optional[SessionSummaryManager] = None,
-        compress_tool_results: bool = False,
-        compression_manager: Optional[CompressionManager] = None,
+        compact_tools: bool = False,
+        compact_context: bool = False,
+        compaction_manager: Optional[CompactionManager] = None,
+        # Deprecated aliases (use compact_tools and compaction_manager)
+        compress_tool_results: Optional[bool] = None,
+        compression_manager: Optional[CompactionManager] = None,
         offload_tool_results: Optional[Union[bool, "ResultStore"]] = None,
         add_history_to_context: bool = False,
         num_history_runs: Optional[int] = None,
@@ -538,9 +544,22 @@ class Agent:
 
         self.add_session_summary_to_context = add_session_summary_to_context
 
-        # Context compression settings
-        self.compress_tool_results = compress_tool_results
-        self.compression_manager = compression_manager
+        # Context compaction settings (with backward compat for old names)
+        if compress_tool_results is not None:
+            from agno.utils.log import log_debug
+
+            log_debug("compress_tool_results is deprecated, use compact_tools")
+            self.compact_tools = compress_tool_results
+        else:
+            self.compact_tools = compact_tools
+        self.compact_context = compact_context
+        if compression_manager is not None:
+            from agno.utils.log import log_debug
+
+            log_debug("compression_manager is deprecated, use compaction_manager")
+            self.compaction_manager = compression_manager
+        else:
+            self.compaction_manager = compaction_manager
 
         # Result offloading settings
         self.offload_tool_results = offload_tool_results

--- a/libs/agno/agno/compression/_context.py
+++ b/libs/agno/agno/compression/_context.py
@@ -120,6 +120,7 @@ class CompactionResult:
 
     compacted_messages: List[Message]
     summary: Optional[str] = None
+    stats: Dict[str, Any] = field(default_factory=dict)
 
 
 # --- Pure functions ---

--- a/libs/agno/agno/compression/_context.py
+++ b/libs/agno/agno/compression/_context.py
@@ -1,0 +1,417 @@
+"""Internal context compaction functions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from textwrap import dedent
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
+
+from agno.compression._tool import acompact_tools, compact_tools
+from agno.models.base import Model
+from agno.models.message import Message
+from agno.utils.log import log_debug, log_error, log_info
+from agno.utils.message import safe_truncation_index
+
+if TYPE_CHECKING:
+    from agno.metrics import RunMetrics
+    from agno.run.agent import RunOutput
+    from agno.run.team import TeamRunOutput
+
+from agno.metrics import ModelType, accumulate_model_metrics
+
+DEFAULT_COMPACTION_PROMPT = dedent("""\
+    You are creating a context checkpoint for an AI agent to continue work seamlessly.
+
+    OUTPUT STRUCTURE (use these exact headings):
+
+    ## Active Task
+    Copy the user's most recent request or goal verbatim.
+
+    ## Completed Actions
+    Format each as: N. ACTION target - outcome [tool: name]
+    Example: "1. READ agent.py - Agent dataclass, 40+ config fields, delegates to _run.py [read_file]"
+
+    ## Key Findings
+    - Concrete facts: file paths, function names, class structures, values discovered
+    - Decisions made and their rationale
+    - User preferences or corrections stated
+    - Architecture/patterns identified
+
+    ## Pending / Blocked
+    - Unresolved tasks or next steps
+    - Exact error messages if any (quote verbatim)
+
+    ## Critical Context
+    - Identifiers: IDs, versions, timestamps, URLs
+    - Constraints or requirements mentioned
+    - Configuration values (no secrets)
+
+    RULES:
+    - No narrative preamble ("The conversation covered...", "We discussed...")
+    - Preserve exact identifiers, paths, numbers, error strings
+    - Use terse bullets, verbs first
+    - Maximum 2000 tokens
+    """)
+
+
+SUMMARY_PREFIX = dedent("""\
+    Another language model started this conversation and produced a summary of the work so far. \
+    Use this to continue without duplicating work:
+
+    """)
+
+
+def create_summary_message(summary: str) -> Message:
+    """Create a summary message from a summary string."""
+    return Message(
+        role="user",
+        content=SUMMARY_PREFIX + summary,
+        from_history=True,
+    )
+
+
+@dataclass
+class CompactionState:
+    """Tracks context compaction state for a run."""
+
+    summary: str = ""
+    compacted_message_ids: Set[str] = field(default_factory=set)
+    compacted_count: int = 0
+    total_compactions: int = 0
+    total_tokens_saved: int = 0
+    updated_at: Optional[datetime] = None
+
+    def get_summary_message(self) -> Message:
+        return Message(
+            role="user",
+            content=SUMMARY_PREFIX + self.summary,
+            from_history=True,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "summary": self.summary,
+            "compacted_message_ids": list(self.compacted_message_ids),
+            "compacted_count": self.compacted_count,
+            "total_compactions": self.total_compactions,
+            "total_tokens_saved": self.total_tokens_saved,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CompactionState":
+        updated_at = data.get("updated_at")
+        if updated_at and isinstance(updated_at, str):
+            updated_at = datetime.fromisoformat(updated_at)
+        return cls(
+            summary=data.get("summary", ""),
+            compacted_message_ids=set(data.get("compacted_message_ids", [])),
+            compacted_count=data.get("compacted_count", 0),
+            total_compactions=data.get("total_compactions", 0),
+            total_tokens_saved=data.get("total_tokens_saved", 0),
+            updated_at=updated_at,
+        )
+
+
+@dataclass
+class CompactionResult:
+    """Result of a compaction operation."""
+
+    compacted_messages: List[Message]
+    summary: Optional[str] = None
+
+
+# --- Pure functions ---
+
+
+def should_compact_context(
+    messages: List[Message],
+    model: Optional[Model],
+    message_limit: Optional[int],
+    token_limit: Optional[int],
+) -> bool:
+    """Check if messages exceed compaction threshold."""
+    if token_limit is not None and model is not None:
+        token_count = model.count_tokens(messages)
+        if token_count >= token_limit:
+            return True
+
+    if message_limit is not None and len(messages) >= message_limit:
+        return True
+
+    return False
+
+
+async def ashould_compact_context(
+    messages: List[Message],
+    model: Optional[Model],
+    message_limit: Optional[int],
+    token_limit: Optional[int],
+) -> bool:
+    """Async check if messages exceed compaction threshold."""
+    if token_limit is not None and model is not None:
+        token_count = await model.acount_tokens(messages)
+        if token_count >= token_limit:
+            return True
+
+    if message_limit is not None and len(messages) >= message_limit:
+        return True
+
+    return False
+
+
+def compact_context(
+    messages: List[Message],
+    model: Optional[Model],
+    keep_recent: int = 10,
+    preserve_user_budget: int = 20_000,
+    token_limit: Optional[int] = None,
+    instructions: Optional[str] = None,
+    run_response: Optional[Union["RunOutput", "TeamRunOutput"]] = None,
+    run_metrics: Optional["RunMetrics"] = None,
+) -> CompactionResult:
+    """Compact messages by summarizing old ones."""
+    log_debug(f"[COMPACTION] compact_context() with {len(messages)} messages")
+
+    if model is None:
+        return CompactionResult(compacted_messages=messages)
+
+    # Split messages
+    system_msgs = [m for m in messages if m.role == "system"]
+    non_system = [m for m in messages if m.role != "system"]
+    old_messages, preserved_user, recent_messages = _split_messages(
+        non_system, model, keep_recent, preserve_user_budget
+    )
+
+    if not old_messages:
+        return CompactionResult(compacted_messages=messages)
+
+    # Get existing summary if any
+    existing_summary = run_response.compaction_state.summary if run_response and run_response.compaction_state else None
+
+    # Summarize
+    new_summary = _summarize(old_messages, existing_summary, model, instructions, run_metrics)
+    if not new_summary:
+        return CompactionResult(compacted_messages=messages)
+
+    # Build compacted messages
+    summary_msg = Message(role="user", content=SUMMARY_PREFIX + new_summary, from_history=True)
+    compacted_messages = system_msgs + [summary_msg] + preserved_user + recent_messages
+
+    # Log metrics
+    tokens_before = model.count_tokens(messages)
+    tokens_after = model.count_tokens(compacted_messages)
+    tokens_saved = tokens_before - tokens_after
+    ratio = tokens_after / tokens_before if tokens_before > 0 else 1.0
+    summary_tokens = model.count_tokens([summary_msg])
+
+    log_info(
+        f"[COMPACTION] {len(messages)} -> {len(compacted_messages)} msgs | "
+        f"{tokens_before} -> {tokens_after} tokens | ratio={ratio:.2f} | "
+        f"saved={tokens_saved} | summary={summary_tokens} tok"
+    )
+
+    # Compress tool results if still over limit
+    if token_limit and model.count_tokens(compacted_messages) > token_limit:
+        compact_tools(recent_messages, model=model, run_metrics=run_metrics)
+        compacted_messages = system_msgs + [summary_msg] + preserved_user + recent_messages
+        log_info(f"[COMPACTION] Compressed tool results, now {model.count_tokens(compacted_messages)} tokens")
+
+    # Update state
+    _update_compaction_state(run_response, old_messages, new_summary, tokens_saved)
+
+    return CompactionResult(compacted_messages=compacted_messages, summary=new_summary)
+
+
+async def acompact_context(
+    messages: List[Message],
+    model: Optional[Model],
+    keep_recent: int = 10,
+    preserve_user_budget: int = 20_000,
+    token_limit: Optional[int] = None,
+    instructions: Optional[str] = None,
+    run_response: Optional[Union["RunOutput", "TeamRunOutput"]] = None,
+    run_metrics: Optional["RunMetrics"] = None,
+) -> CompactionResult:
+    """Async compact messages by summarizing old ones."""
+    log_debug(f"[COMPACTION] acompact_context() with {len(messages)} messages")
+
+    if model is None:
+        return CompactionResult(compacted_messages=messages)
+
+    # Split messages
+    system_msgs = [m for m in messages if m.role == "system"]
+    non_system = [m for m in messages if m.role != "system"]
+    old_messages, preserved_user, recent_messages = _split_messages(
+        non_system, model, keep_recent, preserve_user_budget
+    )
+
+    if not old_messages:
+        return CompactionResult(compacted_messages=messages)
+
+    # Get existing summary if any
+    existing_summary = run_response.compaction_state.summary if run_response and run_response.compaction_state else None
+
+    # Summarize
+    new_summary = await _asummarize(old_messages, existing_summary, model, instructions, run_metrics)
+    if not new_summary:
+        return CompactionResult(compacted_messages=messages)
+
+    # Build compacted messages
+    summary_msg = Message(role="user", content=SUMMARY_PREFIX + new_summary, from_history=True)
+    compacted_messages = system_msgs + [summary_msg] + preserved_user + recent_messages
+
+    # Log metrics
+    tokens_before = await model.acount_tokens(messages)
+    tokens_after = await model.acount_tokens(compacted_messages)
+    tokens_saved = tokens_before - tokens_after
+    ratio = tokens_after / tokens_before if tokens_before > 0 else 1.0
+    summary_tokens = await model.acount_tokens([summary_msg])
+
+    log_info(
+        f"[COMPACTION] {len(messages)} -> {len(compacted_messages)} msgs | "
+        f"{tokens_before} -> {tokens_after} tokens | ratio={ratio:.2f} | "
+        f"saved={tokens_saved} | summary={summary_tokens} tok"
+    )
+
+    # Compress tool results if still over limit
+    if token_limit and await model.acount_tokens(compacted_messages) > token_limit:
+        await acompact_tools(recent_messages, model=model, run_metrics=run_metrics)
+        compacted_messages = system_msgs + [summary_msg] + preserved_user + recent_messages
+        log_info(f"[COMPACTION] Compressed tool results, now {await model.acount_tokens(compacted_messages)} tokens")
+
+    # Update state
+    _update_compaction_state(run_response, old_messages, new_summary, tokens_saved)
+
+    return CompactionResult(compacted_messages=compacted_messages, summary=new_summary)
+
+
+# --- Internal helpers ---
+
+
+def _split_messages(
+    messages: List[Message],
+    model: Optional[Model],
+    keep_recent: int,
+    preserve_user_budget: int,
+) -> Tuple[List[Message], List[Message], List[Message]]:
+    """Split messages into: old (to summarize), preserved_user, recent."""
+    if not messages:
+        return [], [], []
+
+    keep_count = min(keep_recent, len(messages))
+    split_idx = safe_truncation_index(messages, len(messages) - keep_count)
+    recent_messages = messages[split_idx:]
+    older = messages[:split_idx]
+
+    if not older:
+        return [], [], recent_messages
+
+    preserved_user, preserved_indices = _extract_user_messages(older, model, preserve_user_budget)
+    old_messages = [m for i, m in enumerate(older) if i not in preserved_indices]
+
+    return old_messages, preserved_user, recent_messages
+
+
+def _extract_user_messages(
+    messages: List[Message],
+    model: Optional[Model],
+    budget: int,
+) -> Tuple[List[Message], Set[int]]:
+    """Extract recent user messages up to token budget."""
+    preserved: List[Message] = []
+    indices: Set[int] = set()
+    used = 0
+
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if msg.role == "user" and not msg.from_history:
+            tokens = model.count_tokens([msg]) if model else 0
+            if used + tokens <= budget:
+                preserved.insert(0, msg)
+                indices.add(i)
+                used += tokens
+            else:
+                break
+
+    return preserved, indices
+
+
+def _build_summarization_prompt(
+    old_messages: List[Message],
+    existing_summary: Optional[str],
+    instructions: Optional[str],
+) -> List[Message]:
+    """Build prompt for summarization."""
+    system_prompt = instructions or DEFAULT_COMPACTION_PROMPT
+    prompt: List[Message] = [Message(role="system", content=system_prompt)]
+
+    if existing_summary:
+        prompt.append(Message(role="user", content=f"Previous summary to update:\n{existing_summary}"))
+
+    prompt.extend(old_messages)
+    prompt.append(Message(role="user", content="Now provide a concise summary of the conversation above."))
+    return prompt
+
+
+def _summarize(
+    old_messages: List[Message],
+    existing_summary: Optional[str],
+    model: Model,
+    instructions: Optional[str],
+    run_metrics: Optional["RunMetrics"],
+) -> Optional[str]:
+    """Generate summary via LLM."""
+    prompt = _build_summarization_prompt(old_messages, existing_summary, instructions)
+    try:
+        response = model.response(messages=prompt)
+        if run_metrics is not None:
+            accumulate_model_metrics(response, model, ModelType.COMPRESSION_MODEL, run_metrics)
+        return response.content
+    except Exception as e:
+        log_error(f"Compaction LLM call failed: {e}")
+        return None
+
+
+async def _asummarize(
+    old_messages: List[Message],
+    existing_summary: Optional[str],
+    model: Model,
+    instructions: Optional[str],
+    run_metrics: Optional["RunMetrics"],
+) -> Optional[str]:
+    """Async generate summary via LLM."""
+    prompt = _build_summarization_prompt(old_messages, existing_summary, instructions)
+    try:
+        response = await model.aresponse(messages=prompt)
+        if run_metrics is not None:
+            accumulate_model_metrics(response, model, ModelType.COMPRESSION_MODEL, run_metrics)
+        return response.content
+    except Exception as e:
+        log_error(f"Compaction LLM call failed: {e}")
+        return None
+
+
+def _update_compaction_state(
+    run_response: Optional[Union["RunOutput", "TeamRunOutput"]],
+    old_messages: List[Message],
+    new_summary: str,
+    tokens_saved: int = 0,
+) -> None:
+    """Update run_response.compaction_state."""
+    if run_response is None:
+        return
+
+    prev = run_response.compaction_state
+    new_ids = {msg.id for msg in old_messages if msg.id}
+    all_ids = new_ids.union(prev.compacted_message_ids if prev else set())
+
+    run_response.compaction_state = CompactionState(
+        summary=new_summary,
+        compacted_message_ids=all_ids,
+        compacted_count=(prev.compacted_count if prev else 0) + len(old_messages),
+        total_compactions=(prev.total_compactions if prev else 0) + 1,
+        total_tokens_saved=(prev.total_tokens_saved if prev else 0) + tokens_saved,
+        updated_at=datetime.now(),
+    )

--- a/libs/agno/agno/compression/_tool.py
+++ b/libs/agno/agno/compression/_tool.py
@@ -1,0 +1,258 @@
+"""Internal tool result compaction helpers."""
+
+import asyncio
+from textwrap import dedent
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
+
+from pydantic import BaseModel
+
+from agno.models.base import Model
+from agno.models.message import Message
+from agno.models.utils import get_model
+from agno.utils.log import log_error, log_info, log_warning
+
+if TYPE_CHECKING:
+    from agno.metrics import RunMetrics
+
+DEFAULT_TOOL_COMPACTION_PROMPT = dedent("""\
+    You are compacting tool call results to save context space while preserving critical information.
+
+    Your goal: Extract only the essential information from the tool output.
+
+    ALWAYS PRESERVE:
+    - Specific facts: numbers, statistics, amounts, prices, quantities, metrics
+    - Temporal data: dates, times, timestamps (use short format: "Oct 21 2025")
+    - Entities: people, companies, products, locations, organizations
+    - Identifiers: URLs, IDs, codes, technical identifiers, versions
+    - Key quotes, citations, sources (if relevant to agent's task)
+
+    COMPRESS TO ESSENTIALS:
+    - Descriptions: keep only key attributes
+    - Explanations: distill to core insight
+    - Lists: focus on most relevant items based on agent context
+    - Background: minimal context only if critical
+
+    REMOVE ENTIRELY:
+    - Introductions, conclusions, transitions
+    - Hedging language ("might", "possibly", "appears to")
+    - Meta-commentary ("According to", "The results show")
+    - Formatting artifacts (markdown, HTML, JSON structure)
+    - Redundant or repetitive information
+    - Generic background not relevant to agent's task
+    - Promotional language, filler words
+
+    EXAMPLE:
+    Input: "According to recent market analysis and industry reports, OpenAI has made several significant announcements in the technology sector. The company revealed ChatGPT Atlas on October 21, 2025, which represents a new AI-powered browser application that has been specifically designed for macOS users. This browser is strategically positioned to compete with traditional search engines in the market. Additionally, on October 6, 2025, OpenAI launched Apps in ChatGPT, which includes a comprehensive software development kit (SDK) for developers. The company has also announced several initial strategic partners who will be integrating with this new feature, including well-known companies such as Spotify, the popular music streaming service, Zillow, which is a real estate marketplace platform, and Canva, a graphic design platform."
+
+    Output: "OpenAI - Oct 21 2025: ChatGPT Atlas (AI browser, macOS, search competitor); Oct 6 2025: Apps in ChatGPT + SDK; Partners: Spotify, Zillow, Canva"
+
+    Be concise while retaining all critical facts.
+    """)
+
+
+def _is_tool_result_message(msg: Message) -> bool:
+    return msg.role == "tool"
+
+
+def should_compact_tools(
+    messages: List[Message],
+    compact_tools: bool,
+    compact_tools_limit: Optional[int],
+    compact_tools_token_limit: Optional[int],
+    tools: Optional[List] = None,
+    model: Optional[Model] = None,
+    response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+) -> bool:
+    """Check if tool results should be compacted."""
+    if not compact_tools:
+        return False
+
+    # Token-based threshold check
+    if compact_tools_token_limit is not None and model is not None:
+        tokens = model.count_tokens(messages, tools, response_format)
+        if tokens >= compact_tools_token_limit:
+            log_info(f"Token limit hit: {tokens} >= {compact_tools_token_limit}")
+            return True
+
+    # Count-based threshold check
+    if compact_tools_limit is not None:
+        uncompressed_count = len([m for m in messages if _is_tool_result_message(m) and m.compressed_content is None])
+        if uncompressed_count >= compact_tools_limit:
+            log_info(f"Tool count limit hit: {uncompressed_count} >= {compact_tools_limit}")
+            return True
+
+    return False
+
+
+async def ashould_compact_tools(
+    messages: List[Message],
+    compact_tools: bool,
+    compact_tools_limit: Optional[int],
+    compact_tools_token_limit: Optional[int],
+    tools: Optional[List] = None,
+    model: Optional[Model] = None,
+    response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+) -> bool:
+    """Async check if tool results should be compacted."""
+    if not compact_tools:
+        return False
+
+    if compact_tools_token_limit is not None and model is not None:
+        tokens = await model.acount_tokens(messages, tools, response_format)
+        if tokens >= compact_tools_token_limit:
+            log_info(f"Token limit hit: {tokens} >= {compact_tools_token_limit}")
+            return True
+
+    if compact_tools_limit is not None:
+        uncompressed_count = len([m for m in messages if _is_tool_result_message(m) and m.compressed_content is None])
+        if uncompressed_count >= compact_tools_limit:
+            log_info(f"Tool count limit hit: {uncompressed_count} >= {compact_tools_limit}")
+            return True
+
+    return False
+
+
+def _compact_single_tool_result(
+    tool_result: Message,
+    model: Optional[Model],
+    instructions: Optional[str] = None,
+    run_metrics: Optional["RunMetrics"] = None,
+) -> Optional[str]:
+    """Compress a single tool result message."""
+    if not tool_result:
+        return None
+
+    tool_content = f"Tool: {tool_result.tool_name or 'unknown'}\n{tool_result.content}"
+
+    resolved_model = get_model(model)
+    if not resolved_model:
+        log_warning("No compaction model available")
+        return None
+
+    prompt = instructions or DEFAULT_TOOL_COMPACTION_PROMPT
+    user_message = "Tool Results to Compress: " + tool_content + "\n"
+
+    try:
+        response = resolved_model.response(
+            messages=[
+                Message(role="system", content=prompt),
+                Message(role="user", content=user_message),
+            ]
+        )
+
+        if run_metrics is not None:
+            from agno.metrics import ModelType, accumulate_model_metrics
+
+            accumulate_model_metrics(response, resolved_model, ModelType.COMPRESSION_MODEL, run_metrics)
+
+        return response.content
+    except Exception as e:
+        log_error(f"Error compacting tool result: {str(e)}")
+        return tool_content
+
+
+async def _acompact_single_tool_result(
+    tool_result: Message,
+    model: Optional[Model],
+    instructions: Optional[str] = None,
+    run_metrics: Optional["RunMetrics"] = None,
+) -> Optional[str]:
+    """Async compress a single tool result message."""
+    if not tool_result:
+        return None
+
+    tool_content = f"Tool: {tool_result.tool_name or 'unknown'}\n{tool_result.content}"
+
+    resolved_model = get_model(model)
+    if not resolved_model:
+        log_warning("No compaction model available")
+        return None
+
+    prompt = instructions or DEFAULT_TOOL_COMPACTION_PROMPT
+    user_message = "Tool Results to Compress: " + tool_content + "\n"
+
+    try:
+        response = await resolved_model.aresponse(
+            messages=[
+                Message(role="system", content=prompt),
+                Message(role="user", content=user_message),
+            ]
+        )
+
+        if run_metrics is not None:
+            from agno.metrics import ModelType, accumulate_model_metrics
+
+            accumulate_model_metrics(response, resolved_model, ModelType.COMPRESSION_MODEL, run_metrics)
+
+        return response.content
+    except Exception as e:
+        log_error(f"Error compacting tool result: {str(e)}")
+        return tool_content
+
+
+def compact_tools(
+    messages: List[Message],
+    model: Optional[Model],
+    compact_tools_enabled: bool = True,
+    instructions: Optional[str] = None,
+    run_metrics: Optional["RunMetrics"] = None,
+) -> Dict[str, Any]:
+    """Compress uncompressed tool results. Returns stats dict."""
+    stats: Dict[str, Any] = {}
+
+    if not compact_tools_enabled:
+        return stats
+
+    uncompressed = [msg for msg in messages if msg.role == "tool" and msg.compressed_content is None]
+    if not uncompressed:
+        return stats
+
+    for tool_msg in uncompressed:
+        original_len = len(str(tool_msg.content)) if tool_msg.content else 0
+        compressed = _compact_single_tool_result(tool_msg, model, instructions, run_metrics)
+
+        if compressed:
+            tool_msg.compressed_content = compressed
+            tool_count = len(tool_msg.tool_calls) if tool_msg.tool_calls else 1
+            stats["tool_results_compressed"] = stats.get("tool_results_compressed", 0) + tool_count
+            stats["original_size"] = stats.get("original_size", 0) + original_len
+            stats["compressed_size"] = stats.get("compressed_size", 0) + len(compressed)
+        else:
+            log_warning(f"Compaction failed for {tool_msg.tool_name}")
+
+    return stats
+
+
+async def acompact_tools(
+    messages: List[Message],
+    model: Optional[Model],
+    compact_tools_enabled: bool = True,
+    instructions: Optional[str] = None,
+    run_metrics: Optional["RunMetrics"] = None,
+) -> Dict[str, Any]:
+    """Async compress uncompressed tool results. Returns stats dict."""
+    stats: Dict[str, Any] = {}
+
+    if not compact_tools_enabled:
+        return stats
+
+    uncompressed = [msg for msg in messages if msg.role == "tool" and msg.compressed_content is None]
+    if not uncompressed:
+        return stats
+
+    original_sizes = [len(str(msg.content)) if msg.content else 0 for msg in uncompressed]
+
+    tasks = [_acompact_single_tool_result(msg, model, instructions, run_metrics) for msg in uncompressed]
+    results = await asyncio.gather(*tasks)
+
+    for msg, compressed, original_len in zip(uncompressed, results, original_sizes):
+        if compressed:
+            msg.compressed_content = compressed
+            tool_count = len(msg.tool_calls) if msg.tool_calls else 1
+            stats["tool_results_compressed"] = stats.get("tool_results_compressed", 0) + tool_count
+            stats["original_size"] = stats.get("original_size", 0) + original_len
+            stats["compressed_size"] = stats.get("compressed_size", 0) + len(compressed)
+        else:
+            log_warning(f"Compaction failed for {msg.tool_name}")
+
+    return stats

--- a/libs/agno/agno/compression/context.py
+++ b/libs/agno/agno/compression/context.py
@@ -1,19 +1,17 @@
+"""Backward compatibility shim - imports from _context.py."""
+
 from agno.compression._context import (
+    DEFAULT_COMPACTION_PROMPT,
     SUMMARY_PREFIX,
     CompactionResult,
     CompactionState,
     create_summary_message,
 )
-from agno.compression.manager import CompactionManager
-
-# Backward compatibility alias (deprecated, use CompactionManager)
-CompressionManager = CompactionManager
 
 __all__ = [
-    "CompactionManager",
-    "CompressionManager",  # Deprecated alias
     "CompactionState",
     "CompactionResult",
     "SUMMARY_PREFIX",
+    "DEFAULT_COMPACTION_PROMPT",
     "create_summary_message",
 ]

--- a/libs/agno/agno/compression/manager.py
+++ b/libs/agno/agno/compression/manager.py
@@ -1,6 +1,6 @@
 """Unified compaction manager for tool results and conversation history."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
 from pydantic import BaseModel
@@ -73,8 +73,6 @@ class CompactionManager:
     compact_context_keep_recent: int = 10
     compact_context_preserve_user_budget: Optional[int] = None
     compact_context_instructions: Optional[str] = None
-
-    stats: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         # Handle deprecated compress_tool_results -> compact_tools
@@ -177,31 +175,29 @@ class CompactionManager:
         self,
         messages: List[Message],
         run_metrics: Optional["RunMetrics"] = None,
-    ) -> None:
-        """Compress uncompressed tool results."""
-        stats = compact_tools(
+    ) -> Dict[str, Any]:
+        """Compress uncompressed tool results. Returns stats for this call."""
+        return compact_tools(
             messages=messages,
             model=self.model,
             compact_tools_enabled=self.compact_tools,
             instructions=self.compact_tools_instructions,
             run_metrics=run_metrics,
         )
-        self._merge_stats(stats)
 
     async def acompact_tool_results(
         self,
         messages: List[Message],
         run_metrics: Optional["RunMetrics"] = None,
-    ) -> None:
-        """Async compress uncompressed tool results."""
-        stats = await acompact_tools(
+    ) -> Dict[str, Any]:
+        """Async compress uncompressed tool results. Returns stats for this call."""
+        return await acompact_tools(
             messages=messages,
             model=self.model,
             compact_tools_enabled=self.compact_tools,
             instructions=self.compact_tools_instructions,
             run_metrics=run_metrics,
         )
-        self._merge_stats(stats)
 
     # --- Context compaction (delegates to _context.py) ---
 
@@ -277,12 +273,17 @@ class CompactionManager:
             run_metrics=run_metrics,
         )
 
-    # --- Stats ---
+    # --- Stats (deprecated - now returned per-call for async safety) ---
 
-    def _merge_stats(self, stats: Dict[str, Any]) -> None:
-        """Merge stats from tool compaction."""
-        for key, value in stats.items():
-            self.stats[key] = self.stats.get(key, 0) + value
+    @property
+    def stats(self) -> Dict[str, Any]:
+        """Deprecated: stats are now returned per-call from compact_tool_results().
+
+        Returns empty dict for backward compatibility with print_response code
+        that reads this property. In async environments, use the stats returned
+        from each compact_tool_results() call instead.
+        """
+        return {}
 
     # --- Deprecated method aliases (backward compat) ---
 
@@ -310,17 +311,17 @@ class CompactionManager:
         self,
         messages: List[Message],
         run_metrics: Optional["RunMetrics"] = None,
-    ) -> None:
+    ) -> Dict[str, Any]:
         """Deprecated: use compact_tool_results()."""
-        self.compact_tool_results(messages, run_metrics)
+        return self.compact_tool_results(messages, run_metrics)
 
     async def acompress(
         self,
         messages: List[Message],
         run_metrics: Optional["RunMetrics"] = None,
-    ) -> None:
+    ) -> Dict[str, Any]:
         """Deprecated: use acompact_tool_results()."""
-        await self.acompact_tool_results(messages, run_metrics)
+        return await self.acompact_tool_results(messages, run_metrics)
 
 
 # Backward compatibility alias

--- a/libs/agno/agno/compression/manager.py
+++ b/libs/agno/agno/compression/manager.py
@@ -1,70 +1,290 @@
-import asyncio
+"""Unified compaction manager for tool results and conversation history."""
+
 from dataclasses import dataclass, field
-from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
 from pydantic import BaseModel
 
+from agno.compression._context import (
+    CompactionResult,
+    acompact_context,
+    ashould_compact_context,
+    compact_context,
+    should_compact_context,
+)
+from agno.compression._tool import (
+    acompact_tools,
+    ashould_compact_tools,
+    compact_tools,
+    should_compact_tools,
+)
 from agno.models.base import Model
 from agno.models.message import Message
-from agno.models.utils import get_model
-from agno.utils.log import log_error, log_info, log_warning
+from agno.utils.log import log_debug
 
 if TYPE_CHECKING:
     from agno.metrics import RunMetrics
-
-DEFAULT_COMPRESSION_PROMPT = dedent("""\
-    You are compressing tool call results to save context space while preserving critical information.
-    
-    Your goal: Extract only the essential information from the tool output.
-    
-    ALWAYS PRESERVE:
-    • Specific facts: numbers, statistics, amounts, prices, quantities, metrics
-    • Temporal data: dates, times, timestamps (use short format: "Oct 21 2025")
-    • Entities: people, companies, products, locations, organizations
-    • Identifiers: URLs, IDs, codes, technical identifiers, versions
-    • Key quotes, citations, sources (if relevant to agent's task)
-    
-    COMPRESS TO ESSENTIALS:
-    • Descriptions: keep only key attributes
-    • Explanations: distill to core insight
-    • Lists: focus on most relevant items based on agent context
-    • Background: minimal context only if critical
-    
-    REMOVE ENTIRELY:
-    • Introductions, conclusions, transitions
-    • Hedging language ("might", "possibly", "appears to")
-    • Meta-commentary ("According to", "The results show")
-    • Formatting artifacts (markdown, HTML, JSON structure)
-    • Redundant or repetitive information
-    • Generic background not relevant to agent's task
-    • Promotional language, filler words
-    
-    EXAMPLE:
-    Input: "According to recent market analysis and industry reports, OpenAI has made several significant announcements in the technology sector. The company revealed ChatGPT Atlas on October 21, 2025, which represents a new AI-powered browser application that has been specifically designed for macOS users. This browser is strategically positioned to compete with traditional search engines in the market. Additionally, on October 6, 2025, OpenAI launched Apps in ChatGPT, which includes a comprehensive software development kit (SDK) for developers. The company has also announced several initial strategic partners who will be integrating with this new feature, including well-known companies such as Spotify, the popular music streaming service, Zillow, which is a real estate marketplace platform, and Canva, a graphic design platform."
-    
-    Output: "OpenAI - Oct 21 2025: ChatGPT Atlas (AI browser, macOS, search competitor); Oct 6 2025: Apps in ChatGPT + SDK; Partners: Spotify, Zillow, Canva"
-    
-    Be concise while retaining all critical facts.
-    """)
+    from agno.run.agent import RunOutput
+    from agno.run.team import TeamRunOutput
 
 
 @dataclass
-class CompressionManager:
-    model: Optional[Model] = None  # model used for compression
-    compress_tool_results: bool = True
-    compress_tool_results_limit: Optional[int] = None
+class CompactionManager:
+    """Unified compaction manager for tool results and message history.
+
+    Handles two types of compaction:
+    1. Tool compaction (mid-loop): Compresses individual tool results
+    2. Context compaction (pre-loop): Summarizes old conversation history
+
+    Usage:
+        # Tool compaction only (default)
+        compaction_manager = CompactionManager(model=OpenAI(id="gpt-4o-mini"))
+
+        # Both tool and context compaction
+        compaction_manager = CompactionManager(
+            model=OpenAI(id="gpt-4o-mini"),
+            compact_context=True,
+            compact_context_token_limit=50_000,
+        )
+    """
+
+    model: Optional[Model] = None
+
+    # Tool compaction settings
+    compact_tools: bool = True
+    compact_tools_limit: Optional[int] = None
+    compact_tools_token_limit: Optional[int] = None
+    compact_tools_instructions: Optional[str] = None
+
+    # Deprecated tool aliases (backward compat)
+    compress_tool_results: Optional[bool] = None
+    tool_result_limit: Optional[int] = None
+    compact_tool_results_limit: Optional[int] = None
+    tool_token_limit: Optional[int] = None
+    tool_instructions: Optional[str] = None
     compress_token_limit: Optional[int] = None
     compress_tool_call_instructions: Optional[str] = None
+    compress_tool_results_limit: Optional[int] = None
+
+    # Context compaction settings
+    compact_context: bool = False
+    compact_context_message_limit: Optional[int] = None
+    compact_context_token_limit: Optional[int] = None
+    compact_context_keep_recent: int = 10
+    compact_context_preserve_user_budget: Optional[int] = None
+    compact_context_instructions: Optional[str] = None
 
     stats: Dict[str, Any] = field(default_factory=dict)
 
-    def __post_init__(self):
-        if self.compress_tool_results_limit is None and self.compress_token_limit is None:
-            self.compress_tool_results_limit = 3
+    def __post_init__(self) -> None:
+        # Handle deprecated compress_tool_results -> compact_tools
+        if self.compress_tool_results is not None:
+            log_debug("compress_tool_results is deprecated, use compact_tools")
+            self.compact_tools = self.compress_tool_results
 
-    def _is_tool_result_message(self, msg: Message) -> bool:
-        return msg.role == "tool"
+        # Handle deprecated tool aliases
+        if self.tool_result_limit is not None and self.compact_tools_limit is None:
+            log_debug("tool_result_limit is deprecated, use compact_tools_limit")
+            self.compact_tools_limit = self.tool_result_limit
+        if self.compact_tool_results_limit is not None and self.compact_tools_limit is None:
+            log_debug("compact_tool_results_limit is deprecated, use compact_tools_limit")
+            self.compact_tools_limit = self.compact_tool_results_limit
+        if self.tool_token_limit is not None and self.compact_tools_token_limit is None:
+            log_debug("tool_token_limit is deprecated, use compact_tools_token_limit")
+            self.compact_tools_token_limit = self.tool_token_limit
+        if self.tool_instructions is not None and self.compact_tools_instructions is None:
+            log_debug("tool_instructions is deprecated, use compact_tools_instructions")
+            self.compact_tools_instructions = self.tool_instructions
+        if self.compress_token_limit is not None and self.compact_tools_token_limit is None:
+            log_debug("compress_token_limit is deprecated, use compact_tools_token_limit")
+            self.compact_tools_token_limit = self.compress_token_limit
+        if self.compress_tool_call_instructions is not None and self.compact_tools_instructions is None:
+            log_debug("compress_tool_call_instructions is deprecated, use compact_tools_instructions")
+            self.compact_tools_instructions = self.compress_tool_call_instructions
+        if self.compress_tool_results_limit is not None and self.compact_tools_limit is None:
+            log_debug("compress_tool_results_limit is deprecated, use compact_tools_limit")
+            self.compact_tools_limit = self.compress_tool_results_limit
+
+        # Default tool limit to 3 if neither limit is set
+        if self.compact_tools_limit is None and self.compact_tools_token_limit is None:
+            self.compact_tools_limit = 3
+            # Sync deprecated alias to reflect default value
+            if self.compress_tool_results_limit is None:
+                self.compress_tool_results_limit = 3
+
+        # Default context message limit if neither specified
+        if self.compact_context:
+            if self.compact_context_message_limit is None and self.compact_context_token_limit is None:
+                self.compact_context_message_limit = 50
+
+        # Derive preserve_user_budget as 25% of token_limit if not set
+        if self.compact_context_preserve_user_budget is None:
+            if self.compact_context_token_limit is not None:
+                self.compact_context_preserve_user_budget = int(self.compact_context_token_limit * 0.25)
+            else:
+                self.compact_context_preserve_user_budget = 20_000
+
+    # --- Backward compatibility properties ---
+
+    @property
+    def compact_history(self) -> bool:
+        return self.compact_context
+
+    @property
+    def compress_tool_results_limit_compat(self) -> Optional[int]:
+        """Deprecated: returns compact_tools_limit for backward compat."""
+        return self.compact_tools_limit
+
+    # --- Tool compaction (delegates to _tool.py) ---
+
+    def should_compact_tools(
+        self,
+        messages: List[Message],
+        tools: Optional[List] = None,
+        model: Optional[Model] = None,
+        response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+    ) -> bool:
+        """Check if tool results should be compacted."""
+        return should_compact_tools(
+            messages=messages,
+            compact_tools=self.compact_tools,
+            compact_tools_limit=self.compact_tools_limit,
+            compact_tools_token_limit=self.compact_tools_token_limit,
+            tools=tools,
+            model=model or self.model,
+            response_format=response_format,
+        )
+
+    async def ashould_compact_tools(
+        self,
+        messages: List[Message],
+        tools: Optional[List] = None,
+        model: Optional[Model] = None,
+        response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+    ) -> bool:
+        """Async check if tool results should be compacted."""
+        return await ashould_compact_tools(
+            messages=messages,
+            compact_tools=self.compact_tools,
+            compact_tools_limit=self.compact_tools_limit,
+            compact_tools_token_limit=self.compact_tools_token_limit,
+            tools=tools,
+            model=model or self.model,
+            response_format=response_format,
+        )
+
+    def compact_tool_results(
+        self,
+        messages: List[Message],
+        run_metrics: Optional["RunMetrics"] = None,
+    ) -> None:
+        """Compress uncompressed tool results."""
+        stats = compact_tools(
+            messages=messages,
+            model=self.model,
+            compact_tools_enabled=self.compact_tools,
+            instructions=self.compact_tools_instructions,
+            run_metrics=run_metrics,
+        )
+        self._merge_stats(stats)
+
+    async def acompact_tool_results(
+        self,
+        messages: List[Message],
+        run_metrics: Optional["RunMetrics"] = None,
+    ) -> None:
+        """Async compress uncompressed tool results."""
+        stats = await acompact_tools(
+            messages=messages,
+            model=self.model,
+            compact_tools_enabled=self.compact_tools,
+            instructions=self.compact_tools_instructions,
+            run_metrics=run_metrics,
+        )
+        self._merge_stats(stats)
+
+    # --- Context compaction (delegates to _context.py) ---
+
+    def should_compact(self, messages: List[Message]) -> bool:
+        """Check if context should be compacted."""
+        if not self.compact_context:
+            return False
+        return should_compact_context(
+            messages=messages,
+            model=self.model,
+            message_limit=self.compact_context_message_limit,
+            token_limit=self.compact_context_token_limit,
+        )
+
+    async def ashould_compact(self, messages: List[Message]) -> bool:
+        """Async check if context should be compacted."""
+        if not self.compact_context:
+            return False
+        return await ashould_compact_context(
+            messages=messages,
+            model=self.model,
+            message_limit=self.compact_context_message_limit,
+            token_limit=self.compact_context_token_limit,
+        )
+
+    def compact(
+        self,
+        messages: List[Message],
+        run_response: Optional[Union["RunOutput", "TeamRunOutput"]] = None,
+        run_metrics: Optional["RunMetrics"] = None,
+    ) -> CompactionResult:
+        """Compact context into summary message."""
+        if not self.compact_context:
+            return CompactionResult(compacted_messages=messages)
+
+        if not self.should_compact(messages):
+            return CompactionResult(compacted_messages=messages)
+
+        log_debug("[COMPACTION_MANAGER] compact()")
+        return compact_context(
+            messages=messages,
+            model=self.model,
+            keep_recent=self.compact_context_keep_recent,
+            preserve_user_budget=self.compact_context_preserve_user_budget or 20_000,
+            token_limit=self.compact_context_token_limit,
+            instructions=self.compact_context_instructions,
+            run_response=run_response,
+            run_metrics=run_metrics,
+        )
+
+    async def acompact(
+        self,
+        messages: List[Message],
+        run_response: Optional[Union["RunOutput", "TeamRunOutput"]] = None,
+        run_metrics: Optional["RunMetrics"] = None,
+    ) -> CompactionResult:
+        """Async compact context into summary message."""
+        if not self.compact_context:
+            return CompactionResult(compacted_messages=messages)
+
+        if not await self.ashould_compact(messages):
+            return CompactionResult(compacted_messages=messages)
+
+        log_debug("[COMPACTION_MANAGER] acompact()")
+        return await acompact_context(
+            messages=messages,
+            model=self.model,
+            keep_recent=self.compact_context_keep_recent,
+            preserve_user_budget=self.compact_context_preserve_user_budget or 20_000,
+            token_limit=self.compact_context_token_limit,
+            instructions=self.compact_context_instructions,
+            run_response=run_response,
+            run_metrics=run_metrics,
+        )
+
+    # --- Stats ---
+
+    def _merge_stats(self, stats: Dict[str, Any]) -> None:
+        """Merge stats from tool compaction."""
+        for key, value in stats.items():
+            self.stats[key] = self.stats.get(key, 0) + value
+
+    # --- Deprecated method aliases (backward compat) ---
 
     def should_compress(
         self,
@@ -73,103 +293,9 @@ class CompressionManager:
         model: Optional[Model] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     ) -> bool:
-        """Check if tool results should be compressed.
+        """Deprecated: use should_compact_tools()."""
+        return self.should_compact_tools(messages, tools, model, response_format)
 
-        Args:
-            messages: List of messages to check.
-            tools: List of tools for token counting.
-            model: The Agent / Team model.
-            response_format: Output schema for accurate token counting.
-        """
-        if not self.compress_tool_results:
-            return False
-
-        # Token-based threshold check
-        if self.compress_token_limit is not None and model is not None:
-            tokens = model.count_tokens(messages, tools, response_format)
-            if tokens >= self.compress_token_limit:
-                log_info(f"Token limit hit: {tokens} >= {self.compress_token_limit}")
-                return True
-
-        # Count-based threshold check
-        if self.compress_tool_results_limit is not None:
-            uncompressed_tools_count = len(
-                [m for m in messages if self._is_tool_result_message(m) and m.compressed_content is None]
-            )
-            if uncompressed_tools_count >= self.compress_tool_results_limit:
-                log_info(f"Tool count limit hit: {uncompressed_tools_count} >= {self.compress_tool_results_limit}")
-                return True
-
-        return False
-
-    def _compress_tool_result(
-        self,
-        tool_result: Message,
-        run_metrics: Optional["RunMetrics"] = None,
-    ) -> Optional[str]:
-        if not tool_result:
-            return None
-
-        tool_content = f"Tool: {tool_result.tool_name or 'unknown'}\n{tool_result.content}"
-
-        self.model = get_model(self.model)
-        if not self.model:
-            log_warning("No compression model available")
-            return None
-
-        compression_prompt = self.compress_tool_call_instructions or DEFAULT_COMPRESSION_PROMPT
-        compression_message = "Tool Results to Compress: " + tool_content + "\n"
-
-        try:
-            response = self.model.response(
-                messages=[
-                    Message(role="system", content=compression_prompt),
-                    Message(role="user", content=compression_message),
-                ]
-            )
-
-            # Accumulate compression model metrics
-            if run_metrics is not None:
-                from agno.metrics import ModelType, accumulate_model_metrics
-
-                accumulate_model_metrics(response, self.model, ModelType.COMPRESSION_MODEL, run_metrics)
-
-            return response.content
-        except Exception as e:
-            log_error(f"Error compressing tool result: {str(e)}")
-            return tool_content
-
-    def compress(
-        self,
-        messages: List[Message],
-        run_metrics: Optional["RunMetrics"] = None,
-    ) -> None:
-        """Compress uncompressed tool results"""
-        if not self.compress_tool_results:
-            return
-
-        uncompressed_tools = [msg for msg in messages if msg.role == "tool" and msg.compressed_content is None]
-
-        if not uncompressed_tools:
-            return
-
-        # Compress uncompressed tool results
-        for tool_msg in uncompressed_tools:
-            original_len = len(str(tool_msg.content)) if tool_msg.content else 0
-            compressed = self._compress_tool_result(tool_msg, run_metrics=run_metrics)
-            if compressed:
-                tool_msg.compressed_content = compressed
-                # Count actual tool results (Gemini combines multiple in one message)
-                tool_results_count = len(tool_msg.tool_calls) if tool_msg.tool_calls else 1
-                self.stats["tool_results_compressed"] = (
-                    self.stats.get("tool_results_compressed", 0) + tool_results_count
-                )
-                self.stats["original_size"] = self.stats.get("original_size", 0) + original_len
-                self.stats["compressed_size"] = self.stats.get("compressed_size", 0) + len(compressed)
-            else:
-                log_warning(f"Compression failed for {tool_msg.tool_name}")
-
-    # * Async methods *#
     async def ashould_compress(
         self,
         messages: List[Message],
@@ -177,104 +303,25 @@ class CompressionManager:
         model: Optional[Model] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     ) -> bool:
-        """Async check if tool results should be compressed.
+        """Deprecated: use ashould_compact_tools()."""
+        return await self.ashould_compact_tools(messages, tools, model, response_format)
 
-        Args:
-            messages: List of messages to check.
-            tools: List of tools for token counting.
-            model: The Agent / Team model.
-            response_format: Output schema for accurate token counting.
-        """
-        if not self.compress_tool_results:
-            return False
-
-        # Token-based threshold check
-        if self.compress_token_limit is not None and model is not None:
-            tokens = await model.acount_tokens(messages, tools, response_format)
-            if tokens >= self.compress_token_limit:
-                log_info(f"Token limit hit: {tokens} >= {self.compress_token_limit}")
-                return True
-
-        # Count-based threshold check
-        if self.compress_tool_results_limit is not None:
-            uncompressed_tools_count = len(
-                [m for m in messages if self._is_tool_result_message(m) and m.compressed_content is None]
-            )
-            if uncompressed_tools_count >= self.compress_tool_results_limit:
-                log_info(f"Tool count limit hit: {uncompressed_tools_count} >= {self.compress_tool_results_limit}")
-                return True
-
-        return False
-
-    async def _acompress_tool_result(
+    def compress(
         self,
-        tool_result: Message,
+        messages: List[Message],
         run_metrics: Optional["RunMetrics"] = None,
-    ) -> Optional[str]:
-        """Async compress a single tool result"""
-        if not tool_result:
-            return None
-
-        tool_content = f"Tool: {tool_result.tool_name or 'unknown'}\n{tool_result.content}"
-
-        self.model = get_model(self.model)
-        if not self.model:
-            log_warning("No compression model available")
-            return None
-
-        compression_prompt = self.compress_tool_call_instructions or DEFAULT_COMPRESSION_PROMPT
-        compression_message = "Tool Results to Compress: " + tool_content + "\n"
-
-        try:
-            response = await self.model.aresponse(
-                messages=[
-                    Message(role="system", content=compression_prompt),
-                    Message(role="user", content=compression_message),
-                ]
-            )
-
-            # Accumulate compression model metrics
-            if run_metrics is not None:
-                from agno.metrics import ModelType, accumulate_model_metrics
-
-                accumulate_model_metrics(response, self.model, ModelType.COMPRESSION_MODEL, run_metrics)
-
-            return response.content
-        except Exception as e:
-            log_error(f"Error compressing tool result: {str(e)}")
-            return tool_content
+    ) -> None:
+        """Deprecated: use compact_tool_results()."""
+        self.compact_tool_results(messages, run_metrics)
 
     async def acompress(
         self,
         messages: List[Message],
         run_metrics: Optional["RunMetrics"] = None,
     ) -> None:
-        """Async compress uncompressed tool results"""
-        if not self.compress_tool_results:
-            return
+        """Deprecated: use acompact_tool_results()."""
+        await self.acompact_tool_results(messages, run_metrics)
 
-        uncompressed_tools = [msg for msg in messages if msg.role == "tool" and msg.compressed_content is None]
 
-        if not uncompressed_tools:
-            return
-
-        # Track original sizes before compression
-        original_sizes = [len(str(msg.content)) if msg.content else 0 for msg in uncompressed_tools]
-
-        # Parallel compression using asyncio.gather
-        tasks = [self._acompress_tool_result(msg, run_metrics=run_metrics) for msg in uncompressed_tools]
-        results = await asyncio.gather(*tasks)
-
-        # Apply results and track stats
-        for msg, compressed, original_len in zip(uncompressed_tools, results, original_sizes):
-            if compressed:
-                msg.compressed_content = compressed
-                # Count actual tool results (Gemini combines multiple in one message)
-                tool_results_count = len(msg.tool_calls) if msg.tool_calls else 1
-                self.stats["tool_results_compressed"] = (
-                    self.stats.get("tool_results_compressed", 0) + tool_results_count
-                )
-                self.stats["original_size"] = self.stats.get("original_size", 0) + original_len
-                self.stats["compressed_size"] = self.stats.get("compressed_size", 0) + len(compressed)
-            else:
-                log_warning(f"Compression failed for {msg.tool_name}")
+# Backward compatibility alias
+CompressionManager = CompactionManager

--- a/libs/agno/agno/environments/runner.py
+++ b/libs/agno/agno/environments/runner.py
@@ -496,7 +496,7 @@ _ISOLATE_FIELD_ACTIONS: Dict[str, str] = {
     "learning": "writes-severed-copy",  # global reads keep the caller's db; every write engine cut
     "memory_manager": "fresh-db-rebind",  # per-user state: reads come from the attempt's empty db
     "session_summary_manager": "isolated-copy",  # resolution binds the attempt model on the copy
-    "compression_manager": "isolated-copy",
+    "compaction_manager": "isolated-copy",
     "fallback_config": "cache-off-copies",
     "reasoning_agent": "recursive-isolate",
     "save_response_to_file": "nulled",
@@ -871,9 +871,9 @@ def _isolate_attempt(agent: Any, model_override: Optional[Model] = None, _seen: 
             )
             agent.learning = None
 
-    compression_manager = getattr(agent, "compression_manager", None)
-    if compression_manager is not None:
-        agent.compression_manager = _isolated_manager_copy(compression_manager, reset_stats=True)
+    compaction_manager = getattr(agent, "compaction_manager", None)
+    if compaction_manager is not None:
+        agent.compaction_manager = _isolated_manager_copy(compaction_manager, reset_stats=True)
 
     # A manager this block has never seen is nulled loudly, BEFORE resolution
     # can bind anything onto it: managers bind db and model by pattern, and

--- a/libs/agno/agno/environments/runner.py
+++ b/libs/agno/agno/environments/runner.py
@@ -514,12 +514,16 @@ def _cache_off_copy(model_like: Any) -> Any:
 def _isolated_manager_copy(manager: Any, db: Any = None, reset_stats: bool = False) -> Any:
     """An attempt-local shallow copy of a manager: resolution binds db and model
     onto the copy, never onto the caller's instance. `db` rebinds the copy's
-    store; a model already set on the manager gets the cache-off treatment."""
+    store; a model already set on the manager gets the cache-off treatment.
+
+    Note: stats are no longer accumulated on the manager (async-safety fix).
+    They are returned per-call and stored on run_response.compression_stats.
+    The reset_stats parameter is kept for API compatibility but is now a no-op.
+    """
     manager_copy = copy.copy(manager)
     if db is not None:
         manager_copy.db = db
-    if reset_stats and hasattr(manager_copy, "stats"):
-        manager_copy.stats = {}
+    # reset_stats is now a no-op - stats are per-run, not on manager
     manager_model = getattr(manager_copy, "model", None)
     if manager_model is not None and hasattr(manager_model, "cache_response"):
         manager_copy.model = _cache_off_copy(manager_model)

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -698,15 +698,18 @@ class Model(ABC):
 
         _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
         _compaction_manager = compaction_manager if _compress_tool_results else None
+        _compaction_stats: Dict[str, Any] = {}
 
         while True:
             # Compress tool results if compression is enabled and threshold is met
             if _compaction_manager is not None and _compaction_manager.should_compact_tools(
                 messages, tools, model=self, response_format=response_format
             ):
-                _compaction_manager.compact_tool_results(
+                stats = _compaction_manager.compact_tool_results(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
+                for key, value in stats.items():
+                    _compaction_stats[key] = _compaction_stats.get(key, 0) + value
 
             # Get response from model
             assistant_message = Message(role=self.assistant_message_role)
@@ -876,6 +879,10 @@ class Model(ABC):
         if self.cache_response:
             self._save_model_response_to_cache(cache_key, model_response, is_streaming=False)
 
+        # Store compression stats on run_response (async-safe, per-run)
+        if run_response is not None and _compaction_stats:
+            run_response.compression_stats = _compaction_stats
+
         return model_response
 
     async def aresponse(
@@ -922,17 +929,20 @@ class Model(ABC):
 
         _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
         _compaction_manager = compaction_manager if _compress_tool_results else None
+        _compaction_stats: Dict[str, Any] = {}
 
         function_call_count = 0
 
         while True:
             # Compress existing tool results BEFORE making API call to avoid context overflow
-            if _compaction_manager is not None and await _compaction_manager.ashould_compress(
+            if _compaction_manager is not None and await _compaction_manager.ashould_compact_tools(
                 messages, tools, model=self, response_format=response_format
             ):
-                await _compaction_manager.acompress(
+                stats = await _compaction_manager.acompact_tool_results(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
+                for key, value in stats.items():
+                    _compaction_stats[key] = _compaction_stats.get(key, 0) + value
 
             # Get response from model
             assistant_message = Message(role=self.assistant_message_role)
@@ -1100,6 +1110,10 @@ class Model(ABC):
         # Save to cache if enabled
         if self.cache_response:
             self._save_model_response_to_cache(cache_key, model_response, is_streaming=False)
+
+        # Store compression stats on run_response (async-safe, per-run)
+        if run_response is not None and _compaction_stats:
+            run_response.compression_stats = _compaction_stats
 
         return model_response
 
@@ -1415,23 +1429,26 @@ class Model(ABC):
 
         _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
         _compaction_manager = compaction_manager if _compress_tool_results else None
+        _compaction_stats: Dict[str, Any] = {}
 
         function_call_count = 0
 
         while True:
             # Compress existing tool results BEFORE invoke
-            if _compaction_manager is not None and _compaction_manager.should_compress(
+            if _compaction_manager is not None and _compaction_manager.should_compact_tools(
                 messages, tools, model=self, response_format=response_format
             ):
                 # Emit compression started event
                 yield ModelResponse(event=ModelResponseEvent.compression_started.value)
-                _compaction_manager.compress(
+                stats = _compaction_manager.compact_tool_results(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
+                for key, value in stats.items():
+                    _compaction_stats[key] = _compaction_stats.get(key, 0) + value
                 # Emit compression completed event with stats
                 yield ModelResponse(
                     event=ModelResponseEvent.compression_completed.value,
-                    compression_stats=_compaction_manager.stats.copy(),
+                    compression_stats=_compaction_stats.copy(),
                 )
 
             assistant_message = Message(role=self.assistant_message_role)
@@ -1698,23 +1715,26 @@ class Model(ABC):
 
         _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
         _compaction_manager = compaction_manager if _compress_tool_results else None
+        _compaction_stats: Dict[str, Any] = {}
 
         function_call_count = 0
 
         while True:
             # Compress existing tool results BEFORE making API call to avoid context overflow
-            if _compaction_manager is not None and await _compaction_manager.ashould_compress(
+            if _compaction_manager is not None and await _compaction_manager.ashould_compact_tools(
                 messages, tools, model=self, response_format=response_format
             ):
                 # Emit compression started event
                 yield ModelResponse(event=ModelResponseEvent.compression_started.value)
-                await _compaction_manager.acompress(
+                stats = await _compaction_manager.acompact_tool_results(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
+                for key, value in stats.items():
+                    _compaction_stats[key] = _compaction_stats.get(key, 0) + value
                 # Emit compression completed event with stats
                 yield ModelResponse(
                     event=ModelResponseEvent.compression_completed.value,
-                    compression_stats=_compaction_manager.stats.copy(),
+                    compression_stats=_compaction_stats.copy(),
                 )
 
             # Create assistant message and stream data

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -25,7 +25,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from agno.compression.manager import CompressionManager
+    from agno.compression import CompactionManager
     from agno.offload.store import ResultStore
 from uuid import uuid4
 
@@ -652,9 +652,11 @@ class Model(ABC):
         tool_call_limit: Optional[int] = None,
         run_response: Optional[Union[RunOutput, TeamRunOutput]] = None,
         send_media_to_model: bool = True,
-        compression_manager: Optional["CompressionManager"] = None,
+        compaction_manager: Optional["CompactionManager"] = None,
         result_store: Optional["ResultStore"] = None,
         after_tool_results: Optional[Callable[["ModelResponse"], None]] = None,
+        compacted_messages: Optional[List[Message]] = None,
+        compaction_callback: Optional[Callable[[], Optional[List[Message]]]] = None,
     ) -> ModelResponse:
         """
         Generate a response from the model.
@@ -694,15 +696,15 @@ class Model(ABC):
         _tool_dicts = self._format_tools(tools) if tools is not None else []
         _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
 
-        _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
-        _compression_manager = compression_manager if _compress_tool_results else None
+        _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
+        _compaction_manager = compaction_manager if _compress_tool_results else None
 
         while True:
             # Compress tool results if compression is enabled and threshold is met
-            if _compression_manager is not None and _compression_manager.should_compress(
+            if _compaction_manager is not None and _compaction_manager.should_compact_tools(
                 messages, tools, model=self, response_format=response_format
             ):
-                _compression_manager.compress(
+                _compaction_manager.compact_tool_results(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
 
@@ -885,9 +887,11 @@ class Model(ABC):
         tool_call_limit: Optional[int] = None,
         run_response: Optional[Union[RunOutput, TeamRunOutput]] = None,
         send_media_to_model: bool = True,
-        compression_manager: Optional["CompressionManager"] = None,
+        compaction_manager: Optional["CompactionManager"] = None,
         result_store: Optional["ResultStore"] = None,
         after_tool_results: Optional[Callable[["ModelResponse"], Awaitable[None]]] = None,
+        compacted_messages: Optional[List[Message]] = None,
+        compaction_callback: Optional[Callable[[], Awaitable[Optional[List[Message]]]]] = None,
     ) -> ModelResponse:
         """
         Generate an asynchronous response from the model.
@@ -916,17 +920,17 @@ class Model(ABC):
         _tool_dicts = self._format_tools(tools) if tools is not None else []
         _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
 
-        _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
-        _compression_manager = compression_manager if _compress_tool_results else None
+        _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
+        _compaction_manager = compaction_manager if _compress_tool_results else None
 
         function_call_count = 0
 
         while True:
             # Compress existing tool results BEFORE making API call to avoid context overflow
-            if _compression_manager is not None and await _compression_manager.ashould_compress(
+            if _compaction_manager is not None and await _compaction_manager.ashould_compress(
                 messages, tools, model=self, response_format=response_format
             ):
-                await _compression_manager.acompress(
+                await _compaction_manager.acompress(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
 
@@ -1369,9 +1373,11 @@ class Model(ABC):
         stream_model_response: bool = True,
         run_response: Optional[Union[RunOutput, TeamRunOutput]] = None,
         send_media_to_model: bool = True,
-        compression_manager: Optional["CompressionManager"] = None,
+        compaction_manager: Optional["CompactionManager"] = None,
         result_store: Optional["ResultStore"] = None,
         after_tool_results: Optional[Callable[["ModelResponse"], None]] = None,
+        compacted_messages: Optional[List[Message]] = None,
+        compaction_callback: Optional[Callable[[], Optional[List[Message]]]] = None,
     ) -> Iterator[Union[ModelResponse, RunOutputEvent, TeamRunOutputEvent]]:
         """
         Generate a streaming response from the model.
@@ -1407,25 +1413,25 @@ class Model(ABC):
         _tool_dicts = self._format_tools(tools) if tools is not None else []
         _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
 
-        _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
-        _compression_manager = compression_manager if _compress_tool_results else None
+        _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
+        _compaction_manager = compaction_manager if _compress_tool_results else None
 
         function_call_count = 0
 
         while True:
             # Compress existing tool results BEFORE invoke
-            if _compression_manager is not None and _compression_manager.should_compress(
+            if _compaction_manager is not None and _compaction_manager.should_compress(
                 messages, tools, model=self, response_format=response_format
             ):
                 # Emit compression started event
                 yield ModelResponse(event=ModelResponseEvent.compression_started.value)
-                _compression_manager.compress(
+                _compaction_manager.compress(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
                 # Emit compression completed event with stats
                 yield ModelResponse(
                     event=ModelResponseEvent.compression_completed.value,
-                    compression_stats=_compression_manager.stats.copy(),
+                    compression_stats=_compaction_manager.stats.copy(),
                 )
 
             assistant_message = Message(role=self.assistant_message_role)
@@ -1650,9 +1656,11 @@ class Model(ABC):
         stream_model_response: bool = True,
         run_response: Optional[Union[RunOutput, TeamRunOutput]] = None,
         send_media_to_model: bool = True,
-        compression_manager: Optional["CompressionManager"] = None,
+        compaction_manager: Optional["CompactionManager"] = None,
         result_store: Optional["ResultStore"] = None,
         after_tool_results: Optional[Callable[["ModelResponse"], Awaitable[None]]] = None,
+        compacted_messages: Optional[List[Message]] = None,
+        compaction_callback: Optional[Callable[[], Awaitable[Optional[List[Message]]]]] = None,
     ) -> AsyncIterator[Union[ModelResponse, RunOutputEvent, TeamRunOutputEvent]]:
         """
         Generate an asynchronous streaming response from the model.
@@ -1688,25 +1696,25 @@ class Model(ABC):
         _tool_dicts = self._format_tools(tools) if tools is not None else []
         _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
 
-        _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
-        _compression_manager = compression_manager if _compress_tool_results else None
+        _compress_tool_results = bool(compaction_manager is not None and compaction_manager.compact_tools)
+        _compaction_manager = compaction_manager if _compress_tool_results else None
 
         function_call_count = 0
 
         while True:
             # Compress existing tool results BEFORE making API call to avoid context overflow
-            if _compression_manager is not None and await _compression_manager.ashould_compress(
+            if _compaction_manager is not None and await _compaction_manager.ashould_compress(
                 messages, tools, model=self, response_format=response_format
             ):
                 # Emit compression started event
                 yield ModelResponse(event=ModelResponseEvent.compression_started.value)
-                await _compression_manager.acompress(
+                await _compaction_manager.acompress(
                     messages, run_metrics=run_response.metrics if run_response is not None else None
                 )
                 # Emit compression completed event with stats
                 yield ModelResponse(
                     event=ModelResponseEvent.compression_completed.value,
-                    compression_stats=_compression_manager.stats.copy(),
+                    compression_stats=_compaction_manager.stats.copy(),
                 )
 
             # Create assistant message and stream data

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -23,6 +23,7 @@ from agno.utils.media import (
 )
 
 if TYPE_CHECKING:
+    from agno.compression import CompactionState
     from agno.session.summary import SessionSummary
 
 
@@ -660,6 +661,9 @@ class RunOutput:
     metadata: Optional[Dict[str, Any]] = None
     session_state: Optional[Dict[str, Any]] = None
 
+    # Point-in-time compaction state for continue_run time travel
+    compaction_state: Optional["CompactionState"] = None
+
     created_at: int = field(default_factory=lambda: int(time()))
 
     events: Optional[List[RunOutputEvent]] = None
@@ -743,6 +747,7 @@ class RunOutput:
         "references",
         "requirements",
         "followups",
+        "compaction_state",
     )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -849,6 +854,9 @@ class RunOutput:
         if self.input is not None:
             _dict["input"] = self.input.to_dict()
 
+        if self.compaction_state is not None:
+            _dict["compaction_state"] = self.compaction_state.to_dict()
+
         return _dict
 
     def to_json(self, separators=(", ", ": "), indent: Optional[int] = 2) -> str:
@@ -936,6 +944,14 @@ class RunOutput:
         if references is not None:
             references = [MessageReferences.model_validate(reference) for reference in references]
 
+        # Handle compaction state deserialization
+        compaction_data = data.pop("compaction_state", None)
+        compaction_state = None
+        if compaction_data and isinstance(compaction_data, dict):
+            from agno.compression import CompactionState
+
+            compaction_state = CompactionState.from_dict(compaction_data)
+
         # Filter data to only include fields that are actually defined in the RunOutput dataclass
         from dataclasses import fields
 
@@ -959,6 +975,7 @@ class RunOutput:
             reasoning_messages=reasoning_messages,
             references=references,
             requirements=requirements,
+            compaction_state=compaction_state,
             **filtered_data,
         )
 

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -663,6 +663,8 @@ class RunOutput:
 
     # Point-in-time compaction state for continue_run time travel
     compaction_state: Optional["CompactionState"] = None
+    # Per-run compression stats (async-safe, not shared across runs)
+    compression_stats: Optional[Dict[str, Any]] = None
 
     created_at: int = field(default_factory=lambda: int(time()))
 

--- a/libs/agno/agno/run/messages.py
+++ b/libs/agno/agno/run/messages.py
@@ -19,6 +19,8 @@ class RunMessages:
     system_message: Optional[Message] = None
     user_message: Optional[Message] = None
     extra_messages: Optional[List[Message]] = None
+    # Compacted messages for model API calls; storage reads from messages
+    compacted_messages: Optional[List[Message]] = None
 
     def get_input_messages(self) -> List[Message]:
         """Get the input messages for the model."""

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -2,9 +2,12 @@ from copy import copy
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from time import time
-from typing import Any, Dict, List, Optional, Sequence, Union, get_args
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union, get_args
 
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from agno.compression import CompactionState
 
 from agno.media import Audio, File, Image, Video
 from agno.metrics import RunMetrics
@@ -787,6 +790,10 @@ class TeamRunOutput:
     additional_input: Optional[List[Message]] = None
     reasoning_steps: Optional[List[ReasoningStep]] = None
     reasoning_messages: Optional[List[Message]] = None
+
+    # Point-in-time compaction state for continue_run time travel
+    compaction_state: Optional["CompactionState"] = None
+
     created_at: int = field(default_factory=lambda: int(time()))
 
     events: Optional[List[Union[RunOutputEvent, TeamRunOutputEvent]]] = None
@@ -862,6 +869,7 @@ class TeamRunOutput:
         "followups",
         "member_responses",
         "input",
+        "compaction_state",
     )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -951,6 +959,9 @@ class TeamRunOutput:
         if self.input is not None:
             _dict["input"] = self.input.to_dict()
 
+        if self.compaction_state is not None:
+            _dict["compaction_state"] = self.compaction_state.to_dict()
+
         return _dict
 
     def to_json(self, separators=(", ", ": "), indent: Optional[int] = 2) -> str:
@@ -1037,6 +1048,13 @@ class TeamRunOutput:
         citations = data.pop("citations", None)
         citations = Citations.model_validate(citations) if citations else None
 
+        compaction_data = data.pop("compaction_state", None)
+        compaction_state = None
+        if compaction_data:
+            from agno.compression import CompactionState
+
+            compaction_state = CompactionState.from_dict(compaction_data)
+
         # Filter data to only include fields that are actually defined in the TeamRunOutput dataclass
         from dataclasses import fields
 
@@ -1061,6 +1079,7 @@ class TeamRunOutput:
             tools=tools,
             requirements=requirements,
             events=events,
+            compaction_state=compaction_state,
             **filtered_data,
         )
 

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -793,6 +793,8 @@ class TeamRunOutput:
 
     # Point-in-time compaction state for continue_run time travel
     compaction_state: Optional["CompactionState"] = None
+    # Per-run compression stats (async-safe, not shared across runs)
+    compression_stats: Optional[Dict[str, Any]] = None
 
     created_at: int = field(default_factory=lambda: int(time()))
 

--- a/libs/agno/agno/session/agent.py
+++ b/libs/agno/agno/session/agent.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import copy
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, List, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Set, Union
 
 from agno.models.message import Message
 from agno.run.agent import RunOutput
 from agno.run.base import HISTORY_SKIP_STATUSES, RunStatus
 from agno.run.team import TeamRunOutput
 from agno.session.summary import SessionSummary
+
+if TYPE_CHECKING:
+    from agno.compression import CompactionState
+
 from agno.utils.log import log_debug, log_warning
 
 
@@ -127,6 +131,33 @@ class AgentSession:
                 return run
         return None
 
+    def get_compaction_state(self, run_id: Optional[str] = None) -> Optional["CompactionState"]:
+        """Get compaction state, optionally at a specific run's point in time.
+
+        Args:
+            run_id: If provided, get compaction as of this run. If None, get latest.
+
+        Returns:
+            CompactionState if found, None otherwise.
+        """
+        runs = self.runs or []
+        if not runs:
+            return None
+
+        if run_id:
+            target_idx = next((i for i, r in enumerate(runs) if r.run_id == run_id), None)
+            if target_idx is None:
+                return None
+            start_idx = target_idx
+        else:
+            start_idx = len(runs) - 1
+
+        for i in range(start_idx, -1, -1):
+            compaction_state = getattr(runs[i], "compaction_state", None)
+            if compaction_state is not None:
+                return compaction_state
+        return None
+
     def get_messages(
         self,
         agent_id: Optional[str] = None,
@@ -136,6 +167,7 @@ class AgentSession:
         skip_roles: Optional[List[str]] = None,
         skip_statuses: Optional[List[RunStatus]] = None,
         skip_history_messages: bool = True,
+        compacted_message_ids: Optional[Set[str]] = None,
     ) -> List[Message]:
         """Returns the messages belonging to the session that fit the given criteria.
 
@@ -147,10 +179,12 @@ class AgentSession:
             skip_roles: Skip messages with these roles.
             skip_statuses: Skip messages with these statuses.
             skip_history_messages: Skip messages that were tagged as history in previous runs.
+            compacted_message_ids: Set of message IDs to skip (already in compaction summary).
 
         Returns:
             A list of Messages belonging to the session.
         """
+        compacted_ids: Set[str] = compacted_message_ids or set()
 
         def _should_skip_message(
             message: Message, skip_roles: Optional[List[str]] = None, skip_history_messages: bool = True
@@ -162,6 +196,10 @@ class AgentSession:
 
             # Skip messages with specified role
             if skip_roles and message.role in skip_roles:
+                return True
+
+            # Skip compacted messages (their content is in the summary)
+            if compacted_ids and message.id and message.id in compacted_ids:
                 return True
 
             return False

--- a/libs/agno/agno/session/team.py
+++ b/libs/agno/agno/session/team.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Set, Tuple, Union
 
 from pydantic import BaseModel
 
@@ -11,6 +11,10 @@ from agno.run.agent import RunOutput, RunStatus
 from agno.run.base import HISTORY_SKIP_STATUSES
 from agno.run.team import TeamRunOutput
 from agno.session.summary import SessionSummary
+
+if TYPE_CHECKING:
+    from agno.compression import CompactionState
+
 from agno.utils.log import log_debug, log_warning
 
 
@@ -100,6 +104,35 @@ class TeamSession:
                 return run
         return None
 
+    def get_compaction_state(self, run_id: Optional[str] = None) -> Optional["CompactionState"]:
+        """Get compaction state, optionally at a specific run's point in time.
+
+        Args:
+            run_id: If provided, get compaction as of this run. If None, get latest.
+
+        Returns:
+            CompactionState if found, None otherwise.
+        """
+        # Only top-level team runs carry the team's own compaction state; member runs
+        # (parent_run_id set) have their own state and must not leak into it
+        runs = [r for r in (self.runs or []) if r.parent_run_id is None]
+        if not runs:
+            return None
+
+        if run_id:
+            target_idx = next((i for i, r in enumerate(runs) if r.run_id == run_id), None)
+            if target_idx is None:
+                return None
+            start_idx = target_idx
+        else:
+            start_idx = len(runs) - 1
+
+        for i in range(start_idx, -1, -1):
+            compaction_state = getattr(runs[i], "compaction_state", None)
+            if compaction_state is not None:
+                return compaction_state
+        return None
+
     def upsert_run(self, run_response: Union[TeamRunOutput, RunOutput]):
         """Adds a RunOutput, together with some calculated data, to the runs list."""
         messages = run_response.messages
@@ -137,6 +170,7 @@ class TeamSession:
         skip_statuses: Optional[List[RunStatus]] = None,
         skip_history_messages: bool = True,
         skip_member_messages: bool = True,
+        compacted_message_ids: Optional[Set[str]] = None,
     ) -> List[Message]:
         """Returns the messages belonging to the session that fit the given criteria.
 
@@ -149,10 +183,12 @@ class TeamSession:
             skip_statuses: Skip messages with these statuses.
             skip_history_messages: Skip messages that were tagged as history in previous runs.
             skip_member_messages: Skip messages created by members of the team.
+            compacted_message_ids: Set of message IDs to skip (compacted into summary).
 
         Returns:
             A list of Messages belonging to the session.
         """
+        compacted_ids: Set[str] = compacted_message_ids or set()
 
         def _should_skip_message(
             message: Message, skip_roles: Optional[List[str]] = None, skip_history_messages: bool = True
@@ -165,6 +201,11 @@ class TeamSession:
             # Skip messages with specified role
             if skip_roles and message.role in skip_roles:
                 return True
+
+            # Skip compacted messages (their content is in the summary)
+            if compacted_ids and message.id and message.id in compacted_ids:
+                return True
+
             return False
 
         if (member_ids is not None or team_id is not None) and skip_member_messages:

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -28,7 +28,7 @@ from uuid import uuid4
 from pydantic import BaseModel
 
 from agno.agent import Agent
-from agno.compression.manager import CompressionManager
+from agno.compression.manager import CompactionManager
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.eval.base import BaseEval
 from agno.filters import FilterExpr
@@ -155,8 +155,12 @@ def __init__(
     add_session_summary_to_context: Optional[bool] = None,
     learning: Optional[Union[bool, LearningMachine]] = None,
     add_learnings_to_context: bool = True,
-    compress_tool_results: bool = False,
-    compression_manager: Optional["CompressionManager"] = None,
+    compact_tools: bool = False,
+    compact_context: bool = False,
+    compaction_manager: Optional["CompactionManager"] = None,
+    # Deprecated aliases
+    compress_tool_results: Optional[bool] = None,
+    compression_manager: Optional["CompactionManager"] = None,
     offload_tool_results: Optional[Union[bool, "ResultStore"]] = None,
     metadata: Optional[Dict[str, Any]] = None,
     reasoning_model: Optional[Union[Model, str]] = None,
@@ -335,9 +339,18 @@ def __init__(
     team.learning = learning
     team.add_learnings_to_context = add_learnings_to_context
 
-    # Context compression settings
-    team.compress_tool_results = compress_tool_results
-    team.compression_manager = compression_manager
+    # Context compaction settings (with backward compat)
+    if compress_tool_results is not None:
+        log_debug("compress_tool_results is deprecated, use compact_tools")
+        team.compact_tools = compress_tool_results
+    else:
+        team.compact_tools = compact_tools
+    team.compact_context = compact_context
+    if compression_manager is not None:
+        log_debug("compression_manager is deprecated, use compaction_manager")
+        team.compaction_manager = compression_manager
+    else:
+        team.compaction_manager = compaction_manager
 
     # Result offloading settings
     team.offload_tool_results = offload_tool_results
@@ -614,10 +627,10 @@ def _bind_member_result_store(team: "Team", member: Union[Agent, "Team"]) -> Non
         # A compressing member cannot take the team's store: compression
         # rewrites the tool messages that hold stored-result envelopes. The
         # member has to opt out of one of the two.
-        if getattr(member, "compress_tool_results", False):
+        if getattr(member, "compact_tools", False):
             member_name = member.name or member.id or "member"
             raise ValueError(
-                f"Member '{member_name}' has compress_tool_results enabled and would inherit the "
+                f"Member '{member_name}' has compact_tools enabled and would inherit the "
                 "team's result store; the two cannot run together. Set offload_tool_results=False "
                 "on the member or disable its compression."
             )
@@ -657,9 +670,9 @@ def _set_result_store(team: "Team") -> None:
 
     # Compression rewrites the tool messages that hold stored-result
     # envelopes, so the two features refuse to run together.
-    if team.compress_tool_results and team.offload_tool_results:
+    if team.compact_tools and team.offload_tool_results:
         raise ValueError(
-            "offload_tool_results and compress_tool_results cannot be enabled together: "
+            "offload_tool_results and compact_tools cannot be enabled together: "
             "compression rewrites the tool messages that hold stored-result envelopes. "
             "Disable one of the two."
         )
@@ -692,20 +705,26 @@ def _ensure_result_store(team: "Team") -> None:
     _set_result_store(team)
 
 
-def _set_compression_manager(team: "Team") -> None:
-    if team.compress_tool_results and team.compression_manager is None:
-        team.compression_manager = CompressionManager(
+def _set_compaction_manager(team: "Team") -> None:
+    """Initialize compaction_manager for tool and/or history compaction."""
+    # Auto-create if either compaction flag is set
+    if (team.compact_tools or team.compact_context) and team.compaction_manager is None:
+        team.compaction_manager = CompactionManager(
             model=team.model,
+            compact_tools=team.compact_tools,
+            compact_context=team.compact_context,
         )
-    elif team.compression_manager is not None and team.compression_manager.model is None:
-        # If compression manager exists but has no model, use the team's model
-        team.compression_manager.model = team.model
 
-    if team.compression_manager is not None:
-        if team.compression_manager.model is None:
-            team.compression_manager.model = team.model
-        if team.compression_manager.compress_tool_results:
-            team.compress_tool_results = True
+    # If manager exists, sync the compact_context flag
+    if team.compaction_manager is not None and team.compact_context:
+        team.compaction_manager.compact_context = True
+
+    if team.compaction_manager is not None:
+        if team.compaction_manager.model is None:
+            team.compaction_manager.model = team.model
+        # Sync compact_tools flag from manager back to team
+        if team.compaction_manager.compact_tools:
+            team.compact_tools = True
 
 
 def _set_learning_machine(team: "Team") -> None:
@@ -865,17 +884,17 @@ def initialize_team(team: "Team", debug_mode: Optional[bool] = None) -> None:
         _set_memory_manager(team)
     if team.enable_session_summaries or team.session_summary_manager is not None:
         _set_session_summary_manager(team)
-    if team.compress_tool_results or team.compression_manager is not None:
-        _set_compression_manager(team)
+    if team.compact_tools or team.compact_context or team.compaction_manager is not None:
+        _set_compaction_manager(team)
     # Offloading and tool-result compression cannot run together: compression
     # rewrites the tool messages that hold stored-result envelopes. Refuse the
     # combination loudly instead of silently favouring one of them.
     # Resolved when a setting is present or when a store exists.
     if team.offload_tool_results or team._result_store is not None:
-        if team.compress_tool_results:
+        if team.compact_tools:
             raise ValueError(
-                "offload_tool_results and compress_tool_results cannot be enabled together: "
-                "compression rewrites the tool messages that hold stored-result envelopes. "
+                "offload_tool_results and compact_tools cannot be enabled together: "
+                "compaction rewrites the tool messages that hold stored-result envelopes. "
                 "Disable one of the two."
             )
         _ensure_result_store(team)

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -1020,6 +1020,21 @@ def _get_run_messages(
 
     # 3. Add history to run_messages
     if add_history_to_context:
+        from copy import deepcopy
+
+        # Find applicable compaction state from previous runs
+        compaction_state = session.get_compaction_state()
+
+        # Inject compaction summary before history (replaces compacted messages)
+        if compaction_state is not None:
+            log_debug(
+                f"[TEAM-MESSAGES] Injecting compaction summary: total={compaction_state.total_compactions}, "
+                f"ids={len(compaction_state.compacted_message_ids)}"
+            )
+            run_messages.messages.append(compaction_state.get_summary_message())
+            # Seed run_response.compaction_state for mid-loop compaction to build on
+            run_response.compaction_state = deepcopy(compaction_state)
+
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
         # to preserve conversation continuity.
@@ -1030,6 +1045,7 @@ def _get_run_messages(
             limit=team.num_history_messages,
             skip_roles=[skip_role] if skip_role else None,
             team_id=team.id if team.parent_team_id is not None else None,
+            compacted_message_ids=compaction_state.compacted_message_ids if compaction_state else None,
         )
 
         if len(history) > 0:
@@ -1045,7 +1061,7 @@ def _get_run_messages(
             if team.max_tool_calls_from_history is not None:
                 filter_tool_calls(history_copy, team.max_tool_calls_from_history)
 
-            log_debug(f"Adding {len(history_copy)} messages from history")
+            log_debug(f"[TEAM-MESSAGES] Adding {len(history_copy)} messages from history")
 
             # Extend the messages with the history
             run_messages.messages += history_copy
@@ -1155,6 +1171,21 @@ async def _aget_run_messages(
 
     # 3. Add history to run_messages
     if add_history_to_context:
+        from copy import deepcopy
+
+        # Find applicable compaction state from previous runs
+        compaction_state = session.get_compaction_state()
+
+        # Inject compaction summary before history (replaces compacted messages)
+        if compaction_state is not None:
+            log_debug(
+                f"[TEAM-MESSAGES] Injecting compaction summary: total={compaction_state.total_compactions}, "
+                f"ids={len(compaction_state.compacted_message_ids)}"
+            )
+            run_messages.messages.append(compaction_state.get_summary_message())
+            # Seed run_response.compaction_state for mid-loop compaction to build on
+            run_response.compaction_state = deepcopy(compaction_state)
+
         # Only skip messages from history when system_message_role is NOT a standard conversation role.
         # Standard conversation roles ("user", "assistant", "tool") should never be filtered
         # to preserve conversation continuity.
@@ -1164,6 +1195,7 @@ async def _aget_run_messages(
             limit=team.num_history_messages,
             skip_roles=[skip_role] if skip_role else None,
             team_id=team.id if team.parent_team_id is not None else None,
+            compacted_message_ids=compaction_state.compacted_message_ids if compaction_state else None,
         )
 
         if len(history) > 0:
@@ -1179,7 +1211,7 @@ async def _aget_run_messages(
             if team.max_tool_calls_from_history is not None:
                 filter_tool_calls(history_copy, team.max_tool_calls_from_history)
 
-            log_debug(f"Adding {len(history_copy)} messages from history")
+            log_debug(f"[TEAM-MESSAGES] Adding {len(history_copy)} messages from history")
 
             # Extend the messages with the history
             run_messages.messages += history_copy

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1012,7 +1012,21 @@ def _handle_model_response_stream(
         stream_model_response = False
 
     # Lazy import — _run imports _response, so we can't import at module top.
-    from agno.team._run import build_team_after_tool_results_callback
+    from agno.team._run import build_team_after_tool_results_callback, build_team_compaction_callback
+
+    # Pre-loop compaction: compress history BEFORE first model call
+    if team.compaction_manager is not None and team.compaction_manager.compact_context:
+        log_debug(f"[TEAM-STREAM-SYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+        compaction_result = team.compaction_manager.compact(
+            run_messages.messages,
+            run_response=run_response,
+            run_metrics=run_response.metrics,
+        )
+        if compaction_result.summary:
+            run_messages.compacted_messages = compaction_result.compacted_messages
+            log_debug(
+                f"[TEAM-STREAM-SYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+            )
 
     full_model_response = ModelResponse()
     for model_response_event in call_model_stream_with_fallback(
@@ -1026,7 +1040,9 @@ def _handle_model_response_stream(
         stream_model_response=stream_model_response,
         run_response=run_response,
         send_media_to_model=team.send_media_to_model,
-        compression_manager=team.compaction_manager if team.compact_tools else None,
+        compaction_manager=team.compaction_manager if team.compact_tools else None,
+        compacted_messages=run_messages.compacted_messages,
+        compaction_callback=build_team_compaction_callback(team, run_messages, run_response),
         **result_store_kwargs(team),
         after_tool_results=build_team_after_tool_results_callback(
             team, run_response, session, run_messages, run_context
@@ -1173,7 +1189,21 @@ async def _ahandle_model_response_stream(
         stream_model_response = False
 
     # Lazy import — _run imports _response, so we can't import at module top.
-    from agno.team._run import abuild_team_after_tool_results_callback
+    from agno.team._run import abuild_team_after_tool_results_callback, abuild_team_compaction_callback
+
+    # Pre-loop compaction: compress history BEFORE first model call
+    if team.compaction_manager is not None and team.compaction_manager.compact_context:
+        log_debug(f"[TEAM-STREAM-ASYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+        compaction_result = await team.compaction_manager.acompact(
+            run_messages.messages,
+            run_response=run_response,
+            run_metrics=run_response.metrics,
+        )
+        if compaction_result.summary:
+            run_messages.compacted_messages = compaction_result.compacted_messages
+            log_debug(
+                f"[TEAM-STREAM-ASYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+            )
 
     full_model_response = ModelResponse()
     model_stream = acall_model_stream_with_fallback(
@@ -1187,7 +1217,9 @@ async def _ahandle_model_response_stream(
         stream_model_response=stream_model_response,
         send_media_to_model=team.send_media_to_model,
         run_response=run_response,
-        compression_manager=team.compaction_manager if team.compact_tools else None,
+        compaction_manager=team.compaction_manager if team.compact_tools else None,
+        compacted_messages=run_messages.compacted_messages,
+        compaction_callback=await abuild_team_compaction_callback(team, run_messages, run_response),
         **result_store_kwargs(team),
         after_tool_results=abuild_team_after_tool_results_callback(
             team, run_response, session, run_messages, run_context

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1026,7 +1026,7 @@ def _handle_model_response_stream(
         stream_model_response=stream_model_response,
         run_response=run_response,
         send_media_to_model=team.send_media_to_model,
-        compression_manager=team.compression_manager if team.compress_tool_results else None,
+        compression_manager=team.compaction_manager if team.compact_tools else None,
         **result_store_kwargs(team),
         after_tool_results=build_team_after_tool_results_callback(
             team, run_response, session, run_messages, run_context
@@ -1187,7 +1187,7 @@ async def _ahandle_model_response_stream(
         stream_model_response=stream_model_response,
         send_media_to_model=team.send_media_to_model,
         run_response=run_response,
-        compression_manager=team.compression_manager if team.compress_tool_results else None,
+        compression_manager=team.compaction_manager if team.compact_tools else None,
         **result_store_kwargs(team),
         after_tool_results=abuild_team_after_tool_results_callback(
             team, run_response, session, run_messages, run_context

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -393,7 +393,7 @@ def _run_tasks(
                 tool_call_limit=team.tool_call_limit,
                 run_response=run_response,
                 send_media_to_model=team.send_media_to_model,
-                compression_manager=team.compression_manager if team.compress_tool_results else None,
+                compression_manager=team.compaction_manager if team.compact_tools else None,
                 **result_store_kwargs(team),
                 after_tool_results=build_team_after_tool_results_callback(
                     team, run_response, session, run_messages, run_context
@@ -1261,7 +1261,7 @@ def _run(
                     tool_call_limit=team.tool_call_limit,
                     run_response=run_response,
                     send_media_to_model=team.send_media_to_model,
-                    compression_manager=team.compression_manager if team.compress_tool_results else None,
+                    compression_manager=team.compaction_manager if team.compact_tools else None,
                     **result_store_kwargs(team),
                     after_tool_results=build_team_after_tool_results_callback(
                         team, run_response, session, run_messages, run_context
@@ -2284,7 +2284,7 @@ async def _arun_tasks(
                 tool_call_limit=team.tool_call_limit,
                 run_response=run_response,
                 send_media_to_model=team.send_media_to_model,
-                compression_manager=team.compression_manager if team.compress_tool_results else None,
+                compression_manager=team.compaction_manager if team.compact_tools else None,
                 **result_store_kwargs(team),
                 after_tool_results=abuild_team_after_tool_results_callback(
                     team, run_response, team_session, run_messages, run_context
@@ -3242,7 +3242,7 @@ async def _arun(
                     response_format=response_format,
                     send_media_to_model=team.send_media_to_model,
                     run_response=run_response,
-                    compression_manager=team.compression_manager if team.compress_tool_results else None,
+                    compression_manager=team.compaction_manager if team.compact_tools else None,
                     **result_store_kwargs(team),
                     after_tool_results=abuild_team_after_tool_results_callback(
                         team, run_response, team_session, run_messages, run_context
@@ -6978,7 +6978,7 @@ async def _ahandle_model_response_for_continue(
         tool_call_limit=team.tool_call_limit,
         run_response=run_response,
         send_media_to_model=team.send_media_to_model,
-        compression_manager=team.compression_manager if team.compress_tool_results else None,
+        compression_manager=team.compaction_manager if team.compact_tools else None,
         **result_store_kwargs(team),
         after_tool_results=abuild_team_after_tool_results_callback(
             team, run_response, team_session, run_messages, run_context
@@ -8333,7 +8333,7 @@ def _continue_run(
                     tool_call_limit=team.tool_call_limit,
                     run_response=run_response,
                     send_media_to_model=team.send_media_to_model,
-                    compression_manager=team.compression_manager if team.compress_tool_results else None,
+                    compression_manager=team.compaction_manager if team.compact_tools else None,
                     **result_store_kwargs(team),
                     after_tool_results=build_team_after_tool_results_callback(
                         team, run_response, session, run_messages, run_context

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -3249,7 +3249,21 @@ async def _arun(
                 # Check for cancellation before model call
                 await araise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # 6. Get the model response for the team leader
+                # 6. Pre-loop compaction: compress history BEFORE first model call
+                if team.compaction_manager is not None and team.compaction_manager.compact_context:
+                    log_debug(f"[TEAM-RUN-ASYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+                    compaction_result = await team.compaction_manager.acompact(
+                        run_messages.messages,
+                        run_response=run_response,
+                        run_metrics=run_response.metrics,
+                    )
+                    if compaction_result.summary:
+                        run_messages.compacted_messages = compaction_result.compacted_messages
+                        log_debug(
+                            f"[TEAM-RUN-ASYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+                        )
+
+                # 7. Get the model response for the team leader
                 model_response = await acall_model_with_fallback(
                     team.model,
                     team.fallback_config,
@@ -3261,6 +3275,8 @@ async def _arun(
                     send_media_to_model=team.send_media_to_model,
                     run_response=run_response,
                     compaction_manager=team.compaction_manager if team.compact_tools else None,
+                    compacted_messages=run_messages.compacted_messages,
+                    compaction_callback=await abuild_team_compaction_callback(team, run_messages, run_response),
                     **result_store_kwargs(team),
                     after_tool_results=abuild_team_after_tool_results_callback(
                         team, run_response, team_session, run_messages, run_context

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -11,6 +11,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
+    Awaitable,
+    Callable,
     Dict,
     Iterator,
     List,
@@ -393,7 +395,7 @@ def _run_tasks(
                 tool_call_limit=team.tool_call_limit,
                 run_response=run_response,
                 send_media_to_model=team.send_media_to_model,
-                compression_manager=team.compaction_manager if team.compact_tools else None,
+                compaction_manager=team.compaction_manager if team.compact_tools else None,
                 **result_store_kwargs(team),
                 after_tool_results=build_team_after_tool_results_callback(
                     team, run_response, session, run_messages, run_context
@@ -1249,7 +1251,21 @@ def _run(
                 # Check for cancellation before model call
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # 6. Get the model response for the team leader
+                # 6. Pre-loop compaction: compress history BEFORE first model call
+                if team.compaction_manager is not None and team.compaction_manager.compact_context:
+                    log_debug(f"[TEAM-RUN-SYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+                    compaction_result = team.compaction_manager.compact(
+                        run_messages.messages,
+                        run_response=run_response,
+                        run_metrics=run_response.metrics,
+                    )
+                    if compaction_result.summary:
+                        run_messages.compacted_messages = compaction_result.compacted_messages
+                        log_debug(
+                            f"[TEAM-RUN-SYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+                        )
+
+                # 7. Get the model response for the team leader
                 team.model = cast(Model, team.model)
                 model_response: ModelResponse = call_model_with_fallback(
                     team.model,
@@ -1261,7 +1277,9 @@ def _run(
                     tool_call_limit=team.tool_call_limit,
                     run_response=run_response,
                     send_media_to_model=team.send_media_to_model,
-                    compression_manager=team.compaction_manager if team.compact_tools else None,
+                    compaction_manager=team.compaction_manager if team.compact_tools else None,
+                    compacted_messages=run_messages.compacted_messages,
+                    compaction_callback=build_team_compaction_callback(team, run_messages, run_response),
                     **result_store_kwargs(team),
                     after_tool_results=build_team_after_tool_results_callback(
                         team, run_response, session, run_messages, run_context
@@ -2284,7 +2302,7 @@ async def _arun_tasks(
                 tool_call_limit=team.tool_call_limit,
                 run_response=run_response,
                 send_media_to_model=team.send_media_to_model,
-                compression_manager=team.compaction_manager if team.compact_tools else None,
+                compaction_manager=team.compaction_manager if team.compact_tools else None,
                 **result_store_kwargs(team),
                 after_tool_results=abuild_team_after_tool_results_callback(
                     team, run_response, team_session, run_messages, run_context
@@ -3242,7 +3260,7 @@ async def _arun(
                     response_format=response_format,
                     send_media_to_model=team.send_media_to_model,
                     run_response=run_response,
-                    compression_manager=team.compaction_manager if team.compact_tools else None,
+                    compaction_manager=team.compaction_manager if team.compact_tools else None,
                     **result_store_kwargs(team),
                     after_tool_results=abuild_team_after_tool_results_callback(
                         team, run_response, team_session, run_messages, run_context
@@ -5165,6 +5183,63 @@ async def acheckpoint_team_run(
     await _apersist_team_run_in_session(team, run_response, session, run_context)
 
 
+def build_team_compaction_callback(
+    team: "Team",
+    run_messages: "RunMessages",  # noqa: F821
+    run_response: TeamRunOutput,
+) -> Optional[Callable[[], Optional[List[Message]]]]:
+    """Build the sync mid-loop compaction callback for Team.
+
+    Returns ``None`` when context compaction is not enabled.
+    """
+    compaction_manager = team.compaction_manager
+    if compaction_manager is None:
+        return None
+
+    def _callback() -> Optional[List[Message]]:
+        messages_to_compact = (
+            run_messages.compacted_messages if run_messages.compacted_messages else run_messages.messages
+        )
+        result = compaction_manager.compact(
+            messages_to_compact,
+            run_response=run_response,
+            run_metrics=run_response.metrics,
+        )
+        if result.summary:
+            run_messages.compacted_messages = result.compacted_messages
+            return result.compacted_messages
+        return None
+
+    return _callback
+
+
+async def abuild_team_compaction_callback(
+    team: "Team",
+    run_messages: "RunMessages",  # noqa: F821
+    run_response: TeamRunOutput,
+) -> Optional[Callable[[], Awaitable[Optional[List[Message]]]]]:
+    """Async variant of :func:`build_team_compaction_callback`."""
+    compaction_manager = team.compaction_manager
+    if compaction_manager is None:
+        return None
+
+    async def _callback() -> Optional[List[Message]]:
+        messages_to_compact = (
+            run_messages.compacted_messages if run_messages.compacted_messages else run_messages.messages
+        )
+        result = await compaction_manager.acompact(
+            messages_to_compact,
+            run_response=run_response,
+            run_metrics=run_response.metrics,
+        )
+        if result.summary:
+            run_messages.compacted_messages = result.compacted_messages
+            return result.compacted_messages
+        return None
+
+    return _callback
+
+
 def build_team_after_tool_results_callback(
     team: "Team",
     run_response: TeamRunOutput,
@@ -7003,7 +7078,7 @@ async def _ahandle_model_response_for_continue(
         tool_call_limit=team.tool_call_limit,
         run_response=run_response,
         send_media_to_model=team.send_media_to_model,
-        compression_manager=team.compaction_manager if team.compact_tools else None,
+        compaction_manager=team.compaction_manager if team.compact_tools else None,
         **result_store_kwargs(team),
         after_tool_results=abuild_team_after_tool_results_callback(
             team, run_response, team_session, run_messages, run_context
@@ -8363,7 +8438,7 @@ def _continue_run(
                     tool_call_limit=team.tool_call_limit,
                     run_response=run_response,
                     send_media_to_model=team.send_media_to_model,
-                    compression_manager=team.compaction_manager if team.compact_tools else None,
+                    compaction_manager=team.compaction_manager if team.compact_tools else None,
                     **result_store_kwargs(team),
                     after_tool_results=build_team_after_tool_results_callback(
                         team, run_response, session, run_messages, run_context

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -361,6 +361,20 @@ def _run_tasks(
 
         raise_if_cancelled(run_response.run_id)  # type: ignore
 
+        # Pre-loop compaction: compress history BEFORE first model call
+        if team.compaction_manager is not None and team.compaction_manager.compact_context:
+            log_debug(f"[TEAM-TASKS-SYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+            compaction_result = team.compaction_manager.compact(
+                run_messages.messages,
+                run_response=run_response,
+                run_metrics=run_response.metrics,
+            )
+            if compaction_result.summary:
+                run_messages.compacted_messages = compaction_result.compacted_messages
+                log_debug(
+                    f"[TEAM-TASKS-SYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+                )
+
         # Use accumulated messages for the iterative loop
         accumulated_messages = run_messages.messages
 
@@ -383,6 +397,9 @@ def _run_tasks(
                     "When the goal is met, write your answer and call `mark_all_complete`.",
                 )
                 accumulated_messages.append(state_message)
+                # Dual-append: when compaction is active, model sees compacted_messages only
+                if run_messages.compacted_messages is not None:
+                    run_messages.compacted_messages.append(state_message)
 
             # Get model response
             model_response = call_model_with_fallback(
@@ -396,6 +413,8 @@ def _run_tasks(
                 run_response=run_response,
                 send_media_to_model=team.send_media_to_model,
                 compaction_manager=team.compaction_manager if team.compact_tools else None,
+                compacted_messages=run_messages.compacted_messages,
+                compaction_callback=build_team_compaction_callback(team, run_messages, run_response),
                 **result_store_kwargs(team),
                 after_tool_results=build_team_after_tool_results_callback(
                     team, run_response, session, run_messages, run_context
@@ -2268,6 +2287,20 @@ async def _arun_tasks(
 
         await araise_if_cancelled(run_response.run_id)  # type: ignore
 
+        # Pre-loop compaction: compress history BEFORE first model call
+        if team.compaction_manager is not None and team.compaction_manager.compact_context:
+            log_debug(f"[TEAM-TASKS-ASYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+            compaction_result = await team.compaction_manager.acompact(
+                run_messages.messages,
+                run_response=run_response,
+                run_metrics=run_response.metrics,
+            )
+            if compaction_result.summary:
+                run_messages.compacted_messages = compaction_result.compacted_messages
+                log_debug(
+                    f"[TEAM-TASKS-ASYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+                )
+
         # Use accumulated messages for the iterative loop
         accumulated_messages = run_messages.messages
 
@@ -2290,6 +2323,9 @@ async def _arun_tasks(
                     "When the goal is met, write your answer and call `mark_all_complete`.",
                 )
                 accumulated_messages.append(state_message)
+                # Dual-append: when compaction is active, model sees compacted_messages only
+                if run_messages.compacted_messages is not None:
+                    run_messages.compacted_messages.append(state_message)
 
             # Get model response
             model_response = await acall_model_with_fallback(
@@ -2303,6 +2339,8 @@ async def _arun_tasks(
                 run_response=run_response,
                 send_media_to_model=team.send_media_to_model,
                 compaction_manager=team.compaction_manager if team.compact_tools else None,
+                compacted_messages=run_messages.compacted_messages,
+                compaction_callback=await abuild_team_compaction_callback(team, run_messages, run_response),
                 **result_store_kwargs(team),
                 after_tool_results=abuild_team_after_tool_results_callback(
                     team, run_response, team_session, run_messages, run_context
@@ -7084,6 +7122,21 @@ async def _ahandle_model_response_for_continue(
     )
 
     team.model = cast(Model, team.model)
+
+    # Pre-loop compaction: compress history BEFORE model call
+    if team.compaction_manager is not None and team.compaction_manager.compact_context:
+        log_debug(f"[TEAM-CONTINUE-ASYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+        compaction_result = await team.compaction_manager.acompact(
+            run_messages.messages,
+            run_response=run_response,
+            run_metrics=run_response.metrics,
+        )
+        if compaction_result.summary:
+            run_messages.compacted_messages = compaction_result.compacted_messages
+            log_debug(
+                f"[TEAM-CONTINUE-ASYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+            )
+
     model_response: ModelResponse = await acall_model_with_fallback(
         team.model,
         team.fallback_config,
@@ -7095,6 +7148,8 @@ async def _ahandle_model_response_for_continue(
         run_response=run_response,
         send_media_to_model=team.send_media_to_model,
         compaction_manager=team.compaction_manager if team.compact_tools else None,
+        compacted_messages=run_messages.compacted_messages,
+        compaction_callback=await abuild_team_compaction_callback(team, run_messages, run_response),
         **result_store_kwargs(team),
         after_tool_results=abuild_team_after_tool_results_callback(
             team, run_response, team_session, run_messages, run_context
@@ -8437,6 +8492,20 @@ def _continue_run(
 
     team.model = cast(Model, team.model)
 
+    # Pre-loop compaction: compress history BEFORE model call
+    if team.compaction_manager is not None and team.compaction_manager.compact_context:
+        log_debug(f"[TEAM-CONTINUE-SYNC] Pre-loop compaction check: {len(run_messages.messages)} messages")
+        compaction_result = team.compaction_manager.compact(
+            run_messages.messages,
+            run_response=run_response,
+            run_metrics=run_response.metrics,
+        )
+        if compaction_result.summary:
+            run_messages.compacted_messages = compaction_result.compacted_messages
+            log_debug(
+                f"[TEAM-CONTINUE-SYNC] Pre-loop compaction: {len(run_messages.messages)} -> {len(run_messages.compacted_messages)}"
+            )
+
     try:
         num_attempts = team.retries + 1
         for attempt in range(num_attempts):
@@ -8455,6 +8524,8 @@ def _continue_run(
                     run_response=run_response,
                     send_media_to_model=team.send_media_to_model,
                     compaction_manager=team.compaction_manager if team.compact_tools else None,
+                    compacted_messages=run_messages.compacted_messages,
+                    compaction_callback=build_team_compaction_callback(team, run_messages, run_response),
                     **result_store_kwargs(team),
                     after_tool_results=build_team_after_tool_results_callback(
                         team, run_response, session, run_messages, run_context

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5401,6 +5401,7 @@ def _build_continue_run_messages(
     session: Optional[TeamSession] = None,
     add_history_to_context: Optional[bool] = None,
     run_context: Optional[RunContext] = None,
+    run_response: Optional[TeamRunOutput] = None,
 ) -> RunMessages:
     """Build a RunMessages object from the existing conversation messages.
 
@@ -5438,7 +5439,28 @@ def _build_continue_run_messages(
         run_messages.messages.append(system_message)
 
     if add_history_to_context and session is not None and not input_has_history:
+        from copy import deepcopy
+
         from agno.utils.message import copy_history_message, filter_tool_calls
+
+        # Get compaction state for point-in-time filtering (time-travel for continue_run)
+        compaction_state = None
+        if run_response is not None:
+            compaction_state = run_response.compaction_state
+            if compaction_state is None:
+                lookup_id = run_response.forked_from_run_id or run_response.run_id
+                compaction_state = session.get_compaction_state(run_id=lookup_id)
+                # Seed run_response so mid-loop compaction can merge with prior state
+                if compaction_state is not None:
+                    run_response.compaction_state = deepcopy(compaction_state)
+
+        # Inject compaction summary before history (replaces compacted messages)
+        if compaction_state is not None:
+            log_debug(
+                f"[TEAM-RUN] continue_run: injecting compaction summary: "
+                f"total={compaction_state.total_compactions}, ids={len(compaction_state.compacted_message_ids)}"
+            )
+            run_messages.messages.append(compaction_state.get_summary_message())
 
         skip_role = team.system_message_role if team.system_message_role not in ["user", "assistant", "tool"] else None
 
@@ -5447,13 +5469,14 @@ def _build_continue_run_messages(
             limit=team.num_history_messages,
             skip_roles=[skip_role] if skip_role else None,
             team_id=team.id if team.parent_team_id is not None else None,
+            compacted_message_ids=compaction_state.compacted_message_ids if compaction_state else None,
         )
 
         if len(history) > 0:
             history_copy = [copy_history_message(msg) for msg in history]
             if team.max_tool_calls_from_history is not None:
                 filter_tool_calls(history_copy, team.max_tool_calls_from_history)
-            log_debug(f"Adding {len(history_copy)} messages from history")
+            log_debug(f"[TEAM-RUN] Adding {len(history_copy)} messages from history")
             run_messages.messages += history_copy
 
     # Add remaining input messages (skip system to avoid duplication)
@@ -5474,12 +5497,13 @@ def _get_continue_run_messages(
     session: Optional[TeamSession] = None,
     add_history_to_context: Optional[bool] = None,
     run_context: Optional[RunContext] = None,
+    run_response: Optional[TeamRunOutput] = None,
 ) -> RunMessages:
     """Build the messages that resume a paused run, reading offloaded media back first.
 
     The paused run's own messages come off the database carrying a reference and no bytes.
     """
-    run_messages = _build_continue_run_messages(team, input, session, add_history_to_context, run_context)
+    run_messages = _build_continue_run_messages(team, input, session, add_history_to_context, run_context, run_response)
     if team.media_storage is not None:
         from agno.utils.media_offload import refresh_messages_media
 
@@ -5493,9 +5517,10 @@ async def _aget_continue_run_messages(
     session: Optional[TeamSession] = None,
     add_history_to_context: Optional[bool] = None,
     run_context: Optional[RunContext] = None,
+    run_response: Optional[TeamRunOutput] = None,
 ) -> RunMessages:
     """Async variant of :func:`_get_continue_run_messages`."""
-    run_messages = _build_continue_run_messages(team, input, session, add_history_to_context, run_context)
+    run_messages = _build_continue_run_messages(team, input, session, add_history_to_context, run_context, run_response)
     if team.media_storage is not None:
         from agno.utils.media_offload import arefresh_messages_media
 
@@ -7711,6 +7736,7 @@ def continue_run_dispatch(
             session=team_session,
             add_history_to_context=team.add_history_to_context,
             run_context=run_context,
+            run_response=run_response,
         )
 
         log_debug(f"Team Continue Run (forked): {run_response.run_id}", center=True)
@@ -7955,6 +7981,7 @@ def continue_run_dispatch(
             session=team_session,
             add_history_to_context=team.add_history_to_context,
             run_context=run_context,
+            run_response=run_response,
         )
 
         # Handle tool call updates (execute confirmed tools, etc.)
@@ -8027,6 +8054,7 @@ def continue_run_dispatch(
             session=team_session,
             add_history_to_context=team.add_history_to_context,
             run_context=run_context,
+            run_response=run_response,
         )
 
         # Prepare for member HITL continuation
@@ -8189,6 +8217,7 @@ def _continue_run_dispatch_stream_with_member_events(
             session=team_session,
             add_history_to_context=team.add_history_to_context,
             run_context=run_context,
+            run_response=run_response,
         )
 
         _handle_team_tool_call_updates(team, run_response=run_response, run_messages=run_messages, tools=_tools)
@@ -8240,6 +8269,7 @@ def _continue_run_dispatch_stream_with_member_events(
             session=team_session,
             add_history_to_context=team.add_history_to_context,
             run_context=run_context,
+            run_response=run_response,
         )
 
         _prepare_member_hitl_continuation(run_response, run_messages, member_results)

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -796,16 +796,18 @@ def to_dict(team: "Team") -> Dict[str, Any]:
     if team.store_history_messages:  # default is False
         config["store_history_messages"] = team.store_history_messages
 
-    # --- Compression settings ---
-    if team.compress_tool_results:
-        config["compress_tool_results"] = team.compress_tool_results
+    # --- Compaction settings ---
+    if team.compact_tools:
+        config["compact_tools"] = team.compact_tools
+    if team.compact_context:
+        config["compact_context"] = team.compact_context
 
     # --- Result offloading settings ---
     if team.offload_tool_results is not None:
         config["offload_tool_results"] = _offload_to_config(team.offload_tool_results)
-    # TODO: implement compression manager serialization
-    # if team.compression_manager is not None:
-    #     config["compression_manager"] = team.compression_manager.to_dict()
+    # TODO: implement compaction manager serialization
+    # if team.compaction_manager is not None:
+    #     config["compaction_manager"] = team.compaction_manager.to_dict()
 
     # --- Reasoning settings ---
     if team.reasoning_model is not None:
@@ -1379,9 +1381,10 @@ def from_dict(
             num_history_runs=config.get("num_history_runs"),
             num_history_messages=config.get("num_history_messages"),
             max_tool_calls_from_history=config.get("max_tool_calls_from_history"),
-            # --- Compression settings ---
-            compress_tool_results=config.get("compress_tool_results", False),
-            # compression_manager=config.get("compression_manager"),  # TODO
+            # --- Compaction settings (with backward compat for old config keys) ---
+            compact_tools=config.get("compact_tools") or config.get("compress_tool_results", False),
+            compact_context=config.get("compact_context", False),
+            # compaction_manager=config.get("compaction_manager"),  # TODO
             # --- Result offloading settings ---
             offload_tool_results=_offload_from_config(config.get("offload_tool_results")),
             # --- Reasoning settings ---

--- a/libs/agno/agno/team/_utils.py
+++ b/libs/agno/agno/team/_utils.py
@@ -221,7 +221,7 @@ def _deep_copy_field(team: Team, field_name: str, field_value: Any) -> Any:
         "parser_model",
         "output_model",
         "session_summary_manager",
-        "compression_manager",
+        "compaction_manager",
         "learning",
         "skills",
     ):

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -23,7 +23,7 @@ from typing import (
 from pydantic import BaseModel
 
 from agno.agent import Agent
-from agno.compression.manager import CompressionManager
+from agno.compression.manager import CompactionManager
 from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, UserMemory
 from agno.eval.base import BaseEval
 from agno.filters import FilterExpr
@@ -333,11 +333,13 @@ class Team:
     # Add learnings context to system prompt
     add_learnings_to_context: bool = True
 
-    # --- Context Compression ---
-    # If True, compress tool call results to save context
-    compress_tool_results: bool = False
-    # Compression manager for compressing tool call results
-    compression_manager: Optional["CompressionManager"] = None
+    # --- Context Compaction ---
+    # If True, compact tool call results to save context
+    compact_tools: bool = False
+    # If True, compact conversation history to save context
+    compact_context: bool = False
+    # Compaction manager for tool results and/or conversation history
+    compaction_manager: Optional["CompactionManager"] = None
 
     # --- Result Offloading ---
     # Store tool results and member answers longer than a threshold as files
@@ -551,8 +553,12 @@ class Team:
         add_session_summary_to_context: Optional[bool] = None,
         learning: Optional[Union[bool, LearningMachine]] = None,
         add_learnings_to_context: bool = True,
-        compress_tool_results: bool = False,
-        compression_manager: Optional["CompressionManager"] = None,
+        compact_tools: bool = False,
+        compact_context: bool = False,
+        compaction_manager: Optional["CompactionManager"] = None,
+        # Deprecated aliases
+        compress_tool_results: Optional[bool] = None,
+        compression_manager: Optional["CompactionManager"] = None,
         offload_tool_results: Optional[Union[bool, "ResultStore"]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         reasoning_model: Optional[Union[Model, str]] = None,
@@ -670,6 +676,9 @@ class Team:
             add_session_summary_to_context=add_session_summary_to_context,
             learning=learning,
             add_learnings_to_context=add_learnings_to_context,
+            compact_tools=compact_tools,
+            compact_context=compact_context,
+            compaction_manager=compaction_manager,
             compress_tool_results=compress_tool_results,
             compression_manager=compression_manager,
             offload_tool_results=offload_tool_results,

--- a/libs/agno/agno/utils/print_response/agent.py
+++ b/libs/agno/agno/utils/print_response/agent.py
@@ -195,7 +195,7 @@ def print_response_stream(
                 show_reasoning=show_reasoning,
                 show_full_reasoning=show_full_reasoning,
                 accumulated_tool_calls=accumulated_tool_calls,
-                compression_manager=agent.compression_manager,
+                compaction_manager=agent.compaction_manager,
             )
             panels.extend(additional_panels)
             if panels:
@@ -222,8 +222,8 @@ def print_response_stream(
             agent.session_summary_manager.summaries_updated = False
 
         # Clear compression stats after final display
-        if agent.compression_manager is not None:
-            agent.compression_manager.stats.clear()
+        if agent.compaction_manager is not None:
+            agent.compaction_manager.stats.clear()
 
         response_timer.stop()
 
@@ -402,7 +402,7 @@ async def aprint_response_stream(
                 show_reasoning=show_reasoning,
                 show_full_reasoning=show_full_reasoning,
                 accumulated_tool_calls=accumulated_tool_calls,
-                compression_manager=agent.compression_manager,
+                compaction_manager=agent.compaction_manager,
             )
             panels.extend(additional_panels)
             if panels:
@@ -429,8 +429,8 @@ async def aprint_response_stream(
             agent.session_summary_manager.summaries_updated = False
 
         # Clear compression stats after final display
-        if agent.compression_manager is not None:
-            agent.compression_manager.stats.clear()
+        if agent.compaction_manager is not None:
+            agent.compaction_manager.stats.clear()
 
         response_timer.stop()
 
@@ -448,7 +448,7 @@ def build_panels_stream(
     show_reasoning: bool = True,
     show_full_reasoning: bool = False,
     accumulated_tool_calls: Optional[List] = None,
-    compression_manager: Optional[Any] = None,
+    compaction_manager: Optional[Any] = None,
 ):
     from rich.markdown import Markdown
 
@@ -494,8 +494,8 @@ def build_panels_stream(
         tool_calls_text = tool_calls_content.plain.rstrip()
 
         # Add compression stats if available (don't clear - caller will clear after final display)
-        if compression_manager is not None and compression_manager.stats:
-            stats = compression_manager.stats
+        if compaction_manager is not None and compaction_manager.stats:
+            stats = compaction_manager.stats
             saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
             orig = stats.get("original_size", 1)
             if stats.get("tool_results_compressed", 0) > 0:
@@ -642,7 +642,7 @@ def print_response(
             show_full_reasoning=show_full_reasoning,
             tags_to_include_in_markdown=tags_to_include_in_markdown,
             markdown=markdown,
-            compression_manager=agent.compression_manager,
+            compaction_manager=agent.compaction_manager,
         )
         panels.extend(additional_panels)
 
@@ -762,7 +762,7 @@ async def aprint_response(
             show_full_reasoning=show_full_reasoning,
             tags_to_include_in_markdown=tags_to_include_in_markdown,
             markdown=markdown,
-            compression_manager=agent.compression_manager,
+            compaction_manager=agent.compaction_manager,
         )
         panels.extend(additional_panels)
 
@@ -799,7 +799,7 @@ def build_panels(
     show_full_reasoning: bool = False,
     tags_to_include_in_markdown: Optional[Set[str]] = None,
     markdown: bool = False,
-    compression_manager: Optional[Any] = None,
+    compaction_manager: Optional[Any] = None,
 ):
     from rich.markdown import Markdown
 
@@ -857,13 +857,13 @@ def build_panels(
         tool_calls_text = tool_calls_content.plain.rstrip()
 
         # Add compression stats if available
-        if compression_manager is not None and compression_manager.stats:
-            stats = compression_manager.stats
+        if compaction_manager is not None and compaction_manager.stats:
+            stats = compaction_manager.stats
             saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
             orig = stats.get("original_size", 1)
             if stats.get("tool_results_compressed", 0) > 0:
                 tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
-            compression_manager.stats.clear()
+            compaction_manager.stats.clear()
 
         tool_calls_panel = create_panel(
             content=tool_calls_text,

--- a/libs/agno/agno/utils/print_response/team.py
+++ b/libs/agno/agno/utils/print_response/team.py
@@ -278,13 +278,13 @@ def print_response(
                     tool_calls_text = "\n\n".join(lines)
 
                     # Add compression stats at end of tool calls
-                    if team.compression_manager is not None and team.compression_manager.stats:
-                        stats = team.compression_manager.stats
+                    if team.compaction_manager is not None and team.compaction_manager.stats:
+                        stats = team.compaction_manager.stats
                         saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
                         orig = stats.get("original_size", 1)
                         if stats.get("tool_results_compressed", 0) > 0:
                             tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
-                        team.compression_manager.stats.clear()
+                        team.compaction_manager.stats.clear()
 
                     team_tool_calls_panel = create_panel(
                         content=tool_calls_text,
@@ -658,8 +658,8 @@ def print_response_stream(
                     tool_calls_text = "\n\n".join(lines)
 
                     # Add compression stats if available (don't clear - will be cleared in final_panels)
-                    if team.compression_manager is not None and team.compression_manager.stats:
-                        stats = team.compression_manager.stats
+                    if team.compaction_manager is not None and team.compaction_manager.stats:
+                        stats = team.compaction_manager.stats
                         saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
                         orig = stats.get("original_size", 1)
                         if stats.get("tool_results_compressed", 0) > 0:
@@ -894,13 +894,13 @@ def print_response_stream(
                 tool_calls_text = "\n\n".join(lines)
 
                 # Add compression stats at end of tool calls
-                if team.compression_manager is not None and team.compression_manager.stats:
-                    stats = team.compression_manager.stats
+                if team.compaction_manager is not None and team.compaction_manager.stats:
+                    stats = team.compaction_manager.stats
                     saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
                     orig = stats.get("original_size", 1)
                     if stats.get("tool_results_compressed", 0) > 0:
                         tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
-                    team.compression_manager.stats.clear()
+                    team.compaction_manager.stats.clear()
 
                 team_tool_calls_panel = create_panel(
                     content=tool_calls_text,
@@ -1211,13 +1211,13 @@ async def aprint_response(
                     tool_calls_text = "\n\n".join(lines)
 
                     # Add compression stats at end of tool calls
-                    if team.compression_manager is not None and team.compression_manager.stats:
-                        stats = team.compression_manager.stats
+                    if team.compaction_manager is not None and team.compaction_manager.stats:
+                        stats = team.compaction_manager.stats
                         saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
                         orig = stats.get("original_size", 1)
                         if stats.get("tool_results_compressed", 0) > 0:
                             tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
-                        team.compression_manager.stats.clear()
+                        team.compaction_manager.stats.clear()
 
                     team_tool_calls_panel = create_panel(
                         content=tool_calls_text,
@@ -1589,8 +1589,8 @@ async def aprint_response_stream(
                     tool_calls_text = "\n\n".join(lines)
 
                     # Add compression stats if available (don't clear - will be cleared in final_panels)
-                    if team.compression_manager is not None and team.compression_manager.stats:
-                        stats = team.compression_manager.stats
+                    if team.compaction_manager is not None and team.compaction_manager.stats:
+                        stats = team.compaction_manager.stats
                         saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
                         orig = stats.get("original_size", 1)
                         if stats.get("tool_results_compressed", 0) > 0:
@@ -1843,13 +1843,13 @@ async def aprint_response_stream(
                 tool_calls_text = "\n\n".join(lines)
 
                 # Add compression stats at end of tool calls
-                if team.compression_manager is not None and team.compression_manager.stats:
-                    stats = team.compression_manager.stats
+                if team.compaction_manager is not None and team.compaction_manager.stats:
+                    stats = team.compaction_manager.stats
                     saved = stats.get("original_size", 0) - stats.get("compressed_size", 0)
                     orig = stats.get("original_size", 1)
                     if stats.get("tool_results_compressed", 0) > 0:
                         tool_calls_text += f"\n\ncompressed: {stats.get('tool_results_compressed', 0)} | Saved: {saved:,} chars ({saved / orig * 100:.0f}%)"
-                    team.compression_manager.stats.clear()
+                    team.compaction_manager.stats.clear()
 
                 team_tool_calls_panel = create_panel(
                     content=tool_calls_text,

--- a/libs/agno/tests/unit/agent/test_run_regressions.py
+++ b/libs/agno/tests/unit/agent/test_run_regressions.py
@@ -3,11 +3,10 @@ from typing import Any, Optional
 
 import pytest
 
-from agno.exceptions import RunNotFoundError
-
 from agno.agent import _init, _messages, _response, _run, _session, _storage, _tools
 from agno.agent.agent import Agent
 from agno.db.base import SessionType
+from agno.exceptions import RunNotFoundError
 from agno.run import RunContext
 from agno.run.agent import RunErrorEvent, RunOutput
 from agno.run.base import RunStatus

--- a/libs/agno/tests/unit/environments/test_runner.py
+++ b/libs/agno/tests/unit/environments/test_runner.py
@@ -1096,7 +1096,7 @@ async def test_hermetic_real_agent_full_override_set(tmp_path):
     caller_db = InMemoryDb()
     reasoning_db = InMemoryDb()
     summary_manager = SessionSummaryManager()
-    compression_manager = CompressionManager()
+    compaction_manager = CompressionManager()
     skills = Skills(loaders=[])
     save_path = tmp_path / "response.txt"
     caller = Agent(
@@ -1106,7 +1106,7 @@ async def test_hermetic_real_agent_full_override_set(tmp_path):
         followup_model=followup_model,
         fallback_models=[fallback_model],
         session_summary_manager=summary_manager,
-        compression_manager=compression_manager,
+        compaction_manager=compaction_manager,
         skills=skills,
         reasoning_agent=Agent(model=sub_model, db=reasoning_db, telemetry=False),
         save_response_to_file=str(save_path),
@@ -1142,9 +1142,9 @@ async def test_hermetic_real_agent_full_override_set(tmp_path):
         # read flag unresolved -- exactly what a fresh production run would see.
         assert attempt_agent.add_memories_to_context is None
         assert attempt_agent.add_session_summary_to_context is True
-        assert attempt_agent.compression_manager is not compression_manager
-        assert attempt_agent.compression_manager.stats == {}
-        assert attempt_agent.compression_manager.stats is not compression_manager.stats
+        assert attempt_agent.compaction_manager is not compaction_manager
+        assert attempt_agent.compaction_manager.stats == {}
+        assert attempt_agent.compaction_manager.stats is not compaction_manager.stats
         assert attempt_agent.reasoning_agent is not caller.reasoning_agent
         assert isinstance(attempt_agent.reasoning_agent.db, InMemoryDb)
         assert attempt_agent.reasoning_agent.db is not reasoning_db
@@ -1741,7 +1741,7 @@ async def test_write_isolation_deep_freeze(tmp_path):
         fallback_models=[fallback_model],
         memory_manager=MemoryManager(),
         session_summary_manager=SessionSummaryManager(),
-        compression_manager=CompressionManager(),
+        compaction_manager=CompressionManager(),
         learning=LearningMachine(
             learned_knowledge=LearnedKnowledgeConfig(knowledge=learned_store, mode=LearningMode.ALWAYS)
         ),


### PR DESCRIPTION
# Context Compaction for Long-Running Agents and Teams

> **DX Note:** The developer experience is under review. [#9479](https://github.com/agno-agi/agno/pull/9479) unifies `compression_manager` + `context_compaction_manager` into a single `context_manager` field. This PR provides the core compaction engine; the final API surface may change when that PR merges.

## Summary

When agents run for hours/days or across many sessions, conversation history grows unbounded and eventually exceeds the model's context window. This PR adds **context compaction** — automatic compression of old messages into an LLM-generated summary.

---

## Problem Statement

```
Run #1:  "What's the weather?"        → 3 messages
Run #2:  "Book a flight"              → 8 messages  
Run #3:  "Find hotels"                → 12 messages
...
Run #45: "Summarize trip"             → 450 messages total, ~90K tokens

Run #46: CONTEXT OVERFLOW → Model fails
```

---

## Solution: The Compaction Pattern

```
Trigger:    tokens >= 90% of context window (or message_limit)
Preserve:   Last N messages (keep_recent, default 10)
Summarize:  Everything before that boundary → LLM summary
Result:     [system] + [summary_message] + [preserved_messages]
```

---

## Architecture: Two Scenarios

| Scenario | Trigger | Where |
|----------|---------|-------|
| **Multi-run session** | Before model call, at run start | `_run.py` (pre-loop) |
| **Long single run** | Mid-loop via `compaction_callback` | `models/base.py` |

Both use the **same `compact()` method** — only timing differs.

---

## Data Flow: Multi-Run Session

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                         COMPRESSION FLOW                                    │
└─────────────────────────────────────────────────────────────────────────────┘

    agent.run("Question")
         │
         ▼
    ┌────────────────────────────────────┐
    │ 1. Load session from DB            │
    │    • Get compaction_state from     │
    │      session (backward scan)       │
    │    • session.runs = [run1...runN]  │
    └────────────────────────────────────┘
         │
         ▼
    ┌────────────────────────────────────┐
    │ 2. Build messages                  │
    │    _messages.py:get_run_messages() │
    │                                    │
    │    • Inject existing summary       │
    │      after system message          │
    │    • Load history, filter by       │
    │      compacted_message_ids         │
    └────────────────────────────────────┘
         │
         ▼
    ┌────────────────────────────────────────────────────────────────┐
    │ 3. Pre-loop check (before first model API call)                │
    │                                                                │
    │    if context_compaction_manager.should_compact(messages):     │
    │        compaction_state = compact(messages)                    │
    └────────────────────────────────────────────────────────────────┘
         │
         ▼ (if threshold exceeded)
    ┌────────────────────────────────────────────────────────────────┐
    │ 4. compact() — compression/context.py                          │
    │                                                                │
    │    ┌──────────────────────────────────────────────────────┐    │
    │    │ a. Split messages into groups                        │    │
    │    │                                                      │    │
    │    │    │ old_messages    │ preserved_user │ recent      │    │
    │    │    │ (to summarize)  │ (keep intent)  │ (keep as-is)│    │
    │    │    │─────────────────│────────────────│─────────────│    │
    │    │    │ ~80% of msgs    │ ~10% of user   │ last N msgs │    │
    │    │                                                      │    │
    │    │ b. Two-phase compression:                            │    │
    │    │    Phase 1: Compress oversized tool results          │    │
    │    │    Phase 2: Summarize old_messages via LLM           │    │
    │    │    → Returns ~200-500 token summary                  │    │
    │    │                                                      │    │
    │    │ c. Build compacted view:                             │    │
    │    │    [system] + [summary_msg] + [preserved] + [recent] │    │
    │    │                                                      │    │
    │    │ d. Update compaction_state:                          │    │
    │    │    • summary = new_summary                           │    │
    │    │    • compacted_message_ids += old_message_ids        │    │
    │    └──────────────────────────────────────────────────────┘    │
    └────────────────────────────────────────────────────────────────┘
         │
         ▼
    ┌────────────────────────────────────┐
    │ 5. Model call with compressed view │
    │    ~3K tokens instead of ~90K      │
    └────────────────────────────────────┘
         │
         ▼
    ┌────────────────────────────────────┐
    │ 6. Save to DB                      │
    │    • run.compaction_state persisted│
    │    • run.messages saved (full)     │
    └────────────────────────────────────┘
```

---

## Data Flow: Long Single Run (Mid-Loop)

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                      MID-LOOP COMPRESSION                                   │
└─────────────────────────────────────────────────────────────────────────────┘

    Model loop (base.py)
         │
         ▼
    while has_tool_calls:
         │
         ├──► Model response
         │
         ├──► Execute tools
         │
         ├──► Append results to messages
         │
         └──► compaction_callback ◄── COMPRESSION HOOK
                   │
                   ▼
              ┌────────────────────────────────┐
              │ if should_compact(messages):   │
              │     result = compact(messages) │
              │     run_messages.compacted_    │
              │       messages = result.       │
              │       compacted_messages       │
              └────────────────────────────────┘
                   │
                   ▼
              Next model call uses
              compacted_messages (model view)
              
              Original messages list preserved
              (for storage)
```

---

## Data Structures

### CompactionState (`compression/context.py`)

```python
@dataclass
class CompactionState:
    summary: str                           # LLM-generated summary text
    summary_message_id: str                # Stable ID for filtering
    compacted_message_ids: Set[str]        # IDs of summarized messages
    compacted_count: int                   # Count of compacted messages
    total_compactions: int                 # Total compactions in session
    updated_at: Optional[datetime]         # Last compaction timestamp
```

### Where State is Stored

```
runs table (run_data JSONB):
┌─────────────────────────────────────────┐
│ run_id: "run-123"                       │
│ compaction_state: {                     │  ← Per-run snapshot
│   "summary": "User planned trip...",    │
│   "summary_message_id": "sum-123",      │
│   "compacted_message_ids": ["id1",...], │
│   "compacted_count": 45,                │
│   "total_compactions": 3,               │
│   "updated_at": "2026-08-06T..."        │
│ }                                       │
└─────────────────────────────────────────┘
```

---

## The Two-List Architecture

```
run_messages.messages            run_messages.compacted_messages
(canonical, for storage)         (model view, ephemeral)
         │                                │
         │                                │
         ▼                                ▼
┌────────────────────┐          ┌────────────────────┐
│ [sys, user1, asst1,│          │ [sys, summary,     │
│  user2, asst2, ... │          │  user45, asst45,   │
│  user50, asst50]   │          │  user50, asst50]   │
│                    │          │                    │
│ Full history       │          │ Compressed view    │
│ ~90K tokens        │          │ ~3K tokens         │
└────────────────────┘          └────────────────────┘
         │                                │
         │                                │
         ▼                                ▼
    Saved to DB                   Sent to model
```

**Why two lists?**
- Model sees compressed view (fits in context)
- DB stores full history (for auditing, continue_run)
- Summary injection is ephemeral, not persisted in messages

**Dual-append pattern:** Mid-loop messages must be added to BOTH lists so compaction boundary is preserved.

---

## History Filtering: `compacted_message_ids`

```python
# session/agent.py
def get_messages(self, ..., compacted_message_ids=None):
    if compacted_message_ids:
        for run in self.runs:
            for msg in run.messages:
                if msg.id in compacted_message_ids:
                    continue  # Skip — already in summary
                result.append(msg)
```

This ensures:
- Old messages don't reload (they're in the summary)
- Old summaries don't reload (their ID is in the set)
- Only recent messages + current summary load

---

## The Time Travel Problem (continue_run)

### The Bug

```
Run 3: [COMPACTION v3] → compaction_state = v3
Run 5: Saved (v3 active)
Run 7: [COMPACTION v7] → compaction_state = v7
Run 10: [COMPACTION v10] → compaction_state = v10

User: continue_run(run_5)
  WRONG: uses session's latest = v10
  RIGHT: use v3 (what run_5 actually saw)
```

### The Solution: Per-Run Snapshot + Backward Scan

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                      CONTINUE_RUN FIX                                       │
└─────────────────────────────────────────────────────────────────────────────┘

SAVE (at persist_run_in_session):
    run.compaction_state = deepcopy(current_state)
         │
         ▼
    runs table: run_data.compaction_state = v3 snapshot

LOAD (continue_run):
    lookup_id = run.forked_from_run_id or run.run_id
    compaction_state = session.get_compaction_state(run_id=lookup_id)
         │
         ▼
    Inject v3.summary ✓
    Filter by v3.compacted_message_ids ✓
```

**Why per-run storage?** The IDs MUST come from same source as summary. Using session's latest would filter messages not covered by the summary → silent context loss.

---

## Team Support

Team compaction follows the same pattern as Agent with these additions:

| Feature | Implementation |
|---------|----------------|
| **All modes supported** | coordinate, route, broadcast, tasks |
| **Member run filtering** | `get_compaction_state()` filters by `parent_run_id is None` |
| **Dual-append for state_message** | Tasks mode injects state between iterations |
| **Continue-run seeding** | Seeds `run_response.compaction_state` from session |

---

## Code Changes

### Core Components

| File | Purpose |
|------|---------|
| `compression/context.py` | `ContextCompactionManager`, `CompactionState`, `compact()` |
| `compression/__init__.py` | Export new classes |

### Agent Integration

| File | Change |
|------|--------|
| `agent/agent.py` | Add `context_compaction_manager` field |
| `agent/_run.py` | Pre-loop compaction, mid-loop callback wiring |
| `agent/_response.py` | Streaming path compaction |
| `agent/_messages.py` | Summary injection, seeding, filtering |
| `agent/_init.py` | Callback construction |
| `session/agent.py` | `get_compaction_state()`, `get_messages()` with ID filtering |
| `run/agent.py` | `compaction_state` field on `RunOutput` |
| `run/messages.py` | `compacted_messages` field on `RunMessages` |
| `models/base.py` | `compaction_callback` in `response()`/`aresponse()` |

### Team Integration

| File | Change |
|------|--------|
| `team/team.py` | Add `context_compaction_manager` field |
| `team/_run.py` | Pre-loop, mid-loop, dual-append for all modes |
| `team/_response.py` | Streaming path compaction |
| `team/_messages.py` | Summary injection, seeding |
| `team/_init.py` | Callback construction |
| `session/team.py` | `get_compaction_state()` with `parent_run_id` filter |
| `run/team.py` | `compaction_state`, `parent_run_id` fields |

---

## Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| **Storage location** | Per-run `compaction_state` | Enables time-travel for `continue_run` |
| **Trigger** | Token + message threshold | Threshold-based; configurable |
| **Two-phase compression** | Tool results first, then history | Handles oversized tool outputs |
| **Summary injection** | Ephemeral (not persisted) | Rebuilt from state; avoids duplication |
| **Backward scan** | Find latest run with state | Sparse storage: only runs where compaction happened |
| **Scrub-safe** | Top-level field on RunOutput | Survives default message scrubbing |

---

## Alternatives Ruled Out

| Alternative | Why It Fails |
|-------------|--------------|
| Flag on messages (`is_compacted`) | Requires mutating historical rows |
| Session-level only | No time travel for continue_run |
| Store summary in messages | Scrubbed by default + needs IDs anyway |
| Query DB on demand | No historical versions exist |

---

## Test Coverage

| Test File | Tests | Coverage |
|-----------|-------|----------|
| `test_context_compaction_manager.py` | 20 | Manager: thresholds, partitioning, two-phase |
| `test_compaction_state.py` | 10 | State merging, cumulative IDs, metrics |
| `test_compaction_serialization.py` | 8 | JSON round-trips for all fields |
| `test_team_compaction.py` | 14 | `get_compaction_state()`, fresh-run message building |
| `test_continue_run_compaction.py` | 9 | Continue-run seeding, time-travel, forking |
| **Total** | **61** | All functional (no mocks, no model calls) |

---

## Usage

```python
from agno.agent import Agent
from agno.compression.context import ContextCompactionManager
from agno.models.openai import OpenAIChat

agent = Agent(
    model=OpenAIChat(id="gpt-4o"),
    context_compaction_manager=ContextCompactionManager(
        model=OpenAIChat(id="gpt-4o-mini"),  # Cheaper model for summarization
        token_limit=100_000,                  # Trigger at 100K tokens
        keep_recent=10,                       # Preserve last 10 messages
        preserve_user_budget=True,            # Keep recent user messages intact
    ),
    add_history_to_context=True,
)
```

---

## Related PRs

| PR | Status | Description |
|----|--------|-------------|
| [#9468](https://github.com/agno-agi/agno/pull/9468) | Open | Adds `CompactionStarted`/`CompactionCompleted` events, stats, print utilities |
| [#9479](https://github.com/agno-agi/agno/pull/9479) | Open | Unifies `compression_manager` + `context_compaction_manager` → `context_manager` |
| [#9480](https://github.com/agno-agi/agno/pull/9480) | Open | General-purpose compaction prompts |

---

## Future Work

The summary preserves **what was discussed** but not **the full detail**. Planned enhancements:

1. **Transcript search tool** — Use summary as an index to fetch detailed context from DB when needed
2. **Compression events** — UI visibility for compaction progress (see [#9468](https://github.com/agno-agi/agno/pull/9468))
3. **Unified context manager** — Single API for tool compression + history compaction (see [#9479](https://github.com/agno-agi/agno/pull/9479))

---

## Type of Change

- [ ] Bug fix
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows Agno's coding patterns
- [x] Ran `./scripts/format.sh` and `./scripts/validate.sh`
- [x] Both sync and async variants implemented
- [x] All 4 Team modes supported (coordinate, route, broadcast, tasks)
- [x] 61 unit tests added (no mocks, no model calls)
- [x] No agent creation inside loops