### PR TITLE
[feat] Add file IDs of run input media to session state

### DIFF
--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -12,6 +12,7 @@ from typing import (
     Type,
     Union,
 )
+from uuid import uuid4
 
 from pydantic import BaseModel
 
@@ -1200,6 +1201,43 @@ async def aget_user_message(
 # ---------------------------------------------------------------------------
 
 
+def _add_media_ids_to_session_state(
+    run_context: RunContext,
+    images: Optional[Sequence[Image]] = None,
+    audio: Optional[Sequence[Audio]] = None,
+    videos: Optional[Sequence[Video]] = None,
+    files: Optional[Sequence[File]] = None,
+) -> None:
+    """Record references to the media provided with the run input in the session state.
+
+    Only media references (id and name/filename) are stored, never the media content.
+    Media items without an id are assigned one, so tools can reference them reliably.
+    Entries are appended across runs and de-duplicated by id.
+    """
+    if run_context.session_state is None:
+        run_context.session_state = {}
+
+    for key, media_list in (("images", images), ("videos", videos), ("audios", audio), ("files", files)):
+        if not media_list:
+            continue
+        existing_entries = run_context.session_state.get(key)
+        if not isinstance(existing_entries, list):
+            existing_entries = []
+        existing_ids = {entry.get("id") for entry in existing_entries if isinstance(entry, dict)}
+        for media in media_list:
+            if media.id is None:
+                media.id = str(uuid4())
+            if media.id in existing_ids:
+                continue
+            entry: Dict[str, Any] = {"id": media.id}
+            name = getattr(media, "filename", None) or getattr(media, "name", None)
+            if name:
+                entry["name"] = name
+            existing_entries.append(entry)
+            existing_ids.add(media.id)
+        run_context.session_state[key] = existing_entries
+
+
 def get_run_messages(
     agent: Agent,
     *,
@@ -1244,6 +1282,10 @@ def get_run_messages(
 
     # Initialize the RunMessages object (no media here - that's in RunInput now)
     run_messages = RunMessages()
+
+    # 0. If enabled, record references to the input media in the session state
+    if agent.add_file_ids_to_session_state:
+        _add_media_ids_to_session_state(run_context, images=images, audio=audio, videos=videos, files=files)
 
     # 1. Add system message to run_messages
     system_message = get_system_message(
@@ -1450,6 +1492,10 @@ async def aget_run_messages(
 
     # Initialize the RunMessages object (no media here - that's in RunInput now)
     run_messages = RunMessages()
+
+    # 0. If enabled, record references to the input media in the session state
+    if agent.add_file_ids_to_session_state:
+        _add_media_ids_to_session_state(run_context, images=images, audio=audio, videos=videos, files=files)
 
     # 1. Add system message to run_messages
     system_message = await aget_system_message(

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -598,6 +598,8 @@ def to_dict(agent: Agent) -> Dict[str, Any]:
         config["read_tool_call_history"] = agent.read_tool_call_history
     if not agent.send_media_to_model:
         config["send_media_to_model"] = agent.send_media_to_model
+    if agent.add_file_ids_to_session_state:
+        config["add_file_ids_to_session_state"] = agent.add_file_ids_to_session_state
     if not agent.store_media:
         config["store_media"] = agent.store_media
     if not agent.store_tool_messages:
@@ -930,6 +932,7 @@ def from_dict(cls: Type[Agent], data: Dict[str, Any], registry: Optional[Registr
         update_knowledge=config.get("update_knowledge", False),
         read_tool_call_history=config.get("read_tool_call_history", False),
         send_media_to_model=config.get("send_media_to_model", True),
+        add_file_ids_to_session_state=config.get("add_file_ids_to_session_state", False),
         store_media=config.get("store_media", True),
         store_tool_messages=config.get("store_tool_messages", True),
         store_history_messages=config.get("store_history_messages", False),

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -219,6 +219,9 @@ class Agent:
     read_tool_call_history: bool = False
     # If False, media (images, videos, audio, files) is only available to tools and not sent to the LLM
     send_media_to_model: bool = True
+    # If True, add the ids of media (images, videos, audio, files) provided with the run input to the session state.
+    # Only media references (id and name/filename) are stored, never the media content.
+    add_file_ids_to_session_state: bool = False
     # If True, store media in run output
     store_media: bool = True
     # If True, store tool results in run output
@@ -451,6 +454,7 @@ class Agent:
         update_knowledge: bool = False,
         read_tool_call_history: bool = False,
         send_media_to_model: bool = True,
+        add_file_ids_to_session_state: bool = False,
         system_message: Optional[Union[str, Callable, Message]] = None,
         system_message_role: str = "system",
         introduction: Optional[str] = None,
@@ -623,6 +627,7 @@ class Agent:
         self.update_knowledge = update_knowledge
         self.read_tool_call_history = read_tool_call_history
         self.send_media_to_model = send_media_to_model
+        self.add_file_ids_to_session_state = add_file_ids_to_session_state
         self.system_message = system_message
         self.system_message_role = system_message_role
         self.build_context = build_context

--- a/libs/agno/tests/unit/agent/test_add_file_ids_to_session_state.py
+++ b/libs/agno/tests/unit/agent/test_add_file_ids_to_session_state.py
@@ -1,0 +1,232 @@
+"""Tests for the add_file_ids_to_session_state Agent option.
+
+Verifies https://github.com/agno-agi/agno/issues/7306 —
+when enabled, references (id and name/filename) of the media provided with the
+run input are recorded in session_state, so tools can discover them even when
+the media itself is not sent to the model (send_media_to_model=False).
+Only references are stored, never the media content.
+"""
+
+from typing import Any, AsyncIterator, Iterator
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from agno.agent._messages import _add_media_ids_to_session_state
+from agno.agent.agent import Agent
+from agno.media import Audio, File, Image, Video
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run import RunContext
+
+
+class MockModel(Model):
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.instructions = None
+
+        self._mock_response = ModelResponse(
+            content="Done",
+            role="assistant",
+            response_usage=MessageMetrics(),
+        )
+
+        self.response = Mock(return_value=self._mock_response)
+        self.aresponse = AsyncMock(return_value=self._mock_response)
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return await self.aresponse(*args, **kwargs)
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._mock_response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._mock_response
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._mock_response
+
+
+def test_disabled_by_default_does_not_record_media():
+    """With the default (flag off), session_state must not be modified."""
+    agent = Agent(model=MockModel())
+
+    result = agent.run(
+        "Process this file",
+        files=[File(url="https://example.com/report.csv", id="file-1", filename="report.csv")],
+        images=[Image(url="https://example.com/chart.png", id="img-1")],
+    )
+
+    assert result.session_state is not None
+    assert "files" not in result.session_state
+    assert "images" not in result.session_state
+
+
+def test_records_media_references_sync():
+    """Flag on: ids and names of all input media types are recorded in session_state."""
+    agent = Agent(model=MockModel(), add_file_ids_to_session_state=True)
+
+    result = agent.run(
+        "Process these",
+        images=[Image(url="https://example.com/chart.png", id="img-1")],
+        videos=[Video(url="https://example.com/clip.mp4", id="vid-1")],
+        audio=[Audio(url="https://example.com/voice.mp3", id="aud-1")],
+        files=[File(url="https://example.com/report.csv", id="file-1", filename="report.csv")],
+    )
+
+    assert result.session_state is not None
+    assert result.session_state["images"] == [{"id": "img-1"}]
+    assert result.session_state["videos"] == [{"id": "vid-1"}]
+    assert result.session_state["audios"] == [{"id": "aud-1"}]
+    assert result.session_state["files"] == [{"id": "file-1", "name": "report.csv"}]
+
+
+def test_generates_id_for_media_without_id():
+    """Media without an id gets one assigned, so the session_state reference is usable."""
+    agent = Agent(model=MockModel(), add_file_ids_to_session_state=True)
+    upload = File(url="https://example.com/data.xls", filename="data.xls")
+
+    result = agent.run("Process this file", files=[upload])
+
+    assert upload.id is not None
+    assert result.session_state is not None
+    assert result.session_state["files"] == [{"id": upload.id, "name": "data.xls"}]
+
+
+@pytest.mark.asyncio
+async def test_records_media_references_async():
+    """Async path: ids are recorded in session_state as well."""
+    agent = Agent(model=MockModel(), add_file_ids_to_session_state=True)
+
+    result = await agent.arun(
+        "Process this file",
+        files=[File(url="https://example.com/report.csv", id="file-1", filename="report.csv")],
+    )
+
+    assert result.session_state is not None
+    assert result.session_state["files"] == [{"id": "file-1", "name": "report.csv"}]
+
+
+def test_appends_and_dedupes_across_runs():
+    """Existing entries are kept, known ids are not duplicated, new media is appended."""
+    agent = Agent(model=MockModel(), add_file_ids_to_session_state=True)
+    session_state = {"files": [{"id": "file-1", "name": "first.csv"}]}
+
+    result = agent.run(
+        "Process these files",
+        files=[
+            File(url="https://example.com/first.csv", id="file-1", filename="first.csv"),
+            File(url="https://example.com/second.csv", id="file-2", filename="second.csv"),
+        ],
+        session_state=session_state,
+    )
+
+    assert result.session_state is not None
+    assert result.session_state["files"] == [
+        {"id": "file-1", "name": "first.csv"},
+        {"id": "file-2", "name": "second.csv"},
+    ]
+
+
+def test_preserves_existing_session_state_keys():
+    """Recording media references must not clobber unrelated session_state keys."""
+    agent = Agent(model=MockModel(), add_file_ids_to_session_state=True)
+
+    result = agent.run(
+        "Process this file",
+        files=[File(url="https://example.com/report.csv", id="file-1", filename="report.csv")],
+        session_state={"customer_id": "cust-123"},
+    )
+
+    assert result.session_state is not None
+    assert result.session_state["customer_id"] == "cust-123"
+    assert result.session_state["files"] == [{"id": "file-1", "name": "report.csv"}]
+
+
+def test_records_media_when_not_sent_to_model():
+    """The issue scenario: send_media_to_model=False, tools still learn about the file."""
+    agent = Agent(model=MockModel(), send_media_to_model=False, add_file_ids_to_session_state=True)
+
+    result = agent.run(
+        "Sum the columns in this spreadsheet",
+        files=[File(url="https://example.com/data.xls", id="file-1", filename="data.xls")],
+    )
+
+    assert result.session_state is not None
+    assert result.session_state["files"] == [{"id": "file-1", "name": "data.xls"}]
+
+
+def test_serialization_round_trip():
+    """The flag survives to_dict/from_dict so stored agents keep the behavior."""
+    agent = Agent(model=MockModel(), add_file_ids_to_session_state=True)
+
+    config = agent.to_dict()
+    assert config["add_file_ids_to_session_state"] is True
+
+    # The mock model provider is not a registered provider, so drop it before rebuilding
+    config.pop("model", None)
+    restored = Agent.from_dict(config)
+    assert restored.add_file_ids_to_session_state is True
+
+    # Default agents don't serialize the flag and restore it as False
+    default_config = Agent(model=MockModel()).to_dict()
+    assert "add_file_ids_to_session_state" not in default_config
+    default_config.pop("model", None)
+    assert Agent.from_dict(default_config).add_file_ids_to_session_state is False
+
+
+def test_helper_initializes_none_session_state():
+    """The helper works on a bare RunContext whose session_state is None."""
+    run_context = RunContext(run_id="r1", session_id="s1")
+
+    _add_media_ids_to_session_state(
+        run_context,
+        files=[File(url="https://example.com/report.csv", id="file-1", filename="report.csv")],
+    )
+
+    assert run_context.session_state is not None
+    assert run_context.session_state["files"] == [{"id": "file-1", "name": "report.csv"}]
+
+
+def test_helper_replaces_non_list_existing_value():
+    """A pre-existing non-list value under a media key is replaced, not corrupted."""
+    run_context = RunContext(run_id="r1", session_id="s1", session_state={"files": "stale-value"})
+
+    _add_media_ids_to_session_state(
+        run_context,
+        files=[File(url="https://example.com/report.csv", id="file-1", filename="report.csv")],
+    )
+
+    assert run_context.session_state["files"] == [{"id": "file-1", "name": "report.csv"}]
+
+
+def test_helper_ignores_empty_media():
+    """No media input leaves session_state untouched."""
+    run_context = RunContext(run_id="r1", session_id="s1", session_state={"customer_id": "cust-123"})
+
+    _add_media_ids_to_session_state(run_context)
+
+    assert run_context.session_state == {"customer_id": "cust-123"}


### PR DESCRIPTION
## Description

Adds an opt-in Agent flag `add_file_ids_to_session_state` (default `False`). When enabled, references (`id` and `name`/`filename`) of the images, videos, audio, and files provided with a run's input are recorded in `session_state` — never the media content.

Motivation: with `send_media_to_model=False`, media is stripped from the model input, so the agent has no way to know a file was provided during a turn (e.g. an uploaded spreadsheet meant to be processed via tool calls). Recording the references in session state lets the agent and its tools discover uploaded files.

Implementation:
- New `add_file_ids_to_session_state` parameter on `Agent`
- Recording happens in `get_run_messages` / `aget_run_messages` (sync and async paths), before the system message is built, so `add_session_state_to_context` also surfaces the references to the model
- Media items without an `id` are assigned one; entries append across runs and are de-duplicated by `id`
- `to_dict` / `from_dict` serialization support

## Related Issues

Fixes #7306

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] My code follows Agno's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [x] I have added/updated tests
- [x] I have updated documentation
- [x] My changes do not introduce new warnings or errors
- [x] I have checked for potential security risks or exposed secrets

## AI Disclosure (Required)

- [x] This PR includes AI-generated content
- [x] I have reviewed and understand all AI-generated code
- [x] I have tested all AI-generated code

If yes, describe the extent of AI assistance:
Implemented with AI assistance (Cursor). The full diff has been manually reviewed and tested locally.

## Additional Notes

- Fully opt-in: behavior is unchanged when the flag is `False` (default).
- Scope is intentionally limited to `Agent` (not `Team`) to keep the change small.
- Prior attempts (#7316, #7996, #8209) went stale or were closed incomplete — missing the sync path, serialization, and tests. This implementation covers all four run paths with 11 new unit tests; the full unit suite passes locally (11,739 tests).