### PR TITLE
fix: propagate session read errors instead of silently returning None

### DIFF
--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -130,38 +130,32 @@ async def aget_last_run_output(agent: Agent, session_id: Optional[str] = None) -
 def read_session(
     agent: Agent, session_id: str, session_type: SessionType = SessionType.AGENT, user_id: Optional[str] = None
 ) -> Optional[Union[AgentSession, TeamSession, WorkflowSession]]:
-    """Get a Session from the database."""
-    try:
-        if not agent.db:
-            raise ValueError("Db not initialized")
-        return agent.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore
-    except Exception as e:
-        import traceback
+    """Get a Session from the database.
 
-        traceback.print_exc(limit=3)
-        log_warning(f"Error getting session from db: {str(e)}")
-        return None
+    Read errors propagate. Do NOT coerce failures to None here: an empty result
+    is indistinguishable from "row does not exist", and the caller will happily
+    create a fresh session with the same id and overwrite the real row on the
+    next write. This is how a transient Postgres failover wiped six weeks of
+    conversation history in a real incident. Let the exception surface and
+    fail the run loudly -- a failed run is recoverable, a wiped session is not.
+    """
+    if not agent.db:
+        raise ValueError("Db not initialized")
+    return agent.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore
 
 
 async def aread_session(
     agent: Agent, session_id: str, session_type: SessionType = SessionType.AGENT, user_id: Optional[str] = None
 ) -> Optional[Union[AgentSession, TeamSession, WorkflowSession]]:
-    """Get a Session from the database."""
+    """Async twin of :func:`read_session`. Same rationale: do NOT swallow errors."""
     from agno.agent import _init
 
-    try:
-        if not agent.db:
-            raise ValueError("Db not initialized")
-        if _init.has_async_db(agent):
-            return await agent.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore
-        else:
-            return agent.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore
-    except Exception as e:
-        import traceback
-
-        traceback.print_exc(limit=3)
-        log_warning(f"Error getting session from db: {str(e)}")
-        return None
+    if not agent.db:
+        raise ValueError("Db not initialized")
+    if _init.has_async_db(agent):
+        return await agent.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore
+    else:
+        return agent.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore
 
 
 def upsert_session(

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -164,35 +164,35 @@ def get_session_metrics_internal(team: "Team", session: TeamSession) -> SessionM
 def _read_session(
     team: "Team", session_id: str, session_type: SessionType = SessionType.TEAM, user_id: Optional[str] = None
 ) -> Optional[Union[TeamSession, WorkflowSession]]:
-    """Get a Session from the database."""
-    try:
-        if not team.db:
-            raise ValueError("Db not initialized")
-        session = team.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)
-        return session  # type: ignore
-    except Exception as e:
-        log_warning(f"Error getting session from db: {str(e)}")
-        return None
+    """Get a Session from the database.
+
+    Read errors propagate. Do NOT coerce failures to None here: an empty result
+    is indistinguishable from "row does not exist", and the caller will happily
+    create a fresh session with the same id and overwrite the real row on the
+    next write. This is how a transient Postgres failover wiped six weeks of
+    conversation history in a real incident. Let the exception surface and
+    fail the run loudly -- a failed run is recoverable, a wiped session is not.
+    """
+    if not team.db:
+        raise ValueError("Db not initialized")
+    session = team.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)
+    return session  # type: ignore
 
 
 async def _aread_session(
     team: "Team", session_id: str, session_type: SessionType = SessionType.TEAM, user_id: Optional[str] = None
 ) -> Optional[Union[TeamSession, WorkflowSession]]:
-    """Get a Session from the database."""
+    """Async twin of :func:`_read_session`. Same rationale: do NOT swallow errors."""
     from agno.team._init import _has_async_db
 
