### PR TITLE
feat: component-aware schedule tools and history parameters in StudioTools

### DIFF
--- a/libs/agno/agno/tools/scheduler.py
+++ b/libs/agno/agno/tools/scheduler.py
@@ -19,6 +19,7 @@ Example:
 """
 
 import json
+import time
 from typing import Any, Callable, Dict, List, Optional
 
 from agno.scheduler.manager import ScheduleManager
@@ -66,6 +67,7 @@ class SchedulerTools(Toolkit):
             self.delete_schedule,
             self.enable_schedule,
             self.disable_schedule,
+            self.trigger_schedule,
             self.get_schedule_runs,
         ]
 
@@ -76,6 +78,7 @@ class SchedulerTools(Toolkit):
             (self.adelete_schedule, "delete_schedule"),
             (self.aenable_schedule, "enable_schedule"),
             (self.adisable_schedule, "disable_schedule"),
+            (self.atrigger_schedule, "trigger_schedule"),
             (self.aget_schedule_runs, "get_schedule_runs"),
         ]
 
@@ -303,6 +306,39 @@ class SchedulerTools(Toolkit):
             )
         except Exception as e:
             logger.exception("Failed to disable schedule")
+            return json.dumps({"error": str(e)})
+
+    def trigger_schedule(self, schedule_id: str) -> str:
+        """Queue an enabled schedule to run now.
+
+        Sets the schedule's next run time to now; the scheduler poller claims and
+        executes it within one poll interval. The regular cron cadence resumes
+        after the run.
+
+        Args:
+            schedule_id (str): The ID of the schedule to trigger.
+
+        Returns:
+            str: JSON string confirming the trigger.
+        """
+        try:
+            schedule = self.manager.get(schedule_id)
+            if schedule is None:
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+            if not schedule.enabled:
+                return json.dumps(
+                    {"error": f"Schedule is disabled: {schedule_id}. Call enable_schedule first, then trigger it."}
+                )
+            self.manager.update(schedule_id, next_run_at=int(time.time()))
+            return json.dumps(
+                {
+                    "status": "triggered",
+                    "id": schedule_id,
+                    "note": "The scheduler poller will execute it within one poll interval.",
+                }
+            )
+        except Exception as e:
+            logger.exception("Failed to trigger schedule")
             return json.dumps({"error": str(e)})
 
     def get_schedule_runs(self, schedule_id: str, limit: int = 10) -> str:
@@ -535,6 +571,39 @@ class SchedulerTools(Toolkit):
             )
         except Exception as e:
             logger.exception("Failed to disable schedule")
+            return json.dumps({"error": str(e)})
+
+    async def atrigger_schedule(self, schedule_id: str) -> str:
+        """Queue an enabled schedule to run now.
+
+        Sets the schedule's next run time to now; the scheduler poller claims and
+        executes it within one poll interval. The regular cron cadence resumes
+        after the run.
+
+        Args:
+            schedule_id (str): The ID of the schedule to trigger.
+
+        Returns:
+            str: JSON string confirming the trigger.
+        """
+        try:
+            schedule = await self.manager.aget(schedule_id)
+            if schedule is None:
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+            if not schedule.enabled:
+                return json.dumps(
+                    {"error": f"Schedule is disabled: {schedule_id}. Call enable_schedule first, then trigger it."}
+                )
+            await self.manager.aupdate(schedule_id, next_run_at=int(time.time()))
+            return json.dumps(
+                {
+                    "status": "triggered",
+                    "id": schedule_id,
+                    "note": "The scheduler poller will execute it within one poll interval.",
+                }
+            )
+        except Exception as e:
+            logger.exception("Failed to trigger schedule")
             return json.dumps({"error": str(e)})
 
     async def aget_schedule_runs(self, schedule_id: str, limit: int = 10) -> str:

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -87,6 +87,9 @@ class StudioTools(Toolkit):
         teams_list: Same as ``agents_list`` but for teams.
         workflows_list: Same as ``agents_list`` but for workflows.
         default_model_id: Model id to use when a caller omits one.
+        default_num_history_runs: History depth for created agents when a
+            caller omits ``num_history_runs``. None lets Agent's own default
+            apply.
         agents: Expose agent operations. Defaults to True.
         teams: Expose team operations. Defaults to False (see module docstring
             for auto-enable rules).
@@ -112,6 +115,7 @@ class StudioTools(Toolkit):
         teams_list: Optional[List["Team"]] = None,
         workflows_list: Optional[List["Workflow"]] = None,
         default_model_id: Optional[str] = None,
+        default_num_history_runs: Optional[int] = None,
         agents: Optional[bool] = None,
         teams: Optional[bool] = None,
         workflows: Optional[bool] = None,
@@ -125,6 +129,7 @@ class StudioTools(Toolkit):
         self.teams_list = teams_list
         self.workflows_list = workflows_list
         self.default_model_id = default_model_id
+        self.default_num_history_runs = default_num_history_runs
 
         self.enable_agents, self.enable_teams, self.enable_workflows = _resolve_flags(
             agents=agents,
@@ -273,6 +278,8 @@ class StudioTools(Toolkit):
             "are exact and case-sensitive -- do NOT guess.",
             "Create: create_agent/create_team/create_workflow. When the user mentions specific "
             "tools, you MUST include ALL of those names in tool_names; do not silently drop any.",
+            "Created agents remember the session by default; pass add_history_to_context=False "
+            "only for stateless agents.",
             "Edit: ALWAYS call get_agent/get_team/get_workflow first to read the current state, "
             "then call edit_agent/edit_team/edit_workflow with only the fields that change.",
         ]
@@ -797,6 +804,8 @@ class StudioTools(Toolkit):
                 "instructions": getattr(agent, "instructions", None),
                 "description": getattr(agent, "description", None),
                 "tools": self._normalize_tool_names(_summarize_tools(getattr(agent, "tools", None))),
+                "add_history_to_context": getattr(agent, "add_history_to_context", None),
+                "num_history_runs": getattr(agent, "num_history_runs", None),
             },
             default=str,
         )
@@ -873,6 +882,8 @@ class StudioTools(Toolkit):
         tool_names: Optional[List[str]] = None,
         db_id: Optional[str] = None,
         description: Optional[str] = None,
+        add_history_to_context: bool = True,
+        num_history_runs: Optional[int] = None,
     ) -> str:
         """Create a new agent and persist it as a published component.
 
@@ -884,9 +895,14 @@ class StudioTools(Toolkit):
                 (see list_tools). Include EVERY tool the user mentioned.
             db_id (Optional[str]): Database id from the registry. Uses the default if omitted.
             description (Optional[str]): Optional human-readable description.
+            add_history_to_context (bool): Include prior turns of the session so the
+                agent remembers the conversation. Defaults to True; pass False for a
+                stateless agent.
+            num_history_runs (Optional[int]): How many prior runs to include when
+                history is on. Omit for the default.
 
         Returns:
-            str: JSON with {status, id, name, model_id, tools, db_version}.
+            str: JSON with {status, id, name, model_id, tools, add_history_to_context, db_version}.
         """
         from agno.agent.agent import Agent
 
@@ -909,6 +925,8 @@ class StudioTools(Toolkit):
                 instructions=instructions,
                 db=db,
                 description=description,
+                add_history_to_context=add_history_to_context,
+                num_history_runs=num_history_runs if num_history_runs is not None else self.default_num_history_runs,
             )
 
             version = _persist_only(agent, db)
@@ -920,6 +938,7 @@ class StudioTools(Toolkit):
                     "name": name,
                     "model_id": getattr(model, "id", None),
                     "tools": _summarize_tools(tools),
+                    "add_history_to_context": add_history_to_context,
                     "db_version": version,
                 }
             )
@@ -1059,6 +1078,8 @@ class StudioTools(Toolkit):
         model_id: Optional[str] = None,
         tool_names: Optional[List[str]] = None,
         description: Optional[str] = None,
+        add_history_to_context: Optional[bool] = None,
+        num_history_runs: Optional[int] = None,
     ) -> str:
         """Edit an agent.
 
@@ -1073,6 +1094,9 @@ class StudioTools(Toolkit):
             model_id (Optional[str]): New model id from the registry. Omit to keep.
             tool_names (Optional[List[str]]): New tool list (replaces existing). Omit to keep.
             description (Optional[str]): New description. Omit to keep.
