### PR TITLE
[fix] handle batch JSON responses in OpenAI streams

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from os import getenv
@@ -388,6 +389,26 @@ class OpenAIChat(Model):
         normalized = reformat_tool_call_ids(messages, provider="openai_chat")
         return [self._format_message(m, compress_tool_results) for m in normalized]
 
+    @staticmethod
+    def _is_json_response(response: httpx.Response) -> bool:
+        content_type = response.headers.get("content-type", "")
+        media_type = content_type.partition(";")[0].strip()
+        return media_type.lower() == "application/json"
+
+    def _parse_json_stream_response(
+        self,
+        response_body: bytes,
+        response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+    ) -> ModelResponse:
+        response_data = json.loads(response_body)
+        if isinstance(response_data, dict) and response_data.get("error"):
+            error = response_data["error"]
+            error_message = error.get("message", "Unknown model error") if isinstance(error, dict) else str(error)
+            raise ModelProviderError(message=str(error_message), model_name=self.name, model_id=self.id)
+
+        provider_response = ChatCompletion.model_validate(response_data)
+        return self._parse_provider_response(provider_response, response_format=response_format)
+
     def invoke(
         self,
         messages: List[Message],
@@ -604,12 +625,12 @@ class OpenAIChat(Model):
             )
 
             # Some OpenAI-compatible providers ignore stream=True and return a batch completion.
-            if provider_stream.response.headers.get("content-type", "").lower().startswith("application/json"):
+            if self._is_json_response(provider_stream.response):
                 try:
-                    provider_response = ChatCompletion.model_validate_json(provider_stream.response.read())
+                    response_body = provider_stream.response.read()
                 finally:
                     provider_stream.close()
-                yield self._parse_provider_response(provider_response, response_format=response_format)
+                yield self._parse_json_stream_response(response_body, response_format=response_format)
             else:
                 for chunk in provider_stream:
                     yield self._parse_provider_response_delta(chunk)
@@ -662,6 +683,8 @@ class OpenAIChat(Model):
         except ModelAuthenticationError as e:
             log_error(f"Model authentication error from OpenAI API: {str(e)}")
             raise e
+        except ModelProviderError:
+            raise
         except Exception as e:
             log_error(f"Error from OpenAI API: {str(e)}")
             raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
@@ -701,12 +724,12 @@ class OpenAIChat(Model):
             )
 
             # Some OpenAI-compatible providers ignore stream=True and return a batch completion.
-            if async_stream.response.headers.get("content-type", "").lower().startswith("application/json"):
+            if self._is_json_response(async_stream.response):
                 try:
-                    provider_response = ChatCompletion.model_validate_json(await async_stream.response.aread())
+                    response_body = await async_stream.response.aread()
                 finally:
                     await async_stream.close()
-                yield self._parse_provider_response(provider_response, response_format=response_format)
+                yield self._parse_json_stream_response(response_body, response_format=response_format)
             else:
                 async for chunk in async_stream:
                     yield self._parse_provider_response_delta(chunk)
@@ -759,6 +782,8 @@ class OpenAIChat(Model):
         except ModelAuthenticationError as e:
             log_error(f"Model authentication error from OpenAI API: {str(e)}")
             raise e
+        except ModelProviderError:
+            raise
         except Exception as e:
             log_error(f"Error from OpenAI API: {str(e)}")
             raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -593,7 +593,7 @@ class OpenAIChat(Model):
         try:
             assistant_message.metrics.start_timer()
 
-            for chunk in self.get_client().chat.completions.create(
+            provider_stream = self.get_client().chat.completions.create(
                 model=self.id,
                 messages=self._format_all_messages(messages, compress_tool_results),  # type: ignore
                 stream=True,
@@ -601,8 +601,18 @@ class OpenAIChat(Model):
                 **self.get_request_params(
                     response_format=response_format, tools=tools, tool_choice=tool_choice, run_response=run_response
                 ),
-            ):
-                yield self._parse_provider_response_delta(chunk)
+            )
+
+            # Some OpenAI-compatible providers ignore stream=True and return a batch completion.
+            if provider_stream.response.headers.get("content-type", "").lower().startswith("application/json"):
+                try:
+                    provider_response = ChatCompletion.model_validate_json(provider_stream.response.read())
+                finally:
+                    provider_stream.close()
+                yield self._parse_provider_response(provider_response, response_format=response_format)
+            else:
+                for chunk in provider_stream:
+                    yield self._parse_provider_response_delta(chunk)
 
             assistant_message.metrics.stop_timer()
 
