### PR TITLE
refactor: collapse clean_text into a single pass over the text

### DIFF
--- a/libs/agno/agno/knowledge/chunking/strategy.py
+++ b/libs/agno/agno/knowledge/chunking/strategy.py
@@ -36,23 +36,26 @@ class ChunkingStrategy(ABC):
         return self.chunk(document)
 
     def clean_text(self, text: str) -> str:
-        """Clean the text by replacing multiple newlines with a single newline"""
-        import re
+        """Collapse every run of whitespace into a single space.
 
-        # Replace multiple newlines with a single newline
-        cleaned_text = re.sub(r"\n+", "\n", text)
-        # Replace multiple spaces with a single space
-        cleaned_text = re.sub(r"\s+", " ", cleaned_text)
-        # Replace multiple tabs with a single tab
-        cleaned_text = re.sub(r"\t+", "\t", cleaned_text)
-        # Replace multiple carriage returns with a single carriage return
-        cleaned_text = re.sub(r"\r+", "\r", cleaned_text)
-        # Replace multiple form feeds with a single form feed
-        cleaned_text = re.sub(r"\f+", "\f", cleaned_text)
-        # Replace multiple vertical tabs with a single vertical tab
-        cleaned_text = re.sub(r"\v+", "\v", cleaned_text)
-
-        return cleaned_text
+        The previous implementation ran six `re.sub` passes. The second of them,
+        `re.sub(r"\\s+", " ", ...)`, already replaces every whitespace character,
+        so the four that followed it could never match and the one before it was
+        redundant. `str.split()` splits on exactly the same character set as `\\s`,
+        so this produces identical output in one pass instead of six.
+        """
+        words = text.split()
+        if not words:
+            # `split()` discards whitespace, so an all-whitespace string collapses
+            # to a single space and an empty string stays empty.
+            return " " if text else text
+        # `split()` also drops leading and trailing whitespace, which the previous
+        # implementation collapsed to a single space rather than removing.
+        if text[0].isspace():
+            words[0] = " " + words[0]
+        if text[-1].isspace():
+            words[-1] = words[-1] + " "
+        return " ".join(words)
 
 
 class ChunkingStrategyType(str, Enum):