+            add_history_to_context (Optional[bool]): Whether the agent sees prior turns
+                of the session. Omit to keep.
+            num_history_runs (Optional[int]): New history depth. Omit to keep.
         """
         if self.db is None:
             return json.dumps({"error": "StudioTools has no db configured; cannot edit components."})
@@ -1100,6 +1124,13 @@ class StudioTools(Toolkit):
                 agent.model = model
             if tool_names is not None:
                 agent.tools = self._resolve_tools(tool_names) or None
+            if add_history_to_context is not None:
+                agent.add_history_to_context = add_history_to_context
+            if num_history_runs is not None:
+                agent.num_history_runs = num_history_runs
+                # Mirror Agent.__init__'s resolution: num_history_runs wins
+                # over num_history_messages.
+                agent.num_history_messages = None
 
             result = self._save_edit(agent)
             log_debug(f"StudioTools edited agent id={agent_id} result={result}")
@@ -1755,6 +1786,8 @@ class StudioTools(Toolkit):
         tool_names: Optional[List[str]] = None,
         db_id: Optional[str] = None,
         description: Optional[str] = None,
+        add_history_to_context: bool = True,
+        num_history_runs: Optional[int] = None,
     ) -> str:
         """Async variant of create_agent."""
         return await self._run_sync_tool(
@@ -1765,6 +1798,8 @@ class StudioTools(Toolkit):
             tool_names=tool_names,
             db_id=db_id,
             description=description,
+            add_history_to_context=add_history_to_context,
+            num_history_runs=num_history_runs,
         )
 
     async def acreate_team(
@@ -1810,6 +1845,8 @@ class StudioTools(Toolkit):
         model_id: Optional[str] = None,
         tool_names: Optional[List[str]] = None,
         description: Optional[str] = None,
+        add_history_to_context: Optional[bool] = None,
+        num_history_runs: Optional[int] = None,
     ) -> str:
         """Async variant of edit_agent."""
         return await self._run_sync_tool(
@@ -1819,6 +1856,8 @@ class StudioTools(Toolkit):
             model_id=model_id,
             tool_names=tool_names,
             description=description,
+            add_history_to_context=add_history_to_context,
+            num_history_runs=num_history_runs,
         )
 
     async def aedit_team(

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -38,6 +38,9 @@ Enable flags:
       False overrides the auto-enable.
     * Versioning tools (list_versions, get_version, publish_component,
       set_current_version, delete_version) are exposed only when versions=True.
+    * Schedule tools (create_schedule, list_schedules, get_schedule_runs,
+      trigger_schedule, enable_schedule, disable_schedule, delete_schedule)
+      are exposed only when schedules=True.
 
 Persistence:
     * Studio saves ONLY the component it creates/edits. It does NOT cascade to
@@ -48,6 +51,7 @@ Persistence:
 from __future__ import annotations
 
 import json
+import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from agno.tools.function import Function
@@ -59,11 +63,14 @@ if TYPE_CHECKING:
     from agno.db.base import BaseDb, ComponentType
     from agno.models.base import Model
     from agno.registry.registry import Registry
+    from agno.scheduler.manager import ScheduleManager
     from agno.team.team import Team
     from agno.workflow.workflow import Workflow
 
 Component = Union["Agent", "Team", "Workflow"]
 TeamMember = Union["Agent", "Team"]
+
+_SCHEDULE_TARGET_TYPES = ("agent", "team", "workflow")
 
 
 class StudioTools(Toolkit):
@@ -88,6 +95,13 @@ class StudioTools(Toolkit):
             publish_component, set_current_version, delete_version). Defaults
             to False; without versioning, edits publish immediately instead of
             producing drafts.
+        schedules: Expose component-aware schedule tools (create_schedule,
+            list_schedules, get_schedule_runs, trigger_schedule,
+            enable_schedule, disable_schedule, delete_schedule). Defaults to
+            False. Requires the optional scheduler dependencies (croniter and
+            pytz -- ``pip install agno[scheduler]``); when they are missing,
+            the first schedule tool call that needs them returns an error JSON
+            instead of raising at import time.
     """
 
     def __init__(
@@ -102,6 +116,7 @@ class StudioTools(Toolkit):
         teams: Optional[bool] = None,
         workflows: Optional[bool] = None,
         versions: bool = False,
+        schedules: bool = False,
         **kwargs: Any,
     ):
         self.registry = registry
@@ -119,6 +134,8 @@ class StudioTools(Toolkit):
             has_teams_list=teams_list is not None,
         )
         self.enable_versions: bool = versions
+        self.enable_schedules: bool = schedules
+        self._schedule_manager: Optional["ScheduleManager"] = None  # lazy -- needs self.db
 
         tools: List[Callable] = [
             # Discovery -- always available regardless of flags.
@@ -174,6 +191,20 @@ class StudioTools(Toolkit):
                 ]
             )
 
+        # Schedules target existing components of any enabled type; opt-in.
+        if self.enable_schedules:
+            tools.extend(
+                [
+                    self.create_schedule,
+                    self.list_schedules,
+                    self.get_schedule_runs,
+                    self.trigger_schedule,
+                    self.enable_schedule,
+                    self.disable_schedule,
+                    self.delete_schedule,
+                ]
+            )
+
         async_tools: List[tuple[Callable[..., Any], str]] = [
             (self.alist_models, "list_models"),
             (self.alist_tools, "list_tools"),
@@ -223,6 +254,18 @@ class StudioTools(Toolkit):
                     (self.adelete_version, "delete_version"),
                 ]
             )
+        if self.enable_schedules:
+            async_tools.extend(
+                [
+                    (self.acreate_schedule, "create_schedule"),
+                    (self.alist_schedules, "list_schedules"),
+                    (self.aget_schedule_runs, "get_schedule_runs"),
+                    (self.atrigger_schedule, "trigger_schedule"),
+                    (self.aenable_schedule, "enable_schedule"),
+                    (self.adisable_schedule, "disable_schedule"),
+                    (self.adelete_schedule, "delete_schedule"),
+                ]
+            )
 
         instruction_lines = [
             "Compose agents, teams, and workflows from registry primitives.",
@@ -251,6 +294,13 @@ class StudioTools(Toolkit):
             instruction_lines.append(
                 "Workflow rules: each step_spec is a dict with 'name' and exactly one of "
                 "'agent_id', 'team_id', or 'function_name'. Use function_name values from list_functions."
+            )
+        if self.enable_schedules:
+            instruction_lines.append(
+                "Schedules: create_schedule targets an existing component by target_type "
+                "('agent'/'team'/'workflow') + target_id (ids from list_agents/list_teams/list_workflows) "
+                "and requires a message. Cron is 5-field; timezone is an IANA name. trigger_schedule "
+                "queues an enabled schedule to run now via the platform poller."
             )
 
         # Toolkit instructions are only injected into the system message when
@@ -1423,6 +1473,237 @@ class StudioTools(Toolkit):
             return json.dumps({"error": str(e)})
 
     # ------------------------------------------------------------------
+    # Schedules (component-aware)
+    # ------------------------------------------------------------------
+
+    def create_schedule(
+        self,
+        name: str,
+        cron: str,
+        target_type: str,
+        target_id: str,
+        message: str,
+        timezone: str = "UTC",
+        description: Optional[str] = None,
+    ) -> str:
+        """Create (or update) a schedule that runs an existing component on a cron cadence.
+
+        Args:
+            name (str): Unique schedule name (e.g. "daily-news-digest"). Re-using an
+                existing name updates that schedule in place.
+            cron (str): 5-field cron expression (e.g. "0 9 * * *" for daily at 9am).
+            target_type (str): One of 'agent', 'team', or 'workflow'.
+            target_id (str): Id (or name) of an existing component -- use ids from
+                list_agents/list_teams/list_workflows.
+            message (str): The message sent to the component on every scheduled run.
+            timezone (str): IANA timezone name for the cron expression
+                (e.g. "America/New_York"). Defaults to "UTC".
+            description (Optional[str]): Human-readable description of the schedule.
+
+        Returns:
+            str: JSON with {status, id, name, cron, target_type, target_id, endpoint,
+                timezone, enabled, next_run_at}.
+        """
+        try:
+            component_id, target_error = self._resolve_schedule_target(target_type, target_id)
+            if target_error is not None:
+                return json.dumps({"error": target_error})
+            if not message or not message.strip():
+                return json.dumps(
+                    {
+                        "error": "message must be a non-empty string; it is the prompt "
+                        "sent to the component on every scheduled run."
+                    }
+                )
+            manager = self._get_schedule_manager()
+            schedule = manager.create(
+                name=name,
+                cron=cron,
+                endpoint=f"/{target_type}s/{component_id}/runs",
+                method="POST",
+                description=description,
+                payload={"message": message},
+                timezone=timezone,
+                if_exists="update",
+            )
+            log_debug(f"StudioTools created schedule name={name} target={target_type}:{component_id}")
+            return json.dumps(
+                {
+                    "status": "created",
+                    "id": schedule.id,
+                    "name": schedule.name,
+                    "cron": schedule.cron_expr,
+                    "target_type": target_type,
+                    "target_id": component_id,
+                    "endpoint": schedule.endpoint,
+                    "timezone": schedule.timezone,
+                    "enabled": schedule.enabled,
+                    "next_run_at": schedule.next_run_at,
+                }
+            )
+        except Exception as e:
+            logger.exception("Failed to create schedule")
+            return json.dumps({"error": str(e)})
+
+    def list_schedules(self, enabled_only: bool = False) -> str:
+        """List all existing schedules.
+
+        Args:
+            enabled_only (bool): If True, only return enabled schedules. Defaults to False.
+
+        Returns:
+            str: JSON with {schedules, count}.
+        """
+        try:
+            enabled_filter = True if enabled_only else None
+            schedules = self._get_schedule_manager().list(enabled=enabled_filter)
+            result = [
+                {
+                    "id": s.id,
+                    "name": s.name,
+                    "cron": s.cron_expr,
+                    "endpoint": s.endpoint,
+                    "timezone": s.timezone,
+                    "enabled": s.enabled,
+                    "description": s.description,
+                }
+                for s in schedules
+            ]
+            return json.dumps({"schedules": result, "count": len(result)})
+        except Exception as e:
+            logger.exception("Failed to list schedules")
+            return json.dumps({"error": str(e)})
+
+    def get_schedule_runs(self, schedule_id: str, limit: int = 10) -> str:
+        """Get the run history for a schedule.
+
+        Args:
+            schedule_id (str): The id of the schedule to get runs for.
+            limit (int): Maximum number of runs to return. Defaults to 10.
+
+        Returns:
+            str: JSON with {runs, count}.
+        """
+        try:
+            runs = self._get_schedule_manager().get_runs(schedule_id, limit=limit)
+            result = [
+                {
+                    "id": r.id,
+                    "status": r.status,
+                    "triggered_at": r.triggered_at,
+                    "completed_at": r.completed_at,
+                    "error": r.error,
+                }
+                for r in runs
+            ]
+            return json.dumps({"runs": result, "count": len(result)})
+        except Exception as e:
+            logger.exception("Failed to get schedule runs")
+            return json.dumps({"error": str(e)})
+
+    def trigger_schedule(self, schedule_id: str) -> str:
+        """Queue an enabled schedule to run now.
+
+        Sets the schedule's next run time to now; the scheduler poller claims and
+        executes it within one poll interval. The regular cron cadence resumes
+        after the run.
+
+        Args:
+            schedule_id (str): The id of the schedule to trigger.
+
+        Returns:
+            str: JSON with {status, id, note}.
+        """
+        try:
+            manager = self._get_schedule_manager()
+            schedule = manager.get(schedule_id)
+            if schedule is None:
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+            if not schedule.enabled:
+                return json.dumps(
+                    {"error": f"Schedule is disabled: {schedule_id}. Call enable_schedule first, then trigger it."}
+                )
+            manager.update(schedule_id, next_run_at=int(time.time()))
+            return json.dumps(
+                {
+                    "status": "triggered",
+                    "id": schedule_id,
+                    "note": "The scheduler poller will execute it within one poll interval.",
+                }
+            )
+        except Exception as e:
+            logger.exception("Failed to trigger schedule")
+            return json.dumps({"error": str(e)})
+
+    def enable_schedule(self, schedule_id: str) -> str:
+        """Enable a disabled schedule so it starts running again.
+
+        Args:
+            schedule_id (str): The id of the schedule to enable.
+
+        Returns:
+            str: JSON with {status, id, name, enabled}.
+        """
+        try:
+            schedule = self._get_schedule_manager().enable(schedule_id)
+            if schedule is None:
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+            return json.dumps(
+                {
+                    "status": "enabled",
+                    "id": schedule.id,
+                    "name": schedule.name,
+                    "enabled": schedule.enabled,
+                }
+            )
+        except Exception as e:
+            logger.exception("Failed to enable schedule")
+            return json.dumps({"error": str(e)})
+
+    def disable_schedule(self, schedule_id: str) -> str:
+        """Disable a schedule so it stops running. Can be re-enabled later.
+
+        Args:
+            schedule_id (str): The id of the schedule to disable.
+
+        Returns:
+            str: JSON with {status, id, name, enabled}.
+        """
+        try:
+            schedule = self._get_schedule_manager().disable(schedule_id)
+            if schedule is None:
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+            return json.dumps(
+                {
+                    "status": "disabled",
+                    "id": schedule.id,
+                    "name": schedule.name,
+                    "enabled": schedule.enabled,
+                }
+            )
+        except Exception as e:
+            logger.exception("Failed to disable schedule")
+            return json.dumps({"error": str(e)})
+
+    def delete_schedule(self, schedule_id: str) -> str:
+        """Delete a schedule by its id. This permanently removes the schedule.
+
+        Args:
+            schedule_id (str): The id of the schedule to delete.
+
+        Returns:
+            str: JSON with {status, id}.
+        """
+        try:
+            deleted = self._get_schedule_manager().delete(schedule_id)
+            if deleted:
+                return json.dumps({"status": "deleted", "id": schedule_id})
+            return json.dumps({"error": f"Schedule not found or could not be deleted: {schedule_id}"})
+        except Exception as e:
+            logger.exception("Failed to delete schedule")
+            return json.dumps({"error": str(e)})
+
+    # ------------------------------------------------------------------
     # Async tools
     # ------------------------------------------------------------------
 
@@ -1655,6 +1936,52 @@ class StudioTools(Toolkit):
             logger.exception("Failed to run workflow")
             return json.dumps({"error": str(e)})
 
+    async def acreate_schedule(
+        self,
+        name: str,
+        cron: str,
+        target_type: str,
+        target_id: str,
+        message: str,
+        timezone: str = "UTC",
+        description: Optional[str] = None,
+    ) -> str:
+        """Async variant of create_schedule."""
+        return await self._run_sync_tool(
+            self.create_schedule,
+            name,
+            cron,
+            target_type,
+            target_id,
+            message,
+            timezone=timezone,
+            description=description,
+        )
+
+    async def alist_schedules(self, enabled_only: bool = False) -> str:
+        """Async variant of list_schedules."""
+        return await self._run_sync_tool(self.list_schedules, enabled_only=enabled_only)
+
+    async def aget_schedule_runs(self, schedule_id: str, limit: int = 10) -> str:
+        """Async variant of get_schedule_runs."""
+        return await self._run_sync_tool(self.get_schedule_runs, schedule_id, limit=limit)
+
+    async def atrigger_schedule(self, schedule_id: str) -> str:
+        """Async variant of trigger_schedule."""
+        return await self._run_sync_tool(self.trigger_schedule, schedule_id)
+
+    async def aenable_schedule(self, schedule_id: str) -> str:
+        """Async variant of enable_schedule."""
+        return await self._run_sync_tool(self.enable_schedule, schedule_id)
+
+    async def adisable_schedule(self, schedule_id: str) -> str:
+        """Async variant of disable_schedule."""
+        return await self._run_sync_tool(self.disable_schedule, schedule_id)
+
+    async def adelete_schedule(self, schedule_id: str) -> str:
+        """Async variant of delete_schedule."""
+        return await self._run_sync_tool(self.delete_schedule, schedule_id)
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -1677,6 +2004,39 @@ class StudioTools(Toolkit):
             candidate = f"{base}-{suffix}"
             suffix += 1
         return candidate
+
+    def _get_schedule_manager(self) -> "ScheduleManager":
+        """Lazily build the ScheduleManager over the toolkit's db."""
+        if self._schedule_manager is None:
+            if self.db is None:
+                raise ValueError("StudioTools has no db configured; cannot manage schedules.")
+            from agno.scheduler.manager import ScheduleManager
+
+            self._schedule_manager = ScheduleManager(db=self.db)
+        return self._schedule_manager
+
+    def _resolve_schedule_target(self, target_type: str, target_id: str) -> tuple[Optional[str], Optional[str]]:
+        """Resolve a schedule target to a real component id.
+
+        Returns ``(component_id, error)``: exactly one side is set. Targets
+        resolve through the Studio lookup path (code-defined lists, then DB;
+        matched by id or name), so schedules always point at a component's
+        real id even when the caller passed its display name.
+        """
+        if target_type not in _SCHEDULE_TARGET_TYPES:
+            return None, f"Invalid target_type: {target_type}. Must be one of {list(_SCHEDULE_TARGET_TYPES)}."
+        finders: Dict[str, Callable[[str], Optional[Any]]] = {
+            "agent": self._find_agent,
+            "team": self._find_team,
+            "workflow": self._find_workflow,
+        }
+        component = finders[target_type](target_id)
+        if component is None:
+            return None, f"{target_type.capitalize()} not found: {target_id}"
+        component_id = getattr(component, "id", None)
+        if component_id is None:
+            return None, f"{target_type.capitalize()} has no id: {target_id}"
+        return component_id, None
 
     def _component_id_exists(self, component_id: str, db: "BaseDb") -> bool:
         for component in [*self._iter_agents(), *self._iter_teams(), *self._iter_workflows()]:

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -806,6 +806,7 @@ class StudioTools(Toolkit):
                 "tools": self._normalize_tool_names(_summarize_tools(getattr(agent, "tools", None))),
                 "add_history_to_context": getattr(agent, "add_history_to_context", None),
                 "num_history_runs": getattr(agent, "num_history_runs", None),
+                "add_datetime_to_context": getattr(agent, "add_datetime_to_context", None),
             },
             default=str,
         )
