### PR TITLE
fix: scrub the legacy runs blob on SQL adapter deletes

### DIFF
--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -1,7 +1,7 @@
 import json
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Set, Tuple, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -33,6 +33,7 @@ from agno.db.utils import (
     deserialize_sessions,
     json_serializer,
     merge_runs_table_with_legacy_blob,
+    scrub_run_ids_from_legacy_blob,
     validate_pagination,
 )
 from agno.run.agent import RunOutput
@@ -675,13 +676,51 @@ class AsyncMySQLDb(AsyncBaseDb):
             log_error(f"Exception reading from runs table: {str(e)}")
             return [] if deserialize else ([], 0)
 
+    async def _scrub_run_ids_from_session_legacy_blob(
+        self, sess, runs_table: Table, sessions_table: Optional[Table], run_ids: Set[str]
+    ) -> None:
+        """Remove ``run_ids`` from the legacy ``runs`` blob of every session that owns them.
+
+        Partial-migration hygiene: the v3 migration copies runs into the runs table but
+        leaves the legacy sessions ``runs`` column in place as a frozen backup, so reads
+        merge the two. Deleting only the runs-table row lets
+        ``merge_runs_table_with_legacy_blob`` resurrect the run on the next read.
+
+        Must be called before the runs-table rows are deleted, since the owning
+        session ids are resolved from those rows. ``sessions_table`` is resolved by
+        the caller so the table is not reflected from inside the open transaction.
+        """
+        # The legacy column only exists on databases upgraded from v2.x.
+        if not run_ids or sessions_table is None or "runs" not in sessions_table.c:
+            return
+
+        result = await sess.execute(select(runs_table.c.session_id).where(runs_table.c.run_id.in_(run_ids)))
+        session_ids = {row[0] for row in result if row[0]}
+        if not session_ids:
+            return
+
+        result = await sess.execute(
+            select(sessions_table.c.session_id, sessions_table.c.runs).where(
+                sessions_table.c.session_id.in_(session_ids)
+            )
+        )
+        for session_id, legacy_runs in result.fetchall():
+            kept = scrub_run_ids_from_legacy_blob(legacy_runs, run_ids)
+            if kept is None:
+                continue
+            await sess.execute(
+                sessions_table.update().where(sessions_table.c.session_id == session_id).values(runs=kept)
+            )
+
     async def delete_run(self, run_id: str) -> bool:
         """Delete a single run from the runs table."""
         try:
             table = await self._get_table(table_type="runs")
             if table is None:
                 return False
+            sessions_table = await self._get_table(table_type="sessions")
             async with self.async_session_factory() as sess, sess.begin():
+                await self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, {run_id})
                 result = await sess.execute(table.delete().where(table.c.run_id == run_id))
                 return result.rowcount > 0  # type: ignore
         except Exception as e:
@@ -694,7 +733,9 @@ class AsyncMySQLDb(AsyncBaseDb):
             table = await self._get_table(table_type="runs")
             if table is None:
                 return
+            sessions_table = await self._get_table(table_type="sessions")
             async with self.async_session_factory() as sess, sess.begin():
+                await self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, set(run_ids))
                 result = await sess.execute(table.delete().where(table.c.run_id.in_(run_ids)))
             log_debug(f"Successfully deleted {result.rowcount} runs")  # type: ignore
         except Exception as e:

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -1,7 +1,7 @@
 import json
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -33,6 +33,7 @@ from agno.db.utils import (
     deserialize_sessions,
     json_serializer,
     merge_runs_table_with_legacy_blob,
+    scrub_run_ids_from_legacy_blob,
     validate_pagination,
 )
 from agno.run.agent import RunOutput
@@ -680,13 +681,53 @@ class MySQLDb(BaseDb):
             log_error(f"Exception reading from runs table: {str(e)}")
             raise e
 
