### PR TITLE
fix: support multiple WorkflowTools on one Agent with unique tool names

### DIFF
--- a/libs/agno/agno/tools/workflow.py
+++ b/libs/agno/agno/tools/workflow.py
@@ -1,4 +1,5 @@
 import json
+import re
 from textwrap import dedent
 from typing import Any, Dict, Optional
 
@@ -15,7 +16,27 @@ class RunWorkflowInput(BaseModel):
     additional_data: Optional[Dict[str, Any]] = Field(default=None, description="The additional data for the workflow.")
 
 
+def _sanitize_tool_name_component(value: str) -> str:
+    """Turn a workflow id/name into a tool-name-safe component."""
+    cleaned = re.sub(r"[^0-9A-Za-z_]+", "_", value.strip())
+    cleaned = re.sub(r"_+", "_", cleaned).strip("_").lower()
+    if cleaned and cleaned[0].isdigit():
+        cleaned = f"wf_{cleaned}"
+    return cleaned or "workflow"
+
+
 class WorkflowTools(Toolkit):
+    """Toolkit that exposes a Workflow as agent tools.
+
+    By default tool names stay ``run_workflow`` / ``think`` / ``analyze`` for
+    backward compatibility. To attach multiple ``WorkflowTools`` to one Agent or
+    Team without collisions, use one of:
+
+    - ``unique=True`` — auto-suffix from ``workflow.id`` or ``workflow.name``
+    - ``name_prefix="blog"`` — ``run_workflow_blog``, ``think_blog``, ...
+    - ``tool_name="run_blog_workflow"`` — explicit run-tool override
+    """
+
     def __init__(
         self,
         workflow: Workflow,
@@ -28,22 +49,65 @@ class WorkflowTools(Toolkit):
         add_few_shot: bool = False,
         few_shot_examples: Optional[str] = None,
         async_mode: bool = False,
+        tool_name: Optional[str] = None,
+        name_prefix: Optional[str] = None,
+        unique: bool = False,
         **kwargs,
     ):
-        # Add instructions for using this toolkit
-        if instructions is None:
-            self.instructions = self.DEFAULT_INSTRUCTIONS
-            if add_few_shot:
-                if few_shot_examples is not None:
-                    self.instructions += "\n" + few_shot_examples
-        else:
-            self.instructions = instructions
+        """Initialize WorkflowTools.
 
+        Args:
+            workflow: The workflow to expose as tools.
+            enable_run_workflow: Register the run tool.
+            enable_think: Register the think scratchpad tool.
+            enable_analyze: Register the analyze tool.
+            all: Enable run, think, and analyze.
+            instructions: Optional custom toolkit instructions.
+            add_instructions: Whether to add toolkit instructions to the agent.
+            add_few_shot: Append few-shot examples to default instructions.
+            few_shot_examples: Few-shot examples to append when ``add_few_shot`` is True.
+            async_mode: Register async entrypoints.
+            tool_name: Explicit name for the run tool (overrides the default / prefixed name).
+            name_prefix: Prefix/suffix component for run/think/analyze tool names.
+            unique: When True (and ``name_prefix`` is omitted), derive a name prefix from
+                ``workflow.id`` or ``workflow.name`` so multiple toolkits do not collide.
+            **kwargs: Forwarded to ``Toolkit``.
+        """
         # The workflow to execute
         self.workflow: Workflow = workflow
 