@@ -884,6 +885,7 @@ class StudioTools(Toolkit):
         description: Optional[str] = None,
         add_history_to_context: bool = True,
         num_history_runs: Optional[int] = None,
+        add_datetime_to_context: bool = True,
     ) -> str:
         """Create a new agent and persist it as a published component.
 
@@ -900,9 +902,13 @@ class StudioTools(Toolkit):
                 stateless agent.
             num_history_runs (Optional[int]): How many prior runs to include when
                 history is on. Omit for the default.
+            add_datetime_to_context (bool): Add the current date and time to the
+                agent's context so it can date and time-reference reliably.
+                Defaults to True; pass False to omit.
 
         Returns:
-            str: JSON with {status, id, name, model_id, tools, add_history_to_context, db_version}.
+            str: JSON with {status, id, name, model_id, tools, add_history_to_context,
+            add_datetime_to_context, db_version}.
         """
         from agno.agent.agent import Agent
 
@@ -927,6 +933,7 @@ class StudioTools(Toolkit):
                 description=description,
                 add_history_to_context=add_history_to_context,
                 num_history_runs=num_history_runs if num_history_runs is not None else self.default_num_history_runs,
+                add_datetime_to_context=add_datetime_to_context,
             )
 
             version = _persist_only(agent, db)
@@ -939,6 +946,7 @@ class StudioTools(Toolkit):
                     "model_id": getattr(model, "id", None),
                     "tools": _summarize_tools(tools),
                     "add_history_to_context": add_history_to_context,
+                    "add_datetime_to_context": add_datetime_to_context,
                     "db_version": version,
                 }
             )
@@ -1080,6 +1088,7 @@ class StudioTools(Toolkit):
         description: Optional[str] = None,
         add_history_to_context: Optional[bool] = None,
         num_history_runs: Optional[int] = None,
+        add_datetime_to_context: Optional[bool] = None,
     ) -> str:
         """Edit an agent.
 
@@ -1097,6 +1106,8 @@ class StudioTools(Toolkit):
             add_history_to_context (Optional[bool]): Whether the agent sees prior turns
                 of the session. Omit to keep.
             num_history_runs (Optional[int]): New history depth. Omit to keep.
+            add_datetime_to_context (Optional[bool]): Whether the agent sees the
+                current date and time. Omit to keep.
         """
         if self.db is None:
             return json.dumps({"error": "StudioTools has no db configured; cannot edit components."})
@@ -1131,6 +1142,8 @@ class StudioTools(Toolkit):
                 # Mirror Agent.__init__'s resolution: num_history_runs wins
                 # over num_history_messages.
                 agent.num_history_messages = None
+            if add_datetime_to_context is not None:
+                agent.add_datetime_to_context = add_datetime_to_context
 
             result = self._save_edit(agent)
             log_debug(f"StudioTools edited agent id={agent_id} result={result}")
@@ -1788,6 +1801,7 @@ class StudioTools(Toolkit):
         description: Optional[str] = None,
         add_history_to_context: bool = True,
         num_history_runs: Optional[int] = None,
+        add_datetime_to_context: bool = True,
     ) -> str:
         """Async variant of create_agent."""
         return await self._run_sync_tool(
@@ -1800,6 +1814,7 @@ class StudioTools(Toolkit):
             description=description,
             add_history_to_context=add_history_to_context,
             num_history_runs=num_history_runs,
+            add_datetime_to_context=add_datetime_to_context,
         )
 
     async def acreate_team(
@@ -1847,6 +1862,7 @@ class StudioTools(Toolkit):
         description: Optional[str] = None,
         add_history_to_context: Optional[bool] = None,
         num_history_runs: Optional[int] = None,
+        add_datetime_to_context: Optional[bool] = None,
     ) -> str:
         """Async variant of edit_agent."""
         return await self._run_sync_tool(
@@ -1858,6 +1874,7 @@ class StudioTools(Toolkit):
             description=description,
             add_history_to_context=add_history_to_context,
             num_history_runs=num_history_runs,
+            add_datetime_to_context=add_datetime_to_context,
         )
 
     async def aedit_team(

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -89,9 +89,9 @@ class StudioTools(Toolkit):
         teams_list: Same as ``agents_list`` but for teams.
         workflows_list: Same as ``agents_list`` but for workflows.
         default_model_id: Model id to use when a caller omits one.
-        default_num_history_runs: History depth for created agents when a
-            caller omits ``num_history_runs``. None lets Agent's own default
-            apply.
+        default_num_history_runs: History depth for created agents and teams
+            when a caller omits ``num_history_runs``. None lets the
+            component's own default apply.
         agents: Expose agent operations. Defaults to True.
         teams: Expose team operations. Defaults to False (see module docstring
             for auto-enable rules).
@@ -289,8 +289,8 @@ class StudioTools(Toolkit):
             "are exact and case-sensitive -- do NOT guess.",
             "Create: create_agent/create_team/create_workflow. When the user mentions specific "
             "tools, you MUST include ALL of those names in tool_names; do not silently drop any.",
-            "Created agents remember the session by default; pass add_history_to_context=False "
-            "only for stateless agents.",
+            "Created agents and teams remember the session by default; pass "
+            "add_history_to_context=False only for stateless components.",
             "Edit: ALWAYS call get_agent/get_team/get_workflow first to read the current state, "
             "then call edit_agent/edit_team/edit_workflow with only the fields that change.",
         ]