@@ -690,8 +700,16 @@ class OpenAIChat(Model):
                 ),
             )
 
-            async for chunk in async_stream:
-                yield self._parse_provider_response_delta(chunk)
+            # Some OpenAI-compatible providers ignore stream=True and return a batch completion.
+            if async_stream.response.headers.get("content-type", "").lower().startswith("application/json"):
+                try:
+                    provider_response = ChatCompletion.model_validate_json(await async_stream.response.aread())
+                finally:
+                    await async_stream.close()
+                yield self._parse_provider_response(provider_response, response_format=response_format)
+            else:
+                async for chunk in async_stream:
+                    yield self._parse_provider_response_delta(chunk)
 
             assistant_message.metrics.stop_timer()
 

--- a/libs/agno/tests/unit/models/openai/test_non_streaming_compatible_response.py
+++ b/libs/agno/tests/unit/models/openai/test_non_streaming_compatible_response.py
@@ -4,6 +4,8 @@ import httpx
 import pytest
 
 from agno.agent import Agent
+from agno.exceptions import ModelProviderError
+from agno.models.message import Message
 from agno.models.openai import OpenAILike
 from agno.os.interfaces.a2a.utils import stream_a2a_response
 
@@ -14,6 +16,7 @@ def _batch_response(request: httpx.Request) -> httpx.Response:
 
     return httpx.Response(
         status_code=200,
+        headers={"content-type": "Application/JSON;charset=utf-8"},
         json={
             "id": "chatcmpl-batch",
             "object": "chat.completion",
@@ -29,6 +32,12 @@ def _batch_response(request: httpx.Request) -> httpx.Response:
             "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
         },
     )
+
+
+def _error_response(request: httpx.Request) -> httpx.Response:
+    request_body = json.loads(request.read())
+    assert request_body["stream"] is True
+    return httpx.Response(200, json={"error": {"message": "mock backend failed"}})
 
 
 def _streaming_response(request: httpx.Request) -> httpx.Response:
@@ -84,6 +93,24 @@ def test_sync_stream_keeps_sse_response() -> None:
     assert events[-1].content == "streamed response"
 
 
+def test_sync_stream_converts_json_error_to_provider_error() -> None:
+    with httpx.Client(transport=httpx.MockTransport(_error_response)) as http_client:
+        model = OpenAILike(
+            id="mock-model",
+            api_key="not-needed",
+            base_url="http://mock.local/v1",
+            http_client=http_client,
+        )
+
+        with pytest.raises(ModelProviderError, match="mock backend failed"):
+            list(
+                model.invoke_stream(
+                    messages=[Message(role="user", content="hello")],
+                    assistant_message=Message(role="assistant"),
+                )
+            )
+
+
 @pytest.mark.asyncio
 async def test_a2a_stream_accepts_batch_json_response() -> None:
     async with httpx.AsyncClient(transport=httpx.MockTransport(_batch_response)) as http_client:
@@ -116,3 +143,21 @@ async def test_async_stream_keeps_sse_response() -> None:
         events = [event async for event in agent.arun("hello", stream=True, stream_events=True)]
 
     assert events[-1].content == "streamed response"
+
+
+@pytest.mark.asyncio
+async def test_async_stream_converts_json_error_to_provider_error() -> None:
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_error_response)) as http_client:
+        model = OpenAILike(
+            id="mock-model",
+            api_key="not-needed",
+            base_url="http://mock.local/v1",
+            http_client=http_client,
+        )
+
+        with pytest.raises(ModelProviderError, match="mock backend failed"):
+            async for _ in model.ainvoke_stream(
+                messages=[Message(role="user", content="hello")],
+                assistant_message=Message(role="assistant"),
+            ):
+                pass

