### PR TITLE
feat: preserve document images in Knowledge RAG

### DIFF
--- a/libs/agno/agno/knowledge/__init__.py
+++ b/libs/agno/agno/knowledge/__init__.py
@@ -1,4 +1,15 @@
 from agno.knowledge.filesystem import FileSystemKnowledge
+from agno.knowledge.image import (
+    KnowledgeImageRef,
+    KnowledgeImageStore,
+    LocalKnowledgeImageStore,
+    build_image_url,
+    build_markdown_image,
+    get_image_store,
+    save_image_markdown,
+    save_image_url,
+    set_image_store,
+)
 from agno.knowledge.knowledge import Knowledge
 from agno.knowledge.protocol import KnowledgeProtocol
 
@@ -6,4 +17,13 @@ __all__ = [
     "FileSystemKnowledge",
     "Knowledge",
     "KnowledgeProtocol",
+    "KnowledgeImageRef",
+    "KnowledgeImageStore",
+    "LocalKnowledgeImageStore",
+    "build_image_url",
+    "build_markdown_image",
+    "get_image_store",
+    "set_image_store",
+    "save_image_url",
+    "save_image_markdown",
 ]

--- a/libs/agno/agno/knowledge/image.py
+++ b/libs/agno/agno/knowledge/image.py
@@ -1,0 +1,282 @@
+"""Pluggable storage for knowledge document images.
+
+Preserves original images extracted by readers (e.g. DocxReader, DoclingReader)
+and serves them via stable URLs such as ``/knowledge/images/{content_id}/{image_id}``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import mimetypes
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Protocol, runtime_checkable
+from uuid import uuid4
+
+from agno.exceptions import PathSecurityError
+from agno.utils.log import log_debug, log_warning
+from agno.utils.path_safety import safe_join_filename, safe_join_relative_path
+
+DEFAULT_IMAGE_BASE_URL = "/knowledge/images"
+DEFAULT_MEDIA_TYPE = "image/png"
+
+
+@dataclass
+class KnowledgeImageRef:
+    """Stable reference to a stored knowledge image."""
+
+    image_id: str
+    content_id: str
+    media_type: str = DEFAULT_MEDIA_TYPE
+
+
+@runtime_checkable
+class KnowledgeImageStore(Protocol):
+    """Protocol for storing and serving knowledge document images."""
+
+    def save(
+        self,
+        *,
+        content_id: str,
+        data: bytes,
+        media_type: str = DEFAULT_MEDIA_TYPE,
+    ) -> KnowledgeImageRef:
+        """Persist image bytes and return a stable reference."""
+        ...
+
+    async def asave(
+        self,
+        *,
+        content_id: str,
+        data: bytes,
+        media_type: str = DEFAULT_MEDIA_TYPE,
+    ) -> KnowledgeImageRef:
+        """Async variant of :meth:`save`."""
+        ...
+
+    def delete(self, *, content_id: str, image_id: Optional[str] = None) -> None:
+        """Delete one image or all images for a content document."""
+        ...
+
+    async def adelete(self, *, content_id: str, image_id: Optional[str] = None) -> None:
+        """Async variant of :meth:`delete`."""
+        ...
+
+    def open(
+        self,
+        ref: KnowledgeImageRef,
+        *,
+        user_id: Optional[str] = None,
+        **context: Any,
+    ) -> bytes:
+        """Load image bytes. Custom stores may enforce authorization here."""
+        ...
+
+    async def aopen(
+        self,
+        ref: KnowledgeImageRef,
+        *,
+        user_id: Optional[str] = None,
+        **context: Any,
+    ) -> bytes:
+        """Async variant of :meth:`open`."""
+        ...
+
+
+def build_image_url(
+    ref: KnowledgeImageRef,
+    *,
+    image_base_url: str = DEFAULT_IMAGE_BASE_URL,
+) -> str:
+    """Build the fixed HTTP path for a stored image: ``/knowledge/images/{content_id}/{image_id}``."""
+    base = image_base_url.rstrip("/")
+    return f"{base}/{ref.content_id}/{ref.image_id}"
+
+
+def build_markdown_image(
+    ref: KnowledgeImageRef,
+    *,
+    image_base_url: str = DEFAULT_IMAGE_BASE_URL,
+    alt_text: str = "",
+) -> str:
+    """Return an inline image link ``![alt](url)`` for the stored image."""
+    return f"![{alt_text}]({build_image_url(ref, image_base_url=image_base_url)})"
+
+
+def save_image_url(
+    *,
+    content_id: str,
+    data: bytes,
+    media_type: str = DEFAULT_MEDIA_TYPE,
+    image_base_url: str = DEFAULT_IMAGE_BASE_URL,
+) -> str:
+    """Persist an image via the global store and return its public URL path."""
+    ref = get_image_store().save(content_id=content_id, data=data, media_type=media_type)
+    return build_image_url(ref, image_base_url=image_base_url)
+
+
+def save_image_markdown(
+    *,
+    content_id: str,
+    data: bytes,
+    media_type: str = DEFAULT_MEDIA_TYPE,
+    image_base_url: str = DEFAULT_IMAGE_BASE_URL,
+    alt_text: str = "",
+) -> str:
+    """Persist an image and return an inline image link: ``![alt](url)``.
+
+    This is a single markdown image tag for embedding in plain text, not a
+    markdown document conversion.
+    """
+    url = save_image_url(
+        content_id=content_id,
+        data=data,
+        media_type=media_type,
+        image_base_url=image_base_url,
+    )
+    return f"![{alt_text}]({url})"
+
+
+def _extension_for_media_type(media_type: str) -> str:
+    ext = mimetypes.guess_extension(media_type.split(";")[0].strip()) or ".png"
+    # guess_extension returns ".jpe" for image/jpeg on some platforms
+    if ext in {".jpe", ".jpeg"}:
+        return ".jpg"
+    return ext
+
+
+def _generate_image_id(data: bytes) -> str:
+    digest = hashlib.md5(data).hexdigest()[:8]
+    return f"img-{uuid4().hex[:8]}-{digest}"
+
+
+@dataclass
+class LocalKnowledgeImageStore:
+    """Filesystem-backed knowledge image store.
+
+    Layout: ``{base_dir}/{content_id}/{image_id}{ext}``
+    """
+
+    base_dir: str = "doc_images"
+
+    def __post_init__(self) -> None:
+        self._base_path = Path(self.base_dir)
+        self._base_path.mkdir(parents=True, exist_ok=True)
+
+    def save(
+        self,
+        *,
+        content_id: str,
+        data: bytes,
+        media_type: str = DEFAULT_MEDIA_TYPE,
+    ) -> KnowledgeImageRef:
+        content_id = _sanitize_id(content_id, "content_id")
+        image_id = _generate_image_id(data)
+        extension = _extension_for_media_type(media_type)
+        content_dir = safe_join_relative_path(self._base_path, content_id)
+        content_dir.mkdir(parents=True, exist_ok=True)
+        path = safe_join_filename(content_dir, f"{image_id}{extension}")
+        path.write_bytes(data)
+        log_debug(f"Saved knowledge image: {path}")
+        return KnowledgeImageRef(image_id=image_id, content_id=content_id, media_type=media_type)
+
+    async def asave(
+        self,
+        *,
+        content_id: str,
+        data: bytes,
+        media_type: str = DEFAULT_MEDIA_TYPE,
+    ) -> KnowledgeImageRef:
+        import asyncio
+
+        return await asyncio.to_thread(self.save, content_id=content_id, data=data, media_type=media_type)
+
+    def delete(self, *, content_id: str, image_id: Optional[str] = None) -> None:
+        import shutil
+
+        content_id = _sanitize_id(content_id, "content_id")
+        content_dir = safe_join_relative_path(self._base_path, content_id)
+        if not content_dir.exists():
+            return
+
+        if image_id is None:
+            shutil.rmtree(content_dir, ignore_errors=True)
+            log_debug(f"Deleted knowledge images for content: {content_id}")
+            return
+
+        image_id = _sanitize_id(image_id, "image_id")
+        removed = False
+        for path in content_dir.glob(f"{image_id}.*"):
+            try:
+                path.unlink(missing_ok=True)
+                removed = True
+            except OSError as e:
+                log_warning(f"Failed to delete knowledge image {path}: {e}")
+        if removed and content_dir.exists() and not any(content_dir.iterdir()):
+            content_dir.rmdir()
+
+    async def adelete(self, *, content_id: str, image_id: Optional[str] = None) -> None:
+        import asyncio
+
+        await asyncio.to_thread(self.delete, content_id=content_id, image_id=image_id)
+
+    def open(
+        self,
+        ref: KnowledgeImageRef,
+        *,
+        user_id: Optional[str] = None,
+        **context: Any,
+    ) -> bytes:
+        # Local default ignores user_id; custom stores may authorize here.
+        _ = user_id, context
+        content_id = _sanitize_id(ref.content_id, "content_id")
+        image_id = _sanitize_id(ref.image_id, "image_id")
+        content_dir = safe_join_relative_path(self._base_path, content_id)
+        matches = sorted(content_dir.glob(f"{image_id}.*"))
+        if not matches:
+            raise FileNotFoundError(f"Knowledge image not found: {content_id}/{image_id}")
+        path = matches[0]
+        guessed, _ = mimetypes.guess_type(path.name)
+        if guessed:
+            ref.media_type = guessed
+        return path.read_bytes()
+
+    async def aopen(
+        self,
+        ref: KnowledgeImageRef,
+        *,
+        user_id: Optional[str] = None,
+        **context: Any,
+    ) -> bytes:
+        import asyncio
+
+        return await asyncio.to_thread(self.open, ref, user_id=user_id, **context)
+
+
+# Process-wide store shared by readers, Knowledge cleanup, and AgentOS image routes.
+_image_store: Optional[KnowledgeImageStore] = None
+
+
+def get_image_store() -> KnowledgeImageStore:
+    """Return the global knowledge image store, creating a local default if needed."""
+    global _image_store
+    if _image_store is None:
+        _image_store = LocalKnowledgeImageStore()
+    return _image_store
+
+
+def set_image_store(store: Optional[KnowledgeImageStore]) -> None:
+    """Replace the global knowledge image store (e.g. at application startup)."""
+    global _image_store
+    _image_store = store
+
+
+def _sanitize_id(value: str, field_name: str) -> str:
+    if not value or not value.strip():
+        raise PathSecurityError(f"Invalid {field_name}: {value!r}")
+    # IDs are single path segments; reject separators up front.
+    if "/" in value or "\\" in value or ".." in value:
+        raise PathSecurityError(f"Invalid {field_name}: {value!r}")
+    from agno.utils.path_safety import sanitize_filename
+
+    return sanitize_filename(value)

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -969,9 +969,17 @@ class Knowledge(RemoteKnowledge):
         return self.readers.get(reader_type)
 
     def _select_reader(self, extension: str) -> Reader:
-        """Select the appropriate reader for a file extension."""
+        """Select the appropriate reader for a file extension or MIME type.
+
+        Prefers ``Knowledge.readers`` (via ``_get_reader``), falling back to
+        ``ReaderFactory`` when the key is not already configured.
+        """
         log_info(f"Selecting reader for extension: {extension}")
-        return ReaderFactory.get_reader_for_extension(extension)
+        key = ReaderFactory.get_reader_key_for_extension(extension)
+        reader = self._get_reader(key)
+        if reader is None:
+            raise ValueError(f"No reader for extension: {extension}")
+        return reader
 
     def _should_include_file(self, file_path: str, include: Optional[List[str]], exclude: Optional[List[str]]) -> bool:
         """