@@ -842,6 +842,9 @@ class StudioTools(Toolkit):
                 "instructions": getattr(team, "instructions", None),
                 "description": getattr(team, "description", None),
                 "member_ids": [getattr(m, "id", None) for m in members] if not callable(members) else [],
+                "add_history_to_context": getattr(team, "add_history_to_context", None),
+                "num_history_runs": getattr(team, "num_history_runs", None),
+                "add_datetime_to_context": getattr(team, "add_datetime_to_context", None),
             },
             default=str,
         )
@@ -973,6 +976,9 @@ class StudioTools(Toolkit):
         model_id: Optional[str] = None,
         db_id: Optional[str] = None,
         description: Optional[str] = None,
+        add_history_to_context: bool = True,
+        num_history_runs: Optional[int] = None,
+        add_datetime_to_context: bool = True,
     ) -> str:
         """Create a new team and persist it as a published component.
 
@@ -983,9 +989,18 @@ class StudioTools(Toolkit):
             model_id (Optional[str]): Model id for the team leader.
             db_id (Optional[str]): Database id from the registry.
             description (Optional[str]): Optional description.
+            add_history_to_context (bool): Include prior turns of the session so the
+                team remembers the conversation. Defaults to True; pass False for a
+                stateless team.
+            num_history_runs (Optional[int]): How many prior runs to include when
+                history is on. Omit for the default.
+            add_datetime_to_context (bool): Add the current date and time to the
+                team's context so it can date and time-reference reliably.
+                Defaults to True; pass False to omit.
 
         Returns:
-            str: JSON with {status, id, name, model_id, member_ids, db_version}.
+            str: JSON with {status, id, name, model_id, member_ids, add_history_to_context,
+            add_datetime_to_context, db_version}.
         """
         from agno.team.team import Team
 
@@ -1013,6 +1028,9 @@ class StudioTools(Toolkit):
                 instructions=instructions,
                 db=db,
                 description=description,
+                add_history_to_context=add_history_to_context,
+                num_history_runs=num_history_runs if num_history_runs is not None else self.default_num_history_runs,
+                add_datetime_to_context=add_datetime_to_context,
             )
 
             version = _persist_only(team, db)
@@ -1024,6 +1042,8 @@ class StudioTools(Toolkit):
                     "name": name,
                     "model_id": getattr(model, "id", None),
                     "member_ids": [getattr(m, "id", None) for m in members],
+                    "add_history_to_context": add_history_to_context,
+                    "add_datetime_to_context": add_datetime_to_context,
                     "db_version": version,
                 }
             )
@@ -1170,6 +1190,9 @@ class StudioTools(Toolkit):
         model_id: Optional[str] = None,
         member_ids: Optional[List[str]] = None,
         description: Optional[str] = None,
+        add_history_to_context: Optional[bool] = None,
+        num_history_runs: Optional[int] = None,
+        add_datetime_to_context: Optional[bool] = None,
     ) -> str:
         """Edit a team.
 
@@ -1184,6 +1207,11 @@ class StudioTools(Toolkit):
             model_id (Optional[str]): New model id. Omit to keep.
             member_ids (Optional[List[str]]): New member ids (replaces existing). Omit to keep.
             description (Optional[str]): New description. Omit to keep.
+            add_history_to_context (Optional[bool]): Whether the team sees prior turns
+                of the session. Omit to keep.
+            num_history_runs (Optional[int]): New history depth. Omit to keep.
+            add_datetime_to_context (Optional[bool]): Whether the team sees the
+                current date and time. Omit to keep.
         """
         if self.db is None:
             return json.dumps({"error": "StudioTools has no db configured; cannot edit components."})
@@ -1216,6 +1244,15 @@ class StudioTools(Toolkit):
                 if not members:
                     return json.dumps({"error": "A team must have at least one member"})
                 team.members = members
+            if add_history_to_context is not None:
+                team.add_history_to_context = add_history_to_context
+            if num_history_runs is not None:
+                team.num_history_runs = num_history_runs
+                # Mirror Team.__init__'s resolution: num_history_runs wins
+                # over num_history_messages.
+                team.num_history_messages = None
+            if add_datetime_to_context is not None:
+                team.add_datetime_to_context = add_datetime_to_context
 
             result = self._save_edit(team)
             log_debug(f"StudioTools edited team id={team_id} result={result}")
@@ -1678,6 +1715,9 @@ class StudioTools(Toolkit):
         model_id: Optional[str] = None,
         db_id: Optional[str] = None,
         description: Optional[str] = None,
+        add_history_to_context: bool = True,
+        num_history_runs: Optional[int] = None,
+        add_datetime_to_context: bool = True,
     ) -> str:
         """Async variant of create_team."""
         return await self._run_sync_tool(
@@ -1688,6 +1728,9 @@ class StudioTools(Toolkit):
             model_id=model_id,
             db_id=db_id,
             description=description,
+            add_history_to_context=add_history_to_context,
+            num_history_runs=num_history_runs,
+            add_datetime_to_context=add_datetime_to_context,
         )
 
     async def acreate_workflow(
@@ -1737,6 +1780,9 @@ class StudioTools(Toolkit):
         model_id: Optional[str] = None,
         member_ids: Optional[List[str]] = None,
         description: Optional[str] = None,
+        add_history_to_context: Optional[bool] = None,
+        num_history_runs: Optional[int] = None,
+        add_datetime_to_context: Optional[bool] = None,
     ) -> str:
         """Async variant of edit_team."""
         return await self._run_sync_tool(
@@ -1746,6 +1792,9 @@ class StudioTools(Toolkit):
             model_id=model_id,
             member_ids=member_ids,
             description=description,
+            add_history_to_context=add_history_to_context,
+            num_history_runs=num_history_runs,
+            add_datetime_to_context=add_datetime_to_context,
         )
 
     async def aedit_workflow(

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -38,9 +38,11 @@ Enable flags:
       False overrides the auto-enable.
     * Versioning tools (list_versions, get_version, publish_component,
       set_current_version, delete_version) are exposed only when versions=True.
-    * Schedule tools (create_schedule, list_schedules, get_schedule_runs,
-      trigger_schedule, enable_schedule, disable_schedule, delete_schedule)
-      are exposed only when schedules=True.
+    * Schedule tools (create_schedule, list_schedules, get_schedule,
+      get_schedule_runs, trigger_schedule, enable_schedule, disable_schedule,
+      delete_schedule) are exposed only when schedules=True. create_schedule is
+      Studio's own (component-aware targets); the management tools are shared
+      with SchedulerTools.
 
 Persistence:
     * Studio saves ONLY the component it creates/edits. It does NOT cascade to
@@ -51,7 +53,6 @@ Persistence:
 from __future__ import annotations
 
 import json
-import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from agno.tools.function import Function
@@ -65,6 +66,7 @@ if TYPE_CHECKING:
     from agno.registry.registry import Registry
     from agno.scheduler.manager import ScheduleManager
     from agno.team.team import Team
+    from agno.tools.scheduler import SchedulerTools
     from agno.workflow.workflow import Workflow
 
 Component = Union["Agent", "Team", "Workflow"]
@@ -98,8 +100,9 @@ class StudioTools(Toolkit):
             publish_component, set_current_version, delete_version). Defaults
             to False; without versioning, edits publish immediately instead of
             producing drafts.
-        schedules: Expose component-aware schedule tools (create_schedule,
-            list_schedules, get_schedule_runs, trigger_schedule,
+        schedules: Expose schedule tools: Studio's own create_schedule
+            (component-aware targets) plus the SchedulerTools management tools
+            (list_schedules, get_schedule, get_schedule_runs, trigger_schedule,
             enable_schedule, disable_schedule, delete_schedule). Defaults to
             False. Requires the optional scheduler dependencies (croniter and
             pytz -- ``pip install agno[scheduler]``); when they are missing,
@@ -140,7 +143,13 @@ class StudioTools(Toolkit):
         )
         self.enable_versions: bool = versions
         self.enable_schedules: bool = schedules
-        self._schedule_manager: Optional["ScheduleManager"] = None  # lazy -- needs self.db
+        # Schedule management is shared with SchedulerTools; Studio owns only
+        # create_schedule (component targets, internally built endpoint).
+        self._scheduler_tools: Optional["SchedulerTools"] = None
+        if self.enable_schedules:
+            from agno.tools.scheduler import SchedulerTools
+
+            self._scheduler_tools = SchedulerTools(db=self.db)
 
         tools: List[Callable] = [
             # Discovery -- always available regardless of flags.
@@ -197,16 +206,17 @@ class StudioTools(Toolkit):
             )
 
         # Schedules target existing components of any enabled type; opt-in.
-        if self.enable_schedules:
+        if self._scheduler_tools is not None:
             tools.extend(
                 [
                     self.create_schedule,
-                    self.list_schedules,
-                    self.get_schedule_runs,
-                    self.trigger_schedule,
-                    self.enable_schedule,
-                    self.disable_schedule,
-                    self.delete_schedule,
+                    self._scheduler_tools.list_schedules,
+                    self._scheduler_tools.get_schedule,
+                    self._scheduler_tools.get_schedule_runs,
+                    self._scheduler_tools.trigger_schedule,
+                    self._scheduler_tools.enable_schedule,
+                    self._scheduler_tools.disable_schedule,
+                    self._scheduler_tools.delete_schedule,
                 ]
             )
 
@@ -259,16 +269,17 @@ class StudioTools(Toolkit):
                     (self.adelete_version, "delete_version"),
                 ]
             )