+    def _scrub_run_ids_from_session_legacy_blob(
+        self, sess, runs_table: Table, sessions_table: Optional[Table], run_ids: Set[str]
+    ) -> None:
+        """Remove ``run_ids`` from the legacy ``runs`` blob of every session that owns them.
+
+        Partial-migration hygiene: the v3 migration copies runs into the runs table but
+        leaves the legacy sessions ``runs`` column in place as a frozen backup, so reads
+        merge the two. Deleting only the runs-table row lets
+        ``merge_runs_table_with_legacy_blob`` resurrect the run on the next read.
+
+        Must be called before the runs-table rows are deleted, since the owning
+        session ids are resolved from those rows. ``sessions_table`` is resolved by
+        the caller: ``self.Session`` is a scoped session, so reflecting a table from
+        inside the open transaction would re-enter it.
+        """
+        # The legacy column only exists on databases upgraded from v2.x.
+        if not run_ids or sessions_table is None or "runs" not in sessions_table.c:
+            return
+
+        session_ids = {
+            row[0]
+            for row in sess.execute(select(runs_table.c.session_id).where(runs_table.c.run_id.in_(run_ids)))
+            if row[0]
+        }
+        if not session_ids:
+            return
+
+        rows = sess.execute(
+            select(sessions_table.c.session_id, sessions_table.c.runs).where(
+                sessions_table.c.session_id.in_(session_ids)
+            )
+        ).fetchall()
+        for session_id, legacy_runs in rows:
+            kept = scrub_run_ids_from_legacy_blob(legacy_runs, run_ids)
+            if kept is None:
+                continue
+            sess.execute(sessions_table.update().where(sessions_table.c.session_id == session_id).values(runs=kept))
+
     def delete_run(self, run_id: str) -> bool:
         """Delete a single run from the runs table."""
         try:
             table = self._get_table(table_type="runs")
             if table is None:
                 return False
+            sessions_table = self._get_table(table_type="sessions")
             with self.Session() as sess, sess.begin():
+                self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, {run_id})
                 result = sess.execute(table.delete().where(table.c.run_id == run_id))
                 return result.rowcount > 0
         except Exception as e:
@@ -699,7 +740,9 @@ class MySQLDb(BaseDb):
             table = self._get_table(table_type="runs")
             if table is None:
                 return
+            sessions_table = self._get_table(table_type="sessions")
             with self.Session() as sess, sess.begin():
+                self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, set(run_ids))
                 result = sess.execute(table.delete().where(table.c.run_id.in_(run_ids)))
             log_debug(f"Successfully deleted {result.rowcount} runs")
         except Exception as e:

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -37,6 +37,7 @@ from agno.db.utils import (
     json_serializer,
     learning_search_patterns,
     merge_runs_table_with_legacy_blob,
+    scrub_run_ids_from_legacy_blob,
     validate_pagination,
 )
 from agno.run.agent import RunOutput
@@ -829,6 +830,42 @@ class AsyncPostgresDb(AsyncBaseDb):
             log_error(f"Exception reading from runs table: {str(e)}")
             return [] if deserialize else ([], 0)
 