@@ -1184,22 +1192,10 @@ class Knowledge(RemoteKnowledge):
             return provided_reader, ""
 
         file_extension = file_extension.lower()
-        if file_extension == ".csv":
-            return self.csv_reader, "data.csv"
-        elif file_extension == ".pdf":
-            return self.pdf_reader, ""
-        elif file_extension == ".docx":
-            return self.docx_reader, ""
-        elif file_extension == ".pptx":
-            return self.pptx_reader, ""
-        elif file_extension == ".json":
-            return self.json_reader, ""
-        elif file_extension == ".markdown":
-            return self.markdown_reader, ""
-        elif file_extension in [".xlsx", ".xls"]:
-            return self.excel_reader, ""
-        else:
-            return self.text_reader, ""
+        key = ReaderFactory.get_reader_key_for_extension(file_extension)
+        # Preserve historical default name for CSV uploads without an explicit name.
+        name = "data.csv" if key == "csv" else ""
+        return self._get_reader(key), name
 
     def _select_reader_by_uri(self, uri: str, provided_reader: Optional[Reader] = None) -> Optional[Reader]:
         """
@@ -1215,23 +1211,12 @@ class Knowledge(RemoteKnowledge):
         if provided_reader:
             return provided_reader
 
-        uri_lower = uri.lower()
-        if uri_lower.endswith(".pdf"):
-            return self.pdf_reader
-        elif uri_lower.endswith(".csv"):
-            return self.csv_reader
-        elif uri_lower.endswith(".docx"):
-            return self.docx_reader
-        elif uri_lower.endswith(".pptx"):
-            return self.pptx_reader
-        elif uri_lower.endswith(".json"):
-            return self.json_reader
-        elif uri_lower.endswith(".markdown"):
-            return self.markdown_reader
-        elif uri_lower.endswith(".xlsx") or uri_lower.endswith(".xls"):
-            return self.excel_reader
-        else:
-            return self.text_reader
+        # Strip query/fragment so Path.suffix sees the real extension.
+        path_part = uri.split("?", 1)[0].split("#", 1)[0]
+        extension = Path(path_part).suffix.lower()
+        if not extension:
+            return self._get_reader("text")
+        return self._get_reader(ReaderFactory.get_reader_key_for_extension(extension))
 
     def _delete_content_images(self, content_id: str) -> None:
         if not content_id:
@@ -1403,7 +1388,7 @@ class Knowledge(RemoteKnowledge):
                 if content.reader:
                     reader = content.reader
                 else:
-                    reader = ReaderFactory.get_reader_for_extension(path.suffix)
+                    reader = self._select_reader(path.suffix)
                     log_debug(f"Using Reader: {reader.__class__.__name__}")
 
                 if reader:
@@ -1492,7 +1477,7 @@ class Knowledge(RemoteKnowledge):
                 if content.reader:
                     reader = content.reader
                 else:
-                    reader = ReaderFactory.get_reader_for_extension(path.suffix)
+                    reader = self._select_reader(path.suffix)
                     log_debug(f"Using Reader: {reader.__class__.__name__}")
 
                 if reader:

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -17,6 +17,7 @@ from agno.db.schemas.knowledge import KnowledgeRow
 from agno.filters import EQ, FilterExpr
 from agno.knowledge.content import Content, ContentAuth, ContentStatus, FileData
 from agno.knowledge.document import Document
+from agno.knowledge.image import get_image_store
 from agno.knowledge.reader import Reader, ReaderFactory
 from agno.knowledge.remote_content.base import BaseStorageConfig
 from agno.knowledge.remote_content.remote_content import (
@@ -715,6 +716,8 @@ class Knowledge(RemoteKnowledge):
         if self.contents_db is not None:
             self.contents_db.delete_knowledge_content(content_id)
 
+        self._delete_content_images(content_id)
+
     async def aremove_content_by_id(self, content_id: str):
         if self.vector_db is not None:
             if self.vector_db.__class__.__name__ == "LightRag":
@@ -732,6 +735,8 @@ class Knowledge(RemoteKnowledge):
                 await self.contents_db.delete_knowledge_content(content_id)
             else:
                 self.contents_db.delete_knowledge_content(content_id)
+
+        await self._adelete_content_images(content_id)
 
     def remove_all_content(self):
         contents, _ = self.get_content()
@@ -1228,12 +1233,29 @@ class Knowledge(RemoteKnowledge):
         else:
             return self.text_reader
 
+    def _delete_content_images(self, content_id: str) -> None:
+        if not content_id:
+            return
+        try:
+            get_image_store().delete(content_id=content_id)
+        except Exception as e:
+            log_warning(f"Failed to delete knowledge images for content {content_id}: {e}")
+
+    async def _adelete_content_images(self, content_id: str) -> None:
+        if not content_id:
+            return
+        try:
+            await get_image_store().adelete(content_id=content_id)
+        except Exception as e:
+            log_warning(f"Failed to delete knowledge images for content {content_id}: {e}")
+
     def _read(
         self,
         reader: Reader,
         source: Union[Path, str, BytesIO],
         name: Optional[str] = None,
         password: Optional[str] = None,
+        content: Optional[Content] = None,
     ) -> List[Document]:
         """
         Read content using a reader with optional password handling.
@@ -1243,6 +1265,7 @@ class Knowledge(RemoteKnowledge):
             source: Source to read from (Path, URL string, or BytesIO)
             name: Optional name for the document
             password: Optional password for protected files
+            content: Optional content metadata used for image context
 
         Returns:
             List of documents read
@@ -1250,16 +1273,16 @@ class Knowledge(RemoteKnowledge):
         import inspect
 
         read_signature = inspect.signature(reader.read)
+        content_id = content.id if content is not None else None
+        include_content_id = content_id is not None and "content_id" in read_signature.parameters
         if password is not None and "password" in read_signature.parameters:
-            if isinstance(source, BytesIO):
-                return reader.read(source, name=name, password=password)
-            else:
-                return reader.read(source, name=name, password=password)
+            if include_content_id:
+                return reader.read(source, name=name, password=password, content_id=content_id)
+            return reader.read(source, name=name, password=password)
         else:
-            if isinstance(source, BytesIO):
-                return reader.read(source, name=name)
-            else:
-                return reader.read(source, name=name)
+            if include_content_id:
+                return reader.read(source, name=name, content_id=content_id)
+            return reader.read(source, name=name)
 
     async def _aread(
         self,
@@ -1267,6 +1290,7 @@ class Knowledge(RemoteKnowledge):
         source: Union[Path, str, BytesIO],
         name: Optional[str] = None,
         password: Optional[str] = None,
+        content: Optional[Content] = None,
     ) -> List[Document]:
         """
         Read content using a reader's async_read method with optional password handling.
@@ -1276,6 +1300,7 @@ class Knowledge(RemoteKnowledge):
             source: Source to read from (Path, URL string, or BytesIO)
             name: Optional name for the document
             password: Optional password for protected files
+            content: Optional content metadata used for image context
 
         Returns:
             List of documents read
@@ -1283,13 +1308,16 @@ class Knowledge(RemoteKnowledge):
         import inspect
 
         read_signature = inspect.signature(reader.async_read)
+        content_id = content.id if content is not None else None
+        include_content_id = content_id is not None and "content_id" in read_signature.parameters
         if password is not None and "password" in read_signature.parameters:
+            if include_content_id:
+                return await reader.async_read(source, name=name, password=password, content_id=content_id)
             return await reader.async_read(source, name=name, password=password)
         else:
-            if isinstance(source, BytesIO):
-                return await reader.async_read(source, name=name)
-            else:
-                return await reader.async_read(source, name=name)
+            if include_content_id:
+                return await reader.async_read(source, name=name, content_id=content_id)
+            return await reader.async_read(source, name=name)
 
     def _prepare_documents_for_insert(
         self,
@@ -1380,7 +1408,11 @@ class Knowledge(RemoteKnowledge):
 
                 if reader:
                     password = content.auth.password if content.auth and content.auth.password is not None else None
-                    read_documents = await self._aread(reader, path, name=content.name or path.name, password=password)
+                    if content.id:
+                        await self._adelete_content_images(content.id)
+                    read_documents = await self._aread(
+                        reader, path, name=content.name or path.name, password=password, content=content
+                    )
                 else:
                     read_documents = []
 
@@ -1465,7 +1497,11 @@ class Knowledge(RemoteKnowledge):
 
                 if reader:
                     password = content.auth.password if content.auth and content.auth.password is not None else None
-                    read_documents = self._read(reader, path, name=content.name or path.name, password=password)
+                    if content.id:
+                        self._delete_content_images(content.id)
+                    read_documents = self._read(
+                        reader, path, name=content.name or path.name, password=password, content=content
+                    )
                 else:
                     read_documents = []
 
@@ -1604,7 +1640,7 @@ class Knowledge(RemoteKnowledge):
                 else:
                     password = content.auth.password if content.auth and content.auth.password is not None else None
                     source = bytes_content if bytes_content else content.url
-                    read_documents = await self._aread(reader, source, name=name, password=password)
+                    read_documents = await self._aread(reader, source, name=name, password=password, content=content)
 
         except Exception as e:
             log_error(f"Error reading URL: {content.url}: {str(e)}")
@@ -1759,7 +1795,7 @@ class Knowledge(RemoteKnowledge):
                 else:
                     password = content.auth.password if content.auth and content.auth.password is not None else None
                     source = bytes_content if bytes_content else content.url
-                    read_documents = self._read(reader, source, name=name, password=password)
+                    read_documents = self._read(reader, source, name=name, password=password, content=content)
 
         except Exception as e:
             log_error(f"Error reading URL: {content.url}: {str(e)}")
@@ -1866,11 +1902,11 @@ class Knowledge(RemoteKnowledge):
 
             if content.reader:
                 log_debug(f"Using reader: {content.reader.__class__.__name__} to read content")
-                read_documents = await content.reader.async_read(content_io, name=name)
+                read_documents = await self._aread(content.reader, content_io, name=name, content=content)
             else:
                 text_reader = self.text_reader
                 if text_reader:
-                    read_documents = await text_reader.async_read(content_io, name=name)
+                    read_documents = await self._aread(text_reader, content_io, name=name, content=content)
                 else:
                     content.status = ContentStatus.FAILED
                     content.status_message = "Text reader not available"
@@ -1902,9 +1938,10 @@ class Knowledge(RemoteKnowledge):
                     reader = self._select_reader(reader_hint)
                 # Use file_data.filename for reader (preserves extension for format detection)
                 reader_name = content.file_data.filename or content.name or f"content_{content.file_data.type}"
-                read_documents = await reader.async_read(content_io, name=reader_name)
                 if not content.id:
                     content.id = generate_id(content.content_hash or "")
+                await self._adelete_content_images(content.id)
+                read_documents = await self._aread(reader, content_io, name=reader_name, content=content)
                 self._prepare_documents_for_insert(read_documents, content.id, metadata=content.metadata)
 
                 if len(read_documents) == 0:
@@ -1973,11 +2010,11 @@ class Knowledge(RemoteKnowledge):
 
             if content.reader:
                 log_debug(f"Using reader: {content.reader.__class__.__name__} to read content")
-                read_documents = content.reader.read(content_io, name=name)
+                read_documents = self._read(content.reader, content_io, name=name, content=content)
             else:
                 text_reader = self.text_reader
                 if text_reader:
-                    read_documents = text_reader.read(content_io, name=name)
+                    read_documents = self._read(text_reader, content_io, name=name, content=content)
                 else:
                     content.status = ContentStatus.FAILED
                     content.status_message = "Text reader not available"
@@ -2009,9 +2046,10 @@ class Knowledge(RemoteKnowledge):
                     reader = self._select_reader(reader_hint)
                 # Use file_data.filename for reader (preserves extension for format detection)
                 reader_name = content.file_data.filename or content.name or f"content_{content.file_data.type}"
-                read_documents = reader.read(content_io, name=reader_name)
                 if not content.id:
                     content.id = generate_id(content.content_hash or "")
+                self._delete_content_images(content.id)
+                read_documents = self._read(reader, content_io, name=reader_name, content=content)
                 self._prepare_documents_for_insert(read_documents, content.id, metadata=content.metadata)
 
                 if len(read_documents) == 0:

--- a/libs/agno/agno/knowledge/reader/base.py
+++ b/libs/agno/agno/knowledge/reader/base.py
@@ -56,7 +56,13 @@ class Reader:
         except ValueError as e:
             raise ValueError(f"Failed to set chunking strategy: {e}")
 
-    def read(self, obj: Any, name: Optional[str] = None, password: Optional[str] = None) -> List[Document]:
+    def read(
+        self,
+        obj: Any,
+        name: Optional[str] = None,
+        password: Optional[str] = None,
+        content_id: Optional[str] = None,
+    ) -> List[Document]:
         """Read ``obj`` and return the resulting documents.
 
         Subclasses must honor ``self.chunk``. When ``self.chunk``
@@ -64,10 +70,22 @@ class Reader:
         when False, return whole documents unchanged. Ingestion does not chunk on
         the reader's behalf, so a reader that ignores ``self.chunk`` will silently
         drop the caller's chunking preference.
+
+        ``content_id`` is the Knowledge content id for this insert. Readers that
+        preserve images (or otherwise need a stable content-scoped id) should use
+        it. Callers that still use an older ``read`` signature without
+        ``content_id`` continue to work: Knowledge only passes the argument when
+        it is present on the method signature.
         """
         raise NotImplementedError
 
-    async def async_read(self, obj: Any, name: Optional[str] = None, password: Optional[str] = None) -> List[Document]:
+    async def async_read(
+        self,
+        obj: Any,
+        name: Optional[str] = None,
+        password: Optional[str] = None,
+        content_id: Optional[str] = None,
+    ) -> List[Document]:
         """Async variant of :meth:`read`. Subclasses must honor ``self.chunk`` (see :meth:`read`)."""
         raise NotImplementedError
 

--- a/libs/agno/agno/knowledge/reader/docling_reader.py
+++ b/libs/agno/agno/knowledge/reader/docling_reader.py
@@ -358,23 +358,14 @@ class DoclingReader(Reader):
             return result.document.export_to_markdown()
 
         try:
-            markdown = result.document.export_to_markdown(image_mode=ImageRefMode.REFERENCED)
+            return result.document.export_to_markdown(image_mode=ImageRefMode.REFERENCED)
         except TypeError:
+            # Older docling versions may not accept image_mode on export_to_markdown.
             log_warning("Docling export_to_markdown does not accept image_mode; exporting without it")
-            markdown = result.document.export_to_markdown()
+            return result.document.export_to_markdown()
         except Exception as e:
             log_warning(f"Docling referenced markdown export failed: {e}")
-            markdown = result.document.export_to_markdown()
-
-        if any(url in markdown for url in image_urls):
-            return markdown
-
-        # Fallback when URI rewrite did not stick (e.g. older Docling / Windows Path).
-        for url in image_urls:
-            if "<!-- image -->" not in markdown:
-                break
-            markdown = markdown.replace("<!-- image -->", f"![]({url})", 1)
-        return markdown
+            return result.document.export_to_markdown()
 
     async def async_read(
         self, file: Union[Path, str, IO[Any]], name: Optional[str] = None, content_id: Optional[str] = None

--- a/libs/agno/agno/knowledge/reader/docling_reader.py
+++ b/libs/agno/agno/knowledge/reader/docling_reader.py
@@ -8,14 +8,18 @@ from uuid import uuid4
 from agno.knowledge.chunking.document import DocumentChunking
 from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
 from agno.knowledge.document.base import Document
+from agno.knowledge.image import (
+    DEFAULT_IMAGE_BASE_URL,
+    save_image_url,
+)
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.reader.utils.url_validation import is_host_allowed, validate_allowed_hosts
 from agno.knowledge.types import ContentType
-from agno.utils.log import log_debug, log_error
+from agno.utils.log import log_debug, log_error, log_warning
 
 try:
-    from docling.datamodel.base_models import DocumentStream, OutputFormat
-    from docling.document_converter import DocumentConverter
+    from docling.datamodel.base_models import DocumentStream, InputFormat, OutputFormat
+    from docling.document_converter import DocumentConverter, PdfFormatOption
 except ImportError:
     raise ImportError("The `docling` package is not installed. Please install it via `pip install docling`.")
 
@@ -45,6 +49,9 @@ class DoclingReader(Reader):
 
     Converts all formats into a unified DoclingDocument representation,
     then exports to markdown, text, json, html, doctags, etc.
+
+    Set ``preserve_images=True`` to extract figures, persist them via
+    the global image store, and keep fixed markdown image links in reading order.
     """
 
     def __init__(
@@ -54,6 +61,8 @@ class DoclingReader(Reader):
         converter: Optional[DocumentConverter] = None,
         format_options: Optional[Dict[Any, Any]] = None,
         allowed_hosts: Optional[List[str]] = None,
+        preserve_images: bool = False,
+        image_base_url: str = DEFAULT_IMAGE_BASE_URL,
         **kwargs,
     ):
         """Initialize the DoclingReader.
@@ -74,6 +83,9 @@ class DoclingReader(Reader):
             allowed_hosts: Optional hostname allowlist for URL inputs. When set, only URLs
                 whose hostname is in the list are converted; others are refused. When None
                 (default), all hosts are allowed (backwards compatible).
+            preserve_images: When True (and ``output_format="markdown"``), extract
+                figures and insert fixed markdown links. Ignored for other formats.
+            image_base_url: Public URL prefix for markdown image links.
             **kwargs: Additional arguments passed to the Reader class
         """
         if chunking_strategy is None:
@@ -87,14 +99,39 @@ class DoclingReader(Reader):
                 f"Invalid output format: '{output_format}'. Valid options: {list(OUTPUT_FORMAT_MAP.keys())}"
             )
 
+        self.preserve_images = preserve_images
+        images_enabled = preserve_images and self.output_format == OutputFormat.MARKDOWN
+        if preserve_images and not images_enabled:
+            log_warning("preserve_images only applies when output_format='markdown'; ignoring")
+        self.image_base_url = image_base_url
+
         if converter is not None:
             self.converter = converter
         elif format_options is not None:
             self.converter = DocumentConverter(format_options=format_options)
+        elif images_enabled:
+            self.converter = self._build_image_aware_converter()
         else:
             self.converter = DocumentConverter()
 
         self.allowed_hosts: Optional[List[str]] = validate_allowed_hosts(allowed_hosts)
+
+    @staticmethod
+    def _build_image_aware_converter() -> DocumentConverter:
+        """Configure Docling to keep picture images for referenced markdown export."""
+        try:
+            from docling.datamodel.pipeline_options import PdfPipelineOptions
+        except ImportError:
+            log_warning("PdfPipelineOptions unavailable; Docling may not preserve picture images")
+            return DocumentConverter()
+
+        pipeline_options = PdfPipelineOptions()
+        pipeline_options.generate_picture_images = True
+        return DocumentConverter(
+            format_options={
+                InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
+            }
+        )
 
     @classmethod
     def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:
@@ -174,13 +211,17 @@ class DoclingReader(Reader):
             ContentType.VIDEO_MOV,
         ]
 
-    def read(self, file: Union[Path, str, IO[Any]], name: Optional[str] = None) -> List[Document]:
+    def read(
+        self, file: Union[Path, str, IO[Any]], name: Optional[str] = None, content_id: Optional[str] = None
+    ) -> List[Document]:
         """Reads document using Docling.
 
         Args:
             file: Path to file, file path string, URL, or file-like object.
                  URLs starting with http:// or https:// are supported.
             name: Optional name for the document
+            content_id: Knowledge content id for image storage paths. Required when
+                ``preserve_images=True`` (passed by Knowledge on each insert).
 
         Returns:
             List of Document objects
@@ -228,7 +269,9 @@ class DoclingReader(Reader):
 
             result = self.converter.convert(source)
 
-            if self.output_format == OutputFormat.TEXT:
+            if self.preserve_images and self.output_format == OutputFormat.MARKDOWN:
+                doc_content = self._export_markdown_with_images(result, content_id=content_id)
+            elif self.output_format == OutputFormat.TEXT:
                 doc_content = result.document.export_to_text()
             elif self.output_format == OutputFormat.JSON:
                 doc_content = json.dumps(result.document.export_to_dict(), ensure_ascii=False)
@@ -271,10 +314,74 @@ class DoclingReader(Reader):
             log_error(f"Error converting document: {file}: {str(e)}")
             return []
 
-    async def async_read(self, file: Union[Path, str, IO[Any]], name: Optional[str] = None) -> List[Document]:
+    def _export_markdown_with_images(self, result: Any, *, content_id: Optional[str]) -> str:
+        """Export markdown with figures saved through KnowledgeImageStore."""
+        try:
+            from docling_core.types.doc import ImageRefMode, PictureItem
+        except ImportError:
+            log_warning("docling_core ImageRefMode unavailable; falling back to plain markdown")
+            return result.document.export_to_markdown()
+
+        if not content_id:
+            raise ValueError("content_id is required when preserve_images=True")
+
+        image_urls: List[str] = []
+        try:
+            for element, _level in result.document.iterate_items():
+                if not isinstance(element, PictureItem):
+                    continue
+                image = element.get_image(result.document)
+                if image is None:
+                    continue
+                buffer = BytesIO()
+                image.save(buffer, format="PNG")
+                url = save_image_url(
+                    content_id=content_id,
+                    data=buffer.getvalue(),
+                    media_type="image/png",
+                    image_base_url=self.image_base_url,
+                )
+                image_urls.append(url)
+                # Docling's ImageRef.uri is Union[AnyUrl, Path]. Absolute app paths
+                # like ``/knowledge/images/...`` are not valid AnyUrl values, but Path
+                # round-trips correctly into REFERENCED markdown.
+                image_ref = getattr(element, "image", None)
+                if image_ref is not None and hasattr(image_ref, "uri"):
+                    try:
+                        image_ref.uri = Path(url)
+                    except Exception as e:
+                        log_debug(f"Could not rewrite Docling picture URI to Path: {e}")
+        except Exception as e:
+            log_warning(f"Failed while extracting Docling pictures: {e}")
+
+        if not image_urls:
+            return result.document.export_to_markdown()
+
+        try:
+            markdown = result.document.export_to_markdown(image_mode=ImageRefMode.REFERENCED)
+        except TypeError:
+            log_warning("Docling export_to_markdown does not accept image_mode; exporting without it")
+            markdown = result.document.export_to_markdown()
+        except Exception as e:
+            log_warning(f"Docling referenced markdown export failed: {e}")
+            markdown = result.document.export_to_markdown()
+
+        if any(url in markdown for url in image_urls):
+            return markdown
+
+        # Fallback when URI rewrite did not stick (e.g. older Docling / Windows Path).
+        for url in image_urls:
+            if "<!-- image -->" not in markdown:
+                break
+            markdown = markdown.replace("<!-- image -->", f"![]({url})", 1)
+        return markdown
+
+    async def async_read(
+        self, file: Union[Path, str, IO[Any]], name: Optional[str] = None, content_id: Optional[str] = None
+    ) -> List[Document]:
         """Asynchronously read a docling file and return a list of documents."""
         try:
-            return await asyncio.to_thread(self.read, file, name)
+            return await asyncio.to_thread(self.read, file, name=name, content_id=content_id)
         except (FileNotFoundError, ValueError):
             raise
         except Exception as e:

--- a/libs/agno/agno/knowledge/reader/docling_reader.py
+++ b/libs/agno/agno/knowledge/reader/docling_reader.py
@@ -63,6 +63,7 @@ class DoclingReader(Reader):
         allowed_hosts: Optional[List[str]] = None,
         preserve_images: bool = False,
         image_base_url: str = DEFAULT_IMAGE_BASE_URL,
+        images_scale: float = 2.0,
         **kwargs,
     ):
         """Initialize the DoclingReader.
@@ -86,6 +87,10 @@ class DoclingReader(Reader):
             preserve_images: When True (and ``output_format="markdown"``), extract
                 figures and insert fixed markdown links. Ignored for other formats.
             image_base_url: Public URL prefix for markdown image links.