-        if self.enable_schedules:
+        if self._scheduler_tools is not None:
             async_tools.extend(
                 [
                     (self.acreate_schedule, "create_schedule"),
-                    (self.alist_schedules, "list_schedules"),
-                    (self.aget_schedule_runs, "get_schedule_runs"),
-                    (self.atrigger_schedule, "trigger_schedule"),
-                    (self.aenable_schedule, "enable_schedule"),
-                    (self.adisable_schedule, "disable_schedule"),
-                    (self.adelete_schedule, "delete_schedule"),
+                    (self._scheduler_tools.alist_schedules, "list_schedules"),
+                    (self._scheduler_tools.aget_schedule, "get_schedule"),
+                    (self._scheduler_tools.aget_schedule_runs, "get_schedule_runs"),
+                    (self._scheduler_tools.atrigger_schedule, "trigger_schedule"),
+                    (self._scheduler_tools.aenable_schedule, "enable_schedule"),
+                    (self._scheduler_tools.adisable_schedule, "disable_schedule"),
+                    (self._scheduler_tools.adelete_schedule, "delete_schedule"),
                 ]
             )
 
@@ -1589,164 +1600,6 @@ class StudioTools(Toolkit):
             logger.exception("Failed to create schedule")
             return json.dumps({"error": str(e)})
 
-    def list_schedules(self, enabled_only: bool = False) -> str:
-        """List all existing schedules.
-
-        Args:
-            enabled_only (bool): If True, only return enabled schedules. Defaults to False.
-
-        Returns:
-            str: JSON with {schedules, count}.
-        """
-        try:
-            enabled_filter = True if enabled_only else None
-            schedules = self._get_schedule_manager().list(enabled=enabled_filter)
-            result = [
-                {
-                    "id": s.id,
-                    "name": s.name,
-                    "cron": s.cron_expr,
-                    "endpoint": s.endpoint,
-                    "timezone": s.timezone,
-                    "enabled": s.enabled,
-                    "description": s.description,
-                }
-                for s in schedules
-            ]
-            return json.dumps({"schedules": result, "count": len(result)})
-        except Exception as e:
-            logger.exception("Failed to list schedules")
-            return json.dumps({"error": str(e)})
-
-    def get_schedule_runs(self, schedule_id: str, limit: int = 10) -> str:
-        """Get the run history for a schedule.
-
-        Args:
-            schedule_id (str): The id of the schedule to get runs for.
-            limit (int): Maximum number of runs to return. Defaults to 10.
-
-        Returns:
-            str: JSON with {runs, count}.
-        """
-        try:
-            runs = self._get_schedule_manager().get_runs(schedule_id, limit=limit)
-            result = [
-                {
-                    "id": r.id,
-                    "status": r.status,
-                    "triggered_at": r.triggered_at,
-                    "completed_at": r.completed_at,
-                    "error": r.error,
-                }
-                for r in runs
-            ]
-            return json.dumps({"runs": result, "count": len(result)})
-        except Exception as e:
-            logger.exception("Failed to get schedule runs")
-            return json.dumps({"error": str(e)})
-
-    def trigger_schedule(self, schedule_id: str) -> str:
-        """Queue an enabled schedule to run now.
-
-        Sets the schedule's next run time to now; the scheduler poller claims and
-        executes it within one poll interval. The regular cron cadence resumes
-        after the run.
-
-        Args:
-            schedule_id (str): The id of the schedule to trigger.
-
-        Returns:
-            str: JSON with {status, id, note}.
-        """
-        try:
-            manager = self._get_schedule_manager()
-            schedule = manager.get(schedule_id)
-            if schedule is None:
-                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
-            if not schedule.enabled:
-                return json.dumps(
-                    {"error": f"Schedule is disabled: {schedule_id}. Call enable_schedule first, then trigger it."}
-                )
-            manager.update(schedule_id, next_run_at=int(time.time()))
-            return json.dumps(
-                {
-                    "status": "triggered",
-                    "id": schedule_id,
-                    "note": "The scheduler poller will execute it within one poll interval.",
-                }
-            )
-        except Exception as e:
-            logger.exception("Failed to trigger schedule")
-            return json.dumps({"error": str(e)})
-
-    def enable_schedule(self, schedule_id: str) -> str:
-        """Enable a disabled schedule so it starts running again.
-
-        Args:
-            schedule_id (str): The id of the schedule to enable.
-
-        Returns:
-            str: JSON with {status, id, name, enabled}.
-        """
-        try:
-            schedule = self._get_schedule_manager().enable(schedule_id)
-            if schedule is None:
-                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
-            return json.dumps(
-                {
-                    "status": "enabled",
-                    "id": schedule.id,
-                    "name": schedule.name,
-                    "enabled": schedule.enabled,
-                }
-            )
-        except Exception as e:
-            logger.exception("Failed to enable schedule")
-            return json.dumps({"error": str(e)})
-
-    def disable_schedule(self, schedule_id: str) -> str:
-        """Disable a schedule so it stops running. Can be re-enabled later.
-
-        Args:
-            schedule_id (str): The id of the schedule to disable.
-
-        Returns:
-            str: JSON with {status, id, name, enabled}.
-        """
-        try:
-            schedule = self._get_schedule_manager().disable(schedule_id)
-            if schedule is None:
-                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
-            return json.dumps(
-                {
-                    "status": "disabled",
-                    "id": schedule.id,
-                    "name": schedule.name,
-                    "enabled": schedule.enabled,
-                }
-            )
-        except Exception as e:
-            logger.exception("Failed to disable schedule")
-            return json.dumps({"error": str(e)})
-
-    def delete_schedule(self, schedule_id: str) -> str:
-        """Delete a schedule by its id. This permanently removes the schedule.
-
-        Args:
-            schedule_id (str): The id of the schedule to delete.
-
-        Returns:
-            str: JSON with {status, id}.
-        """
-        try:
-            deleted = self._get_schedule_manager().delete(schedule_id)
-            if deleted:
-                return json.dumps({"status": "deleted", "id": schedule_id})
-            return json.dumps({"error": f"Schedule not found or could not be deleted: {schedule_id}"})
-        except Exception as e:
-            logger.exception("Failed to delete schedule")
-            return json.dumps({"error": str(e)})
-
     # ------------------------------------------------------------------
     # Async tools
     # ------------------------------------------------------------------
@@ -2014,30 +1867,6 @@ class StudioTools(Toolkit):
             description=description,
         )
 
-    async def alist_schedules(self, enabled_only: bool = False) -> str:
-        """Async variant of list_schedules."""
-        return await self._run_sync_tool(self.list_schedules, enabled_only=enabled_only)
-
-    async def aget_schedule_runs(self, schedule_id: str, limit: int = 10) -> str:
-        """Async variant of get_schedule_runs."""
-        return await self._run_sync_tool(self.get_schedule_runs, schedule_id, limit=limit)
-
-    async def atrigger_schedule(self, schedule_id: str) -> str:
-        """Async variant of trigger_schedule."""
-        return await self._run_sync_tool(self.trigger_schedule, schedule_id)
-
-    async def aenable_schedule(self, schedule_id: str) -> str:
-        """Async variant of enable_schedule."""
-        return await self._run_sync_tool(self.enable_schedule, schedule_id)
-
-    async def adisable_schedule(self, schedule_id: str) -> str:
-        """Async variant of disable_schedule."""
-        return await self._run_sync_tool(self.disable_schedule, schedule_id)
-
-    async def adelete_schedule(self, schedule_id: str) -> str:
-        """Async variant of delete_schedule."""
-        return await self._run_sync_tool(self.delete_schedule, schedule_id)
-
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -2062,14 +1891,12 @@ class StudioTools(Toolkit):
         return candidate
 
     def _get_schedule_manager(self) -> "ScheduleManager":