+        # Resolve tool names. Defaults stay `run_workflow` / `think` / `analyze` for
+        # backward compatibility. Use `tool_name`, `name_prefix`, or `unique=True`
+        # so multiple WorkflowTools can coexist on one Agent/Team.
+        prefix = name_prefix
+        if unique and not prefix:
+            prefix = workflow.id or workflow.name or "workflow"
+        if prefix:
+            prefix = _sanitize_tool_name_component(prefix)
+
+        self.name_prefix: Optional[str] = prefix
+        self.run_tool_name: str = tool_name or (f"run_workflow_{prefix}" if prefix else "run_workflow")
+        self.think_tool_name: str = f"think_{prefix}" if prefix else "think"
+        self.analyze_tool_name: str = f"analyze_{prefix}" if prefix else "analyze"
+
+        if instructions is None:
+            self.instructions = self._default_instructions(
+                run_name=self.run_tool_name,
+                think_name=self.think_tool_name,
+                analyze_name=self.analyze_tool_name,
+                workflow=workflow,
+            )
+            if add_few_shot and few_shot_examples is not None:
+                self.instructions += "\n" + few_shot_examples
+        else:
+            self.instructions = instructions
+
+        toolkit_name = f"workflow_tools_{prefix}" if prefix else kwargs.pop("name", "workflow_tools")
+        if prefix:
+            kwargs.pop("name", None)
+
         super().__init__(
-            name="workflow_tools",
+            name=toolkit_name,
             instructions=self.instructions,
             add_instructions=add_instructions,
             auto_register=False,
@@ -52,19 +116,112 @@ class WorkflowTools(Toolkit):
 
         if enable_think or all:
             if async_mode:
-                self.register(self.async_think, name="think")
+                self.register(self.async_think, name=self.think_tool_name)
             else:
-                self.register(self.think, name="think")
+                self.register(self.think, name=self.think_tool_name)
+            self._set_tool_description(
+                self.think_tool_name,
+                self._think_description(workflow=workflow, tool_name=self.think_tool_name),
+            )
         if enable_run_workflow or all:
             if async_mode:
-                self.register(self.async_run_workflow, name="run_workflow")
+                self.register(self.async_run_workflow, name=self.run_tool_name)
             else:
-                self.register(self.run_workflow, name="run_workflow")
+                self.register(self.run_workflow, name=self.run_tool_name)
+            self._set_tool_description(
+                self.run_tool_name,
+                self._run_description(workflow=workflow, tool_name=self.run_tool_name),
+            )
         if enable_analyze or all:
             if async_mode:
-                self.register(self.async_analyze, name="analyze")
+                self.register(self.async_analyze, name=self.analyze_tool_name)
             else:
-                self.register(self.analyze, name="analyze")
+                self.register(self.analyze, name=self.analyze_tool_name)
+            self._set_tool_description(
+                self.analyze_tool_name,
+                self._analyze_description(workflow=workflow, tool_name=self.analyze_tool_name),
+            )
+
+    def _set_tool_description(self, name: str, description: str) -> None:
+        fn = self.functions.get(name) or self.async_functions.get(name)
+        if fn is not None:
+            fn.description = description
+
+    @staticmethod
+    def _workflow_label(workflow: Workflow) -> str:
+        return workflow.name or workflow.id or "workflow"
+
+    @classmethod
+    def _run_description(cls, workflow: Workflow, tool_name: str) -> str:
+        label = cls._workflow_label(workflow)
+        parts = [
+            f"Execute the '{label}' workflow via `{tool_name}`.",
+        ]
+        if workflow.id:
+            parts.append(f"Workflow id: {workflow.id}.")
+        if workflow.description:
+            desc = workflow.description.strip()
+            if not desc.endswith("."):
+                desc += "."
+            parts.append(desc)
+        parts.append("Pass input_data and optional additional_data.")
+        return " ".join(parts)
+
+    @classmethod
+    def _think_description(cls, workflow: Workflow, tool_name: str) -> str:
+        label = cls._workflow_label(workflow)
+        return (
+            f"Scratchpad (`{tool_name}`) for planning execution of the '{label}' workflow: "
+            "brainstorm inputs, refine approach, or decide strategy. Notes are not shown to the user."
+        )
+
+    @classmethod
+    def _analyze_description(cls, workflow: Workflow, tool_name: str) -> str:
+        label = cls._workflow_label(workflow)
+        return (
+            f"Evaluate (`{tool_name}`) whether results from the '{label}' workflow are correct and sufficient. "
+            "If not, go back to think or run with refined inputs."
+        )
+
+    @classmethod
+    def _default_instructions(
+        cls,
+        run_name: str,
+        think_name: str,
+        analyze_name: str,
+        workflow: Workflow,
+    ) -> str:
+        label = cls._workflow_label(workflow)
+        identity = f"'{label}'"
+        if workflow.id and workflow.name and workflow.id != workflow.name:
+            identity = f"'{workflow.name}' (id={workflow.id})"
+        elif workflow.id and not workflow.name:
+            identity = f"id={workflow.id}"
+
+        return dedent(f"""\
+            You have access to tools for the {identity} workflow. Use these tools as frequently as needed to complete workflow-based tasks.
+            ## How to use the Think, Run Workflow, and Analyze tools:
+
+            1. **Think** (`{think_name}`)
+            - Purpose: A scratchpad for planning workflow execution, brainstorming inputs, and refining your approach. You never reveal your "Think" content to the user.
+            - Usage: Call `{think_name}` whenever you need to figure out what workflow inputs to use, analyze requirements, or decide on execution strategy before (or after) you run the workflow.
+            2. **Run Workflow** (`{run_name}`)
+            - Purpose: Executes the {identity} workflow with specified inputs and parameters.
+            - Usage: Call `{run_name}` with appropriate input data whenever you want to execute this workflow.
+                - For all workflows, start with simple inputs and gradually increase complexity
+            3. **Analyze** (`{analyze_name}`)
+            - Purpose: Evaluate whether the workflow execution results are correct and sufficient. If not, go back to "Think" or "Run Workflow" with refined inputs.
+            - Usage: Call `{analyze_name}` after getting workflow results to verify the quality and correctness of the execution. Consider:
+                - Completeness: Did the workflow complete all expected steps?
+                - Quality: Are the results accurate and meet the requirements?
+                - Errors: Were there any failures or unexpected behaviors?
+            **Important Guidelines**:
+            - Do not include your internal chain-of-thought in direct user responses.
+            - Use "Think" to reason internally. These notes are never exposed to the user.
+            - When you provide a final answer to the user, be clear, concise, and based on the workflow results.
+            - If workflow execution fails or produces unexpected results, acknowledge limitations and explain what went wrong.
+            - Synthesize information from multiple workflow runs if you execute the workflow several times with different inputs.\
+        """)
 
     def think(self, run_context: RunContext, thought: str) -> str:
         """Use this tool as a scratchpad to reason about the workflow execution, refine your approach, brainstorm workflow inputs, or revise your plan.
@@ -259,28 +416,3 @@ class WorkflowTools(Toolkit):
         except Exception as e:
             log_error(f"Error recording workflow analysis: {str(e)}")
             return f"Error recording workflow analysis: {e}"
-
-    DEFAULT_INSTRUCTIONS = dedent("""\
-        You have access to the Think, Run Workflow, and Analyze tools that will help you execute workflows and analyze their results. Use these tools as frequently as needed to successfully complete workflow-based tasks.
-        ## How to use the Think, Run Workflow, and Analyze tools:
-
-        1. **Think**
-        - Purpose: A scratchpad for planning workflow execution, brainstorming inputs, and refining your approach. You never reveal your "Think" content to the user.
-        - Usage: Call `think` whenever you need to figure out what workflow inputs to use, analyze requirements, or decide on execution strategy before (or after) you run the workflow.
-        2. **Run Workflow**
-        - Purpose: Executes the workflow with specified inputs and parameters.
-        - Usage: Call `run_workflow` with appropriate input data whenever you want to execute the workflow.
-            - For all workflows, start with simple inputs and gradually increase complexity
-        3. **Analyze**
-        - Purpose: Evaluate whether the workflow execution results are correct and sufficient. If not, go back to "Think" or "Run Workflow" with refined inputs.
-        - Usage: Call `analyze` after getting workflow results to verify the quality and correctness of the execution. Consider:
-            - Completeness: Did the workflow complete all expected steps?
-            - Quality: Are the results accurate and meet the requirements?
-            - Errors: Were there any failures or unexpected behaviors?
-        **Important Guidelines**:
-        - Do not include your internal chain-of-thought in direct user responses.
-        - Use "Think" to reason internally. These notes are never exposed to the user.
-        - When you provide a final answer to the user, be clear, concise, and based on the workflow results.
-        - If workflow execution fails or produces unexpected results, acknowledge limitations and explain what went wrong.
-        - Synthesize information from multiple workflow runs if you execute the workflow several times with different inputs.\
-    """)

--- a/libs/agno/tests/unit/tools/test_workflow_tools.py
+++ b/libs/agno/tests/unit/tools/test_workflow_tools.py
@@ -1,0 +1,154 @@
+"""Tests for WorkflowTools unique naming across multiple toolkit instances."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.agent._tools import parse_tools
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.run.base import RunContext
+from agno.tools.workflow import WorkflowTools, _sanitize_tool_name_component
+from agno.workflow.types import StepInput, StepOutput
+from agno.workflow.workflow import Workflow
+
+
+def _step(prefix: str):
+    def _inner(step_input: StepInput) -> StepOutput:
+        return StepOutput(content=f"{prefix}:{step_input.input}")
+
+    return _inner
+
+
+def _workflow(tmp_path: Path, *, name: str, workflow_id: str) -> Workflow:
+    return Workflow(
+        name=name,
+        id=workflow_id,
+        description=f"Description for {name}",
+        db=SqliteDb(db_file=str(tmp_path / f"{workflow_id}.db")),
+        steps=[_step(name)],
+        telemetry=False,
+    )
+
+
+def test_sanitize_tool_name_component() -> None:
+    assert _sanitize_tool_name_component("Blog Workflow") == "blog_workflow"
+    assert _sanitize_tool_name_component("wf-blog") == "wf_blog"
+    assert _sanitize_tool_name_component("123-start") == "wf_123_start"
+    assert _sanitize_tool_name_component("___") == "workflow"
+
+
+def test_default_names_remain_backward_compatible(tmp_path: Path) -> None:
+    wf = _workflow(tmp_path, name="BlogWorkflow", workflow_id="wf-blog")
+    tools = WorkflowTools(workflow=wf, enable_think=True, enable_analyze=True)
+
+    assert tools.run_tool_name == "run_workflow"
+    assert tools.think_tool_name == "think"
+    assert tools.analyze_tool_name == "analyze"
+    assert set(tools.functions) == {"run_workflow", "think", "analyze"}
+    assert tools.name == "workflow_tools"
+
+
+def test_tool_name_override(tmp_path: Path) -> None:
+    wf = _workflow(tmp_path, name="BlogWorkflow", workflow_id="wf-blog")
+    tools = WorkflowTools(workflow=wf, tool_name="run_blog_workflow")
+
+    assert tools.run_tool_name == "run_blog_workflow"
+    assert "run_blog_workflow" in tools.functions
+    assert "run_workflow" not in tools.functions
+    assert "BlogWorkflow" in (tools.functions["run_blog_workflow"].description or "")
+
+
+def test_name_prefix_applies_to_all_tools(tmp_path: Path) -> None:
+    wf = _workflow(tmp_path, name="BlogWorkflow", workflow_id="wf-blog")
+    tools = WorkflowTools(
+        workflow=wf,
+        name_prefix="blog",
+        enable_think=True,
+        enable_analyze=True,
+    )
+
+    assert tools.run_tool_name == "run_workflow_blog"
+    assert tools.think_tool_name == "think_blog"
+    assert tools.analyze_tool_name == "analyze_blog"
+    assert set(tools.functions) == {"run_workflow_blog", "think_blog", "analyze_blog"}
+    assert tools.name == "workflow_tools_blog"
+
+
+def test_unique_derives_prefix_from_workflow_id(tmp_path: Path) -> None:
+    wf = _workflow(tmp_path, name="BlogWorkflow", workflow_id="wf-blog")
+    tools = WorkflowTools(workflow=wf, unique=True, enable_think=True)
+
+    assert tools.run_tool_name == "run_workflow_wf_blog"
+    assert tools.think_tool_name == "think_wf_blog"
+    assert "wf-blog" in (tools.functions["run_workflow_wf_blog"].description or "")
+
+
+def test_multiple_workflow_tools_parse_without_collision(tmp_path: Path) -> None:
+    wf_blog = _workflow(tmp_path, name="BlogWorkflow", workflow_id="wf-blog")
+    wf_weather = _workflow(tmp_path, name="WeatherWorkflow", workflow_id="wf-weather")
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[
+            WorkflowTools(workflow=wf_blog, unique=True),
+            WorkflowTools(workflow=wf_weather, unique=True),
+        ],
+        telemetry=False,
+    )
+
+    rc = RunContext(run_id="r1", session_id="s1", user_id="u1")
+    parsed = parse_tools(agent=agent, tools=list(agent.tools or []), model=agent.model, run_context=rc)
+    names = sorted(t.name for t in parsed)
+
+    assert names == ["run_workflow_wf_blog", "run_workflow_wf_weather"]
+
+    blog_tools, weather_tools = agent.tools  # type: ignore[misc]
+    assert isinstance(blog_tools, WorkflowTools)
+    assert isinstance(weather_tools, WorkflowTools)
+    assert blog_tools.workflow.id == "wf-blog"
+    assert weather_tools.workflow.id == "wf-weather"
+    assert blog_tools.run_tool_name == "run_workflow_wf_blog"
+    assert weather_tools.run_tool_name == "run_workflow_wf_weather"
+    assert "BlogWorkflow" in (blog_tools.functions["run_workflow_wf_blog"].description or "")
+    assert "WeatherWorkflow" in (weather_tools.functions["run_workflow_wf_weather"].description or "")
+
+
+def test_multiple_workflow_tools_with_explicit_tool_names(tmp_path: Path) -> None:
+    wf_blog = _workflow(tmp_path, name="BlogWorkflow", workflow_id="wf-blog")
+    wf_weather = _workflow(tmp_path, name="WeatherWorkflow", workflow_id="wf-weather")
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[
+            WorkflowTools(workflow=wf_blog, tool_name="run_blog_workflow"),
+            WorkflowTools(workflow=wf_weather, tool_name="run_weather_workflow"),
+        ],
+        telemetry=False,
+    )
+
+    rc = RunContext(run_id="r1", session_id="s1", user_id="u1")
+    parsed = parse_tools(agent=agent, tools=list(agent.tools or []), model=agent.model, run_context=rc)
+    names = sorted(t.name for t in parsed)
+
+    assert names == ["run_blog_workflow", "run_weather_workflow"]
+
+
+def test_duplicate_default_names_still_collide(tmp_path: Path) -> None:
+    """Without unique/tool_name/name_prefix, the historical collision remains."""
+    wf_blog = _workflow(tmp_path, name="BlogWorkflow", workflow_id="wf-blog")
+    wf_weather = _workflow(tmp_path, name="WeatherWorkflow", workflow_id="wf-weather")
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[
+            WorkflowTools(workflow=wf_blog),
+            WorkflowTools(workflow=wf_weather),
+        ],
+        telemetry=False,
+    )
+
+    rc = RunContext(run_id="r1", session_id="s1", user_id="u1")
+    parsed = parse_tools(agent=agent, tools=list(agent.tools or []), model=agent.model, run_context=rc)
+    assert [t.name for t in parsed] == ["run_workflow"]


