### PR TITLE
fix: restore user_id on continue_run after HITL confirmation

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3321,6 +3321,11 @@ def continue_run_dispatch(
     session_id = run_response.session_id if run_response else session_id
     run_id: str = run_response.run_id if run_response else run_id  # type: ignore
 
+    # Restore identity from the paused/continued run when the caller omits user_id=
+    # (e.g. Agent.continue_run(run_response=paused) or workflow executor HITL routing).
+    if not user_id and run_response is not None:
+        user_id = run_response.user_id
+
     session_id, user_id = initialize_session(
         agent,
         session_id=session_id,
@@ -3357,6 +3362,8 @@ def continue_run_dispatch(
         knowledge_filters=opts.knowledge_filters,
         metadata=opts.metadata,
     )
+    if run_context.user_id is None and user_id is not None:
+        run_context.user_id = user_id
     # Apply options with precedence: explicit args > existing run_context > resolved defaults.
     opts.apply_to_context(
         run_context,
@@ -3412,6 +3419,12 @@ def continue_run_dispatch(
             raise RunNotFoundError(f"No runs found for run ID {run_id}")
         if run_response.status == RunStatus.cancelled:
             raise RunNotContinuableError(f"Cannot continue run {run_response.run_id}: run is cancelled")
+
+        # run_response was not available before initialize_session; restore identity now.
+        if not user_id and run_response.user_id:
+            user_id = run_response.user_id
+            if run_context.user_id is None:
+                run_context.user_id = user_id
 
         continue_index = _resolve_continue_from(
             run_response,
@@ -4192,6 +4205,11 @@ def acontinue_run_dispatch(  # type: ignore
     session_id = run_response.session_id if run_response else session_id
     run_id: str = run_response.run_id if run_response else run_id  # type: ignore
 
+    # Restore identity from the paused/continued run when the caller omits user_id=
+    # (e.g. Agent.acontinue_run(run_response=paused) or workflow executor HITL routing).
+    if not user_id and run_response is not None:
+        user_id = run_response.user_id
+
     session_id, user_id = initialize_session(
         agent,
         session_id=session_id,
@@ -4237,6 +4255,8 @@ def acontinue_run_dispatch(  # type: ignore
         knowledge_filters=opts.knowledge_filters,
         metadata=opts.metadata,
     )
+    if run_context.user_id is None and user_id is not None:
+        run_context.user_id = user_id
     # Apply options with precedence: explicit args > existing run_context > resolved defaults.
     opts.apply_to_context(
         run_context,

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -6412,6 +6412,10 @@ def continue_run_dispatch(
     session_id = run_response.session_id if run_response else session_id
     run_id_resolved: str = run_response.run_id if run_response else run_id  # type: ignore
 
+    # Restore identity from the paused/continued run when the caller omits user_id=
+    if not user_id and run_response is not None:
+        user_id = run_response.user_id
+
     session_id, user_id = _initialize_session(team, session_id=session_id, user_id=user_id)
 
     # Initialize the Team
@@ -6445,6 +6449,8 @@ def continue_run_dispatch(
         knowledge_filters=opts.knowledge_filters,
         metadata=opts.metadata,
     )
+    if run_context.user_id is None and user_id is not None:
+        run_context.user_id = user_id
     if dependencies is not None:
         run_context.dependencies = opts.dependencies
     elif run_context.dependencies is None:
@@ -7756,6 +7762,10 @@ def acontinue_run_dispatch(  # type: ignore
     session_id_resolved = run_response.session_id if run_response else session_id
     run_id_resolved: str = run_response.run_id if run_response else run_id  # type: ignore
 
+    # Restore identity from the paused/continued run when the caller omits user_id=
+    if not user_id and run_response is not None:
+        user_id = run_response.user_id
+
     session_id_resolved, user_id = _initialize_session(team, session_id=session_id_resolved, user_id=user_id)
 
     # Initialize the Team
@@ -7782,6 +7792,8 @@ def acontinue_run_dispatch(  # type: ignore
         knowledge_filters=opts.knowledge_filters,
         metadata=opts.metadata,
     )
+    if run_context.user_id is None and user_id is not None:
+        run_context.user_id = user_id
     if dependencies is not None:
         run_context.dependencies = opts.dependencies
     elif run_context.dependencies is None:

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -276,6 +276,18 @@ def _find_paused_executor_run(
     )
 
 
+def _resolve_continue_user_id(
+    paused_run_response: Any,
+    workflow_run_response: "WorkflowRunOutput",
+) -> Optional[str]:
+    """Resolve user_id to forward when continuing a paused executor run.
+
+    Nested executor runs sometimes persist without user_id even when the workflow
+    run had one, so fall back to the workflow run's user_id.
+    """
+    return getattr(paused_run_response, "user_id", None) or getattr(workflow_run_response, "user_id", None)
+
+
 def _apply_requirements_to_run_response(run_response: Any, requirements: list) -> None:
     """Apply resolved requirements to a paused run_response before continuing.
 
@@ -6517,6 +6529,7 @@ class Workflow:
         # Call executor's continue_run with the stored run_response
         continued_response = executor.continue_run(
             run_response=paused_run_response,
+            user_id=_resolve_continue_user_id(paused_run_response, workflow_run_response),
         )
 
         # Store executor response for potential chained HITL
@@ -6576,6 +6589,7 @@ class Workflow:
         # Call executor's continue_run with the stored run_response (streaming).
         response_stream = executor.continue_run(
             run_response=paused_run_response,
+            user_id=_resolve_continue_user_id(paused_run_response, workflow_run_response),
             stream=True,
             stream_events=True,
             yield_run_output=True,
@@ -6665,6 +6679,7 @@ class Workflow:
         # stream_events=True ensures RunCompleted/RunError lifecycle events are emitted.
         response_stream = executor.acontinue_run(
             run_response=paused_run_response,
+            user_id=_resolve_continue_user_id(paused_run_response, workflow_run_response),
             stream=True,
             stream_events=True,
             yield_run_output=True,
@@ -6748,6 +6763,7 @@ class Workflow:
         # Call executor's acontinue_run with the stored run_response
         continued_response = await executor.acontinue_run(
             run_response=paused_run_response,
+            user_id=_resolve_continue_user_id(paused_run_response, workflow_run_response),
         )
 
         # Store executor response for potential chained HITL

--- a/libs/agno/tests/unit/agent/test_continue_run_user_id_hitl.py
+++ b/libs/agno/tests/unit/agent/test_continue_run_user_id_hitl.py
@@ -1,0 +1,186 @@
+"""Regression: continue_run must restore RunContext.user_id after HITL confirmation.
+
+Issue #9288 — when resuming via continue_run(run_response=...) without an explicit
+user_id=, Agno previously only fell back to agent.user_id and dropped the identity
+stored on the paused RunOutput. Workflow executor HITL also called continue_run
+without forwarding user_id, so confirmed tools saw RunContext.user_id is None.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, Iterator, Optional
+
+import pytest
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run.base import RunContext
+from agno.run.workflow import WorkflowRunOutput
+from agno.tools import tool
+from agno.workflow.step import Step
+from agno.workflow.workflow import Workflow, _resolve_continue_user_id
+
+
+CAPTURE: Dict[str, Any] = {}
+
+
+class ToolCallThenDoneModel(Model):
+    """First call requests a tool; second call returns plain content."""
+
+    def __init__(self) -> None:
+        super().__init__(id="repro-model", name="repro-model", provider="test")
+        self.calls = 0
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> "ToolCallThenDoneModel":
+        clone = type(self)()
+        clone.calls = self.calls
+        return clone
+
+    def _next(self) -> ModelResponse:
+        self.calls += 1
+        if self.calls == 1:
+            return ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "tc-probe-1",
+                        "type": "function",
+                        "function": {"name": "probe", "arguments": "{}"},
+                    }
+                ],
+                response_usage=MessageMetrics(),
+            )
+        return ModelResponse(role="assistant", content="done", response_usage=MessageMetrics())
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield self._next()
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        yield self._next()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+
+@tool(requires_confirmation=True)
+def probe(run_context: Optional[RunContext] = None) -> str:
+    CAPTURE["tool_user_id"] = getattr(run_context, "user_id", None) if run_context else None
+    return f"probe_user={CAPTURE['tool_user_id']!r}"
+
+
+def test_resolve_continue_user_id_prefers_paused_then_workflow() -> None:
+    paused = type("Paused", (), {"user_id": "from-paused"})()
+    workflow = type("WorkflowRun", (), {"user_id": "from-workflow"})()
+    assert _resolve_continue_user_id(paused, workflow) == "from-paused"
+
+    paused_missing = type("Paused", (), {"user_id": None})()
+    assert _resolve_continue_user_id(paused_missing, workflow) == "from-workflow"
+
+
+def test_agent_continue_run_restores_user_id_after_confirmation(tmp_path: Path) -> None:
+    CAPTURE.clear()
+    agent = Agent(
+        name="ProbeAgent",
+        model=ToolCallThenDoneModel(),
+        tools=[probe],
+        db=SqliteDb(db_file=str(tmp_path / "agent.db")),
+        telemetry=False,
+    )
+
+    paused = agent.run("go", user_id="user-from-run")
+    assert paused.is_paused
+    assert paused.user_id == "user-from-run"
+
+    for req in paused.active_requirements or []:
+        req.confirm()
+
+    # Intentionally omit user_id= — identity must come from paused.run_response.
+    continued = agent.continue_run(run_response=paused)
+    assert not continued.is_paused
+    assert CAPTURE.get("tool_user_id") == "user-from-run"
+
+
+@pytest.mark.asyncio
+async def test_agent_acontinue_run_restores_user_id_after_confirmation(tmp_path: Path) -> None:
+    CAPTURE.clear()
+    agent = Agent(
+        name="ProbeAgentAsync",
+        model=ToolCallThenDoneModel(),
+        tools=[probe],
+        db=SqliteDb(db_file=str(tmp_path / "agent_async.db")),
+        telemetry=False,
+    )
+
+    paused = await agent.arun("go", user_id="user-from-arun")
+    assert paused.is_paused
+    assert paused.user_id == "user-from-arun"
+
+    for req in paused.active_requirements or []:
+        req.confirm()
+
+    continued = await agent.acontinue_run(run_response=paused)
+    assert not continued.is_paused
+    assert CAPTURE.get("tool_user_id") == "user-from-arun"
+
+
+def test_workflow_executor_hitl_continue_preserves_user_id(tmp_path: Path) -> None:
+    CAPTURE.clear()
+    db = SqliteDb(db_file=str(tmp_path / "workflow.db"))
+    agent = Agent(
+        name="ProbeAgent2",
+        model=ToolCallThenDoneModel(),
+        tools=[probe],
+        db=db,
+        telemetry=False,
+    )
+    wf = Workflow(
+        name="ProbeWorkflow",
+        db=db,
+        steps=[Step(name="probe_step", agent=agent)],
+        telemetry=False,
+    )
+
+    paused_wf = wf.run(input="go", user_id="user-from-workflow")
+    assert paused_wf.is_paused
+    assert paused_wf.user_id == "user-from-workflow"
+    assert paused_wf.step_requirements
+
+    req = paused_wf.step_requirements[-1]
+    for executor_req in req.executor_requirements or []:
+        if isinstance(executor_req, dict):
+            executor_req["confirmation"] = True
+            te = executor_req.get("tool_execution")
+            if isinstance(te, dict):
+                te["confirmed"] = True
+        else:
+            executor_req.confirm()
+
+    continued = wf.continue_run(paused_wf)
+    assert not continued.is_paused
+    assert CAPTURE.get("tool_user_id") == "user-from-workflow"
+
+
+def test_workflow_continue_forwards_user_id_when_paused_executor_lacks_it() -> None:
+    """Even if nested RunOutput.user_id is missing, workflow identity is forwarded."""
+    paused = type("Paused", (), {"user_id": None})()
+    workflow_run = WorkflowRunOutput(
+        run_id="wf-run",
+        workflow_id="wf",
+        workflow_name="wf",
+        session_id="s1",
+        user_id="wf-user",
+    )
+    assert _resolve_continue_user_id(paused, workflow_run) == "wf-user"


### PR DESCRIPTION
## Summary

After HITL confirmation, `continue_run` / `acontinue_run` no longer drop `RunContext.user_id` when the caller omits an explicit `user_id=` argument.

Previously, Agent/Team continue dispatch only fell back to `agent.user_id` / `team.user_id`, and Workflow executor HITL routing called `continue_run` without forwarding identity. Confirmed tools then saw `run_context.user_id is None`, breaking auth/tenancy checks that depend on the original run's user.

This change:
- Restores `user_id` from the paused `RunOutput` / `TeamRunOutput` in Agent and Team continue dispatch (sync + async)
- Forwards `user_id` from the paused executor run (falling back to the workflow run) in all Workflow `_route_executor_requirements*` paths
- Adds offline regression coverage for Agent continue, Agent acontinue, and Workflow executor HITL continue

Fixes: #9288

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Files changed
- `libs/agno/agno/agent/_run.py` — restore `user_id` from paused run in `continue_run_dispatch` / `acontinue_run_dispatch` (and from loaded run when continuing by `run_id`)
- `libs/agno/agno/team/_run.py` — same restore for Team continue dispatch (sync + async)
- `libs/agno/agno/workflow/workflow.py` — `_resolve_continue_user_id` helper; forward `user_id` in all four executor HITL route methods
- `libs/agno/tests/unit/agent/test_continue_run_user_id_hitl.py` — regression tests (mock model, no network)

### Validation
- `python -m ruff format` / `python -m ruff check` on touched files — passed
- `python -m pytest libs/agno/tests/unit/agent/test_continue_run_user_id_hitl.py -q` — **5 passed**
- `python -m pytest libs/agno/tests/unit/agent/test_unified_continue.py libs/agno/tests/unit/team/test_continue_run_requirements.py libs/agno/tests/unit/workflow/test_executor_hitl.py -q` — **166 passed**
- Full `./scripts/format.sh` and `./scripts/validate.sh` were not run end-to-end on Windows for this change; targeted ruff + focused pytest coverage was used instead. Leave the full format/validation checklist item unchecked until those scripts are run in the usual environment.