+            images_scale: Docling render scale used when ``preserve_images=True``.
+                Docling crops page-rendered figure regions (not original embedded
+                assets); ``1.0`` is display size and often looks soft. Default
+                ``2.0`` is sharper; try ``3.0`` for higher fidelity (slower, larger).
             **kwargs: Additional arguments passed to the Reader class
         """
         if chunking_strategy is None:
@@ -100,6 +105,7 @@ class DoclingReader(Reader):
             )
 
         self.preserve_images = preserve_images
+        self.images_scale = images_scale
         images_enabled = preserve_images and self.output_format == OutputFormat.MARKDOWN
         if preserve_images and not images_enabled:
             log_warning("preserve_images only applies when output_format='markdown'; ignoring")
@@ -110,14 +116,14 @@ class DoclingReader(Reader):
         elif format_options is not None:
             self.converter = DocumentConverter(format_options=format_options)
         elif images_enabled:
-            self.converter = self._build_image_aware_converter()
+            self.converter = self._build_image_aware_converter(images_scale=images_scale)
         else:
             self.converter = DocumentConverter()
 
         self.allowed_hosts: Optional[List[str]] = validate_allowed_hosts(allowed_hosts)
 
     @staticmethod
-    def _build_image_aware_converter() -> DocumentConverter:
+    def _build_image_aware_converter(images_scale: float = 2.0) -> DocumentConverter:
         """Configure Docling to keep picture images for referenced markdown export."""
         try:
             from docling.datamodel.pipeline_options import PdfPipelineOptions
@@ -127,6 +133,7 @@ class DoclingReader(Reader):
 
         pipeline_options = PdfPipelineOptions()
         pipeline_options.generate_picture_images = True
+        pipeline_options.images_scale = images_scale
         return DocumentConverter(
             format_options={
                 InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),

--- a/libs/agno/agno/knowledge/reader/docx_reader.py
+++ b/libs/agno/agno/knowledge/reader/docx_reader.py
@@ -1,29 +1,65 @@
 import asyncio
 from pathlib import Path
-from typing import IO, Any, List, Optional, Union
+from typing import IO, Any, Callable, Iterator, List, Optional, Tuple, Union
 from uuid import uuid4
 
 from agno.knowledge.chunking.document import DocumentChunking
 from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
 from agno.knowledge.document.base import Document
+from agno.knowledge.image import (
+    DEFAULT_IMAGE_BASE_URL,
+    save_image_markdown,
+)
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
-from agno.utils.log import log_debug, log_error
+from agno.utils.log import log_debug, log_error, log_warning
 
 try:
     from docx import Document as DocxDocument  # type: ignore
+    from docx.oxml.ns import qn  # type: ignore
+    from docx.table import Table  # type: ignore
+    from docx.text.paragraph import Paragraph  # type: ignore
 except ImportError:
     raise ImportError("The `python-docx` package is not installed. Please install it via `pip install python-docx`.")
 
+_REL_EMBED = qn("r:embed")
+_REL_LINK = qn("r:link")
+_REL_ID = qn("r:id")
+_W_P = qn("w:p")
+_W_TBL = qn("w:tbl")
+_W_T = qn("w:t")
+_W_TAB = qn("w:tab")
+_W_BR = qn("w:br")
+_W_CR = qn("w:cr")
+_W_DRAWING = qn("w:drawing")
+_W_PICT = qn("w:pict")
+
 
 class DocxReader(Reader):
-    """Reader for Doc/Docx files"""
+    """Reader for Doc/Docx files.
 
