### PR TITLE
refactor: skip the discarded asdict walk in RunOutput.to_dict

### DIFF
--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -1,4 +1,6 @@
-from dataclasses import asdict, dataclass, field
+from copy import deepcopy as _deepcopy
+from dataclasses import dataclass, field, fields
+from dataclasses import is_dataclass as _is_dataclass
 from enum import Enum
 from time import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
@@ -32,6 +34,30 @@ class Followups(BaseModel):
         ...,
         description="Short action-oriented followup prompts (5-10 words each)",
     )
+
+
+# Exact types only: a subclass (an IntEnum, say) must still go through the
+# slow path so its own copy semantics are preserved.
+_ASDICT_IMMUTABLE = frozenset({str, int, float, bool, bytes, type(None)})
+
+
+def _asdict_value(v: Any) -> Any:
+    """Reproduce dataclasses.asdict()'s per-value conversion for a single value.
+
+    Same recursion as dataclasses._asdict_inner: dataclass instances become
+    dicts, lists/tuples/dicts are rebuilt element-wise, everything else is
+    deep-copied. Immutable scalars are returned as-is, which is what
+    copy.deepcopy() does for them anyway.
+    """
+    if type(v) in _ASDICT_IMMUTABLE:
+        return v
+    if _is_dataclass(v) and not isinstance(v, type):
+        return {f.name: _asdict_value(getattr(v, f.name)) for f in fields(v)}
+    if isinstance(v, (list, tuple)):
+        return type(v)(_asdict_value(x) for x in v)
+    if isinstance(v, dict):
+        return type(v)((_asdict_value(k), _asdict_value(x)) for k, x in v.items())
+    return _deepcopy(v)
 
 
 @dataclass
@@ -712,32 +738,41 @@ class RunOutput:
         return [t for t in self.tools if t.external_execution_required] if self.tools else []
 
     def to_dict(self) -> Dict[str, Any]:
-        _dict = {
-            k: v
-            for k, v in asdict(self).items()
-            if v is not None
-            and k
-            not in [
-                "messages",
-                "metrics",
-                "tools",
-                "metadata",
-                "images",
-                "videos",
-                "audio",
-                "files",
-                "response_audio",
-                "input",
-                "citations",
-                "events",
-                "additional_input",
-                "reasoning_steps",
-                "reasoning_messages",
-                "references",
-                "requirements",
-                "followups",
-            ]
+        # Build the dict from fields(self) rather than asdict(self).
+        # asdict() recursively walks and deep-copies EVERY field, including
+        # messages, events, tools, metrics and input -- and each of those is
+        # then dropped by the skip set below and recomputed properly further
+        # down, so all of that copying is discarded. WorkflowRunOutput.to_dict()
+        # already avoids asdict() for the same reason.
+        # _asdict_value keeps asdict()'s exact per-value semantics for the
+        # fields that do survive, so the returned dict is unchanged.
+        _skip_fields = {
+            "messages",
+            "metrics",
+            "tools",
+            "metadata",
+            "images",
+            "videos",
+            "audio",
+            "files",
+            "response_audio",
+            "input",
+            "citations",
+            "events",
+            "additional_input",
+            "reasoning_steps",
+            "reasoning_messages",
+            "references",
+            "requirements",
+            "followups",
         }
+        _dict: Dict[str, Any] = {}
+        for _f in fields(self):
+            if _f.name in _skip_fields:
+                continue
+            _v = getattr(self, _f.name)
+            if _v is not None:
+                _dict[_f.name] = _asdict_value(_v)
 
         if self.metrics is not None:
             _dict["metrics"] = self.metrics.to_dict() if isinstance(self.metrics, RunMetrics) else self.metrics

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -1,4 +1,6 @@
-from dataclasses import asdict, dataclass, field
+from copy import deepcopy as _deepcopy
+from dataclasses import dataclass, field, fields
+from dataclasses import is_dataclass as _is_dataclass
 from enum import Enum
 from time import time
 from typing import Any, Dict, List, Optional, Sequence, Union
@@ -21,6 +23,30 @@ from agno.utils.media import (
     reconstruct_response_audio,
     reconstruct_videos,
 )
+
+
+# Exact types only: a subclass (an IntEnum, say) must still go through the
+# slow path so its own copy semantics are preserved.
+_ASDICT_IMMUTABLE = frozenset({str, int, float, bool, bytes, type(None)})
+
+
+def _asdict_value(v: Any) -> Any:
+    """Reproduce dataclasses.asdict()'s per-value conversion for a single value.
+
+    Same recursion as dataclasses._asdict_inner: dataclass instances become
+    dicts, lists/tuples/dicts are rebuilt element-wise, everything else is
+    deep-copied. Immutable scalars are returned as-is, which is what
+    copy.deepcopy() does for them anyway.
+    """
+    if type(v) in _ASDICT_IMMUTABLE:
+        return v
+    if _is_dataclass(v) and not isinstance(v, type):
+        return {f.name: _asdict_value(getattr(v, f.name)) for f in fields(v)}
+    if isinstance(v, (list, tuple)):
+        return type(v)(_asdict_value(x) for x in v)
+    if isinstance(v, dict):
+        return type(v)((_asdict_value(k), _asdict_value(x)) for k, x in v.items())
+    return _deepcopy(v)
 
 
 @dataclass
@@ -827,32 +853,41 @@ class TeamRunOutput:
         return self.status == RunStatus.cancelled
 
     def to_dict(self) -> Dict[str, Any]:
-        _dict = {
-            k: v
-            for k, v in asdict(self).items()
-            if v is not None
-            and k
-            not in [
-                "messages",
-                "metrics",
-                "status",
-                "tools",
-                "metadata",
-                "images",
-                "videos",
-                "audio",
-                "files",
-                "response_audio",
-                "citations",
-                "events",
-                "additional_input",
-                "reasoning_steps",
-                "reasoning_messages",
-                "references",
-                "requirements",
-                "followups",
-            ]
+        # Build the dict from fields(self) rather than asdict(self).
+        # asdict() recursively walks and deep-copies EVERY field, including
+        # messages, events, tools, metrics and input -- and each of those is
+        # then dropped by the skip set below and recomputed properly further
+        # down, so all of that copying is discarded. WorkflowRunOutput.to_dict()
+        # already avoids asdict() for the same reason.
+        # _asdict_value keeps asdict()'s exact per-value semantics for the
+        # fields that do survive, so the returned dict is unchanged.
+        _skip_fields = {
+            "messages",
+            "metrics",
+            "status",
+            "tools",
+            "metadata",
+            "images",
+            "videos",
+            "audio",
+            "files",
+            "response_audio",
+            "citations",
+            "events",
+            "additional_input",
+            "reasoning_steps",
+            "reasoning_messages",
+            "references",
+            "requirements",
+            "followups",
         }
+        _dict: Dict[str, Any] = {}
+        for _f in fields(self):
+            if _f.name in _skip_fields:
+                continue
+            _v = getattr(self, _f.name)
+            if _v is not None:
+                _dict[_f.name] = _asdict_value(_v)
         if self.events is not None:
             _dict["events"] = [e.to_dict() for e in self.events]
 

--- a/libs/agno/tests/unit/run/test_run_output_to_dict.py
+++ b/libs/agno/tests/unit/run/test_run_output_to_dict.py
@@ -1,0 +1,142 @@
+"""Unit tests for RunOutput.to_dict() / TeamRunOutput.to_dict().
+
+These pin the observable contract of the serialization head, which is what the
+session row is built from on every save:
+
+  * the same keys and values as before, for every field that survives the
+    skip set;
+  * a dataclass-valued ``content`` is still converted to a plain dict;
+  * the kept dict fields are still copies, so mutating the serialized result
+    cannot reach back into the RunOutput.
+"""
+
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+from agno.models.message import Message
+from agno.models.response import ToolExecution
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.team import TeamRunOutput
+
+
+@dataclass
+class _DataclassContent:
+    a: int
+    b: str
+
+
+class _ModelContent(BaseModel):
+    a: int
+    b: str
+
+
+def _run_output(**overrides) -> RunOutput:
+    kwargs = dict(
+        run_id="run-1",
+        agent_id="agent-1",
+        agent_name="agent",
+        session_id="session-1",
+        user_id="user-1",
+        content="hello",
+        content_type="str",
+        model="test-model",
+        model_provider="test",
+        messages=[Message(role="user", content="hi")],
+        tools=[ToolExecution(tool_name="t", tool_call_id="c", result="r")],
+        status=RunStatus.completed,
+        created_at=1750000000,
+    )
+    kwargs.update(overrides)
+    return RunOutput(**kwargs)
+
+
+def test_to_dict_keeps_scalar_fields_and_rebuilds_the_rest():
+    run = _run_output(metadata={"tag": "x"})
+    d = run.to_dict()
+
+    assert d["run_id"] == "run-1"
+    assert d["agent_id"] == "agent-1"
+    assert d["session_id"] == "session-1"
+    assert d["model"] == "test-model"
+    assert d["content"] == "hello"
+    assert d["status"] == RunStatus.completed.value
+    assert d["created_at"] == 1750000000
+
+    # the expensive fields are rebuilt through their own serializers
+    assert d["messages"] == [m.to_dict() for m in run.messages]
+    assert d["tools"] == [t.to_dict() for t in run.tools]
+    assert d["metadata"] == {"tag": "x"}
+
+
+def test_to_dict_omits_none_valued_fields():
+    d = _run_output(reasoning_content=None).to_dict()
+    assert "reasoning_content" not in d
+    assert "parent_run_id" not in d
+
+
+def test_to_dict_converts_a_dataclass_content_to_a_dict():
+    d = _run_output(content=_DataclassContent(a=1, b="x")).to_dict()
+    assert d["content"] == {"a": 1, "b": "x"}
+
+
+def test_to_dict_handles_a_pydantic_content():
+    d = _run_output(content=_ModelContent(a=1, b="x")).to_dict()
+    assert d["content"] == {"a": 1, "b": "x"}
+
+
+def test_to_dict_does_not_alias_the_kept_dict_fields():
+    """Mutating the serialized result must not reach back into the RunOutput."""
+    state = {"k": [1, 2, 3]}
+    provider_data = {"raw": {"nested": 1}}
+    run = _run_output(session_state=state, model_provider_data=provider_data)
+
+    d = run.to_dict()
+    d["session_state"]["injected"] = True
+    d["session_state"]["k"].append(99)
+    d["model_provider_data"]["injected"] = True
+
+    assert state == {"k": [1, 2, 3]}
+    assert provider_data == {"raw": {"nested": 1}}
+    assert run.session_state == {"k": [1, 2, 3]}
+
+
+def test_team_run_output_to_dict_matches_the_same_contract():
+    run = TeamRunOutput(
+        run_id="run-1",
+        team_id="team-1",
+        team_name="team",
+        session_id="session-1",
+        content="hello",
+        content_type="str",
+        model="test-model",
+        model_provider="test",
+        messages=[Message(role="user", content="hi")],
+        status=RunStatus.completed,
+        created_at=1750000000,
+    )
+    d = run.to_dict()
+
+    assert d["run_id"] == "run-1"
+    assert d["team_id"] == "team-1"
+    assert d["content"] == "hello"
+    assert d["status"] == RunStatus.completed.value
+    assert d["messages"] == [m.to_dict() for m in run.messages]
+    assert "metrics" not in d
+
+
+def test_team_run_output_to_dict_does_not_alias_kept_dicts():
+    provider_data = {"raw": {"nested": 1}}
+    run = TeamRunOutput(
+        run_id="run-1",
+        team_id="team-1",
+        session_id="session-1",
+        content="hello",
+        model_provider_data=provider_data,
+        messages=[Message(role="user", content="hi")],
+        status=RunStatus.completed,
+        created_at=1750000000,
+    )
+    run.to_dict()["model_provider_data"]["injected"] = True
+    assert provider_data == {"raw": {"nested": 1}}


### PR DESCRIPTION
## Summary

`RunOutput.to_dict()` and `TeamRunOutput.to_dict()` both open by calling
`dataclasses.asdict(self)` and then discarding most of what it just built:

```python
_dict = {
    k: v
    for k, v in asdict(self).items()
    if v is not None
    and k not in ["messages", "metrics", "tools", "metadata", ...]   # ~18 names
}
```

`asdict()` walks the entire object graph and deep-copies it before the comprehension
gets a chance to filter anything. Messages are pydantic models, so each one goes
through `copy.deepcopy`, and so does every tool execution, event, image and metrics
object. The skip list then drops all of them, and the `if self.<field> is not None:`
blocks further down rebuild each one properly anyway. Of 40 fields only about 22 plain
scalars survive the comprehension, and none of them needed a recursive walk.

`WorkflowRunOutput.to_dict()` doesn't do this. It builds from `fields(self)` and a skip
set, with a comment noting that it avoids `asdict()` precisely because of the recursive
walk. This brings the other two in line with it.

I came at this from the other direction, wondering why session saves get slower as a
conversation grows. `persist_run_in_session()` runs on every run's cleanup and on every
mid-run checkpoint, and lands at `AgentSession.to_dict()`, which does `[run.to_dict()
for run in self.runs]`. Every run already in the session is re-serialized on every
`agent.run()`, and each one pays for a deep copy that is thrown away immediately.

## Numbers

Python 3.12.13, pydantic 2.13.4, idle machine, medians of 11 runs.

A single `to_dict()` call, by how much conversation the run carries:

| messages | tool calls | total | wasted in `asdict` |
|---:|---:|---:|---:|
| 12 | 4 | 0.499 ms | 0.392 ms (79%) |
| 24 | 8 | 0.928 ms | 0.706 ms (76%) |
| 40 | 12 | 1.430 ms | 1.122 ms (78%) |

That discarded work costs 13, 25 and 41 `copy.deepcopy` calls respectively, one per
message and per tool execution. Afterwards it costs none.

Serializing a whole session (50 `RunOutput` plus 50 `TeamRunOutput`, 3-9 messages and
0-4 tool calls each, regenerated randomly on every repetition) goes from **22.09 ms to
5.47 ms**, so roughly **16.6 ms less CPU per session save**.

Worth being precise about what that is: framework CPU, not provider latency. Against a
hosted model with a 1-10 s turnaround it disappears into the noise, and I'm not
claiming otherwise. It matters in two places. `to_dict()` is reached synchronously from
`arun`, so this blocks the event loop and eats into how many concurrent runs an
AgentOS process can serve. And on local or self-hosted models the whole turn is short
(#8181 mentions a `llama-server` turn around 130 ms), where 16 ms is a real slice. It
also grows with session length, since the cost is per stored run per save.

## Keeping the behaviour identical

`asdict()` quietly does two things a plain attribute read does not, and both are easy
to lose here:

1. it converts a dataclass-valued `content` into a plain dict;
2. it deep-copies the kept dict fields, so mutating the dict you get back cannot reach
   into the `RunOutput` afterwards.

`_asdict_value` preserves both. It returns immutable scalars as-is, which is what
`copy.deepcopy` does for them anyway, and falls through to the full copy for everything
else. I checked by serializing randomly generated sessions through the patched and
unpatched trees in separate processes and diffing the JSON byte-for-byte, and the new
tests pin both properties for `RunOutput` and `TeamRunOutput`. They fail if you drop
either one.

`BaseRunOutputEvent.to_dict()` in `run/base.py` has the same shape. I've left it alone
to keep this focused, and because #9023 is already touching that class.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

I tried a number of shapes for the rewrite before settling on this one, each scored
against the unmodified tree for byte-identical output. The search record, including the
variants that were rejected, is at
https://dashboard.weco.ai/share/3pl6_X5WtAyxoBNQBIneuJqfh-KNp-qm

The fastest variants all hard-coded the list of surviving field names, which would
silently drop any field added to the dataclass later, and there are open PRs adding
fields to `RunOutput` right now. So I kept the `fields(self)` form. It gives up about a
millisecond per hundred runs and cannot rot.
