### PR TITLE
[fix] Correct the v1 to v2 migration script paths in the migrations README

### DIFF
--- a/libs/agno/migrations/README.md
+++ b/libs/agno/migrations/README.md
@@ -9,8 +9,8 @@ This is a guide on how to handle migrations for your Agno database.
 
 Before attempting this, make sure you have read the [Agno v2 Migration Guide](https://docs.agno.com/how-to/v2-migration) and are familiar with the changes in the new version.
 
-- For migrating your "Storage" and "Memory" databases, use our migration script: `libs/agno/scripts/v1_to_v2/migrate_to_v2.py`
-- For migrating your Vector Database, use our migration script: `libs/agno/scripts/v1_to_v2/migrate_to_v2_vector_db.py`
+- For migrating your "Storage" and "Memory" databases, use our migration script: `libs/agno/migrations/v1_to_v2/migrate_to_v2.py`
+- For migrating your Vector Database, use our migration script: `libs/agno/migrations/v1_to_v2/migrate_vectordbs_to_v2.py`
   
 Notice:
 - The script won’t cleanup the old tables, in case you still need them.


### PR DESCRIPTION
## Summary

Both bullets under "How to migrate from Agno v1 to v2" in `libs/agno/migrations/README.md` point at `libs/agno/scripts/v1_to_v2/`, a directory that does not exist. The scripts ship under `libs/agno/migrations/v1_to_v2/`.

The vector database bullet is wrong twice: wrong directory *and* wrong filename. It names `migrate_to_v2_vector_db.py`; the file is `migrate_vectordbs_to_v2.py`. That leaves `migrate_vectordbs_to_v2.py` with no working reference anywhere in the repository — a user upgrading from v1 has no in-repo way to find the vector database migration.

```
- `libs/agno/scripts/v1_to_v2/migrate_to_v2.py`             -> libs/agno/migrations/v1_to_v2/migrate_to_v2.py
- `libs/agno/scripts/v1_to_v2/migrate_to_v2_vector_db.py`   -> libs/agno/migrations/v1_to_v2/migrate_vectordbs_to_v2.py
```

Both corrected paths resolve against this branch. Documentation only; no code changes.

This is one of three items in #9343. It is independent of the other two and does not close the issue.

(Issue number: #9343)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — not applicable, Markdown only
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — not applicable
- [x] Tested in clean environment — verified both paths resolve from a fresh worktree at `upstream/main`
- [ ] Tests added/updated (if applicable) — not applicable

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The paths have been wrong since `libs/agno/migrations/README.md` was introduced in #5421.

Related work on the same issue:

- agno-agi/docs#747 adds a "Migrating your VectorDB" section to the v2 migration guide, which currently omits the step entirely.
- The third item — having `PgVector` warn when it opens a table that is missing the v2 columns, instead of failing at first write with `UndefinedColumn` — needs a design decision on where the check lives. I've raised it on #9343 and am holding that change until there's a direction.