+    async def _scrub_run_ids_from_session_legacy_blob(
+        self, sess, runs_table: Table, sessions_table: Optional[Table], run_ids: Set[str]
+    ) -> None:
+        """Remove ``run_ids`` from the legacy ``runs`` blob of every session that owns them.
+
+        Partial-migration hygiene: the v3 migration copies runs into the runs table but
+        leaves the legacy sessions ``runs`` column in place as a frozen backup, so reads
+        merge the two. Deleting only the runs-table row lets
+        ``merge_runs_table_with_legacy_blob`` resurrect the run on the next read.
+
+        Must be called before the runs-table rows are deleted, since the owning
+        session ids are resolved from those rows. ``sessions_table`` is resolved by
+        the caller so the table is not reflected from inside the open transaction.
+        """
+        # The legacy column only exists on databases upgraded from v2.x.
+        if not run_ids or sessions_table is None or "runs" not in sessions_table.c:
+            return
+
+        result = await sess.execute(select(runs_table.c.session_id).where(runs_table.c.run_id.in_(run_ids)))
+        session_ids = {row[0] for row in result if row[0]}
+        if not session_ids:
+            return
+
+        result = await sess.execute(
+            select(sessions_table.c.session_id, sessions_table.c.runs).where(
+                sessions_table.c.session_id.in_(session_ids)
+            )
+        )
+        for session_id, legacy_runs in result.fetchall():
+            kept = scrub_run_ids_from_legacy_blob(legacy_runs, run_ids)
+            if kept is None:
+                continue
+            await sess.execute(
+                sessions_table.update().where(sessions_table.c.session_id == session_id).values(runs=kept)
+            )
+
     async def delete_run(self, run_id: str) -> bool:
         """Delete a single run from the runs table.
 
@@ -843,7 +880,9 @@ class AsyncPostgresDb(AsyncBaseDb):
             if table is None:
                 return False
 
+            sessions_table = await self._get_table(table_type="sessions")
             async with self.async_session_factory() as sess, sess.begin():
+                await self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, {run_id})
                 result = await sess.execute(table.delete().where(table.c.run_id == run_id))
                 return result.rowcount > 0  # type: ignore
 
@@ -862,7 +901,9 @@ class AsyncPostgresDb(AsyncBaseDb):
             if table is None:
                 return
 
+            sessions_table = await self._get_table(table_type="sessions")
             async with self.async_session_factory() as sess, sess.begin():
+                await self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, set(run_ids))
                 result = await sess.execute(table.delete().where(table.c.run_id.in_(run_ids)))
 
             log_debug(f"Successfully deleted {result.rowcount} runs")  # type: ignore

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -46,6 +46,7 @@ from agno.db.utils import (
     json_serializer,
     learning_search_patterns,
     merge_runs_table_with_legacy_blob,
+    scrub_run_ids_from_legacy_blob,
     validate_pagination,
 )
 from agno.run.agent import RunOutput
@@ -1018,6 +1019,44 @@ class PostgresDb(BaseDb):
             log_error(f"Exception reading from runs table: {str(e)}")
             raise e
 
+    def _scrub_run_ids_from_session_legacy_blob(
+        self, sess, runs_table: Table, sessions_table: Optional[Table], run_ids: Set[str]
+    ) -> None:
+        """Remove ``run_ids`` from the legacy ``runs`` blob of every session that owns them.
+
+        Partial-migration hygiene: the v3 migration copies runs into the runs table but
+        leaves the legacy ``agno_sessions.runs`` column in place as a frozen backup, so
+        reads merge the two. Deleting only the runs-table row lets
+        ``merge_runs_table_with_legacy_blob`` resurrect the run on the next read.
+
+        Must be called before the runs-table rows are deleted, since the owning
+        session ids are resolved from those rows. ``sessions_table`` is resolved by
+        the caller: ``self.Session`` is a scoped session, so reflecting a table from
+        inside the open transaction would re-enter it.
+        """
+        # The legacy column only exists on databases upgraded from v2.x.
+        if not run_ids or sessions_table is None or "runs" not in sessions_table.c:
+            return
+
+        session_ids = {
+            row[0]
+            for row in sess.execute(select(runs_table.c.session_id).where(runs_table.c.run_id.in_(run_ids)))
+            if row[0]
+        }
+        if not session_ids:
+            return
+
+        rows = sess.execute(
+            select(sessions_table.c.session_id, sessions_table.c.runs).where(
+                sessions_table.c.session_id.in_(session_ids)
+            )
+        ).fetchall()
+        for session_id, legacy_runs in rows:
+            kept = scrub_run_ids_from_legacy_blob(legacy_runs, run_ids)
+            if kept is None:
+                continue
+            sess.execute(sessions_table.update().where(sessions_table.c.session_id == session_id).values(runs=kept))
+
     def delete_run(self, run_id: str) -> bool:
         """Delete a single run from the runs table.
 
@@ -1032,7 +1071,9 @@ class PostgresDb(BaseDb):
             if table is None:
                 return False
 
+            sessions_table = self._get_table(table_type="sessions")
             with self.Session() as sess, sess.begin():
+                self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, {run_id})
                 result = sess.execute(table.delete().where(table.c.run_id == run_id))
                 return result.rowcount > 0
 
@@ -1051,7 +1092,9 @@ class PostgresDb(BaseDb):
             if table is None:
                 return
 
+            sessions_table = self._get_table(table_type="sessions")
             with self.Session() as sess, sess.begin():
