### PR TITLE
fix: data-integrity fixes for v3 session denormalization

### DIFF
--- a/libs/agno/agno/db/firestore/firestore.py
+++ b/libs/agno/agno/db/firestore/firestore.py
@@ -593,13 +593,22 @@ class FirestoreDb(BaseDb):
             for doc in docs:
                 doc.reference.delete()
 
-                # Cascade-delete the session's runs
+                # Cascade-delete the session's runs, chunked to Firestore's
+                # 500-op-per-commit limit so sessions with many runs don't blow
+                # the batch (mirrors delete_sessions).
                 if runs_collection_ref is not None:
                     runs_query = runs_collection_ref.where(filter=FieldFilter("session_id", "==", session_id))
                     batch = self.db_client.batch()
+                    in_batch = 0
                     for run_doc in runs_query.stream():
                         batch.delete(run_doc.reference)
-                    batch.commit()
+                        in_batch += 1
+                        if in_batch >= FIRESTORE_BATCH_LIMIT:
+                            batch.commit()
+                            batch = self.db_client.batch()
+                            in_batch = 0
+                    if in_batch > 0:
+                        batch.commit()
 
                 log_debug(f"Successfully deleted session with session_id: {session_id}")
                 return True

--- a/libs/agno/agno/db/migrations/versions/v3_0_0.py
+++ b/libs/agno/agno/db/migrations/versions/v3_0_0.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.db.migrations.utils import quote_db_identifier
 from agno.db.utils import CustomJSONEncoder
-from agno.utils.log import log_error, log_info
+from agno.utils.log import log_error, log_info, log_warning
 
 try:
     from sqlalchemy import text