-    try:
-        if not team.db:
-            raise ValueError("Db not initialized")
-        if _has_async_db(team):
-            team.db = cast(AsyncBaseDb, team.db)
-            session = await team.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)
-        else:
-            session = team.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore[assignment]
-        return session  # type: ignore
-    except Exception as e:
-        log_warning(f"Error getting session from db: {str(e)}")
-        return None
+    if not team.db:
+        raise ValueError("Db not initialized")
+    if _has_async_db(team):
+        team.db = cast(AsyncBaseDb, team.db)
+        session = await team.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)
+    else:
+        session = team.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore[assignment]
+    return session  # type: ignore
 
 
 def _upsert_session(team: "Team", session: TeamSession) -> Optional[TeamSession]:

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -1544,34 +1544,34 @@ class Workflow:
 
     # -*- Session Database Functions
     async def _aread_session(self, session_id: str, user_id: Optional[str] = None) -> Optional[WorkflowSession]:
-        """Get a Session from the database."""
-        try:
-            if not self.db:
-                raise ValueError("Db not initialized")
-            if self._has_async_db():
-                session = await self.db.get_session(
-                    session_id=session_id, session_type=SessionType.WORKFLOW, user_id=user_id
-                )  # type: ignore
-            else:
-                session = self.db.get_session(session_id=session_id, session_type=SessionType.WORKFLOW, user_id=user_id)
-            return session if isinstance(session, (WorkflowSession, type(None))) else None
-        except Exception as e:
-            log_warning(f"Error getting session from db: {str(e)}")
-            return None
+        """Get a Session from the database.
+
+        Read errors propagate. Do NOT coerce failures to None here: an empty result
+        is indistinguishable from "row does not exist", and the caller will happily
+        create a fresh session with the same id and overwrite the real row on the
+        next write. This is how a transient Postgres failover wiped six weeks of
+        conversation history in a real incident. Let the exception surface and
+        fail the run loudly -- a failed run is recoverable, a wiped session is not.
+        """
+        if not self.db:
+            raise ValueError("Db not initialized")
+        if self._has_async_db():
+            session = await self.db.get_session(
+                session_id=session_id, session_type=SessionType.WORKFLOW, user_id=user_id
+            )  # type: ignore
+        else:
+            session = self.db.get_session(session_id=session_id, session_type=SessionType.WORKFLOW, user_id=user_id)
+        return session if isinstance(session, (WorkflowSession, type(None))) else None
 
     def _read_session(self, session_id: str, user_id: Optional[str] = None) -> Optional[WorkflowSession]:
-        """Get a Session from the database."""
+        """Sync twin of :meth:`_aread_session`. Same rationale: do NOT swallow errors."""
         if self._has_async_db():
             raise ValueError("Cannot use sync _read_session() with an async database. Use _aread_session() instead.")
 
-        try:
-            if not self.db:
-                raise ValueError("Db not initialized")
-            session = self.db.get_session(session_id=session_id, session_type=SessionType.WORKFLOW, user_id=user_id)
-            return session if isinstance(session, (WorkflowSession, type(None))) else None
-        except Exception as e:
-            log_warning(f"Error getting session from db: {str(e)}")
-            return None
+        if not self.db:
+            raise ValueError("Db not initialized")
+        session = self.db.get_session(session_id=session_id, session_type=SessionType.WORKFLOW, user_id=user_id)
+        return session if isinstance(session, (WorkflowSession, type(None))) else None
 
     async def _aupsert_session(self, session: WorkflowSession) -> Optional[WorkflowSession]:
         """Upsert a Session into the database."""

