### PR TITLE
fix: Team.load crashes on SQLite with unexpected keyword argument 'label'

### DIFF
--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -4453,12 +4453,14 @@ class SqliteDb(BaseDb):
         self,
         component_id: str,
         version: Optional[int] = None,
+        label: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Load a component with its full resolved graph.
 
         Args:
             component_id: The component ID.
             version: Specific version or None for current.
+            label: Optional label of the component.
 
         Returns:
             Dictionary with component, config, links, and resolved children.

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -18,6 +18,7 @@ import pytest
 
 from agno.agent.agent import Agent
 from agno.db.base import BaseDb, ComponentType
+from agno.db.sqlite import SqliteDb
 from agno.registry import Registry
 from agno.session import TeamSession
 from agno.team.team import Team, get_team_by_id, get_teams
@@ -813,6 +814,25 @@ class TestTeamLoad:
 
         assert team is not None
         assert team.db == mock_db
+
+    def test_load_round_trips_on_real_sqlite_db(self, tmp_path):
+        """Test save/load round-trips on a real SqliteDb.
+
+        The mock_db fixture accepts any call signature, so only a real backend
+        catches an override whose signature diverges from BaseDb (SqliteDb's
+        load_component_graph rejected the label kwarg that load() always passes).
+        """
+        db = SqliteDb(db_file=str(tmp_path / "team_load.db"))
+        team = Team(id="rt-team", name="Round Trip Team", members=[Agent(id="rt-agent", name="Round Trip Agent")])
+        team.save(db=db)
+
+        loaded = Team.load(id="rt-team", db=db)
+
+        assert loaded is not None
+        assert loaded.id == "rt-team"
+        assert loaded.name == "Round Trip Team"
+        assert len(loaded.members) == 1
+        assert loaded.members[0].id == "rt-agent"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Every `Team.load()` against a `SqliteDb` crashes:

```
TypeError: SqliteDb.load_component_graph() got an unexpected keyword argument 'label'
```

`Team.load` always forwards `label` to the backend — even when the caller never set one:

```
Team.load(id, db=SqliteDb(...))
  └─ team/_storage.py:1211    db.load_component_graph(id, version=version, label=label)   # label is ALWAYS passed
       └─ SqliteDb.load_component_graph(self, component_id, version)                      # no label param
            └─ TypeError
```

SQLite was the only backend whose override lacked the parameter:

| Backend | `load_component_graph` signature | Result |
|---|---|---|
| `BaseDb` (base.py) | declares `label: Optional[str] = None` | — |
| `PostgresDb` | declares `label` (accepts, ignores) | works |
| `AsyncSqliteDb` | declares `label` (raises `NotImplementedError` by design) | works |
| `SqliteDb` | **missing `label`** | **crashes on every `Team.load()`** |

### The fix

One parameter in `sqlite.py`:

```python
# before
def load_component_graph(
    self,
    component_id: str,
    version: Optional[int] = None,
) -> Optional[Dict[str, Any]]:

# after
def load_component_graph(
    self,
    component_id: str,
    version: Optional[int] = None,
    label: Optional[str] = None,
) -> Optional[Dict[str, Any]]:
```

Accept-and-ignore, matching Postgres exactly. Deliberately **no** SQLite-only label filtering: Postgres ignores `label` on this path too, and making one backend honor a parameter the other silently drops would be a worse inconsistency than the one this PR fixes (see the flag below).

### The test

`TestTeamLoad::test_load_round_trips_on_real_sqlite_db` — the first `Team.load` test against a real backend. The existing `TestTeamLoad` coverage uses a `MagicMock` db, which accepts any call signature and is exactly what hid this mismatch. The new test saves a team (with a member agent) to a real temp-file `SqliteDb` and loads it back. It fails with the `label` TypeError on the current code and passes with the fix.

## Flag for maintainers — `label` is accepted but ignored on this path (not fixed here)

Both `PostgresDb` and `SqliteDb` `load_component_graph` resolve `current_version` internally and call `get_config(component_id, version=resolved)`, never passing `label` through — even though `get_config` on both backends does support label lookup. So `Team.load(label="production")` silently loads the **current** version on every backend.

Note the failure-mode change on SQLite: before this PR a labeled load raised the TypeError above; after it, SQLite matches Postgres's silent behavior. Wiring `label` through properly (pass it to `get_config`, derive the resolved version from the returned row, use that version for links) is a cross-backend behavior change that needs its own tests on both backends — flagging it here rather than bundling it.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- `AsyncSqliteDb` needs no change: it already declares `label` and raises `NotImplementedError` (the documented async-components stance).
- A signature sweep of every `SqliteDb` override against `BaseDb` confirms this was the only divergence with a live caller: the only other mismatch is `get_spans` missing the base's `limit` parameter, which is latent — all six call sites pass only `trace_id`.
- `validate.sh` mypy baseline on `main` is 26 pre-existing errors; the error set is byte-identical before and after this change. `unit/team`: 546 passed, 1 skipped. `unit/db`: 245 passed (5 files need optional deps not in the dev venv: pymongo, clickhouse-connect, surrealdb — pre-existing).
