### PR TITLE
feat: support custom retriever in KnowledgeTools

### DIFF
--- a/cookbook/02_agents/07_knowledge/README.md
+++ b/cookbook/02_agents/07_knowledge/README.md
@@ -7,6 +7,7 @@ Examples for retrieval-augmented generation, knowledge filters, and custom retri
 - `agentic_rag_with_reasoning.py` - Agentic RAG with reasoning tools.
 - `agentic_rag_with_reranking.py` - Agentic RAG with Cohere reranking.
 - `custom_retriever.py` - Use a custom retrieval function instead of a Knowledge instance.
+- `knowledge_tools_custom_retriever.py` - KnowledgeTools Think/Search/Analyze with a custom retriever.
 - `knowledge_filters.py` - Filter knowledge searches with static or agentic filters.
 - `rag_custom_embeddings.py` - RAG with custom embeddings.
 - `references_format.py` - Control reference format (JSON vs YAML).

--- a/cookbook/02_agents/07_knowledge/knowledge_tools_custom_retriever.py
+++ b/cookbook/02_agents/07_knowledge/knowledge_tools_custom_retriever.py
@@ -1,0 +1,66 @@
+"""
+KnowledgeTools with Custom Retriever
+====================================
+
+Combine the Think -> Search -> Analyze workflow from KnowledgeTools
+with a custom knowledge_retriever (same contract as Agent.knowledge_retriever).
+
+This lets you keep structured knowledge reasoning while searching multiple
+sources, calling an external service, or applying custom ranking.
+"""
+
+from typing import List, Optional
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.knowledge import KnowledgeTools
+
+DOCUMENTS = [
+    {
+        "title": "Python Basics",
+        "content": "Python is a high-level programming language known for its readability.",
+    },
+    {
+        "title": "TypeScript Intro",
+        "content": "TypeScript adds static typing to JavaScript.",
+    },
+    {
+        "title": "Rust Overview",
+        "content": "Rust is a systems language focused on safety and performance.",
+    },
+]
+
+
+def custom_retriever(
+    query: str, num_documents: Optional[int] = None, **kwargs
+) -> Optional[List[dict]]:
+    """Search documents by simple keyword matching."""
+    query_lower = query.lower()
+    results = [
+        doc
+        for doc in DOCUMENTS
+        if query_lower in doc["content"].lower() or query_lower in doc["title"].lower()
+    ]
+    if num_documents:
+        results = results[:num_documents]
+    return results if results else None
+
+
+knowledge_tools = KnowledgeTools(
+    knowledge_retriever=custom_retriever,
+    enable_think=True,
+    enable_search=True,
+    enable_analyze=True,
+)
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[knowledge_tools],
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Tell me about Python.",
+        stream=True,
+    )

--- a/libs/agno/agno/tools/knowledge.py
+++ b/libs/agno/agno/tools/knowledge.py
@@ -1,6 +1,7 @@
 import json
+from inspect import isawaitable, iscoroutinefunction, signature
 from textwrap import dedent
-from typing import Any, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
@@ -12,7 +13,8 @@ from agno.utils.log import log_debug, log_error
 class KnowledgeTools(Toolkit):
     def __init__(
         self,
-        knowledge: Knowledge,
+        knowledge: Optional[Knowledge] = None,
+        knowledge_retriever: Optional[Callable[..., Optional[List[Union[Dict[str, Any], str]]]]] = None,
         enable_think: bool = True,
         enable_search: bool = True,
         enable_analyze: bool = True,
@@ -23,8 +25,8 @@ class KnowledgeTools(Toolkit):
         all: bool = False,
         **kwargs,
     ):
-        if knowledge is None:
-            raise ValueError("knowledge must be provided when using KnowledgeTools")
+        if knowledge is None and knowledge_retriever is None:
+            raise ValueError("Either knowledge or knowledge_retriever must be provided when using KnowledgeTools")
 
         # Add instructions for using this toolkit
         if instructions is None:
@@ -37,20 +39,25 @@ class KnowledgeTools(Toolkit):
         else:
             self.instructions = instructions
 
-        # The knowledge to search
-        self.knowledge: Knowledge = knowledge
+        # The knowledge to search (optional when a custom retriever is provided)
+        self.knowledge: Optional[Knowledge] = knowledge
+        # Optional custom retriever with the same callable contract as Agent.knowledge_retriever
+        self.knowledge_retriever = knowledge_retriever
 
         tools: List[Any] = []
