### PR TITLE
[fix] Team.update_session_state broken: still uses functools.partial

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -14,6 +14,7 @@ from copy import copy
 from typing import (
     Any,
     AsyncIterator,
+    Callable,
     Dict,
     Iterator,
     List,
@@ -242,6 +243,23 @@ def _update_session_state_tool(team: "Team", run_context: RunContext, session_st
         session_state[key] = value
 
     return f"Updated session state: {session_state}"
+
+
+def make_update_session_state_entrypoint(team: "Team") -> Callable:
+    """Create a closure that binds team to the _update_session_state_tool function."""
+
+    def _entrypoint(run_context: RunContext, session_state_updates: dict) -> str:
+        """
+        Update the shared session state.  Provide any updates as a dictionary of key-value pairs.
+        Example:
+            "session_state_updates": {"shopping_list": ["milk", "eggs", "bread"]}
+
+        Args:
+            session_state_updates (dict): The updates to apply to the shared session state. Should be a dictionary of key-value pairs.
+        """
+        return _update_session_state_tool(team, run_context, session_state_updates)
+
+    return _entrypoint
 
 
 def _search_past_sessions_function(

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -128,16 +128,14 @@ def _determine_tools_for_model(
     learning_tools: Optional[List[Callable]] = None,
 ) -> List[Union[Function, dict]]:
     # Connect tools that require connection management
-    from functools import partial
-
     from agno.team._default_tools import (
         _get_chat_history_function,
         _get_delegate_task_function,
         _get_update_user_memory_function,
         _read_past_session_function,
         _search_past_sessions_function,
-        _update_session_state_tool,
         create_knowledge_search_tool,
+        make_update_session_state_entrypoint,
     )
     from agno.team._init import _connect_connectable_tools
     from agno.team._messages import _get_user_message
@@ -203,7 +201,12 @@ def _determine_tools_for_model(
             _tools.extend(_learning_tools)
 
     if team.enable_agentic_state:
-        _tools.append(Function(name="update_session_state", entrypoint=partial(_update_session_state_tool, team)))
+        _tools.append(
+            Function(
+                name="update_session_state",
+                entrypoint=make_update_session_state_entrypoint(team),
+            )
+        )
 
     if team.search_past_sessions:
         _tools.append(


### PR DESCRIPTION
## Summary

`Team.update_session_state` is broken: it still registers the built-in tool with `functools.partial(_update_session_state_tool, team)`, which breaks signature introspection — the tool schema built from the partial never includes `session_state_updates`, so the model calls the tool with no arguments and gets a `TypeError`.

`Agent`'s equivalent tool already uses a closure (`make_update_session_state_entrypoint`) instead of `partial` and works correctly. Both patterns were introduced in the same PR (#6429, the v2.5 Agent/Team refactor baseline) — Agent got the closure, Team got `partial()`, and that inconsistency has been there ever since.

Two prior attempts at exactly this fix (#7296, #7297) were auto-closed by the PR-triage bot because the linked issue (#7175) was assigned to someone else — not for any technical reason. That issue was closed 2026-06-04 and, as far as I can tell, only the Agent side ever actually got fixed.

## Live-verified impact

Tested against a real `Team` with `enable_agentic_state=True` and a real Anthropic call:

```
WARNING  Could not parse args for update_session_state: functools.partial(...)
...
Running: update_session_state()
WARNING  Could not run function update_session_state(): _update_session_state_tool() missing 1 required positional argument: 'session_state_updates'
ERROR    _update_session_state_tool() missing 1 required positional argument: 'session_state_updates'
```

The model retries once, hits the same error again, then gives up and answers as if it succeeded ("Session focus set: Q3 audit... I'm tracking this as the current operational priority...") — while the persisted `session_state` stays `{}`. That's the dangerous part: it doesn't fail loudly, it fails by lying to the caller.

After this fix, the same test produces a correctly persisted `session_state` and no warnings/errors.

## Fix

Port the closure-based registration from `agent/_default_tools.py` to `team/_default_tools.py` (new `make_update_session_state_entrypoint`), and update `team/_tools.py`'s registration to use it, matching `agent/_tools.py`'s pattern exactly. Drops the now-unused `functools.partial` import.

(If applicable, issue number: none in this repo — filed as a downstream tracking issue in my own project, referenced for context: thrugz/Agno#28)

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines — `ruff format --check` / `ruff check` pass with the pinned `ruff==0.15.20` from `libs/agno/pyproject.toml`
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — ran the pinned ruff format/check directly against the two changed files rather than the full dev setup; happy to run the full scripts if a maintainer wants that before merge
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — docstring on the new closure mirrors `agent/_default_tools.py`'s wording
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — n/a, no public API change
- [x] Tested in clean environment — verified live against a real Team + real Anthropic model call (see above), before and after the fix
- [ ] Tests added/updated (if applicable) — no existing unit test coverage for Team's `update_session_state` schema to extend (Agent has one, from #8231, which this PR doesn't touch); happy to add an equivalent `libs/agno/tests/unit/team/test_agentic_state_schema.py` if wanted

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach — #7296/#7297 previously proposed the same fix and were auto-closed for a procedural reason (issue assignment conflict), not a technical one; this PR is a fresh, live-verified version of the same idea, kept minimal and matching the already-merged Agent-side pattern exactly
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — **yes.** I (Bram, repo owner of a downstream Agno-based project) asked Claude Code to investigate why `enable_agentic_state` behaved inconsistently between an `Agent` and a `Team` in my own app, which led here. Claude Code wrote and live-verified the fix end-to-end (before/after, against a real Team + real Anthropic call) under my direction; I reviewed the diff before it was pushed.

---

## Additional Notes

No deployment/migration concerns — this only changes how one built-in tool is registered when `enable_agentic_state=True`, which defaults to `False`.
