### PR TITLE
fix: persist ERROR run for foreground streaming workflows

### DIFF
--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -1671,6 +1671,54 @@ class Workflow:
             run_index=run_index,
         )
 
+    def _persist_errored_run_stream(self, session: WorkflowSession, run: "WorkflowRunOutput") -> None:
+        """Persist an errored streaming run and finish its terminal bookkeeping.
+
+        Foreground streaming re-raises step exceptions past the fall-through
+        terminal persist, so without this the ERROR run would never reach the
+        runs store (breaking ``get_run``/history and ``/resume`` after a
+        restart). Mirrors the cancelled branch. Guarded so a persistence
+        failure never masks the original exception being re-raised.
+        """
+        if run.metrics:
+            run.metrics.stop_timer()
+        try:
+            self._update_session_metrics(session=session, workflow_run_response=run)
+            session.upsert_run(run=run)
+            self._persist_session_and_run(session=session, run=run)
+        except Exception as store_err:
+            log_warning(f"Failed to persist errored run: {store_err}")
+        cleanup_run(run.run_id)  # type: ignore
+        cleanup_member_runs(run.run_id)  # type: ignore
+        try:
+            from agno.os.managers import event_buffer
+
+            event_buffer.set_run_completed(run.run_id, run.status or RunStatus.error)  # type: ignore
+        except Exception as buffer_err:
+            log_debug(f"Failed to mark run as completed in buffer: {buffer_err}")
+
+    async def _apersist_errored_run_stream(self, session: WorkflowSession, run: "WorkflowRunOutput") -> None:
+        """Async variant of ``_persist_errored_run_stream``."""
+        if run.metrics:
+            run.metrics.stop_timer()
+        try:
+            self._update_session_metrics(session=session, workflow_run_response=run)
+            session.upsert_run(run=run)
+            if self._has_async_db():
+                await self._apersist_session_and_run(session=session, run=run)
+            else:
+                self._persist_session_and_run(session=session, run=run)
+        except Exception as store_err:
+            log_warning(f"Failed to persist errored run: {store_err}")
+        await acleanup_run(run.run_id)  # type: ignore
+        await acleanup_member_runs(run.run_id)  # type: ignore
+        try:
+            from agno.os.managers import event_buffer
+
+            event_buffer.set_run_completed(run.run_id, run.status or RunStatus.error)  # type: ignore
+        except Exception as buffer_err:
+            log_debug(f"Failed to mark run as completed in buffer: {buffer_err}")
+
     def _update_metadata(self, session: WorkflowSession):
         """Update the extra_data in the session"""
         from agno.utils.merge_dict import merge_dictionaries
@@ -2545,6 +2593,27 @@ class Workflow:
                 if self.telemetry:
                     self._log_workflow_telemetry(session_id=session.session_id, run_id=workflow_run_response.run_id)
                 return
+            except Exception as e:
+                logger.exception("Workflow execution failed")
+
+                from agno.run.workflow import WorkflowErrorEvent
+
+                error_event = WorkflowErrorEvent(
+                    run_id=workflow_run_response.run_id or "",
+                    workflow_id=self.id,
+                    workflow_name=self.name,
+                    session_id=session.session_id,
+                    error=str(e),
+                )
+                yield error_event
+
+                # Update workflow_run_response with error
+                workflow_run_response.content = error_event.error
+                workflow_run_response.status = RunStatus.error
+
+                # Persist the ERROR run before re-raising so it is not lost.
+                self._persist_errored_run_stream(session=session, run=workflow_run_response)
+                raise e
 
         else:
             try:
@@ -3017,6 +3086,9 @@ class Workflow:
                 # Update workflow_run_response with error
                 workflow_run_response.content = error_event.error
                 workflow_run_response.status = RunStatus.error
+
+                # Persist the ERROR run before re-raising so it is not lost.
+                self._persist_errored_run_stream(session=session, run=workflow_run_response)
                 raise e
 
         # Yield workflow completed event
@@ -3606,6 +3678,27 @@ class Workflow:
                         session_id=workflow_session.session_id, run_id=workflow_run_response.run_id
                     )
                 return
+            except Exception as e:
+                logger.exception("Workflow execution failed")
+
+                from agno.run.workflow import WorkflowErrorEvent
+
+                error_event = WorkflowErrorEvent(
+                    run_id=workflow_run_response.run_id or "",
+                    workflow_id=self.id,
+                    workflow_name=self.name,
+                    session_id=session_id,
+                    error=str(e),
+                )
+                yield error_event
+
+                # Update workflow_run_response with error
+                workflow_run_response.content = error_event.error
+                workflow_run_response.status = RunStatus.error
+
+                # Persist the ERROR run before re-raising so it is not lost.
+                await self._apersist_errored_run_stream(session=workflow_session, run=workflow_run_response)
+                raise e
 
         else:
             try:
