### PR TITLE
feat: add SciverseTools for scientific literature search

### DIFF
--- a/cookbook/91_tools/sciverse_tools.py
+++ b/cookbook/91_tools/sciverse_tools.py
@@ -1,0 +1,81 @@
+"""
+Sciverse Tools - Scientific Literature Search over Full Text
+
+Sciverse indexes paper metadata and full text, so semantic_search returns citable
+passages from paper bodies (not just abstracts) along with the character offset where
+each passage lives. Feed that doc_id and offset to read_paper_content to read around it.
+
+SciverseTools is a small tool (<6 functions) so it uses enable_ flags.
+
+Get an API token at https://sciverse.space, then: `export SCIVERSE_API_TOKEN=***`
+"""
+
+from agno.agent import Agent
+from agno.tools.sciverse import SciverseTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+
+# Example 1: Default functions (semantic search, metadata search, full-text reading)
+agent_full = Agent(
+    tools=[SciverseTools()],
+    description="You are a research assistant that answers from primary literature.",
+    instructions=[
+        "Search for relevant passages before answering",
+        "Quote the passage you relied on and name the paper it came from",
+        "Read more of the original text when a passage is not enough to answer",
+    ],
+    markdown=True,
+)
+
+# Example 2: Retrieval only, no full-text reading
+agent_search_only = Agent(
+    tools=[
+        SciverseTools(
+            enable_semantic_search=True,
+            enable_search_papers=True,
+            enable_read_paper_content=False,
+        )
+    ],
+    description="You are a literature discovery specialist.",
+    instructions=[
+        "Find the most relevant papers and passages for the topic",
+        "Summarize what each result contributes",
+    ],
+    markdown=True,
+)
+
+# Example 3: Enable all functions, including citation graph traversal
+agent_comprehensive = Agent(
+    tools=[SciverseTools(all=True)],
+    description="You are a comprehensive research assistant for literature reviews.",
+    instructions=[
+        "Start from semantic search, then follow references to trace a line of work",
+        "Distinguish what a paper cites from what cites it",
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    print("=== Question Answering over Full Text ===")
+    agent_full.print_response(
+        "How do vision transformers handle image patches? Quote the papers you use.",
+        markdown=True,
+    )
+
+    print("\n=== Structured Literature Discovery ===")
+    agent_search_only.print_response(
+        "Find papers on CRISPR gene editing published between 2021 and 2023",
+        markdown=True,
+    )
+
+    print("\n=== Literature Review with Citations ===")
+    agent_comprehensive.print_response(
+        "Summarize recent work on protein folding prediction and trace what it builds on",
+        markdown=True,
+    )

--- a/libs/agno/agno/tools/sciverse.py
+++ b/libs/agno/agno/tools/sciverse.py
@@ -1,0 +1,231 @@
+import json
+from os import getenv
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agno.tools import Toolkit
+from agno.utils.log import log_debug, log_error
+
+DEFAULT_BASE_URL = "https://api.sciverse.space"
+
+# Maps the user-facing search mode to the API's retrieval knobs
+# (`retrieval`: recall backend, `sub_queries`: LLM query-rewrite fan-out).
+_SEARCH_MODES: Dict[str, Dict[str, Any]] = {
+    "fast": {"retrieval": "es"},
+    "balanced": {"retrieval": "hybrid"},
+    "quality": {"retrieval": "hybrid", "sub_queries": 3},
+}
+
+
+class SciverseTools(Toolkit):
+    """Tools for searching scientific literature via the Sciverse open platform.
+
+    Sciverse indexes paper metadata *and* full text, so it can return citable passages
+    from paper bodies rather than just abstracts, and read the surrounding original text
+    by byte offset.
+
+    Get an API token at https://sciverse.space and set `SCIVERSE_API_TOKEN`.
+
+    Args:
+        enable_semantic_search (bool): Enable natural-language passage retrieval. Default True.
+        enable_search_papers (bool): Enable structured metadata search. Default True.
+        enable_read_paper_content (bool): Enable reading original full text. Default True.
+        enable_list_paper_relations (bool): Enable citation/reference listing. Default False.
+        all (bool): Enable all tools. Overrides individual flags when True. Default False.
+        api_key (Optional[str]): Sciverse API token. Falls back to `SCIVERSE_API_TOKEN`.
+        base_url (Optional[str]): API base URL. Falls back to `SCIVERSE_BASE_URL`.
+        timeout (float): Request timeout in seconds. Default 30.0.
+    """
+
+    def __init__(
+        self,
+        enable_semantic_search: bool = True,
+        enable_search_papers: bool = True,
+        enable_read_paper_content: bool = True,
+        enable_list_paper_relations: bool = False,
+        all: bool = False,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: float = 30.0,
+        **kwargs,
+    ):
+        self.api_key = api_key or getenv("SCIVERSE_API_TOKEN")
+        if not self.api_key:
+            log_error("SCIVERSE_API_TOKEN not set. Please set the SCIVERSE_API_TOKEN environment variable.")
+
+        self.base_url = (base_url or getenv("SCIVERSE_BASE_URL") or DEFAULT_BASE_URL).rstrip("/")
+        self.timeout = timeout
+
+        tools: List[Any] = []
+        if all or enable_semantic_search:
+            tools.append(self.semantic_search)
+        if all or enable_search_papers:
+            tools.append(self.search_papers)
+        if all or enable_read_paper_content:
+            tools.append(self.read_paper_content)
+        if all or enable_list_paper_relations:
+            tools.append(self.list_paper_relations)
+
+        super().__init__(name="sciverse", tools=tools, **kwargs)
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            # Lets Sciverse attribute traffic to this integration.
+            "X-Sciverse-Source": "oss_agno",
+        }
+
+    def _request(self, method: str, path: str, **kwargs) -> str:
+        """Issue a request and return the response body as a JSON string.
+
+        Errors are returned as a JSON object with an `error` key so the model can see
+        what went wrong and adjust, rather than the tool call raising.
+        """
+        try:
+            with httpx.Client(base_url=self.base_url, timeout=self.timeout) as client:
+                response = client.request(method, path, headers=self._headers(), **kwargs)
+                response.raise_for_status()
+                return json.dumps(response.json(), indent=2, ensure_ascii=False)
+        except httpx.HTTPStatusError as e:
+            message = e.response.text
+            try:
+                body = e.response.json()
+                message = body.get("message") or body.get("code") or message
+            except Exception:
+                pass
+            log_error(f"Sciverse request failed ({e.response.status_code}): {message}")
+            return json.dumps({"error": f"HTTP {e.response.status_code}", "message": message}, ensure_ascii=False)
+        except Exception as e:
+            log_error(f"Sciverse request failed: {e}")
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
+
+    def semantic_search(self, query: str, top_k: int = 10, mode: str = "balanced") -> str:
+        """Search scientific literature with a natural-language question and get back
+        the most relevant passages from paper full text.
+
+        Use this when you have a question rather than exact filter criteria, and you want
+        quotable evidence. Hits that carry a doc_id locate the passage in the original
+        document, so you can call read_paper_content with that doc_id and offset to read
+        more around it (hits without doc_id are preview-only).
+
+        Args:
+            query (str): The natural-language question. Works best under 200 characters.
+            top_k (int, optional): Number of passages to return, 1-100. Defaults to 10.
+            mode (str, optional): One of "fast" (keyword only, ~200ms), "balanced" (hybrid
+                retrieval, ~600ms) or "quality" (LLM query rewriting + hybrid, ~2-4s).
+                Defaults to "balanced"; unknown values fall back to "balanced".
+        Returns:
+            str: JSON with a list of hits, each holding chunk (the passage text), title,
+                score, abstract, and doc_id plus offset when the full text is available.
+        """
+        log_debug(f"Sciverse semantic search: {query}")
+        payload: Dict[str, Any] = {"query": query, "top_k": top_k}
+        payload.update(_SEARCH_MODES.get(mode, _SEARCH_MODES["balanced"]))
+        return self._request("POST", "/agentic-search", json=payload)
+
+    def search_papers(
+        self,
+        query: Optional[str] = None,
+        authors: Optional[List[str]] = None,
+        journals: Optional[List[str]] = None,
+        year_from: Optional[int] = None,
+        year_to: Optional[int] = None,
+        page: int = 1,
+        page_size: int = 10,
+    ) -> str:
+        """Search scientific paper metadata by structured criteria such as author, journal
+        or publication year.
+
+        Use this when you know what to filter on. For an open-ended question, use
+        semantic_search instead.
+
+        Args:
+            query (str, optional): Free-text query matched against title and abstract.
+            authors (list[str], optional): Author names; a paper matches any of them.
+                Matching is exact against the stored name variants, so pass the full name
+                (e.g. "Geoffrey Hinton"). A surname alone matches only the subset of papers
+                that happen to store that bare variant, and mixes in every other author who
+                shares the surname, so it is not a way to broaden a search.
+            journals (list[str], optional): Journal or venue names; a paper matches any of
+                them. Exact match on the normalized venue name (e.g. "Nature Communications").
+            year_from (int, optional): Earliest publication year, inclusive.
+            year_to (int, optional): Latest publication year, inclusive.
+            page (int, optional): 1-based page number. Defaults to 1.
+            page_size (int, optional): Results per page, max 200. Defaults to 10.
+        Returns:
+            str: JSON with paper records holding unique_id (always present), doc_id (only when
+                full text exists), title, author, abstract, publication venue and year.
+        """
+        log_debug(f"Sciverse paper search: query={query} authors={authors} years={year_from}-{year_to}")
+        payload: Dict[str, Any] = {"page": page, "page_size": page_size}
+        if query:
+            payload["query"] = query
+
+        filters: List[Dict[str, Any]] = []
+        if authors:
+            filters.append({"field": "author", "operator": "FILTER_OP_IN", "value": list(authors)})
+        if journals:
+            filters.append(
+                {
+                    "field": "publication_venue_name_unified",
+                    "operator": "FILTER_OP_IN",
+                    "value": list(journals),
+                }
+            )
+        if year_from is not None:
+            filters.append({"field": "publication_published_year", "operator": "FILTER_OP_GTE", "value": year_from})
+        if year_to is not None:
+            filters.append({"field": "publication_published_year", "operator": "FILTER_OP_LTE", "value": year_to})
+        if filters:
+            payload["filters"] = filters
+
+        return self._request("POST", "/meta-search", json=payload)
+
+    def read_paper_content(self, doc_id: str, offset: int = 0, limit: int = 4096) -> str:
+        """Read the original full text of a paper, one segment at a time.
+
+        Pair this with semantic_search: take the doc_id and offset of a hit and read around
+        it to get more context than the returned passage. Offsets count Unicode characters
+        (same unit as Python's len(str)), matching the offset values semantic_search returns.
+
+        Args:
+            doc_id (str): Document ID from semantic_search or search_papers.
+            offset (int, optional): Character offset to start reading from. Defaults to 0.
+            limit (int, optional): Characters to read, max 524288. Defaults to 4096.
+        Returns:
+            str: JSON with text (the segment), next_offset (pass as offset to continue)
+                and more (whether content follows).
+        """
+        log_debug(f"Sciverse read content: doc_id={doc_id} offset={offset}")
+        params = {"doc_id": doc_id, "offset": offset, "limit": limit}
+        return self._request("GET", "/content", params=params)
+
+    def list_paper_relations(
+        self,
+        unique_id: str,
+        relation: str = "REFERENCES",
+        page: int = 1,
+        page_size: int = 25,
+    ) -> str:
+        """List the citation relationships of a paper.
+
+        Args:
+            unique_id (str): The paper's unique_id from search_papers or semantic_search.
+                Note this is unique_id, not doc_id.
+            relation (str, optional): "REFERENCES" (works this paper cites), "CITATIONS"
+                (works citing this paper) or "RELATED_WORKS". Defaults to "REFERENCES".
+            page (int, optional): 1-based page number. Defaults to 1.
+            page_size (int, optional): Results per page. Defaults to 25.
+        Returns:
+            str: JSON with the related paper records and pagination info.
+        """
+        log_debug(f"Sciverse paper relations: unique_id={unique_id} relation={relation}")
+        payload = {
+            "unique_id": unique_id,
+            "relation": relation,
+            "page": page,
+            "page_size": page_size,
+        }
+        return self._request("POST", "/meta-paper-relations", json=payload)

--- a/libs/agno/tests/unit/tools/test_sciverse.py
+++ b/libs/agno/tests/unit/tools/test_sciverse.py
@@ -1,0 +1,162 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from agno.tools.sciverse import SciverseTools
+
+
+def _mock_client(mock_client_class, payload=None):
+    """Wire a mocked httpx.Client and return the client mock for assertions."""
+    response = MagicMock()
+    response.json.return_value = payload if payload is not None else {"hits": []}
+    response.raise_for_status.return_value = None
+    client = mock_client_class.return_value.__enter__.return_value
+    client.request.return_value = response
+    return client
+
+
+def test_initialization_registers_default_tools():
+    tools = SciverseTools(api_key="test-key")
+
+    assert tools.name == "sciverse"
+    assert set(tools.functions) == {
+        "semantic_search",
+        "search_papers",
+        "read_paper_content",
+    }
+
+
+def test_list_paper_relations_is_opt_in():
+    assert "list_paper_relations" not in SciverseTools(api_key="test-key").functions
+    assert "list_paper_relations" in SciverseTools(api_key="test-key", all=True).functions
+
+
+def test_disabled_tool_is_not_registered():
+    tools = SciverseTools(api_key="test-key", enable_search_papers=False)
+
+    assert "search_papers" not in tools.functions
+    assert "semantic_search" in tools.functions
+
+
+def test_initialization_reads_api_key_from_environment():
+    with patch.dict("os.environ", {"SCIVERSE_API_TOKEN": "env-key"}):
+        tools = SciverseTools()
+
+    assert tools.api_key == "env-key"
+
+
+def test_base_url_defaults_and_strips_trailing_slash():
+    assert SciverseTools(api_key="k").base_url == "https://api.sciverse.space"
+    assert SciverseTools(api_key="k", base_url="https://example.test/").base_url == "https://example.test"
+
+
+@patch("agno.tools.sciverse.httpx.Client")
+def test_semantic_search_posts_query_with_auth_and_source_header(mock_client_class):
+    client = _mock_client(mock_client_class, {"hits": [{"doc_id": "p_x", "chunk": "text"}]})
+    tools = SciverseTools(api_key="test-key")
+
+    result = tools.semantic_search("how does attention work", top_k=3, mode="quality")
+
+    assert json.loads(result)["hits"][0]["doc_id"] == "p_x"
+    client.request.assert_called_once_with(
+        "POST",
+        "/agentic-search",
+        headers={
+            "Authorization": "Bearer test-key",
+            "Content-Type": "application/json",
+            "X-Sciverse-Source": "oss_agno",
+        },
+        json={"query": "how does attention work", "top_k": 3, "retrieval": "hybrid", "sub_queries": 3},
+    )
+
+
+@patch("agno.tools.sciverse.httpx.Client")
+def test_semantic_search_maps_modes_to_retrieval_params(mock_client_class):
+    client = _mock_client(mock_client_class)
+    tools = SciverseTools(api_key="test-key")
+
+    tools.semantic_search("q", mode="fast")
+    assert client.request.call_args.kwargs["json"] == {"query": "q", "top_k": 10, "retrieval": "es"}
+
+    tools.semantic_search("q")  # default: balanced
+    assert client.request.call_args.kwargs["json"] == {"query": "q", "top_k": 10, "retrieval": "hybrid"}
+
+    tools.semantic_search("q", mode="bogus")  # unknown mode falls back to balanced
+    assert client.request.call_args.kwargs["json"] == {"query": "q", "top_k": 10, "retrieval": "hybrid"}
+
+
+@patch("agno.tools.sciverse.httpx.Client")
+def test_search_papers_builds_filters_from_convenience_arguments(mock_client_class):
+    client = _mock_client(mock_client_class, {"items": []})
+    tools = SciverseTools(api_key="test-key")
+
+    tools.search_papers(query="crispr", authors=["Jennifer Doudna"], year_from=2020, year_to=2023)
+
+    payload = client.request.call_args.kwargs["json"]
+    assert payload["query"] == "crispr"
+    assert payload["filters"] == [
+        {"field": "author", "operator": "FILTER_OP_IN", "value": ["Jennifer Doudna"]},
+        {"field": "publication_published_year", "operator": "FILTER_OP_GTE", "value": 2020},
+        {"field": "publication_published_year", "operator": "FILTER_OP_LTE", "value": 2023},
+    ]
+
+
+@patch("agno.tools.sciverse.httpx.Client")
+def test_search_papers_omits_filters_when_no_criteria_given(mock_client_class):
+    client = _mock_client(mock_client_class, {"items": []})
+    tools = SciverseTools(api_key="test-key")
+
+    tools.search_papers(query="transformer")
+
+    payload = client.request.call_args.kwargs["json"]
+    assert "filters" not in payload
+    assert payload["page"] == 1
+
+
+@patch("agno.tools.sciverse.httpx.Client")
+def test_read_paper_content_passes_byte_range_as_query_params(mock_client_class):
+    client = _mock_client(mock_client_class, {"content": "abc", "next_offset": 100})
+    tools = SciverseTools(api_key="test-key")
+
+    tools.read_paper_content("p_x", offset=64, limit=128)
+
+    assert client.request.call_args.args == ("GET", "/content")
+    assert client.request.call_args.kwargs["params"] == {"doc_id": "p_x", "offset": 64, "limit": 128}
+
+
+@patch("agno.tools.sciverse.httpx.Client")
+def test_list_paper_relations_posts_unique_id_and_relation(mock_client_class):
+    client = _mock_client(mock_client_class, {"items": []})
+    tools = SciverseTools(api_key="test-key", all=True)
+
+    tools.list_paper_relations("u_1", relation="CITATIONS")
+
+    payload = client.request.call_args.kwargs["json"]
+    assert payload["unique_id"] == "u_1"
+    assert payload["relation"] == "CITATIONS"
+
+
+@patch("agno.tools.sciverse.httpx.Client")
+def test_http_error_is_returned_to_the_model_instead_of_raising(mock_client_class):
+    response = MagicMock()
+    response.status_code = 401
+    response.json.return_value = {"code": "UNAUTHORIZED", "message": "Invalid token"}
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "unauthorized", request=MagicMock(), response=response
+    )
+    mock_client_class.return_value.__enter__.return_value.request.return_value = response
+    tools = SciverseTools(api_key="bad-key")
+
+    result = json.loads(tools.semantic_search("anything"))
+
+    assert result["error"] == "HTTP 401"
+    assert result["message"] == "Invalid token"
+
+
+@patch("agno.tools.sciverse.httpx.Client")
+def test_transport_error_is_returned_to_the_model_instead_of_raising(mock_client_class):
+    mock_client_class.return_value.__enter__.return_value.request.side_effect = httpx.ConnectError("boom")
+    tools = SciverseTools(api_key="test-key")
+
+    assert "boom" in json.loads(tools.semantic_search("anything"))["error"]