+                self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, set(run_ids))
                 result = sess.execute(table.delete().where(table.c.run_id.in_(run_ids)))
 
             log_debug(f"Successfully deleted {result.rowcount} runs")

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -1,7 +1,7 @@
 import json
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Set, Tuple, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -33,6 +33,7 @@ from agno.db.utils import (
     deserialize_sessions,
     json_serializer,
     merge_runs_table_with_legacy_blob,
+    scrub_run_ids_from_legacy_blob,
     validate_pagination,
 )
 from agno.run.agent import RunOutput
@@ -743,12 +744,52 @@ class SingleStoreDb(BaseDb):
             log_error(f"Exception reading from runs table: {str(e)}")
             raise e
 
+    def _scrub_run_ids_from_session_legacy_blob(
+        self, sess, runs_table: Table, sessions_table: Optional[Table], run_ids: Set[str]
+    ) -> None:
+        """Remove ``run_ids`` from the legacy ``runs`` blob of every session that owns them.
+
+        Partial-migration hygiene: the v3 migration copies runs into the runs table but
+        leaves the legacy sessions ``runs`` column in place as a frozen backup, so reads
+        merge the two. Deleting only the runs-table row lets
+        ``merge_runs_table_with_legacy_blob`` resurrect the run on the next read.
+
+        Must be called before the runs-table rows are deleted, since the owning
+        session ids are resolved from those rows. ``sessions_table`` is resolved by
+        the caller: ``self.Session`` is a scoped session, so reflecting a table from
+        inside the open transaction would re-enter it.
+        """
+        # The legacy column only exists on databases upgraded from v2.x.
+        if not run_ids or sessions_table is None or "runs" not in sessions_table.c:
+            return
+
+        session_ids = {
+            row[0]
+            for row in sess.execute(select(runs_table.c.session_id).where(runs_table.c.run_id.in_(run_ids)))
+            if row[0]
+        }
+        if not session_ids:
+            return
+
+        rows = sess.execute(
+            select(sessions_table.c.session_id, sessions_table.c.runs).where(
+                sessions_table.c.session_id.in_(session_ids)
+            )
+        ).fetchall()
+        for session_id, legacy_runs in rows:
+            kept = scrub_run_ids_from_legacy_blob(legacy_runs, run_ids)
+            if kept is None:
+                continue
+            sess.execute(sessions_table.update().where(sessions_table.c.session_id == session_id).values(runs=kept))
+
     def delete_run(self, run_id: str) -> bool:
         try:
             table = self._get_table(table_type="runs")
             if table is None:
                 return False
+            sessions_table = self._get_table(table_type="sessions")
             with self.Session() as sess, sess.begin():
+                self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, {run_id})
                 result = sess.execute(table.delete().where(table.c.run_id == run_id))
                 return result.rowcount > 0
         except Exception as e:
@@ -760,7 +801,9 @@ class SingleStoreDb(BaseDb):
             table = self._get_table(table_type="runs")
             if table is None:
                 return
+            sessions_table = self._get_table(table_type="sessions")
             with self.Session() as sess, sess.begin():
+                self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, set(run_ids))
                 result = sess.execute(table.delete().where(table.c.run_id.in_(run_ids)))
             log_debug(f"Successfully deleted {result.rowcount} runs")
         except Exception as e:

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -40,6 +40,7 @@ from agno.db.utils import (
     deserialize_session_json_fields,
     deserialize_sessions,
     merge_runs_table_with_legacy_blob,
+    scrub_run_ids_from_legacy_blob,
     serialize_session_json_fields,
     validate_pagination,
 )
@@ -828,6 +829,42 @@ class AsyncSqliteDb(AsyncBaseDb):
             log_error(f"Exception reading from runs table: {str(e)}")
             raise e
 