@@ -4129,6 +4222,9 @@ class Workflow:
                 # Update workflow_run_response with error
                 workflow_run_response.content = error_event.error
                 workflow_run_response.status = RunStatus.error
+
+                # Persist the ERROR run before re-raising so it is not lost.
+                await self._apersist_errored_run_stream(session=workflow_session, run=workflow_run_response)
                 raise e
 
         # Yield workflow completed event

--- a/libs/agno/tests/unit/workflow/test_stream_error_persist.py
+++ b/libs/agno/tests/unit/workflow/test_stream_error_persist.py
@@ -1,0 +1,119 @@
+"""Regression tests: a foreground STREAMING workflow that fails with a generic
+exception must still persist the ERROR run.
+
+Before the fix, _execute_stream / _aexecute_stream set status=error, yielded a
+WorkflowErrorEvent, then ``raise e`` — but the terminal persist sat AFTER the
+try/except (not in a finally), so the re-raise skipped it. The run was never
+written to the runs store: get_run/aget_run returned None forever and /resume
+could not surface the failure after a restart. This is asymmetric with the
+non-streaming path (finally-wrapped), the cancelled branch (persists inline),
+and agent/team streaming (persist ERROR via cleanup_and_store).
+
+The custom-function (callable steps) branch had no generic handler at all, so a
+generic exception propagated uncaught and skipped persistence the same way.
+
+Note: a ``Step`` executor's own exception is caught + retried by the step
+framework and does NOT escape to the generic handler, so these tests force an
+exception that escapes the step loop (an orchestration error), or use the
+callable branch which invokes the function directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agno.db.sqlite import SqliteDb
+from agno.run.base import RunStatus
+from agno.workflow.step import Step
+from agno.workflow.types import StepInput, StepOutput
+from agno.workflow.workflow import Workflow
+
+
+def _ok_step(step_input: StepInput) -> StepOutput:
+    return StepOutput(content="ok")
+
+
+def _boom_custom_function(execution_input) -> str:
+    raise RuntimeError("callable exploded")
+
+
+def _boom_orchestration(*args, **kwargs):
+    # Escapes the step loop (unlike a Step executor error, which is caught/retried).
+    raise RuntimeError("orchestration exploded")
+
+
+def _drain(iterator) -> list:
+    return [event for event in iterator]
+
+
+async def _adrain(async_iterator) -> list:
+    return [event async for event in async_iterator]
+
+
+def _make_db(tmp_path, name: str = "wf.db") -> SqliteDb:
+    return SqliteDb(db_file=str(tmp_path / name))
+
+
+class TestStreamingWorkflowErrorPersist:
+    def test_sync_multistep_stream_error_persists_error_run(self, tmp_path):
+        wf = Workflow(name="wf", steps=[Step(name="s", executor=_ok_step)], db=_make_db(tmp_path))
+        wf._create_step_input = _boom_orchestration  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError, match="orchestration exploded"):
+            _drain(wf.run("input", session_id="s1", run_id="r1", stream=True))
+
+        run = wf.get_run("r1", session_id="s1")
+        assert run is not None, "errored streaming run must be persisted, not lost"
+        assert run.status == RunStatus.error
+
+    async def test_async_multistep_stream_error_persists_error_run(self, tmp_path):
+        wf = Workflow(name="wf", steps=[Step(name="s", executor=_ok_step)], db=_make_db(tmp_path))
+        wf._create_step_input = _boom_orchestration  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError, match="orchestration exploded"):
+            await _adrain(wf.arun("input", session_id="s1", run_id="r1", stream=True))
+
+        run = wf.get_run("r1", session_id="s1")
+        assert run is not None, "errored async streaming run must be persisted, not lost"
+        assert run.status == RunStatus.error
+
+    def test_sync_callable_stream_error_persists_error_run(self, tmp_path):
+        """The custom-function branch had no generic except at all."""
+        wf = Workflow(name="wf", steps=_boom_custom_function, db=_make_db(tmp_path))
+
+        with pytest.raises(RuntimeError, match="callable exploded"):
+            _drain(wf.run("input", session_id="s1", run_id="r1", stream=True))
+
+        run = wf.get_run("r1", session_id="s1")
+        assert run is not None, "errored callable-workflow streaming run must be persisted"
+        assert run.status == RunStatus.error
+
+    def test_persist_failure_does_not_mask_original_exception(self, tmp_path):
+        """If persistence itself fails on the error path, the ORIGINAL exception
+        must still propagate (persist is guarded + logged)."""
+        wf = Workflow(name="wf", steps=_boom_custom_function, db=_make_db(tmp_path))
+
+        def _explode_persist(*args, **kwargs):
+            raise RuntimeError("persist boom")
+
+        wf._persist_session_and_run = _explode_persist  # type: ignore[method-assign]
+
+        # The callable's RuntimeError, not the persistence one, must surface.
+        with pytest.raises(RuntimeError, match="callable exploded"):
+            _drain(wf.run("input", session_id="s1", run_id="r1", stream=True))
+
+    def test_streaming_matches_nonstreaming_error_persistence(self, tmp_path):
+        """Parity: non-streaming and streaming both persist an ERROR row."""
+        wf_ns = Workflow(name="wf", steps=[Step(name="s", executor=_ok_step)], db=_make_db(tmp_path, "ns.db"))
+        wf_ns._create_step_input = _boom_orchestration  # type: ignore[method-assign]
+        with pytest.raises(RuntimeError, match="orchestration exploded"):
+            wf_ns.run("input", session_id="s1", run_id="r1")
+        ns_run = wf_ns.get_run("r1", session_id="s1")
+        assert ns_run is not None and ns_run.status == RunStatus.error
+
+        wf_s = Workflow(name="wf", steps=[Step(name="s", executor=_ok_step)], db=_make_db(tmp_path, "s.db"))
+        wf_s._create_step_input = _boom_orchestration  # type: ignore[method-assign]
+        with pytest.raises(RuntimeError, match="orchestration exploded"):
+            _drain(wf_s.run("input", session_id="s1", run_id="r1", stream=True))
+        s_run = wf_s.get_run("r1", session_id="s1")
+        assert s_run is not None and s_run.status == RunStatus.error


### PR DESCRIPTION
## Summary

A foreground **streaming** workflow that fails with a generic exception never
wrote the ERROR run to the runs store — so `get_run`/`aget_run` returned `None`
forever, the run never appeared in `session.runs`/history, and `/resume`
returned "not found" after a restart.

In `_execute_stream` and `_aexecute_stream`, the generic `except Exception`
sets `status=error`, yields a `WorkflowErrorEvent`, then re-raises — but the
terminal persist (`upsert_run` + `_persist_session_and_run`) sits **after** the
try/except, not in a `finally`, so the re-raise skips it. The custom-function
(callable `steps`) branch had **no** generic handler at all, so the exception
propagated uncaught and skipped persistence the same way.

This was asymmetric with every sibling path:
- non-streaming `_execute` wraps the persist in a `finally` → always writes;
- the streaming **cancelled** branch persists inline before returning;
- **agent/team** streaming persist ERROR via `cleanup_and_store`.

Only the workflow foreground streaming generic-exception path leaked.

### Fix

Add `_persist_errored_run_stream` / `_apersist_errored_run_stream` helpers that
mirror the cancelled branch (stop metrics timer, `upsert_run`,
`_persist_session_and_run`, run-tracking cleanup, mark the run terminal in the
event buffer) and call them **before re-raising** in all four sites
(sync/async × multi-step/callable). The persist is guarded with an inner
`try/except` + `log_warning`, so a persistence failure never masks the original
exception. Cancellation, `InputCheckError`/`OutputCheckError`, and the happy
path are unchanged.

### Notes

- This bug is **pre-existing on `main`** (not introduced by the denormalization
  work), but it lives in the same methods the denormalization PR touches, so
  this targets `feat/denormalize-sessions-table` and is kept as a separate,
  focused PR rather than folded into #9308.
- A `Step` executor's own exception is caught + retried by the step framework
  and does not escape to the generic handler (that path already persists
  normally); the leak is for exceptions that escape the step loop and for the
  callable branch. The tests drive both.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Tests in `libs/agno/tests/unit/workflow/test_stream_error_persist.py`:
- sync + async multi-step streaming: an escaping error persists a `status=error` run;
- callable/custom-function streaming: same;
- a persist failure on the error path does **not** mask the original exception;
- streaming matches non-streaming error persistence (parity).

Full `libs/agno/tests/unit/workflow` suite: 446 passed, 7 skipped, no regressions.