-    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
+    Set ``preserve_images=True`` to extract embedded images, persist them via
+    the global image store, and insert inline image links (``![](...)``) at
+    their original positions. This is not a full markdown export of the
+    document—surrounding text stays plain paragraph text.
+
+    Readers may be reused as singletons. Pass ``content_id`` to each ``read`` /
+    ``async_read`` call when preserving images (Knowledge does this automatically).
+    """
+
+    def __init__(
+        self,
+        chunking_strategy: Optional[ChunkingStrategy] = None,
+        preserve_images: bool = False,
+        image_base_url: str = DEFAULT_IMAGE_BASE_URL,
+        **kwargs,
+    ):
         if chunking_strategy is None:
             chunk_size = kwargs.get("chunk_size", 5000)
             chunking_strategy = DocumentChunking(chunk_size=chunk_size)
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
+        self.preserve_images = preserve_images
+        self.image_base_url = image_base_url
 
     @classmethod
     def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:
@@ -41,8 +77,20 @@ class DocxReader(Reader):
     def get_supported_content_types(cls) -> List[ContentType]:
         return [ContentType.DOCX, ContentType.DOC]
 
-    def read(self, file: Union[Path, IO[Any]], name: Optional[str] = None) -> List[Document]:
-        """Read a docx file and return a list of documents"""
+    def read(
+        self,
+        file: Union[Path, IO[Any]],
+        name: Optional[str] = None,
+        content_id: Optional[str] = None,
+    ) -> List[Document]:
+        """Read a docx file and return a list of documents.
+
+        Args:
+            file: Path or file-like object to read.
+            name: Optional document name.
+            content_id: Knowledge content id for image storage paths. Required when
+                ``preserve_images=True`` (passed by Knowledge on each insert).
+        """
         try:
             if isinstance(file, Path):
                 if not file.exists():
@@ -55,7 +103,10 @@ class DocxReader(Reader):
                 docx_document = DocxDocument(file)
                 doc_name = name or getattr(file, "name", "docx_file").split(".")[0]
 
-            doc_content = "\n\n".join([para.text for para in docx_document.paragraphs])
+            if self.preserve_images:
+                doc_content = self._extract_with_images(docx_document, content_id=content_id)
+            else:
+                doc_content = "\n\n".join([para.text for para in docx_document.paragraphs])
 
             documents = [
                 Document(
@@ -75,10 +126,136 @@ class DocxReader(Reader):
             log_error(f"Error reading file: {str(e)}")
             return []
 
-    async def async_read(self, file: Union[Path, IO[Any]], name: Optional[str] = None) -> List[Document]:
+    async def async_read(
+        self,
+        file: Union[Path, IO[Any]],
+        name: Optional[str] = None,
+        content_id: Optional[str] = None,
+    ) -> List[Document]:
         """Asynchronously read a docx file and return a list of documents"""
         try:
-            return await asyncio.to_thread(self.read, file, name)
+            return await asyncio.to_thread(self.read, file, name=name, content_id=content_id)
         except Exception as e:
             log_error(f"Error reading file asynchronously: {str(e)}")
             return []
+
+    def _extract_with_images(self, docx_document: Any, *, content_id: Optional[str]) -> str:
+        if not content_id:
+            raise ValueError("content_id is required when preserve_images=True")
+        lines: List[str] = []
+
+        def save_image(blob: bytes, media_type: str = "image/png") -> str:
+            return save_image_markdown(
+                content_id=content_id,
+                data=blob,
+                media_type=media_type,
+                image_base_url=self.image_base_url,
+            )
+
+        for block in self._iter_block_items(docx_document):
+            if isinstance(block, Paragraph):
+                line = self._paragraph_with_inline_images(docx_document, block, save_image)
+                if line:
+                    lines.append(line)
+            elif isinstance(block, Table):
+                for row in block.rows:
+                    for cell in row.cells:
+                        for para in cell.paragraphs:
+                            line = self._paragraph_with_inline_images(docx_document, para, save_image)
+                            if line:
+                                lines.append(line)
+
+        return "\n\n".join(lines)
+
+    @staticmethod
+    def _iter_block_items(document: Any) -> Iterator[Union[Paragraph, Table]]:
+        """Yield body paragraphs and tables in document order."""
+        body = document.element.body
+        for child in body.iterchildren():
+            if child.tag == _W_P:
+                yield Paragraph(child, document)
+            elif child.tag == _W_TBL:
+                yield Table(child, document)
+
+    def _paragraph_with_inline_images(
+        self,
+        doc: Any,
+        para: Any,
+        save_image: Callable[[bytes, str], str],
+    ) -> str:
+        """Join run text with inline ``![](...)`` image links; not full markdown."""
+        parts: List[str] = []
+        for run in para.runs:
+            parts.extend(self._run_to_parts(doc, run, save_image))
+        return "".join(parts).strip()
+
+    def _run_to_parts(
+        self,
+        doc: Any,
+        run: Any,
+        save_image: Callable[[bytes, str], str],
+    ) -> List[str]:
+        """Walk run XML in order so text and images stay interleaved."""
+        parts: List[str] = []
+        for child in run._element.iterchildren():
+            if child.tag == _W_T:
+                if child.text:
+                    parts.append(child.text)
+            elif child.tag == _W_TAB:
+                parts.append("\t")
+            elif child.tag in {_W_BR, _W_CR}:
+                parts.append("\n")
+            elif child.tag in {_W_DRAWING, _W_PICT}:
+                for blob, media_type in self._extract_images_from_element(doc, child):
+                    parts.append(save_image(blob, media_type))
+            else:
+                # Nested containers (e.g. w:r inside smart tags) — look for drawings/picts.
+                for blob, media_type in self._extract_images_from_element(doc, child):
+                    parts.append(save_image(blob, media_type))
+        return parts
+
+    def _extract_images_from_element(self, doc: Any, element: Any) -> List[Tuple[bytes, str]]:
+        """Extract all resolvable images under a drawing/pict (or nested) element."""
+        images: List[Tuple[bytes, str]] = []
+        try:
+            # DrawingML pictures (modern Word)
+            for blip in element.xpath(".//a:blip"):
+                resolved = self._resolve_image_part(
+                    doc,
+                    blip.get(_REL_EMBED) or blip.get(_REL_LINK),
+                )
+                if resolved is not None:
+                    images.append(resolved)
+        except Exception as e:
+            log_error(f"Failed to extract DrawingML DOCX image: {e}")
+
+        try:
+            # Legacy VML pictures (`v` is not in python-docx's default nsmap).
+            for imagedata in element.xpath(".//*[local-name()='imagedata']"):
+                resolved = self._resolve_image_part(
+                    doc,
+                    imagedata.get(_REL_ID) or imagedata.get(_REL_EMBED),
+                )
+                if resolved is not None:
+                    images.append(resolved)
+        except Exception as e:
+            log_error(f"Failed to extract VML DOCX image: {e}")
+
+        return images
+
+    @staticmethod
+    def _resolve_image_part(doc: Any, r_id: Optional[str]) -> Optional[Tuple[bytes, str]]:
+        if not r_id:
+            return None
+        related_parts = doc.part.related_parts
+        if r_id not in related_parts:
+            log_warning(f"DOCX image relationship not found: {r_id}")
+            return None
+        image_part = related_parts[r_id]
+        blob = getattr(image_part, "blob", None)
+        if blob is None:
+            blob = getattr(image_part, "_blob", None)
+        if not blob:
+            return None
+        content_type = getattr(image_part, "content_type", None) or "image/png"
+        return blob, content_type

--- a/libs/agno/agno/knowledge/reader/reader_factory.py
+++ b/libs/agno/agno/knowledge/reader/reader_factory.py
@@ -10,6 +10,28 @@ class ReaderFactory:
     # Cache for instantiated readers
     _reader_cache: Dict[str, Reader] = {}
 
+    # Default extension / MIME → reader key. Mutate via set_reader_key_for_extension.
+    _DEFAULT_EXTENSION_TO_KEY: Dict[str, str] = {
+        ".pdf": "pdf",
+        "application/pdf": "pdf",
+        ".csv": "csv",
+        "text/csv": "csv",
+        ".xlsx": "excel",
+        ".xls": "excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "excel",
+        "application/vnd.ms-excel": "excel",
+        ".docx": "docx",
+        ".doc": "docx",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+        ".pptx": "pptx",
+        ".json": "json",
+        ".md": "markdown",
+        ".markdown": "markdown",
+        ".txt": "text",
+        ".text": "text",
+    }
+    _EXTENSION_TO_KEY: Dict[str, str] = dict(_DEFAULT_EXTENSION_TO_KEY)
+
     # Static metadata for readers - avoids instantiation just to get metadata
     READER_METADATA: Dict[str, Dict[str, str]] = {
         "pdf": {
@@ -380,35 +402,31 @@ class ReaderFactory:
         return reader
 
     @classmethod
-    def get_reader_for_extension(cls, extension: str) -> Reader:
-        """Get the appropriate reader for a file extension."""
-        # TODO: add docling for unique file extensions eg: images, audios, etc.
-        extension = extension.lower()
+    def set_reader(cls, reader_key: str, reader: Reader, *, replace: bool = True) -> Reader:
+        """Inject or replace a cached reader instance (e.g. with custom config)."""
+        if replace or reader_key not in cls._reader_cache:
+            cls._reader_cache[reader_key] = reader
+        return cls._reader_cache[reader_key]
 
-        if extension in [".pdf", "application/pdf"]:
-            return cls.create_reader("pdf")
-        elif extension in [".csv", "text/csv"]:
-            return cls.create_reader("csv")
-        elif extension in [
-            ".xlsx",
-            ".xls",
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            "application/vnd.ms-excel",
-        ]:
-            return cls.create_reader("excel")
-        elif extension in [".docx", ".doc", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"]:
-            return cls.create_reader("docx")
-        elif extension == ".pptx":
-            return cls.create_reader("pptx")
-        elif extension == ".json":
-            return cls.create_reader("json")
-        elif extension in [".md", ".markdown"]:
-            return cls.create_reader("markdown")
-        elif extension in [".txt", ".text"]:
-            return cls.create_reader("text")
-        else:
-            # Default to text reader for unknown extensions
-            return cls.create_reader("text")
+    @classmethod
+    def get_reader_key_for_extension(cls, extension: str) -> str:
+        """Map a file extension or MIME type to a reader key (default: ``text``)."""
+        return cls._EXTENSION_TO_KEY.get(extension.lower(), "text")
+
+    @classmethod
+    def set_reader_key_for_extension(cls, extension: str, reader_key: str) -> None:
+        """Globally map an extension / MIME type to a reader key (e.g. ``.pdf`` → ``docling``)."""
+        cls._EXTENSION_TO_KEY[extension.lower()] = reader_key
+
+    @classmethod
+    def reset_extension_map(cls) -> None:
+        """Restore the default extension → reader key mapping."""
+        cls._EXTENSION_TO_KEY = dict(cls._DEFAULT_EXTENSION_TO_KEY)
+
+    @classmethod
+    def get_reader_for_extension(cls, extension: str) -> Reader:
+        """Get the appropriate reader for a file extension or MIME type."""
+        return cls.create_reader(cls.get_reader_key_for_extension(extension))
 
     @classmethod
     def get_reader_for_url(cls, url: str) -> Reader:

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -19,6 +19,7 @@ from agno.agent import Agent, AgentFactory, RemoteAgent
 from agno.agent.protocol import AgentProtocol
 from agno.agents.base import BaseExternalAgent
 from agno.db.base import AsyncBaseDb, BaseDb
+from agno.knowledge.image import KnowledgeImageStore, set_image_store
 from agno.knowledge.knowledge import Knowledge
 from agno.os.config import (
     AgentOSConfig,
@@ -256,6 +257,7 @@ class AgentOS:
         run_hooks_in_background: bool = False,
         telemetry: bool = True,
         registry: Optional[Registry] = None,
+        image_store: Optional[KnowledgeImageStore] = None,
         scheduler: bool = False,
         scheduler_poll_interval: int = 15,
         scheduler_base_url: Optional[str] = None,
@@ -311,6 +313,9 @@ class AgentOS:
             run_hooks_in_background: If True, run agent/team pre/post hooks as FastAPI background tasks (non-blocking)
             telemetry: Whether to enable telemetry
             registry: Optional registry to use for the AgentOS
+            image_store: Optional global knowledge image store. When set, registers it via
+                ``set_image_store`` so readers, content cleanup, and
+                ``GET /knowledge/images/...`` share the same store.
             scheduler: Whether to enable the cron scheduler
             scheduler_poll_interval: Seconds between scheduler poll cycles (default: 15)
             scheduler_base_url: Base URL for scheduler HTTP calls (default: http://127.0.0.1:7777)
@@ -356,6 +361,9 @@ class AgentOS:
         self.description = description
         self.db = db
         self.checkpoint = checkpoint
+        self.image_store = image_store
+        if image_store is not None:
+            set_image_store(image_store)
 
         self.telemetry = telemetry
         self.tracing = tracing

--- a/libs/agno/agno/os/routers/knowledge/knowledge.py
+++ b/libs/agno/agno/os/routers/knowledge/knowledge.py
@@ -1471,6 +1471,46 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
             ),
         )
 
+    @router.get(
+        "/knowledge/images/{content_id}/{image_id}",
+        operation_id="get_knowledge_image",
+        summary="Get Knowledge Image",
+        description=(
+            "Return a document image preserved during knowledge ingestion. "
+            "Uses the global knowledge image store; custom stores may authorize via user_id from JWT."
+        ),
+        responses={
+            200: {"description": "Image bytes"},
+            404: {"description": "Image or knowledge store not found", "model": NotFoundResponse},
+        },
+    )
+    async def get_knowledge_image(
+        request: Request,
+        content_id: str = Path(..., description="Knowledge content id"),
+        image_id: str = Path(..., description="Knowledge image id"),
+    ):
+        from fastapi.responses import Response
+
+        from agno.exceptions import PathSecurityError
+        from agno.knowledge.image import KnowledgeImageRef, get_image_store
+
+        user_id = getattr(request.state, "user_id", None)
+        ref = KnowledgeImageRef(image_id=image_id, content_id=content_id)
+        image_store = get_image_store()
+        try:
+            data = await image_store.aopen(ref, user_id=user_id)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail="Image not found")
+        except PathSecurityError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except PermissionError as e:
+            raise HTTPException(status_code=403, detail=str(e))
+        except Exception as e:
+            log_error(f"Failed to load knowledge image {content_id}/{image_id}: {e}")
+            raise HTTPException(status_code=500, detail="Failed to load image")
+
+        return Response(content=data, media_type=ref.media_type or "image/png")
+
     return router
 
 

--- a/libs/agno/tests/unit/knowledge/test_image_store.py
+++ b/libs/agno/tests/unit/knowledge/test_image_store.py
@@ -1,0 +1,93 @@
+"""Unit tests for knowledge image store."""
+
+from pathlib import Path
+
+import pytest
+
+from agno.exceptions import PathSecurityError
+from agno.knowledge.image import (
+    KnowledgeImageRef,
+    LocalKnowledgeImageStore,
+    build_image_url,
+    build_markdown_image,
+    save_image_markdown,
+    save_image_url,
+)
+
+
+def test_local_store_save_open_delete(tmp_path: Path):
+    store = LocalKnowledgeImageStore(base_dir=str(tmp_path / "images"))
+    data = b"fake-png-bytes"
+    ref = store.save(content_id="content-abc", data=data, media_type="image/png")
+
+    assert ref.content_id == "content-abc"
+    assert ref.image_id.startswith("img-")
+    assert ref.media_type == "image/png"
+    assert (tmp_path / "images" / "content-abc" / f"{ref.image_id}.png").exists()
+
+    loaded = store.open(ref)
+    assert loaded == data
+
+    url = build_image_url(ref)
+    assert url == f"/knowledge/images/content-abc/{ref.image_id}"
+    assert build_markdown_image(ref) == f"![]({url})"
+
+    store.delete(content_id="content-abc", image_id=ref.image_id)
+    assert not list((tmp_path / "images" / "content-abc").glob(f"{ref.image_id}.*"))
+
+
+def test_save_image_helpers(tmp_path: Path):
+    from agno.knowledge.image import set_image_store
+
+    store = LocalKnowledgeImageStore(base_dir=str(tmp_path / "images"))
+    set_image_store(store)
+    try:
+        url = save_image_url(content_id="c1", data=b"png-bytes", media_type="image/png")
+        assert url.startswith("/knowledge/images/c1/img-")
+        assert not url.endswith(".png")
+
+        md = save_image_markdown(
+            content_id="c1",
+            data=b"jpg-bytes",
+            media_type="image/jpeg",
+            alt_text="chart",
+        )
+        assert md.startswith("![chart](/knowledge/images/c1/img-")
+        assert md.endswith(")")
+        assert ".jpg)" not in md
+    finally:
+        set_image_store(None)
+
+
+def test_local_store_delete_content_dir(tmp_path: Path):
+    store = LocalKnowledgeImageStore(base_dir=str(tmp_path / "images"))
+    store.save(content_id="c1", data=b"one")
+    store.save(content_id="c1", data=b"two")
+    store.delete(content_id="c1")
+    assert not (tmp_path / "images" / "c1").exists()
+
+
+def test_local_store_rejects_path_traversal(tmp_path: Path):
+    store = LocalKnowledgeImageStore(base_dir=str(tmp_path / "images"))
+    with pytest.raises(PathSecurityError):
+        store.save(content_id="../escape", data=b"x")
+
+
+@pytest.mark.asyncio
+async def test_local_store_async(tmp_path: Path):
+    store = LocalKnowledgeImageStore(base_dir=str(tmp_path / "images"))
+    ref = await store.asave(content_id="c1", data=b"async-img")
+    data = await store.aopen(KnowledgeImageRef(image_id=ref.image_id, content_id="c1"))
+    assert data == b"async-img"
+    await store.adelete(content_id="c1")
+
+
+def test_global_image_store_singleton(tmp_path: Path):
+    from agno.knowledge.image import get_image_store, set_image_store
+
+    store = LocalKnowledgeImageStore(base_dir=str(tmp_path / "global-images"))
+    set_image_store(store)
+    try:
+        assert get_image_store() is store
+    finally:
+        set_image_store(None)

--- a/libs/agno/tests/unit/knowledge/test_reader_content_id_kwargs.py
+++ b/libs/agno/tests/unit/knowledge/test_reader_content_id_kwargs.py
@@ -1,0 +1,51 @@
+"""Knowledge only passes content_id when the reader signature accepts it."""
+
+from typing import Any, List, Optional
+
+from agno.knowledge.content import Content
+from agno.knowledge.document.base import Document
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.base import Reader
+
+
+class LegacyReader(Reader):
+    """Old-style reader without content_id / password parameters."""
+
+    def read(self, obj: Any, name: Optional[str] = None) -> List[Document]:
+        return [Document(name=name or "legacy", content=str(obj))]
+
+    async def async_read(self, obj: Any, name: Optional[str] = None) -> List[Document]:
+        return self.read(obj, name=name)
+
+
+class ModernReader(Reader):
+    def read(
+        self,
+        obj: Any,
+        name: Optional[str] = None,
+        content_id: Optional[str] = None,
+    ) -> List[Document]:
+        return [Document(name=name or "modern", content=f"{obj}:{content_id}")]
+
+    async def async_read(
+        self,
+        obj: Any,
+        name: Optional[str] = None,
+        content_id: Optional[str] = None,
+    ) -> List[Document]:
+        return self.read(obj, name=name, content_id=content_id)
+
+
+def test_read_works_with_legacy_reader_signature():
+    knowledge = Knowledge()
+    content = Content(id="cid-1", name="n")
+    docs = knowledge._read(LegacyReader(chunk=False), "hello", name="doc", content=content)
+    assert len(docs) == 1
+    assert docs[0].content == "hello"
+
+
+def test_read_passes_content_id_to_modern_reader():
+    knowledge = Knowledge()
+    content = Content(id="cid-1", name="n")
+    docs = knowledge._read(ModernReader(chunk=False), "hello", name="doc", content=content)
+    assert docs[0].content == "hello:cid-1"

--- a/libs/agno/tests/unit/knowledge/test_reader_factory_extension_map.py
+++ b/libs/agno/tests/unit/knowledge/test_reader_factory_extension_map.py
@@ -1,0 +1,81 @@
+"""Unit tests for configurable ReaderFactory extension mapping and Knowledge selection."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.docx_reader import DocxReader
+from agno.knowledge.reader.reader_factory import ReaderFactory
+from agno.knowledge.reader.text_reader import TextReader
+
+
+@pytest.fixture(autouse=True)
+def _reset_reader_factory():
+    ReaderFactory.clear_cache()
+    ReaderFactory.reset_extension_map()
+    yield
+    ReaderFactory.clear_cache()
+    ReaderFactory.reset_extension_map()
+
+
+def test_default_extension_mapping():
+    assert ReaderFactory.get_reader_key_for_extension(".pdf") == "pdf"
+    assert ReaderFactory.get_reader_key_for_extension("application/pdf") == "pdf"
+    assert ReaderFactory.get_reader_key_for_extension(".docx") == "docx"
+    assert ReaderFactory.get_reader_key_for_extension(".unknown") == "text"
+
+
+def test_set_reader_key_for_extension():
+    ReaderFactory.set_reader_key_for_extension(".pdf", "docling")
+    assert ReaderFactory.get_reader_key_for_extension(".pdf") == "docling"
+    assert ReaderFactory.get_reader_key_for_extension(".PDF") == "docling"
+
+
+def test_set_reader_injects_cache():
+    custom = DocxReader(preserve_images=True)
+    ReaderFactory.set_reader("docx", custom)
+    assert ReaderFactory.create_reader("docx") is custom
+    assert ReaderFactory.get_reader_for_extension(".docx") is custom
+
+
+def test_set_reader_replace_false_keeps_existing():
+    first = DocxReader(preserve_images=False)
+    second = DocxReader(preserve_images=True)
+    ReaderFactory.set_reader("docx", first)
+    ReaderFactory.set_reader("docx", second, replace=False)
+    assert ReaderFactory.create_reader("docx") is first
+
+
+def test_knowledge_select_reader_uses_instance_readers():
+    custom_pdf = MagicMock(name="CustomPdfReader")
+    custom_docx = DocxReader(preserve_images=True)
+    knowledge = Knowledge(
+        readers={
+            "pdf": custom_pdf,
+            "docx": custom_docx,
+        }
+    )
+
+    assert knowledge._select_reader(".pdf") is custom_pdf
+    assert knowledge._select_reader(".docx") is custom_docx
+    reader, name = knowledge._select_reader_by_extension(".pdf")
+    assert reader is custom_pdf
+    assert name == ""
+    assert knowledge._select_reader_by_uri("s3://bucket/docs/file.docx") is custom_docx
+
+
+def test_knowledge_select_reader_respects_factory_extension_remap():
+    custom_docling = MagicMock(name="CustomDoclingReader")
+    ReaderFactory.set_reader_key_for_extension(".pdf", "docling")
+    knowledge = Knowledge(readers={"docling": custom_docling})
+
+    assert knowledge._select_reader(".pdf") is custom_docling
+    assert knowledge._select_reader_by_uri("/tmp/report.PDF") is custom_docling
+
+
+def test_select_reader_by_extension_csv_default_name():
+    knowledge = Knowledge(readers={"csv": TextReader()})
+    reader, name = knowledge._select_reader_by_extension(".csv")
+    assert reader is knowledge.readers["csv"]
+    assert name == "data.csv"