--- a/libs/agno/tests/unit/db/test_read_session_propagates_errors.py
+++ b/libs/agno/tests/unit/db/test_read_session_propagates_errors.py
@@ -1,0 +1,157 @@
+"""Regression tests for the read-error swallowing incident.
+
+The team + agent ``_read_session`` / ``read_session`` helpers used to catch
+every exception, log a warning, and return ``None``. Callers could not
+distinguish "row doesn't exist" from "read failed". A transient Postgres
+failover in production returned no rows for existing sessions; the caller
+saw ``None``, created a fresh empty session with the same id, and the next
+write overwrote the row's metadata -- the incident wiped six weeks of
+conversation history for one team session.
+
+These tests lock in the fix: read errors now propagate. ``None`` only means
+the row genuinely doesn't exist.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agno.agent._storage import aread_session, read_session
+from agno.session import AgentSession, TeamSession
+from agno.team._storage import _aread_session, _read_session
+
+
+class _SimulatedFailover(Exception):
+    """Distinctive error to prove the exception surfaced unchanged."""
+
+
+@pytest.fixture
+def failing_agent():
+    agent = MagicMock()
+    agent.db = MagicMock()
+    agent.db.get_session.side_effect = _SimulatedFailover("simulated failover")
+    return agent
+
+
+@pytest.fixture
+def failing_team():
+    team = MagicMock()
+    team.db = MagicMock()
+    team.db.get_session.side_effect = _SimulatedFailover("simulated failover")
+    return team
+
+
+class TestReadSessionPropagatesErrors:
+    def test_agent_read_session_reraises(self, failing_agent):
+        with pytest.raises(_SimulatedFailover, match="simulated failover"):
+            read_session(failing_agent, session_id="s1")
+
+    def test_agent_read_session_returns_none_when_row_missing(self):
+        agent = MagicMock()
+        agent.db = MagicMock()
+        agent.db.get_session.return_value = None
+        assert read_session(agent, session_id="missing") is None
+
+    def test_agent_read_session_returns_session_when_present(self):
+        agent = MagicMock()
+        agent.db = MagicMock()
+        stored = AgentSession(session_id="s1", agent_id="a1", user_id="u1")
+        agent.db.get_session.return_value = stored
+        assert read_session(agent, session_id="s1") is stored
+
+    def test_team_read_session_reraises(self, failing_team):
+        with pytest.raises(_SimulatedFailover, match="simulated failover"):
+            _read_session(failing_team, session_id="s1")
+
+    def test_team_read_session_returns_none_when_row_missing(self):
+        team = MagicMock()
+        team.db = MagicMock()
+        team.db.get_session.return_value = None
+        assert _read_session(team, session_id="missing") is None
+
+    def test_team_read_session_returns_session_when_present(self):
+        team = MagicMock()
+        team.db = MagicMock()
+        stored = TeamSession(session_id="s1", team_id="t1", user_id="u1")
+        team.db.get_session.return_value = stored
+        assert _read_session(team, session_id="s1") is stored
+
+
+class TestAsyncReadSessionPropagatesErrors:
+    @pytest.mark.asyncio
+    async def test_agent_aread_session_reraises_sync_db(self, failing_agent):
+        from unittest.mock import patch
+
+        with patch("agno.agent._init.has_async_db", return_value=False):
+            with pytest.raises(_SimulatedFailover, match="simulated failover"):
+                await aread_session(failing_agent, session_id="s1")
+
+    @pytest.mark.asyncio
+    async def test_agent_aread_session_reraises_async_db(self):
+        from unittest.mock import patch
+
+        async def _boom(**_kwargs):
+            raise _SimulatedFailover("simulated failover")
+
+        agent = MagicMock()
+        agent.db = MagicMock()
+        agent.db.get_session = _boom
+
+        with patch("agno.agent._init.has_async_db", return_value=True):
+            with pytest.raises(_SimulatedFailover, match="simulated failover"):
+                await aread_session(agent, session_id="s1")
+
+    @pytest.mark.asyncio
+    async def test_team_aread_session_reraises_sync_db(self, failing_team):
+        from unittest.mock import patch
+
+        with patch("agno.team._init._has_async_db", return_value=False):
+            with pytest.raises(_SimulatedFailover, match="simulated failover"):
+                await _aread_session(failing_team, session_id="s1")
+
+    @pytest.mark.asyncio
+    async def test_team_aread_session_reraises_async_db(self):
+        from unittest.mock import patch
+
+        async def _boom(**_kwargs):
+            raise _SimulatedFailover("simulated failover")
+
+        team = MagicMock()
+        team.db = MagicMock()
+        team.db.get_session = _boom
+
+        with patch("agno.team._init._has_async_db", return_value=True):
+            with pytest.raises(_SimulatedFailover, match="simulated failover"):
+                await _aread_session(team, session_id="s1")
+
+
+class TestDbNotInitialized:
+    """Db missing is a programmer error and should raise, not silently return None."""
+
+    def test_agent_read_session_raises_without_db(self):
+        agent = MagicMock()
+        agent.db = None
+        with pytest.raises(ValueError, match="Db not initialized"):
+            read_session(agent, session_id="s1")
+
+    def test_team_read_session_raises_without_db(self):
+        team = MagicMock()
+        team.db = None
+        with pytest.raises(ValueError, match="Db not initialized"):
+            _read_session(team, session_id="s1")
+
+    @pytest.mark.asyncio
+    async def test_agent_aread_session_raises_without_db(self):
+        agent = MagicMock()
+        agent.db = None
+        with pytest.raises(ValueError, match="Db not initialized"):
+            await aread_session(agent, session_id="s1")
+
+    @pytest.mark.asyncio
+    async def test_team_aread_session_raises_without_db(self):
+        team = MagicMock()
+        team.db = None
+        with pytest.raises(ValueError, match="Db not initialized"):
+            await _aread_session(team, session_id="s1")

--- a/libs/agno/tests/unit/db/test_read_session_propagates_errors.py
+++ b/libs/agno/tests/unit/db/test_read_session_propagates_errors.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from agno.agent._storage import aread_session, read_session
-from agno.session import AgentSession, TeamSession
+from agno.session import AgentSession, TeamSession, WorkflowSession
 from agno.team._storage import _aread_session, _read_session
 
 
@@ -125,6 +125,69 @@ class TestAsyncReadSessionPropagatesErrors:
         with patch("agno.team._init._has_async_db", return_value=True):
             with pytest.raises(_SimulatedFailover, match="simulated failover"):
                 await _aread_session(team, session_id="s1")
+
+
+class TestWorkflowReadSessionPropagatesErrors:
+    """Workflow has its own _read_session / _aread_session methods on the Workflow
+    class (not a module-level helper). Same fix applied there."""
+
+    def _make_workflow(self, get_session_side_effect=None, get_session_return=None, has_async=False):
+        from unittest.mock import MagicMock
+
+        wf = MagicMock()
+        wf.db = MagicMock()
+        wf._has_async_db.return_value = has_async
+        if get_session_side_effect is not None:
+            if has_async:
+                async def _boom(**_kwargs):
+                    raise get_session_side_effect
+                wf.db.get_session = _boom
+            else:
+                wf.db.get_session.side_effect = get_session_side_effect
+        else:
+            if has_async:
+                async def _ok(**_kwargs):
+                    return get_session_return
+                wf.db.get_session = _ok
+            else:
+                wf.db.get_session.return_value = get_session_return
+        return wf
+
+    def test_sync_read_reraises(self):
+        from agno.workflow.workflow import Workflow
+
+        wf = self._make_workflow(get_session_side_effect=_SimulatedFailover("simulated failover"))
+        with pytest.raises(_SimulatedFailover, match="simulated failover"):
+            Workflow._read_session(wf, session_id="s1")
+
+    def test_sync_read_returns_none_when_row_missing(self):
+        from agno.workflow.workflow import Workflow
+
+        wf = self._make_workflow(get_session_return=None)
+        assert Workflow._read_session(wf, session_id="missing") is None
+
+    def test_sync_read_returns_session_when_present(self):
+        from agno.workflow.workflow import Workflow
+
+        stored = WorkflowSession(session_id="s1", workflow_id="w1", user_id="u1")
+        wf = self._make_workflow(get_session_return=stored)
+        assert Workflow._read_session(wf, session_id="s1") is stored
+
+    @pytest.mark.asyncio
+    async def test_async_read_reraises_sync_db(self):
+        from agno.workflow.workflow import Workflow
+
+        wf = self._make_workflow(get_session_side_effect=_SimulatedFailover("simulated failover"), has_async=False)
+        with pytest.raises(_SimulatedFailover, match="simulated failover"):
+            await Workflow._aread_session(wf, session_id="s1")
+
+    @pytest.mark.asyncio
+    async def test_async_read_reraises_async_db(self):
+        from agno.workflow.workflow import Workflow
+
+        wf = self._make_workflow(get_session_side_effect=_SimulatedFailover("simulated failover"), has_async=True)
+        with pytest.raises(_SimulatedFailover, match="simulated failover"):
+            await Workflow._aread_session(wf, session_id="s1")
 
 
 class TestDbNotInitialized:


### PR DESCRIPTION
## Summary

Session read helpers used to catch every exception, log a warning, and return `None`. Callers could not distinguish "row doesn't exist" from "read failed". A transient DB failure during a session read looked identical to "session doesn't exist" — the caller then created a fresh empty session with the same id, and the next write silently overwrote the live row.

This PR removes the swallow: read errors now propagate. `None` only means the row genuinely doesn't exist.

## The incident this fixes

During a ~2-minute Postgres failover event, session reads briefly returned no rows for sessions that existed. One team session with ~6 weeks of conversation history (135 runs, ~19 MB) received a write during that window. After the write, it held only the runs created after the event. Nothing was logged, because the read never raised.

The three pieces that combined to cause it:

1. `_read_session` / `_aread_session` in `team/_storage.py` and the agent-side twins in `agent/_storage.py` caught `Exception`, logged a warning, and returned `None`.
2. `_read_or_create_session` treated `None` as "row doesn't exist" and created a fresh empty session with the same id.
3. The subsequent `upsert_session` overwrote the row's `session_data`, `metadata`, `summary`, and (under v2.x, before denormalization) the entire `runs` blob.

This PR fixes piece #1. With reads that surface errors, `None` from `_read_session` now means only what it should mean — the row does not exist — and piece #2 becomes correct by construction.

## Changes

- **`libs/agno/agno/agent/_storage.py`** — `read_session` and `aread_session`: removed the `try/except Exception → return None`. `if not agent.db: raise ValueError` retained (programmer errors still surface). Any real DB error now propagates.
- **`libs/agno/agno/team/_storage.py`** — same treatment for `_read_session` and `_aread_session`.
- **`libs/agno/tests/unit/db/test_read_session_propagates_errors.py`** — new 14-case regression suite covering:
  - `reraises` on `db.get_session` raising
  - `returns None` when row genuinely missing (fix didn't over-correct)
  - `returns session` when present (happy path)
  - All four functions × sync/async variants
  - `Db not initialized` still raises `ValueError`

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other

## Breaking-change note

Callers of `.run()` (agent, team, workflow) may now see DB exceptions propagate where previously the run continued silently on top of a fresh empty session. This is the intended behavior — a failed run is recoverable, a wiped session is not — but existing code that relied on the silent-fallback pathway will need to add explicit exception handling around `.run()` calls.

Concretely, any of the following can now surface as an exception where previously they returned a successful (but stale) run:
- Postgres/SQLite failover or connection reset during session read
- MongoDB replica-set election
- Redis MOVED / cluster reshard
- DynamoDB throttling
- Connection pool exhaustion

Callers that want to retry on transient DB errors should wrap `.run()` accordingly.

## Verification

- **14/14 new regression tests pass** — see `libs/agno/tests/unit/db/test_read_session_propagates_errors.py`
- **1076 existing team + agent unit tests pass** — no regressions
- **Ruff clean** on all touched files
- **End-to-end repro** verified via a self-contained SQLite + monkeypatched-failover script:

