### PR TITLE
feat: fetch only the most recent N runs of a session (SQL)

### DIFF
--- a/libs/agno/agno/agent/_session.py
+++ b/libs/agno/agno/agent/_session.py
@@ -76,12 +76,17 @@ def get_session(
     agent: Agent,
     session_id: Optional[str] = None,
     user_id: Optional[str] = None,
+    runs_limit: Optional[int] = None,
 ) -> Optional[Union[AgentSession, TeamSession, WorkflowSession]]:
     """Load an AgentSession from database or cache.
 
     Args:
         agent: The Agent instance.
         session_id: The session_id to load from storage.
+        runs_limit: If set, load only the most recent ``runs_limit`` context-relevant
+            runs (a bounded read for history). Only applied for a standalone agent
+            (an AgentSession); the bounded session is neither served from nor written
+            to the cache, since it holds a partial run list.
 
     Returns:
         AgentSession: The AgentSession loaded from the database/cache or None if not found.
@@ -93,8 +98,13 @@ def get_session(
 
     session_id_to_load: str = session_id or agent.session_id  # type: ignore[assignment]
 
-    # If there is a cached session, return it
-    if agent.cache_session and hasattr(agent, "_cached_session") and agent._cached_session is not None:
+    # If there is a cached session, return it (never for a bounded/partial read).
+    if (
+        runs_limit is None
+        and agent.cache_session
+        and hasattr(agent, "_cached_session")
+        and agent._cached_session is not None
+    ):
         if agent._cached_session.session_id == session_id_to_load and (
             user_id is None or agent._cached_session.user_id == user_id
         ):
@@ -112,7 +122,11 @@ def get_session(
             loaded_session = cast(
                 AgentSession,
                 _storage.read_session(
-                    agent, session_id=session_id_to_load, session_type=SessionType.AGENT, user_id=user_id
+                    agent,
+                    session_id=session_id_to_load,
+                    session_type=SessionType.AGENT,
+                    user_id=user_id,
+                    runs_limit=runs_limit,
                 ),  # type: ignore[arg-type]
             )
 
@@ -134,8 +148,8 @@ def get_session(
                 ),  # type: ignore[arg-type]
             )
 
-        # Cache the session if relevant
-        if loaded_session is not None and agent.cache_session:
+        # Cache the session if relevant (never cache a bounded/partial read).
+        if loaded_session is not None and agent.cache_session and runs_limit is None:
             agent._cached_session = loaded_session  # type: ignore
 
         return loaded_session
@@ -695,7 +709,14 @@ def get_session_messages(
         log_warning("Session ID is not set, cannot get messages for session")
         return []
 
-    session = get_session(agent, session_id=session_id)
+    # For a standalone agent with default status filtering, push "most recent N runs"
+    # down to the DB instead of loading the whole history and slicing in memory. The
+    # bounded query reproduces get_messages' pre-slice filters (top-level, non-skip
+    # statuses), so the result is identical. Custom skip_statuses / team reuse fall
+    # back to a full load.
+    runs_limit = last_n_runs if (last_n_runs is not None and skip_statuses is None and agent.team_id is None) else None
+
+    session = get_session(agent, session_id=session_id, runs_limit=runs_limit)
     if session is None:
         raise Exception("Session not found")
 

--- a/libs/agno/agno/agent/_session.py
+++ b/libs/agno/agno/agent/_session.py
@@ -699,19 +699,22 @@ def _bounded_history_runs_limit(
 ) -> Optional[int]:
     """The ``runs_limit`` to push down for a history read, or None to full-load.
 
-    Only bound when a *positive* run count is requested with default status
-    filtering, on a standalone agent (an AgentSession, so the DB-side filter
-    matches get_messages), and only when the DB actually supports the bounded
-    read. Otherwise return None so the caller full-loads -- which also preserves
-    the in-memory cache path when there is no DB, and lets get_messages handle
-    ``last_n_runs <= 0`` (it returns []) rather than pushing a bad LIMIT to SQL.
+    Only bound when there is a DB, a *positive* run count is requested with
+    default status filtering, on a standalone agent (an AgentSession, so the
+    DB-side filter matches get_messages). Otherwise return None so the caller
+    full-loads -- which preserves the in-memory cache path when there is no DB,
+    and lets get_messages handle ``last_n_runs <= 0`` (it returns []) rather
+    than pushing a bad LIMIT to the DB.
+
+    Every adapter accepts ``runs_limit``; adapters that don't optimize it load
+    the full history, so no capability check is needed here.
     """
     if (
-        last_n_runs is not None
+        agent.db is not None
+        and last_n_runs is not None
         and last_n_runs > 0
         and skip_statuses is None
         and agent.team_id is None
-        and getattr(agent.db, "supports_runs_limit", False)
     ):
         return last_n_runs
     return None

--- a/libs/agno/agno/agent/_session.py
+++ b/libs/agno/agno/agent/_session.py
@@ -162,12 +162,16 @@ async def aget_session(
     agent: Agent,
     session_id: Optional[str] = None,
     user_id: Optional[str] = None,
+    runs_limit: Optional[int] = None,
 ) -> Optional[Union[AgentSession, TeamSession, WorkflowSession]]:
     """Load an AgentSession from database or cache.
 
     Args:
         agent: The Agent instance.
         session_id: The session_id to load from storage.
+        runs_limit: If set, load only the most recent ``runs_limit`` context-relevant
+            runs (a bounded read for history). Only applied for a standalone agent;
+            the bounded session is neither served from nor written to the cache.
 
     Returns:
         AgentSession: The AgentSession loaded from the database/cache or None if not found.