### PR DESCRIPTION
## Summary

`WorkflowTools` always registered fixed tool names (`run_workflow`, and optionally `think` / `analyze`), so attaching more than one instance to an Agent/Team caused Agno to skip duplicates. Orchestrator agents could not choose among multiple workflows via tools.

This change adds first-class naming controls while keeping the default `run_workflow` / `think` / `analyze` names for backward compatibility:

- `unique=True` — auto-suffix from `workflow.id` or `workflow.name`
- `name_prefix="blog"` — `run_workflow_blog`, `think_blog`, `analyze_blog`
- `tool_name="run_blog_workflow"` — explicit run-tool override

Tool descriptions and default toolkit instructions now include the workflow identity and the resolved tool names so the model can tell workflows apart.

Example:

    Agent(
        tools=[
            WorkflowTools(workflow=wf_blog, unique=True),
            WorkflowTools(workflow=wf_weather, unique=True),
        ]
    )
    # -> run_workflow_wf_blog, run_workflow_wf_weather

Fixes https://github.com/agno-agi/agno/issues/9293

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Files changed

- `libs/agno/agno/tools/workflow.py` — `tool_name` / `name_prefix` / `unique` naming, richer descriptions + instructions
- `libs/agno/tests/unit/tools/test_workflow_tools.py` — unit coverage for naming, multi-toolkit parse_tools, and backward-compatible defaults

### Validation

- `python -m ruff check` / `ruff format --check` on touched files — passed
- `python -m pytest libs/agno/tests/unit/tools/test_workflow_tools.py -q` — 8 passed
- Full `./scripts/format.sh` and `./scripts/validate.sh` were not run end-to-end on Windows for this change; targeted ruff + focused pytest were used instead

### Design note

Defaults remain `run_workflow` / `think` / `analyze` so existing cookbooks and prompts keep working. Multi-workflow agents should pass `unique=True` or explicit `tool_name` / `name_prefix`.