-        """Lazily build the ScheduleManager over the toolkit's db."""
-        if self._schedule_manager is None:
-            if self.db is None:
-                raise ValueError("StudioTools has no db configured; cannot manage schedules.")
-            from agno.scheduler.manager import ScheduleManager
-
-            self._schedule_manager = ScheduleManager(db=self.db)
-        return self._schedule_manager
+        """The shared SchedulerTools instance's manager."""
+        if self.db is None:
+            raise ValueError("StudioTools has no db configured; cannot manage schedules.")
+        if self._scheduler_tools is None:
+            raise ValueError("StudioTools was built with schedules=False; cannot manage schedules.")
+        return self._scheduler_tools.manager
 
     def _resolve_schedule_target(self, target_type: str, target_id: str) -> tuple[Optional[str], Optional[str]]:
         """Resolve a schedule target to a real component id.

--- a/libs/agno/tests/unit/tools/test_scheduler.py
+++ b/libs/agno/tests/unit/tools/test_scheduler.py
@@ -79,6 +79,7 @@ class TestSchedulerToolsInitialization:
             "delete_schedule",
             "enable_schedule",
             "disable_schedule",
+            "trigger_schedule",
             "get_schedule_runs",
         ]
         for name in expected:
@@ -93,14 +94,15 @@ class TestSchedulerToolsInitialization:
             "delete_schedule",
             "enable_schedule",
             "disable_schedule",
+            "trigger_schedule",
             "get_schedule_runs",
         ]
         for name in expected:
             assert name in async_names, f"Missing async tool: {name}"
 
     def test_tool_count(self, tools):
-        assert len(tools.functions) == 7
-        assert len(tools.async_functions) == 7
+        assert len(tools.functions) == 8
+        assert len(tools.async_functions) == 8
 
     def test_default_config(self, tools):
         assert tools.default_endpoint == "/agents/test-agent/runs"
@@ -335,6 +337,36 @@ class TestEnableDisableSchedule:
         assert "error" in result
 
 
+class TestTriggerSchedule:
+    def test_trigger_success(self, tools):
+        tools.manager.get.return_value = _make_schedule()
+
+        result = json.loads(tools.trigger_schedule("sched-001"))
+
+        assert result["status"] == "triggered"
+        assert result["id"] == "sched-001"
+        args, kwargs = tools.manager.update.call_args
+        assert args == ("sched-001",)
+        assert isinstance(kwargs["next_run_at"], int)
+
+    def test_trigger_not_found(self, tools):
+        tools.manager.get.return_value = None
+
+        result = json.loads(tools.trigger_schedule("ghost"))
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_trigger_disabled(self, tools):
+        tools.manager.get.return_value = _make_schedule(enabled=False)
+
+        result = json.loads(tools.trigger_schedule("sched-001"))
+
+        assert "error" in result
+        assert "disabled" in result["error"]
+        tools.manager.update.assert_not_called()
+
+
 class TestGetScheduleRuns:
     def test_get_runs(self, tools):
         tools.manager.get_runs.return_value = [
@@ -424,3 +456,28 @@ class TestAsyncCreateSchedule:
             )
         )
         assert result["status"] == "created"
+
+
+@pytest.mark.asyncio
+class TestAsyncTriggerSchedule:
+    async def test_atrigger_success(self, tools):
+        tools.manager.aget = AsyncMock(return_value=_make_schedule())
+        tools.manager.aupdate = AsyncMock()
+
+        result = json.loads(await tools.atrigger_schedule("sched-001"))
+
+        assert result["status"] == "triggered"
+        assert result["id"] == "sched-001"
+        args, kwargs = tools.manager.aupdate.call_args
+        assert args == ("sched-001",)
+        assert isinstance(kwargs["next_run_at"], int)
+
+    async def test_atrigger_disabled(self, tools):
+        tools.manager.aget = AsyncMock(return_value=_make_schedule(enabled=False))
+        tools.manager.aupdate = AsyncMock()
+
+        result = json.loads(await tools.atrigger_schedule("sched-001"))
+
+        assert "error" in result
+        assert "disabled" in result["error"]
+        tools.manager.aupdate.assert_not_called()

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -7,6 +7,7 @@ config persistence path is exercised, not mocked.
 import json
 import time
 from datetime import datetime
+from importlib.util import find_spec
 from typing import Any, Dict
 
 import pytest
@@ -1069,6 +1070,10 @@ class TestVersioning:
 # ----------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    find_spec("croniter") is None or find_spec("pytz") is None,
+    reason="scheduler extras not installed (pip install agno[scheduler])",
+)
 class TestSchedules:
     def _create_target_agent(self, studio, name="digest"):
         return _loads(studio.create_agent(name=name, instructions="i", model_id="gpt-5.4"))

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -399,6 +399,34 @@ class TestCreateAgent:
         config = db.get_config("async-stateless")["config"]
         assert "add_history_to_context" not in config
 
+    def test_datetime_on_by_default(self, studio, db):
+        out = _loads(studio.create_agent(name="dated", instructions="i", model_id="gpt-5.4"))
+        assert out["add_datetime_to_context"] is True
+
+        config = db.get_config("dated")["config"]
+        assert config["add_datetime_to_context"] is True
+
+    def test_datetime_opt_out_omits_key_from_config(self, studio, db):
+        out = _loads(
+            studio.create_agent(name="undated", instructions="i", model_id="gpt-5.4", add_datetime_to_context=False)
+        )
+        assert out["add_datetime_to_context"] is False
+
+        # to_dict omits falsy add_datetime_to_context, so the key is absent.
+        config = db.get_config("undated")["config"]
+        assert "add_datetime_to_context" not in config
+
+    @pytest.mark.asyncio
+    async def test_async_create_agent_datetime_opt_out(self, studio, db):
+        out = _loads(
+            await studio.acreate_agent(
+                name="async-undated", instructions="i", model_id="gpt-5.4", add_datetime_to_context=False
+            )
+        )
+        assert out["add_datetime_to_context"] is False
+        config = db.get_config("async-undated")["config"]
+        assert "add_datetime_to_context" not in config
+
 
 class TestToolNameResolution:
     """Multiple MCP servers in one registry must stay independently addressable."""
@@ -720,6 +748,21 @@ class TestEditAgent:
         got = _loads(studio.get_agent("tutor"))
         assert got["add_history_to_context"] is True
         assert got["num_history_runs"] == 3
+
+    def test_edit_turns_datetime_off_and_keeps_other_fields(self, studio):
+        self._create(studio)
+        out = _loads(studio.edit_agent(agent_id="tutor", add_datetime_to_context=False))
+        assert out["status"] == "edited"
+
+        got = _loads(studio.get_agent("tutor"))
+        assert got["add_datetime_to_context"] is False
+        assert got["instructions"] == "orig"
+        assert got["tools"] == ["calculator"]
+
+    def test_get_agent_reports_datetime_setting(self, studio):
+        self._create(studio)
+        got = _loads(studio.get_agent("tutor"))
+        assert got["add_datetime_to_context"] is True
 
     def test_edit_unknown_agent_returns_error(self, studio):
         out = _loads(studio.edit_agent(agent_id="ghost", instructions="x"))

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -353,6 +353,52 @@ class TestCreateAgent:
         assert out["status"] == "created"
         assert db.get_component("async-agent") is not None
 
+    def test_history_on_by_default(self, studio, db):
+        out = _loads(studio.create_agent(name="mem", instructions="i", model_id="gpt-5.4"))
+        assert out["add_history_to_context"] is True
+
+        config = db.get_config("mem")["config"]
+        assert config["add_history_to_context"] is True
+        assert config["num_history_runs"] == 3  # Agent.__init__ normalization
+
+    def test_stateless_opt_out_omits_history_from_config(self, studio, db):
+        out = _loads(
+            studio.create_agent(name="stateless", instructions="i", model_id="gpt-5.4", add_history_to_context=False)
+        )
+        assert out["add_history_to_context"] is False
+
+        # to_dict omits falsy add_history_to_context, so the key is absent.
+        config = db.get_config("stateless")["config"]
+        assert "add_history_to_context" not in config
+
+    def test_explicit_num_history_runs_round_trips(self, studio, db):
+        studio.create_agent(name="deep", instructions="i", model_id="gpt-5.4", num_history_runs=10)
+
+        config = db.get_config("deep")["config"]
+        assert config["num_history_runs"] == 10
+
+        agent = studio._load_agent_from_db("deep")
+        assert agent.add_history_to_context is True
+        assert agent.num_history_runs == 10
+
+    def test_toolkit_default_num_history_runs_applies(self, registry, db):
+        tool = StudioTools(registry=registry, db=db, default_num_history_runs=5)
+        tool.create_agent(name="five", instructions="i", model_id="gpt-5.4")
+
+        config = db.get_config("five")["config"]
+        assert config["num_history_runs"] == 5
+
+    @pytest.mark.asyncio
+    async def test_async_create_agent_stateless(self, studio, db):
+        out = _loads(
+            await studio.acreate_agent(
+                name="async-stateless", instructions="i", model_id="gpt-5.4", add_history_to_context=False
+            )
+        )
+        assert out["add_history_to_context"] is False
+        config = db.get_config("async-stateless")["config"]
+        assert "add_history_to_context" not in config
+
 
 class TestToolNameResolution:
     """Multiple MCP servers in one registry must stay independently addressable."""
@@ -641,6 +687,39 @@ class TestEditAgent:
         draft = _loads(studio_versioned.get_version("tutor", version=out["draft_version"]))
         assert draft["config"]["instructions"] == "new instructions"
         assert draft["config"]["description"] == "new description"
+
+    def test_edit_turns_history_off_and_keeps_other_fields(self, studio):
+        self._create(studio)
+        out = _loads(studio.edit_agent(agent_id="tutor", add_history_to_context=False))
+        assert out["status"] == "edited"
+
+        got = _loads(studio.get_agent("tutor"))
+        assert got["add_history_to_context"] is False
+        assert got["instructions"] == "orig"
+        assert got["tools"] == ["calculator"]
+
+    def test_edit_num_history_runs_only_keeps_history_on(self, studio):
+        self._create(studio)
+        _loads(studio.edit_agent(agent_id="tutor", num_history_runs=7))
+
+        got = _loads(studio.get_agent("tutor"))
+        assert got["add_history_to_context"] is True  # untouched from create
+        assert got["num_history_runs"] == 7
+
+    def test_history_edit_accumulates_in_same_draft(self, studio_versioned):
+        self._create(studio_versioned)
+        studio_versioned.edit_agent(agent_id="tutor", add_history_to_context=False)
+        out = _loads(studio_versioned.edit_agent(agent_id="tutor", description="new description"))
+
+        draft = _loads(studio_versioned.get_version("tutor", version=out["draft_version"]))
+        assert "add_history_to_context" not in draft["config"]  # history off survives edit 2
+        assert draft["config"]["description"] == "new description"
+
+    def test_get_agent_reports_history_settings(self, studio):
+        self._create(studio)
+        got = _loads(studio.get_agent("tutor"))
+        assert got["add_history_to_context"] is True
+        assert got["num_history_runs"] == 3
 
     def test_edit_unknown_agent_returns_error(self, studio):
         out = _loads(studio.edit_agent(agent_id="ghost", instructions="x"))

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -654,6 +654,72 @@ class TestCreateTeam:
         out = _loads(studio.create_team(name="squad", instructions="i", member_ids=[], model_id="gpt-5.4"))
         assert "error" in out
 
+    def test_history_and_datetime_on_by_default(self, studio, db):
+        self._make_members(studio)
+        out = _loads(studio.create_team(name="squad", instructions="i", member_ids=["a1"], model_id="gpt-5.4"))
+        assert out["add_history_to_context"] is True
+        assert out["add_datetime_to_context"] is True
+
+        config = db.get_config("squad")["config"]
+        assert config["add_history_to_context"] is True
+        assert config["num_history_runs"] == 3  # Team.__init__ normalization
+        assert config["add_datetime_to_context"] is True
+
+    def test_stateless_opt_out_omits_history_from_config(self, studio, db):
+        self._make_members(studio)
+        out = _loads(
+            studio.create_team(
+                name="squad",
+                instructions="i",
+                member_ids=["a1"],
+                model_id="gpt-5.4",
+                add_history_to_context=False,
+                add_datetime_to_context=False,
+            )
+        )
+        assert out["add_history_to_context"] is False
+        assert out["add_datetime_to_context"] is False
+
+        # to_dict omits falsy flags, so the keys are absent.
+        config = db.get_config("squad")["config"]
+        assert "add_history_to_context" not in config
+        assert "add_datetime_to_context" not in config
+
+    def test_explicit_num_history_runs_round_trips(self, studio, db):
+        self._make_members(studio)
+        studio.create_team(name="squad", instructions="i", member_ids=["a1"], model_id="gpt-5.4", num_history_runs=10)
+
+        config = db.get_config("squad")["config"]
+        assert config["num_history_runs"] == 10
+
+        team = studio._load_team_from_db("squad")
+        assert team.add_history_to_context is True
+        assert team.num_history_runs == 10
+
+    def test_toolkit_default_num_history_runs_applies(self, registry, db):
+        tool = StudioTools(registry=registry, db=db, default_num_history_runs=5)
+        tool.create_agent(name="a1", instructions="i", model_id="gpt-5.4")
+        tool.create_team(name="five", instructions="i", member_ids=["a1"], model_id="gpt-5.4")
+
+        config = db.get_config("five")["config"]
+        assert config["num_history_runs"] == 5
+
+    @pytest.mark.asyncio
+    async def test_async_create_team_stateless(self, studio, db):
+        self._make_members(studio)
+        out = _loads(
+            await studio.acreate_team(
+                name="async-squad",
+                instructions="i",
+                member_ids=["a1"],
+                model_id="gpt-5.4",
+                add_history_to_context=False,
+            )
+        )
+        assert out["add_history_to_context"] is False
+        config = db.get_config("async-squad")["config"]
+        assert "add_history_to_context" not in config
+
 
 class TestCreateWorkflow:
     def _make_agents(self, studio):
@@ -835,6 +901,40 @@ class TestEditTeam:
         self._setup(studio)
         out = _loads(studio.edit_team(team_id="squad", member_ids=["ghost"]))
         assert "error" in out
+
+    def test_edit_turns_history_off_and_keeps_other_fields(self, studio):
+        self._setup(studio)
+        out = _loads(studio.edit_team(team_id="squad", add_history_to_context=False))
+        assert out["status"] == "edited"
+
+        got = _loads(studio.get_team("squad"))
+        assert got["add_history_to_context"] is False
+        assert got["instructions"] == "orig"
+        assert got["member_ids"] == ["a1"]
+
+    def test_edit_num_history_runs_only_keeps_history_on(self, studio):
+        self._setup(studio)
+        _loads(studio.edit_team(team_id="squad", num_history_runs=7))
+
+        got = _loads(studio.get_team("squad"))
+        assert got["add_history_to_context"] is True  # untouched from create
+        assert got["num_history_runs"] == 7
+
+    def test_get_team_reports_history_and_datetime_settings(self, studio):
+        self._setup(studio)
+        got = _loads(studio.get_team("squad"))
+        assert got["add_history_to_context"] is True
+        assert got["num_history_runs"] == 3
+        assert got["add_datetime_to_context"] is True
+
+    @pytest.mark.asyncio
+    async def test_async_edit_team_datetime_off(self, studio):
+        self._setup(studio)
+        out = _loads(await studio.aedit_team(team_id="squad", add_datetime_to_context=False))
+        assert out["status"] == "edited"
+
+        got = _loads(studio.get_team("squad"))
+        assert got["add_datetime_to_context"] is False
 
 
 class TestEditWorkflow:

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -60,6 +60,11 @@ def _loads(s: str) -> Dict[str, Any]:
     return json.loads(s)
 
 
+def _tool(toolkit: StudioTools, name: str):
+    """The registered entrypoint for a tool -- what an agent actually calls."""
+    return toolkit.functions[name].entrypoint
+
+
 # ----------------------------------------------------------------------
 # Backward-compatible alias
 # ----------------------------------------------------------------------
@@ -91,6 +96,7 @@ VERSIONING_TOOLS = {
 SCHEDULE_TOOLS = {
     "create_schedule",
     "list_schedules",
+    "get_schedule",
     "get_schedule_runs",
     "trigger_schedule",
     "enable_schedule",
@@ -140,6 +146,16 @@ class TestInitialization:
         assert SCHEDULE_TOOLS.issubset(set(studio_schedules.functions.keys()))
         assert SCHEDULE_TOOLS.issubset(set(studio_schedules.async_functions.keys()))
         assert "Schedules:" in studio_schedules.instructions
+
+    def test_management_tools_are_shared_with_scheduler_toolkit(self, studio_schedules):
+        from agno.tools.scheduler import SchedulerTools
+
+        for tool_name in SCHEDULE_TOOLS - {"create_schedule"}:
+            sync_owner = studio_schedules.functions[tool_name].entrypoint.__self__
+            async_owner = studio_schedules.async_functions[tool_name].entrypoint.__self__
+            assert isinstance(sync_owner, SchedulerTools), tool_name
+            assert isinstance(async_owner, SchedulerTools), tool_name
+        assert studio_schedules.functions["create_schedule"].entrypoint.__self__ is studio_schedules
 
     def test_instructions_reflect_versioning_flag(self, studio, studio_versioned):
         assert "published immediately" in studio.instructions
@@ -1030,36 +1046,44 @@ class TestSchedules:
         assert second["id"] == first["id"]
         assert second["cron"] == "30 18 * * *"
 
-        listed = _loads(studio_schedules.list_schedules())
+        listed = _loads(_tool(studio_schedules, "list_schedules")())
         assert listed["count"] == 1
         assert listed["schedules"][0]["cron"] == "30 18 * * *"
+
+    def test_get_schedule_reports_endpoint_and_payload(self, studio_schedules):
+        self._create_target_agent(studio_schedules)
+        schedule_id = self._create_schedule(studio_schedules)["id"]
+
+        out = _loads(_tool(studio_schedules, "get_schedule")(schedule_id))
+        assert out["endpoint"] == "/agents/digest/runs"
+        assert out["payload"] == {"message": "Send the daily digest."}
 
     def test_enable_disable_delete_roundtrip(self, studio_schedules):
         self._create_target_agent(studio_schedules)
         schedule_id = self._create_schedule(studio_schedules)["id"]
 
-        disabled = _loads(studio_schedules.disable_schedule(schedule_id))
+        disabled = _loads(_tool(studio_schedules, "disable_schedule")(schedule_id))
         assert disabled["status"] == "disabled"
         assert disabled["enabled"] is False
-        assert _loads(studio_schedules.list_schedules(enabled_only=True))["count"] == 0
+        assert _loads(_tool(studio_schedules, "list_schedules")(enabled_only=True))["count"] == 0
 
-        enabled = _loads(studio_schedules.enable_schedule(schedule_id))
+        enabled = _loads(_tool(studio_schedules, "enable_schedule")(schedule_id))
         assert enabled["status"] == "enabled"
         assert enabled["enabled"] is True
-        assert _loads(studio_schedules.list_schedules(enabled_only=True))["count"] == 1
+        assert _loads(_tool(studio_schedules, "list_schedules")(enabled_only=True))["count"] == 1
 
-        deleted = _loads(studio_schedules.delete_schedule(schedule_id))
+        deleted = _loads(_tool(studio_schedules, "delete_schedule")(schedule_id))
         assert deleted["status"] == "deleted"
-        assert _loads(studio_schedules.list_schedules())["count"] == 0
+        assert _loads(_tool(studio_schedules, "list_schedules")())["count"] == 0
 
     def test_delete_unknown_schedule_returns_error(self, studio_schedules):
-        out = _loads(studio_schedules.delete_schedule("ghost"))
+        out = _loads(_tool(studio_schedules, "delete_schedule")("ghost"))
         assert "error" in out
 
     def test_get_schedule_runs_empty_for_new_schedule(self, studio_schedules):
         self._create_target_agent(studio_schedules)
         schedule_id = self._create_schedule(studio_schedules)["id"]
-        out = _loads(studio_schedules.get_schedule_runs(schedule_id))
+        out = _loads(_tool(studio_schedules, "get_schedule_runs")(schedule_id))
         assert out["runs"] == []
         assert out["count"] == 0
 
@@ -1067,7 +1091,7 @@ class TestSchedules:
         self._create_target_agent(studio_schedules)
         schedule_id = self._create_schedule(studio_schedules)["id"]
 
-        out = _loads(studio_schedules.trigger_schedule(schedule_id))
+        out = _loads(_tool(studio_schedules, "trigger_schedule")(schedule_id))
         assert out["status"] == "triggered"
         assert out["id"] == schedule_id
         assert "poll interval" in out["note"]
@@ -1080,14 +1104,14 @@ class TestSchedules:
     def test_trigger_disabled_schedule_returns_error(self, studio_schedules):
         self._create_target_agent(studio_schedules)
         schedule_id = self._create_schedule(studio_schedules)["id"]
-        studio_schedules.disable_schedule(schedule_id)
+        _tool(studio_schedules, "disable_schedule")(schedule_id)
 
-        out = _loads(studio_schedules.trigger_schedule(schedule_id))
+        out = _loads(_tool(studio_schedules, "trigger_schedule")(schedule_id))
         assert "error" in out
         assert "disabled" in out["error"]
 
     def test_trigger_unknown_schedule_returns_error(self, studio_schedules):
-        out = _loads(studio_schedules.trigger_schedule("ghost"))
+        out = _loads(_tool(studio_schedules, "trigger_schedule")("ghost"))
         assert "error" in out
         assert "Schedule not found" in out["error"]
 

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -5,6 +5,7 @@ config persistence path is exercised, not mocked.
 """
 
 import json
