### PR TITLE
[fix] Cohere: stop dropping zero-valued sampling params

### DIFF
--- a/libs/agno/agno/models/cohere/chat.py
+++ b/libs/agno/agno/models/cohere/chat.py
@@ -140,21 +140,22 @@ class Cohere(Model):
         tools: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
         _request_params: Dict[str, Any] = {}
-        if self.temperature:
+        if self.temperature is not None:
             _request_params["temperature"] = self.temperature
         if self.max_tokens:
             _request_params["max_tokens"] = self.max_tokens
-        if self.top_k:
+        if self.top_k is not None:
             _request_params["k"] = self.top_k
+        # Cohere's `p` accepts 0.01-0.99, so a 0.0 is out of range; only forward truthy values.
         if self.top_p:
             _request_params["p"] = self.top_p
-        if self.seed:
+        if self.seed is not None:
             _request_params["seed"] = self.seed
         if self.logprobs:
             _request_params["logprobs"] = self.logprobs
-        if self.frequency_penalty:
+        if self.frequency_penalty is not None:
             _request_params["frequency_penalty"] = self.frequency_penalty
-        if self.presence_penalty:
+        if self.presence_penalty is not None:
             _request_params["presence_penalty"] = self.presence_penalty
 
         if response_format:

--- a/libs/agno/tests/unit/models/test_cohere_request_params.py
+++ b/libs/agno/tests/unit/models/test_cohere_request_params.py
@@ -1,0 +1,84 @@
+"""Unit tests for Cohere request params: zero-valued sampling params
+must not be silently dropped by a truthiness check."""
+
+import pytest
+
+pytest.importorskip("cohere")
+
+from agno.models.cohere.chat import Cohere
+
+
+def test_temperature_zero_included():
+    """temperature=0.0 must appear in request params (falsy-check regression)."""
+    params = Cohere(temperature=0.0).get_request_params()
+    assert "temperature" in params
+    assert params["temperature"] == 0.0
+
+
+def test_top_p_zero_excluded():
+    """top_p=0.0 is below Cohere's min of 0.01, so it must stay omitted."""
+    params = Cohere(top_p=0.0).get_request_params()
+    assert "p" not in params
+
+
+def test_top_p_in_range_included():
+    """A valid top_p is forwarded under Cohere's 'p' key."""
+    params = Cohere(top_p=0.01).get_request_params()
+    assert params["p"] == 0.01
+
+
+def test_top_k_zero_included():
+    """top_k=0 must appear in request params under Cohere's 'k' key."""
+    params = Cohere(top_k=0).get_request_params()
+    assert "k" in params
+    assert params["k"] == 0
+
+
+def test_seed_zero_included():
+    """seed=0 is a valid deterministic seed and must appear in request params."""
+    params = Cohere(seed=0).get_request_params()
+    assert "seed" in params
+    assert params["seed"] == 0
+
+
+def test_frequency_penalty_zero_included():
+    """frequency_penalty=0.0 must appear in request params."""
+    params = Cohere(frequency_penalty=0.0).get_request_params()
+    assert "frequency_penalty" in params
+    assert params["frequency_penalty"] == 0.0
+
+
+def test_presence_penalty_zero_included():
+    """presence_penalty=0.0 must appear in request params."""
+    params = Cohere(presence_penalty=0.0).get_request_params()
+    assert "presence_penalty" in params
+    assert params["presence_penalty"] == 0.0
+
+
+def test_unset_sampling_params_excluded():
+    """Unset (None) sampling params must not appear in request params."""
+    params = Cohere().get_request_params()
+    for key in ("temperature", "p", "k", "seed", "frequency_penalty", "presence_penalty"):
+        assert key not in params
+
+
+def test_positive_temperature_included():
+    """Positive temperature is still forwarded correctly."""
+    params = Cohere(temperature=0.7).get_request_params()
+    assert params["temperature"] == 0.7
+
+
+def test_all_zero_valued_params_survive_together():
+    """Every in-range zero-valued param must survive together (top_p excluded: 0.0 is out of range)."""
+    params = Cohere(
+        temperature=0.0,
+        top_k=0,
+        seed=0,
+        frequency_penalty=0.0,
+        presence_penalty=0.0,
+    ).get_request_params()
+    assert params["temperature"] == 0.0
+    assert params["k"] == 0
+    assert params["seed"] == 0
+    assert params["frequency_penalty"] == 0.0
+    assert params["presence_penalty"] == 0.0


### PR DESCRIPTION
## Summary

Fixes #9299.

`Cohere.get_request_params` gated its numeric sampling params on truthiness, so an explicit `0` was silently dropped and Cohere fell back to its own defaults. Since every field is `Optional[...] = None`, `None` already encodes "unset" and `0` is a real value the user picked. `temperature=0.0` for deterministic output quietly became sampled output (Cohere's default is `0.3`).

- Switch `temperature`, `top_k`, `seed`, `frequency_penalty`, `presence_penalty` to `is not None`, matching the Claude models (anthropic/aws/vertexai).
- Leave `top_p` on the truthiness check: it maps to Cohere's `p`, documented as `min 0.01, max 0.99`, so `0.0` is out of range and every valid value is already truthy.
- Leave `max_tokens` and `logprobs` unchanged: `0` tokens is not a meaningful request, and `logprobs=False` equals Cohere's default.
- Add `tests/unit/models/test_cohere_request_params.py` covering each zero value, the `top_p` range exception, and the unset case.

This is the same falsy-check bug that `AzureFoundryClaude` had in #9249 (fixed in #9247). Cohere is a separate code path that fix does not touch.

Base commit: `7c68873` (release 2.8.6).

Before:
```python
Cohere(temperature=0.0, top_k=0, seed=0, frequency_penalty=0.0, presence_penalty=0.0).get_request_params()
# {}
```
After:
```python
# {'temperature': 0.0, 'k': 0, 'seed': 0, 'frequency_penalty': 0.0, 'presence_penalty': 0.0}
Cohere(top_p=0.0).get_request_params()   # {}  (p omitted, 0.0 is out of range)
Cohere(top_p=0.5).get_request_params()   # {'p': 0.5}
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Test plan (fresh `uv` venv, cohere 7.0.8):

- [x] `pytest libs/agno/tests/unit/models/test_cohere_request_params.py` -> 10 passed
- [x] `ruff format --check` and `ruff check` on both files -> clean
- [x] `mypy libs/agno/agno/models/cohere/chat.py` -> no new issues
- [x] Reproduced before/after by hand as shown above

The five in-range zeros are the whole fix. This does not add full range validation, so an out-of-range but truthy value (`top_p=1.0`, `frequency_penalty=2.0`) is still forwarded and rejected by Cohere, same as before. That is a separate, pre-existing gap.

