### PR TITLE
fix: robust audio tool-result handling, switch Smallest AI cookbook to Gemini

### DIFF
--- a/cookbook/91_tools/TEST_LOG.md
+++ b/cookbook/91_tools/TEST_LOG.md
@@ -1,5 +1,15 @@
 # Test Log
 
+### smallest_tools.py (switch to Gemini for audio-input support)
+
+**Status:** PASS
+
+**Description:** Switched `audio_agent` and `pro_audio_agent` from `OpenAIResponses(id="gpt-5.5")` to `Gemini(id="gemini-pro-latest")` so the agent actually receives the audio a tool call generates, instead of it being silently dropped with an "audio input unsupported" warning.
+
+**Result:** Ran both agents end-to-end. No warning logged; each agent's response accurately described the audio it generated, confirming Gemini received the audio content.
+
+---
+
 ### file_generation_tools.py (generate_code_file)
 
 **Status:** PASS

--- a/cookbook/91_tools/smallest_tools.py
+++ b/cookbook/91_tools/smallest_tools.py
@@ -4,6 +4,11 @@ Smallest AI text-to-speech tools.
 Requires the SMALLEST_API_KEY environment variable.
 Get an API key at https://app.smallest.ai/dashboard (Developer -> API Keys).
 
+Also requires GOOGLE_API_KEY for the agent's model. Gemini is used here because it
+natively accepts audio as input, so the agent can hand the generated clip back to the
+model instead of dropping it with an "audio input unsupported" warning (as most other
+model providers currently do when a tool call returns an Audio artifact).
+
 Models:
 - lightning_v3.1 (default): 12 languages, supports cloned voices
 - lightning_v3.1_pro: premium voice pool, 29 languages
@@ -17,7 +22,7 @@ import base64
 from textwrap import dedent
 
 from agno.agent import Agent
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from agno.tools.smallest import SmallestTools
 from agno.utils.media import save_base64_data
 