--- a/libs/agno/tests/unit/os/test_agentos_db.py
+++ b/libs/agno/tests/unit/os/test_agentos_db.py
@@ -64,3 +64,17 @@ def test_tracing_uses_default_db(mock_setup_tracing, default_db):
     AgentOS(agents=[agent], db=default_db, tracing=True)
 
     mock_setup_tracing.assert_called_once_with(db=default_db)
+
+
+def test_image_store_registers_global_store(default_db, tmp_path):
+    """Test that AgentOS(image_store=...) registers the global knowledge image store."""
+    from agno.knowledge.image import LocalKnowledgeImageStore, get_image_store, set_image_store
+
+    store = LocalKnowledgeImageStore(base_dir=str(tmp_path / "images"))
+    agent = Agent(name="test-agent", id="test-agent-id")
+    try:
+        agent_os = AgentOS(agents=[agent], db=default_db, image_store=store)
+        assert agent_os.image_store is store
+        assert get_image_store() is store
+    finally:
+        set_image_store(None)

--- a/libs/agno/tests/unit/reader/test_docling_reader.py
+++ b/libs/agno/tests/unit/reader/test_docling_reader.py
@@ -485,6 +485,18 @@ def test_preserve_images_flag_defaults_off(mock_converter):
     assert reader.preserve_images is False
 
 
+def test_images_scale_default_and_pipeline_option(mock_converter):
+    from docling.datamodel.base_models import InputFormat
+
+    reader = DoclingReader(converter=mock_converter, preserve_images=True)
+    assert reader.images_scale == 2.0
+
+    converter = DoclingReader._build_image_aware_converter(images_scale=3.0)
+    pdf_option = converter.format_to_options[InputFormat.PDF]
+    assert pdf_option.pipeline_options.generate_picture_images is True
+    assert pdf_option.pipeline_options.images_scale == 3.0
+
+
 def test_preserve_images_uses_markdown_export(mock_converter, mock_docling_result, tmp_path):
     from agno.knowledge.image import LocalKnowledgeImageStore, set_image_store
 

--- a/libs/agno/tests/unit/reader/test_docling_reader.py
+++ b/libs/agno/tests/unit/reader/test_docling_reader.py
@@ -478,3 +478,29 @@ def test_allowed_hosts_rejects_str_input():
     """Passing a single string (instead of a list) must raise error."""
     with pytest.raises(TypeError, match="must be a list"):
         DoclingReader(allowed_hosts="docs.agno.com")
