### PR TITLE
[fix] Support component agents and teams in evaluations

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -577,6 +577,8 @@ class AgentOS:
                 dbs=self.dbs,
                 agents=self._agents or None,  # type: ignore[arg-type]
                 teams=self._teams or None,  # type: ignore[arg-type]
+                os_db=self.db,
+                registry=self.registry,
             ),
             get_metrics_router(dbs=self.dbs),
             get_knowledge_router(knowledge_instances=self.knowledge_instances),
@@ -1113,6 +1115,8 @@ class AgentOS:
                 dbs=self.dbs,
                 agents=self._agents or None,  # type: ignore[arg-type]
                 teams=self._teams or None,  # type: ignore[arg-type]
+                os_db=self.db,
+                registry=self.registry,
             ),
             get_metrics_router(dbs=self.dbs),
             get_knowledge_router(knowledge_instances=self.knowledge_instances),

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -12,6 +12,7 @@ from fastapi import (
 from agno import __version__ as agno_version
 from agno.agent.factory import AgentFactory
 from agno.agent.protocol import AgentProtocol
+from agno.db.base import BaseDb
 from agno.exceptions import RemoteServerUnavailableError
 from agno.os.auth import (
     get_authentication_dependency,
@@ -177,6 +178,27 @@ def get_base_router(
             workflow_summaries = (
                 [WorkflowSummaryResponse.from_workflow(w) for w in os.workflows] if os.workflows else []
             )
+
+            if os.db and isinstance(os.db, BaseDb):
+                from agno.agent.agent import get_agents
+                from agno.team.team import get_teams
+
+                registry = os.registry
+                agent_ids = registry.get_agent_ids() if registry else None
+                team_ids = registry.get_team_ids() if registry else None
+
+                db_agents = get_agents(
+                    db=os.db,
+                    registry=registry,
+                    exclude_component_ids=agent_ids or None,
+                )
+                db_teams = get_teams(
+                    db=os.db,
+                    registry=registry,
+                    exclude_component_ids=team_ids or None,
+                )
+                agent_summaries.extend(AgentSummaryResponse.from_agent(agent) for agent in db_agents)
+                team_summaries.extend(TeamSummaryResponse.from_team(team) for team in db_teams)
         except RemoteServerUnavailableError as e:
             raise HTTPException(
                 status_code=502,

--- a/libs/agno/agno/os/routers/evals/evals.py
+++ b/libs/agno/agno/os/routers/evals/evals.py
@@ -33,6 +33,7 @@ from agno.os.schema import (
 )
 from agno.os.settings import AgnoAPISettings
 from agno.os.utils import get_agent_by_id, get_db, get_team_by_id
+from agno.registry import Registry
 from agno.remote.base import RemoteDb
 from agno.team import RemoteTeam, Team
 from agno.utils.log import log_warning
@@ -45,6 +46,8 @@ def get_eval_router(
     agents: Optional[List[Union[Agent, RemoteAgent]]] = None,
     teams: Optional[List[Union[Team, RemoteTeam]]] = None,
     settings: AgnoAPISettings = AgnoAPISettings(),
+    os_db: Optional[Union[BaseDb, AsyncBaseDb]] = None,
+    registry: Optional[Registry] = None,
 ) -> APIRouter:
     """Create eval router with comprehensive OpenAPI documentation for agent/team evaluation endpoints."""
     router = APIRouter(
@@ -58,7 +61,14 @@ def get_eval_router(
             500: {"description": "Internal Server Error", "model": InternalServerErrorResponse},
         },
     )
-    return attach_routes(router=router, dbs=dbs, agents=agents, teams=teams)
+    return attach_routes(
+        router=router,
+        dbs=dbs,
+        agents=agents,
+        teams=teams,
+        os_db=os_db,
+        registry=registry,
+    )
 
 
 def attach_routes(
@@ -66,6 +76,8 @@ def attach_routes(
     dbs: dict[str, list[Union[BaseDb, AsyncBaseDb, RemoteDb]]],
     agents: Optional[List[Union[Agent, RemoteAgent]]] = None,
     teams: Optional[List[Union[Team, RemoteTeam]]] = None,
+    os_db: Optional[Union[BaseDb, AsyncBaseDb]] = None,
+    registry: Optional[Registry] = None,
 ) -> APIRouter:
     @router.get(
         "/eval-runs",
@@ -415,7 +427,13 @@ def attach_routes(
         if eval_run_input.agent_id:
             # create_fresh: the eval mutates the resolved agent (e.g. agent.model below), so
             # it must run on a per-request deep_copy, never the shared singleton instance.
-            agent = get_agent_by_id(agent_id=eval_run_input.agent_id, agents=agents, create_fresh=True)
+            agent = get_agent_by_id(
+                agent_id=eval_run_input.agent_id,
+                agents=agents,
+                db=os_db,
+                registry=registry,
+                create_fresh=True,
+            )
             if not agent:
                 raise HTTPException(status_code=404, detail=f"Agent with id '{eval_run_input.agent_id}' not found")
             if isinstance(agent, RemoteAgent):
@@ -444,7 +462,13 @@ def attach_routes(
 
         elif eval_run_input.team_id:
             # create_fresh: mirror the agent path -- eval runs must not share the singleton.
-            team = get_team_by_id(team_id=eval_run_input.team_id, teams=teams, create_fresh=True)
+            team = get_team_by_id(
+                team_id=eval_run_input.team_id,
+                teams=teams,
+                db=os_db,
+                registry=registry,
+                create_fresh=True,
+            )
             if not team:
                 raise HTTPException(status_code=404, detail=f"Team with id '{eval_run_input.team_id}' not found")
             if isinstance(team, RemoteTeam):

--- a/libs/agno/tests/unit/os/routers/test_evals_router.py
+++ b/libs/agno/tests/unit/os/routers/test_evals_router.py
@@ -1,0 +1,69 @@
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.db.schemas.evals import EvalType
+from agno.db.sqlite.sqlite import SqliteDb
+from agno.os import AgentOS
+from agno.os.routers.evals.schemas import EvalSchema
+from agno.team import Team
+
+
+def _eval_result(*, agent_id: str | None = None, team_id: str | None = None) -> EvalSchema:
+    return EvalSchema(
+        id="eval-run",
+        agent_id=agent_id,
+        team_id=team_id,
+        eval_type=EvalType.ACCURACY,
+        eval_data={"passed": True},
+    )
+
+
+def test_run_eval_resolves_database_agent(tmp_path):
+    db = SqliteDb(db_file=str(tmp_path / "components.db"))
+    agent = Agent(id="database-agent", name="Database Agent", telemetry=False)
+    agent.save(db=db)
+    client = TestClient(AgentOS(db=db, agents=[], telemetry=False).get_app())
+
+    with patch(
+        "agno.os.routers.evals.evals.run_accuracy_eval",
+        new=AsyncMock(return_value=_eval_result(agent_id=agent.id)),
+    ) as run_accuracy_eval:
+        response = client.post(
+            "/eval-runs",
+            json={
+                "agent_id": agent.id,
+                "eval_type": "accuracy",
+                "input": "hello",
+                "expected_output": "hello",
+            },
+        )
+
+    assert response.status_code == 200
+    assert run_accuracy_eval.await_args.kwargs["agent"].id == agent.id
+
+
+def test_run_eval_resolves_database_team(tmp_path):
+    db = SqliteDb(db_file=str(tmp_path / "components.db"))
+    member = Agent(id="database-team-member", name="Database Team Member", telemetry=False)
+    team = Team(id="database-team", name="Database Team", members=[member], telemetry=False)
+    team.save(db=db)
+    client = TestClient(AgentOS(db=db, teams=[], telemetry=False).get_app())
+
+    with patch(
+        "agno.os.routers.evals.evals.run_accuracy_eval",
+        new=AsyncMock(return_value=_eval_result(team_id=team.id)),
+    ) as run_accuracy_eval:
+        response = client.post(
+            "/eval-runs",
+            json={
+                "team_id": team.id,
+                "eval_type": "accuracy",
+                "input": "hello",
+                "expected_output": "hello",
+            },
+        )
+
+    assert response.status_code == 200
+    assert run_accuracy_eval.await_args.kwargs["team"].id == team.id

--- a/libs/agno/tests/unit/os/test_config.py
+++ b/libs/agno/tests/unit/os/test_config.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
 from agno.agent.agent import Agent
+from agno.db.sqlite.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat
 from agno.os import AgentOS
 from agno.os.config import AgentOSConfig, ChatConfig, Manifest
@@ -259,6 +260,22 @@ class TestConfigEndpointSerialization:
         assert resp.status_code == 200
         # response_model_exclude_none=True on the route - so None manifest is omitted.
         assert "manifest" not in resp.json()
+
+    def test_config_includes_database_components(self, tmp_path):
+        db = SqliteDb(db_file=str(tmp_path / "components.db"))
+        agent = Agent(id="database-agent", name="Database Agent", telemetry=False)
+        member = Agent(id="database-team-member", name="Database Team Member", telemetry=False)
+        team = Team(id="database-team", name="Database Team", members=[member], telemetry=False)
+        agent.save(db=db)
+        team.save(db=db)
+
+        client = TestClient(AgentOS(db=db, agents=[], teams=[], telemetry=False).get_app())
+        response = client.get("/config")
+
+        assert response.status_code == 200
+        config = response.json()
+        assert "database-agent" in [summary["id"] for summary in config["agents"]]
+        assert "database-team" in [summary["id"] for summary in config["teams"]]
 
 
 class TestAgentSummaryModelField:


### PR DESCRIPTION
## Summary\n\n- Include database-backed agent and team components in GET /config, matching the catalog surfaced by the resource routes.\n- Pass the AgentOS database and registry into evaluation target resolution so POST /eval-runs can evaluate component agents and teams.\n- Add coverage for database component discovery and evaluation execution.\n\nFixes #9304\n\n## Type of change\n\n- [x] Bug fix\n- [ ] New feature\n- [ ] Breaking change\n- [ ] Improvement\n- [ ] Model update\n- [ ] Other:\n\n---\n\n## Checklist\n\n- [x] Code complies with style guidelines\n- [x] Ran format/validation scripts\n- [x] Self-review completed\n- [ ] Documentation updated (comments, docstrings)\n- [ ] Examples and guides: Relevant cookbook examples have been included or updated (not applicable for this API bug fix)\n- [x] Tested in clean environment\n- [x] Tests added/updated\n\n### Duplicate and AI-Generated PR Check\n\n- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue\n- [ ] If a similar PR exists, I have explained below why this PR is a better approach\n- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)\n\n---\n\n## Additional Notes\n\nThe change was implemented with AI assistance and reviewed and validated by the contributor. The targeted suite passes (29 tests), along with the repository format and validation scripts.