@@ -27,7 +32,7 @@ from agno.utils.media import save_base64_data
 
 
 audio_agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-pro-latest"),
     tools=[
         SmallestTools(
             voice_id="magnus",
@@ -50,7 +55,7 @@ audio_agent = Agent(
 
 # Premium voices: use the Lightning v3.1 Pro pool with a Pro voice
 pro_audio_agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-pro-latest"),
     tools=[
         SmallestTools(
             voice_id="meher",

--- a/cookbook/91_tools/smallest_tools.py
+++ b/cookbook/91_tools/smallest_tools.py
@@ -4,10 +4,9 @@ Smallest AI text-to-speech tools.
 Requires the SMALLEST_API_KEY environment variable.
 Get an API key at https://app.smallest.ai/dashboard (Developer -> API Keys).
 
-Also requires GOOGLE_API_KEY for the agent's model. Gemini is used here because it
-natively accepts audio as input, so the agent can hand the generated clip back to the
-model instead of dropping it with an "audio input unsupported" warning (as most other
-model providers currently do when a tool call returns an Audio artifact).
+Also requires GOOGLE_API_KEY for the agent's model. Use a model with audio input
+support (Gemini here) so the agent can hear the audio it generates across multi-turn
+conversations, instead of losing it after the first response.
 
 Models:
 - lightning_v3.1 (default): 12 languages, supports cloned voices

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -3066,7 +3066,7 @@ class Model(ABC):
             # message with the media artifacts which throws error for some models
             media_message = Message(
                 role="user",
-                content="Take note of the following content",
+                content="The tool call above generated the attached media.",
                 images=all_images if all_images else None,
                 videos=all_videos if all_videos else None,
                 audio=all_audio if all_audio else None,

--- a/libs/agno/tests/unit/models/test_model_helpers.py
+++ b/libs/agno/tests/unit/models/test_model_helpers.py
@@ -3,7 +3,8 @@
 Covers methods in agno/models/base.py that are not tested by
 test_retry_error_classification.py: to_dict, get_provider,
 _remove_temporary_messages, cache methods, __deepcopy__,
-_handle_agent_exception, __post_init__, and get_system_message_for_model.
+_handle_agent_exception, __post_init__, get_system_message_for_model,
+and _handle_function_call_media.
 """
 
 import json
@@ -18,6 +19,7 @@ import pytest
 os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
 
 from agno.exceptions import AgentRunException
+from agno.media import Audio
 from agno.models.base import _handle_agent_exception
 from agno.models.message import Message
 from agno.models.openai.chat import OpenAIChat
@@ -441,3 +443,59 @@ class TestHandleAgentException:
         assert len(additional) == 2
         assert additional[0].role == "user"
         assert additional[1].role == "assistant"
+
+
+class TestHandleFunctionCallMedia:
+    """Regression tests for https://github.com/agno-agi/agno — a tool call that
+    returns audio (e.g. SmallestTools.text_to_speech) used to get a follow-up
+    "Take note of the following content" user message appended with nothing
+    after it once the media itself was stripped (models that don't accept
+    audio input drop it silently, e.g. OpenAIResponses). That dangling
+    sentence confused the model into asking the user to "share the content"
+    instead of confirming the tool call. The message must stand on its own
+    regardless of whether the attached media survives to the model."""
+
+    def test_audio_result_gets_self_contained_followup_message(self, model):
+        messages: list = []
+        tool_message = Message(role="tool", content="Audio generated successfully")
+        tool_message.audio = [Audio(id="a1", content=b"RIFF...", mime_type="audio/wav")]
+
+        model._handle_function_call_media(messages, [tool_message])
+
+        assert len(messages) == 1
+        followup = messages[0]
+        assert followup.role == "user"
+        assert "take note of the following content" not in followup.content.lower()
+        assert followup.content.strip().endswith(".")
+
+    def test_media_removed_from_original_tool_message(self, model):
+        messages: list = []
+        tool_message = Message(role="tool", content="Audio generated successfully")
+        tool_message.audio = [Audio(id="a1", content=b"RIFF...", mime_type="audio/wav")]
+
+        model._handle_function_call_media(messages, [tool_message])
+
+        # The audio is relocated onto the synthetic follow-up message, not left on the tool message.
+        assert tool_message.audio is None
+        assert messages[0].audio is not None
+        assert messages[0].audio[0].id == "a1"
+
+    def test_no_followup_message_when_no_media(self, model):
+        messages: list = []
+        tool_message = Message(role="tool", content="No media here")
+
+        model._handle_function_call_media(messages, [tool_message])
+
+        assert messages == []
+
+    def test_no_followup_message_when_send_media_to_model_false(self, model):
+        messages: list = []
+        tool_message = Message(role="tool", content="Audio generated successfully")
+        tool_message.audio = [Audio(id="a1", content=b"RIFF...", mime_type="audio/wav")]
+
+        model._handle_function_call_media(messages, [tool_message], send_media_to_model=False)
+
+        # No follow-up message is added, and the media is still stripped from
+        # the original tool message (it's still dropped to avoid erroring some LLMs).
+        assert messages == []
+        assert tool_message.audio is None


### PR DESCRIPTION
## Summary

- Fixed `_handle_function_call_media` (`libs/agno/agno/models/base.py`) so the synthetic follow-up message added when a tool call returns audio/image/video is self-contained regardless of whether the model actually accepts that media as input. Previously it read exactly `"Take note of the following content"` with nothing after it whenever the model dropped the media (e.g. `OpenAIResponses`, which doesn't support audio input and logs `"Audio input is currently unsupported."`), which could non-deterministically confuse the model into asking the user to "share the content" instead of confirming the tool call.
- Switched `cookbook/91_tools/smallest_tools.py` from `OpenAIResponses(id="gpt-5.5")` to `Gemini(id="gemini-pro-latest")`. Gemini's integration (`agno/models/google/gemini.py`) genuinely embeds audio content into the request, so the agent now actually hears the audio `SmallestTools.text_to_speech` generates instead of getting a placeholder. `gemini-2.5-pro` was tried first but returns a 404 from Google's API for new API keys ("no longer available to new users"); used the auto-updating `gemini-pro-latest` alias instead to avoid pinning to a model string that can be deprecated without notice.

## Type of change

- [x] Bug fix
- [x] Improvement

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — yes, built with Claude Code

## Additional Notes

`./scripts/validate.sh` reports 23 pre-existing mypy errors in `agno/models/google/gemini.py`, `agno/models/google/gemini_interactions.py`, and `agno/utils/models/_genai_compat.py`. Confirmed these are unrelated to this change — they reproduce identically on a clean `origin/main` checkout with this diff fully stashed out, and appear to stem from an unpinned `google-genai` version (no `uv.lock` in the repo) rather than anything in this PR.

Added a new `TestHandleFunctionCallMedia` test class (4 tests) to `libs/agno/tests/unit/models/test_model_helpers.py` covering the media-message fix. Ran `cookbook/91_tools/smallest_tools.py` end-to-end (both `audio_agent` and `pro_audio_agent`) with live `SMALLEST_API_KEY` + `GOOGLE_API_KEY` — no warning logged, and each agent's response accurately described the audio it generated.