### PR DESCRIPTION
## Summary

Adds `SciverseTools`, a toolkit for searching scientific literature through the [Sciverse](https://sciverse.space) open platform.

**What makes this different from the existing literature tools:** `ArxivTools` and `PubmedTools` return metadata and abstracts. Sciverse indexes paper *full text*, so `semantic_search` returns the actual passage from the paper body along with the character offset it came from, and `read_paper_content` reads the original text around that offset. An agent can quote a specific claim and then read more of its surrounding context instead of reasoning from the abstract alone.

Four tools:

| Tool | Purpose |
| --- | --- |
| `semantic_search` | Natural-language question → relevant passages from paper full text |
| `search_papers` | Structured metadata search (author, journal, year range) |
| `read_paper_content` | Read the original full text by character offset |
| `list_paper_relations` | Citations / references / related works (off by default) |

Notes on the implementation:

- **No new dependencies.** Uses `httpx`, already a core agno dependency, so `pyproject.toml` is untouched. No optional extra to install.
- **Errors are returned, not raised.** A failed request comes back as `{"error": ..., "message": ...}` JSON so the model can see what went wrong and adjust, rather than aborting the run. This follows the pattern used elsewhere in the toolkits.
- **`list_paper_relations` is off by default** — most agents want retrieval, and citation-graph traversal is a different job. Enable it with `all=True` or `enable_list_paper_relations=True`.
- **Docstrings carry the API's real constraints,** since they are what the model reads. Notably: `search_papers` matches author and journal names exactly against stored name variants, so a surname alone silently returns an arbitrary partial subset mixed with other authors who share it — the docstring says so, because a model would otherwise reach for surnames to broaden a search.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The closest neighbour is #8751 (Semantic Scholar tools), which has the same file layout but a different data source — Semantic Scholar serves metadata, Sciverse serves full text with offset-addressable reads. They are complementary rather than competing, in the same way arxiv.py and pubmed.py already coexist. This PR does not supersede #8751 and has no conflicts with it.

This PR was written with Claude Code Fable 5. I have reviewed every line, and verified the integration against the live Sciverse API rather than against mocks alone:

Retrieval modes (fast / balanced / quality) map to the API's retrieval and sub_queries parameters. Confirmed against per-stage upstream timings: quality runs the LLM query-rewrite stage, fast runs keyword recall only, balanced runs hybrid recall without rewriting.
Offset alignment: the text returned by read_paper_content(doc_id, offset) matches the passage semantic_search reported at that offset, character for character.
list_paper_relations reference counts cross-checked against each paper's own reference_count metadata field, on three papers: 21/21, 107/107, 21/21.
Auth failure path: an invalid token produces the documented error JSON and does not raise.
Anyone reviewing this can reproduce those checks with a token from https://sciverse.space/.
