### PR TITLE
fix: infer correct JSON type for Enum values

### DIFF
--- a/libs/agno/agno/utils/json_schema.py
+++ b/libs/agno/agno/utils/json_schema.py
@@ -162,11 +162,15 @@ def get_json_schema_for_arg(type_hint: Any) -> Optional[Dict[str, Any]]:
 
     if isinstance(type_hint, type) and issubclass(type_hint, Enum):
         enum_values = [member.value for member in type_hint]
+        if not enum_values:
+            return {"type": "string", "enum": []}
         if all(isinstance(v, bool) for v in enum_values):
             return {"type": "boolean", "enum": enum_values}
         if all(isinstance(v, int) and not isinstance(v, bool) for v in enum_values):
             return {"type": "integer", "enum": enum_values}
         if all(isinstance(v, float) for v in enum_values):
+            return {"type": "number", "enum": enum_values}
+        if all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in enum_values):
             return {"type": "number", "enum": enum_values}
         if all(isinstance(v, str) for v in enum_values):
             return {"type": "string", "enum": enum_values}

--- a/libs/agno/agno/utils/json_schema.py
+++ b/libs/agno/agno/utils/json_schema.py
@@ -162,7 +162,15 @@ def get_json_schema_for_arg(type_hint: Any) -> Optional[Dict[str, Any]]:
 
     if isinstance(type_hint, type) and issubclass(type_hint, Enum):
         enum_values = [member.value for member in type_hint]
-        return {"type": "string", "enum": enum_values}
+        if all(isinstance(v, bool) for v in enum_values):
+            return {"type": "boolean", "enum": enum_values}
+        if all(isinstance(v, int) and not isinstance(v, bool) for v in enum_values):
+            return {"type": "integer", "enum": enum_values}
+        if all(isinstance(v, float) for v in enum_values):
+            return {"type": "number", "enum": enum_values}
+        if all(isinstance(v, str) for v in enum_values):
+            return {"type": "string", "enum": enum_values}
+        return {"enum": enum_values}
 
     if isinstance(type_hint, type) and issubclass(type_hint, BaseModel):
         # Get the schema and inline it

--- a/libs/agno/tests/unit/utils/test_json_schema.py
+++ b/libs/agno/tests/unit/utils/test_json_schema.py
@@ -491,12 +491,48 @@ def test_get_json_schema_for_enum_integer():
     assert schema == {"type": "integer", "enum": [0, 1, 2]}
 
 
-def test_get_json_schema_for_enum_mixed():
-    """Test that mixed enums have enum values set (even without inferred type)."""
+def test_get_json_schema_for_enum_bool():
+    """Test that bool-based enums get type 'boolean' (not 'integer')."""
     schema = get_json_schema_for_arg(FlagBoolFlag)
-    assert "enum" in schema
-    assert False in schema["enum"]
-    assert True in schema["enum"]
+    assert schema == {"type": "boolean", "enum": [False, True]}
+
+
+def test_get_json_schema_for_enum_float():
+    """Test that float-based enums get type 'number'."""
+    schema = get_json_schema_for_arg(PriorityFloatEnum)
+    assert schema == {"type": "number", "enum": [0.5, 1.5, 2.5]}
+
+
+class EmptyEnum(Enum):
+    pass
+
+
+def test_get_json_schema_for_enum_empty():
+    """Test that empty enums return type 'string' with empty enum list (A1 fix)."""
+    schema = get_json_schema_for_arg(EmptyEnum)
+    assert schema == {"type": "string", "enum": []}
+
+
+class NumMixEnum(Enum):
+    A = 1
+    B = 2.5
+
+
+def test_get_json_schema_for_enum_numeric_mixed():
+    """Test that mixed int+float enums get type 'number' (A2 fix)."""
+    schema = get_json_schema_for_arg(NumMixEnum)
+    assert schema == {"type": "number", "enum": [1, 2.5]}
+
+
+class HeteroEnum(Enum):
+    A = 1
+    B = "x"
+
+
+def test_get_json_schema_for_enum_heterogeneous():
+    """Test that heterogeneous enums fall back to no type key."""
+    schema = get_json_schema_for_arg(HeteroEnum)
+    assert schema == {"enum": [1, "x"]}
 
 
 def test_get_json_schema_for_function_with_intenum():

