### PR TITLE
fix(utils): restrict unpickling to mitigate CWE-502 RCE (#9233)

### DIFF
--- a/libs/agno/agno/utils/pickle.py
+++ b/libs/agno/agno/utils/pickle.py
@@ -1,3 +1,4 @@
+import pickle
 from pathlib import Path
 from typing import Any, Optional
 
@@ -6,24 +7,66 @@ from agno.utils.log import logger
 
 def pickle_object_to_file(obj: Any, file_path: Path) -> Any:
     """Pickles and saves object to file_path"""
-    import pickle
-
     _obj_parent = file_path.parent
     if not _obj_parent.exists():
         _obj_parent.mkdir(parents=True, exist_ok=True)
-    pickle.dump(obj, file_path.open("wb"))
+    with file_path.open("wb") as _file:
+        pickle.dump(obj, _file)
+
+
+# Modules whose globals can execute arbitrary code when referenced during
+# unpickling. Unpickling untrusted data with unrestricted access to them is
+# CWE-502 (Deserialization of Untrusted Data). See:
+# https://docs.python.org/3/library/pickle.html#restricting-globals
+_FORBIDDEN_PICKLE_MODULES = frozenset(
+    {
+        "atexit",
+        "builtins",
+        "ctypes",
+        "functools",
+        "gc",
+        "importlib",
+        "multiprocessing",
+        "os",
+        "posix",
+        "pty",
+        "shutil",
+        "signal",
+        "socket",
+        "subprocess",
+        "sys",
+        "threading",
+    }
+)
+
+
+class RestrictedUnpickler(pickle.Unpickler):
+    """Unpickler that rejects globals from modules which can execute arbitrary code.
+
+    Used to mitigate CWE-502 when loading objects from files that may be
+    attacker-controlled (e.g. shared storage or agent workspace exports).
+    """
+
+    def find_class(self, module: str, name: str) -> Any:
+        if module in _FORBIDDEN_PICKLE_MODULES:
+            raise pickle.UnpicklingError(
+                f"global '{module}.{name}' is forbidden for security (CWE-502)"
+            )
+        return super().find_class(module, name)
 
 
 def unpickle_object_from_file(file_path: Path, verify_class: Optional[Any] = None) -> Any:
     """Reads the contents of file_path and unpickles the binary content into an object.
     If verify_class is provided, checks if the object is an instance of that class.
-    """
-    import pickle
 
+    Loading is performed with :class:`RestrictedUnpickler`, which rejects globals
+    from modules that can execute arbitrary code (``os``, ``subprocess``, ``builtins``, ...),
+    mitigating CWE-502 (Deserialization of Untrusted Data) on attacker-controlled files.
+    """
     _obj = None
-    # log_debug(f"Reading {file_path}")
     if file_path.exists() and file_path.is_file():
-        _obj = pickle.load(file_path.open("rb"))
+        with file_path.open("rb") as _file:
+            _obj = RestrictedUnpickler(_file).load()
 
     if _obj and verify_class and not isinstance(_obj, verify_class):
         logger.warning(f"Object does not match {verify_class}")

--- a/libs/agno/tests/unit/utils/test_pickle.py
+++ b/libs/agno/tests/unit/utils/test_pickle.py
@@ -28,6 +28,13 @@ class _Exploit:
         return (self._callable, self._args)
 
 
+class _User:
+    """Module-level class so pickle can reference it by qualified name."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+
 def _write_pickle(path: pathlib.Path, obj) -> pathlib.Path:
     with path.open("wb") as f:
         pickle.dump(obj, f)
@@ -59,15 +66,11 @@ def test_roundtrip_list():
 
 
 def test_roundtrip_custom_class():
-    class User:
-        def __init__(self, name: str):
-            self.name = name
-
     with tempfile.TemporaryDirectory() as tmp:
         f = pathlib.Path(tmp) / "u.pkl"
-        pickle_object_to_file(User("agno"), f)
+        pickle_object_to_file(_User("agno"), f)
         loaded = unpickle_object_from_file(f)
-        assert isinstance(loaded, User)
+        assert isinstance(loaded, _User)
         assert loaded.name == "agno"
 
 

--- a/libs/agno/tests/unit/utils/test_pickle.py
+++ b/libs/agno/tests/unit/utils/test_pickle.py
@@ -1,0 +1,136 @@
+"""Tests for agno.utils.pickle RestrictedUnpickler (CWE-502 mitigation).
+
+The tests assert both directions of the security contract:
+- legitimate objects (dict/list/pathlib.Path/custom classes) round-trip unchanged;
+- globals from modules that can execute arbitrary code (os, subprocess,
+  builtins, functools, ...) are rejected with UnpicklingError.
+"""
+import functools
+import os
+import pathlib
+import pickle
+import subprocess
+import tempfile
+
+import pytest
+
+from agno.utils.pickle import RestrictedUnpickler, pickle_object_to_file, unpickle_object_from_file
+
+
+class _Exploit:
+    """De-weaponized payload helper: returns (callable, args) for __reduce__."""
+
+    def __init__(self, callable_, args):
+        self._callable = callable_
+        self._args = args
+
+    def __reduce__(self):
+        return (self._callable, self._args)
+
+
+def _write_pickle(path: pathlib.Path, obj) -> pathlib.Path:
+    with path.open("wb") as f:
+        pickle.dump(obj, f)
+    return path
+
+
+# --- legit round-trips must be unaffected --------------------------------
+
+
+def test_roundtrip_dict():
+    with tempfile.TemporaryDirectory() as tmp:
+        f = pathlib.Path(tmp) / "d.pkl"
+        pickle_object_to_file({"a": 1, "b": [1, 2, 3]}, f)
+        assert unpickle_object_from_file(f) == {"a": 1, "b": [1, 2, 3]}
+
+
+def test_roundtrip_path():
+    with tempfile.TemporaryDirectory() as tmp:
+        f = pathlib.Path(tmp) / "p.pkl"
+        pickle_object_to_file(pathlib.Path("/tmp/x"), f)
+        assert unpickle_object_from_file(f) == pathlib.Path("/tmp/x")
+
+
+def test_roundtrip_list():
+    with tempfile.TemporaryDirectory() as tmp:
+        f = pathlib.Path(tmp) / "l.pkl"
+        pickle_object_to_file(list(range(10)), f)
+        assert unpickle_object_from_file(f) == list(range(10))
+
+
+def test_roundtrip_custom_class():
+    class User:
+        def __init__(self, name: str):
+            self.name = name
+
+    with tempfile.TemporaryDirectory() as tmp:
+        f = pathlib.Path(tmp) / "u.pkl"
+        pickle_object_to_file(User("agno"), f)
+        loaded = unpickle_object_from_file(f)
+        assert isinstance(loaded, User)
+        assert loaded.name == "agno"
+
+
+def test_verify_class_mismatch_returns_none():
+    with tempfile.TemporaryDirectory() as tmp:
+        f = pathlib.Path(tmp) / "u.pkl"
+        pickle_object_to_file({"k": 1}, f)
+        assert unpickle_object_from_file(f, verify_class=list) is None
+
+
+def test_corrupted_file_fails_safely():
+    with tempfile.TemporaryDirectory() as tmp:
+        f = pathlib.Path(tmp) / "bad.pkl"
+        f.write_bytes(b"not-a-pickle")
+        with pytest.raises(Exception):
+            unpickle_object_from_file(f)
+
+
+# --- arbitrary-code globals must be rejected ------------------------------
+
+
+@pytest.mark.parametrize(
+    "label, callable_, args",
+    [
+        ("os.system", os.system, ("echo PWNED > /tmp/agno_rce_proof",)),
+        ("builtins.eval", eval, ("__import__('os').system('id')",)),
+        ("subprocess.check_call", subprocess.check_call, (["touch", "/tmp/x"],)),
+        ("functools.partial(os.system)", functools.partial, (os.system, "touch /tmp/x")),
+    ],
+)
+def test_blocks_rce_payloads(label, callable_, args):
+    with tempfile.TemporaryDirectory() as tmp:
+        f = _write_pickle(pathlib.Path(tmp) / f"evil_{label}.pkl", _Exploit(callable_, args))
+        with pytest.raises(pickle.UnpicklingError):
+            unpickle_object_from_file(f)
+
+
+@pytest.mark.parametrize(
+    "module, name",
+    [
+        ("os", "system"),
+        ("os", "popen"),
+        ("subprocess", "check_call"),
+        ("builtins", "eval"),
+        ("builtins", "exec"),
+        ("posix", "system"),
+        ("shutil", "rmtree"),
+        ("sys", "exit"),
+        ("importlib", "import_module"),
+        ("functools", "partial"),
+    ],
+)
+def test_find_class_forbids_dangerous_modules(module, name):
+    with pytest.raises(pickle.UnpicklingError):
+        RestrictedUnpickler.__new__(RestrictedUnpickler).find_class(module, name)
+
+
+def test_find_class_allows_safe_modules():
+    unpickler = RestrictedUnpickler.__new__(RestrictedUnpickler)
+    # collections.OrderedDict is a plain container and must stay loadable.
+    from collections import OrderedDict
+
+    with tempfile.TemporaryDirectory() as tmp:
+        f = pathlib.Path(tmp) / "od.pkl"
+        pickle_object_to_file(OrderedDict([("k", 1)]), f)
+        assert unpickle_object_from_file(f) == OrderedDict([("k", 1)])


### PR DESCRIPTION
## Summary

Mitigates CWE-502 (Deserialization of Untrusted Data) in `agno/utils/pickle.py`. See issue #9233: `unpickle_object_from_file()` calls `pickle.load()` on a file path with no validation or sandboxing. A crafted pickle file can execute arbitrary code on load (e.g. via `__reduce__` returning `os.system`).

## Change

- Add `RestrictedUnpickler(pickle.Unpickler)` that overrides `find_class()` and raises `UnpicklingError` for globals from modules that can execute arbitrary code: `os`, `subprocess`, `builtins`, `posix`, `sys`, `shutil`, `importlib`, `functools`, `ctypes`, `multiprocessing`, `pty`, `socket`, `signal`, `gc`, `atexit`, `threading`.
- `unpickle_object_from_file()` now loads through `RestrictedUnpickler`; the existing `verify_class` check remains as a second defense layer.
- Hoisted `import pickle` to module level (required by the subclass).
- File handles are now closed via context managers (also relates to #7405).

## Why this approach

Follows the mitigation recommended in Python's official pickle docs (https://docs.python.org/3/library/pickle.html#restricting-globals) and in #9233. No safe module allowlist is imposed, so legitimate objects (dict/list/pathlib Path/custom classes/collections) are unaffected.

## Verification (local, defensive only — no weaponized PoC)

- Roundtrip of dict / list / pathlib.Path / custom class / OrderedDict: ✅
- `verify_class` mismatch still returns None: ✅
- `os.system` payload (#9233 PoC): ✅ blocked (UnpicklingError)
- `builtins.eval` / `subprocess.check_call` / `functools.partial(os.system)`: ✅ blocked
- Corrupted file fails safely: ✅

Related: #9233