### PR TITLE
fix: exclude nltk 3.10.1, which breaks the unstructured import chain

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -198,7 +198,9 @@ chonkie = [
 csv = ["aiofiles"]
 docx = ["python-docx"]
 excel = ["openpyxl", "xlrd"]
-markdown = ["unstructured<0.18.31", "markdown", "aiofiles"]
+# nltk!=3.10.1: its inisec import hook falsely blocks site-packages imports when
+# the venv lives inside the CWD, breaking the unstructured import chain.
+markdown = ["unstructured<0.18.31", "nltk!=3.10.1", "markdown", "aiofiles"]
 pdf = ["pypdf", "rapidocr_onnxruntime"]
 pptx = ["python-pptx"]
 text = ["aiofiles"]


### PR DESCRIPTION
## Summary

nltk 3.10.1 [(released 2026-08-01)](https://pypi.org/project/nltk/#history) added inisec.py, an import hook that resolves each imported module's real file path and blocks it if that path is anywhere under the current working directory. CI runs python -m pytest from the repo root with the venv at ./.venv, so .venv/.../defusedxml resolves inside CWD and gets blocked.

This is an upstream false positive affecting any in-project venv layout, the uv and in-project Poetry default. Tracked upstream as nltk/nltk#3730. 

Fixing this by excluding the single broken version in the markdown extra.                                                               
                             
Failing CI run: https://github.com/agno-agi/agno/actions/runs/30804893040/job/91657836422

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
