### PR TITLE
[fix] Key entity memory per user under the "user" namespace (#9319)

### DIFF
--- a/libs/agno/agno/learn/stores/entity_memory.py
+++ b/libs/agno/agno/learn/stores/entity_memory.py
@@ -36,7 +36,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from os import getenv
 from textwrap import dedent
-from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union, cast
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 from weakref import WeakKeyDictionary
 
 from agno.learn.config import EntityMemoryConfig, LearningMode
@@ -1602,7 +1602,9 @@ class EntityMemoryStore(LearningStore):
             # A minimal entity created by link_entities acquires its real type;
             # the row key embeds the type, so the old row must be replaced.
             if entity_obj.entity_type == _UNKNOWN_ENTITY_TYPE and normalized_type != _UNKNOWN_ENTITY_TYPE:
-                stale_row_key = self._build_entity_db_id(entity_obj.entity_id, entity_obj.entity_type, namespace)
+                stale_row_key = self._build_entity_db_id(
+                    entity_obj.entity_id, entity_obj.entity_type, namespace, user_id
+                )
                 entity_obj.entity_type = normalized_type
 
             # Remember the name variant this write arrived under, bounded so the
@@ -3390,6 +3392,7 @@ class EntityMemoryStore(LearningStore):
         entity_id: str,
         entity_type: str,
         namespace: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> bool:
         """Hard-delete an entity from the store (data API - not exposed as a tool)."""
         db = self._sync_db()
@@ -3397,8 +3400,15 @@ class EntityMemoryStore(LearningStore):
             return False
 
         effective_namespace = namespace or self.config.namespace
+        if effective_namespace == "user" and not user_id:
+            log_warning("EntityMemoryStore.delete: namespace='user' requires user_id")
+            return False
+
+        row_key = self._build_entity_db_id(entity_id, entity_type, effective_namespace, user_id)
+        if row_key is None:
+            return False
         try:
-            return bool(db.delete_learning(id=self._build_entity_db_id(entity_id, entity_type, effective_namespace)))
+            return bool(db.delete_learning(id=row_key))
         except Exception as e:
             log_debug(f"EntityMemoryStore.delete failed: {e}")
             return False
@@ -3408,22 +3418,24 @@ class EntityMemoryStore(LearningStore):
         entity_id: str,
         entity_type: str,
         namespace: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> bool:
         """Async version of delete."""
         if not self.db:
             return False
 
         effective_namespace = namespace or self.config.namespace
+        if effective_namespace == "user" and not user_id:
+            log_warning("EntityMemoryStore.adelete: namespace='user' requires user_id")
+            return False
+
+        row_key = self._build_entity_db_id(entity_id, entity_type, effective_namespace, user_id)
+        if row_key is None:
+            return False
         try:
             if isinstance(self.db, AsyncBaseDb):
-                return bool(
-                    await self.db.delete_learning(
-                        id=self._build_entity_db_id(entity_id, entity_type, effective_namespace)
-                    )
-                )
-            return bool(
-                self.db.delete_learning(id=self._build_entity_db_id(entity_id, entity_type, effective_namespace))
-            )
+                return bool(await self.db.delete_learning(id=row_key))
+            return bool(self.db.delete_learning(id=row_key))
         except Exception as e:
             log_debug(f"EntityMemoryStore.adelete failed: {e}")
             return False
@@ -3452,8 +3464,12 @@ class EntityMemoryStore(LearningStore):
             if not content:
                 return False
 
+            row_key = self._build_entity_db_id(entity.entity_id, entity.entity_type, effective_namespace, user_id)
+            if row_key is None:
+                return False
+
             db.upsert_learning(
-                id=self._build_entity_db_id(entity.entity_id, entity.entity_type, effective_namespace),
+                id=row_key,
                 learning_type=self.learning_type,
                 entity_id=entity.entity_id,
                 entity_type=entity.entity_type,
@@ -3489,9 +3505,13 @@ class EntityMemoryStore(LearningStore):
             if not content:
                 return False
 
+            row_key = self._build_entity_db_id(entity.entity_id, entity.entity_type, effective_namespace, user_id)
+            if row_key is None:
+                return False
+
             if isinstance(self.db, AsyncBaseDb):
                 await self.db.upsert_learning(
-                    id=self._build_entity_db_id(entity.entity_id, entity.entity_type, effective_namespace),
+                    id=row_key,
                     learning_type=self.learning_type,
                     entity_id=entity.entity_id,
                     entity_type=entity.entity_type,
@@ -3503,7 +3523,7 @@ class EntityMemoryStore(LearningStore):
                 )
             else:
                 self.db.upsert_learning(
-                    id=self._build_entity_db_id(entity.entity_id, entity.entity_type, effective_namespace),
+                    id=row_key,
                     learning_type=self.learning_type,
                     entity_id=entity.entity_id,
                     entity_type=entity.entity_type,
@@ -3529,11 +3549,20 @@ class EntityMemoryStore(LearningStore):
         entity_id: str,
         entity_type: str,
         namespace: str,
-    ) -> str:
-        """Build unique DB ID for entity."""
-        return cast(
-            str,
-            build_learning_id("entity_memory", entity_id=entity_id, entity_type=entity_type, namespace=namespace),
+        user_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Build unique DB ID for entity.
+
+        Returns None under the "user" namespace when no user_id is available: that key is
+        per-user, and a user-less one would collide across users. Callers already refuse
+        "user"-namespace operations without a user_id, so this is the belt to that braces.
+        """
+        return build_learning_id(
+            "entity_memory",
+            entity_id=entity_id,
+            entity_type=entity_type,
+            namespace=namespace,
+            user_id=user_id,
         )
 
     def _format_entity_basic(self, entity: Any) -> str:

--- a/libs/agno/agno/learn/utils.py
+++ b/libs/agno/agno/learn/utils.py
@@ -52,7 +52,14 @@ def build_learning_id(
         return f"session_context_{session_id}" if session_id else None
     if learning_type == "entity_memory":
         if entity_id and entity_type:
-            return f"entity_{namespace or DEFAULT_LEARNING_NAMESPACE}_{entity_type}_{entity_id}"
+            effective_namespace = namespace or DEFAULT_LEARNING_NAMESPACE
+            if effective_namespace == "user":
+                # The "user" namespace is private per user, and reads filter by user_id.
+                # Leaving the user out of the key gives every user the same row for the same
+                # entity: one user's write overwrites another's facts, and the later writer
+                # can never read their own data back. Key it like the other per-user stores.
+                return f"entity_user_{user_id}_{entity_type}_{entity_id}" if user_id else None
+            return f"entity_{effective_namespace}_{entity_type}_{entity_id}"
         return None
     return None
 

--- a/libs/agno/tests/unit/learn/test_build_learning_id.py
+++ b/libs/agno/tests/unit/learn/test_build_learning_id.py
@@ -20,8 +20,8 @@ class TestBuildLearningId:
             build_learning_id("entity_memory", entity_id="acme", entity_type="company") == "entity_global_company_acme"
         )
         assert (
-            build_learning_id("entity_memory", entity_id="acme", entity_type="company", namespace="user")
-            == "entity_user_company_acme"
+            build_learning_id("entity_memory", entity_id="acme", entity_type="company", namespace="user", user_id="u1")
+            == "entity_user_u1_company_acme"
         )
 
     def test_missing_identity_fields_returns_none(self):
@@ -29,6 +29,30 @@ class TestBuildLearningId:
         assert build_learning_id("user_memory") is None
         assert build_learning_id("session_context") is None
         assert build_learning_id("entity_memory", entity_id="acme") is None  # needs entity_type too
+        # The "user" namespace keys per user, so it needs a user_id the same way user_profile does.
+        assert build_learning_id("entity_memory", entity_id="acme", entity_type="company", namespace="user") is None
+
+    def test_entity_memory_user_namespace_is_keyed_per_user(self):
+        """Under namespace="user" two users must not share one row for the same entity.
+
+        Reads filter by user_id, so a user-less key let one user's write overwrite another's
+        facts while the later writer could never read their own data back.
+        """
+        alice = build_learning_id(
+            "entity_memory", entity_id="acme", entity_type="company", namespace="user", user_id="alice"
+        )
+        bob = build_learning_id(
+            "entity_memory", entity_id="acme", entity_type="company", namespace="user", user_id="bob"
+        )
+        assert alice != bob
+
+        # Other namespaces stay shared, and user_id must not leak into their key.
+        for namespace in (None, "global", "team"):
+            assert build_learning_id(
+                "entity_memory", entity_id="acme", entity_type="company", namespace=namespace, user_id="alice"
+            ) == build_learning_id(
+                "entity_memory", entity_id="acme", entity_type="company", namespace=namespace, user_id="bob"
+            )
 
     def test_non_identity_types_return_none(self):
         assert build_learning_id("decision_log", user_id="u1") is None
@@ -66,4 +90,7 @@ class TestStoresDelegateToHelper:
         store = EntityMemoryStore.__new__(EntityMemoryStore)
         assert store._build_entity_db_id("acme", "company", "global") == build_learning_id(
             "entity_memory", entity_id="acme", entity_type="company", namespace="global"
+        )
+        assert store._build_entity_db_id("acme", "company", "user", "u1") == build_learning_id(
+            "entity_memory", entity_id="acme", entity_type="company", namespace="user", user_id="u1"
         )

--- a/libs/agno/tests/unit/learn/test_entity_memory_store.py
+++ b/libs/agno/tests/unit/learn/test_entity_memory_store.py
@@ -258,6 +258,32 @@ class TestRememberAbout:
         entity = store.get(entity_id="secret_project", entity_type="project", user_id="alice")
         assert entity is not None and entity.archived_at is None
 
+    def test_user_namespace_isolates_the_same_entity_across_users(self, tmp_path) -> None:
+        """Two users recording the same entity name must not share one physical row.
+
+        The row key used to omit the user, so both users' "Acme" collided: the second
+        write landed inside the first user's row (the on-conflict clause never rewrites
+        user_id), destroying their facts and leaking them to the other user, while the
+        second writer's user-filtered read came back empty.
+
+        Uses SqliteDb rather than the fake db above because the leak lives in the
+        interaction between the user-less key and the user-filtered read.
+        """
+        from agno.db.sqlite import SqliteDb
+
+        sqlite_db = SqliteDb(db_file=str(tmp_path / "entities.db"))
+        store = EntityMemoryStore(config=EntityMemoryConfig(db=sqlite_db, namespace="user"))  # type: ignore[arg-type]
+
+        store.remember_about(entity="Acme", entity_type="company", facts=["alice fact"], user_id="alice")
+        store.remember_about(entity="Acme", entity_type="company", facts=["bob fact"], user_id="bob")
+
+        for user, own_fact, other_fact in (("alice", "alice fact", "bob fact"), ("bob", "bob fact", "alice fact")):
+            entity = store.get(entity_id="acme", entity_type="company", user_id=user, namespace="user")
+            assert entity is not None, f"{user} cannot read back their own entity"
+            contents = [fact.get("content") for fact in entity.facts]
+            assert own_fact in contents
+            assert other_fact not in contents, f"{user} can see the other user's private fact"
+
     def test_blank_entity_name_is_rejected(self, store: EntityMemoryStore, db: RecordingLearningDb) -> None:
         assert "Entity name is required" in store.remember_about(entity="   ", entity_type="person")
         assert db.rows == {}


### PR DESCRIPTION
## Summary

Fixes #9319.

`EntityMemoryStore` documents the `"user"` namespace as *"Private to current user"*, requires a `user_id` on every call, and filters reads by it — but `build_learning_id("entity_memory", ...)` returned `f"entity_{namespace}_{entity_type}_{entity_id}"`, with no user component. Compare the genuinely per-user stores: `user_profile_{user_id}`, `memories_{user_id}`.

So two users recording the same entity name collided on one physical row. Reads are user-filtered, so the second writer's `_resolve` found nothing and composed a fresh entity from only their own facts; `_save_entity` then upserted onto the same key, and the on-conflict clause (`index_elements=["learning_id"]`, `set_=dict(content=..., metadata=..., updated_at=...)`) never rewrites `user_id`. Net effect: the first writer keeps ownership but loses their data and gains the other user's private facts, and every later writer's data is invisible to them. No error, no warning — both writes report success.

Reproduced on `main` with SQLite (the issue's script):

```
A writes: Created company/acme. Recorded 1 fact(s).
B writes: Created company/acme. Recorded 1 fact(s).
alice@corp.com reads: ["Bob's private note: they churned"]
bob@corp.com reads: None
```

After this change:

```
alice@corp.com reads: ["Alice's private note: renewal at $50k"]
bob@corp.com reads: ["Bob's private note: they churned"]
```

## The change

- `build_learning_id` includes the user in the key under `namespace="user"` (`entity_user_{user_id}_{entity_type}_{entity_id}`), and returns `None` without a `user_id` — exactly how `user_profile` / `user_memory` already behave. Other namespaces are untouched and stay shared.
- `_build_entity_db_id` takes `user_id` and returns `Optional[str]`; `user_id` is threaded through `_apply_remember`, `_save_entity` and `_asave_entity`, all of which already had it in scope.
- `delete()` / `adelete()` take an optional `user_id` and fail closed under `"user"` without one, matching the guard `recall`/`arecall`/`remember_about` already have. The added parameter is last and defaults to `None`, so existing calls keep working (there are none in-tree).
- The REST create path needs no change: `os/routers/learnings/router.py` already forwards `user_id` and `namespace` to `build_learning_id`, so a POST now derives the same per-user key. A `"user"`-namespace entity POSTed without a `user_id` now returns the existing 422 for identity-keyed types rather than silently landing on a shared row.

## Scope I deliberately left out

Adding `user_id` to the conflict index would stop the overwrite but leave keyed lookups (`get`, `delete`) unable to tell users apart, so the key change is the more complete fix — this PR does only that and does not touch the DB schema or the on-conflict clauses.

**Migration note:** existing `"user"`-namespace entity rows are re-keyed and become orphaned. Given the behavior above, any such rows are already cross-contaminated (one user's row holding another user's facts), so there is no clean data to preserve — but it is a behavior change worth calling out in release notes. Other namespaces are unaffected.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change (existing `"user"`-namespace entity rows are re-keyed — see migration note)
- [ ] Improvement
- [ ] Model update

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts — `ruff==0.15.20 format --check` and `check` clean on all four files with the repo `pyproject.toml`; `mypy==2.1.0` clean on both source modules under the repo's settings (`check_untyped_defs`, `no_implicit_optional`, `disable_error_code=override`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides — no cookbook change needed; behavior now matches what `/learning/stores/entity-memory` already documents
- [x] Tested in clean environment
- [x] Tests added/updated

### Testing

`libs/agno/tests/unit/learn` on Windows / Python 3.12, against `2.8.6` (byte-identical to `main` for both touched modules):

| | result |
|---|---|
| `main`, before any change | 253 passed |
| `main` + the new/updated tests, source **unpatched** | **5 failed**, 250 passed |
| this branch | **255 passed** |

The five failures on unpatched source are the point of the tests — the end-to-end one fails as `assert 'alice fact' in ['bob fact']`, i.e. the leak itself.

Added:
- `test_entity_memory_user_namespace_is_keyed_per_user` — two users' keys differ under `"user"`; under `None`/`"global"`/`"team"` they stay identical, so `user_id` cannot leak into a shared key.
- `test_user_namespace_isolates_the_same_entity_across_users` — end-to-end against `SqliteDb` (not the fake db, since the leak lives in the interaction between the user-less key and the user-filtered read): each user reads back their own fact and not the other's.

Updated `test_identity_keyed_types` / `test_missing_identity_fields_returns_none` / `test_entity_memory_store`: the old assertion `build_learning_id(..., namespace="user") == "entity_user_company_acme"` encoded the buggy user-less key, so it had to change. It now asserts the per-user key with a `user_id` and `None` without one, mirroring the existing `user_profile` assertions.

Also verified by hand: the async path (`aremember_about`/`aget`) isolates the same way, and `delete(..., "user")` without a `user_id` now warns and returns `False` instead of building a colliding key, while `delete(..., "user", "alice")` leaves Bob's row intact.

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

AI-assisted (Claude Code) and human reviewed. The mechanism was confirmed by reading `learn/utils.py` and `learn/stores/entity_memory.py` on `main`, and every result above is from an actual run, not an estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