@@ -1412,6 +1412,63 @@ def _revert_inmemorydb(db: BaseDb, table_name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
+# DynamoDB error codes that indicate a transient, retryable failure.
+_DYNAMO_THROTTLE_CODES = {
+    "ProvisionedThroughputExceededException",
+    "ThrottlingException",
+    "RequestLimitExceeded",
+    "InternalServerError",
+}
+
+
+def _dynamo_put_run_with_retry(
+    client,
+    table_name: str,
+    item: Dict[str, Any],
+    max_retries: int = 5,
+    initial_backoff_seconds: float = 0.1,
+) -> bool:
+    """Conditionally put a run item, retrying transient throttling failures.
+
+    The write is guarded by ``attribute_not_exists(run_id)`` so a run that was
+    already copied (e.g. by a partial/lazy self-migration) is left untouched --
+    keeping the migration idempotent and preserving the "store wins" invariant.
+
+    On throttling, retries with exponential backoff. Any non-throttling error,
+    or throttling that survives ``max_retries``, is propagated so a partial
+    migration fails loudly instead of silently dropping runs (the legacy blob is
+    lazily nulled on the next session write, so a silent skip means data loss).
+
+    Returns:
+        True if the item was written, False if it already existed.
+    """
+    backoff = initial_backoff_seconds
+    for attempt in range(max_retries + 1):
+        try:
+            client.put_item(
+                TableName=table_name,
+                Item=item,
+                ConditionExpression="attribute_not_exists(run_id)",
+            )
+            return True
+        except client.exceptions.ConditionalCheckFailedException:
+            return False
+        except Exception as e:
+            code = getattr(e, "response", {}).get("Error", {}).get("Code")
+            if code in _DYNAMO_THROTTLE_CODES and attempt < max_retries:
+                log_warning(
+                    f"Dynamo put_item throttled ({code}) migrating run "
+                    f"{item.get('run_id', {}).get('S')}; retry {attempt + 1}/{max_retries} "
+                    f"after {backoff:.2f}s"
+                )
+                time.sleep(backoff)
+                backoff = min(backoff * 2, 5.0)
+                continue
+            raise
+    # Unreachable: the final attempt above always returns or raises.
+    raise RuntimeError(f"Failed to migrate run into {table_name} after {max_retries} retries")
+
+
 def _migrate_dynamodb(db: BaseDb, table_name: str) -> bool:
     """Copy legacy `runs` blob from each session item into the agno_runs table."""
     import json as _json
@@ -1463,17 +1520,11 @@ def _migrate_dynamodb(db: BaseDb, table_name: str) -> bool:
             if "run_data" in payload and isinstance(payload["run_data"], (dict, list)):
                 payload["run_data"] = _json.dumps(payload["run_data"])
             dynamo_item = _serialize_to_dynamo_item_minimal(payload)
-            try:
-                client.put_item(
-                    TableName=runs_table,
-                    Item=dynamo_item,
-                    ConditionExpression="attribute_not_exists(run_id)",
-                )
+            # Propagates on non-transient failure so a partial migration aborts
+            # loudly rather than silently dropping runs. Safe to re-run (the
+            # conditional write skips already-migrated runs).
+            if _dynamo_put_run_with_retry(client, runs_table, dynamo_item):
                 migrated += 1
-            except client.exceptions.ConditionalCheckFailedException:
-                continue
-            except Exception as e:
-                log_error(f"Failed to migrate run {payload.get('run_id')}: {str(e)}")
 
     log_info(
         f"-- Copied {migrated} runs into {runs_table}. The legacy 'runs' attribute on each session item "

--- a/libs/agno/agno/db/migrations/versions/v3_0_0.py
+++ b/libs/agno/agno/db/migrations/versions/v3_0_0.py
@@ -1567,6 +1567,7 @@ def _revert_dynamodb(db: BaseDb, table_name: str) -> bool:
             continue
         runs_by_session.setdefault(sid, []).append((run_index, created_at, payload))
 
+    failed_sids: set = set()
     for sid, items_for_session in runs_by_session.items():
         items_for_session.sort(key=lambda t: (t[0], t[1]))
         legacy_runs = [t[2] for t in items_for_session]
@@ -1580,16 +1581,28 @@ def _revert_dynamodb(db: BaseDb, table_name: str) -> bool:
             )
         except Exception as e:
             log_error(f"Failed to revert runs onto session {sid}: {str(e)}")
+            failed_sids.add(sid)
 
-    # Best-effort: truncate the runs table
+    # Truncate the runs table, but preserve runs for any session whose blob
+    # rebuild failed -- deleting them would lose the only remaining copy.
+    preserved = 0
     for it in items:
         run_id = it.get("run_id", {}).get("S")
         if not run_id:
+            continue
+        if it.get("session_id", {}).get("S") in failed_sids:
+            preserved += 1
             continue
         try:
             client.delete_item(TableName=runs_table, Key={"run_id": {"S": run_id}})
         except Exception:
             pass
+
+    if failed_sids:
+        log_warning(
+            f"Preserved {preserved} run(s) in {runs_table} for {len(failed_sids)} session(s) whose "
+            "blob rebuild failed; re-run down() after resolving the error."
+        )
 
     return True
 
@@ -1684,6 +1697,7 @@ def _revert_surrealdb(db: BaseDb, table_name: str) -> bool:
         )
 
     sessions_table = table_name
+    failed_sids: set = set()
     for sid, items in runs_by_session.items():
         items.sort(key=lambda t: (t[0], t[1]))
         legacy_runs = [t[2] for t in items if t[2] is not None]
@@ -1694,9 +1708,34 @@ def _revert_surrealdb(db: BaseDb, table_name: str) -> bool:
             )
         except Exception as e:
             log_error(f"Failed to revert runs onto session {sid}: {str(e)}")
+            failed_sids.add(sid)
 