--- a/libs/agno/tests/unit/models/openai/test_non_streaming_compatible_response.py
+++ b/libs/agno/tests/unit/models/openai/test_non_streaming_compatible_response.py
@@ -1,0 +1,118 @@
+import json
+
+import httpx
+import pytest
+
+from agno.agent import Agent
+from agno.models.openai import OpenAILike
+from agno.os.interfaces.a2a.utils import stream_a2a_response
+
+
+def _batch_response(request: httpx.Request) -> httpx.Response:
+    request_body = json.loads(request.read())
+    assert request_body["stream"] is True
+
+    return httpx.Response(
+        status_code=200,
+        json={
+            "id": "chatcmpl-batch",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "mock-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "batch response"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+        },
+    )
+
+
+def _streaming_response(request: httpx.Request) -> httpx.Response:
+    request_body = json.loads(request.read())
+    assert request_body["stream"] is True
+
+    chunk = {
+        "id": "chatcmpl-stream",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "mock-model",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": "streamed response"},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+    body = f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n"
+    return httpx.Response(200, text=body, headers={"content-type": "text/event-stream"})
+
+
+def test_sync_stream_accepts_batch_json_response() -> None:
+    with httpx.Client(transport=httpx.MockTransport(_batch_response)) as http_client:
+        agent = Agent(
+            model=OpenAILike(
+                id="mock-model",
+                api_key="not-needed",
+                base_url="http://mock.local/v1",
+                http_client=http_client,
+            )
+        )
+
+        events = list(agent.run("hello", stream=True, stream_events=True))
+
+    assert events[-1].content == "batch response"
+
+
+def test_sync_stream_keeps_sse_response() -> None:
+    with httpx.Client(transport=httpx.MockTransport(_streaming_response)) as http_client:
+        agent = Agent(
+            model=OpenAILike(
+                id="mock-model",
+                api_key="not-needed",
+                base_url="http://mock.local/v1",
+                http_client=http_client,
+            )
+        )
+
+        events = list(agent.run("hello", stream=True, stream_events=True))
+
+    assert events[-1].content == "streamed response"
+
+
+@pytest.mark.asyncio
+async def test_a2a_stream_accepts_batch_json_response() -> None:
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_batch_response)) as http_client:
+        agent = Agent(
+            model=OpenAILike(
+                id="mock-model",
+                api_key="not-needed",
+                base_url="http://mock.local/v1",
+                http_client=http_client,
+            )
+        )
+        event_stream = agent.arun("hello", stream=True, stream_events=True)
+        chunks = [chunk async for chunk in stream_a2a_response(event_stream, request_id="request-id")]
+
+    final_task = json.loads(chunks[-1].split("data: ", 1)[1])["result"]
+    assert final_task["history"][0]["parts"] == [{"kind": "text", "text": "batch response"}]
+
+
+@pytest.mark.asyncio
+async def test_async_stream_keeps_sse_response() -> None:
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_streaming_response)) as http_client:
+        agent = Agent(
+            model=OpenAILike(
+                id="mock-model",
+                api_key="not-needed",
+                base_url="http://mock.local/v1",
+                http_client=http_client,
+            )
+        )
+        events = [event async for event in agent.arun("hello", stream=True, stream_events=True)]
+
+    assert events[-1].content == "streamed response"


### PR DESCRIPTION
## Summary

- detect OpenAI-compatible streaming requests that return a complete `application/json` ChatCompletion instead of SSE
- parse that response through the existing full-response parser in both sync and async streaming paths
- centralize JSON Content-Type detection and normalize JSON error envelopes to `ModelProviderError`
- preserve the existing SSE path and add regression coverage for batch JSON and standard SSE responses

Fixes #9316.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`libs/agno/scripts/format.bat` and `libs/agno/scripts/validate.bat`)
- [x] Self-review completed
- [ ] Documentation updated (not applicable; no public API changed)
- [ ] Examples and guides included or updated (not applicable; this is a compatibility fix)
- [x] Tested in a clean project-specific Conda environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] This PR was developed with Codex assistance and is submitted as a draft for human review

---

## Validation

- `pytest libs/agno/tests/unit/models/openai/test_non_streaming_compatible_response.py -q` (`6 passed`)
- `pytest libs/agno/tests/unit/models/openai -q -k "not test_format_file_mime_type_guessed_from_filepath"` (`77 passed, 1 deselected`)
- `libs/agno/scripts/format.bat` (`2003 files left unchanged` after formatting the change)
- `libs/agno/scripts/validate.bat` (Ruff passed; Mypy passed for 953 source files)

## Additional Notes

The full OpenAI unit directory has one pre-existing Windows-specific failure: `.csv` is resolved as `application/vnd.ms-excel` by the local MIME registry while the test expects `text/csv`. The failure reproduces in isolation and is unrelated to this change.

The fix does not retry the model request. It reads and parses the already-returned JSON body, avoiding duplicate model calls or tool side effects.