+    async def _scrub_run_ids_from_session_legacy_blob(
+        self, sess, runs_table: Table, sessions_table: Optional[Table], run_ids: Set[str]
+    ) -> None:
+        """Remove ``run_ids`` from the legacy ``runs`` blob of every session that owns them.
+
+        Partial-migration hygiene: the v3 migration copies runs into the runs table but
+        leaves the legacy sessions ``runs`` column in place as a frozen backup, so reads
+        merge the two. Deleting only the runs-table row lets
+        ``merge_runs_table_with_legacy_blob`` resurrect the run on the next read.
+
+        Must be called before the runs-table rows are deleted, since the owning
+        session ids are resolved from those rows. ``sessions_table`` is resolved by
+        the caller so the table is not reflected from inside the open transaction.
+        """
+        # The legacy column only exists on databases upgraded from v2.x.
+        if not run_ids or sessions_table is None or "runs" not in sessions_table.c:
+            return
+
+        result = await sess.execute(select(runs_table.c.session_id).where(runs_table.c.run_id.in_(run_ids)))
+        session_ids = {row[0] for row in result if row[0]}
+        if not session_ids:
+            return
+
+        result = await sess.execute(
+            select(sessions_table.c.session_id, sessions_table.c.runs).where(
+                sessions_table.c.session_id.in_(session_ids)
+            )
+        )
+        for session_id, legacy_runs in result.fetchall():
+            kept = scrub_run_ids_from_legacy_blob(legacy_runs, run_ids)
+            if kept is None:
+                continue
+            await sess.execute(
+                sessions_table.update().where(sessions_table.c.session_id == session_id).values(runs=kept)
+            )
+
     async def delete_run(self, run_id: str) -> bool:
         """Delete a single run from the runs table.
 
@@ -842,7 +879,9 @@ class AsyncSqliteDb(AsyncBaseDb):
             if table is None:
                 return False
 
+            sessions_table = await self._get_table(table_type="sessions")
             async with self.async_session_factory() as sess, sess.begin():
+                await self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, {run_id})
                 result = await sess.execute(table.delete().where(table.c.run_id == run_id))
                 return result.rowcount > 0  # type: ignore
 
@@ -861,7 +900,9 @@ class AsyncSqliteDb(AsyncBaseDb):
             if table is None:
                 return
 
+            sessions_table = await self._get_table(table_type="sessions")
             async with self.async_session_factory() as sess, sess.begin():
+                await self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, set(run_ids))
                 result = await sess.execute(table.delete().where(table.c.run_id.in_(run_ids)))
 
             log_debug(f"Successfully deleted {result.rowcount} runs")  # type: ignore

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -48,6 +48,7 @@ from agno.db.utils import (
     deserialize_sessions,
     learning_search_patterns,
     merge_runs_table_with_legacy_blob,
+    scrub_run_ids_from_legacy_blob,
     serialize_session_json_fields,
     validate_pagination,
 )
@@ -1027,6 +1028,44 @@ class SqliteDb(BaseDb):
             log_error(f"Exception reading from runs table: {str(e)}")
             raise e
 
+    def _scrub_run_ids_from_session_legacy_blob(
+        self, sess, runs_table: Table, sessions_table: Optional[Table], run_ids: Set[str]
+    ) -> None:
+        """Remove ``run_ids`` from the legacy ``runs`` blob of every session that owns them.
+
+        Partial-migration hygiene: the v3 migration copies runs into the runs table but
+        leaves the legacy sessions ``runs`` column in place as a frozen backup, so reads
+        merge the two. Deleting only the runs-table row lets
+        ``merge_runs_table_with_legacy_blob`` resurrect the run on the next read.
+
+        Must be called before the runs-table rows are deleted, since the owning
+        session ids are resolved from those rows. ``sessions_table`` is resolved by
+        the caller: ``self.Session`` is a scoped session, so reflecting a table from
+        inside the open transaction would re-enter it.
+        """
+        # The legacy column only exists on databases upgraded from v2.x.
+        if not run_ids or sessions_table is None or "runs" not in sessions_table.c:
+            return
+
+        session_ids = {
+            row[0]
+            for row in sess.execute(select(runs_table.c.session_id).where(runs_table.c.run_id.in_(run_ids)))
+            if row[0]
+        }
+        if not session_ids:
+            return
+
+        rows = sess.execute(
+            select(sessions_table.c.session_id, sessions_table.c.runs).where(
+                sessions_table.c.session_id.in_(session_ids)
+            )
+        ).fetchall()
+        for session_id, legacy_runs in rows:
+            kept = scrub_run_ids_from_legacy_blob(legacy_runs, run_ids)
+            if kept is None:
+                continue
+            sess.execute(sessions_table.update().where(sessions_table.c.session_id == session_id).values(runs=kept))
+
     def delete_run(self, run_id: str) -> bool:
         """Delete a single run from the runs table.
 