-    try:
-        db.client.delete(runs_table)  # type: ignore
-    except Exception:
-        pass
+    if not failed_sids:
+        # No failures: truncate the whole runs table.
+        try:
+            db.client.delete(runs_table)  # type: ignore
+        except Exception:
+            pass
+    else:
+        # Preserve runs for sessions whose blob rebuild failed -- deleting them
+        # would lose the only remaining copy. Delete the rest by record id.
+        preserved = 0
+        for r in rows_raw:
+            sid = r.get("session_id")
+            if isinstance(sid, RecordID):
+                sid = sid.id
+            if sid in failed_sids:
+                preserved += 1
+                continue
+            rid = r.get("id")
+            if rid is None:
+                continue
+            try:
+                db.client.delete(rid)  # type: ignore
+            except Exception:
+                pass
+        log_warning(
+            f"Preserved {preserved} run(s) in {runs_table} for {len(failed_sids)} session(s) whose "
+            "blob rebuild failed; re-run down() after resolving the error."
+        )
     return True

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -1,3 +1,4 @@
+import json
 import time
 from datetime import date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
@@ -523,7 +524,7 @@ class AsyncMySQLDb(AsyncBaseDb):
             .order_by(runs_table.c.run_index.asc(), runs_table.c.created_at.asc())
         )
         result = await sess.execute(stmt)
-        return [row[0] for row in result.fetchall()]
+        return [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in result.fetchall()]
 
     async def _get_sessions_runs_data(
         self, sess, runs_table: Table, session_ids: List[str]
@@ -539,6 +540,8 @@ class AsyncMySQLDb(AsyncBaseDb):
         result = await sess.execute(stmt)
         runs_by_session: Dict[str, List[Dict[str, Any]]] = {}
         for session_id, run_data in result.fetchall():
+            if isinstance(run_data, str):
+                run_data = json.loads(run_data)
             runs_by_session.setdefault(session_id, []).append(run_data)
         return runs_by_session
 

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -1,3 +1,4 @@
+import json
 import time
 from datetime import date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
@@ -521,7 +522,7 @@ class MySQLDb(BaseDb):
             .where(runs_table.c.session_id == session_id)
             .order_by(runs_table.c.run_index.asc(), runs_table.c.created_at.asc())
         )
-        return [row[0] for row in sess.execute(stmt).fetchall()]
+        return [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
 
     def _get_sessions_runs_data(
         self, sess, runs_table: Table, session_ids: List[str]
@@ -536,6 +537,8 @@ class MySQLDb(BaseDb):
         )
         runs_by_session: Dict[str, List[Dict[str, Any]]] = {}
         for session_id, run_data in sess.execute(stmt).fetchall():
+            if isinstance(run_data, str):
+                run_data = json.loads(run_data)
             runs_by_session.setdefault(session_id, []).append(run_data)
         return runs_by_session
 

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -597,7 +597,7 @@ class SingleStoreDb(BaseDb):
             .where(runs_table.c.session_id == session_id)
             .order_by(runs_table.c.run_index.asc(), runs_table.c.created_at.asc())
         )