+
+
+def test_preserve_images_flag_defaults_off(mock_converter):
+    reader = DoclingReader(converter=mock_converter)
+    assert reader.preserve_images is False
+
+
+def test_preserve_images_uses_markdown_export(mock_converter, mock_docling_result, tmp_path):
+    from agno.knowledge.image import LocalKnowledgeImageStore, set_image_store
+
+    mock_docling_result.document.export_to_markdown.return_value = "# Title\n\nBody"
+    mock_docling_result.document.iterate_items.return_value = []
+    store = LocalKnowledgeImageStore(base_dir=str(tmp_path / "images"))
+    set_image_store(store)
+    try:
+        reader = DoclingReader(
+            converter=mock_converter,
+            preserve_images=True,
+            chunk=False,
+        )
+        with patch("pathlib.Path.exists", return_value=True):
+            documents = reader.read(Path("test.pdf"), content_id="c1")
+        assert len(documents) == 1
+        assert "Title" in documents[0].content
+    finally:
+        set_image_store(None)

--- a/libs/agno/tests/unit/reader/test_docx_reader_images.py
+++ b/libs/agno/tests/unit/reader/test_docx_reader_images.py
@@ -1,0 +1,127 @@
+"""Unit tests for DocxReader image preservation."""
+
+from pathlib import Path
+
+import pytest
+
+from agno.knowledge.image import LocalKnowledgeImageStore, set_image_store
+from agno.knowledge.reader.docx_reader import DocxReader
+
+pil = pytest.importorskip("PIL.Image")
+
+
+@pytest.fixture
+def image_store(tmp_path: Path):
+    store = LocalKnowledgeImageStore(base_dir=str(tmp_path / "doc_images"))
+    set_image_store(store)
+    yield store
+    set_image_store(None)
+
+
+def _png(tmp_path: Path, name: str = "figure.png") -> Path:
+    image_path = tmp_path / name
+    pil.new("RGB", (8, 8), color=(255, 0, 0)).save(image_path)
+    return image_path
+
+
+def _build_docx_with_inline_image(tmp_path: Path) -> Path:
+    from docx import Document as DocxDocument
+
+    image_path = _png(tmp_path)
+    doc = DocxDocument()
+    doc.add_paragraph("Before image")
+    paragraph = doc.add_paragraph()
+    run = paragraph.add_run()
+    run.add_picture(str(image_path))
+    doc.add_paragraph("After image")
+
+    out = tmp_path / "sample.docx"
+    doc.save(out)
+    return out
+
+
+def _build_docx_with_table_image(tmp_path: Path) -> Path:
+    from docx import Document as DocxDocument
+
+    image_path = _png(tmp_path, "table.png")
+    doc = DocxDocument()
+    doc.add_paragraph("Intro")
+    table = doc.add_table(rows=1, cols=1)
+    cell = table.cell(0, 0)
+    cell.text = "Cell text"
+    cell.paragraphs[0].add_run().add_picture(str(image_path))
+    doc.add_paragraph("Outro")
+
+    out = tmp_path / "table.docx"
+    doc.save(out)
+    return out
+
+
+def _build_docx_with_text_and_image_same_run(tmp_path: Path) -> Path:
+    from docx import Document as DocxDocument
+
+    image_path = _png(tmp_path, "mixed.png")
+    doc = DocxDocument()
+    paragraph = doc.add_paragraph()
+    run = paragraph.add_run("Prefix ")
+    run.add_picture(str(image_path))
+    paragraph.add_run(" suffix")
+
+    out = tmp_path / "mixed.docx"
+    doc.save(out)
+    return out
+
+
+def test_docx_reader_preserve_images_inserts_inline_image_link(tmp_path: Path, image_store):
+    docx_path = _build_docx_with_inline_image(tmp_path)
+    reader = DocxReader(
+        preserve_images=True,
+        image_base_url="/knowledge/images",
+        chunk=False,
+    )
+
+    documents = reader.read(docx_path, content_id="doc-1")
+    assert len(documents) == 1
+    content = documents[0].content
+    assert "Before image" in content
+    assert "After image" in content
+    assert "![](/knowledge/images/doc-1/" in content
+    saved = list((tmp_path / "doc_images" / "doc-1").glob("img-*"))
+    assert saved
+
+
+def test_docx_reader_preserve_images_in_table(tmp_path: Path, image_store):
+    docx_path = _build_docx_with_table_image(tmp_path)
+    reader = DocxReader(
+        preserve_images=True,
+        image_base_url="/knowledge/images",
+        chunk=False,
+    )
+
+    content = reader.read(docx_path, content_id="doc-table")[0].content
+    assert "Intro" in content
+    assert "Cell text" in content
+    assert "Outro" in content
+    assert "![](/knowledge/images/doc-table/" in content
+    assert list((tmp_path / "doc_images" / "doc-table").glob("img-*"))
+
+
+def test_docx_reader_preserves_text_around_inline_image(tmp_path: Path, image_store):
+    docx_path = _build_docx_with_text_and_image_same_run(tmp_path)
+    reader = DocxReader(
+        preserve_images=True,
+        image_base_url="/knowledge/images",
+        chunk=False,
+    )
+
+    content = reader.read(docx_path, content_id="doc-mixed")[0].content
+    assert "Prefix" in content
+    assert "suffix" in content
+    assert "![](/knowledge/images/doc-mixed/" in content
+    assert content.index("Prefix") < content.index("![")
+    assert content.index("![") < content.index("suffix")
+
+
+def test_docx_reader_preserve_images_default_off():
+    reader = DocxReader()
+    assert reader.preserve_images is False


### PR DESCRIPTION
## Summary

Implements knowledge document image preservation for RAG, addressing #9026:

- Add pluggable global `KnowledgeImageStore` (`LocalKnowledgeImageStore` default) with `get_image_store` / `set_image_store`
- `DocxReader` and `DoclingReader` support `preserve_images=True` to extract original figures, persist them, and insert `![](/knowledge/images/{content_id}/{image_id})` at the original location
- Knowledge insert passes `content_id` into readers (signature-compatible) and deletes stored images when content is removed
- AgentOS serves images at `GET /knowledge/images/{content_id}/{image_id}`; optional `AgentOS(image_store=...)` wires a custom store at startup
- Make extension → reader mapping configurable and consistent across insert paths (`file_data` / `path` / `url`)

Closes #9026

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Configurable extension → reader mapping

Previously, `file_data` used `ReaderFactory.get_reader_for_extension` while `path` / `url` used `Knowledge.readers` (`self.pdf_reader`, etc.), so `Knowledge(readers=...)` did not cover uploads.

This PR:

- Moves the hard-coded extension / MIME map into `ReaderFactory._DEFAULT_EXTENSION_TO_KEY`
- Adds `get_reader_key_for_extension`, `set_reader_key_for_extension`, `set_reader`, and `reset_extension_map`
- Routes `_select_reader`, `_select_reader_by_extension`, `_select_reader_by_uri`, and path insert through `_get_reader` so `Knowledge.readers` wins on all insert paths
- Adds unit coverage in `test_reader_factory_extension_map.py` (7 tests)

**Pattern A — override the `pdf` slot (no extension remap):**

```python
Knowledge(
    readers={
        "docx": DocxReader(preserve_images=True),
        "pdf": DoclingReader(preserve_images=True, output_format="markdown"),
    }
)
```

Default is still `.pdf` → `"pdf"`, so the configured Docling instance must be keyed as `"pdf"`.

**Pattern B — remap `.pdf` → `docling` globally:**

```python
ReaderFactory.set_reader_key_for_extension(".pdf", "docling")
Knowledge(
    readers={
        "docling": DoclingReader(preserve_images=True, output_format="markdown"),
    }
)
# optional: also pin the factory cache
ReaderFactory.set_reader(
    "docling",
    DoclingReader(preserve_images=True, output_format="markdown"),
)
```

The `readers` dict key must match whatever `get_reader_key_for_extension` returns.

### Docling image sharpness

Docling preserves **page-rendered figure crops**, not the original embedded PDF assets. With Docling's default `images_scale=1.0` those crops are display-sized and often look soft.

`DoclingReader(preserve_images=True)` now defaults to `images_scale=2.0`. Raise further if needed:

```python
DoclingReader(preserve_images=True, output_format="markdown", images_scale=3.0)
```

Higher scale = sharper images, slower conversion, larger stored files.

### Image preservation usage

```python
from agno.knowledge.image import LocalKnowledgeImageStore, set_image_store
from agno.knowledge.reader.docx_reader import DocxReader
from agno.os import AgentOS

set_image_store(LocalKnowledgeImageStore(base_dir="/data/knowledge-images"))
# or: AgentOS(..., image_store=LocalKnowledgeImageStore(...))

knowledge.insert(path="doc.docx", reader=DocxReader(preserve_images=True))
# PDF figures: DoclingReader(preserve_images=True, output_format="markdown")
```

### Verified locally

- Unit tests for image store, DocxReader images, content_id kwargs, AgentOS `image_store`, reader extension map
- E2E Word (DocxReader) and PDF (DoclingReader): insert → store → `knowledge.search` returns chunks with image markdown
- HTTP `GET /knowledge/images/{content_id}/{image_id}` returns PNG bytes (200) / missing → 404
- `./scripts/format.sh` clean; `./scripts/validate.sh`: our changes pass (pre-existing mypy issue in `llms_txt_reader.py` on `main`)