@@ -1041,7 +1080,9 @@ class SqliteDb(BaseDb):
             if table is None:
                 return False
 
+            sessions_table = self._get_table(table_type="sessions")
             with self.Session() as sess, sess.begin():
+                self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, {run_id})
                 result = sess.execute(table.delete().where(table.c.run_id == run_id))
                 return result.rowcount > 0
 
@@ -1060,7 +1101,9 @@ class SqliteDb(BaseDb):
             if table is None:
                 return
 
+            sessions_table = self._get_table(table_type="sessions")
             with self.Session() as sess, sess.begin():
+                self._scrub_run_ids_from_session_legacy_blob(sess, table, sessions_table, set(run_ids))
                 result = sess.execute(table.delete().where(table.c.run_id.in_(run_ids)))
 
             log_debug(f"Successfully deleted {result.rowcount} runs")

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -3,7 +3,7 @@
 import json
 import time
 from datetime import date, datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union, cast
 from uuid import UUID
 
 from agno.metrics import ModelMetrics, RunMetrics, SessionMetrics
@@ -344,6 +344,52 @@ def merge_runs_table_with_legacy_blob(
         merged.append(table_run)
 
     return merged
+
+
+def scrub_run_ids_from_legacy_blob(
+    legacy_runs: Optional[Union[str, List[Any]]],
+    run_ids: Set[str],
+) -> Optional[Union[str, List[Dict[str, Any]]]]:
+    """Remove ``run_ids`` from a session's legacy ``runs`` blob.
+
+    Write-side counterpart to :func:`merge_runs_table_with_legacy_blob`. Deleting a
+    run from the runs table is not enough while a session is partially migrated: the
+    read path merges the table with the legacy blob, so a run left in the blob is
+    resurrected on the next read.
+
+    The return value keeps the storage shape it was given. Adapters back this column
+    with different types (a JSON string on SQLite/MySQL, a native JSON column on
+    Postgres), so a string blob is re-encoded as a string and a list stays a list.
+
+    Args:
+        legacy_runs: The raw value of the legacy ``runs`` column (may be a list, a
+            JSON-encoded string, or ``None``).
+        run_ids: The run ids being deleted.
+
+    Returns:
+        The remaining runs when the blob actually contained one of ``run_ids``, or
+        ``None`` when there is nothing to write back (blob absent, unparseable, or
+        untouched by this delete). ``None`` means "leave the column alone" so callers
+        skip the UPDATE entirely.
+    """
+    if not run_ids or not legacy_runs:
+        return None
+
+    was_encoded = isinstance(legacy_runs, str)
+    if was_encoded:
+        try:
+            legacy_runs = json.loads(cast(str, legacy_runs))
+        except (json.JSONDecodeError, TypeError):
+            log_warning("Could not parse legacy runs blob during scrub; leaving it untouched")
+            return None
+
+    if not isinstance(legacy_runs, list):
+        return None
+
+    kept = [run for run in legacy_runs if not (isinstance(run, dict) and run.get("run_id") in run_ids)]
+    if len(kept) == len(legacy_runs):
+        return None
+    return json.dumps(kept) if was_encoded else kept
 
 
 async def resolve_session_type(

--- a/libs/agno/tests/unit/db/test_delete_run_scrubs_legacy_blob.py
+++ b/libs/agno/tests/unit/db/test_delete_run_scrubs_legacy_blob.py
@@ -21,9 +21,13 @@ import tempfile
 
 import pytest
 
+from agno.db.base import SessionType
 from agno.db.in_memory.in_memory_db import InMemoryDb
 from agno.db.json.json_db import JsonDb
 from agno.db.migrations.versions.v3_0_0 import _migrate_jsondb
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.session.agent import AgentSession
 
 
 @pytest.fixture
@@ -178,3 +182,135 @@ class TestInMemoryDbDeleteRunDoesNotResurrect:
         assert db.get_run("r0") is None
         sess = db.get_session(session_id="s1", deserialize=False)
         assert [r["run_id"] for r in sess.get("runs") or []] == ["r1"]
+
+
+def _make_partially_migrated_sqlite(db_file: str) -> None:
+    """Put a SQLite database into the state an upgraded v2.x install is left in.
+
+    The v3 migration copies runs into the runs table but deliberately leaves the
+    legacy ``runs`` column on the sessions table as a frozen backup, so a session
+    that predates the upgrade keeps a non-null blob indefinitely.
+    """
+    import sqlite3
+
+    from agno.db.sqlite.sqlite import SqliteDb
+
+    db = SqliteDb(db_file=db_file)
+    r0 = RunOutput(run_id="r0", session_id="s1", agent_id="a1", status=RunStatus.completed)
+    r1 = RunOutput(run_id="r1", session_id="s1", agent_id="a1", status=RunStatus.completed)
+    db.upsert_session(AgentSession(session_id="s1", agent_id="a1", user_id="u1", runs=[r0, r1], created_at=1))
+    db.upsert_run(r0, session_id="s1", user_id="u1", run_index=0)
+    db.upsert_run(r1, session_id="s1", user_id="u1", run_index=1)
+
+    def _loads_deep(value):
+        while isinstance(value, str):
+            value = json.loads(value)
+        return value
+
+    con = sqlite3.connect(db_file)
+    con.execute("ALTER TABLE agno_sessions ADD COLUMN runs TEXT")
+    r0_dict = _loads_deep(con.execute("SELECT run_data FROM agno_runs WHERE run_id='r0'").fetchone()[0])
+    con.execute("UPDATE agno_sessions SET runs=? WHERE session_id='s1'", (json.dumps([r0_dict]),))
+    con.commit()
+    con.close()
+
+
+@pytest.fixture
+def sqlite_db_file():
+    return os.path.join(tempfile.mkdtemp(), "partial_migration.db")
+
+
+class TestSqliteDbDeleteRunScrubsLegacyBlob:
+    """The SQL adapters never got the scrub the doc adapters have.
+
+    A pre-upgrade session is permanently in the partial-migration state (the
+    migration leaves the legacy column populated and writes preserve it), so the
+    read path always merges table + blob and a blob-only run comes back.
+    """
+
+    def test_delete_run_does_not_resurrect_via_legacy_blob(self, sqlite_db_file):
+        from agno.db.sqlite.sqlite import SqliteDb
+
+        _make_partially_migrated_sqlite(sqlite_db_file)
+        db = SqliteDb(db_file=sqlite_db_file)
+
+        assert db.delete_run("r0") is True
+        assert db.get_run(run_id="r0") is None
+
+        session = db.get_session(session_id="s1", session_type=SessionType.AGENT)
+        run_ids = [r.run_id for r in (session.runs or [])]
+        assert "r0" not in run_ids, f"deleted r0 resurrected from the legacy blob: got {run_ids}"
+        assert run_ids == ["r1"]
+
+    def test_delete_runs_bulk_does_not_resurrect(self, sqlite_db_file):
+        from agno.db.sqlite.sqlite import SqliteDb
+
+        _make_partially_migrated_sqlite(sqlite_db_file)
+        db = SqliteDb(db_file=sqlite_db_file)
+
+        db.delete_runs(["r0", "r1"])
+
+        session = db.get_session(session_id="s1", session_type=SessionType.AGENT)
+        assert [r.run_id for r in (session.runs or [])] == []
+
+    def test_delete_run_without_legacy_column_is_unaffected(self):
+        """A database created fresh on v3 has no legacy column; the scrub no-ops."""
+        from agno.db.sqlite.sqlite import SqliteDb
+
+        db_file = os.path.join(tempfile.mkdtemp(), "fresh.db")
+        db = SqliteDb(db_file=db_file)
+        run = RunOutput(run_id="r0", session_id="s1", agent_id="a1", status=RunStatus.completed)
+        db.upsert_session(AgentSession(session_id="s1", agent_id="a1", user_id="u1", runs=[run], created_at=1))
+        db.upsert_run(run, session_id="s1", user_id="u1", run_index=0)
+
+        assert db.delete_run("r0") is True
+        assert db.get_run(run_id="r0") is None
+
+    def test_deleting_a_post_migration_run_leaves_the_blob_alone(self, sqlite_db_file):
+        """Runs written after the upgrade exist only in the runs table. Deleting one
+        must not disturb the frozen backup of the runs that predate it."""
+        import sqlite3
+
+        from agno.db.sqlite.sqlite import SqliteDb
+
+        _make_partially_migrated_sqlite(sqlite_db_file)
+        db = SqliteDb(db_file=sqlite_db_file)
+
+        r2 = RunOutput(run_id="r2", session_id="s1", agent_id="a1", status=RunStatus.completed)
+        db.upsert_run(r2, session_id="s1", user_id="u1", run_index=2)
+        db.delete_run("r2")
+
+        con = sqlite3.connect(sqlite_db_file)
+        blob = con.execute("SELECT runs FROM agno_sessions WHERE session_id='s1'").fetchone()[0]
+        con.close()
+        assert [r["run_id"] for r in json.loads(blob)] == ["r0"]
+
+
+class TestAsyncSqliteDbDeleteRunScrubsLegacyBlob:
+    """Same invariant on the async adapter."""
+
+    @pytest.mark.asyncio
+    async def test_delete_run_does_not_resurrect_via_legacy_blob(self, sqlite_db_file):
+        from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+
+        _make_partially_migrated_sqlite(sqlite_db_file)
+        db = AsyncSqliteDb(db_file=sqlite_db_file)
+
+        assert await db.delete_run("r0") is True
+
+        session = await db.get_session(session_id="s1", session_type=SessionType.AGENT)
+        run_ids = [r.run_id for r in (session.runs or [])]
+        assert "r0" not in run_ids, f"deleted r0 resurrected from the legacy blob: got {run_ids}"
+        assert run_ids == ["r1"]
+
+    @pytest.mark.asyncio
+    async def test_delete_runs_bulk_does_not_resurrect(self, sqlite_db_file):
+        from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+
+        _make_partially_migrated_sqlite(sqlite_db_file)
+        db = AsyncSqliteDb(db_file=sqlite_db_file)
+
+        await db.delete_runs(["r0", "r1"])
+
+        session = await db.get_session(session_id="s1", session_type=SessionType.AGENT)
+        assert [r.run_id for r in (session.runs or [])] == []


### PR DESCRIPTION
## Summary

`delete_run()` / `delete_runs()` on the seven SQL adapters removed rows from the runs table without touching the legacy `runs` blob on the sessions table. Since the read path merges the two, the deleted run reappeared on the next read.

This hits the default state of an upgraded database rather than an edge case: the v3.0.0 migration leaves the legacy column populated, writes preserve it, and reclaiming it is a manual `cleanup_legacy_runs_column()` call. So every pre-upgrade session stays in the partial-migration state permanently.

Issue number: #9324

### Changes

`db/utils.py` gains `scrub_run_ids_from_legacy_blob`, the write-side counterpart to `merge_runs_table_with_legacy_blob`. It keeps the storage shape it was given, since the column is a JSON string on SQLite/MySQL and a native JSON column on Postgres.

Each of `PostgresDb`, `AsyncPostgresDb`, `SqliteDb`, `AsyncSqliteDb`, `MySQLDb`, `AsyncMySQLDb` and `SingleStoreDb` gains a `_scrub_run_ids_from_session_legacy_blob` that resolves the owning sessions from the runs table and rewrites their blobs, called inside the existing transaction before the delete.

Two details worth flagging for review:

The sessions table is reflected by the caller, outside the transaction. `self.Session` is a scoped session, so reflecting from inside an open transaction raises `A transaction is already begun on this Session`.

The scrub is skipped when the sessions table has no `runs` column, which is the case for any database created fresh on v3.

### Tests

`tests/unit/db/test_delete_run_scrubs_legacy_blob.py` gains SQLite coverage, sync and async: single delete, bulk delete, a database with no legacy column, and a post-migration run whose deletion must leave the frozen backup alone. The four resurrection tests fail on the unmodified branch and pass with the change.

Full `tests/unit/db` run is unchanged at 13 pre-existing failures (missing valkey/gcs drivers locally), with 425 passing before and 431 after.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)