-        return [row[0] for row in sess.execute(stmt).fetchall()]
+        return [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
 
     def _get_sessions_runs_data(
         self, sess, runs_table: Table, session_ids: List[str]
@@ -611,6 +611,8 @@ class SingleStoreDb(BaseDb):
         )
         runs_by_session: Dict[str, List[Dict[str, Any]]] = {}
         for session_id, run_data in sess.execute(stmt).fetchall():
+            if isinstance(run_data, str):
+                run_data = json.loads(run_data)
             runs_by_session.setdefault(session_id, []).append(run_data)
         return runs_by_session
 

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -159,6 +159,11 @@ def deserialize_run(run_type: Optional[str], run_data: Dict[str, Any]) -> Any:
     from agno.run.team import TeamRunOutput
     from agno.run.workflow import WorkflowRunOutput
 
+    # Some JSON columns (MySQL/SingleStore drivers, SQLite TEXT) hand back the
+    # payload as a str rather than a dict; normalize before dispatching.
+    if isinstance(run_data, str):
+        run_data = json.loads(run_data)
+
     if run_type is None:
         run_type = get_run_type(run_data)
     if run_type == "agent":

--- a/libs/agno/agno/session/agent.py
+++ b/libs/agno/agno/session/agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Mapping, Optional, Union
 
@@ -44,12 +45,12 @@ class AgentSession:
     updated_at: Optional[int] = None
 
     def to_dict(self, include_runs: bool = True) -> Dict[str, Any]:
-        # Exclude runs from asdict to avoid the deep serialization cost when not needed
-        runs, self.runs = self.runs, None
-        try:
-            session_dict = asdict(self)
-        finally:
-            self.runs = runs
+        # Exclude runs from asdict to avoid the deep serialization cost. Serialize
+        # a shallow copy so we never mutate a live (possibly shared/cached) session
+        # while another thread reads self.runs.
+        session_copy = copy.copy(self)
+        session_copy.runs = None
+        session_dict = asdict(session_copy)
 
         if include_runs:
             session_dict["runs"] = [run.to_dict() for run in self.runs] if self.runs else None

--- a/libs/agno/agno/session/team.py
+++ b/libs/agno/agno/session/team.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
@@ -43,12 +44,12 @@ class TeamSession:
     updated_at: Optional[int] = None
 
     def to_dict(self, include_runs: bool = True) -> Dict[str, Any]:
-        # Exclude runs from asdict to avoid the deep serialization cost when not needed
-        runs, self.runs = self.runs, None
-        try:
-            session_dict = asdict(self)
-        finally:
-            self.runs = runs
+        # Exclude runs from asdict to avoid the deep serialization cost. Serialize
+        # a shallow copy so we never mutate a live (possibly shared/cached) session
+        # while another thread reads self.runs.
+        session_copy = copy.copy(self)
+        session_copy.runs = None
+        session_dict = asdict(session_copy)
 
         if include_runs:
             session_dict["runs"] = [run.to_dict() for run in self.runs] if self.runs else None

--- a/libs/agno/tests/unit/db/test_deserialize_run_str_payload.py
+++ b/libs/agno/tests/unit/db/test_deserialize_run_str_payload.py
@@ -1,0 +1,32 @@
+"""Regression test: deserialize_run must tolerate a str run_data payload.
+
+MySQL/SingleStore JSON columns (and SQLite TEXT) can hand the run payload back
+as a JSON string rather than a dict, depending on the driver. ``deserialize_run``
+fed that straight into ``RunOutput.from_dict``, which breaks on a str. It now
+normalizes a str payload with ``json.loads`` first, so ``get_run``/``get_runs``
+work uniformly across adapters.
+"""
+
+from __future__ import annotations
+
+import json
+
+from agno.db.utils import deserialize_run
+
+
+class TestDeserializeRunStrPayload:
+    def test_str_payload_matches_dict_payload(self):
+        run = {"run_id": "r1", "agent_id": "a1", "status": "COMPLETED"}
+
+        from_str = deserialize_run("agent", json.dumps(run))
+        from_dict = deserialize_run("agent", run)
+
+        assert from_str.run_id == from_dict.run_id == "r1"
+
+    def test_str_payload_with_inferred_run_type(self):
+        # run_type=None forces get_run_type() to inspect the (parsed) payload.
+        run = {"run_id": "r1", "team_id": "t1"}
+
+        result = deserialize_run(None, json.dumps(run))
+
+        assert result.run_id == "r1"

--- a/libs/agno/tests/unit/db/test_firestore_batch_chunking.py
+++ b/libs/agno/tests/unit/db/test_firestore_batch_chunking.py
@@ -110,3 +110,71 @@ class TestDeleteRunsChunksAt500:
 
         # No batches created (loop never entered)
         assert len(batches) == 0
+
+
+class TestDeleteSessionCascadeChunksAt500:
+    """The single-session ``delete_session`` cascade also has to chunk its run
+    deletes -- the plural ``delete_sessions`` did, but ``delete_session`` staged
+    every run into one batch, so deleting a session with >500 runs (exactly the
+    long-lived sessions v3 targets) hit Firestore's INVALID_ARGUMENT.
+    """
+
+    def _setup(self, num_runs: int, db: FirestoreDb) -> list:
+        sessions_collection = MagicMock()
+        runs_collection = MagicMock()
+
+        def get_collection(table_type: str = "sessions", **kwargs):
+            return runs_collection if table_type == "runs" else sessions_collection
+
+        db._get_collection = MagicMock(side_effect=get_collection)  # type: ignore[method-assign]
+
+        # One session doc matches the delete query.
+        session_doc = MagicMock()
+        sessions_collection.where.return_value.stream.return_value = [session_doc]
+
+        # num_runs run docs cascade off it.
+        run_docs = [MagicMock() for _ in range(num_runs)]
+        runs_collection.where.return_value.stream.return_value = run_docs
+
+        batches: list = []
+
+        def new_batch():
+            b = MagicMock()
+            batches.append(b)
+            return b
+
+        db.db_client.batch.side_effect = new_batch
+        return batches
+
+    def test_501_runs_cascade_produces_two_commits(self):
+        db = _make_db_with_mock_client()
+        batches = self._setup(501, db)
+
+        assert db.delete_session("s1") is True
+
+        assert len(batches) == 2, f"expected 2 batches for 501 run deletes, got {len(batches)}"
+        assert batches[0].delete.call_count == 500
+        assert batches[1].delete.call_count == 1
+        assert batches[0].commit.call_count == 1
+        assert batches[1].commit.call_count == 1
+
+    def test_499_runs_cascade_produces_one_commit(self):
+        db = _make_db_with_mock_client()
+        batches = self._setup(499, db)
+
+        assert db.delete_session("s1") is True
+
+        assert len(batches) == 1
+        assert batches[0].delete.call_count == 499
+        assert batches[0].commit.call_count == 1
+
+    def test_zero_runs_cascade_commits_nothing(self):
+        db = _make_db_with_mock_client()
+        batches = self._setup(0, db)
+
+        assert db.delete_session("s1") is True
+
+        # An empty batch may be opened, but nothing is deleted or committed.
+        for b in batches:
+            assert b.delete.call_count == 0
+            assert b.commit.call_count == 0

--- a/libs/agno/tests/unit/db/test_v3_dynamo_migration_retry.py
+++ b/libs/agno/tests/unit/db/test_v3_dynamo_migration_retry.py
@@ -1,0 +1,135 @@
+"""Regression tests for the v3 DynamoDB migration's per-run write.
+
+The migration copies each legacy run into the runs table with a conditional
+``put_item``. The original code wrapped that put in ``except Exception: log``,
+so a throttled/transient failure silently skipped the run. The migration still
+returned success, and because the legacy ``runs`` blob is lazily nulled on the
+next session write, the skipped run was permanently lost.
+
+Fix: ``_dynamo_put_run_with_retry`` retries transient throttling with backoff
+and propagates any other error (or throttling that outlives the retry budget),
+so a partial migration aborts loudly. The conditional write keeps it idempotent
+and safe to re-run.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+try:
+    from agno.db.migrations.versions.v3_0_0 import _dynamo_put_run_with_retry, _migrate_dynamodb
+except ImportError:
+    _dynamo_put_run_with_retry = None  # type: ignore[assignment]
+    _migrate_dynamodb = None  # type: ignore[assignment]
+
+
+pytestmark = pytest.mark.skipif(_dynamo_put_run_with_retry is None, reason="sqlalchemy/boto3 not installed")
+
+
+class _CondCheckFailed(Exception):
+    """Stand-in for ``client.exceptions.ConditionalCheckFailedException``."""
+
+
+class _ClientError(Exception):
+    """botocore-style error exposing ``.response['Error']['Code']``."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+def _make_client() -> MagicMock:
+    client = MagicMock()
+    client.exceptions.ConditionalCheckFailedException = _CondCheckFailed
+    return client
+
+
+_ITEM = {"run_id": {"S": "r1"}}
+
+
+class TestDynamoPutRunWithRetry:
+    def test_returns_true_on_write(self):
+        client = _make_client()
+        assert _dynamo_put_run_with_retry(client, "runs", _ITEM) is True
+        assert client.put_item.call_count == 1
+
+    def test_returns_false_when_run_already_exists(self):
+        """A conditional-check failure means the run was already migrated -- skip
+        it (idempotent), don't count it, don't raise."""
+        client = _make_client()
+        client.put_item.side_effect = _CondCheckFailed()
+
+        assert _dynamo_put_run_with_retry(client, "runs", _ITEM) is False
+
+    def test_retries_throttling_then_succeeds(self):
+        client = _make_client()
+        client.put_item.side_effect = [
+            _ClientError("ProvisionedThroughputExceededException"),
+            _ClientError("ThrottlingException"),
+            None,  # third attempt succeeds
+        ]
+
+        with patch("agno.db.migrations.versions.v3_0_0.time.sleep"):
+            assert _dynamo_put_run_with_retry(client, "runs", _ITEM, initial_backoff_seconds=0) is True
+        assert client.put_item.call_count == 3
+
+    def test_propagates_non_throttling_error_immediately(self):
+        """A real error (e.g. ValidationException) must abort at once -- never
+        get swallowed into a silent skip."""
+        client = _make_client()
+        client.put_item.side_effect = _ClientError("ValidationException")
+
+        with pytest.raises(_ClientError):
+            _dynamo_put_run_with_retry(client, "runs", _ITEM, initial_backoff_seconds=0)
+        assert client.put_item.call_count == 1
+
+    def test_raises_when_throttling_outlives_retry_budget(self):
+        client = _make_client()
+        client.put_item.side_effect = _ClientError("ProvisionedThroughputExceededException")
+
+        with patch("agno.db.migrations.versions.v3_0_0.time.sleep"):
+            with pytest.raises(_ClientError):
+                _dynamo_put_run_with_retry(client, "runs", _ITEM, max_retries=2, initial_backoff_seconds=0)
+        # initial attempt + 2 retries
+        assert client.put_item.call_count == 3
+
+
+class TestMigrateDynamodbPropagates:
+    def _make_db(self, client: MagicMock) -> MagicMock:
+        db = MagicMock()
+        db.client = client
+        db.runs_table_name = "agno_runs"
+        db._get_table = MagicMock()
+        return db
+
+    def _session_item_with_one_run(self) -> dict:
+        import json
+
+        run = {"run_id": "r1", "agent_id": "a1", "status": "COMPLETED"}
+        return {
+            "session_id": {"S": "s1"},
+            "user_id": {"S": "u1"},
+            "runs": {"S": json.dumps([run])},
+        }
+
+    def test_persistent_throttling_aborts_migration(self):
+        """The whole point: a run that can't be written must NOT be silently
+        skipped with the migration reporting success."""
+        client = _make_client()
+        client.scan.return_value = {"Items": [self._session_item_with_one_run()]}
+        client.put_item.side_effect = _ClientError("ProvisionedThroughputExceededException")
+        db = self._make_db(client)
+
+        with patch("agno.db.migrations.versions.v3_0_0.time.sleep"):
+            with pytest.raises(_ClientError):
+                _migrate_dynamodb(db, "agno_sessions")
+
+    def test_successful_run_is_migrated(self):
+        client = _make_client()
+        client.scan.return_value = {"Items": [self._session_item_with_one_run()]}
+        db = self._make_db(client)
+
+        assert _migrate_dynamodb(db, "agno_sessions") is True
+        assert client.put_item.call_count == 1

--- a/libs/agno/tests/unit/db/test_v3_revert_atomicity.py
+++ b/libs/agno/tests/unit/db/test_v3_revert_atomicity.py
@@ -1,0 +1,73 @@
+"""Regression tests for v3 down-migration (revert) atomicity.
+
+The revert rebuilds the legacy ``runs`` blob on each session, then deletes the
+runs store. The original DynamoDB and SurrealDB reverts truncated the runs store
+*unconditionally* -- even for sessions whose blob rebuild failed. A throttled
+rebuild followed by the delete lost that session's runs entirely.
+
+Fix: track sessions whose rebuild failed and preserve their runs (skip the
+delete for them) so a partial revert never loses data and can be re-run.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    from agno.db.migrations.versions.v3_0_0 import _revert_dynamodb
+except ImportError:
+    _revert_dynamodb = None  # type: ignore[assignment]
+
+
+pytestmark = pytest.mark.skipif(_revert_dynamodb is None, reason="sqlalchemy not installed")
+
+
+def _run_item(run_id: str, session_id: str) -> dict:
+    return {
+        "run_id": {"S": run_id},
+        "session_id": {"S": session_id},
+        "run_index": {"N": "0"},
+        "created_at": {"N": "0"},
+        "run_data": {"S": json.dumps({"run_id": run_id})},
+    }
+
+
+class TestRevertDynamoPreservesRunsOnFailure:
+    def _make_db(self, client: MagicMock) -> MagicMock:
+        db = MagicMock()
+        db.client = client
+        db.runs_table_name = "agno_runs"
+        return db
+
+    def test_failed_session_rebuild_preserves_its_runs(self):
+        client = MagicMock()
+        client.scan.return_value = {"Items": [_run_item("r1", "s1"), _run_item("r2", "s2")]}
+
+        # Rebuild succeeds for s1, throttles for s2.
+        def update_item(**kwargs):
+            if kwargs["Key"]["session_id"]["S"] == "s2":
+                raise Exception("ProvisionedThroughputExceededException")
+            return {}
+
+        client.update_item.side_effect = update_item
+        db = self._make_db(client)
+
+        assert _revert_dynamodb(db, "agno_sessions") is True
+
+        deleted = {c.kwargs["Key"]["run_id"]["S"] for c in client.delete_item.call_args_list}
+        assert "r1" in deleted, "successfully-reverted session's runs should be deleted"
+        assert "r2" not in deleted, "failed session's runs must be preserved, not deleted"
+
+    def test_all_success_deletes_everything(self):
+        client = MagicMock()
+        client.scan.return_value = {"Items": [_run_item("r1", "s1"), _run_item("r2", "s2")]}
+        client.update_item.return_value = {}
+        db = self._make_db(client)
+
+        assert _revert_dynamodb(db, "agno_sessions") is True
+
+        deleted = {c.kwargs["Key"]["run_id"]["S"] for c in client.delete_item.call_args_list}
+        assert deleted == {"r1", "r2"}

--- a/libs/agno/tests/unit/session/test_to_dict_no_mutation.py
+++ b/libs/agno/tests/unit/session/test_to_dict_no_mutation.py
@@ -1,0 +1,68 @@
+"""Regression tests: Session.to_dict(include_runs=False) must not mutate self.
+
+The runs-denormalization work made adapters call ``to_dict(include_runs=False)``
+to skip the deep run serialization when writing the session row. The first
+implementation excluded runs by temporarily nulling ``self.runs`` during
+``asdict(self)`` -- a live, possibly shared/cached session object. A concurrent
+reader on another thread could observe ``session.runs is None`` mid-serialize.
+The fix serializes a shallow copy, so ``self`` is never mutated.
+"""
+
+from __future__ import annotations
+
+from agno.session.agent import AgentSession
+from agno.session.team import TeamSession
+
+
+class _FakeRun:
+    def __init__(self, run_id: str):
+        self.run_id = run_id
+
+    def to_dict(self) -> dict:
+        return {"run_id": self.run_id}
+
+
+class TestAgentSessionToDict:
+    def test_include_runs_false_does_not_mutate_self(self):
+        runs = [_FakeRun("r1"), _FakeRun("r2")]
+        session = AgentSession(session_id="s1", runs=runs)
+
+        result = session.to_dict(include_runs=False)
+
+        # self.runs must be the exact same object, untouched.
+        assert session.runs is runs
+        assert "runs" not in result
+
+    def test_include_runs_true_preserves_self_and_serializes(self):
+        runs = [_FakeRun("r1")]
+        session = AgentSession(session_id="s1", runs=runs)
+
+        result = session.to_dict(include_runs=True)
+
+        assert session.runs is runs
+        assert result["runs"] == [{"run_id": "r1"}]
+
+    def test_no_runs_is_fine(self):
+        session = AgentSession(session_id="s1")
+        assert session.to_dict(include_runs=False).get("runs") is None
+        assert session.to_dict(include_runs=True)["runs"] is None
+
+
+class TestTeamSessionToDict:
+    def test_include_runs_false_does_not_mutate_self(self):
+        runs = [_FakeRun("r1"), _FakeRun("r2")]
+        session = TeamSession(session_id="s1", runs=runs)
+
+        result = session.to_dict(include_runs=False)
+
+        assert session.runs is runs
+        assert "runs" not in result
+
+    def test_include_runs_true_preserves_self_and_serializes(self):
+        runs = [_FakeRun("r1")]
+        session = TeamSession(session_id="s1", runs=runs)
+
+        result = session.to_dict(include_runs=True)
+
+        assert session.runs is runs
+        assert result["runs"] == [{"run_id": "r1"}]


### PR DESCRIPTION
## Summary

Data-integrity fixes on top of the session-denormalization branch (#8350).
Five fixes total — two blockers (data loss / hard failure) and three MED
issues surfaced in review.

### Blockers

**1. DynamoDB v3 migration silently dropped runs on throttling.**
`_migrate_dynamodb` copied each run with a per-row `put_item` wrapped in
`except Exception: log`. A throttled write was swallowed (run skipped) while the
migration still reported success. Because the legacy `runs` blob is lazily
nulled on the next `upsert_session` (Dynamo `put_item` replaces the whole item),
the skipped run's only remaining copy was erased → permanent loss. Now routed
through `_dynamo_put_run_with_retry`: exponential-backoff retry on throttling,
propagate anything else so a partial migration aborts loudly. The write stays
conditional (`attribute_not_exists(run_id)`), so re-running is idempotent.

**2. Firestore `delete_session` cascade exceeded the 500-op batch limit.**
The singular path staged the whole run cascade into one batch (the plural
`delete_sessions` already chunked). A session with >500 runs hit
`INVALID_ARGUMENT`. Now chunked at `FIRESTORE_BATCH_LIMIT`.

### MED

**3. Revert (down-migration) atomicity — data loss on partial failure.**
`_revert_dynamodb` and `_revert_surrealdb` truncated the runs store
unconditionally, even for sessions whose legacy-blob rebuild failed
(throttling/transient) — that session's runs were the only remaining copy and
got deleted. Now they track failed sessions and preserve those runs (skip the
delete), logging a warning to re-run `down()`. Firestore already aborted before
the delete on a failed rebuild, so it was already safe.

**4. MySQL/SingleStore returned str `run_data` breaking `get_run`/`get_runs`.**
Their JSON drivers can hand the payload back as a str, which `deserialize_run`
fed straight to `from_dict`. SQLite already guarded this; MySQL/SingleStore did
not. Normalized centrally in `deserialize_run` (covers `get_run`/`get_runs` for
all adapters) plus the raw run-data helpers, matching the SQLite pattern.

**5. `Session.to_dict(include_runs=False)` mutated a live session.**
It temporarily nulled `self.runs` during `asdict()` on a possibly shared/cached
session — a concurrent reader on another thread could observe `runs=None`
mid-serialize. Now serializes a shallow copy, so `self` is never mutated
(mirrors `WorkflowSession`).

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Targets `feat/denormalize-sessions-table`, not `main`.
- Tests: `test_v3_dynamo_migration_retry.py`, `test_v3_revert_atomicity.py`,
  `test_deserialize_run_str_payload.py`, `test_to_dict_no_mutation.py` (new),
  and a `delete_session` cascade class added to `test_firestore_batch_chunking.py`.
- Verified against the full `libs/agno/tests/unit/db` + `unit/session` suites:
  556 passed, no regressions (3 pre-existing mongomock-version failures are
  present with these changes stashed too).