+import time
 from datetime import datetime
 from typing import Any, Dict
 
@@ -50,6 +51,11 @@ def studio_versioned(registry, db):
     return StudioTools(registry=registry, db=db, versions=True)
 
 
+@pytest.fixture
+def studio_schedules(registry, db):
+    return StudioTools(registry=registry, db=db, schedules=True)
+
+
 def _loads(s: str) -> Dict[str, Any]:
     return json.loads(s)
 
@@ -82,6 +88,16 @@ VERSIONING_TOOLS = {
     "delete_version",
 }
 
+SCHEDULE_TOOLS = {
+    "create_schedule",
+    "list_schedules",
+    "get_schedule_runs",
+    "trigger_schedule",
+    "enable_schedule",
+    "disable_schedule",
+    "delete_schedule",
+}
+
 
 class TestInitialization:
     def test_default_registers_agents_plus_discovery(self, studio):
@@ -112,6 +128,18 @@ class TestInitialization:
         assert studio_versioned.enable_versions is True
         assert VERSIONING_TOOLS.issubset(set(studio_versioned.functions.keys()))
         assert VERSIONING_TOOLS.issubset(set(studio_versioned.async_functions.keys()))
+
+    def test_schedule_tools_not_registered_by_default(self, studio):
+        assert studio.enable_schedules is False
+        assert not SCHEDULE_TOOLS & set(studio.functions.keys())
+        assert not SCHEDULE_TOOLS & set(studio.async_functions.keys())
+        assert "Schedules:" not in studio.instructions
+
+    def test_schedules_flag_registers_schedule_tools(self, studio_schedules):
+        assert studio_schedules.enable_schedules is True
+        assert SCHEDULE_TOOLS.issubset(set(studio_schedules.functions.keys()))
+        assert SCHEDULE_TOOLS.issubset(set(studio_schedules.async_functions.keys()))
+        assert "Schedules:" in studio_schedules.instructions
 
     def test_instructions_reflect_versioning_flag(self, studio, studio_versioned):
         assert "published immediately" in studio.instructions