+        async_tools: List[Any] = []
         if enable_think or all:
             tools.append(self.think)
         if enable_search or all:
             tools.append(self.search_knowledge)
+            async_tools.append((self.asearch_knowledge, "search_knowledge"))
         if enable_analyze or all:
             tools.append(self.analyze)
 
         super().__init__(
             name="knowledge_tools",
             tools=tools,
+            async_tools=async_tools,
             instructions=self.instructions,
             add_instructions=add_instructions,
             **kwargs,
@@ -92,6 +99,43 @@ class KnowledgeTools(Toolkit):
             log_error(f"Error recording thought: {str(e)}")
             return f"Error recording thought: {e}"
 
+    def _num_documents(self) -> Optional[int]:
+        if self.knowledge is None:
+            return None
+        return getattr(self.knowledge, "max_results", None)
+
+    def _build_retriever_kwargs(
+        self,
+        query: str,
+        run_context: RunContext,
+        filters: Optional[Any] = None,
+    ) -> Dict[str, Any]:
+        """Build kwargs for a custom retriever using the same contract as Agentic RAG."""
+        assert self.knowledge_retriever is not None
+        dependencies = run_context.dependencies if run_context else None
+        sig = signature(self.knowledge_retriever)
+        knowledge_retriever_kwargs: Dict[str, Any] = {}
+        if "filters" in sig.parameters:
+            knowledge_retriever_kwargs["filters"] = filters
+        if "run_context" in sig.parameters:
+            knowledge_retriever_kwargs["run_context"] = run_context
+        elif "dependencies" in sig.parameters:
+            knowledge_retriever_kwargs["dependencies"] = dependencies
+        knowledge_retriever_kwargs.update({"query": query, "num_documents": self._num_documents()})
+        return knowledge_retriever_kwargs
+
+    def _format_docs(self, docs: Optional[List[Any]]) -> str:
+        if not docs:
+            return "No documents found"
+
+        serialized: List[Any] = []
+        for doc in docs:
+            if isinstance(doc, Document):
+                serialized.append(doc.to_dict())
+            else:
+                serialized.append(doc)
+        return json.dumps(serialized, indent=2, default=str, ensure_ascii=False)
+
     def search_knowledge(self, run_context: RunContext, query: str) -> str:
         """Use this tool to search the knowledge base for relevant information.
         After thinking through the question, use this tool as many times as needed to search for relevant information.
@@ -105,11 +149,58 @@ class KnowledgeTools(Toolkit):
         try:
             log_debug(f"Searching knowledge base: {query}")
 
-            # Get the relevant documents from the knowledge base
+            if self.knowledge_retriever is not None and callable(self.knowledge_retriever):
+                if iscoroutinefunction(self.knowledge_retriever):
+                    return (
+                        "Error searching knowledge base: knowledge_retriever is async; "
+                        "use agent.arun() / agent.aprint_response() so the async search_knowledge path runs."
+                    )
+                docs = self.knowledge_retriever(**self._build_retriever_kwargs(query=query, run_context=run_context))
+                return self._format_docs(docs)
+
+            if self.knowledge is None:
+                return "Error searching knowledge base: no knowledge or knowledge_retriever configured"
+
             relevant_docs: List[Document] = self.knowledge.search(query=query)
-            if len(relevant_docs) == 0:
-                return "No documents found"
-            return json.dumps([doc.to_dict() for doc in relevant_docs])
+            return self._format_docs(relevant_docs)
+        except Exception as e:
+            log_error(f"Error searching knowledge base: {str(e)}")
+            return f"Error searching knowledge base: {e}"
+
+    async def asearch_knowledge(self, run_context: RunContext, query: str) -> str:
+        """Async variant of search_knowledge. Supports async custom retrievers.
+
+        Args:
+            query: The query to search the knowledge base for.
+
+        Returns:
+            str: A string containing the response from the knowledge base.
+        """
+        try:
+            log_debug(f"Searching knowledge base asynchronously: {query}")
+
+            if self.knowledge_retriever is not None and callable(self.knowledge_retriever):
+                docs = self.knowledge_retriever(**self._build_retriever_kwargs(query=query, run_context=run_context))
+                if isawaitable(docs):
+                    docs = await docs
+                return self._format_docs(docs)
+
+            if self.knowledge is None:
+                return "Error searching knowledge base: no knowledge or knowledge_retriever configured"
+
+            aretrieve_fn = getattr(self.knowledge, "aretrieve", None)
+            if callable(aretrieve_fn):
+                num_documents = self._num_documents() or getattr(self.knowledge, "max_results", 10)
+                relevant_docs = await aretrieve_fn(query=query, max_results=num_documents)
+                return self._format_docs(relevant_docs)
+
+            asearch_fn = getattr(self.knowledge, "asearch", None)
+            if callable(asearch_fn):
+                relevant_docs = await asearch_fn(query=query)
+                return self._format_docs(relevant_docs)
+
+            relevant_docs = self.knowledge.search(query=query)
+            return self._format_docs(relevant_docs)
         except Exception as e:
             log_error(f"Error searching knowledge base: {str(e)}")
             return f"Error searching knowledge base: {e}"

--- a/libs/agno/tests/unit/tools/test_knowledge_tools.py
+++ b/libs/agno/tests/unit/tools/test_knowledge_tools.py
@@ -1,0 +1,177 @@
+"""Unit tests for KnowledgeTools custom retriever support."""
+
+import json
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from agno.knowledge.document import Document
+from agno.run import RunContext
+from agno.tools.knowledge import KnowledgeTools
+
+
+@pytest.fixture
+def run_context() -> RunContext:
+    return RunContext(run_id="test-run", session_id="test-session", session_state={})
+
+
+def test_requires_knowledge_or_retriever():
+    with pytest.raises(ValueError, match="knowledge or knowledge_retriever"):
+        KnowledgeTools(knowledge=None, knowledge_retriever=None)
+
+
+def test_search_falls_back_to_knowledge_search(run_context: RunContext):
+    knowledge = MagicMock()
+    knowledge.search.return_value = [Document(content="hello from knowledge")]
+    knowledge.max_results = 5
+
+    tools = KnowledgeTools(knowledge=knowledge, enable_think=False, enable_analyze=False)
+    result = tools.search_knowledge(run_context=run_context, query="hello")
+
+    knowledge.search.assert_called_once_with(query="hello")
+    docs = json.loads(result)
+    assert docs[0]["content"] == "hello from knowledge"
+
+
+def test_search_uses_custom_retriever(run_context: RunContext):
+    calls: List[Dict[str, Any]] = []
+
+    def custom_retriever(
+        query: str,
+        num_documents: Optional[int] = None,
+        run_context: Optional[RunContext] = None,
+        **kwargs: Any,
+    ) -> List[dict]:
+        calls.append(
+            {
+                "query": query,
+                "num_documents": num_documents,
+                "run_context": run_context,
+            }
+        )
+        return [{"content": f"custom:{query}"}]
+
+    knowledge = MagicMock()
+    knowledge.max_results = 3
+    tools = KnowledgeTools(
+        knowledge=knowledge,
+        knowledge_retriever=custom_retriever,
+        enable_think=False,
+        enable_analyze=False,
+    )
+
+    result = tools.search_knowledge(run_context=run_context, query="python")
+
+    knowledge.search.assert_not_called()
+    assert calls[0]["query"] == "python"
+    assert calls[0]["num_documents"] == 3
+    assert calls[0]["run_context"] is run_context
+    assert json.loads(result) == [{"content": "custom:python"}]
+
+
+def test_search_with_retriever_only(run_context: RunContext):
+    def custom_retriever(query: str, num_documents: Optional[int] = None, **kwargs: Any) -> List[dict]:
+        return [{"content": "retriever-only"}]
+
+    tools = KnowledgeTools(
+        knowledge=None,
+        knowledge_retriever=custom_retriever,
+        enable_think=False,
+        enable_analyze=False,
+    )
+    result = tools.search_knowledge(run_context=run_context, query="x")
+    assert json.loads(result) == [{"content": "retriever-only"}]
+
+
+def test_search_retriever_returns_empty(run_context: RunContext):
+    def custom_retriever(query: str, num_documents: Optional[int] = None, **kwargs: Any) -> None:
+        return None
+
+    tools = KnowledgeTools(
+        knowledge_retriever=custom_retriever,
+        enable_think=False,
+        enable_analyze=False,
+    )
+    assert tools.search_knowledge(run_context=run_context, query="missing") == "No documents found"
+
+
+def test_sync_search_rejects_async_retriever(run_context: RunContext):
+    async def async_retriever(query: str, num_documents: Optional[int] = None, **kwargs: Any) -> List[dict]:
+        return [{"content": "async"}]
+
+    tools = KnowledgeTools(
+        knowledge_retriever=async_retriever,
+        enable_think=False,
+        enable_analyze=False,
+    )
+    result = tools.search_knowledge(run_context=run_context, query="x")
+    assert "async" in result
+    assert "arun" in result
+    assert "search_knowledge" in result
+
+
+@pytest.mark.asyncio
+async def test_async_search_awaits_async_retriever(run_context: RunContext):
+    async def async_retriever(
+        query: str,
+        num_documents: Optional[int] = None,
+        run_context: Optional[RunContext] = None,
+        **kwargs: Any,
+    ) -> List[dict]:
+        return [{"content": f"async:{query}"}]
+
+    tools = KnowledgeTools(
+        knowledge_retriever=async_retriever,
+        enable_think=False,
+        enable_analyze=False,
+    )
+    result = await tools.asearch_knowledge(run_context=run_context, query="teams")
+    assert json.loads(result) == [{"content": "async:teams"}]
+
+
+@pytest.mark.asyncio
+async def test_async_search_falls_back_to_aretrieve(run_context: RunContext):
+    knowledge = MagicMock()
+    knowledge.max_results = 2
+
+    async def aretrieve(query: str, max_results: Optional[int] = None, filters: Any = None) -> List[Document]:
+        return [Document(content=f"aretrieve:{query}:{max_results}")]
+
+    knowledge.aretrieve = aretrieve
+    tools = KnowledgeTools(knowledge=knowledge, enable_think=False, enable_analyze=False)
+    result = await tools.asearch_knowledge(run_context=run_context, query="docs")
+    docs = json.loads(result)
+    assert docs[0]["content"] == "aretrieve:docs:2"
+
+
+def test_registers_async_search_tool():
+    tools = KnowledgeTools(
+        knowledge_retriever=lambda query, num_documents=None, **kwargs: [],
+        enable_think=False,
+        enable_analyze=False,
+    )
+    assert "search_knowledge" in tools.functions
+    assert "search_knowledge" in tools.async_functions
+
+
+def test_retriever_receives_dependencies_when_requested(run_context: RunContext):
+    run_context.dependencies = {"tenant": "acme"}
+    seen: Dict[str, Any] = {}
+
+    def custom_retriever(
+        query: str,
+        num_documents: Optional[int] = None,
+        dependencies: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> List[dict]:
+        seen["dependencies"] = dependencies
+        return [{"content": "ok"}]
+
+    tools = KnowledgeTools(
+        knowledge_retriever=custom_retriever,
+        enable_think=False,
+        enable_analyze=False,
+    )
+    tools.search_knowledge(run_context=run_context, query="x")
+    assert seen["dependencies"] == {"tenant": "acme"}


### PR DESCRIPTION
## Summary

- Add optional `knowledge_retriever` to `KnowledgeTools`, using the same callable contract as Agentic RAG (`query`, `num_documents`, `filters`, `run_context` / `dependencies`)
- Prefer the custom retriever when set; otherwise fall back to `knowledge.search()` / `aretrieve()` / `asearch()`
- Register async `search_knowledge` via `async_tools` so async retrievers work with `agent.arun()`
- Add unit tests and a cookbook example for Think → Search → Analyze with a custom retriever

Closes #9054

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Files changed

- `libs/agno/agno/tools/knowledge.py` — optional `knowledge_retriever`, sync/async search paths
- `libs/agno/tests/unit/tools/test_knowledge_tools.py` — unit coverage
- `cookbook/02_agents/07_knowledge/knowledge_tools_custom_retriever.py` — example
- `cookbook/02_agents/07_knowledge/README.md` — list the example

### Validation

- `pytest libs/agno/tests/unit/tools/test_knowledge_tools.py` — 10 passed
- `./scripts/format.sh` and `./scripts/validate.sh` — passed

### Design notes

- Defaults remain backward compatible: existing `KnowledgeTools(knowledge=...)` callers are unchanged
- `knowledge` is optional when `knowledge_retriever` is provided
- Sync path rejects async retrievers with a clear error directing users to `arun` / `aprint_response`

Made with [Cursor](https://cursor.com)