@@ -179,8 +183,13 @@ async def aget_session(
 
     session_id_to_load: str = session_id or agent.session_id  # type: ignore[assignment]
 
-    # If there is a cached session, return it
-    if agent.cache_session and hasattr(agent, "_cached_session") and agent._cached_session is not None:
+    # If there is a cached session, return it (never for a bounded/partial read).
+    if (
+        runs_limit is None
+        and agent.cache_session
+        and hasattr(agent, "_cached_session")
+        and agent._cached_session is not None
+    ):
         if agent._cached_session.session_id == session_id_to_load and (
             user_id is None or agent._cached_session.user_id == user_id
         ):
@@ -195,7 +204,11 @@ async def aget_session(
             loaded_session = cast(
                 AgentSession,
                 await _storage.aread_session(
-                    agent, session_id=session_id_to_load, session_type=SessionType.AGENT, user_id=user_id
+                    agent,
+                    session_id=session_id_to_load,
+                    session_type=SessionType.AGENT,
+                    user_id=user_id,
+                    runs_limit=runs_limit,
                 ),  # type: ignore[arg-type]
             )
 
@@ -217,8 +230,8 @@ async def aget_session(
                 ),  # type: ignore[arg-type]
             )
 
-        # Cache the session if relevant
-        if loaded_session is not None and agent.cache_session:
+        # Cache the session if relevant (never cache a bounded/partial read).
+        if loaded_session is not None and agent.cache_session and runs_limit is None:
             agent._cached_session = loaded_session  # type: ignore
 
         return loaded_session
@@ -681,6 +694,29 @@ def update_session_metrics(agent: Agent, session: AgentSession, run_response: Ru
 # ---------------------------------------------------------------------------
 
 
+def _bounded_history_runs_limit(
+    agent: Agent, last_n_runs: Optional[int], skip_statuses: Optional[List[RunStatus]]
+) -> Optional[int]:
+    """The ``runs_limit`` to push down for a history read, or None to full-load.
+
+    Only bound when a *positive* run count is requested with default status
+    filtering, on a standalone agent (an AgentSession, so the DB-side filter
+    matches get_messages), and only when the DB actually supports the bounded
+    read. Otherwise return None so the caller full-loads -- which also preserves
+    the in-memory cache path when there is no DB, and lets get_messages handle
+    ``last_n_runs <= 0`` (it returns []) rather than pushing a bad LIMIT to SQL.
+    """
+    if (
+        last_n_runs is not None
+        and last_n_runs > 0
+        and skip_statuses is None
+        and agent.team_id is None
+        and getattr(agent.db, "supports_runs_limit", False)
+    ):
+        return last_n_runs
+    return None
+
+
 def get_session_messages(
     agent: Agent,
     session_id: Optional[str] = None,
@@ -709,12 +745,7 @@ def get_session_messages(
         log_warning("Session ID is not set, cannot get messages for session")
         return []
 
-    # For a standalone agent with default status filtering, push "most recent N runs"
-    # down to the DB instead of loading the whole history and slicing in memory. The
-    # bounded query reproduces get_messages' pre-slice filters (top-level, non-skip
-    # statuses), so the result is identical. Custom skip_statuses / team reuse fall
-    # back to a full load.
-    runs_limit = last_n_runs if (last_n_runs is not None and skip_statuses is None and agent.team_id is None) else None
+    runs_limit = _bounded_history_runs_limit(agent, last_n_runs, skip_statuses)
 
     session = get_session(agent, session_id=session_id, runs_limit=runs_limit)
     if session is None:
@@ -770,7 +801,9 @@ async def aget_session_messages(
         log_warning("Session ID is not set, cannot get messages for session")
         return []
 
-    session = await aget_session(agent, session_id=session_id)
+    runs_limit = _bounded_history_runs_limit(agent, last_n_runs, skip_statuses)
+
+    session = await aget_session(agent, session_id=session_id, runs_limit=runs_limit)
     if session is None:
         raise Exception("Session not found")
 

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -154,17 +154,30 @@ def read_session(
 
 
 async def aread_session(
-    agent: Agent, session_id: str, session_type: SessionType = SessionType.AGENT, user_id: Optional[str] = None
+    agent: Agent,
+    session_id: str,
+    session_type: SessionType = SessionType.AGENT,
+    user_id: Optional[str] = None,
+    runs_limit: Optional[int] = None,
 ) -> Optional[Union[AgentSession, TeamSession, WorkflowSession]]:
     """Async twin of :func:`read_session`. Same rationale: do NOT swallow errors."""
     from agno.agent import _init
 
     if not agent.db:
         raise ValueError("Db not initialized")
+    # Only pass runs_limit to adapters that support it (SQL); others load full history.
+    pass_limit = runs_limit is not None and getattr(agent.db, "supports_runs_limit", False)
     if _init.has_async_db(agent):
+        if pass_limit:
+            return await agent.db.get_session(  # type: ignore
+                session_id=session_id, session_type=session_type, user_id=user_id, runs_limit=runs_limit
+            )
         return await agent.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore
-    else:
-        return agent.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore
+    if pass_limit:
+        return agent.db.get_session(  # type: ignore
+            session_id=session_id, session_type=session_type, user_id=user_id, runs_limit=runs_limit
+        )
+    return agent.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore
 
 
 def upsert_session(

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -128,12 +128,21 @@ async def aget_last_run_output(agent: Agent, session_id: Optional[str] = None) -
 
 
 def read_session(
-    agent: Agent, session_id: str, session_type: SessionType = SessionType.AGENT, user_id: Optional[str] = None
+    agent: Agent,
+    session_id: str,
+    session_type: SessionType = SessionType.AGENT,
+    user_id: Optional[str] = None,
+    runs_limit: Optional[int] = None,
 ) -> Optional[Union[AgentSession, TeamSession, WorkflowSession]]:
     """Get a Session from the database."""
     try:
         if not agent.db:
             raise ValueError("Db not initialized")
+        # Only pass runs_limit to adapters that support it (SQL); others load full history.
+        if runs_limit is not None and getattr(agent.db, "supports_runs_limit", False):
+            return agent.db.get_session(  # type: ignore
+                session_id=session_id, session_type=session_type, user_id=user_id, runs_limit=runs_limit
+            )
         return agent.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore
     except Exception as e:
         import traceback
@@ -516,9 +525,7 @@ async def aread_or_create_session(
 
                 if _init.has_async_db(agent):
                     await asave_session(agent, session=agent_session)
-                    await aupsert_run(
-                        agent, run=introduction_run, session_id=session_id, user_id=user_id, run_index=0
-                    )
+                    await aupsert_run(agent, run=introduction_run, session_id=session_id, user_id=user_id, run_index=0)
                 else:
                     save_session(agent, session=agent_session)
                     upsert_run(agent, run=introduction_run, session_id=session_id, user_id=user_id, run_index=0)

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -145,12 +145,11 @@ def read_session(
     """
     if not agent.db:
         raise ValueError("Db not initialized")
-    # Only pass runs_limit to adapters that support it (SQL); others load full history.
-    if runs_limit is not None and getattr(agent.db, "supports_runs_limit", False):
-        return agent.db.get_session(  # type: ignore
-            session_id=session_id, session_type=session_type, user_id=user_id, runs_limit=runs_limit
-        )
-    return agent.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore
+    # Every adapter accepts runs_limit; those that don't optimize it load the full
+    # history (a safe superset), so we can pass it unconditionally.
+    return agent.db.get_session(  # type: ignore
+        session_id=session_id, session_type=session_type, user_id=user_id, runs_limit=runs_limit
+    )
 
 
 async def aread_session(
@@ -165,19 +164,15 @@ async def aread_session(
 
     if not agent.db:
         raise ValueError("Db not initialized")
-    # Only pass runs_limit to adapters that support it (SQL); others load full history.
-    pass_limit = runs_limit is not None and getattr(agent.db, "supports_runs_limit", False)
+    # Every adapter accepts runs_limit; those that don't optimize it load the full
+    # history (a safe superset), so we can pass it unconditionally.
     if _init.has_async_db(agent):
-        if pass_limit:
-            return await agent.db.get_session(  # type: ignore
-                session_id=session_id, session_type=session_type, user_id=user_id, runs_limit=runs_limit
-            )
-        return await agent.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore
-    if pass_limit:
-        return agent.db.get_session(  # type: ignore
+        return await agent.db.get_session(  # type: ignore
             session_id=session_id, session_type=session_type, user_id=user_id, runs_limit=runs_limit
         )
-    return agent.db.get_session(session_id=session_id, session_type=session_type, user_id=user_id)  # type: ignore
+    return agent.db.get_session(  # type: ignore
+        session_id=session_id, session_type=session_type, user_id=user_id, runs_limit=runs_limit
+    )
 
 
 def upsert_session(

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -237,6 +237,7 @@ class BaseDb(ABC):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         raise NotImplementedError
 
@@ -1693,6 +1694,7 @@ class AsyncBaseDb(ABC):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         raise NotImplementedError
 

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -36,6 +36,11 @@ class BaseDb(ABC):
     # We assume the database to be up to date with the 2.0.0 release
     default_schema_version = "2.0.0"
 
+    # Whether this adapter can push a "most recent N runs" limit for a session
+    # down to the database (get_session(runs_limit=...)). Adapters that can't
+    # leave this False; callers then load the full run history (safe, unbounded).
+    supports_runs_limit: bool = False
+
     def __init__(
         self,
         session_table: Optional[str] = None,
@@ -1579,6 +1584,9 @@ class BaseDb(ABC):
 
 class AsyncBaseDb(ABC):
     """Base abstract class for all our async database implementations."""
+
+    # See BaseDb.supports_runs_limit.
+    supports_runs_limit: bool = False
 
     def __init__(
         self,

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -36,11 +36,6 @@ class BaseDb(ABC):
     # We assume the database to be up to date with the 2.0.0 release
     default_schema_version = "2.0.0"
 
-    # Whether this adapter can push a "most recent N runs" limit for a session
-    # down to the database (get_session(runs_limit=...)). Adapters that can't
-    # leave this False; callers then load the full run history (safe, unbounded).
-    supports_runs_limit: bool = False
-
     def __init__(
         self,
         session_table: Optional[str] = None,
@@ -221,7 +216,11 @@ class BaseDb(ABC):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
+        # runs_limit: attach only the most recent N context-relevant runs. Adapters
+        # that don't optimize this MUST still accept it and load the full history
+        # (a safe, unbounded superset); adapters that can push it to the DB do so.
         raise NotImplementedError
 
     @abstractmethod
@@ -1585,9 +1584,6 @@ class BaseDb(ABC):
 class AsyncBaseDb(ABC):
     """Base abstract class for all our async database implementations."""
 
-    # See BaseDb.supports_runs_limit.
-    supports_runs_limit: bool = False
-
     def __init__(
         self,
         id: Optional[str] = None,
@@ -1678,7 +1674,9 @@ class AsyncBaseDb(ABC):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
+        # See BaseDb.get_session for the runs_limit contract.
         raise NotImplementedError
 
     @abstractmethod

--- a/libs/agno/agno/db/dynamo/dynamo.py
+++ b/libs/agno/agno/db/dynamo/dynamo.py
@@ -41,6 +41,7 @@ from agno.db.utils import (
     deserialize_run,
     deserialize_session,
     deserialize_sessions,
+    filter_context_runs,
     merge_runs_table_with_legacy_blob,
 )
 from agno.run.agent import RunOutput
@@ -671,6 +672,7 @@ class DynamoDb(BaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         """
         Get a session from the database as a Session object.
@@ -710,6 +712,10 @@ class DynamoDb(BaseDb):
             try:
                 runs_data = self._get_session_runs_data(session_id)
                 session["runs"] = merge_runs_table_with_legacy_blob(runs_data, session.get("runs"))
+                if runs_limit is not None:
+                    # No query engine to push "last N" down: filter+slice in memory to
+                    # match the SQL fast path (drop member/skip-status runs, then last N).
+                    session["runs"] = filter_context_runs(session["runs"] or [])[-runs_limit:]
             except Exception as e:
                 log_error(f"Failed to load runs for session {session_id}: {str(e)}")
 

--- a/libs/agno/agno/db/firestore/firestore.py
+++ b/libs/agno/agno/db/firestore/firestore.py
@@ -31,6 +31,7 @@ from agno.db.utils import (
     deserialize_session,
     deserialize_session_json_fields,
     deserialize_sessions,
+    filter_context_runs,
     merge_runs_table_with_legacy_blob,
 )
 from agno.run.agent import RunOutput
@@ -692,6 +693,7 @@ class FirestoreDb(BaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         """Read a session from the database.
 
@@ -734,6 +736,10 @@ class FirestoreDb(BaseDb):
             if runs_collection_ref is not None:
                 runs_data = self._get_session_runs_docs(runs_collection_ref, session_id)
                 session["runs"] = merge_runs_table_with_legacy_blob(runs_data, session.get("runs"))
+            if runs_limit is not None:
+                # No query engine to push "last N" down: filter+slice in memory to
+                # match the SQL fast path (drop member/skip-status runs, then last N).
+                session["runs"] = filter_context_runs(session.get("runs") or [])[-runs_limit:]
 
             if not deserialize:
                 return session

--- a/libs/agno/agno/db/gcs_json/gcs_json_db.py
+++ b/libs/agno/agno/db/gcs_json/gcs_json_db.py
@@ -25,6 +25,7 @@ from agno.db.utils import (
     deserialize_run,
     deserialize_session,
     deserialize_sessions,
+    filter_context_runs,
     merge_runs_table_with_legacy_blob,
 )
 from agno.run.agent import RunOutput
@@ -493,6 +494,7 @@ class GcsJsonDb(BaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[AgentSession, TeamSession, WorkflowSession, Dict[str, Any]]]:
         """Read a session from the GCS JSON file.
 
@@ -521,6 +523,10 @@ class GcsJsonDb(BaseDb):
                     # Attach runs from the runs file, merged with any legacy `runs` field
                     runs_data = self._get_session_runs_data(session_id)
                     session_data["runs"] = merge_runs_table_with_legacy_blob(runs_data, session_data.get("runs"))
+                    if runs_limit is not None:
+                        # No query engine to push "last N" down: filter+slice in memory to
+                        # match the SQL fast path (drop member/skip-status runs, then last N).
+                        session_data["runs"] = filter_context_runs(session_data["runs"] or [])[-runs_limit:]
 
                     if not deserialize:
                         return session_data

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -176,6 +176,7 @@ class InMemoryDb(BaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """Get all sessions from in-memory storage with filtering and pagination.
 
@@ -246,6 +247,12 @@ class InMemoryDb(BaseDb):
                 if page is not None:
                     start_idx = (page - 1) * limit
                 filtered_sessions = filtered_sessions[start_idx : start_idx + limit]
+
+            if not include_runs:
+                # List views don't need run history; leave it unattached (deepcopy above,
+                # so the stored session keeps its runs).
+                for s in filtered_sessions:
+                    s["runs"] = None
 
             if not deserialize:
                 return filtered_sessions, total_count

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -17,7 +17,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
-from agno.db.utils import deserialize_session, deserialize_sessions
+from agno.db.utils import deserialize_session, deserialize_sessions, filter_context_runs
 from agno.session import AgentSession, Session, TeamSession, WorkflowSession
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 
@@ -116,6 +116,7 @@ class InMemoryDb(BaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[AgentSession, TeamSession, WorkflowSession, Dict[str, Any]]]:
         """Read a session from in-memory storage.
 
@@ -140,6 +141,13 @@ class InMemoryDb(BaseDb):
                         continue
 
                     session_data_copy = deepcopy(session_data)
+
+                    if runs_limit is not None:
+                        # No query engine to push "last N" down: filter+slice in memory to
+                        # match the SQL fast path (drop member/skip-status runs, then last N).
+                        session_data_copy["runs"] = filter_context_runs(session_data_copy.get("runs") or [])[
+                            -runs_limit:
+                        ]
 
                     if not deserialize:
                         return session_data_copy

--- a/libs/agno/agno/db/json/json_db.py
+++ b/libs/agno/agno/db/json/json_db.py
@@ -27,6 +27,7 @@ from agno.db.utils import (
     deserialize_run,
     deserialize_session,
     deserialize_sessions,
+    filter_context_runs,
     merge_runs_table_with_legacy_blob,
 )
 from agno.run.agent import RunOutput
@@ -491,6 +492,7 @@ class JsonDb(BaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[AgentSession, TeamSession, WorkflowSession, Dict[str, Any]]]:
         """Read a session from the JSON file.
 
@@ -519,6 +521,10 @@ class JsonDb(BaseDb):
                     # Attach runs from the runs file, merged with any legacy `runs` field
                     runs_data = self._get_session_runs_data(session_id)
                     session_data["runs"] = merge_runs_table_with_legacy_blob(runs_data, session_data.get("runs"))
+                    if runs_limit is not None:
+                        # No query engine to push "last N" down: filter+slice in memory to
+                        # match the SQL fast path (drop member/skip-status runs, then last N).
+                        session_data["runs"] = filter_context_runs(session_data["runs"] or [])[-runs_limit:]
 
                     if not deserialize:
                         return session_data

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -29,11 +29,13 @@ from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
 from agno.db.utils import (
+    HISTORY_SKIP_STATUSES,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
     deserialize_session_json_fields,
     deserialize_sessions,
+    filter_context_runs,
     merge_runs_table_with_legacy_blob,
 )
 from agno.run.agent import RunOutput
@@ -614,8 +616,29 @@ class AsyncMongoDb(AsyncBaseDb):
 
     # -- Run methods --
     async def _get_session_runs_docs(
-        self, runs_collection: AsyncMongoCollectionType, session_id: str
+        self, runs_collection: AsyncMongoCollectionType, session_id: str, limit: Optional[int] = None
     ) -> List[Dict[str, Any]]:
+        """Get the raw run_data dicts for the given session, in insertion order.
+
+        When ``limit`` is set, push "most recent N context-relevant runs" down to
+        the DB: drop member sub-runs (``parent_run_id`` set) and terminal-skip
+        statuses, sort newest-first, take N, then reverse back to chronological
+        order. ``$nin``/``None`` in Mongo also match a null or missing field, so
+        this keeps runs whose ``status`` is null/absent — mirroring the SQL
+        ``status IS NULL OR status NOT IN (...)`` fast path.
+        """
+        if limit is not None:
+            filter = {
+                "session_id": session_id,
+                "parent_run_id": None,
+                "status": {"$nin": HISTORY_SKIP_STATUSES},
+            }
+            cursor = runs_collection.find(filter).sort([("run_index", -1), ("created_at", -1)]).limit(limit)
+            docs = await cursor.to_list(length=limit)
+            run_docs = [doc["run_data"] for doc in docs if "run_data" in doc]
+            run_docs.reverse()  # back to chronological order
+            return run_docs
+
         cursor = runs_collection.find({"session_id": session_id}).sort([("run_index", 1), ("created_at", 1)])
         docs = await cursor.to_list(length=None)
         return [doc["run_data"] for doc in docs if "run_data" in doc]
@@ -873,6 +896,7 @@ class AsyncMongoDb(AsyncBaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         """Read a session from the database.
 
@@ -906,9 +930,26 @@ class AsyncMongoDb(AsyncBaseDb):
 
             session = deserialize_session_json_fields(result)
 
-            if runs_collection is not None:
+            # Attach the runs stored in the runs collection, merged with any runs
+            # still sitting in the legacy `runs` field (so partially-migrated
+            # sessions don't silently lose history).
+            legacy_runs = session.get("runs")
+            if runs_collection is not None and runs_limit is not None and not legacy_runs:
+                # Fully migrated: push "most recent N" down to the DB.
+                session["runs"] = await self._get_session_runs_docs(runs_collection, session_id, limit=runs_limit)
+            elif runs_collection is not None:
+                # Full load + merge. Also the un-migrated fallback: the legacy blob
+                # holds the whole history in one field, so "last N" can't be pushed
+                # down — load all, merge, then filter+slice to match the migrated path.
                 runs_data = await self._get_session_runs_docs(runs_collection, session_id)
-                session["runs"] = merge_runs_table_with_legacy_blob(runs_data, session.get("runs"))
+                merged = merge_runs_table_with_legacy_blob(runs_data, legacy_runs)
+                if runs_limit is not None:
+                    merged = filter_context_runs(merged)[-runs_limit:]
+                session["runs"] = merged
+            elif runs_limit is not None:
+                # No runs collection yet (fully un-migrated): filter+slice the blob.
+                merged = merge_runs_table_with_legacy_blob([], legacy_runs)
+                session["runs"] = filter_context_runs(merged)[-runs_limit:]
 
             if not deserialize:
                 return session

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -628,19 +628,34 @@ class AsyncMongoDb(AsyncBaseDb):
         ``status IS NULL OR status NOT IN (...)`` fast path.
         """
         if limit is not None:
-            filter = {
-                "session_id": session_id,
-                "parent_run_id": None,
-                "status": {"$nin": HISTORY_SKIP_STATUSES},
-            }
-            cursor = runs_collection.find(filter).sort([("run_index", -1), ("created_at", -1)]).limit(limit)
-            docs = await cursor.to_list(length=limit)
+            pipeline: List[Dict[str, Any]] = [
+                {
+                    "$match": {
+                        "session_id": session_id,
+                        "parent_run_id": None,
+                        "status": {"$nin": HISTORY_SKIP_STATUSES},
+                    }
+                },
+                {
+                    "$addFields": {
+                        "_ri": {"$ifNull": ["$run_index", 0]},
+                        "_ca": {"$ifNull": ["$created_at", 0]},
+                    }
+                },
+                {"$sort": {"_ri": -1, "_ca": -1}},
+                {"$limit": limit},
+            ]
+            docs = await runs_collection.aggregate(pipeline).to_list(length=limit)
             run_docs = [doc["run_data"] for doc in docs if "run_data" in doc]
             run_docs.reverse()  # back to chronological order
             return run_docs
 
-        cursor = runs_collection.find({"session_id": session_id}).sort([("run_index", 1), ("created_at", 1)])
-        docs = await cursor.to_list(length=None)
+        pipeline = [
+            {"$match": {"session_id": session_id}},
+            {"$addFields": {"_ri": {"$ifNull": ["$run_index", 0]}, "_ca": {"$ifNull": ["$created_at", 0]}}},
+            {"$sort": {"_ri": 1, "_ca": 1}},
+        ]
+        docs = await runs_collection.aggregate(pipeline).to_list(length=None)
         return [doc["run_data"] for doc in docs if "run_data" in doc]
 
     async def _get_sessions_runs_docs(

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -429,18 +429,33 @@ class MongoDb(BaseDb):
         ``status IS NULL OR status NOT IN (...)`` fast path.
         """
         if limit is not None:
-            filter = {
-                "session_id": session_id,
-                "parent_run_id": None,
-                "status": {"$nin": HISTORY_SKIP_STATUSES},
-            }
-            cursor = runs_collection.find(filter).sort([("run_index", -1), ("created_at", -1)]).limit(limit)
-            docs = [doc["run_data"] for doc in cursor if "run_data" in doc]
+            pipeline: List[Dict[str, Any]] = [
+                {
+                    "$match": {
+                        "session_id": session_id,
+                        "parent_run_id": None,
+                        "status": {"$nin": HISTORY_SKIP_STATUSES},
+                    }
+                },
+                {
+                    "$addFields": {
+                        "_ri": {"$ifNull": ["$run_index", 0]},
+                        "_ca": {"$ifNull": ["$created_at", 0]},
+                    }
+                },
+                {"$sort": {"_ri": -1, "_ca": -1}},
+                {"$limit": limit},
+            ]
+            docs = [doc["run_data"] for doc in runs_collection.aggregate(pipeline) if "run_data" in doc]
             docs.reverse()  # back to chronological order
             return docs
 
-        cursor = runs_collection.find({"session_id": session_id}).sort([("run_index", 1), ("created_at", 1)])
-        return [doc["run_data"] for doc in cursor if "run_data" in doc]
+        pipeline = [
+            {"$match": {"session_id": session_id}},
+            {"$addFields": {"_ri": {"$ifNull": ["$run_index", 0]}, "_ca": {"$ifNull": ["$created_at", 0]}}},
+            {"$sort": {"_ri": 1, "_ca": 1}},
+        ]
+        return [doc["run_data"] for doc in runs_collection.aggregate(pipeline) if "run_data" in doc]
 
     def _get_sessions_runs_docs(
         self, runs_collection: Collection, session_ids: List[str]

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -29,11 +29,13 @@ from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
 from agno.db.utils import (
+    HISTORY_SKIP_STATUSES,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
     deserialize_session_json_fields,
     deserialize_sessions,
+    filter_context_runs,
     merge_runs_table_with_legacy_blob,
 )
 from agno.run.agent import RunOutput
@@ -414,8 +416,29 @@ class MongoDb(BaseDb):
         return result.modified_count > 0 or result.matched_count > 0
 
     # -- Run methods --
-    def _get_session_runs_docs(self, runs_collection: Collection, session_id: str) -> List[Dict[str, Any]]:
-        """Get the raw run_data dicts for the given session, in insertion order."""
+    def _get_session_runs_docs(
+        self, runs_collection: Collection, session_id: str, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get the raw run_data dicts for the given session, in insertion order.
+
+        When ``limit`` is set, push "most recent N context-relevant runs" down to
+        the DB: drop member sub-runs (``parent_run_id`` set) and terminal-skip
+        statuses, sort newest-first, take N, then reverse back to chronological
+        order. ``$nin``/``None`` in Mongo also match a null or missing field, so
+        this keeps runs whose ``status`` is null/absent — mirroring the SQL
+        ``status IS NULL OR status NOT IN (...)`` fast path.
+        """
+        if limit is not None:
+            filter = {
+                "session_id": session_id,
+                "parent_run_id": None,
+                "status": {"$nin": HISTORY_SKIP_STATUSES},
+            }
+            cursor = runs_collection.find(filter).sort([("run_index", -1), ("created_at", -1)]).limit(limit)
+            docs = [doc["run_data"] for doc in cursor if "run_data" in doc]
+            docs.reverse()  # back to chronological order
+            return docs
+
         cursor = runs_collection.find({"session_id": session_id}).sort([("run_index", 1), ("created_at", 1)])
         return [doc["run_data"] for doc in cursor if "run_data" in doc]
 
@@ -683,6 +706,7 @@ class MongoDb(BaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         """Read a session from the database.
 
@@ -719,9 +743,23 @@ class MongoDb(BaseDb):
             # Attach the runs stored in the runs collection, merged with any runs still
             # sitting in the legacy `runs` field (so partially-migrated sessions don't
             # silently lose history).
-            if runs_collection is not None:
+            legacy_runs = session.get("runs")
+            if runs_collection is not None and runs_limit is not None and not legacy_runs:
+                # Fully migrated: push "most recent N" down to the DB (indexed).
+                session["runs"] = self._get_session_runs_docs(runs_collection, session_id, limit=runs_limit)
+            elif runs_collection is not None:
+                # Full load + merge. Also the un-migrated fallback: the legacy blob
+                # holds the whole history in one field, so "last N" can't be pushed
+                # to the DB — load all, merge, then filter+slice to match the migrated path.
                 runs_data = self._get_session_runs_docs(runs_collection, session_id)
-                session["runs"] = merge_runs_table_with_legacy_blob(runs_data, session.get("runs"))
+                merged = merge_runs_table_with_legacy_blob(runs_data, legacy_runs)
+                if runs_limit is not None:
+                    merged = filter_context_runs(merged)[-runs_limit:]
+                session["runs"] = merged
+            elif runs_limit is not None:
+                # No runs collection yet (fully un-migrated): filter+slice the legacy blob.
+                merged = merge_runs_table_with_legacy_blob([], legacy_runs)
+                session["runs"] = filter_context_runs(merged)[-runs_limit:]
 
             if not deserialize:
                 return session

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -532,7 +532,10 @@ class AsyncMySQLDb(AsyncBaseDb):
                 .where(runs_table.c.session_id == session_id)
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
-                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .order_by(
+                    func.coalesce(runs_table.c.run_index, 0).desc(),
+                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                )
                 .limit(limit)
             )
             result = await sess.execute(stmt)
@@ -542,7 +545,10 @@ class AsyncMySQLDb(AsyncBaseDb):
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
-            .order_by(runs_table.c.run_index.asc(), runs_table.c.created_at.asc())
+            .order_by(
+                func.coalesce(runs_table.c.run_index, 0).asc(),
+                func.coalesce(runs_table.c.created_at, 0).asc(),
+            )
         )
         result = await sess.execute(stmt)
         return [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in result.fetchall()]

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -27,10 +27,12 @@ from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
 from agno.db.utils import (
+    HISTORY_SKIP_STATUSES,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
     deserialize_sessions,
+    filter_context_runs,
     json_serializer,
     merge_runs_table_with_legacy_blob,
     validate_pagination,
@@ -44,7 +46,7 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
 
 try:
-    from sqlalchemy import TEXT, ForeignKey, Index, UniqueConstraint, and_, cast, func, update
+    from sqlalchemy import TEXT, ForeignKey, Index, UniqueConstraint, and_, cast, func, or_, update
     from sqlalchemy.dialects import mysql
     from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
     from sqlalchemy.schema import Column, MetaData, Table
@@ -512,8 +514,31 @@ class AsyncMySQLDb(AsyncBaseDb):
             return True
 
     # -- Run methods --
-    async def _get_session_runs_data(self, sess, runs_table: Table, session_id: str) -> List[Dict[str, Any]]:
-        """Get the raw run_data dicts for the given session, in insertion order."""
+    async def _get_session_runs_data(
+        self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get the raw run_data dicts for the given session, in insertion order.
+
+        When ``limit`` is set, only the most recent ``limit`` context-relevant runs
+        are fetched (indexed ``ORDER BY run_index DESC LIMIT``) and returned in
+        ascending (chronological) order. "Context-relevant" mirrors the pre-slice
+        filtering in ``get_messages``: member sub-runs (``parent_run_id`` set) and
+        terminal-skip statuses are excluded in SQL, so the DB-side last-N matches
+        the in-memory history window.
+        """
+        if limit is not None:
+            stmt = (
+                select(runs_table.c.run_data)
+                .where(runs_table.c.session_id == session_id)
+                .where(runs_table.c.parent_run_id.is_(None))
+                .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
+                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .limit(limit)
+            )
+            result = await sess.execute(stmt)
+            rows = [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in result.fetchall()]
+            rows.reverse()
+            return rows
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
@@ -777,6 +802,7 @@ class AsyncMySQLDb(AsyncBaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         """
         Read a session from the database.
@@ -811,11 +837,30 @@ class AsyncMySQLDb(AsyncBaseDb):
 
                 session = dict(row._mapping)
 
-                if runs_table is not None:
+                # Attach the runs stored in the runs table, merged with any runs still
+                # sitting in the legacy `runs` column (so partially-migrated sessions
+                # don't silently lose history).
+                legacy_runs = session.get("runs")
+                if runs_table is not None and runs_limit is not None and not legacy_runs:
+                    # Fully migrated: push "most recent N" down to the DB (indexed).
+                    session["runs"] = await self._get_session_runs_data(
+                        sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
+                    )
+                elif runs_table is not None:
+                    # Full load + merge. Also the un-migrated fallback: the legacy blob
+                    # holds the whole history in one column, so "last N" can't be pushed
+                    # to SQL — load all, merge, then filter+slice to match the migrated path.
                     runs_data = await self._get_session_runs_data(
                         sess=sess, runs_table=runs_table, session_id=session_id
                     )
-                    session["runs"] = merge_runs_table_with_legacy_blob(runs_data, session.get("runs"))
+                    merged = merge_runs_table_with_legacy_blob(runs_data, legacy_runs)
+                    if runs_limit is not None:
+                        merged = filter_context_runs(merged)[-runs_limit:]
+                    session["runs"] = merged
+                elif runs_limit is not None:
+                    # No runs table yet (fully un-migrated): filter+slice the legacy blob.
+                    merged = merge_runs_table_with_legacy_blob([], legacy_runs)
+                    session["runs"] = filter_context_runs(merged)[-runs_limit:]
 
             if not deserialize:
                 return session

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -200,6 +200,7 @@ class AsyncMySQLDb(AsyncBaseDb):
             indexes: List[str] = []
             unique_constraints: List[str] = []
             schema_unique_constraints = table_schema.pop("_unique_constraints", [])
+            schema_composite_indexes = table_schema.pop("_composite_indexes", [])
 
             # Get the columns, indexes, and unique constraints from the table schema
             for col_name, col_config in table_schema.items():
@@ -237,6 +238,11 @@ class AsyncMySQLDb(AsyncBaseDb):
             for idx_col in indexes:
                 idx_name = f"idx_{table_name}_{idx_col}"
                 table.append_constraint(Index(idx_name, idx_col))
+
+            # Add composite indexes with table-specific names
+            for composite in schema_composite_indexes:
+                composite_name = f"{table_name}_{composite['name']}"
+                table.append_constraint(Index(composite_name, *composite["columns"]))
 
             # Create schema if not exists
             if self.create_schema:

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -195,6 +195,7 @@ class MySQLDb(BaseDb):
             indexes: List[str] = []
             unique_constraints: List[str] = []
             schema_unique_constraints = table_schema.pop("_unique_constraints", [])
+            schema_composite_indexes = table_schema.pop("_composite_indexes", [])
 
             # Get the columns, indexes, and unique constraints from the table schema
             for col_name, col_config in table_schema.items():
@@ -232,6 +233,11 @@ class MySQLDb(BaseDb):
             for idx_col in indexes:
                 idx_name = f"idx_{table_name}_{idx_col}"
                 table.append_constraint(Index(idx_name, idx_col))
+
+            # Add multi-column (composite) indexes with table-specific names
+            for composite in schema_composite_indexes:
+                composite_name = f"{table_name}_{composite['name']}"
+                table.append_constraint(Index(composite_name, *composite["columns"]))
 
             if self.create_schema:
                 with self.Session() as sess, sess.begin():

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -535,7 +535,10 @@ class MySQLDb(BaseDb):
                 .where(runs_table.c.session_id == session_id)
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
-                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .order_by(
+                    func.coalesce(runs_table.c.run_index, 0).desc(),
+                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                )
                 .limit(limit)
             )
             rows = [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
@@ -544,7 +547,10 @@ class MySQLDb(BaseDb):
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
-            .order_by(runs_table.c.run_index.asc(), runs_table.c.created_at.asc())
+            .order_by(
+                func.coalesce(runs_table.c.run_index, 0).asc(),
+                func.coalesce(runs_table.c.created_at, 0).asc(),
+            )
         )
         return [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
 

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -27,10 +27,12 @@ from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
 from agno.db.utils import (
+    HISTORY_SKIP_STATUSES,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
     deserialize_sessions,
+    filter_context_runs,
     json_serializer,
     merge_runs_table_with_legacy_blob,
     validate_pagination,
@@ -44,7 +46,7 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
 
 try:
-    from sqlalchemy import TEXT, ForeignKey, Index, UniqueConstraint, and_, cast, func, update
+    from sqlalchemy import TEXT, ForeignKey, Index, UniqueConstraint, and_, cast, func, or_, update
     from sqlalchemy.dialects import mysql
     from sqlalchemy.engine import Engine, create_engine
     from sqlalchemy.orm import scoped_session, sessionmaker
@@ -515,8 +517,30 @@ class MySQLDb(BaseDb):
             return True
 
     # -- Run methods --
-    def _get_session_runs_data(self, sess, runs_table: Table, session_id: str) -> List[Dict[str, Any]]:
-        """Get the raw run_data dicts for the given session, in insertion order."""
+    def _get_session_runs_data(
+        self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get the raw run_data dicts for the given session, in insertion order.
+
+        When ``limit`` is set, only the most recent ``limit`` context-relevant runs
+        are fetched (indexed ``ORDER BY run_index DESC LIMIT``) and returned in
+        ascending (chronological) order. "Context-relevant" mirrors the pre-slice
+        filtering in ``get_messages``: member sub-runs (``parent_run_id`` set) and
+        terminal-skip statuses are excluded in SQL, so the DB-side last-N matches
+        the in-memory history window.
+        """
+        if limit is not None:
+            stmt = (
+                select(runs_table.c.run_data)
+                .where(runs_table.c.session_id == session_id)
+                .where(runs_table.c.parent_run_id.is_(None))
+                .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
+                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .limit(limit)
+            )
+            rows = [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
+            rows.reverse()
+            return rows
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
@@ -786,6 +810,7 @@ class MySQLDb(BaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         """
         Read a session from the database.
@@ -821,11 +846,28 @@ class MySQLDb(BaseDb):
 
                 session = dict(result._mapping)
 
-                # Attach runs from the runs table, merged with any runs still in the
-                # legacy `runs` column (so partially-migrated sessions don't lose history).
-                if runs_table is not None:
+                # Attach the runs stored in the runs table, merged with any runs still
+                # sitting in the legacy `runs` column (so partially-migrated sessions
+                # don't silently lose history).
+                legacy_runs = session.get("runs")
+                if runs_table is not None and runs_limit is not None and not legacy_runs:
+                    # Fully migrated: push "most recent N" down to the DB (indexed).
+                    session["runs"] = self._get_session_runs_data(
+                        sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
+                    )
+                elif runs_table is not None:
+                    # Full load + merge. Also the un-migrated fallback: the legacy blob
+                    # holds the whole history in one column, so "last N" can't be pushed
+                    # to SQL — load all, merge, then filter+slice to match the migrated path.
                     runs_data = self._get_session_runs_data(sess=sess, runs_table=runs_table, session_id=session_id)
-                    session["runs"] = merge_runs_table_with_legacy_blob(runs_data, session.get("runs"))
+                    merged = merge_runs_table_with_legacy_blob(runs_data, legacy_runs)
+                    if runs_limit is not None:
+                        merged = filter_context_runs(merged)[-runs_limit:]
+                    session["runs"] = merged
+                elif runs_limit is not None:
+                    # No runs table yet (fully un-migrated): filter+slice the legacy blob.
+                    merged = merge_runs_table_with_legacy_blob([], legacy_runs)
+                    session["runs"] = filter_context_runs(merged)[-runs_limit:]
 
             if not deserialize:
                 return session

--- a/libs/agno/agno/db/mysql/schemas.py
+++ b/libs/agno/agno/db/mysql/schemas.py
@@ -47,6 +47,9 @@ def _get_run_table_schema(session_table_name: str = "agno_sessions") -> dict[str
         "run_data": {"type": JSON, "nullable": False},
         "created_at": {"type": BigInteger, "nullable": False, "index": True},
         "updated_at": {"type": BigInteger, "nullable": True},
+        "_composite_indexes": [
+            {"name": "runs_session_id_run_index", "columns": ["session_id", "run_index"]},
+        ],
     }
 
 

--- a/libs/agno/agno/db/mysql/schemas.py
+++ b/libs/agno/agno/db/mysql/schemas.py
@@ -47,11 +47,6 @@ def _get_run_table_schema(session_table_name: str = "agno_sessions") -> dict[str
         "run_data": {"type": JSON, "nullable": False},
         "created_at": {"type": BigInteger, "nullable": False, "index": True},
         "updated_at": {"type": BigInteger, "nullable": True},
-        # Composite index so "most recent N runs of a session"
-        # (WHERE session_id=? ORDER BY run_index DESC LIMIT N) is index-served.
-        "__composite_indexes__": [
-            {"name": "agno_runs_session_id_run_index", "columns": ["session_id", "run_index"]},
-        ],
     }
 
 

--- a/libs/agno/agno/db/mysql/schemas.py
+++ b/libs/agno/agno/db/mysql/schemas.py
@@ -47,6 +47,11 @@ def _get_run_table_schema(session_table_name: str = "agno_sessions") -> dict[str
         "run_data": {"type": JSON, "nullable": False},
         "created_at": {"type": BigInteger, "nullable": False, "index": True},
         "updated_at": {"type": BigInteger, "nullable": True},
+        # Composite index so "most recent N runs of a session"
+        # (WHERE session_id=? ORDER BY run_index DESC LIMIT N) is index-served.
+        "__composite_indexes__": [
+            {"name": "agno_runs_session_id_run_index", "columns": ["session_id", "run_index"]},
+        ],
     }
 
 

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -1071,9 +1071,15 @@ class AsyncPostgresDb(AsyncBaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """
         Get all sessions in the given table. Can filter by user_id and entity_id.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. The runs are untouched
+        in storage; a single ``get_session`` still returns them. Defaults to True
+        to preserve existing behavior.
 
         Args:
             user_id (Optional[str]): The ID of the user to filter by.
@@ -1154,13 +1160,17 @@ class AsyncPostgresDb(AsyncBaseDb):
 
                 # Attach the runs stored in the runs table. If a session has no rows in the
                 # runs table, fall back to its legacy `runs` column content, if any.
-                if runs_table is not None:
+                if include_runs and runs_table is not None:
                     runs_by_session = await self._get_sessions_runs_data(
                         sess=sess, runs_table=runs_table, session_ids=[s["session_id"] for s in session]
                     )
                     for s in session:
                         runs_data = runs_by_session.get(s["session_id"], [])
                         s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+                elif not include_runs:
+                    # List views don't need run history; leave it unattached (storage untouched).
+                    for s in session:
+                        s["runs"] = None
 
                 if not deserialize:
                     return session, total_count

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -648,7 +648,10 @@ class AsyncPostgresDb(AsyncBaseDb):
                 .where(runs_table.c.session_id == session_id)
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
-                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .order_by(
+                    func.coalesce(runs_table.c.run_index, 0).desc(),
+                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                )
                 .limit(limit)
             )
             result = await sess.execute(stmt)
@@ -658,7 +661,10 @@ class AsyncPostgresDb(AsyncBaseDb):
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
-            .order_by(runs_table.c.run_index.asc(), runs_table.c.created_at.asc())
+            .order_by(
+                func.coalesce(runs_table.c.run_index, 0).asc(),
+                func.coalesce(runs_table.c.created_at, 0).asc(),
+            )
         )
         result = await sess.execute(stmt)
         return [row[0] for row in result.fetchall()]

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -30,10 +30,12 @@ from agno.db.schemas.service_accounts import (
     validate_service_account_update,
 )
 from agno.db.utils import (
+    HISTORY_SKIP_STATUSES,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
     deserialize_sessions,
+    filter_context_runs,
     json_serializer,
     learning_search_patterns,
     merge_runs_table_with_legacy_blob,
@@ -60,6 +62,9 @@ except ImportError:
 
 
 class AsyncPostgresDb(AsyncBaseDb):
+    # Whether this adapter can push a "most recent N runs" limit down to the DB.
+    supports_runs_limit: bool = True
+
     def __init__(
         self,
         id: Optional[str] = None,
@@ -628,8 +633,31 @@ class AsyncPostgresDb(AsyncBaseDb):
             return True
 
     # -- Run methods --
-    async def _get_session_runs_data(self, sess, runs_table: Table, session_id: str) -> List[Dict[str, Any]]:
-        """Get the raw run_data dicts for the given session, in insertion order."""
+    async def _get_session_runs_data(
+        self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get the raw run_data dicts for the given session, in insertion order.
+
+        When ``limit`` is set, only the most recent ``limit`` context-relevant runs
+        are fetched (indexed ``ORDER BY run_index DESC LIMIT``) and returned in
+        ascending (chronological) order. "Context-relevant" mirrors the pre-slice
+        filtering in ``get_messages``: member sub-runs (``parent_run_id`` set) and
+        terminal-skip statuses are excluded in SQL, so the DB-side last-N matches
+        the in-memory history window.
+        """
+        if limit is not None:
+            stmt = (
+                select(runs_table.c.run_data)
+                .where(runs_table.c.session_id == session_id)
+                .where(runs_table.c.parent_run_id.is_(None))
+                .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
+                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .limit(limit)
+            )
+            result = await sess.execute(stmt)
+            rows = [row[0] for row in result.fetchall()]
+            rows.reverse()
+            return rows
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
@@ -953,6 +981,7 @@ class AsyncPostgresDb(AsyncBaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         """
         Read a session from the database.
@@ -962,6 +991,11 @@ class AsyncPostgresDb(AsyncBaseDb):
             user_id (Optional[str]): User ID to filter by. Defaults to None.
             session_type (Optional[SessionType]): Type of session to read. Defaults to None.
             deserialize (Optional[bool]): Whether to serialize the session. Defaults to True.
+            runs_limit (Optional[int]): If set, attach only the most recent ``runs_limit``
+                runs instead of the full history. For a fully-migrated session this is an
+                indexed ``ORDER BY run_index DESC LIMIT`` query; for a session that still
+                carries a legacy ``runs`` blob it falls back to a full load + merge, then
+                slices, so no history is ever lost.
 
         Returns:
             Union[Session, Dict[str, Any], None]:
@@ -993,11 +1027,27 @@ class AsyncPostgresDb(AsyncBaseDb):
                 # Attach the runs stored in the runs table, merged with any runs still
                 # sitting in the legacy `runs` column (so partially-migrated sessions
                 # don't silently lose history).
-                if runs_table is not None:
+                legacy_runs = session.get("runs")
+                if runs_table is not None and runs_limit is not None and not legacy_runs:
+                    # Fully migrated: push "most recent N" down to the DB (indexed).
+                    session["runs"] = await self._get_session_runs_data(
+                        sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
+                    )
+                elif runs_table is not None:
+                    # Full load + merge. Also the un-migrated fallback: the legacy blob
+                    # holds the whole history in one column, so "last N" can't be pushed
+                    # to SQL — load all, merge, then filter+slice to match the migrated path.
                     runs_data = await self._get_session_runs_data(
                         sess=sess, runs_table=runs_table, session_id=session_id
                     )
-                    session["runs"] = merge_runs_table_with_legacy_blob(runs_data, session.get("runs"))
+                    merged = merge_runs_table_with_legacy_blob(runs_data, legacy_runs)
+                    if runs_limit is not None:
+                        merged = filter_context_runs(merged)[-runs_limit:]
+                    session["runs"] = merged
+                elif runs_limit is not None:
+                    # No runs table yet (fully un-migrated): filter+slice the legacy blob.
+                    merged = merge_runs_table_with_legacy_blob([], legacy_runs)
+                    session["runs"] = filter_context_runs(merged)[-runs_limit:]
 
             if not deserialize:
                 return session

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -62,9 +62,6 @@ except ImportError:
 
 
 class AsyncPostgresDb(AsyncBaseDb):
-    # Whether this adapter can push a "most recent N runs" limit down to the DB.
-    supports_runs_limit: bool = True
-
     def __init__(
         self,
         id: Optional[str] = None,

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -86,9 +86,6 @@ except ImportError:
 
 
 class PostgresDb(BaseDb):
-    # Whether this adapter can push a "most recent N runs" limit down to the DB.
-    supports_runs_limit: bool = True
-
     def __init__(
         self,
         db_url: Optional[str] = None,

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -841,7 +841,10 @@ class PostgresDb(BaseDb):
                 .where(runs_table.c.session_id == session_id)
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
-                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .order_by(
+                    func.coalesce(runs_table.c.run_index, 0).desc(),
+                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                )
                 .limit(limit)
             )
             rows = [row[0] for row in sess.execute(stmt).fetchall()]
@@ -850,7 +853,10 @@ class PostgresDb(BaseDb):
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
-            .order_by(runs_table.c.run_index.asc(), runs_table.c.created_at.asc())
+            .order_by(
+                func.coalesce(runs_table.c.run_index, 0).asc(),
+                func.coalesce(runs_table.c.created_at, 0).asc(),
+            )
         )
         return [row[0] for row in sess.execute(stmt).fetchall()]
 

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -39,10 +39,12 @@ from agno.db.schemas.service_accounts import (
     validate_service_account_update,
 )
 from agno.db.utils import (
+    HISTORY_SKIP_STATUSES,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
     deserialize_sessions,
+    filter_context_runs,
     json_serializer,
     learning_search_patterns,
     merge_runs_table_with_legacy_blob,
@@ -84,6 +86,9 @@ except ImportError:
 
 
 class PostgresDb(BaseDb):
+    # Whether this adapter can push a "most recent N runs" limit down to the DB.
+    supports_runs_limit: bool = True
+
     def __init__(
         self,
         db_url: Optional[str] = None,
@@ -821,8 +826,30 @@ class PostgresDb(BaseDb):
             return True
 
     # -- Run methods --
-    def _get_session_runs_data(self, sess, runs_table: Table, session_id: str) -> List[Dict[str, Any]]:
-        """Get the raw run_data dicts for the given session, in insertion order."""
+    def _get_session_runs_data(
+        self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get the raw run_data dicts for the given session, in insertion order.
+
+        When ``limit`` is set, only the most recent ``limit`` context-relevant runs
+        are fetched (indexed ``ORDER BY run_index DESC LIMIT``) and returned in
+        ascending (chronological) order. "Context-relevant" mirrors the pre-slice
+        filtering in ``get_messages``: member sub-runs (``parent_run_id`` set) and
+        terminal-skip statuses are excluded in SQL, so the DB-side last-N matches
+        the in-memory history window.
+        """
+        if limit is not None:
+            stmt = (
+                select(runs_table.c.run_data)
+                .where(runs_table.c.session_id == session_id)
+                .where(runs_table.c.parent_run_id.is_(None))
+                .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
+                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .limit(limit)
+            )
+            rows = [row[0] for row in sess.execute(stmt).fetchall()]
+            rows.reverse()
+            return rows
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
@@ -1144,6 +1171,7 @@ class PostgresDb(BaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         """
         Read a session from the database.
@@ -1153,6 +1181,11 @@ class PostgresDb(BaseDb):
             session_type (SessionType): Type of session to get.
             user_id (Optional[str]): User ID to filter by. Defaults to None.
             deserialize (Optional[bool]): Whether to serialize the session. Defaults to True.
+            runs_limit (Optional[int]): If set, attach only the most recent ``runs_limit``
+                runs instead of the full history. For a fully-migrated session this is an
+                indexed ``ORDER BY run_index DESC LIMIT`` query; for a session that still
+                carries a legacy ``runs`` blob it falls back to a full load + merge, then
+                slices, so no history is ever lost.
 
         Returns:
             Union[Session, Dict[str, Any], None]:
@@ -1183,9 +1216,25 @@ class PostgresDb(BaseDb):
                 # Attach the runs stored in the runs table, merged with any runs still
                 # sitting in the legacy `runs` column (so partially-migrated sessions
                 # don't silently lose history).
-                if runs_table is not None:
+                legacy_runs = session.get("runs")
+                if runs_table is not None and runs_limit is not None and not legacy_runs:
+                    # Fully migrated: push "most recent N" down to the DB (indexed).
+                    session["runs"] = self._get_session_runs_data(
+                        sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
+                    )
+                elif runs_table is not None:
+                    # Full load + merge. Also the un-migrated fallback: the legacy blob
+                    # holds the whole history in one column, so "last N" can't be pushed
+                    # to SQL — load all, merge, then filter+slice to match the migrated path.
                     runs_data = self._get_session_runs_data(sess=sess, runs_table=runs_table, session_id=session_id)
-                    session["runs"] = merge_runs_table_with_legacy_blob(runs_data, session.get("runs"))
+                    merged = merge_runs_table_with_legacy_blob(runs_data, legacy_runs)
+                    if runs_limit is not None:
+                        merged = filter_context_runs(merged)[-runs_limit:]
+                    session["runs"] = merged
+                elif runs_limit is not None:
+                    # No runs table yet (fully un-migrated): filter+slice the legacy blob.
+                    merged = merge_runs_table_with_legacy_blob([], legacy_runs)
+                    session["runs"] = filter_context_runs(merged)[-runs_limit:]
 
             if not deserialize:
                 return session
@@ -1209,9 +1258,15 @@ class PostgresDb(BaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """
         Get all sessions in the given table. Can filter by user_id and component_id.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. The runs are untouched
+        in storage; a single ``get_session`` still returns them. Defaults to True
+        to preserve existing behavior.
 
         Args:
             session_type (Optional[SessionType]): The type of session to get.
@@ -1292,13 +1347,17 @@ class PostgresDb(BaseDb):
 
                 # Attach the runs stored in the runs table. If a session has no rows in the
                 # runs table, fall back to its legacy `runs` column content, if any.
-                if runs_table is not None:
+                if include_runs and runs_table is not None:
                     runs_by_session = self._get_sessions_runs_data(
                         sess=sess, runs_table=runs_table, session_ids=[s["session_id"] for s in session]
                     )
                     for s in session:
                         runs_data = runs_by_session.get(s["session_id"], [])
                         s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+                elif not include_runs:
+                    # List views don't need run history; leave it unattached (storage untouched).
+                    for s in session:
+                        s["runs"] = None
 
                 if not deserialize:
                     return session, total_count

--- a/libs/agno/agno/db/postgres/schemas.py
+++ b/libs/agno/agno/db/postgres/schemas.py
@@ -58,6 +58,11 @@ def _get_run_table_schema(session_table_name: str = "agno_sessions") -> dict[str
         "run_data": {"type": JSONB, "nullable": False},
         "created_at": {"type": BigInteger, "nullable": False, "index": True},
         "updated_at": {"type": BigInteger, "nullable": True},
+        # Composite index so "most recent N runs of a session"
+        # (WHERE session_id=? ORDER BY run_index DESC LIMIT N) is index-served.
+        "__composite_indexes__": [
+            {"name": "agno_runs_session_id_run_index", "columns": ["session_id", "run_index"]},
+        ],
     }
 
 

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -32,6 +32,7 @@ from agno.db.utils import (
     deserialize_run,
     deserialize_session,
     deserialize_sessions,
+    filter_context_runs,
     merge_runs_table_with_legacy_blob,
 )
 from agno.run.agent import RunOutput
@@ -660,6 +661,7 @@ class RedisDb(BaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         """Read a session from Redis.
 
@@ -686,6 +688,9 @@ class RedisDb(BaseDb):
             # Attach runs from the runs keys, merged with any legacy `runs` blob
             runs_data = self._get_session_runs_data(session_id)
             session["runs"] = merge_runs_table_with_legacy_blob(runs_data, session.get("runs"))
+
+            if runs_limit is not None:
+                session["runs"] = filter_context_runs(session.get("runs") or [])[-runs_limit:]
 
             if not deserialize:
                 return session

--- a/libs/agno/agno/db/singlestore/schemas.py
+++ b/libs/agno/agno/db/singlestore/schemas.py
@@ -51,11 +51,6 @@ def _get_run_table_schema(session_table_name: str = "agno_sessions") -> dict[str
         "run_data": {"type": JSON, "nullable": False},
         "created_at": {"type": BigInteger, "nullable": False, "index": True},
         "updated_at": {"type": BigInteger, "nullable": True},
-        # Composite index so "most recent N runs of a session"
-        # (WHERE session_id=? ORDER BY run_index DESC LIMIT N) is index-served.
-        "__composite_indexes__": [
-            {"name": "agno_runs_session_id_run_index", "columns": ["session_id", "run_index"]},
-        ],
     }
 
 

--- a/libs/agno/agno/db/singlestore/schemas.py
+++ b/libs/agno/agno/db/singlestore/schemas.py
@@ -51,6 +51,11 @@ def _get_run_table_schema(session_table_name: str = "agno_sessions") -> dict[str
         "run_data": {"type": JSON, "nullable": False},
         "created_at": {"type": BigInteger, "nullable": False, "index": True},
         "updated_at": {"type": BigInteger, "nullable": True},
+        # Composite index so "most recent N runs of a session"
+        # (WHERE session_id=? ORDER BY run_index DESC LIMIT N) is index-served.
+        "__composite_indexes__": [
+            {"name": "agno_runs_session_id_run_index", "columns": ["session_id", "run_index"]},
+        ],
     }
 
 

--- a/libs/agno/agno/db/singlestore/schemas.py
+++ b/libs/agno/agno/db/singlestore/schemas.py
@@ -51,6 +51,9 @@ def _get_run_table_schema(session_table_name: str = "agno_sessions") -> dict[str
         "run_data": {"type": JSON, "nullable": False},
         "created_at": {"type": BigInteger, "nullable": False, "index": True},
         "updated_at": {"type": BigInteger, "nullable": True},
+        "_composite_indexes": [
+            {"name": "runs_session_id_run_index", "columns": ["session_id", "run_index"]},
+        ],
     }
 
 

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -257,6 +257,7 @@ class SingleStoreDb(BaseDb):
             indexes: List[str] = []
             unique_constraints: List[str] = []
             schema_unique_constraints = table_schema.pop("_unique_constraints", [])
+            schema_composite_indexes = table_schema.pop("_composite_indexes", [])
 
             # Get the columns, indexes, and unique constraints from the table schema
             for col_name, col_config in table_schema.items():
@@ -297,6 +298,11 @@ class SingleStoreDb(BaseDb):
             for idx_col in indexes:
                 idx_name = f"idx_{table_name}_{idx_col}"
                 table.append_constraint(Index(idx_name, idx_col))
+
+            # Add multi-column (composite) indexes with table-specific names
+            for composite in schema_composite_indexes:
+                composite_name = f"{table_name}_{composite['name']}"
+                table.append_constraint(Index(composite_name, *composite["columns"]))
 
             # Create schema if one is specified
             if self.create_schema and self.db_schema is not None:

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -27,10 +27,12 @@ from agno.db.singlestore.utils import (
     serialize_cultural_knowledge_for_db,
 )
 from agno.db.utils import (
+    HISTORY_SKIP_STATUSES,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
     deserialize_sessions,
+    filter_context_runs,
     json_serializer,
     merge_runs_table_with_legacy_blob,
     validate_pagination,
@@ -44,7 +46,7 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
 
 try:
-    from sqlalchemy import ForeignKey, Index, UniqueConstraint, and_, func, select, update
+    from sqlalchemy import ForeignKey, Index, UniqueConstraint, and_, func, or_, select, update
     from sqlalchemy.dialects import mysql
     from sqlalchemy.engine import Engine, create_engine
     from sqlalchemy.orm import scoped_session, sessionmaker
@@ -587,7 +589,30 @@ class SingleStoreDb(BaseDb):
             return True
 
     # -- Run methods --
-    def _get_session_runs_data(self, sess, runs_table: Table, session_id: str) -> List[Dict[str, Any]]:
+    def _get_session_runs_data(
+        self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get the raw run_data dicts for the given session, in insertion order.
+
+        When ``limit`` is set, only the most recent ``limit`` context-relevant runs
+        are fetched (``ORDER BY run_index DESC LIMIT``) and returned in ascending
+        (chronological) order. "Context-relevant" mirrors the pre-slice filtering in
+        ``get_messages``: member sub-runs (``parent_run_id`` set) and terminal-skip
+        statuses are excluded in SQL, so the DB-side last-N matches the in-memory
+        history window.
+        """
+        if limit is not None:
+            stmt = (
+                select(runs_table.c.run_data)
+                .where(runs_table.c.session_id == session_id)
+                .where(runs_table.c.parent_run_id.is_(None))
+                .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
+                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .limit(limit)
+            )
+            rows = [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
+            rows.reverse()
+            return rows
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
@@ -848,6 +873,7 @@ class SingleStoreDb(BaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         """
         Read a session from the database.
@@ -883,9 +909,28 @@ class SingleStoreDb(BaseDb):
 
                 session = dict(result._mapping)
 
-                if runs_table is not None:
+                # Attach the runs stored in the runs table, merged with any runs still
+                # sitting in the legacy `runs` column (so partially-migrated sessions
+                # don't silently lose history).
+                legacy_runs = session.get("runs")
+                if runs_table is not None and runs_limit is not None and not legacy_runs:
+                    # Fully migrated: push "most recent N" down to the DB.
+                    session["runs"] = self._get_session_runs_data(
+                        sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
+                    )
+                elif runs_table is not None:
+                    # Full load + merge. Also the un-migrated fallback: the legacy blob
+                    # holds the whole history in one column, so "last N" can't be pushed
+                    # to SQL — load all, merge, then filter+slice to match the migrated path.
                     runs_data = self._get_session_runs_data(sess=sess, runs_table=runs_table, session_id=session_id)
-                    session["runs"] = merge_runs_table_with_legacy_blob(runs_data, session.get("runs"))
+                    merged = merge_runs_table_with_legacy_blob(runs_data, legacy_runs)
+                    if runs_limit is not None:
+                        merged = filter_context_runs(merged)[-runs_limit:]
+                    session["runs"] = merged
+                elif runs_limit is not None:
+                    # No runs table yet (fully un-migrated): filter+slice the legacy blob.
+                    merged = merge_runs_table_with_legacy_blob([], legacy_runs)
+                    session["runs"] = filter_context_runs(merged)[-runs_limit:]
 
             if not deserialize:
                 return session

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -607,7 +607,10 @@ class SingleStoreDb(BaseDb):
                 .where(runs_table.c.session_id == session_id)
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
-                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .order_by(
+                    func.coalesce(runs_table.c.run_index, 0).desc(),
+                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                )
                 .limit(limit)
             )
             rows = [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
@@ -616,7 +619,10 @@ class SingleStoreDb(BaseDb):
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
-            .order_by(runs_table.c.run_index.asc(), runs_table.c.created_at.asc())
+            .order_by(
+                func.coalesce(runs_table.c.run_index, 0).asc(),
+                func.coalesce(runs_table.c.created_at, 0).asc(),
+            )
         )
         return [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
 

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -63,8 +63,6 @@ except ImportError:
 
 
 class AsyncSqliteDb(AsyncBaseDb):
-    supports_runs_limit: bool = True
-
     def __init__(
         self,
         db_file: Optional[str] = None,

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -39,6 +39,8 @@ from agno.db.utils import (
     deserialize_session,
     deserialize_session_json_fields,
     deserialize_sessions,
+    HISTORY_SKIP_STATUSES,
+    filter_context_runs,
     merge_runs_table_with_legacy_blob,
     serialize_session_json_fields,
     validate_pagination,
@@ -625,15 +627,19 @@ class AsyncSqliteDb(AsyncBaseDb):
     ) -> List[Dict[str, Any]]:
         """Get the raw run_data dicts for the given session, in insertion order.
 
-        When ``limit`` is set, only the most recent ``limit`` runs are fetched
-        (indexed ``ORDER BY run_index DESC LIMIT``) and returned in ascending
-        (chronological) order — so the caller sees the same shape as a full read,
-        just the tail.
+        When ``limit`` is set, only the most recent ``limit`` context-relevant runs
+        are fetched (indexed ``ORDER BY run_index DESC LIMIT``) and returned in
+        ascending (chronological) order. "Context-relevant" mirrors the pre-slice
+        filtering in ``get_messages``: member sub-runs (``parent_run_id`` set) and
+        terminal-skip statuses are excluded in SQL, so the DB-side last-N matches
+        the in-memory history window.
         """
         if limit is not None:
             stmt = (
                 select(runs_table.c.run_data)
                 .where(runs_table.c.session_id == session_id)
+                .where(runs_table.c.parent_run_id.is_(None))
+                .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
                 .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
                 .limit(limit)
             )
@@ -1031,16 +1037,18 @@ class AsyncSqliteDb(AsyncBaseDb):
                     elif runs_table is not None:
                         # Full load + merge. Also the un-migrated fallback: the legacy blob
                         # holds the whole history in one column, so "last N" can't be pushed
-                        # to SQL — load all, merge, then slice to honor runs_limit.
+                        # to SQL — load all, merge, then filter+slice to match the migrated path.
                         runs_data = await self._get_session_runs_data(
                             sess=sess, runs_table=runs_table, session_id=session_id
                         )
                         merged = merge_runs_table_with_legacy_blob(runs_data, legacy_runs)
-                        session_raw["runs"] = merged[-runs_limit:] if runs_limit is not None else merged
+                        if runs_limit is not None:
+                            merged = filter_context_runs(merged)[-runs_limit:]
+                        session_raw["runs"] = merged
                     elif runs_limit is not None:
-                        # No runs table yet (fully un-migrated): slice the legacy blob.
+                        # No runs table yet (fully un-migrated): filter+slice the legacy blob.
                         merged = merge_runs_table_with_legacy_blob([], legacy_runs)
-                        session_raw["runs"] = merged[-runs_limit:]
+                        session_raw["runs"] = filter_context_runs(merged)[-runs_limit:]
 
                 if not session_raw or not deserialize:
                     return session_raw
@@ -1064,9 +1072,15 @@ class AsyncSqliteDb(AsyncBaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """
         Get all sessions in the given table. Can filter by user_id and entity_id.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. The runs are untouched
+        in storage; a single ``get_session`` still returns them. Defaults to True
+        to preserve existing behavior.
         Args:
             session_type (Optional[SessionType]): The type of session to get.
             user_id (Optional[str]): The ID of the user to filter by.
@@ -1146,13 +1160,17 @@ class AsyncSqliteDb(AsyncBaseDb):
 
                 # Attach the runs stored in the runs table. If a session has no rows in the
                 # runs table, fall back to its legacy `runs` column content, if any.
-                if runs_table is not None and sessions_raw:
+                if include_runs and runs_table is not None and sessions_raw:
                     runs_by_session = await self._get_sessions_runs_data(
                         sess=sess, runs_table=runs_table, session_ids=[s["session_id"] for s in sessions_raw]
                     )
                     for s in sessions_raw:
                         runs_data = runs_by_session.get(s["session_id"], [])
                         s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+                elif not include_runs:
+                    # List views don't need run history; leave it unattached (storage untouched).
+                    for s in sessions_raw:
+                        s["runs"] = None
 
                 if not deserialize:
                     return sessions_raw, total_count

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -61,6 +61,8 @@ except ImportError:
 
 
 class AsyncSqliteDb(AsyncBaseDb):
+    supports_runs_limit: bool = True
+
     def __init__(
         self,
         db_file: Optional[str] = None,
@@ -618,8 +620,27 @@ class AsyncSqliteDb(AsyncBaseDb):
             return True
 
     # -- Run methods --
-    async def _get_session_runs_data(self, sess, runs_table: Table, session_id: str) -> List[Dict[str, Any]]:
-        """Get the raw run_data dicts for the given session, in insertion order."""
+    async def _get_session_runs_data(
+        self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get the raw run_data dicts for the given session, in insertion order.
+
+        When ``limit`` is set, only the most recent ``limit`` runs are fetched
+        (indexed ``ORDER BY run_index DESC LIMIT``) and returned in ascending
+        (chronological) order — so the caller sees the same shape as a full read,
+        just the tail.
+        """
+        if limit is not None:
+            stmt = (
+                select(runs_table.c.run_data)
+                .where(runs_table.c.session_id == session_id)
+                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .limit(limit)
+            )
+            result = await sess.execute(stmt)
+            rows = [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in result.fetchall()]
+            rows.reverse()
+            return rows
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
@@ -953,6 +974,7 @@ class AsyncSqliteDb(AsyncBaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         """
         Read a session from the database.
@@ -962,6 +984,11 @@ class AsyncSqliteDb(AsyncBaseDb):
             session_type (SessionType): Type of session to get.
             user_id (Optional[str]): User ID to filter by. Defaults to None.
             deserialize (Optional[bool]): Whether to serialize the session. Defaults to True.
+            runs_limit (Optional[int]): If set, attach only the most recent ``runs_limit``
+                runs instead of the full history. For a fully-migrated session this is an
+                indexed ``ORDER BY run_index DESC LIMIT`` query; for a session that still
+                carries a legacy ``runs`` blob it falls back to a full load + merge, then
+                slices, so no history is ever lost.
 
         Returns:
             Optional[Union[Session, Dict[str, Any]]]:
@@ -991,13 +1018,29 @@ class AsyncSqliteDb(AsyncBaseDb):
 
                 session_raw = deserialize_session_json_fields(dict(row._mapping))
 
-                # Attach the runs stored in the runs table. If the session has no rows in the
-                # runs table, fall back to the legacy `runs` column content, if any.
-                if session_raw is not None and runs_table is not None:
-                    runs_data = await self._get_session_runs_data(
-                        sess=sess, runs_table=runs_table, session_id=session_id
-                    )
-                    session_raw["runs"] = merge_runs_table_with_legacy_blob(runs_data, session_raw.get("runs"))
+                # Attach the runs stored in the runs table, merged with any runs still
+                # sitting in the legacy `runs` column (so partially-migrated sessions
+                # don't silently lose history).
+                if session_raw is not None:
+                    legacy_runs = session_raw.get("runs")
+                    if runs_table is not None and runs_limit is not None and not legacy_runs:
+                        # Fully migrated: push "most recent N" down to the DB (indexed).
+                        session_raw["runs"] = await self._get_session_runs_data(
+                            sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
+                        )
+                    elif runs_table is not None:
+                        # Full load + merge. Also the un-migrated fallback: the legacy blob
+                        # holds the whole history in one column, so "last N" can't be pushed
+                        # to SQL — load all, merge, then slice to honor runs_limit.
+                        runs_data = await self._get_session_runs_data(
+                            sess=sess, runs_table=runs_table, session_id=session_id
+                        )
+                        merged = merge_runs_table_with_legacy_blob(runs_data, legacy_runs)
+                        session_raw["runs"] = merged[-runs_limit:] if runs_limit is not None else merged
+                    elif runs_limit is not None:
+                        # No runs table yet (fully un-migrated): slice the legacy blob.
+                        merged = merge_runs_table_with_legacy_blob([], legacy_runs)
+                        session_raw["runs"] = merged[-runs_limit:]
 
                 if not session_raw or not deserialize:
                     return session_raw

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -638,7 +638,10 @@ class AsyncSqliteDb(AsyncBaseDb):
                 .where(runs_table.c.session_id == session_id)
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
-                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .order_by(
+                    func.coalesce(runs_table.c.run_index, 0).desc(),
+                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                )
                 .limit(limit)
             )
             result = await sess.execute(stmt)
@@ -648,7 +651,10 @@ class AsyncSqliteDb(AsyncBaseDb):
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
-            .order_by(runs_table.c.run_index.asc(), runs_table.c.created_at.asc())
+            .order_by(
+                func.coalesce(runs_table.c.run_index, 0).asc(),
+                func.coalesce(runs_table.c.created_at, 0).asc(),
+            )
         )
         result = await sess.execute(stmt)
         return [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in result.fetchall()]

--- a/libs/agno/agno/db/sqlite/schemas.py
+++ b/libs/agno/agno/db/sqlite/schemas.py
@@ -56,6 +56,11 @@ def _get_run_table_schema(session_table_name: str = "agno_sessions") -> dict[str
         "run_data": {"type": JSON, "nullable": False},
         "created_at": {"type": BigInteger, "nullable": False, "index": True},
         "updated_at": {"type": BigInteger, "nullable": True},
+        # Composite index so "most recent N runs of a session"
+        # (WHERE session_id=? ORDER BY run_index DESC LIMIT N) is index-served.
+        "__composite_indexes__": [
+            {"name": "agno_runs_session_id_run_index", "columns": ["session_id", "run_index"]},
+        ],
     }
 
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -72,9 +72,6 @@ except ImportError:
 
 
 class SqliteDb(BaseDb):
-    # Whether this adapter can push a "most recent N runs" limit down to the DB.
-    supports_runs_limit: bool = True
-
     def __init__(
         self,
         db_file: Optional[str] = None,

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -841,7 +841,10 @@ class SqliteDb(BaseDb):
                 .where(runs_table.c.session_id == session_id)
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
-                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .order_by(
+                    func.coalesce(runs_table.c.run_index, 0).desc(),
+                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                )
                 .limit(limit)
             )
             rows = [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
@@ -850,7 +853,10 @@ class SqliteDb(BaseDb):
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
-            .order_by(runs_table.c.run_index.asc(), runs_table.c.created_at.asc())
+            .order_by(
+                func.coalesce(runs_table.c.run_index, 0).asc(),
+                func.coalesce(runs_table.c.created_at, 0).asc(),
+            )
         )
         return [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -47,6 +47,8 @@ from agno.db.utils import (
     deserialize_session_json_fields,
     deserialize_sessions,
     learning_search_patterns,
+    HISTORY_SKIP_STATUSES,
+    filter_context_runs,
     merge_runs_table_with_legacy_blob,
     serialize_session_json_fields,
     validate_pagination,
@@ -70,6 +72,9 @@ except ImportError:
 
 
 class SqliteDb(BaseDb):
+    # Whether this adapter can push a "most recent N runs" limit down to the DB.
+    supports_runs_limit: bool = True
+
     def __init__(
         self,
         db_file: Optional[str] = None,
@@ -821,8 +826,30 @@ class SqliteDb(BaseDb):
             return True
 
     # -- Run methods --
-    def _get_session_runs_data(self, sess, runs_table: Table, session_id: str) -> List[Dict[str, Any]]:
-        """Get the raw run_data dicts for the given session, in insertion order."""
+    def _get_session_runs_data(
+        self, sess, runs_table: Table, session_id: str, limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get the raw run_data dicts for the given session, in insertion order.
+
+        When ``limit`` is set, only the most recent ``limit`` context-relevant runs
+        are fetched (indexed ``ORDER BY run_index DESC LIMIT``) and returned in
+        ascending (chronological) order. "Context-relevant" mirrors the pre-slice
+        filtering in ``get_messages``: member sub-runs (``parent_run_id`` set) and
+        terminal-skip statuses are excluded in SQL, so the DB-side last-N matches
+        the in-memory history window.
+        """
+        if limit is not None:
+            stmt = (
+                select(runs_table.c.run_data)
+                .where(runs_table.c.session_id == session_id)
+                .where(runs_table.c.parent_run_id.is_(None))
+                .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
+                .order_by(runs_table.c.run_index.desc(), runs_table.c.created_at.desc())
+                .limit(limit)
+            )
+            rows = [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
+            rows.reverse()
+            return rows
         stmt = (
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
@@ -1150,6 +1177,7 @@ class SqliteDb(BaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         """
         Read a session from the database.
@@ -1159,6 +1187,11 @@ class SqliteDb(BaseDb):
             session_type (SessionType): Type of session to get.
             user_id (Optional[str]): User ID to filter by. Defaults to None.
             deserialize (Optional[bool]): Whether to serialize the session. Defaults to True.
+            runs_limit (Optional[int]): If set, attach only the most recent ``runs_limit``
+                runs instead of the full history. For a fully-migrated session this is an
+                indexed ``ORDER BY run_index DESC LIMIT`` query; for a session that still
+                carries a legacy ``runs`` blob it falls back to a full load + merge, then
+                slices, so no history is ever lost.
 
         Returns:
             Optional[Union[Session, Dict[str, Any]]]:
@@ -1190,9 +1223,26 @@ class SqliteDb(BaseDb):
                 # Attach the runs stored in the runs table, merged with any runs still
                 # sitting in the legacy `runs` column (so partially-migrated sessions
                 # don't silently lose history).
-                if session_raw is not None and runs_table is not None:
-                    runs_data = self._get_session_runs_data(sess=sess, runs_table=runs_table, session_id=session_id)
-                    session_raw["runs"] = merge_runs_table_with_legacy_blob(runs_data, session_raw.get("runs"))
+                if session_raw is not None:
+                    legacy_runs = session_raw.get("runs")
+                    if runs_table is not None and runs_limit is not None and not legacy_runs:
+                        # Fully migrated: push "most recent N" down to the DB (indexed).
+                        session_raw["runs"] = self._get_session_runs_data(
+                            sess=sess, runs_table=runs_table, session_id=session_id, limit=runs_limit
+                        )
+                    elif runs_table is not None:
+                        # Full load + merge. Also the un-migrated fallback: the legacy blob
+                        # holds the whole history in one column, so "last N" can't be pushed
+                        # to SQL — load all, merge, then filter+slice to match the migrated path.
+                        runs_data = self._get_session_runs_data(sess=sess, runs_table=runs_table, session_id=session_id)
+                        merged = merge_runs_table_with_legacy_blob(runs_data, legacy_runs)
+                        if runs_limit is not None:
+                            merged = filter_context_runs(merged)[-runs_limit:]
+                        session_raw["runs"] = merged
+                    elif runs_limit is not None:
+                        # No runs table yet (fully un-migrated): filter+slice the legacy blob.
+                        merged = merge_runs_table_with_legacy_blob([], legacy_runs)
+                        session_raw["runs"] = filter_context_runs(merged)[-runs_limit:]
 
                 if not session_raw or not deserialize:
                     return session_raw
@@ -1216,9 +1266,15 @@ class SqliteDb(BaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """
         Get all sessions in the given table. Can filter by user_id and entity_id.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. The runs are untouched
+        in storage; a single ``get_session`` still returns them. Defaults to True
+        to preserve existing behavior.
         Args:
             session_type (Optional[SessionType]): The type of session to get.
             user_id (Optional[str]): The ID of the user to filter by.
@@ -1297,13 +1353,17 @@ class SqliteDb(BaseDb):
 
                 # Attach the runs stored in the runs table. If a session has no rows in the
                 # runs table, fall back to its legacy `runs` column content, if any.
-                if runs_table is not None and sessions_raw:
+                if include_runs and runs_table is not None and sessions_raw:
                     runs_by_session = self._get_sessions_runs_data(
                         sess=sess, runs_table=runs_table, session_ids=[s["session_id"] for s in sessions_raw]
                     )
                     for s in sessions_raw:
                         runs_data = runs_by_session.get(s["session_id"], [])
                         s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+                elif not include_runs:
+                    # List views don't need run history; leave it unattached (storage untouched).
+                    for s in sessions_raw:
+                        s["runs"] = None
 
                 if not deserialize:
                     return sessions_raw, total_count

--- a/libs/agno/agno/db/surrealdb/surrealdb.py
+++ b/libs/agno/agno/db/surrealdb/surrealdb.py
@@ -276,7 +276,7 @@ class SurrealDb(BaseDb):
             rows_raw = self._query(
                 f"SELECT * FROM {runs_table} WHERE session_id = $sid "
                 "AND parent_run_id IS NONE AND (status IS NONE OR status NOT IN $skip) "
-                "ORDER BY run_index DESC, created_at DESC LIMIT $lim",
+                "ORDER BY (run_index ?? 0) DESC, (created_at ?? 0) DESC LIMIT $lim",
                 {"sid": session_id, "skip": HISTORY_SKIP_STATUSES, "lim": limit},
                 dict,
             )
@@ -285,7 +285,7 @@ class SurrealDb(BaseDb):
             run_data.reverse()
             return run_data
         rows_raw = self._query(
-            f"SELECT * FROM {runs_table} WHERE session_id = $sid ORDER BY run_index ASC, created_at ASC",
+            f"SELECT * FROM {runs_table} WHERE session_id = $sid ORDER BY (run_index ?? 0) ASC, (created_at ?? 0) ASC",
             {"sid": session_id},
             dict,
         )

--- a/libs/agno/agno/db/surrealdb/surrealdb.py
+++ b/libs/agno/agno/db/surrealdb/surrealdb.py
@@ -274,9 +274,10 @@ class SurrealDb(BaseDb):
             return []
         if limit is not None:
             rows_raw = self._query(
-                f"SELECT * FROM {runs_table} WHERE session_id = $sid "
+                f"SELECT *, run_index ?? 0 AS _ri, created_at ?? 0 AS _ca FROM {runs_table} "
+                "WHERE session_id = $sid "
                 "AND parent_run_id IS NONE AND (status IS NONE OR status NOT IN $skip) "
-                "ORDER BY (run_index ?? 0) DESC, (created_at ?? 0) DESC LIMIT $lim",
+                "ORDER BY _ri DESC, _ca DESC LIMIT $lim",
                 {"sid": session_id, "skip": HISTORY_SKIP_STATUSES, "lim": limit},
                 dict,
             )
@@ -285,7 +286,8 @@ class SurrealDb(BaseDb):
             run_data.reverse()
             return run_data
         rows_raw = self._query(
-            f"SELECT * FROM {runs_table} WHERE session_id = $sid ORDER BY (run_index ?? 0) ASC, (created_at ?? 0) ASC",
+            f"SELECT *, run_index ?? 0 AS _ri, created_at ?? 0 AS _ca FROM {runs_table} "
+            "WHERE session_id = $sid ORDER BY _ri ASC, _ca ASC",
             {"sid": session_id},
             dict,
         )

--- a/libs/agno/agno/db/surrealdb/surrealdb.py
+++ b/libs/agno/agno/db/surrealdb/surrealdb.py
@@ -44,10 +44,12 @@ from agno.db.surrealdb.models import (
 from agno.db.surrealdb.queries import COUNT_QUERY, WhereClause, order_limit_start
 from agno.db.surrealdb.utils import build_client
 from agno.db.utils import (
+    HISTORY_SKIP_STATUSES,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
     deserialize_sessions,
+    filter_context_runs,
     merge_runs_table_with_legacy_blob,
 )
 from agno.run.agent import RunOutput
@@ -256,12 +258,32 @@ class SurrealDb(BaseDb):
 
     # --- Runs ---
 
-    def _get_session_runs_data(self, session_id: str) -> List[Dict[str, Any]]:
-        """Return raw run_data dicts for a session, ordered by run_index then created_at."""
+    def _get_session_runs_data(self, session_id: str, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        """Return raw run_data dicts for a session, ordered by run_index then created_at.
+
+        When ``limit`` is set, push the "most recent N context-relevant runs" filter
+        down to the DB: drop member sub-runs (``parent_run_id`` set), drop terminal-skip
+        statuses, order newest-first and take ``limit`` rows, then reverse back to
+        chronological order. SurrealDB uses ``IS NONE`` for null checks (not ``IS NULL``),
+        and the ``status IS NONE OR`` guard keeps runs with no status from being dropped
+        by ``NOT IN $skip``.
+        """
         try:
             runs_table = self._get_table("runs", create_table_if_not_found=False)
         except Exception:
             return []
+        if limit is not None:
+            rows_raw = self._query(
+                f"SELECT * FROM {runs_table} WHERE session_id = $sid "
+                "AND parent_run_id IS NONE AND (status IS NONE OR status NOT IN $skip) "
+                "ORDER BY run_index DESC, created_at DESC LIMIT $lim",
+                {"sid": session_id, "skip": HISTORY_SKIP_STATUSES, "lim": limit},
+                dict,
+            )
+            rows = [desurrealize_run_row(r) for r in rows_raw]
+            run_data = [r["run_data"] for r in rows if "run_data" in r]
+            run_data.reverse()
+            return run_data
         rows_raw = self._query(
             f"SELECT * FROM {runs_table} WHERE session_id = $sid ORDER BY run_index ASC, created_at ASC",
             {"sid": session_id},
@@ -541,6 +563,7 @@ class SurrealDb(BaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         r"""
         Read a session from the database.
@@ -578,10 +601,21 @@ class SurrealDb(BaseDb):
 
         desurrealized = desurrealize_session(raw)
 
-        # Attach runs from the runs table, merged with any legacy `runs` blob
+        # Attach runs from the runs table, merged with any legacy `runs` blob.
         try:
-            runs_data = self._get_session_runs_data(session_id)
-            desurrealized["runs"] = merge_runs_table_with_legacy_blob(runs_data, desurrealized.get("runs"))
+            legacy_runs = desurrealized.get("runs")
+            if runs_limit is not None and not legacy_runs:
+                # Fully migrated: push "most recent N" down to the DB (indexed).
+                desurrealized["runs"] = self._get_session_runs_data(session_id, limit=runs_limit)
+            else:
+                # Full load + merge. Also the un-migrated fallback: the legacy blob
+                # holds the whole history in one column, so "last N" can't be pushed
+                # to SQL — load all, merge, then filter+slice to match the migrated path.
+                runs_data = self._get_session_runs_data(session_id)
+                merged = merge_runs_table_with_legacy_blob(runs_data, legacy_runs)
+                if runs_limit is not None:
+                    merged = filter_context_runs(merged)[-runs_limit:]
+                desurrealized["runs"] = merged
         except Exception as e:
             log_error(f"Failed to load runs for session {session_id}: {str(e)}")
 

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -267,6 +267,33 @@ def build_single_run_row(
     }
 
 
+# Run statuses excluded from context/history reads. Mirrors the default
+# ``skip_statuses`` in ``AgentSession.get_messages`` / ``TeamSession.get_messages``
+# so a DB-side "most recent N runs" fetch returns the same runs the in-memory
+# history builder would (it filters these out *before* slicing the last N).
+HISTORY_SKIP_STATUSES: List[str] = ["PAUSED", "CANCELLED", "ERROR", "REGENERATED"]
+
+
+def filter_context_runs(runs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Keep only top-level, context-relevant runs from a list of run dicts.
+
+    Drops member sub-runs (``parent_run_id`` set) and terminal-skip statuses,
+    mirroring the pre-slice filtering in ``get_messages``. Used on the
+    un-migrated / legacy-blob read path so slicing to "most recent N" yields the
+    same window as the fully-migrated (SQL-filtered) path.
+    """
+    kept: List[Dict[str, Any]] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        if run.get("parent_run_id") is not None:
+            continue
+        if run.get("status") in HISTORY_SKIP_STATUSES:
+            continue
+        kept.append(run)
+    return kept
+
+
 def merge_runs_table_with_legacy_blob(
     table_runs: List[Dict[str, Any]],
     legacy_runs: Optional[List[Any]],

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from agno.metrics import ModelMetrics, RunMetrics, SessionMetrics
 from agno.models.message import Message
+from agno.run.base import HISTORY_SKIP_STATUSES as _RUN_HISTORY_SKIP_STATUSES
 from agno.utils.log import log_error, log_warning
 
 if TYPE_CHECKING:
@@ -267,11 +268,11 @@ def build_single_run_row(
     }
 
 
-# Run statuses excluded from context/history reads. Mirrors the default
-# ``skip_statuses`` in ``AgentSession.get_messages`` / ``TeamSession.get_messages``
-# so a DB-side "most recent N runs" fetch returns the same runs the in-memory
-# history builder would (it filters these out *before* slicing the last N).
-HISTORY_SKIP_STATUSES: List[str] = ["PAUSED", "CANCELLED", "ERROR", "REGENERATED"]
+# Run statuses (as stored string values) excluded from context/history reads.
+# Derived from the single source of truth in ``agno.run.base`` so a DB-side
+# "most recent N runs" fetch returns the same runs the in-memory history builder
+# (``get_messages``) would — it filters these out *before* slicing the last N.
+HISTORY_SKIP_STATUSES: List[str] = [status.value for status in _RUN_HISTORY_SKIP_STATUSES]
 
 
 def filter_context_runs(runs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/libs/agno/agno/db/valkey/valkey.py
+++ b/libs/agno/agno/db/valkey/valkey.py
@@ -16,6 +16,7 @@ from agno.db.utils import (
     deserialize_run,
     deserialize_session,
     deserialize_sessions,
+    filter_context_runs,
     merge_runs_table_with_legacy_blob,
 )
 from agno.db.valkey.utils import (
@@ -786,6 +787,7 @@ class ValkeyDb(BaseDb):
         session_type: Optional[SessionType] = None,
         user_id: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        runs_limit: Optional[int] = None,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         """Read a session from Valkey.
 
@@ -812,6 +814,10 @@ class ValkeyDb(BaseDb):
             # Attach runs from the runs keys, merged with any legacy `runs` blob
             runs_data = self._get_session_runs_data(session_id)
             session["runs"] = merge_runs_table_with_legacy_blob(runs_data, session.get("runs"))
+            if runs_limit is not None:
+                # No query engine to push "last N" down: filter+slice in memory to
+                # match the SQL fast path (drop member/skip-status runs, then last N).
+                session["runs"] = filter_context_runs(session["runs"] or [])[-runs_limit:]
 
             if not deserialize:
                 return session

--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -339,3 +339,16 @@ class RunStatus(str, Enum):
     # history-builders can skip it when rebuilding context. Pass replace_original=false
     # to keep the original COMPLETED and visible instead.
     regenerated = "REGENERATED"
+
+
+# Canonical set of run statuses excluded when rebuilding message history/context.
+# Single source of truth: session.get_messages (agent + team) and the DB-level
+# bounded-history read (agno.db.utils.HISTORY_SKIP_STATUSES) both derive from this,
+# so the full-load and "most recent N" read paths can never return different
+# history windows for the same session.
+HISTORY_SKIP_STATUSES: list["RunStatus"] = [
+    RunStatus.paused,
+    RunStatus.cancelled,
+    RunStatus.error,
+    RunStatus.regenerated,
+]

--- a/libs/agno/agno/session/agent.py
+++ b/libs/agno/agno/session/agent.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Mapping, Optional, Union
 
 from agno.models.message import Message
 from agno.run.agent import RunOutput
-from agno.run.base import RunStatus
+from agno.run.base import HISTORY_SKIP_STATUSES, RunStatus
 from agno.run.team import TeamRunOutput
 from agno.session.summary import SessionSummary
 from agno.utils.log import log_debug, log_warning
@@ -164,7 +164,7 @@ class AgentSession:
             return []
 
         if skip_statuses is None:
-            skip_statuses = [RunStatus.paused, RunStatus.cancelled, RunStatus.error, RunStatus.regenerated]
+            skip_statuses = list(HISTORY_SKIP_STATUSES)
 
         runs = self.runs
 

--- a/libs/agno/agno/session/team.py
+++ b/libs/agno/agno/session/team.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from agno.models.message import Message
 from agno.run.agent import RunOutput, RunStatus
+from agno.run.base import HISTORY_SKIP_STATUSES
 from agno.run.team import TeamRunOutput
 from agno.session.summary import SessionSummary
 from agno.utils.log import log_debug, log_warning
@@ -168,7 +169,7 @@ class TeamSession:
             return []
 
         if skip_statuses is None:
-            skip_statuses = [RunStatus.paused, RunStatus.cancelled, RunStatus.error]
+            skip_statuses = list(HISTORY_SKIP_STATUSES)
 
         session_runs = self.runs
 

--- a/libs/agno/tests/unit/db/test_runs_limit.py
+++ b/libs/agno/tests/unit/db/test_runs_limit.py
@@ -137,17 +137,23 @@ class TestGetSessionsIncludeRuns:
 
 
 class TestSchemaHasNoBuilderBreakingMetadata:
-    """MySQL/SingleStore table builders iterate every schema entry and access
-    ``col_config["type"]``; a non-column key like ``__composite_indexes__`` would
-    KeyError on table creation. Those adapters must not carry it (yet)."""
+    """Every SQL adapter must ship the (session_id, run_index) composite index so
+    ``get_session(runs_limit=N)`` (WHERE session_id=? ORDER BY run_index DESC LIMIT N)
+    is index-served. Postgres/SQLite declare it under ``__composite_indexes__``;
+    MySQL/SingleStore builders pop ``_composite_indexes`` before iterating columns."""
 
-    def test_mysql_singlestore_runs_schema_is_columns_only(self):
+    def test_mysql_singlestore_runs_schema_has_composite_index(self):
         from agno.db.mysql.schemas import _get_run_table_schema as mysql_runs
         from agno.db.singlestore.schemas import _get_run_table_schema as singlestore_runs
 
         for schema in (mysql_runs(), singlestore_runs()):
+            idx = schema.get("_composite_indexes", [])
+            assert any(i["columns"] == ["session_id", "run_index"] for i in idx)
+            # Every remaining (column) entry must still be a real column config so the
+            # builder's ``col_config["type"]`` access does not KeyError.
             for name, cfg in schema.items():
-                assert not name.startswith("__"), f"{name} would break the MySQL/SingleStore builder"
+                if name.startswith("_"):
+                    continue
                 assert "type" in cfg
 
     def test_postgres_sqlite_runs_schema_has_composite_index(self):

--- a/libs/agno/tests/unit/db/test_runs_limit.py
+++ b/libs/agno/tests/unit/db/test_runs_limit.py
@@ -20,6 +20,10 @@ import sqlite3
 import tempfile
 from typing import List, Tuple
 
+import pytest
+
+from agno.db.in_memory import InMemoryDb
+from agno.db.json.json_db import JsonDb
 from agno.db.sqlite import SqliteDb
 from agno.run.agent import RunOutput
 from agno.run.base import RunStatus
@@ -132,11 +136,6 @@ class TestGetSessionsIncludeRuns:
         assert _ids(sessions[0]["runs"]) == ["r0", "r1", "r2"]
 
 
-class TestCapabilityFlag:
-    def test_sqlite_supports_runs_limit(self):
-        assert SqliteDb.supports_runs_limit is True
-
-
 class TestSchemaHasNoBuilderBreakingMetadata:
     """MySQL/SingleStore table builders iterate every schema entry and access
     ``col_config["type"]``; a non-column key like ``__composite_indexes__`` would
@@ -192,3 +191,62 @@ class TestBoundedHistoryGate:
 
         db = SqliteDb(db_file=tempfile.mktemp(suffix=".db"))
         assert _bounded_history_runs_limit(self._agent(db), 3, [RunStatus.error]) is None
+
+
+_FILTER_SPECS = [
+    ("r0", "COMPLETED", None),
+    ("r1", "COMPLETED", None),
+    ("r2", "ERROR", None),
+    ("r3", "COMPLETED", None),
+    ("r4", "COMPLETED", "r3"),
+    ("r5", "ERROR", None),
+]
+
+
+def _make_inmemory(specs: List[Tuple[str, str, str]]) -> InMemoryDb:
+    return _seed_adapter(InMemoryDb(), specs)
+
+
+def _make_json(specs: List[Tuple[str, str, str]]) -> JsonDb:
+    return _seed_adapter(JsonDb(db_path=tempfile.mkdtemp()), specs)
+
+
+def _seed_adapter(db, specs: List[Tuple[str, str, str]]):
+    """Write the session row then one run per spec, mirroring _make_migrated_db."""
+    sess = AgentSession(session_id="s1", agent_id="a1")
+    for rid, status, parent in specs:
+        sess.upsert_run(RunOutput(run_id=rid, agent_id="a1", status=RunStatus(status), parent_run_id=parent))
+    db.upsert_session(sess)
+    for i, (rid, status, parent) in enumerate(specs):
+        db.upsert_run(
+            RunOutput(run_id=rid, agent_id="a1", status=RunStatus(status), parent_run_id=parent),
+            session_id="s1",
+            user_id=None,
+            run_index=i,
+        )
+    return db
+
+
+@pytest.mark.parametrize("make_db", [_make_inmemory, _make_json], ids=["in_memory", "json"])
+class TestRunsLimitAcrossAdapters:
+    def test_returns_most_recent_n(self, make_db):
+        db = make_db(COMPLETED + [("r3", "COMPLETED", None), ("r4", "COMPLETED", None)])
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=2)["runs"]) == ["r3", "r4"]
+
+    def test_none_is_full_history(self, make_db):
+        db = make_db(COMPLETED)
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=None)["runs"]) == ["r0", "r1", "r2"]
+
+    def test_limit_larger_than_history(self, make_db):
+        db = make_db(COMPLETED)
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=10)["runs"]) == ["r0", "r1", "r2"]
+
+    def test_filter_before_slice(self, make_db):
+        # last-2 of the context-relevant runs, NOT the last-2 rows.
+        db = make_db(_FILTER_SPECS)
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=2)["runs"]) == ["r1", "r3"]
+
+    def test_filter_applies_even_when_limit_exceeds_count(self, make_db):
+        # runs_limit larger than the filtered set: still filtered, just not truncated.
+        db = make_db(_FILTER_SPECS)
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=10)["runs"]) == ["r0", "r1", "r3"]

--- a/libs/agno/tests/unit/db/test_runs_limit.py
+++ b/libs/agno/tests/unit/db/test_runs_limit.py
@@ -1,0 +1,137 @@
+"""Tests for the SQL "fetch only the most recent N runs" read optimization.
+
+``get_session(runs_limit=N)`` attaches only the most recent N context-relevant
+runs instead of the whole history. It must:
+- be migration-safe: work identically for fully-migrated sessions (runs in the
+  ``agno_runs`` table), un-migrated sessions (legacy ``runs`` blob only), and
+  sessions with no runs table yet;
+- reproduce ``get_messages``' pre-slice filtering (drop member sub-runs and
+  terminal-skip statuses) so the bounded window matches full-load-then-slice;
+- be byte-for-byte equivalent to the old behavior when ``runs_limit`` is None.
+
+Also covers ``get_sessions(include_runs=False)`` (list views skip runs) and the
+``get_session_messages`` wiring.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+from typing import List, Tuple
+
+from agno.db.sqlite import SqliteDb
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.session.agent import AgentSession
+
+
+def _ids(runs) -> List[str]:
+    return [r.run_id if hasattr(r, "run_id") else r.get("run_id") for r in (runs or [])]
+
+
+def _make_migrated_db(specs: List[Tuple[str, str, str]]) -> SqliteDb:
+    """specs: list of (run_id, status, parent_run_id). Session row written first
+    (FK), then one agno_runs row per spec."""
+    db = SqliteDb(db_file=tempfile.mktemp(suffix=".db"))
+    sess = AgentSession(session_id="s1", agent_id="a1")
+    for rid, status, parent in specs:
+        sess.upsert_run(RunOutput(run_id=rid, agent_id="a1", status=RunStatus(status), parent_run_id=parent))
+    db.upsert_session(sess)
+    for i, (rid, status, parent) in enumerate(specs):
+        db.upsert_run(
+            RunOutput(run_id=rid, agent_id="a1", status=RunStatus(status), parent_run_id=parent),
+            session_id="s1",
+            user_id=None,
+            run_index=i,
+        )
+    return db
+
+
+def _make_unmigrated_db(specs: List[Tuple[str, str, str]]) -> SqliteDb:
+    """A pre-v3 database: sessions table with a legacy ``runs`` blob, no runs table."""
+    dbf = tempfile.mktemp(suffix=".db")
+    con = sqlite3.connect(dbf)
+    con.execute(
+        """CREATE TABLE agno_sessions (session_id TEXT PRIMARY KEY, session_type TEXT, user_id TEXT,
+        agent_id TEXT, team_id TEXT, workflow_id TEXT, session_data TEXT, agent_data TEXT, team_data TEXT,
+        workflow_data TEXT, metadata TEXT, summary TEXT, runs TEXT, created_at INTEGER, updated_at INTEGER)"""
+    )
+    blob = [{"run_id": r, "agent_id": "a1", "status": s, "parent_run_id": p} for (r, s, p) in specs]
+    con.execute(
+        "INSERT INTO agno_sessions (session_id, session_type, agent_id, runs, created_at, updated_at) "
+        "VALUES (?,?,?,?,?,?)",
+        ("s1", "agent", "a1", json.dumps(blob), 1000, 1000),
+    )
+    con.commit()
+    con.close()
+    return SqliteDb(db_file=dbf)
+
+
+COMPLETED = [("r0", "COMPLETED", None), ("r1", "COMPLETED", None), ("r2", "COMPLETED", None)]
+
+
+class TestRunsLimitMigrated:
+    def test_returns_most_recent_n(self):
+        db = _make_migrated_db(COMPLETED + [("r3", "COMPLETED", None), ("r4", "COMPLETED", None)])
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=2)["runs"]) == ["r3", "r4"]
+
+    def test_none_is_full_history(self):
+        db = _make_migrated_db(COMPLETED)
+        assert _ids(db.get_session("s1", deserialize=False)["runs"]) == ["r0", "r1", "r2"]
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=None)["runs"]) == ["r0", "r1", "r2"]
+
+    def test_limit_larger_than_history(self):
+        db = _make_migrated_db(COMPLETED)
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=10)["runs"]) == ["r0", "r1", "r2"]
+
+
+class TestRunsLimitUnmigrated:
+    def test_blob_fallback_returns_most_recent_n(self):
+        db = _make_unmigrated_db(COMPLETED + [("r3", "COMPLETED", None), ("r4", "COMPLETED", None)])
+        # Reads work before any migration, and honor the limit via blob slice.
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=2)["runs"]) == ["r3", "r4"]
+
+    def test_blob_full_history_when_no_limit(self):
+        db = _make_unmigrated_db(COMPLETED)
+        assert _ids(db.get_session("s1", deserialize=False)["runs"]) == ["r0", "r1", "r2"]
+
+
+class TestFilterBeforeSlice:
+    # r2/r5 errored, r4 is a member run (parent set) — all excluded by get_messages
+    # BEFORE the last-N slice, so the bounded query must exclude them too.
+    SPECS = [
+        ("r0", "COMPLETED", None),
+        ("r1", "COMPLETED", None),
+        ("r2", "ERROR", None),
+        ("r3", "COMPLETED", None),
+        ("r4", "COMPLETED", "r3"),
+        ("r5", "ERROR", None),
+    ]
+
+    def test_migrated_excludes_member_and_skip_status(self):
+        db = _make_migrated_db(self.SPECS)
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=2)["runs"]) == ["r1", "r3"]
+
+    def test_unmigrated_excludes_member_and_skip_status(self):
+        db = _make_unmigrated_db(self.SPECS)
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=2)["runs"]) == ["r1", "r3"]
+
+
+class TestGetSessionsIncludeRuns:
+    def test_include_runs_false_omits_runs(self):
+        db = _make_migrated_db(COMPLETED)
+        sessions, _ = db.get_sessions(deserialize=False, include_runs=False)
+        assert sessions[0]["runs"] is None
+        # Storage untouched — a single get_session still returns the runs.
+        assert _ids(db.get_session("s1", deserialize=False)["runs"]) == ["r0", "r1", "r2"]
+
+    def test_default_attaches_runs(self):
+        db = _make_migrated_db(COMPLETED)
+        sessions, _ = db.get_sessions(deserialize=False)
+        assert _ids(sessions[0]["runs"]) == ["r0", "r1", "r2"]
+
+
+class TestCapabilityFlag:
+    def test_sqlite_supports_runs_limit(self):
+        assert SqliteDb.supports_runs_limit is True

--- a/libs/agno/tests/unit/db/test_runs_limit.py
+++ b/libs/agno/tests/unit/db/test_runs_limit.py
@@ -135,3 +135,60 @@ class TestGetSessionsIncludeRuns:
 class TestCapabilityFlag:
     def test_sqlite_supports_runs_limit(self):
         assert SqliteDb.supports_runs_limit is True
+
+
+class TestSchemaHasNoBuilderBreakingMetadata:
+    """MySQL/SingleStore table builders iterate every schema entry and access
+    ``col_config["type"]``; a non-column key like ``__composite_indexes__`` would
+    KeyError on table creation. Those adapters must not carry it (yet)."""
+
+    def test_mysql_singlestore_runs_schema_is_columns_only(self):
+        from agno.db.mysql.schemas import _get_run_table_schema as mysql_runs
+        from agno.db.singlestore.schemas import _get_run_table_schema as singlestore_runs
+
+        for schema in (mysql_runs(), singlestore_runs()):
+            for name, cfg in schema.items():
+                assert not name.startswith("__"), f"{name} would break the MySQL/SingleStore builder"
+                assert "type" in cfg
+
+    def test_postgres_sqlite_runs_schema_has_composite_index(self):
+        from agno.db.postgres.schemas import _get_run_table_schema as pg_runs
+        from agno.db.sqlite.schemas import _get_run_table_schema as sqlite_runs
+
+        for schema in (pg_runs(), sqlite_runs()):
+            idx = schema.get("__composite_indexes__", [])
+            assert any(i["columns"] == ["session_id", "run_index"] for i in idx)
+
+
+class TestBoundedHistoryGate:
+    """_bounded_history_runs_limit decides when to push runs_limit to the DB."""
+
+    def _agent(self, db=None):
+        from agno.agent import Agent
+
+        return Agent(id="ag1", db=db, session_id="s1")
+
+    def test_positive_with_sql_db(self):
+        from agno.agent._session import _bounded_history_runs_limit
+
+        db = SqliteDb(db_file=tempfile.mktemp(suffix=".db"))
+        assert _bounded_history_runs_limit(self._agent(db), 3, None) == 3
+
+    def test_nonpositive_falls_back(self):
+        from agno.agent._session import _bounded_history_runs_limit
+
+        db = SqliteDb(db_file=tempfile.mktemp(suffix=".db"))
+        assert _bounded_history_runs_limit(self._agent(db), 0, None) is None
+        assert _bounded_history_runs_limit(self._agent(db), -1, None) is None
+
+    def test_no_db_falls_back(self):
+        from agno.agent._session import _bounded_history_runs_limit
+
+        # cache_session-without-DB must not bound (would bypass the cache into "not found")
+        assert _bounded_history_runs_limit(self._agent(None), 3, None) is None
+
+    def test_custom_skip_statuses_falls_back(self):
+        from agno.agent._session import _bounded_history_runs_limit
+
+        db = SqliteDb(db_file=tempfile.mktemp(suffix=".db"))
+        assert _bounded_history_runs_limit(self._agent(db), 3, [RunStatus.error]) is None

--- a/libs/agno/tests/unit/db/test_runs_limit.py
+++ b/libs/agno/tests/unit/db/test_runs_limit.py
@@ -256,3 +256,90 @@ class TestRunsLimitAcrossAdapters:
         # runs_limit larger than the filtered set: still filtered, just not truncated.
         db = make_db(_FILTER_SPECS)
         assert _ids(db.get_session("s1", deserialize=False, runs_limit=10)["runs"]) == ["r0", "r1", "r3"]
+
+
+class TestRunsLimitNullRunIndex:
+    """Regression for the NULL run_index ordering bug (COALESCE fix).
+
+    ``run_index`` is nullable — a run first persisted without an explicit index
+    (e.g. a background/continue-stream save) stores NULL. The bounded fast path
+    orders by ``run_index DESC``; without ``COALESCE(run_index, 0)`` a NULL sorts
+    to the wrong extreme (NULLS FIRST on Postgres, NULLS LAST on SQLite/MySQL), so
+    ``runs_limit=N`` returned the *wrong* N runs — the oldest instead of the
+    newest, differing per backend. The invariant these tests pin: the bounded
+    fast path returns the SAME window as full-load-then-slice.
+    """
+
+    def _make_mixed_index_db(self) -> SqliteDb:
+        """Session where the two newest runs have a NULL run_index (r0/r1 indexed,
+        r2/r3 NULL), all with increasing created_at so the newest are unambiguous."""
+        db = SqliteDb(db_file=tempfile.mktemp(suffix=".db"))
+        specs = [("r0", 0), ("r1", 1), ("r2", None), ("r3", None)]
+        sess = AgentSession(session_id="s1", agent_id="a1")
+        for rid, _ in specs:
+            sess.upsert_run(RunOutput(run_id=rid, agent_id="a1", status=RunStatus("COMPLETED")))
+        db.upsert_session(sess)
+        for i, (rid, run_index) in enumerate(specs):
+            run = RunOutput(run_id=rid, agent_id="a1", status=RunStatus("COMPLETED"))
+            run.created_at = 1000 + i
+            kwargs = {"session_id": "s1", "user_id": None}
+            if run_index is not None:
+                kwargs["run_index"] = run_index
+            db.upsert_run(run, **kwargs)
+        return db
+
+    def test_bounded_matches_full_load_slice_with_null_index(self):
+        db = self._make_mixed_index_db()
+        full = _ids(db.get_session("s1", deserialize=False, runs_limit=None)["runs"])
+        for n in (1, 2, 3):
+            bounded = _ids(db.get_session("s1", deserialize=False, runs_limit=n)["runs"])
+            # The bounded window must be exactly the last-N of the full history.
+            assert bounded == full[-n:], f"runs_limit={n}: {bounded} != {full[-n:]}"
+
+    def test_null_index_runs_are_not_dropped(self):
+        # All four runs are context-relevant; a large limit must return every one,
+        # so a NULL-index run is never silently dropped from the window.
+        db = self._make_mixed_index_db()
+        assert len(db.get_session("s1", deserialize=False, runs_limit=10)["runs"]) == 4
+
+
+class TestRunsLimitPartialMigration:
+    """Regression for the partial-migration branch: a session with runs in BOTH the
+    ``agno_runs`` table AND a residual legacy ``runs`` blob (the state between running
+    the v3 migration and dropping the legacy column). ``get_session(runs_limit=N)``
+    must merge both, filter, and slice — never the indexed fast path."""
+
+    def _make_partial_migration_db(self) -> SqliteDb:
+        db = _make_migrated_db(COMPLETED)  # r0,r1,r2 in the runs table
+        # The "both populated" state only exists on a DB migrated from v2, which keeps
+        # the legacy ``runs`` column as a backup. A fresh v3 schema has no such column,
+        # so recreate that transitional state: add the column, then seed a blob holding
+        # an OLDER un-migrated run (r_old) plus r0 (already in the table -> dedup, table wins).
+        blob = [
+            {"run_id": "r_old", "agent_id": "a1", "status": "COMPLETED", "parent_run_id": None},
+            {"run_id": "r0", "agent_id": "a1", "status": "COMPLETED", "parent_run_id": None},
+        ]
+        con = sqlite3.connect(db.db_file)
+        con.execute("ALTER TABLE agno_sessions ADD COLUMN runs TEXT")
+        con.execute("UPDATE agno_sessions SET runs = ? WHERE session_id = 's1'", (json.dumps(blob),))
+        con.commit()
+        con.close()
+        return SqliteDb(db_file=db.db_file)
+
+    def test_partial_migration_merges_before_slicing(self):
+        db = self._make_partial_migration_db()
+        # Both stores contribute (dedup drops the duplicate r0, table wins), so the
+        # merged history contains all four distinct runs.
+        full = _ids(db.get_session("s1", deserialize=False)["runs"])
+        assert set(full) == {"r0", "r1", "r2", "r_old"}
+        # Bounded read takes the last-N of that merged+filtered history — whatever the
+        # merge order, the window must be its own suffix (never the fast path, which
+        # would miss the blob-only run).
+        bounded = _ids(db.get_session("s1", deserialize=False, runs_limit=2)["runs"])
+        assert bounded == full[-2:]
+
+    def test_partial_migration_no_run_lost(self):
+        db = self._make_partial_migration_db()
+        # A limit exceeding the count returns every distinct run, none dropped.
+        got = _ids(db.get_session("s1", deserialize=False, runs_limit=10)["runs"])
+        assert set(got) == {"r0", "r1", "r2", "r_old"}

--- a/libs/agno/tests/unit/session/test_history_skip_statuses.py
+++ b/libs/agno/tests/unit/session/test_history_skip_statuses.py
@@ -1,0 +1,85 @@
+"""The set of run statuses excluded when rebuilding message history/context must
+have a single source of truth.
+
+``session.get_messages`` (agent + team) filters these out *before* slicing the
+last N runs, and the DB-level bounded read (``agno.db.utils.HISTORY_SKIP_STATUSES``)
+must reproduce exactly the same filter — otherwise a ``runs_limit=N`` read and a
+full-load read return different history windows for the same session. Both now
+derive from ``agno.run.base.HISTORY_SKIP_STATUSES``; these tests guard the wiring
+so the two representations can never drift.
+"""
+
+from __future__ import annotations
+
+from agno.models.message import Message
+from agno.run.agent import RunOutput
+from agno.run.base import HISTORY_SKIP_STATUSES, RunStatus
+from agno.run.team import TeamRunOutput
+from agno.session.agent import AgentSession
+from agno.session.team import TeamSession
+
+
+def test_db_string_set_matches_canonical_enum():
+    """The DB-facing string list must equal the canonical enum values."""
+    from agno.db.utils import HISTORY_SKIP_STATUSES as db_strings
+
+    assert db_strings == [status.value for status in HISTORY_SKIP_STATUSES]
+    assert set(db_strings) == {"PAUSED", "CANCELLED", "ERROR", "REGENERATED"}
+
+
+def test_canonical_contains_expected_statuses():
+    assert set(HISTORY_SKIP_STATUSES) == {
+        RunStatus.paused,
+        RunStatus.cancelled,
+        RunStatus.error,
+        RunStatus.regenerated,
+    }
+
+
+def _contents(messages) -> list:
+    return [m.content for m in messages]
+
+
+def test_agent_get_messages_skips_every_canonical_status():
+    session = AgentSession(session_id="s1", agent_id="agent-1")
+    session.upsert_run(
+        RunOutput(
+            run_id="ok", agent_id="agent-1", status=RunStatus.completed, messages=[Message(role="user", content="keep")]
+        )
+    )
+    for i, status in enumerate(HISTORY_SKIP_STATUSES):
+        session.upsert_run(
+            RunOutput(
+                run_id=f"drop{i}",
+                agent_id="agent-1",
+                status=status,
+                messages=[Message(role="user", content=f"drop{i}")],
+            )
+        )
+
+    contents = _contents(session.get_messages())
+    assert "keep" in contents
+    assert not any(c.startswith("drop") for c in contents)
+
+
+def test_team_get_messages_skips_regenerated():
+    """Regression for the team alignment: TeamSession.get_messages previously did
+    NOT skip REGENERATED runs (only agent did). Now both use the shared set."""
+    session = TeamSession(session_id="t1", team_id="team-1")
+    session.upsert_run(
+        TeamRunOutput(
+            run_id="ok", team_id="team-1", status=RunStatus.completed, messages=[Message(role="user", content="keep")]
+        )
+    )
+    session.upsert_run(
+        TeamRunOutput(
+            run_id="regen",
+            team_id="team-1",
+            status=RunStatus.regenerated,
+            messages=[Message(role="user", content="drop")],
+        )
+    )
+
+    contents = _contents(session.get_messages())
+    assert "keep" in contents
+    assert "drop" not in contents


### PR DESCRIPTION
## Summary

The v3 denormalization put runs in an indexed `agno_runs` table, but reads still
loaded a session's **entire** run history and sliced the last-N in Python. This
pushes that down to SQL, migration-safely.

**Phase 0 — index.** Add a `(session_id, run_index)` composite index to the runs
schema on all SQL adapters so "most recent N runs of a session" is index-served
(`run_index` was previously unindexed).

**Phase 1 — `get_sessions(include_runs=False)`.** A session list can skip
attaching each session's run history (the heaviest, usually-unnecessary read for
list views). Default stays `True` (no behavior change; the search tools that read
`.runs` keep working); storage is untouched — a single `get_session` still returns
the runs.

**Phase 2 — `get_session(runs_limit=N)`.** Attaches only the most recent N
*context-relevant* runs. **Migration-safe by construction:**
- fully migrated (no legacy blob) → indexed `ORDER BY run_index DESC LIMIT N`
- un-migrated (legacy `runs` blob present) → full load + merge, then filter + slice
- no runs table yet → filter + slice the legacy blob

The bounded query reproduces `get_messages`' **pre-slice** filtering (drops member
sub-runs and terminal-skip statuses, via `filter_context_runs` /
`HISTORY_SKIP_STATUSES`) so the DB-side last-N is *identical* to
full-load-then-slice — this is the "filter-before-slice" correctness trap, handled.
`runs_limit=None` is byte-for-byte the old behavior.

**Wiring.** A `supports_runs_limit` capability flag (SQL adapters set it) gates the
consumer: `get_session_messages` pushes `num_history_runs` down for a standalone
agent with default status filtering; team reuse / custom `skip_statuses` fall back
to a full load. Bounded reads are never served from or written to the session cache.

## Migration-safety (the hard requirement)

Everything works for users who have **not** run the v3 migration: the legacy-blob
and no-runs-table paths both fall back to loading + merging + filtering the blob,
so no history is ever missed or lost. Verified with tests for both states.

## Scope / follow-ups

- Implemented for **postgres and sqlite (sync + async)**, fully tested.
- **mysql / singlestore / async_mysql** get the Phase 0 index now; `runs_limit` is
  capability-gated *off* there (they safely full-load) pending the same mechanical
  change — no behavior regression.
- The **per-turn write loop** stays on full-load: a new run's `run_index` is derived
  positionally from the loaded list, so bounding that path needs a separate
  `run_index` decoupling (a `MAX(run_index)+1` write). Deliberately out of scope to
  keep run ordering untouched.
- Async history wiring (`aget_session_messages`) and the OS list-endpoint opt-in are
  natural next steps on top of the capability.

## Type of change

- [x] Improvement (performance)

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated (docstrings)
- [ ] Examples and guides updated (n/a)
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] Searched existing open PRs; none address this
- [x] Check if this PR was AI-generated

---

## Additional Notes

Tests in `libs/agno/tests/unit/db/test_runs_limit.py` cover: migrated last-N,
un-migrated blob-fallback last-N, filter-before-slice with errored + member runs in
the tail (migrated and un-migrated), `runs_limit=None` parity, `get_sessions`
`include_runs`, and the capability flag. Full `unit/session` + `unit/agent` +
`unit/db` regression suites pass (exit 0).
