### PR TITLE
fix: address review findings on runs_limit read optimization

### DIFF
--- a/libs/agno/agno/agent/_session.py
+++ b/libs/agno/agno/agent/_session.py
@@ -710,11 +710,11 @@ def _bounded_history_runs_limit(
     the full history, so no capability check is needed here.
     """
     if (
-        agent.db is not None
-        and last_n_runs is not None
+        last_n_runs is not None
         and last_n_runs > 0
         and skip_statuses is None
         and agent.team_id is None
+        and getattr(agent.db, "supports_runs_limit", False)
     ):
         return last_n_runs
     return None

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -145,10 +145,15 @@ def read_session(
     """
     if not agent.db:
         raise ValueError("Db not initialized")
-    # Every adapter accepts runs_limit; those that don't optimize it load the full
-    # history (a safe superset), so we can pass it unconditionally.
+    # Only pass runs_limit to adapters that declare support for it. Omitting the
+    # keyword otherwise keeps third-party BaseDb subclasses on the pre-runs_limit
+    # get_session signature working (they'd raise an unexpected-keyword TypeError).
+    if runs_limit is not None and getattr(agent.db, "supports_runs_limit", False):
+        return agent.db.get_session(  # type: ignore
+            session_id=session_id, session_type=session_type, user_id=user_id, runs_limit=runs_limit
+        )
     return agent.db.get_session(  # type: ignore
-        session_id=session_id, session_type=session_type, user_id=user_id, runs_limit=runs_limit
+        session_id=session_id, session_type=session_type, user_id=user_id
     )
 
 
@@ -164,14 +169,22 @@ async def aread_session(
 
     if not agent.db:
         raise ValueError("Db not initialized")
-    # Every adapter accepts runs_limit; those that don't optimize it load the full
-    # history (a safe superset), so we can pass it unconditionally.
+    # Only pass runs_limit to adapters that declare support (see read_session).
+    supported = runs_limit is not None and getattr(agent.db, "supports_runs_limit", False)
     if _init.has_async_db(agent):
+        if supported:
+            return await agent.db.get_session(  # type: ignore
+                session_id=session_id, session_type=session_type, user_id=user_id, runs_limit=runs_limit
+            )
         return await agent.db.get_session(  # type: ignore
+            session_id=session_id, session_type=session_type, user_id=user_id
+        )
+    if supported:
+        return agent.db.get_session(  # type: ignore
             session_id=session_id, session_type=session_type, user_id=user_id, runs_limit=runs_limit
         )
     return agent.db.get_session(  # type: ignore
-        session_id=session_id, session_type=session_type, user_id=user_id, runs_limit=runs_limit
+        session_id=session_id, session_type=session_type, user_id=user_id
     )
 
 

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -33,6 +33,11 @@ class ComponentType(str, Enum):
 class BaseDb(ABC):
     """Base abstract class for all our Database implementations."""
 
+    # Whether get_session(runs_limit=N) is honored (an indexed "most recent N runs"
+    # read). False = the adapter loads the full history and callers must not pass
+    # runs_limit to it. SQL adapters override this to True.
+    supports_runs_limit: bool = False
+
     # We assume the database to be up to date with the 2.0.0 release
     default_schema_version = "2.0.0"
 
@@ -1584,6 +1589,9 @@ class BaseDb(ABC):
 
 class AsyncBaseDb(ABC):
     """Base abstract class for all our async database implementations."""
+
+    # See BaseDb.supports_runs_limit. SQL adapters override this to True.
+    supports_runs_limit: bool = False
 
     def __init__(
         self,

--- a/libs/agno/agno/db/dynamo/dynamo.py
+++ b/libs/agno/agno/db/dynamo/dynamo.py
@@ -741,7 +741,14 @@ class DynamoDb(BaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
+        """Get all sessions matching the given filters.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. Defaults to True to
+        preserve existing behavior.
+        """
         try:
             table_name = self._get_table("sessions")
             if table_name is None:
@@ -876,7 +883,7 @@ class DynamoDb(BaseDb):
                     sessions_data.append(session_data)
 
             # Attach runs from the runs table, merged with legacy blob
-            if sessions_data:
+            if include_runs and sessions_data:
                 try:
                     runs_by_session = self._get_sessions_runs_data([s["session_id"] for s in sessions_data])
                     for s in sessions_data:
@@ -885,6 +892,9 @@ class DynamoDb(BaseDb):
                         )
                 except Exception as e:
                     log_error(f"Failed to attach runs to sessions: {str(e)}")
+            elif not include_runs:
+                for s in sessions_data:
+                    s["runs"] = None
 
             # Filter by session_name in-memory (stored inside session_data JSON)
             if session_name:

--- a/libs/agno/agno/db/firestore/firestore.py
+++ b/libs/agno/agno/db/firestore/firestore.py
@@ -763,8 +763,13 @@ class FirestoreDb(BaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """Get all sessions.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. Defaults to True to
+        preserve existing behavior.
 
         Args:
             session_type (Optional[SessionType]): The type of session to get.
@@ -851,13 +856,16 @@ class FirestoreDb(BaseDb):
 
             # Attach runs from the runs collection, merged with any runs still
             # in the legacy `runs` field.
-            if runs_collection_ref is not None and sessions_raw:
+            if include_runs and runs_collection_ref is not None and sessions_raw:
                 runs_by_session = self._get_sessions_runs_docs(
                     runs_collection_ref, [s["session_id"] for s in sessions_raw]
                 )
                 for s in sessions_raw:
                     runs_data = runs_by_session.get(s["session_id"], [])
                     s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+            elif not include_runs:
+                for s in sessions_raw:
+                    s["runs"] = None
 
             if not deserialize:
                 return sessions_raw, total_count

--- a/libs/agno/agno/db/gcs_json/gcs_json_db.py
+++ b/libs/agno/agno/db/gcs_json/gcs_json_db.py
@@ -552,8 +552,13 @@ class GcsJsonDb(BaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """Get all sessions from the GCS JSON file with filtering and pagination.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. Defaults to True to
+        preserve existing behavior.
 
         Args:
             session_type (Optional[SessionType]): The type of the sessions to read.
@@ -627,11 +632,14 @@ class GcsJsonDb(BaseDb):
                 filtered_sessions = filtered_sessions[start_idx : start_idx + limit]
 
             # Attach runs from the runs file, merged with any legacy `runs` field
-            if filtered_sessions:
+            if include_runs and filtered_sessions:
                 runs_by_session = self._get_sessions_runs_data([s["session_id"] for s in filtered_sessions])
                 for s in filtered_sessions:
                     runs_data = runs_by_session.get(s["session_id"], [])
                     s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+            elif not include_runs:
+                for s in filtered_sessions:
+                    s["runs"] = None
 
             if not deserialize:
                 return filtered_sessions, total_count

--- a/libs/agno/agno/db/json/json_db.py
+++ b/libs/agno/agno/db/json/json_db.py
@@ -550,8 +550,13 @@ class JsonDb(BaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """Get all sessions from the JSON file with filtering and pagination.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. Defaults to True to
+        preserve existing behavior.
 
         Args:
             session_type (Optional[SessionType]): The type of the sessions to read.
@@ -625,11 +630,14 @@ class JsonDb(BaseDb):
                 filtered_sessions = filtered_sessions[start_idx : start_idx + limit]
 
             # Attach runs from the runs file, merged with any legacy `runs` field
-            if filtered_sessions:
+            if include_runs and filtered_sessions:
                 runs_by_session = self._get_sessions_runs_data([s["session_id"] for s in filtered_sessions])
                 for s in filtered_sessions:
                     runs_data = runs_by_session.get(s["session_id"], [])
                     s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+            elif not include_runs:
+                for s in filtered_sessions:
+                    s["runs"] = None
 
             if not deserialize:
                 return filtered_sessions, total_count

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -988,8 +988,13 @@ class AsyncMongoDb(AsyncBaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """Get all sessions.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. Defaults to True to
+        preserve existing behavior.
 
         Args:
             session_type (Optional[SessionType]): The type of session to get.
@@ -1069,13 +1074,16 @@ class AsyncMongoDb(AsyncBaseDb):
                 return [] if deserialize else ([], 0)
             sessions_raw = [deserialize_session_json_fields(record) for record in records]
 
-            if runs_collection is not None and sessions_raw:
+            if include_runs and runs_collection is not None and sessions_raw:
                 runs_by_session = await self._get_sessions_runs_docs(
                     runs_collection, [s["session_id"] for s in sessions_raw]
                 )
                 for s in sessions_raw:
                     runs_data = runs_by_session.get(s["session_id"], [])
                     s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+            elif not include_runs:
+                for s in sessions_raw:
+                    s["runs"] = None
 
             if not deserialize:
                 return sessions_raw, total_count

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -798,8 +798,13 @@ class MongoDb(BaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """Get all sessions.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. Defaults to True to
+        preserve existing behavior.
 
         Args:
             session_type (Optional[SessionType]): The type of session to get.
@@ -882,11 +887,14 @@ class MongoDb(BaseDb):
 
             # Attach runs from the runs collection, merged with any runs still sitting
             # in the legacy `runs` field.
-            if runs_collection is not None and sessions_raw:
+            if include_runs and runs_collection is not None and sessions_raw:
                 runs_by_session = self._get_sessions_runs_docs(runs_collection, [s["session_id"] for s in sessions_raw])
                 for s in sessions_raw:
                     runs_data = runs_by_session.get(s["session_id"], [])
                     s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+            elif not include_runs:
+                for s in sessions_raw:
+                    s["runs"] = None
 
             if not deserialize:
                 return sessions_raw, total_count

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -56,6 +56,9 @@ except ImportError:
 
 
 class AsyncMySQLDb(AsyncBaseDb):
+    # Indexed "most recent N runs" reads are supported (see BaseDb.supports_runs_limit).
+    supports_runs_limit: bool = True
+
     def __init__(
         self,
         id: Optional[str] = None,
@@ -539,8 +542,9 @@ class AsyncMySQLDb(AsyncBaseDb):
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
                 .order_by(
-                    func.coalesce(runs_table.c.run_index, 0).desc(),
-                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                    runs_table.c.created_at.desc(),
+                    runs_table.c.run_index.desc(),
+                    runs_table.c.run_id.desc(),
                 )
                 .limit(limit)
             )
@@ -552,8 +556,9 @@ class AsyncMySQLDb(AsyncBaseDb):
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
             .order_by(
-                func.coalesce(runs_table.c.run_index, 0).asc(),
-                func.coalesce(runs_table.c.created_at, 0).asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_index.asc(),
+                runs_table.c.run_id.asc(),
             )
         )
         result = await sess.execute(stmt)
@@ -938,9 +943,14 @@ class AsyncMySQLDb(AsyncBaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """
         Get all sessions in the given table. Can filter by user_id and entity_id.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. Defaults to True to
+        preserve existing behavior.
 
         Args:
             user_id (Optional[str]): The ID of the user to filter by.
@@ -1020,13 +1030,16 @@ class AsyncMySQLDb(AsyncBaseDb):
 
                 session = [dict(record._mapping) for record in records]
 
-                if runs_table is not None:
+                if include_runs and runs_table is not None:
                     runs_by_session = await self._get_sessions_runs_data(
                         sess=sess, runs_table=runs_table, session_ids=[s["session_id"] for s in session]
                     )
                     for s in session:
                         runs_data = runs_by_session.get(s["session_id"], [])
                         s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+                elif not include_runs:
+                    for s in session:
+                        s["runs"] = None
 
                 if not deserialize:
                     return session, total_count

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -57,6 +57,9 @@ except ImportError:
 
 
 class MySQLDb(BaseDb):
+    # Indexed "most recent N runs" reads are supported (see BaseDb.supports_runs_limit).
+    supports_runs_limit: bool = True
+
     def __init__(
         self,
         id: Optional[str] = None,
@@ -542,8 +545,9 @@ class MySQLDb(BaseDb):
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
                 .order_by(
-                    func.coalesce(runs_table.c.run_index, 0).desc(),
-                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                    runs_table.c.created_at.desc(),
+                    runs_table.c.run_index.desc(),
+                    runs_table.c.run_id.desc(),
                 )
                 .limit(limit)
             )
@@ -554,8 +558,9 @@ class MySQLDb(BaseDb):
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
             .order_by(
-                func.coalesce(runs_table.c.run_index, 0).asc(),
-                func.coalesce(runs_table.c.created_at, 0).asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_index.asc(),
+                runs_table.c.run_id.asc(),
             )
         )
         return [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
@@ -951,9 +956,14 @@ class MySQLDb(BaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """
         Get all sessions in the given table. Can filter by user_id and entity_id.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. Defaults to True to
+        preserve existing behavior.
 
         Args:
             session_type (Optional[SessionType]): The type of sessions to get.
@@ -1035,13 +1045,16 @@ class MySQLDb(BaseDb):
 
                 session_dicts = [dict(row._mapping) for row in result]
 
-                if runs_table is not None:
+                if include_runs and runs_table is not None:
                     runs_by_session = self._get_sessions_runs_data(
                         sess=sess, runs_table=runs_table, session_ids=[s["session_id"] for s in session_dicts]
                     )
                     for s in session_dicts:
                         runs_data = runs_by_session.get(s["session_id"], [])
                         s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+                elif not include_runs:
+                    for s in session_dicts:
+                        s["runs"] = None
 
                 if not deserialize:
                     return session_dicts, total_count

--- a/libs/agno/agno/db/mysql/schemas.py
+++ b/libs/agno/agno/db/mysql/schemas.py
@@ -48,7 +48,7 @@ def _get_run_table_schema(session_table_name: str = "agno_sessions") -> dict[str
         "created_at": {"type": BigInteger, "nullable": False, "index": True},
         "updated_at": {"type": BigInteger, "nullable": True},
         "_composite_indexes": [
-            {"name": "runs_session_id_run_index", "columns": ["session_id", "run_index"]},
+            {"name": "runs_session_id_created_at", "columns": ["session_id", "created_at"]},
         ],
     }
 

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -62,6 +62,9 @@ except ImportError:
 
 
 class AsyncPostgresDb(AsyncBaseDb):
+    # Indexed "most recent N runs" reads are supported (see BaseDb.supports_runs_limit).
+    supports_runs_limit: bool = True
+
     def __init__(
         self,
         id: Optional[str] = None,
@@ -649,8 +652,9 @@ class AsyncPostgresDb(AsyncBaseDb):
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
                 .order_by(
-                    func.coalesce(runs_table.c.run_index, 0).desc(),
-                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                    runs_table.c.created_at.desc(),
+                    runs_table.c.run_index.desc(),
+                    runs_table.c.run_id.desc(),
                 )
                 .limit(limit)
             )
@@ -662,8 +666,9 @@ class AsyncPostgresDb(AsyncBaseDb):
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
             .order_by(
-                func.coalesce(runs_table.c.run_index, 0).asc(),
-                func.coalesce(runs_table.c.created_at, 0).asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_index.asc(),
+                runs_table.c.run_id.asc(),
             )
         )
         result = await sess.execute(stmt)

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -86,6 +86,9 @@ except ImportError:
 
 
 class PostgresDb(BaseDb):
+    # Indexed "most recent N runs" reads are supported (see BaseDb.supports_runs_limit).
+    supports_runs_limit: bool = True
+
     def __init__(
         self,
         db_url: Optional[str] = None,
@@ -842,8 +845,9 @@ class PostgresDb(BaseDb):
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
                 .order_by(
-                    func.coalesce(runs_table.c.run_index, 0).desc(),
-                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                    runs_table.c.created_at.desc(),
+                    runs_table.c.run_index.desc(),
+                    runs_table.c.run_id.desc(),
                 )
                 .limit(limit)
             )
@@ -854,8 +858,9 @@ class PostgresDb(BaseDb):
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
             .order_by(
-                func.coalesce(runs_table.c.run_index, 0).asc(),
-                func.coalesce(runs_table.c.created_at, 0).asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_index.asc(),
+                runs_table.c.run_id.asc(),
             )
         )
         return [row[0] for row in sess.execute(stmt).fetchall()]

--- a/libs/agno/agno/db/postgres/schemas.py
+++ b/libs/agno/agno/db/postgres/schemas.py
@@ -59,9 +59,9 @@ def _get_run_table_schema(session_table_name: str = "agno_sessions") -> dict[str
         "created_at": {"type": BigInteger, "nullable": False, "index": True},
         "updated_at": {"type": BigInteger, "nullable": True},
         # Composite index so "most recent N runs of a session"
-        # (WHERE session_id=? ORDER BY run_index DESC LIMIT N) is index-served.
+        # (WHERE session_id=? ORDER BY created_at DESC LIMIT N) is index-served.
         "__composite_indexes__": [
-            {"name": "agno_runs_session_id_run_index", "columns": ["session_id", "run_index"]},
+            {"name": "agno_runs_session_id_created_at", "columns": ["session_id", "created_at"]},
         ],
     }
 

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -716,8 +716,13 @@ class RedisDb(BaseDb):
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
         create_index_if_not_found: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """Get all sessions matching the given filters.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. Defaults to True to
+        preserve existing behavior.
 
         Args:
             session_type (Optional[SessionType]): The type of session to filter by.
@@ -775,9 +780,13 @@ class RedisDb(BaseDb):
             sessions = [record for record in sessions]
 
             # Attach runs from the runs keys, merged with any legacy `runs` blob
-            for s in sessions:
-                runs_data = self._get_session_runs_data(s["session_id"])
-                s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+            if include_runs:
+                for s in sessions:
+                    runs_data = self._get_session_runs_data(s["session_id"])
+                    s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+            else:
+                for s in sessions:
+                    s["runs"] = None
 
             if not deserialize:
                 return sessions, len(filtered_sessions)

--- a/libs/agno/agno/db/singlestore/schemas.py
+++ b/libs/agno/agno/db/singlestore/schemas.py
@@ -52,7 +52,7 @@ def _get_run_table_schema(session_table_name: str = "agno_sessions") -> dict[str
         "created_at": {"type": BigInteger, "nullable": False, "index": True},
         "updated_at": {"type": BigInteger, "nullable": True},
         "_composite_indexes": [
-            {"name": "runs_session_id_run_index", "columns": ["session_id", "run_index"]},
+            {"name": "runs_session_id_created_at", "columns": ["session_id", "created_at"]},
         ],
     }
 

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -57,6 +57,9 @@ except ImportError:
 
 
 class SingleStoreDb(BaseDb):
+    # Indexed "most recent N runs" reads are supported (see BaseDb.supports_runs_limit).
+    supports_runs_limit: bool = True
+
     def __init__(
         self,
         id: Optional[str] = None,
@@ -614,8 +617,9 @@ class SingleStoreDb(BaseDb):
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
                 .order_by(
-                    func.coalesce(runs_table.c.run_index, 0).desc(),
-                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                    runs_table.c.created_at.desc(),
+                    runs_table.c.run_index.desc(),
+                    runs_table.c.run_id.desc(),
                 )
                 .limit(limit)
             )
@@ -626,8 +630,9 @@ class SingleStoreDb(BaseDb):
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
             .order_by(
-                func.coalesce(runs_table.c.run_index, 0).asc(),
-                func.coalesce(runs_table.c.created_at, 0).asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_index.asc(),
+                runs_table.c.run_id.asc(),
             )
         )
         return [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]
@@ -1014,9 +1019,14 @@ class SingleStoreDb(BaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """
         Get all sessions in the given table. Can filter by user_id and entity_id.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. Defaults to True to
+        preserve existing behavior.
 
         Args:
             session_type (Optional[SessionType]): The type of session to filter by.
@@ -1099,13 +1109,16 @@ class SingleStoreDb(BaseDb):
 
                 session = [dict(record._mapping) for record in records]
 
-                if runs_table is not None and session:
+                if include_runs and runs_table is not None and session:
                     runs_by_session = self._get_sessions_runs_data(
                         sess=sess, runs_table=runs_table, session_ids=[s["session_id"] for s in session]
                     )
                     for s in session:
                         runs_data = runs_by_session.get(s["session_id"], [])
                         s["runs"] = merge_runs_table_with_legacy_blob(runs_data, s.get("runs"))
+                elif not include_runs:
+                    for s in session:
+                        s["runs"] = None
 
                 if not deserialize:
                     return session, total_count

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -33,13 +33,13 @@ from agno.db.sqlite.utils import (
     serialize_cultural_knowledge_for_db,
 )
 from agno.db.utils import (
+    HISTORY_SKIP_STATUSES,
     CustomJSONEncoder,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
     deserialize_session_json_fields,
     deserialize_sessions,
-    HISTORY_SKIP_STATUSES,
     filter_context_runs,
     merge_runs_table_with_legacy_blob,
     serialize_session_json_fields,
@@ -63,6 +63,9 @@ except ImportError:
 
 
 class AsyncSqliteDb(AsyncBaseDb):
+    # Indexed "most recent N runs" reads are supported (see BaseDb.supports_runs_limit).
+    supports_runs_limit: bool = True
+
     def __init__(
         self,
         db_file: Optional[str] = None,
@@ -639,8 +642,9 @@ class AsyncSqliteDb(AsyncBaseDb):
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
                 .order_by(
-                    func.coalesce(runs_table.c.run_index, 0).desc(),
-                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                    runs_table.c.created_at.desc(),
+                    runs_table.c.run_index.desc(),
+                    runs_table.c.run_id.desc(),
                 )
                 .limit(limit)
             )
@@ -652,8 +656,9 @@ class AsyncSqliteDb(AsyncBaseDb):
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
             .order_by(
-                func.coalesce(runs_table.c.run_index, 0).asc(),
-                func.coalesce(runs_table.c.created_at, 0).asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_index.asc(),
+                runs_table.c.run_id.asc(),
             )
         )
         result = await sess.execute(stmt)

--- a/libs/agno/agno/db/sqlite/schemas.py
+++ b/libs/agno/agno/db/sqlite/schemas.py
@@ -57,9 +57,10 @@ def _get_run_table_schema(session_table_name: str = "agno_sessions") -> dict[str
         "created_at": {"type": BigInteger, "nullable": False, "index": True},
         "updated_at": {"type": BigInteger, "nullable": True},
         # Composite index so "most recent N runs of a session"
-        # (WHERE session_id=? ORDER BY run_index DESC LIMIT N) is index-served.
+        # (WHERE session_id=? ORDER BY created_at DESC LIMIT N) is index-served.
+        # Ordered by created_at (NOT NULL) rather than the nullable run_index.
         "__composite_indexes__": [
-            {"name": "agno_runs_session_id_run_index", "columns": ["session_id", "run_index"]},
+            {"name": "agno_runs_session_id_created_at", "columns": ["session_id", "created_at"]},
         ],
     }
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -40,15 +40,15 @@ from agno.db.sqlite.utils import (
     serialize_cultural_knowledge_for_db,
 )
 from agno.db.utils import (
+    HISTORY_SKIP_STATUSES,
     CustomJSONEncoder,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
     deserialize_session_json_fields,
     deserialize_sessions,
-    learning_search_patterns,
-    HISTORY_SKIP_STATUSES,
     filter_context_runs,
+    learning_search_patterns,
     merge_runs_table_with_legacy_blob,
     serialize_session_json_fields,
     validate_pagination,
@@ -72,6 +72,9 @@ except ImportError:
 
 
 class SqliteDb(BaseDb):
+    # Indexed "most recent N runs" reads are supported (see BaseDb.supports_runs_limit).
+    supports_runs_limit: bool = True
+
     def __init__(
         self,
         db_file: Optional[str] = None,
@@ -836,14 +839,19 @@ class SqliteDb(BaseDb):
         the in-memory history window.
         """
         if limit is not None:
+            # Order by created_at (NOT NULL) first so the newest runs are unambiguous
+            # even when run_index is NULL (a background/continue save can store NULL,
+            # which would sort to a backend-dependent extreme). run_index/run_id are
+            # deterministic tiebreakers. Served by the (session_id, created_at) index.
             stmt = (
                 select(runs_table.c.run_data)
                 .where(runs_table.c.session_id == session_id)
                 .where(runs_table.c.parent_run_id.is_(None))
                 .where(or_(runs_table.c.status.is_(None), runs_table.c.status.notin_(HISTORY_SKIP_STATUSES)))
                 .order_by(
-                    func.coalesce(runs_table.c.run_index, 0).desc(),
-                    func.coalesce(runs_table.c.created_at, 0).desc(),
+                    runs_table.c.created_at.desc(),
+                    runs_table.c.run_index.desc(),
+                    runs_table.c.run_id.desc(),
                 )
                 .limit(limit)
             )
@@ -854,8 +862,9 @@ class SqliteDb(BaseDb):
             select(runs_table.c.run_data)
             .where(runs_table.c.session_id == session_id)
             .order_by(
-                func.coalesce(runs_table.c.run_index, 0).asc(),
-                func.coalesce(runs_table.c.created_at, 0).asc(),
+                runs_table.c.created_at.asc(),
+                runs_table.c.run_index.asc(),
+                runs_table.c.run_id.asc(),
             )
         )
         return [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in sess.execute(stmt).fetchall()]

--- a/libs/agno/agno/db/surrealdb/surrealdb.py
+++ b/libs/agno/agno/db/surrealdb/surrealdb.py
@@ -639,9 +639,14 @@ class SurrealDb(BaseDb):
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         r"""
         Get all sessions in the given table. Can filter by user_id and entity_id.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. Defaults to True to
+        preserve existing behavior.
 
         Args:
             session_type (SessionType): The type of session to get.
@@ -744,7 +749,7 @@ class SurrealDb(BaseDb):
         converted_sessions_raw = [desurrealize_session(session) for session in sessions_raw]
 
         # Attach runs from the runs table, merged with legacy blob
-        if converted_sessions_raw:
+        if include_runs and converted_sessions_raw:
             try:
                 runs_by_session = self._get_sessions_runs_data(
                     [s["session_id"] for s in converted_sessions_raw if s.get("session_id")]
@@ -755,6 +760,9 @@ class SurrealDb(BaseDb):
                         s["runs"] = merge_runs_table_with_legacy_blob(runs_by_session.get(sid, []), s.get("runs"))
             except Exception as e:
                 log_error(f"Failed to attach runs to sessions: {str(e)}")
+        elif not include_runs:
+            for s in converted_sessions_raw:
+                s["runs"] = None
 
         if not deserialize:
             return list(converted_sessions_raw), total_count

--- a/libs/agno/agno/db/valkey/valkey.py
+++ b/libs/agno/agno/db/valkey/valkey.py
@@ -843,8 +843,13 @@ class ValkeyDb(BaseDb):
         sort_order: Optional[str] = None,
         deserialize: Optional[bool] = True,
         create_index_if_not_found: Optional[bool] = True,
+        include_runs: bool = True,
     ) -> Union[List[Session], Tuple[List[Dict[str, Any]], int]]:
         """Get all sessions matching the given filters.
+
+        Pass ``include_runs=False`` to skip attaching each session's run history —
+        a large, usually-unnecessary read for list views. Defaults to True to
+        preserve existing behavior.
 
         Args:
             session_type (Optional[SessionType]): The type of session to filter by.
@@ -906,9 +911,15 @@ class ValkeyDb(BaseDb):
             sessions = apply_pagination(records=sorted_sessions, limit=limit, page=page)
 
             # Attach runs from the runs keys, merged with any legacy `runs` blob
-            runs_by_session = self._get_sessions_runs_data([s["session_id"] for s in sessions])
-            for s in sessions:
-                s["runs"] = merge_runs_table_with_legacy_blob(runs_by_session.get(s["session_id"], []), s.get("runs"))
+            if include_runs:
+                runs_by_session = self._get_sessions_runs_data([s["session_id"] for s in sessions])
+                for s in sessions:
+                    s["runs"] = merge_runs_table_with_legacy_blob(
+                        runs_by_session.get(s["session_id"], []), s.get("runs")
+                    )
+            else:
+                for s in sessions:
+                    s["runs"] = None
 
             if not deserialize:
                 return sessions, len(filtered_sessions)

--- a/libs/agno/tests/unit/db/test_runs_limit.py
+++ b/libs/agno/tests/unit/db/test_runs_limit.py
@@ -137,8 +137,8 @@ class TestGetSessionsIncludeRuns:
 
 
 class TestSchemaHasNoBuilderBreakingMetadata:
-    """Every SQL adapter must ship the (session_id, run_index) composite index so
-    ``get_session(runs_limit=N)`` (WHERE session_id=? ORDER BY run_index DESC LIMIT N)
+    """Every SQL adapter must ship the (session_id, created_at) composite index so
+    ``get_session(runs_limit=N)`` (WHERE session_id=? ORDER BY created_at DESC LIMIT N)
     is index-served. Postgres/SQLite declare it under ``__composite_indexes__``;
     MySQL/SingleStore builders pop ``_composite_indexes`` before iterating columns."""
 
@@ -148,7 +148,7 @@ class TestSchemaHasNoBuilderBreakingMetadata:
 
         for schema in (mysql_runs(), singlestore_runs()):
             idx = schema.get("_composite_indexes", [])
-            assert any(i["columns"] == ["session_id", "run_index"] for i in idx)
+            assert any(i["columns"] == ["session_id", "created_at"] for i in idx)
             # Every remaining (column) entry must still be a real column config so the
             # builder's ``col_config["type"]`` access does not KeyError.
             for name, cfg in schema.items():
@@ -162,7 +162,7 @@ class TestSchemaHasNoBuilderBreakingMetadata:
 
         for schema in (pg_runs(), sqlite_runs()):
             idx = schema.get("__composite_indexes__", [])
-            assert any(i["columns"] == ["session_id", "run_index"] for i in idx)
+            assert any(i["columns"] == ["session_id", "created_at"] for i in idx)
 
 
 class TestBoundedHistoryGate:
@@ -197,6 +197,45 @@ class TestBoundedHistoryGate:
 
         db = SqliteDb(db_file=tempfile.mktemp(suffix=".db"))
         assert _bounded_history_runs_limit(self._agent(db), 3, [RunStatus.error]) is None
+
+    def test_unsupported_db_falls_back(self):
+        # An adapter that does not declare supports_runs_limit must never be bounded,
+        # so read_session never passes it an unexpected runs_limit kwarg.
+        from agno.agent._session import _bounded_history_runs_limit
+
+        assert _bounded_history_runs_limit(self._agent(InMemoryDb()), 3, None) is None
+
+
+class TestCapabilityFlag:
+    """supports_runs_limit gates the whole optimization; third-party BaseDb
+    subclasses on the old get_session signature must not receive runs_limit."""
+
+    def test_sql_adapters_declare_support(self):
+        assert SqliteDb.supports_runs_limit is True
+
+    def test_non_sql_adapters_do_not(self):
+        from agno.db.base import BaseDb
+
+        assert BaseDb.supports_runs_limit is False
+        assert InMemoryDb.supports_runs_limit is False
+        assert JsonDb.supports_runs_limit is False
+
+
+class TestIncludeRunsAccepted:
+    """Every adapter's get_sessions must accept include_runs (P2): a BaseDb-typed
+    caller can legally pass it, so a missing kwarg would be a runtime TypeError."""
+
+    def test_include_runs_false_omits_runs(self):
+        for make_db in (_make_inmemory, _make_json):
+            db = make_db(COMPLETED)
+            sessions, _ = db.get_sessions(deserialize=False, include_runs=False)
+            assert sessions, "expected sessions in the list"
+            assert all(not s.get("runs") for s in sessions)
+
+    def test_include_runs_true_is_default_behavior(self):
+        db = _make_json(COMPLETED)
+        with_runs, _ = db.get_sessions(deserialize=False, include_runs=True)
+        assert any(s.get("runs") for s in with_runs)
 
 
 _FILTER_SPECS = [
@@ -287,6 +326,16 @@ class TestRunsLimitNullRunIndex:
                 kwargs["run_index"] = run_index
             db.upsert_run(run, **kwargs)
         return db
+
+    def test_bounded_returns_the_actual_newest_runs(self):
+        # r2/r3 (NULL index) are the newest by created_at (1002/1003). Assert the
+        # concrete expected IDs -- not just parity with full-load -- so a COALESCE
+        # (run_index, 0) style ordering, which sorts NULL as *oldest*, would fail here.
+        db = self._make_mixed_index_db()
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=None)["runs"]) == ["r0", "r1", "r2", "r3"]
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=1)["runs"]) == ["r3"]
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=2)["runs"]) == ["r2", "r3"]
+        assert _ids(db.get_session("s1", deserialize=False, runs_limit=3)["runs"]) == ["r1", "r2", "r3"]
 
     def test_bounded_matches_full_load_slice_with_null_index(self):
         db = self._make_mixed_index_db()


### PR DESCRIPTION
## Summary

Post-merge review of the `runs_limit` read optimization surfaced three issues (2×P1, 1×P2). This PR fixes all three, on top of the merged work.

**[P1] NULL `run_index` misordered the bounded read.** The "most recent N runs" query ordered by `COALESCE(run_index, 0) DESC`, so a newer run with a NULL `run_index` (a background/continue save can persist NULL) collapsed to index `0` and sorted as the *oldest* — `runs_limit=N` returned the wrong window, differing per backend. COALESCE also prevented the `(session_id, run_index)` index from serving the sort.
- Order by `created_at` (NOT NULL) → `run_index` → `run_id`, no COALESCE, in the bounded **and** full-load branches of every SQL adapter (postgres, sqlite, mysql, singlestore + async).
- Change the composite index to `(session_id, created_at)` so the new `ORDER BY created_at` is index-served.
- Strengthened the NULL-index test to assert the concrete expected newest IDs, not just parity with full-load (the old test passed while both paths were wrong).

**[P1] `runs_limit` passed unconditionally.** `read_session` sent `runs_limit` to `db.get_session()` on every read, so a third-party `BaseDb` subclass implementing the pre-`runs_limit` signature raised `TypeError: unexpected keyword argument 'runs_limit'` on ordinary session reads. Restored the `supports_runs_limit` capability flag (`False` on `BaseDb`/`AsyncBaseDb`, `True` on the SQL adapters); `read_session`/`aread_session` and `_bounded_history_runs_limit` only pass/compute `runs_limit` when the adapter declares support, and omit the keyword otherwise.

**[P2] `include_runs` missing from 12 adapters.** It was added to the `BaseDb.get_sessions` interface but not to MySQL, SingleStore, Mongo, Redis, Dynamo, Firestore, SurrealDB, JSON, GCS-JSON, and Valkey `get_sessions`, so a `BaseDb`-typed caller passing `include_runs=False` hit a `TypeError`. Added the parameter (default `True`, current behavior) to every adapter and gated its run re-attach.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Tests added/updated

## Additional Notes

- Targets `feat/denormalize-sessions-table`.
- Tests: strengthened NULL-index ordering (asserts newest IDs), capability-flag gating (SQL=True, base/non-SQL=False), and `include_runs=False` acceptance across adapters.
- `test_runs_limit.py`: 35 passed. Broader `unit/db` (excluding modules that need uninstalled drivers): 504 passed; `unit/agent`: 529 passed. The only failures locally are pre-existing (valkey trace tests fail on the clean base too) or environmental (missing `pymongo`/`motor`/`pytest-mock`).