--- a/libs/agno/tests/unit/knowledge/chunking/test_clean_text_contract.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_clean_text_contract.py
@@ -1,0 +1,141 @@
+"""Pin the observable contract of ChunkingStrategy.clean_text.
+
+Every case below is the behaviour on `main` before the change, so the tests fail on any
+rewrite that alters the output rather than only its cost. The Unicode and edge-position
+cases are the ones a faster implementation is most likely to get wrong: `" ".join(
+text.split())` is the obvious fast rewrite and it silently drops leading and trailing
+whitespace.
+"""
+
+import pytest
+
+from agno.knowledge.chunking.document import DocumentChunking
+from agno.knowledge.chunking.fixed import FixedSizeChunking
+from agno.knowledge.chunking.recursive import RecursiveChunking
+from agno.knowledge.document.base import Document
+
+
+@pytest.fixture
+def clean():
+    return FixedSizeChunking().clean_text
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("", ""),
+        (" ", " "),
+        ("   ", " "),
+        ("\n", " "),
+        ("\n\n\n", " "),
+        ("\t\t", " "),
+        ("a b", "a b"),
+        ("a  b", "a b"),
+        ("a\nb", "a b"),
+        ("a\n\n\nb", "a b"),
+        ("a\tb", "a b"),
+        ("a\r\nb", "a b"),
+        ("a\x0bb", "a b"),
+        ("a\x0cb", "a b"),
+        ("a \t\r\n b", "a b"),
+        ("line one\nline two\n\nline four", "line one line two line four"),
+    ],
+)
+def test_every_whitespace_run_collapses_to_one_space(clean, raw, expected):
+    assert clean(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (" leading", " leading"),
+        ("  leading", " leading"),
+        ("\nleading", " leading"),
+        ("trailing ", "trailing "),
+        ("trailing  ", "trailing "),
+        ("trailing\n", "trailing "),
+        (" both ", " both "),
+        ("\t both \n", " both "),
+    ],
+)
+def test_leading_and_trailing_whitespace_survives_as_a_single_space(clean, raw, expected):
+    """`" ".join(text.split())` strips these, which is the trap this case exists for."""
+    assert clean(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("a b", "a b"),  # NO-BREAK SPACE
+        ("a b", "a b"),  # EM SPACE
+        ("a b", "a b"),  # OGHAM SPACE MARK
+        ("a b", "a b"),  # LINE SEPARATOR
+        ("a b", "a b"),  # PARAGRAPH SEPARATOR
+        ("ab", "a b"),  # NEXT LINE
+        ("a\x1cb", "a b"),  # FILE SEPARATOR
+        ("a\x1fb", "a b"),  # UNIT SEPARATOR
+        ("a   b", "a b"),
+        ("a​b", "a​b"),  # ZERO WIDTH SPACE is not whitespace
+        ("a﻿b", "a﻿b"),  # BYTE ORDER MARK is not whitespace
+    ],
+)
+def test_unicode_whitespace_is_treated_exactly_as_re_whitespace_is(clean, raw, expected):
+    assert clean(raw) == expected
+
+
+def test_result_contains_no_whitespace_other_than_single_spaces(clean):
+    raw = "para one\n\n\npara two\t\ttabbed\r\ncarriage\x0cff\x0bvt   nbsp"
+    out = clean(raw)
+    assert "  " not in out
+    assert not any(c.isspace() and c != " " for c in out)
+
+
+CHUNKING_TEXT = (
+    "First paragraph with several words in it.\n\n"
+    "Second paragraph\twith a tab and   runs of spaces.\r\n"
+    "Third paragraph\n\n\nafter blank lines, then a closing sentence. "
+)
+
+EXPECTED_CHUNKS = {
+    "fixed": [
+        ("chunk_21b987d81fd4_1", "First paragraph with several words in it. Second paragraph"),
+        ("chunk_77dfa8fb3f1e_2", " with a tab and runs of spaces. Third paragraph after blank"),
+        ("chunk_84ec68adc43a_3", " lines, then a closing sentence. "),
+    ],
+    "fixed_overlap": [
+        ("chunk_21b987d81fd4_1", "First paragraph with several words in it. Second paragraph"),
+        ("chunk_0bf561079983_2", " paragraph with a tab and runs of spaces. Third paragraph"),
+        ("chunk_9b7fd9f99a81_3", " paragraph after blank lines, then a closing sentence. "),
+    ],
+    "recursive": [
+        ("chunk_b21671d25d72_1", "First paragraph with several words in it. "),
+        ("chunk_bd1114cb2f4b_2", "Second paragraph with a tab and runs of spaces. "),
+        ("chunk_c7502374b7e7_3", "Third paragraph "),
+        ("chunk_e952fa55661e_4", "after blank lines, then a closing sentence. "),
+    ],
+    "document": [
+        ("chunk_0a2a32b885d6_1", "First paragraph with several words in it."),
+        ("chunk_93fb21929f7d_2", "Second paragraph with a tab and runs of spaces."),
+        ("chunk_15e2373ae4c3_3", "Third paragraph\n\nafter blank lines, then a closing sentence."),
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    "key,strategy",
+    [
+        ("fixed", FixedSizeChunking(chunk_size=60, overlap=0)),
+        ("fixed_overlap", FixedSizeChunking(chunk_size=60, overlap=10)),
+        ("recursive", RecursiveChunking(chunk_size=60, overlap=0)),
+        ("document", DocumentChunking(chunk_size=60, overlap=0)),
+    ],
+)
+def test_chunk_ids_and_contents_are_stable(key, strategy):
+    """clean_text feeds chunk content, and chunk content feeds the chunk id hash, so any
+    change in clean_text would silently re-key an already-indexed knowledge base. The
+    ids below are the ones produced on main before this change."""
+    doc = Document(id=None, name=None, content=CHUNKING_TEXT, meta_data={})
+    chunks = strategy.chunk(doc)
+    assert [(c.id, c.content) for c in chunks] == EXPECTED_CHUNKS[key]
+    for chunk in chunks:
+        assert chunk.meta_data["chunk_size"] == len(chunk.content)


### PR DESCRIPTION
## Summary

`ChunkingStrategy.clean_text` runs six `re.sub` passes over the whole text:

```python
cleaned_text = re.sub(r"\n+", "\n", text)
cleaned_text = re.sub(r"\s+", " ", cleaned_text)
cleaned_text = re.sub(r"\t+", "\t", cleaned_text)
cleaned_text = re.sub(r"\r+", "\r", cleaned_text)
cleaned_text = re.sub(r"\f+", "\f", cleaned_text)
cleaned_text = re.sub(r"\v+", "\v", cleaned_text)
```

`\s` matches every whitespace character, so after the second pass the string holds no
newline, tab, carriage return, form feed or vertical tab at all. The four passes below
it can never match anything, and the one above it is already covered by it. Five of the
six scans over the text do nothing.

This replaces them with `" ".join(text.split())`, putting back the single leading and
trailing space that `split()` drops. The output does not change.

`FixedSizeChunking` is the default strategy for every reader (`knowledge/reader/base.py`),
so this runs on all ingested content. On a 1 MB document, `clean_text` is 70.6 ms of the
75.2 ms that `TextReader.read(chunk=True)` spends. `ChunkingStrategy.achunk` calls the
synchronous `chunk()`, so it also runs on the event loop during async ingestion.

## Numbers

`TextReader.read(chunk=True)` end to end, `chunk_size=5000`, Python 3.12.13, medians of
9 runs (5 at 5 MB), on an otherwise idle core:

| document | before | after | |
|---:|---:|---:|---:|
| 10 KB | 0.71 ms | 0.08 ms | 8.4x |
| 100 KB | 6.92 ms | 0.67 ms | 10.3x |
| 1 MB | 74.11 ms | 11.03 ms | 6.7x |
| 5 MB | 366.92 ms | 64.71 ms | 5.7x |

Being clear about what that is: ingesting a corpus also makes embedding calls over the
network, and those normally dominate the wall clock. What this changes is CPU in the
chunking stage, and how long that stage occupies the event loop when ingestion is async.
I am not claiming an end-to-end ingestion latency win.

## Why the output is identical

`str.split()` splits on exactly the characters `re` treats as `\s`. Rather than assume
that, I checked all 1,114,112 codepoints: `re.match(r"\s", chr(c))` and
`chr(c).isspace()` accept the same 29 characters, and neither accepts one the other
rejects.

Comparing the new implementation against the old one directly:

* 348 cases, each of those 29 characters placed alone, doubled, tripled, leading,
  trailing, interior and repeated: 0 differences
* 300,000 random strings built from those 29 characters plus ASCII: 0 differences

`split()` differs from a bare `\s+` substitution in two places, and both are leading and
trailing whitespace, which it removes rather than collapsing to one space. The patch
restores both, and there are tests for both.

## Tests

`libs/agno/tests/unit/knowledge/chunking/test_clean_text_contract.py`, 40 tests.

They pin the chunk ids and chunk contents that `FixedSizeChunking`, `RecursiveChunking`
and `DocumentChunking` produce, with and without overlap. `clean_text` feeds chunk
content, and chunk content feeds the chunk id hash, so a change in this function would
re-key a knowledge base that has already been indexed.

I checked the tests can actually fail. Against `" ".join(text.split())` with the edge
restoration removed, 16 of the 40 fail. On this branch all 40 pass.

`libs/agno/tests/unit/knowledge` and `libs/agno/tests/unit/reader` give 778 passed,
8 failed, 58 skipped. The same 8 fail on an unmodified checkout of this base, so they
are not from this change; they need optional drivers I do not have installed.
`ruff check`, `ruff format --check` and `mypy` are clean on the changed file.

## Relationship to #8967

#8967 proposed changing this function so that newlines survive. This change does the
opposite: it keeps the current output byte for byte, so nothing already indexed needs
rebuilding. If the newline-preserving behaviour is wanted, the two are independent and
this does not get in the way of it.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

I tried a number of rewrites before settling on this one, each scored against the
unmodified function for byte-identical output. The record, including the variants that
were rejected, is at
https://dashboard.weco.ai/share/i1suFFRfsQrs3yOObSuDAb07dYqmjLsr

The fastest one is not the one here. It added an ASCII byte path built on
`while b"  " in b: b = b.replace(b"  ", b" ")`, which halves every whitespace run on each
pass. That is quick when runs are one or two characters, which is what my benchmark
corpus happened to generate, and it gets worse as runs get longer. On a document holding
a single run of 500,000 spaces it measured 5.31 ms against 4.93 ms for the current code,
so on that input it was slower than what it was replacing. `split()` does not care how
long a run is, so I kept it.