@@ -796,6 +824,165 @@ class TestVersioning:
         # v1 is published+current — DB should refuse to delete it
         out = _loads(studio_versioned.delete_version("tutor", 1))
         assert "error" in out
+
+
+# ----------------------------------------------------------------------
+# Schedules: component-aware schedule tools with schedules=True
+# ----------------------------------------------------------------------
+
+
+class TestSchedules:
+    def _create_target_agent(self, studio, name="digest"):
+        return _loads(studio.create_agent(name=name, instructions="i", model_id="gpt-5.4"))
+
+    def _create_schedule(self, studio, **overrides):
+        params = {
+            "name": "daily-digest",
+            "cron": "0 9 * * *",
+            "target_type": "agent",
+            "target_id": "digest",
+            "message": "Send the daily digest.",
+        }
+        params.update(overrides)
+        return _loads(studio.create_schedule(**params))
+
+    def test_create_schedule_for_created_agent_persists_endpoint_and_payload(self, studio_schedules):
+        self._create_target_agent(studio_schedules)
+        out = self._create_schedule(studio_schedules)
+
+        assert out["status"] == "created"
+        assert out["target_type"] == "agent"
+        assert out["target_id"] == "digest"
+        assert out["endpoint"] == "/agents/digest/runs"
+        assert out["enabled"] is True
+
+        schedule = studio_schedules._get_schedule_manager().get(out["id"])
+        assert schedule is not None
+        assert schedule.endpoint == "/agents/digest/runs"
+        assert schedule.method == "POST"
+        assert schedule.payload == {"message": "Send the daily digest."}
+
+    def test_name_based_target_resolves_to_real_component_id(self, registry, db):
+        live = Agent(id="live-agent", name="Live Agent", model=OpenAIResponses(id="gpt-5.4"))
+        tool = StudioTools(registry=registry, db=db, agents_list=[live], schedules=True)
+
+        out = self._create_schedule(tool, target_id="Live Agent")
+        assert out["status"] == "created"
+        assert out["target_id"] == "live-agent"
+        assert out["endpoint"] == "/agents/live-agent/runs"
+
+    def test_unknown_target_returns_error(self, studio_schedules):
+        out = self._create_schedule(studio_schedules, target_id="ghost")
+        assert "error" in out
+        assert "Agent not found: ghost" in out["error"]
+
+    def test_bad_target_type_returns_error(self, studio_schedules):
+        self._create_target_agent(studio_schedules)
+        out = self._create_schedule(studio_schedules, target_type="cron-job")
+        assert "error" in out
+        assert "Invalid target_type" in out["error"]
+
+    def test_invalid_cron_returns_error(self, studio_schedules):
+        self._create_target_agent(studio_schedules)
+        out = self._create_schedule(studio_schedules, cron="not-a-cron")
+        assert "error" in out
+        assert "Invalid cron expression" in out["error"]
+
+    def test_invalid_timezone_returns_error(self, studio_schedules):
+        self._create_target_agent(studio_schedules)
+        out = self._create_schedule(studio_schedules, timezone="Mars/Olympus")
+        assert "error" in out
+        assert "Invalid timezone" in out["error"]
+
+    def test_empty_message_returns_error(self, studio_schedules):
+        self._create_target_agent(studio_schedules)
+        out = self._create_schedule(studio_schedules, message="   ")
+        assert "error" in out
+        assert "message" in out["error"]
+
+    def test_same_name_create_updates_in_place(self, studio_schedules):
+        self._create_target_agent(studio_schedules)
+        first = self._create_schedule(studio_schedules)
+        second = self._create_schedule(studio_schedules, cron="30 18 * * *")
+
+        assert second["id"] == first["id"]
+        assert second["cron"] == "30 18 * * *"
+
+        listed = _loads(studio_schedules.list_schedules())
+        assert listed["count"] == 1
+        assert listed["schedules"][0]["cron"] == "30 18 * * *"
+
+    def test_enable_disable_delete_roundtrip(self, studio_schedules):
+        self._create_target_agent(studio_schedules)
+        schedule_id = self._create_schedule(studio_schedules)["id"]
+
+        disabled = _loads(studio_schedules.disable_schedule(schedule_id))
+        assert disabled["status"] == "disabled"
+        assert disabled["enabled"] is False
+        assert _loads(studio_schedules.list_schedules(enabled_only=True))["count"] == 0
+
+        enabled = _loads(studio_schedules.enable_schedule(schedule_id))
+        assert enabled["status"] == "enabled"
+        assert enabled["enabled"] is True
+        assert _loads(studio_schedules.list_schedules(enabled_only=True))["count"] == 1
+
+        deleted = _loads(studio_schedules.delete_schedule(schedule_id))
+        assert deleted["status"] == "deleted"
+        assert _loads(studio_schedules.list_schedules())["count"] == 0
+
+    def test_delete_unknown_schedule_returns_error(self, studio_schedules):
+        out = _loads(studio_schedules.delete_schedule("ghost"))
+        assert "error" in out
+
+    def test_get_schedule_runs_empty_for_new_schedule(self, studio_schedules):
+        self._create_target_agent(studio_schedules)
+        schedule_id = self._create_schedule(studio_schedules)["id"]
+        out = _loads(studio_schedules.get_schedule_runs(schedule_id))
+        assert out["runs"] == []
+        assert out["count"] == 0
+
+    def test_trigger_sets_next_run_at_to_now(self, studio_schedules):
+        self._create_target_agent(studio_schedules)
+        schedule_id = self._create_schedule(studio_schedules)["id"]
+
+        out = _loads(studio_schedules.trigger_schedule(schedule_id))
+        assert out["status"] == "triggered"
+        assert out["id"] == schedule_id
+        assert "poll interval" in out["note"]
+
+        # The poller claims schedules with next_run_at <= now, so the trigger
+        # must have moved next_run_at into the claimable window.
+        schedule = studio_schedules._get_schedule_manager().get(schedule_id)
+        assert schedule.next_run_at <= int(time.time())
+
+    def test_trigger_disabled_schedule_returns_error(self, studio_schedules):
+        self._create_target_agent(studio_schedules)
+        schedule_id = self._create_schedule(studio_schedules)["id"]
+        studio_schedules.disable_schedule(schedule_id)
+
+        out = _loads(studio_schedules.trigger_schedule(schedule_id))
+        assert "error" in out
+        assert "disabled" in out["error"]
+
+    def test_trigger_unknown_schedule_returns_error(self, studio_schedules):
+        out = _loads(studio_schedules.trigger_schedule("ghost"))
+        assert "error" in out
+        assert "Schedule not found" in out["error"]
+
+    @pytest.mark.asyncio
+    async def test_async_create_schedule(self, studio_schedules):
+        self._create_target_agent(studio_schedules)
+        out = _loads(
+            await studio_schedules.acreate_schedule(
+                name="async-digest",
+                cron="0 9 * * *",
+                target_type="agent",
+                target_id="digest",
+                message="Send it.",
+            )
+        )
+        assert out["status"] == "created"
+        assert out["endpoint"] == "/agents/digest/runs"
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two additions that make Studio-built components production-shaped from chat:

**Schedules (`schedules=True`).** A new opt-in tool group (mirrors `versions`) so a Studio agent can put an existing component on a cron in conversation. Only `create_schedule` is Studio's own: targets are `target_type` + `target_id` validated through the Studio lookup path (code-defined lists then DB, so Studio-built components resolve), and the endpoint is built internally (`/{type}s/{id}/runs` — no raw endpoint surface, full URLs impossible by construction). The management tools (`list_schedules` / `get_schedule` / `get_schedule_runs` / `trigger_schedule` / `enable_schedule` / `disable_schedule` / `delete_schedule`) are `SchedulerTools`' own functions, registered as bound methods of an internal instance — no duplicated bodies, and the async variants use `ScheduleManager`'s native async methods instead of a thread offload. `trigger_schedule` is new in `SchedulerTools` as well (next_run_at nudge; the poller's claim predicate `enabled AND next_run_at <= now` was verified in the Postgres backend, cron cadence self-heals after the fire). Cron/timezone validation flows from `ScheduleManager.create`; missing croniter/pytz still surfaces as error JSON on the first schedule call, not at import or construction (`agno.scheduler.cron` guards the imports). Never attach both toolkits to one agent — the tool names collide by design.

**History (`add_history_to_context` / `num_history_runs` on create/edit, default on) — agents and teams.** Studio-built agents and teams were amnesiac even when run with a `session_id`: `create_agent`/`create_team` never set `add_history_to_context`, so the agno default (False) applied. Serialization already round-trips the fields, so the change is create/edit surface only: history defaults on for created agents and teams (same category as the existing `add_instructions` default flip), `num_history_runs` falls back to a new toolkit-level `default_num_history_runs`, edit params are omit-to-keep (with `num_history_messages` cleared when `num_history_runs` is set — `Agent.__init__` and `Team.__init__` resolve the pair identically), and `get_agent`/`get_team` now report the settings. `add_datetime_to_context` defaults on for both as well.

## Changes
- `libs/agno/agno/tools/studio.py` — schedule tool group (shared with SchedulerTools) + history/datetime params on agent and team create/edit/get
- `libs/agno/agno/tools/scheduler.py` — new `trigger_schedule`/`atrigger_schedule` tools
- `libs/agno/tests/unit/tools/test_studio.py` — schedule, agent-history and team-history tests
- `libs/agno/tests/unit/tools/test_scheduler.py` — trigger tests, tool-count updates

## Testing
- `test_studio.py` + `test_scheduler.py`: 182 passed
- Full `tests/unit/tools/`: 1497 passed vs 1481 on main (+16 new tests), identical pre-existing failures (optional-dep collection errors only)
- Missing croniter/pytz proven to surface as error JSON at call time (meta_path blocker test); construction with `schedules=True` stays safe
- ruff check / format clean; mypy clean on `studio.py` and `scheduler.py`

## Release note
Behavior change worth a line: newly created Studio agents and teams carry session history and datetime context by default (existing persisted configs are untouched; an `edit_agent`/`edit_team` call upgrades them). `SchedulerTools` gains a `trigger_schedule` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)