--- a/libs/agno/tests/unit/utils/test_json_schema.py
+++ b/libs/agno/tests/unit/utils/test_json_schema.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass, field
-from enum import Enum, IntEnum, StrEnum
-from typing import Any, Dict, get_type_hints
-from typing import Any, Dict, List, Literal, Optional, Union
+from enum import Enum, IntEnum
+from typing import Any, Dict, List, Literal, Optional, Union, get_type_hints
 
 from pydantic import BaseModel
 
@@ -457,7 +456,7 @@ def test_get_json_schema_with_mixed_nested_structures():
 
 
 # Test cases for Enum type inference (P8 fix)
-class ColorStrEnum(StrEnum):
+class ColorStrEnum(str, Enum):
     RED = "red"
     GREEN = "green"
     BLUE = "blue"

--- a/libs/agno/tests/unit/utils/test_json_schema.py
+++ b/libs/agno/tests/unit/utils/test_json_schema.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass, field
+from enum import Enum, IntEnum, StrEnum
+from typing import Any, Dict, get_type_hints
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel
@@ -452,3 +454,60 @@ def test_get_json_schema_with_mixed_nested_structures():
     assert "contact_info" in dataclass_schema["properties"]
     assert "address" in pydantic_schema["properties"]["contact_info"]["properties"]
     assert "address" in dataclass_schema["properties"]["contact_info"]["properties"]
+
+
+# Test cases for Enum type inference (P8 fix)
+class ColorStrEnum(StrEnum):
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+
+
+class StatusIntEnum(IntEnum):
+    PENDING = 0
+    ACTIVE = 1
+    DONE = 2
+
+
+class PriorityFloatEnum(float, Enum):
+    LOW = 0.5
+    MEDIUM = 1.5
+    HIGH = 2.5
+
+
+class FlagBoolFlag(Enum):
+    OFF = False
+    ON = True
+
+
+def test_get_json_schema_for_enum_string():
+    """Test that str-based enums get type 'string'."""
+    schema = get_json_schema_for_arg(ColorStrEnum)
+    assert schema == {"type": "string", "enum": ["red", "green", "blue"]}
+
+
+def test_get_json_schema_for_enum_integer():
+    """Test that int-based enums get type 'integer' (P8 fix)."""
+    schema = get_json_schema_for_arg(StatusIntEnum)
+    assert schema == {"type": "integer", "enum": [0, 1, 2]}
+
+
+def test_get_json_schema_for_enum_mixed():
+    """Test that mixed enums have enum values set (even without inferred type)."""
+    schema = get_json_schema_for_arg(FlagBoolFlag)
+    assert "enum" in schema
+    assert False in schema["enum"]
+    assert True in schema["enum"]
+
+
+def test_get_json_schema_for_function_with_intenum():
+    """Test that IntEnum in function params gets correct type."""
+
+    def my_func(status: StatusIntEnum = StatusIntEnum.PENDING):
+        pass
+
+    hints = get_type_hints(my_func)
+    schema = get_json_schema(hints)
+    props = schema.get("properties", {})
+    assert "status" in props
+    assert props["status"]["type"] == "integer"


### PR DESCRIPTION
# Summary

Fixed \`get_json_schema_for_arg()\` to correctly infer the JSON type from Enum member values instead of always returning \`\"type\": \"string\"\`. Aligns with existing Literal handling (docs/08-triaj.md — P8).

## Changes in \`utils/json_schema.py\`

- IntEnum values → \`"type": "integer"\`
- Bool enum values → \`"type": "boolean"\`
- Float enum values → \`"type": "number"\`  
- Str enum values → \`"type": "string"\` (unchanged)
- Mixed → \`{enum}\` without type key

## Why it matters

With \`strict=True\` and structured outputs, an IntEnum declared as string would cause validation errors — the model emits \`1\` but schema expects \`"1"\`.

## Tests added

\`\`\`python
class StatusIntEnum(IntEnum): PENDING = 0, ACTIVE = 1, DONE = 2
# get_json_schema_for_arg(StatusIntEnum) == {"type": "integer", "enum": [0, 1, 2]}
\`\`\`

- **Breaking change risk:** Minimal — \`str\`-Enum unchanged; only IntEnum/FloatEnum change (currently broken anyway)
- **Type of change:** Bug fix + minor breaking change (fixes incorrect behavior)

## Checklist

- [x] Code complies with style guidelines
- [x] Ran \`./scripts/format.sh\`
- [x] Self-review completed
- [x] Tests added (\`tests/unit/utils/test_json_schema.py\`)