### PR TITLE
feat: mount support for FileSystem tools

### DIFF
--- a/libs/agno/agno/fs/__init__.py
+++ b/libs/agno/agno/fs/__init__.py
@@ -3,11 +3,12 @@ from agno.fs.errors import (
     FileSystemError,
     InvalidPathError,
     QuotaExceededError,
+    ReadOnlyMountError,
     UnsupportedOperationError,
     VersionConflictError,
 )
 from agno.fs.fs import DEFAULT_NAMESPACE, FileSystem
-from agno.fs.types import ContainsResult, FileMeta, NamespaceUsage, SearchMatch
+from agno.fs.types import ContainsResult, FileMeta, Mount, NamespaceUsage, SearchMatch
 
 __all__ = [
     "DEFAULT_NAMESPACE",
@@ -17,8 +18,10 @@ __all__ = [
     "FileMeta",
     "BaseFS",
     "InvalidPathError",
+    "Mount",
     "NamespaceUsage",
     "QuotaExceededError",
+    "ReadOnlyMountError",
     "SearchMatch",
     "UnsupportedOperationError",
     "VersionConflictError",

--- a/libs/agno/agno/fs/_paths.py
+++ b/libs/agno/agno/fs/_paths.py
@@ -162,6 +162,31 @@ def normalize_template_value(placeholder: str, value: object) -> str:
     return normalized
 
 
+_MOUNT_NAME_RE = re.compile(r"^[a-z0-9._\-]+$")
+
+
+def normalize_mount_name(name: object) -> str:
+    """Validate and canonicalize a mount name: one lowercase, URL-safe path segment.
+
+    A mount name is what the model sees as a top-level directory, so it follows
+    the namespace segment grammar rather than the file-path grammar: lowercased
+    (``Shared`` and ``shared`` are one mount) and restricted to ``a-z``, ``0-9``,
+    ``.``, ``-`` and ``_``. ``/``, braces, whitespace, control characters, ``.``
+    and ``..`` are rejected. Raises ``InvalidPathError`` on any violation.
+    """
+    if not isinstance(name, str) or not name:
+        raise InvalidPathError(f"invalid mount name {name!r}: must be a non-empty string")
+    value = unicodedata.normalize("NFC", name).lower()
+    if value in (".", "..") or not _MOUNT_NAME_RE.match(value):
+        raise InvalidPathError(
+            f"invalid mount name {name!r}: use one lowercase path segment of a-z, 0-9, '.', '-' or '_' "
+            "(no '/', no braces, not '.' or '..')"
+        )
+    if len(value) > MAX_SEGMENT_CHARS:
+        raise InvalidPathError(f"invalid mount name {name!r}: longer than {MAX_SEGMENT_CHARS} characters")
+    return value
+
+
 def normalize_directory(directory: str) -> str:
     """Validate a directory parameter. ``""`` and ``"."`` both mean the namespace root."""
     if not isinstance(directory, str):

--- a/libs/agno/agno/fs/errors.py
+++ b/libs/agno/agno/fs/errors.py
@@ -23,6 +23,14 @@ class QuotaExceededError(FileSystemError):
         self.limit = limit
 
 
+class ReadOnlyMountError(FileSystemError):
+    """Raised when a write-family operation targets a read-only mount.
+
+    The tool layer converts it to the standard ``"Error: ..."`` string, so the
+    model sees an instructive refusal, never an exception.
+    """
+
+
 class VersionConflictError(FileSystemError):
     """Raised when a compare-and-swap write finds a version other than ``expected``.
 

--- a/libs/agno/agno/fs/fs.py
+++ b/libs/agno/agno/fs/fs.py
@@ -19,12 +19,13 @@ Attach the tools, and compose its instructions into your own:
 """
 
 import asyncio
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 from agno.fs._paths import (
     build_chunk,
     normalize_check_lines,
     normalize_directory,
+    normalize_mount_name,
     normalize_namespace,
     normalize_path,
     normalize_template_value,
@@ -33,7 +34,7 @@ from agno.fs._paths import (
 )
 from agno.fs.base import BaseFS
 from agno.fs.errors import InvalidPathError, QuotaExceededError
-from agno.fs.types import ContainsResult, FileMeta, NamespaceUsage, SearchMatch
+from agno.fs.types import ContainsResult, FileMeta, Mount, NamespaceUsage, SearchMatch
 
 if TYPE_CHECKING:
     from agno.tools.toolkit import Toolkit
@@ -76,6 +77,41 @@ files - you have no tool to write, append, move, or delete.
 Conventions:
   - Paths are relative, like notes/decisions.md.
   - Use search_content to find where something is recorded, then read_file to read it."""
+
+
+def normalize_mounts(mounts: Optional[Mapping[str, Union["FileSystem", Mount]]]) -> Dict[str, Mount]:
+    """Validate and canonicalize a mounts declaration.
+
+    Keys become lowercase single-segment names (the mount-name grammar in
+    ``_paths.normalize_mount_name``); bare ``FileSystem`` values coerce to
+    read-only ``Mount``s. Mounts are developer-declared only: nothing about them
+    is model-suppliable, and no tool schema changes when they are present.
+    Raises ``InvalidPathError`` for a bad or duplicate name, ``TypeError`` for a
+    value that is neither a ``FileSystem`` nor a ``Mount``, and ``ValueError``
+    for a mode other than ``"ro"``/``"rw"``. Idempotent on its own output.
+    """
+    if not mounts:
+        return {}
+    normalized: Dict[str, Mount] = {}
+    for name, value in mounts.items():
+        key = normalize_mount_name(name)
+        if key in normalized:
+            raise InvalidPathError(f"duplicate mount name {name!r}: {key!r} is already mounted")
+        if isinstance(value, Mount):
+            mount = value
+        elif isinstance(value, FileSystem):
+            mount = Mount(fs=value, mode="ro")
+        else:
+            raise TypeError(
+                f"mount {name!r} must be a FileSystem or a Mount, got {type(value).__name__}. "
+                'Pass a bare FileSystem for read-only access, or Mount(fs, mode="rw") to allow writes.'
+            )
+        if not isinstance(mount.fs, FileSystem):
+            raise TypeError(f"mount {name!r}: Mount.fs must be a FileSystem, got {type(mount.fs).__name__}")
+        if mount.mode not in ("ro", "rw"):
+            raise ValueError(f"mount {name!r}: mode must be 'ro' or 'rw', got {mount.mode!r}")
+        normalized[key] = mount
+    return normalized
 
 
 def _as_backend(source: Any) -> BaseFS:
@@ -440,7 +476,14 @@ class FileSystem:
     # Agent surface
     # ------------------------------------------------------------------
 
-    def tools(self, *, read_only: bool = False, allow_delete: bool = False, **kwargs) -> "Toolkit":
+    def tools(
+        self,
+        *,
+        read_only: bool = False,
+        allow_delete: bool = False,
+        mounts: Optional[Mapping[str, Union["FileSystem", Mount]]] = None,
+        **kwargs,
+    ) -> "Toolkit":
         """Build the toolkit for this file store.
 
         ``Agent(tools=[fs.tools()], instructions=[..., fs.instructions()])`` is the
@@ -459,21 +502,53 @@ class FileSystem:
         ``read_only=True`` registers only ``read_file``, ``list_files`` and
         ``search_content``; pair it with ``instructions(read_only=True)``. That
         is the surface for a consumer agent that consults another agent's
-        namespace by shared name. ``**kwargs`` forwards to ``Toolkit`` (e.g.
-        ``include_tools``, ``requires_confirmation_tools``).
+        namespace by shared name.
+
+        ``mounts`` grafts other file stores into this one tool surface:
+        ``fs.tools(mounts={"shared": other_fs})`` makes paths under ``shared/``
+        route to ``other_fs`` while every other path stays on this store — one
+        agent, several namespaces, no tool-name collisions and no new tool
+        parameters. A bare ``FileSystem`` value mounts read-only; wrap it in
+        ``Mount(fs, mode="rw")`` to allow writes. Pair it with
+        ``instructions(mounts=...)`` so the agent knows the mounts exist.
+        ``**kwargs`` forwards to ``Toolkit`` (e.g. ``include_tools``,
+        ``requires_confirmation_tools``).
         """
         from agno.fs.toolkit import FileSystemTools
 
-        return FileSystemTools(fs=self, read_only=read_only, allow_delete=allow_delete, **kwargs)
+        return FileSystemTools(fs=self, read_only=read_only, allow_delete=allow_delete, mounts=mounts, **kwargs)
 
     @staticmethod
-    def instructions(read_only: bool = False) -> str:
+    def instructions(
+        read_only: bool = False,
+        mounts: Optional[Mapping[str, Union["FileSystem", Mount]]] = None,
+    ) -> str:
         """Usage guidance for these tools, to compose into the agent's instructions.
 
         Namespace-independent, so it is equally callable on an instance
         (``fs.instructions()``) and on the class, which is what a per-user tool
         factory needs when no instance exists at module scope.
+
+        Pass the same ``mounts`` you gave ``tools()`` to append a convention
+        naming each mount and whether it is read-only; without it the agent has
+        no way to know the mounted directories exist. The text never names a
+        namespace, only the mount names the developer chose.
         """
-        if read_only:
-            return _READ_ONLY_INSTRUCTIONS
-        return _DEFAULT_INSTRUCTIONS
+        base = _READ_ONLY_INSTRUCTIONS if read_only else _DEFAULT_INSTRUCTIONS
+        normalized_mounts = normalize_mounts(mounts)
+        if not normalized_mounts:
+            return base
+        labels = ", ".join(
+            f"{name}/ ({'read-only' if mount.mode == 'ro' else 'read-write'})"
+            for name, mount in sorted(normalized_mounts.items())
+        )
+        lines = [
+            f"  - Some top-level directories are shared mounts maintained outside your own files: {labels}. "
+            "Read and search them like your own files; their contents are shared, not private."
+        ]
+        if not read_only and any(mount.mode == "ro" for mount in normalized_mounts.values()):
+            lines.append(
+                "  - You cannot write, move or delete inside a read-only mount. Record anything of your own "
+                "in your own files instead."
+            )
+        return base + "\n" + "\n".join(lines)

--- a/libs/agno/agno/fs/toolkit.py
+++ b/libs/agno/agno/fs/toolkit.py
@@ -19,6 +19,11 @@ These names deliberately collide with the rest of the file-toolkit family
 keeps the first registration per name and drops later duplicates with a logged
 warning, so attach at most one file-like toolkit per agent; when an agent
 genuinely needs both FileSystem and a local workspace, wrap one in a sub-agent.
+When one agent needs several FileSystem namespaces (its own plus a shared one),
+do not attach two toolkits - mount the second store into the first:
+``fs.tools(mounts={"shared": other_fs})`` routes paths under ``shared/`` to the
+mounted FileSystem (read-only unless the developer passes ``Mount(fs, "rw")``)
+while keeping one toolkit and one set of tool names.
 """
 
 import asyncio
@@ -26,16 +31,17 @@ import json
 from contextlib import AsyncExitStack, asynccontextmanager
 from datetime import datetime, timezone
 from fnmatch import fnmatch
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 from weakref import WeakKeyDictionary
 
 # Real module-level imports, never TYPE_CHECKING-only: with postponed annotations a
 # deferred import does not fail loudly. get_type_hints raises during schema
 # building, the warning is downgraded, and the tool ships an empty JSON schema.
 from agno.agent.agent import Agent
-from agno.fs._paths import build_chunk, normalize_directory, path_sort_key
-from agno.fs.errors import InvalidPathError, QuotaExceededError
-from agno.fs.fs import FileSystem
+from agno.fs._paths import build_chunk, normalize_directory, normalize_path, path_sort_key
+from agno.fs.errors import InvalidPathError, QuotaExceededError, ReadOnlyMountError
+from agno.fs.fs import FileSystem, normalize_mounts
+from agno.fs.types import Mount
 from agno.run import RunContext
 from agno.team.team import Team
 from agno.tools.toolkit import Toolkit
@@ -110,6 +116,15 @@ class FileSystemTools(Toolkit):
     Agno's resolver keeps the first registration per name and drops later duplicates
     with a logged warning, so attach at most one file-like toolkit per agent; if an
     agent genuinely needs both, wrap one in a sub-agent.
+
+    ``mounts`` is how one agent sees several FileSystem namespaces through this
+    single surface: each mount is a developer-declared top-level directory name
+    routing to another FileSystem (read-only by default). Routing is by a path's
+    first segment, so no tool gains a parameter, the word "namespace" still
+    appears in no schema, and the model can never name a store the developer did
+    not mount. A mount name shadows the same-named top level of the primary
+    namespace; shadowed primary paths are dropped from listings and search
+    results because the tools cannot reach them.
     """
 
     # The whole surface, exported for callers that want everything explicitly.
@@ -147,10 +162,16 @@ class FileSystemTools(Toolkit):
         allow_delete: bool = False,
         instructions: Optional[str] = None,
         add_instructions: bool = False,
+        mounts: Optional[Mapping[str, Union[FileSystem, Mount]]] = None,
         **kwargs,
     ):
         self.fs = fs
         self.read_only = read_only
+        # Developer-declared mounts: other FileSystems grafted in as top-level
+        # directory names. Routing is by a path's first segment, so the model
+        # addresses "shared/notes.md" like any other path; no tool schema or
+        # tool name changes, and no model argument can name a namespace.
+        self.mounts: Dict[str, Mount] = normalize_mounts(mounts)
         # Every mutating tool is a read-modify-write over one row, and a model's
         # tool calls for one turn are gathered concurrently (models/base.py) -
         # the path AgentOS REST and /mcp take. Two replace_lines on one note
@@ -161,7 +182,7 @@ class FileSystemTools(Toolkit):
         if read_only and allow_delete:
             raise ValueError("allow_delete=True contradicts read_only=True; pick one.")
         if instructions is None:
-            instructions = FileSystem.instructions(read_only=read_only)
+            instructions = FileSystem.instructions(read_only=read_only, mounts=self.mounts or None)
 
         if kwargs.get("include_tools") is not None:
             # include_tools is a fully explicit whitelist over the whole
@@ -212,6 +233,82 @@ class FileSystemTools(Toolkit):
         """Resolve a templated namespace from injected context. Fails closed."""
         return self.fs._resolve_from_context(run_context=run_context, agent=agent, team=team)
 
+    def _check_writable(self, mount_name: str, mount: Mount) -> None:
+        if mount.mode != "rw":
+            raise ReadOnlyMountError(
+                f"{mount_name}/ is read-only: files in this shared mount can be read but not changed."
+            )
+
+    def _route_path(
+        self,
+        path: str,
+        run_context: Optional[RunContext],
+        agent: Optional[Agent],
+        team: Optional[Team],
+        *,
+        write: bool = False,
+    ) -> Tuple[FileSystem, str, Optional[str]]:
+        """Route a file path to ``(resolved_fs, inner_path, mount_name)``.
+
+        A path whose first segment names a mount (matched case-insensitively,
+        since mount names are lowercase identifiers) targets that mount's
+        FileSystem with the segment stripped; every other path targets the
+        primary store, so mounts add zero cost to the common case. Both sides
+        resolve templated namespaces from the same injected context, fail
+        closed. ``write=True`` raises ``ReadOnlyMountError`` for an ``"ro"``
+        mount before anything touches storage.
+        """
+        normalized = normalize_path(path)
+        first, _, rest = normalized.partition("/")
+        mount = self.mounts.get(first.lower()) if self.mounts else None
+        if mount is None:
+            return self._resolved(run_context, agent, team), normalized, None
+        name = first.lower()
+        if write:
+            self._check_writable(name, mount)
+        if not rest:
+            raise InvalidPathError(
+                f"{name}/ is a shared mount, not a file. Give a path inside it, like {name}/notes/topic.md, "
+                f'or list it with list_files(directory="{name}").'
+            )
+        return mount.fs._resolve_from_context(run_context=run_context, agent=agent, team=team), rest, name
+
+    def _route_directory(
+        self,
+        directory: str,
+        run_context: Optional[RunContext],
+        agent: Optional[Agent],
+        team: Optional[Team],
+    ) -> Tuple[FileSystem, str, Optional[str]]:
+        """Route a directory parameter to ``(resolved_fs, inner_directory, mount_name)``.
+
+        The root (``""``/``"."``) always means the primary store; a directory
+        whose first segment names a mount scopes into that mount (the mount name
+        alone means the mount's root). Directory-taking tools are all reads, so
+        there is no ``write`` flag here.
+        """
+        normalized = normalize_directory(directory)
+        if normalized and self.mounts:
+            first, _, rest = normalized.partition("/")
+            mount = self.mounts.get(first.lower())
+            if mount is not None:
+                resolved = mount.fs._resolve_from_context(run_context=run_context, agent=agent, team=team)
+                return resolved, rest, first.lower()
+        return self._resolved(run_context, agent, team), normalized, None
+
+    def _shadowed(self, path: str) -> bool:
+        """Whether a primary-store path is hidden behind a mount name.
+
+        A mount shadows the same-named top level of the primary namespace: the
+        router sends every ``<mount>/...`` path to the mount, so a primary file
+        under that segment is unreachable through the tools. Listings and search
+        results drop such paths rather than advertise files the model cannot
+        actually read back.
+        """
+        if not self.mounts:
+            return False
+        return path.split("/", 1)[0].lower() in self.mounts
+
     @staticmethod
     def _quota_error(e: QuotaExceededError, path: str) -> str:
         if e.scope == "file":
@@ -254,8 +351,8 @@ class FileSystemTools(Toolkit):
         """
         try:
             log_debug(f"read_file: {path}")
-            fs = self._resolved(run_context, agent, team)
-            contents = fs.read(path)
+            fs, inner_path, _ = self._route_path(path, run_context, agent, team)
+            contents = fs.read(inner_path)
             if contents is None:
                 return f"Error: file not found: {path}"
             total = _line_count(contents)
@@ -311,7 +408,10 @@ class FileSystemTools(Toolkit):
         "dir", ``size`` is human-readable for files and null for dirs, and ``updated``
         is when the file last changed (UTC). Use ``updated`` to tell current working
         state from state you left behind long ago. The result also reports total usage
-        against your storage limit.
+        against the storage limit of the directory you listed. If shared mounts are
+        configured, each appears at the top level as a "dir" entry with a ``mount`` key
+        ("ro" or "rw"); a listing never crosses into a mount unless you scope into it
+        (e.g. directory "shared" or "shared/notes").
 
         :param directory: Directory to list (default "." = top level), e.g. "seen".
         :param pattern: Optional glob to filter names, e.g. "*.md".
@@ -320,10 +420,17 @@ class FileSystemTools(Toolkit):
         :return: JSON with keys ``directory``, ``pattern``, ``recursive``, ``files``, ``usage``.
         """
         try:
-            fs = self._resolved(run_context, agent, team)
-            metas = fs.list(directory)
-            normalized_directory = normalize_directory(directory)
-            prefix_len = 0 if not normalized_directory else len(normalized_directory.split("/"))
+            fs, inner_directory, mount_name = self._route_directory(directory, run_context, agent, team)
+            metas = fs.list(inner_directory)
+            if mount_name is None:
+                # A primary path hidden behind a mount name is unreachable through
+                # the tools (the router sends that prefix to the mount), so a
+                # listing must not advertise it.
+                metas = [meta for meta in metas if not self._shadowed(meta.path)]
+            # Returned paths must be readable back verbatim, so entries inside a
+            # mount carry the mount prefix the model used to get here.
+            display_prefix = f"{mount_name}/" if mount_name else ""
+            prefix_len = 0 if not inner_directory else len(inner_directory.split("/"))
             # Entries appear down to max_depth levels of nesting below `directory`;
             # the boundary directory is itself enumerated, so paths carry up to
             # max_depth + 1 segments below it.
@@ -340,7 +447,7 @@ class FileSystemTools(Toolkit):
                     if not pattern or fnmatch(segments[-1], pattern):
                         file_entries.append(
                             {
-                                "path": meta.path,
+                                "path": display_prefix + meta.path,
                                 "type": "file",
                                 "size": _format_size(meta.size_bytes),
                                 "updated": _format_time(meta.updated_at),
@@ -357,8 +464,18 @@ class FileSystemTools(Toolkit):
                 truncated_dirs = len(sorted_dirs) - _MAX_DIR_ENTRIES
                 sorted_dirs = sorted_dirs[:_MAX_DIR_ENTRIES]
             dir_entries: List[Dict[str, Union[str, None]]] = [
-                {"path": dir_path, "type": "dir", "size": None, "updated": None} for dir_path in sorted_dirs
+                {"path": display_prefix + dir_path, "type": "dir", "size": None, "updated": None}
+                for dir_path in sorted_dirs
             ]
+            if mount_name is None and not inner_directory:
+                # Mounts surface as top-level directories so the model can
+                # discover them; they are developer-declared and few, so they
+                # ride outside the dir-entry cap.
+                for name, mount in sorted(self.mounts.items()):
+                    if not pattern or fnmatch(name, pattern):
+                        dir_entries.append(
+                            {"path": name, "type": "dir", "size": None, "updated": None, "mount": mount.mode}
+                        )
 
             # Cap files as well as dirs. The namespace quota bounds total BYTES, not
             # entry count, so a namespace of many tiny files would otherwise dump an
@@ -413,7 +530,9 @@ class FileSystemTools(Toolkit):
         Each result gives the line number of the first match, so you can follow up with
         read_file(path, start_line=..., end_line=...) instead of reading the whole file.
         ``matches`` counts every occurrence in that file, while ``snippet`` shows only
-        the first.
+        the first. If shared mounts are configured, a search covers only your own files
+        unless you scope into a mount with ``directory`` (e.g. directory "shared"); it
+        never crosses between file stores in one call.
 
         :param query: Substring to search for.
         :param directory: Directory to scope the search (default "." = everything).
@@ -424,11 +543,16 @@ class FileSystemTools(Toolkit):
         try:
             if not query or not query.strip():
                 return "Error: query cannot be empty"
-            fs = self._resolved(run_context, agent, team)
-            matches = fs.search(query, directory=directory, limit=limit)
+            fs, inner_directory, mount_name = self._route_directory(directory, run_context, agent, team)
+            matches = fs.search(query, directory=inner_directory, limit=limit)
+            if mount_name is None:
+                # Same rule as list_files: never report a primary path the router
+                # would resolve into a mount on the read back.
+                matches = [match for match in matches if not self._shadowed(match.path)]
+            display_prefix = f"{mount_name}/" if mount_name else ""
             files = [
                 {
-                    "file": match.path,
+                    "file": display_prefix + match.path,
                     "line": match.line,
                     "matches": match.match_count,
                     "size": _format_size(match.size_bytes),
@@ -456,7 +580,9 @@ class FileSystemTools(Toolkit):
 
         Exact whole-line matching: a line counts as found only if some file contains
         it as a complete line. Use this before acting on items so you never repeat
-        work, then record the new ones with append_file (one per line).
+        work, then record the new ones with append_file (one per line). If shared
+        mounts are configured, the check covers only your own files unless you scope
+        into a mount with ``directory``.
 
         :param lines: The records to check, e.g. a list of URLs or IDs. Max 200. Pass
             each record in exactly the form you will store it. Matching is literal,
@@ -466,8 +592,8 @@ class FileSystemTools(Toolkit):
         :return: JSON: {"found": [...], "missing": [...]}.
         """
         try:
-            fs = self._resolved(run_context, agent, team)
-            result = fs.contains(lines, directory=directory)
+            fs, inner_directory, _ = self._route_directory(directory, run_context, agent, team)
+            result = fs.contains(lines, directory=inner_directory)
             return json.dumps({"found": result.found, "missing": result.missing}, indent=2)
         except InvalidPathError as e:
             return f"Error: {e}"
@@ -498,8 +624,8 @@ class FileSystemTools(Toolkit):
         :return: Success message with the byte count, or an error message.
         """
         try:
-            fs = self._resolved(run_context, agent, team)
-            meta = fs.write(path, content, overwrite=overwrite)
+            fs, inner_path, _ = self._route_path(path, run_context, agent, team, write=True)
+            meta = fs.write(inner_path, content, overwrite=overwrite)
             return f"Wrote {meta.size_bytes} bytes to {path}"
         except FileExistsError:
             if not overwrite:
@@ -510,7 +636,7 @@ class FileSystemTools(Toolkit):
             return f"Error: cannot write {path}: a parent path segment is an existing file."
         except QuotaExceededError as e:
             return self._quota_error(e, path)
-        except InvalidPathError as e:
+        except (InvalidPathError, ReadOnlyMountError) as e:
             return f"Error: {e}"
         except Exception as e:
             log_error(f"write_file failed: {e}")
@@ -539,24 +665,24 @@ class FileSystemTools(Toolkit):
         :return: Success message with the file's new size, or an error message.
         """
         try:
-            fs = self._resolved(run_context, agent, team)
+            fs, inner_path, _ = self._route_path(path, run_context, agent, team, write=True)
             if unique:
                 # Size delta rather than a second copy of the filter: whatever the
                 # dedupe kept is exactly what the file grew by.
-                previous = fs.read(path)
+                previous = fs.read(inner_path)
                 before_bytes = len(previous.encode("utf-8")) if previous else 0
-                meta = fs.append(path, content, unique=True)
+                meta = fs.append(inner_path, content, unique=True)
                 added = meta.size_bytes - before_bytes
                 if added <= 0:
                     return f"Appended nothing to {path}: every line was already present (still {meta.size_bytes} bytes)"
                 return f"Appended {added} bytes to {path}, skipping lines already present (now {meta.size_bytes} bytes)"
-            meta = fs.append(path, content)
+            meta = fs.append(inner_path, content)
             chunk = build_chunk(content)
             appended_bytes = len(chunk.encode("utf-8")) if chunk else 0
             return f"Appended {appended_bytes} bytes to {path} (now {meta.size_bytes} bytes)"
         except QuotaExceededError as e:
             return self._quota_error(e, path)
-        except InvalidPathError as e:
+        except (InvalidPathError, ReadOnlyMountError) as e:
             return f"Error: {e}"
         except Exception as e:
             log_error(f"append_file failed: {e}")
@@ -588,8 +714,8 @@ class FileSystemTools(Toolkit):
         :return: Success message with the file's new size, or an error message.
         """
         try:
-            fs = self._resolved(run_context, agent, team)
-            meta = fs.replace_lines(path, start_line, end_line, content)
+            fs, inner_path, _ = self._route_path(path, run_context, agent, team, write=True)
+            meta = fs.replace_lines(inner_path, start_line, end_line, content)
             action = "Deleted" if not content else "Replaced"
             return f"{action} lines {start_line}-{end_line} in {path} (now {meta.size_bytes} bytes)"
         except FileNotFoundError:
@@ -598,7 +724,7 @@ class FileSystemTools(Toolkit):
             return f"Error: {e}"
         except QuotaExceededError as e:
             return self._quota_error(e, path)
-        except InvalidPathError as e:
+        except (InvalidPathError, ReadOnlyMountError) as e:
             return f"Error: {e}"
         except Exception as e:
             log_error(f"replace_lines failed: {e}")
@@ -614,7 +740,8 @@ class FileSystemTools(Toolkit):
         agent: Optional[Agent] = None,
         team: Optional[Team] = None,
     ) -> str:
-        """Move or rename a file.
+        """Move or rename a file. Both paths must be in the same file store: a move
+        cannot cross between your own files and a shared mount, or between two mounts.
 
         :param src: Source file path.
         :param dst: Destination path. Parent folders are implicit.
@@ -622,8 +749,20 @@ class FileSystemTools(Toolkit):
         :return: Success message, or an error message.
         """
         try:
-            fs = self._resolved(run_context, agent, team)
-            fs.move(src, dst, overwrite=overwrite)
+            fs, inner_src, src_mount = self._route_path(src, run_context, agent, team, write=True)
+            _, inner_dst, dst_mount = self._route_path(dst, run_context, agent, team, write=True)
+            if src_mount != dst_mount:
+                # A cross-store move would be an unatomic read+write+delete spanning
+                # two backends - exactly the race the DB backend's single-statement
+                # move exists to avoid. Refused in v1; copying is explicit instead.
+                src_store = f"{src_mount}/" if src_mount else "your own files"
+                dst_store = f"{dst_mount}/" if dst_mount else "your own files"
+                return (
+                    f"Error: cannot move between file stores: {src} is in {src_store} and {dst} is in "
+                    f"{dst_store}. Copy it instead with read_file + write_file, then delete the original "
+                    "if you can."
+                )
+            fs.move(inner_src, inner_dst, overwrite=overwrite)
             return f"Moved {src} -> {dst}"
         except FileNotFoundError:
             return f"Error: file not found: {src}"
@@ -633,7 +772,7 @@ class FileSystemTools(Toolkit):
             # overwrite=True still surfaced a collision: on the DB backend two runs may
             # have moved onto {dst} at once; on local disk a parent segment may be a file.
             return f"Error: could not move to {dst}; it may have changed concurrently. Retry or use another name."
-        except InvalidPathError as e:
+        except (InvalidPathError, ReadOnlyMountError) as e:
             return f"Error: {e}"
         except Exception as e:
             log_error(f"move_file failed: {e}")
@@ -653,11 +792,11 @@ class FileSystemTools(Toolkit):
         :return: Success message, or an error if the file does not exist.
         """
         try:
-            fs = self._resolved(run_context, agent, team)
-            if not fs.delete(path):
+            fs, inner_path, _ = self._route_path(path, run_context, agent, team, write=True)
+            if not fs.delete(inner_path):
                 return f"Error: file not found: {path}"
             return f"Deleted {path}"
-        except InvalidPathError as e:
+        except (InvalidPathError, ReadOnlyMountError) as e:
             return f"Error: {e}"
         except Exception as e:
             log_error(f"delete_file failed: {e}")
@@ -755,7 +894,12 @@ class FileSystemTools(Toolkit):
         """Hold the write lock for each named file, acquired in a stable order.
 
         Sorted so two tool calls naming the same pair (move_file src/dst) cannot
-        deadlock by taking them in opposite orders.
+        deadlock by taking them in opposite orders. Keys use the model-facing
+        path, which identifies one file per toolkit even with mounts: a mounted
+        path carries its mount prefix. The one gap is two mounts aliasing the
+        SAME store - "a/x.md" and "b/x.md" would not contend - which matches the
+        lock's existing honesty: it serializes one toolkit instance, not the
+        world.
         """
         namespace = getattr(self.fs, "namespace", "")
         async with AsyncExitStack() as stack:

--- a/libs/agno/agno/fs/toolkit.py
+++ b/libs/agno/agno/fs/toolkit.py
@@ -212,7 +212,9 @@ class FileSystemTools(Toolkit):
         async_tools = [(getattr(self, "a" + name), name) for name in registered]
 
         super().__init__(
-            name="filesystem",
+            # Overridable so multiple file toolkits (a shared store and a
+            # per-agent one, say) can coexist in a registry without colliding.
+            name=kwargs.pop("name", "filesystem"),
             tools=sync_tools,
             async_tools=async_tools,
             instructions=instructions,

--- a/libs/agno/agno/fs/types.py
+++ b/libs/agno/agno/fs/types.py
@@ -1,5 +1,24 @@
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Literal, Optional
+
+if TYPE_CHECKING:
+    from agno.fs.fs import FileSystem
+
+
+@dataclass
+class Mount:
+    """One FileSystem mounted into another's tool surface under a top-level name.
+
+    Declared by the developer via ``fs.tools(mounts={"shared": Mount(other_fs)})``
+    (a bare ``FileSystem`` value coerces to a read-only Mount). The mount name
+    becomes a top-level directory in the agent's view: paths whose first segment
+    matches it route to ``fs`` instead of the primary store. ``mode`` is ``"ro"``
+    (the default: reads only, writes return an error to the model) or ``"rw"``.
+    ``fs`` may be templated; it resolves per tool call exactly like the primary.
+    """
+
+    fs: "FileSystem"
+    mode: Literal["ro", "rw"] = "ro"
 
 
 @dataclass

--- a/libs/agno/tests/integration/fs/test_mounts_over_db.py
+++ b/libs/agno/tests/integration/fs/test_mounts_over_db.py
@@ -1,0 +1,62 @@
+"""Mounts exercised over DbFileSystem, both dialects.
+
+The unit suite proves routing over LocalFileSystem; this lane proves the same
+contract against the real backend: a write through an rw mount lands as a row
+in the mounted namespace (never the primary's), ro enforcement holds, and
+scoped reads round-trip through the mount prefix.
+"""
+
+import json
+
+from agno.fs import FileSystem, Mount
+
+PRIMARY_NS = "mounts-primary"
+SHARED_NS = "mounts-shared"
+
+
+class TestMountsOverDb:
+    def test_rw_mount_routes_rows_to_the_mounted_namespace(self, db_fs):
+        primary = FileSystem(backend=db_fs, namespace=PRIMARY_NS)
+        shared = FileSystem(backend=db_fs, namespace=SHARED_NS)
+        tools = primary.tools(mounts={"team": Mount(fs=shared, mode="rw")})
+
+        assert tools.write_file("team/notes/a.md", "in the mount").startswith("Wrote")
+        assert tools.write_file("notes/b.md", "in the primary").startswith("Wrote")
+
+        # Rows land under the mounted namespace, never the primary's.
+        assert db_fs.read(SHARED_NS, "notes/a.md") == "in the mount"
+        assert db_fs.read(PRIMARY_NS, "team/notes/a.md") is None
+        assert db_fs.read(PRIMARY_NS, "notes/b.md") == "in the primary"
+
+        # Scoped listing round-trips: the returned path reads back verbatim.
+        payload = json.loads(tools.list_files(directory="team", recursive=True))
+        paths = [e["path"] for e in payload["files"] if e["type"] == "file"]
+        assert paths == ["team/notes/a.md"]
+        assert "in the mount" in tools.read_file(paths[0])
+
+    def test_ro_mount_refuses_writes_and_serves_reads(self, db_fs):
+        primary = FileSystem(backend=db_fs, namespace=PRIMARY_NS)
+        shared = FileSystem(backend=db_fs, namespace=SHARED_NS)
+        shared.write("seen/log.md", "example.com/a\n")
+        tools = primary.tools(mounts={"shared": shared})
+
+        result = tools.append_file("shared/seen/log.md", "example.com/b")
+        assert result == "Error: shared/ is read-only: files in this shared mount can be read but not changed."
+        assert db_fs.read(SHARED_NS, "seen/log.md") == "example.com/a\n"
+
+        checked = json.loads(tools.check_lines(["example.com/a"], directory="shared/seen"))
+        assert checked["found"] == ["example.com/a"]
+
+        found = json.loads(tools.search_content("example.com", directory="shared"))
+        assert [f["file"] for f in found["files"]] == ["shared/seen/log.md"]
+
+    def test_cross_store_move_is_refused_on_the_db_backend(self, db_fs):
+        primary = FileSystem(backend=db_fs, namespace=PRIMARY_NS)
+        shared = FileSystem(backend=db_fs, namespace=SHARED_NS)
+        tools = primary.tools(mounts={"team": Mount(fs=shared, mode="rw")})
+        primary.write("a.md", "stay put")
+
+        result = tools.move_file("a.md", "team/a.md")
+        assert result.startswith("Error: cannot move between file stores:")
+        assert db_fs.read(PRIMARY_NS, "a.md") == "stay put"
+        assert db_fs.read(SHARED_NS, "a.md") is None

--- a/libs/agno/tests/unit/fs/test_mounts.py
+++ b/libs/agno/tests/unit/fs/test_mounts.py
@@ -1,0 +1,441 @@
+"""Unit tests for FileSystem mounts: one agent, several namespaces, one tool surface.
+
+Mounts are developer-declared top-level directory names routing to another
+FileSystem (read-only by default). The contract under test: routing by first
+path segment, ro enforcement as error strings (never exceptions), no
+cross-store moves, zero tool-schema surface change, per-store quotas, and
+per-call resolution of templated mounted namespaces.
+"""
+
+import json
+
+import pytest
+
+from agno.fs import FileSystem, Mount
+from agno.fs.errors import InvalidPathError
+from agno.fs.local import LocalFileSystem
+from agno.fs.toolkit import FileSystemTools
+
+RO_ERROR = "Error: shared/ is read-only: files in this shared mount can be read but not changed."
+
+
+@pytest.fixture
+def backend(tmp_path) -> LocalFileSystem:
+    return LocalFileSystem(root=tmp_path)
+
+
+@pytest.fixture
+def primary(backend) -> FileSystem:
+    return FileSystem(backend=backend, namespace="brain")
+
+
+@pytest.fixture
+def shared(backend) -> FileSystem:
+    return FileSystem(backend=backend, namespace="global")
+
+
+@pytest.fixture
+def ro_tools(primary, shared) -> FileSystemTools:
+    # Bare FileSystem value: coerces to a read-only Mount.
+    return primary.tools(mounts={"shared": shared})
+
+
+@pytest.fixture
+def rw_tools(primary, shared) -> FileSystemTools:
+    return primary.tools(allow_delete=True, mounts={"team": Mount(fs=shared, mode="rw")})
+
+
+class TestMountDeclaration:
+    """Mount names are validated at construction; bad declarations never build."""
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [".", "..", "a/b", "/", "", "a b", "{user_id}", "a{b}", "a\\b", "a\nb", "sh:ared", "x" * 129],
+    )
+    def test_bad_mount_names_rejected(self, primary, shared, bad_name):
+        with pytest.raises(InvalidPathError):
+            primary.tools(mounts={bad_name: shared})
+
+    def test_non_string_mount_name_rejected(self, primary, shared):
+        with pytest.raises(InvalidPathError):
+            primary.tools(mounts={7: shared})  # type: ignore[dict-item]
+
+    def test_uppercase_name_normalizes_to_lowercase(self, primary, shared):
+        toolkit = primary.tools(mounts={"Shared": shared})
+        assert list(toolkit.mounts.keys()) == ["shared"]
+
+    def test_duplicate_after_normalization_rejected(self, primary, shared):
+        with pytest.raises(InvalidPathError):
+            primary.tools(mounts={"Shared": shared, "shared": shared})
+
+    def test_bare_filesystem_coerces_to_read_only_mount(self, ro_tools):
+        mount = ro_tools.mounts["shared"]
+        assert isinstance(mount, Mount)
+        assert mount.mode == "ro"
+
+    def test_bad_mount_value_type_rejected(self, primary):
+        with pytest.raises(TypeError):
+            primary.tools(mounts={"shared": "not-a-filesystem"})  # type: ignore[dict-item]
+
+    def test_bad_mode_rejected(self, primary, shared):
+        with pytest.raises(ValueError):
+            primary.tools(mounts={"shared": Mount(fs=shared, mode="rwx")})  # type: ignore[arg-type]
+
+    def test_mount_fs_must_be_a_filesystem(self, primary):
+        with pytest.raises(TypeError):
+            primary.tools(mounts={"shared": Mount(fs="nope")})  # type: ignore[arg-type]
+
+    def test_no_mounts_means_empty_dict(self, primary):
+        assert primary.tools().mounts == {}
+
+
+class TestRouting:
+    def test_read_via_mount_prefix_hits_the_mounted_store(self, shared, ro_tools):
+        shared.write("notes/decisions.md", "we chose postgres\n")
+        assert "we chose postgres" in ro_tools.read_file("shared/notes/decisions.md")
+
+    def test_primary_paths_are_unaffected(self, primary, ro_tools):
+        primary.write("notes/mine.md", "my own note\n")
+        assert "my own note" in ro_tools.read_file("notes/mine.md")
+        # And a primary path does not leak into the mount.
+        assert ro_tools.read_file("shared/notes/mine.md") == "Error: file not found: shared/notes/mine.md"
+
+    def test_mount_prefix_matches_case_insensitively(self, shared, ro_tools):
+        # Mount names are lowercase identifiers, so SHARED/ and shared/ are one mount.
+        shared.write("a.md", "x\n")
+        assert "1\tx" in ro_tools.read_file("SHARED/a.md")
+
+    def test_mount_name_alone_is_not_a_file(self, ro_tools):
+        result = ro_tools.read_file("shared")
+        assert result == (
+            "Error: shared/ is a shared mount, not a file. Give a path inside it, like "
+            'shared/notes/topic.md, or list it with list_files(directory="shared").'
+        )
+
+    def test_deleting_the_mount_itself_is_refused(self, primary, shared):
+        toolkit = primary.tools(allow_delete=True, mounts={"team": Mount(fs=shared, mode="rw")})
+        result = toolkit.delete_file("team")
+        assert result.startswith("Error: team/ is a shared mount, not a file.")
+
+    def test_writes_route_to_the_mount_not_a_shadowed_primary_path(self, primary, shared, rw_tools):
+        # The loud-write rule: a write whose first segment names a mount goes to
+        # the mount; it must never silently land in the primary namespace.
+        rw_tools.write_file("team/plan.md", "the plan\n")
+        assert shared.read("plan.md") == "the plan\n"
+        assert primary.read("team/plan.md") is None
+
+
+class TestReadOnlyEnforcement:
+    """Every write-family tool refuses an ro mount with the standard error string:
+    no exception reaches the model, and nothing is written."""
+
+    def test_write_file_refused(self, shared, ro_tools):
+        assert ro_tools.write_file("shared/a.md", "x") == RO_ERROR
+        assert shared.read("a.md") is None
+
+    def test_append_file_refused(self, shared, ro_tools):
+        assert ro_tools.append_file("shared/log.md", "rec-1") == RO_ERROR
+        assert shared.read("log.md") is None
+
+    def test_replace_lines_refused(self, shared, ro_tools):
+        shared.write("a.md", "one\ntwo\n")
+        assert ro_tools.replace_lines("shared/a.md", 1, 1, "ONE") == RO_ERROR
+        assert shared.read("a.md") == "one\ntwo\n"
+
+    def test_move_file_refused_as_src(self, shared, ro_tools):
+        shared.write("a.md", "x\n")
+        assert ro_tools.move_file("shared/a.md", "shared/b.md") == RO_ERROR
+        assert shared.read("a.md") == "x\n"
+
+    def test_move_into_an_ro_mount_refused(self, primary, ro_tools):
+        primary.write("a.md", "x\n")
+        assert ro_tools.move_file("a.md", "shared/a.md") == RO_ERROR
+        assert primary.read("a.md") == "x\n"
+
+    def test_delete_file_refused(self, primary, shared):
+        toolkit = primary.tools(allow_delete=True, mounts={"shared": shared})
+        shared.write("a.md", "x\n")
+        assert toolkit.delete_file("shared/a.md") == RO_ERROR
+        assert shared.read("a.md") == "x\n"
+
+    def test_reads_still_work_on_an_ro_mount(self, shared, ro_tools):
+        shared.write("a.md", "readable\n")
+        assert "readable" in ro_tools.read_file("shared/a.md")
+        assert "a.md" in ro_tools.list_files(directory="shared")
+
+
+class TestReadWriteMount:
+    def test_write_lands_in_the_mounted_store_only(self, primary, shared, rw_tools):
+        assert rw_tools.write_file("team/notes/a.md", "hello") == "Wrote 5 bytes to team/notes/a.md"
+        assert shared.read("notes/a.md") == "hello"
+        assert primary.read("team/notes/a.md") is None
+        assert primary.usage().total_bytes == 0
+
+    def test_append_and_replace_through_the_mount(self, shared, rw_tools):
+        rw_tools.append_file("team/log.md", "rec-1\nrec-2")
+        assert shared.read("log.md") == "rec-1\nrec-2\n"
+        rw_tools.replace_lines("team/log.md", 1, 1, "REC-1")
+        assert shared.read("log.md") == "REC-1\nrec-2\n"
+
+    def test_delete_through_the_mount(self, shared, rw_tools):
+        shared.write("a.md", "x\n")
+        assert rw_tools.delete_file("team/a.md") == "Deleted team/a.md"
+        assert shared.read("a.md") is None
+
+    def test_move_within_one_mount_works(self, shared, rw_tools):
+        shared.write("a.md", "x\n")
+        assert rw_tools.move_file("team/a.md", "team/archive/a.md") == "Moved team/a.md -> team/archive/a.md"
+        assert shared.read("archive/a.md") == "x\n"
+
+
+class TestCrossStoreMove:
+    """A move never crosses file stores: refused with a clear error, src intact."""
+
+    def test_primary_to_mount_refused(self, primary, rw_tools):
+        primary.write("a.md", "x\n")
+        result = rw_tools.move_file("a.md", "team/a.md")
+        assert result == (
+            "Error: cannot move between file stores: a.md is in your own files and team/a.md is in "
+            "team/. Copy it instead with read_file + write_file, then delete the original if you can."
+        )
+        assert primary.read("a.md") == "x\n"
+
+    def test_mount_to_primary_refused(self, shared, rw_tools):
+        shared.write("a.md", "x\n")
+        result = rw_tools.move_file("team/a.md", "a.md")
+        assert result.startswith("Error: cannot move between file stores:")
+        assert shared.read("a.md") == "x\n"
+
+    def test_mount_to_mount_refused(self, primary, backend):
+        other = FileSystem(backend=backend, namespace="other")
+        toolkit = primary.tools(mounts={"a": Mount(fs=primary, mode="rw"), "b": Mount(fs=other, mode="rw")})
+        primary.write("x.md", "x\n")
+        result = toolkit.move_file("a/x.md", "b/x.md")
+        assert result.startswith("Error: cannot move between file stores:")
+        assert primary.read("x.md") == "x\n"
+        assert other.read("x.md") is None
+
+
+class TestListFiles:
+    def test_root_listing_surfaces_mounts_as_dir_entries(self, primary, ro_tools):
+        primary.write("notes/a.md", "x\n")
+        payload = json.loads(ro_tools.list_files())
+        assert {"path": "shared", "type": "dir", "size": None, "updated": None, "mount": "ro"} in payload["files"]
+
+    def test_rw_mount_entry_reports_its_mode(self, rw_tools):
+        payload = json.loads(rw_tools.list_files())
+        assert {"path": "team", "type": "dir", "size": None, "updated": None, "mount": "rw"} in payload["files"]
+
+    def test_root_listing_never_descends_into_a_mount(self, shared, ro_tools):
+        shared.write("notes/deep.md", "x\n")
+        payload = json.loads(ro_tools.list_files(recursive=True))
+        paths = {e["path"] for e in payload["files"]}
+        assert "shared" in paths
+        assert "shared/notes/deep.md" not in paths
+
+    def test_scoped_listing_returns_paths_the_model_can_read_back(self, shared, ro_tools):
+        shared.write("notes/a.md", "round trip\n")
+        payload = json.loads(ro_tools.list_files(directory="shared", recursive=True))
+        paths = [e["path"] for e in payload["files"] if e["type"] == "file"]
+        assert paths == ["shared/notes/a.md"]
+        assert "round trip" in ro_tools.read_file(paths[0])
+
+    def test_scoped_listing_reports_the_mounted_stores_usage(self, primary, backend, ro_tools):
+        shared_small = FileSystem(backend=backend, namespace="tiny", max_namespace_bytes=100)
+        toolkit = primary.tools(mounts={"tiny": shared_small})
+        shared_small.write("a.md", "12345")
+        payload = json.loads(toolkit.list_files(directory="tiny"))
+        assert payload["usage"] == {"files": 1, "bytes_used": 5, "bytes_limit": 100}
+
+    def test_pattern_filters_mount_entries_like_other_dirs(self, ro_tools):
+        payload = json.loads(ro_tools.list_files(pattern="*.md"))
+        assert "shared" not in {e["path"] for e in payload["files"]}
+        kept = json.loads(ro_tools.list_files(pattern="shar*"))
+        assert "shared" in {e["path"] for e in kept["files"]}
+
+    def test_shadowed_primary_paths_are_dropped_from_listings(self, primary, ro_tools):
+        # A primary file under a mount name is unreachable through the tools
+        # (the router sends that prefix to the mount): do not advertise it.
+        primary.write("shared/ghost.md", "unreachable\n")
+        primary.write("notes/real.md", "reachable\n")
+        payload = json.loads(ro_tools.list_files(recursive=True))
+        paths = {e["path"] for e in payload["files"]}
+        assert "shared/ghost.md" not in paths
+        assert "notes/real.md" in paths
+        # The mount entry itself is still there, exactly once.
+        assert [e["path"] for e in payload["files"]].count("shared") == 1
+
+
+class TestSearchAndCheckLines:
+    def test_root_search_covers_the_primary_only(self, primary, shared, ro_tools):
+        primary.write("notes/a.md", "needle in my own files\n")
+        shared.write("notes/b.md", "needle in the mount\n")
+        payload = json.loads(ro_tools.search_content("needle"))
+        assert [f["file"] for f in payload["files"]] == ["notes/a.md"]
+
+    def test_scoped_search_reaches_the_mount_with_prefixed_paths(self, shared, ro_tools):
+        shared.write("notes/b.md", "needle in the mount\n")
+        payload = json.loads(ro_tools.search_content("needle", directory="shared"))
+        assert [f["file"] for f in payload["files"]] == ["shared/notes/b.md"]
+        assert "needle" in ro_tools.read_file(payload["files"][0]["file"])
+
+    def test_scoped_search_within_a_mount_subdirectory(self, shared, ro_tools):
+        shared.write("notes/b.md", "needle here\n")
+        shared.write("other/c.md", "needle there\n")
+        payload = json.loads(ro_tools.search_content("needle", directory="shared/notes"))
+        assert [f["file"] for f in payload["files"]] == ["shared/notes/b.md"]
+
+    def test_shadowed_primary_matches_are_dropped_from_search(self, primary, ro_tools):
+        primary.write("shared/ghost.md", "needle unreachable\n")
+        payload = json.loads(ro_tools.search_content("needle"))
+        assert payload["files"] == []
+
+    def test_check_lines_scopes_into_a_mount(self, primary, shared, ro_tools):
+        shared.write("seen/log.md", "example.com/a\n")
+        primary.write("seen/log.md", "example.com/b\n")
+        scoped = json.loads(ro_tools.check_lines(["example.com/a", "example.com/b"], directory="shared"))
+        assert scoped["found"] == ["example.com/a"]
+        assert scoped["missing"] == ["example.com/b"]
+        # Unscoped stays on the primary.
+        root = json.loads(ro_tools.check_lines(["example.com/a", "example.com/b"]))
+        assert root["found"] == ["example.com/b"]
+
+
+class TestQuotasStayPerStore:
+    def test_write_through_a_mount_charges_the_mounted_quota(self, primary, backend):
+        tiny = FileSystem(backend=backend, namespace="tiny", max_file_bytes=10)
+        toolkit = primary.tools(mounts={"team": Mount(fs=tiny, mode="rw")})
+        result = toolkit.write_file("team/a.md", "0123456789x")
+        assert result == (
+            "Error: team/a.md would be 11 bytes (limit 10 per file). "
+            "Split the topic into smaller files (or partition by date) and retry."
+        )
+        # The primary's own (default) cap is untouched: the same content fits there.
+        assert toolkit.write_file("a.md", "0123456789x").startswith("Wrote 11 bytes")
+
+    def test_mounted_namespace_cap_is_the_mounted_stores(self, primary, backend):
+        tiny = FileSystem(backend=backend, namespace="tiny", max_namespace_bytes=10)
+        toolkit = primary.tools(mounts={"team": Mount(fs=tiny, mode="rw")})
+        toolkit.write_file("team/a.md", "123456")
+        result = toolkit.write_file("team/b.md", "78901")
+        assert result.startswith("Error: storage is full (6 of 10 bytes).")
+        # Primary usage is untouched by mounted writes.
+        assert primary.usage().total_bytes == 0
+
+
+class TestTemplatedMounts:
+    """A mounted FileSystem may be templated; it resolves per call from the same
+    injected context as the primary, and fails closed the same way."""
+
+    @pytest.fixture
+    def per_user_tools(self, backend, primary):
+        per_user = FileSystem(backend=backend, namespace="team/{user_id}")
+        return backend, primary.tools(mounts={"team": Mount(fs=per_user, mode="rw")})
+
+    def test_mounted_template_resolves_per_call(self, per_user_tools):
+        from agno.run import RunContext
+
+        backend, toolkit = per_user_tools
+        ctx_a = RunContext(run_id="r1", session_id="s1", user_id="alice")
+        ctx_b = RunContext(run_id="r2", session_id="s2", user_id="bob")
+        toolkit.write_file("team/a.md", "alice's", run_context=ctx_a)
+        toolkit.write_file("team/a.md", "bob's", run_context=ctx_b)
+        assert backend.read("team/alice", "a.md") == "alice's"
+        assert backend.read("team/bob", "a.md") == "bob's"
+        assert "alice" in toolkit.read_file("team/a.md", run_context=ctx_a)
+
+    def test_mounted_template_fails_closed_without_identity(self, per_user_tools):
+        _backend, toolkit = per_user_tools
+        expected = "Error: this agent's files require user_id for this run and none was provided."
+        assert toolkit.read_file("team/a.md") == expected
+        assert toolkit.write_file("team/a.md", "x") == expected
+        assert toolkit.list_files(directory="team") == expected
+
+    def test_untemplated_primary_still_works_beside_a_templated_mount(self, primary, per_user_tools):
+        _backend, toolkit = per_user_tools
+        assert toolkit.write_file("notes/a.md", "mine").startswith("Wrote")
+        assert primary.read("notes/a.md") == "mine"
+
+
+class TestSurfaceUnchanged:
+    """Mounts add zero model-facing surface: same tools, same schemas, no new params."""
+
+    def test_tool_names_identical_with_and_without_mounts(self, primary, shared):
+        plain = primary.tools()
+        mounted = primary.tools(mounts={"shared": shared})
+        assert list(mounted.functions.keys()) == list(plain.functions.keys())
+        assert list(mounted.async_functions.keys()) == list(plain.async_functions.keys())
+
+    def test_schemas_identical_with_and_without_mounts(self, primary, shared):
+        plain = primary.tools(include_tools=FileSystemTools.FULL_TOOLS)
+        mounted = primary.tools(include_tools=FileSystemTools.FULL_TOOLS, mounts={"shared": shared})
+        for name in FileSystemTools.FULL_TOOLS:
+            plain_fn, mounted_fn = plain.functions[name], mounted.functions[name]
+            plain_fn.process_entrypoint()
+            mounted_fn.process_entrypoint()
+            assert mounted_fn.parameters == plain_fn.parameters
+            properties = mounted_fn.parameters.get("properties", {})
+            assert "namespace" not in properties
+            assert "mount" not in properties
+
+    def test_read_only_toolkit_accepts_mounts(self, primary, shared):
+        toolkit = primary.tools(read_only=True, mounts={"shared": shared})
+        assert list(toolkit.functions.keys()) == FileSystemTools.READ_ONLY_TOOLS
+        shared.write("a.md", "x\n")
+        assert "1\tx" in toolkit.read_file("shared/a.md")
+
+
+class TestInstructions:
+    def test_instructions_name_each_mount_and_its_mode(self, primary, shared):
+        text = FileSystem.instructions(mounts={"shared": shared, "team": Mount(fs=shared, mode="rw")})
+        assert "shared/ (read-only)" in text
+        assert "team/ (read-write)" in text
+        assert "shared mounts" in text
+        assert "cannot write, move or delete inside a read-only mount" in text
+
+    def test_all_rw_mounts_skip_the_read_only_line(self, shared):
+        text = FileSystem.instructions(mounts={"team": Mount(fs=shared, mode="rw")})
+        assert "team/ (read-write)" in text
+        assert "read-only mount" not in text
+
+    def test_no_mounts_leaves_the_text_unchanged(self):
+        assert FileSystem.instructions(mounts=None) == FileSystem.instructions()
+        assert FileSystem.instructions(mounts={}) == FileSystem.instructions()
+
+    def test_toolkit_default_instructions_carry_the_mount_line(self, primary, shared):
+        toolkit = primary.tools(mounts={"shared": shared})
+        assert toolkit.instructions == FileSystem.instructions(mounts={"shared": shared})
+        assert "shared/ (read-only)" in toolkit.instructions
+
+    def test_explicit_instructions_are_respected(self, primary, shared):
+        toolkit = primary.tools(mounts={"shared": shared}, instructions="my own text")
+        assert toolkit.instructions == "my own text"
+
+    def test_mount_conventions_keep_the_one_line_bullet_shape(self, shared):
+        # Composed into an agent's instructions list the block renders as one
+        # bullet; every convention, including the mount lines, must stay one
+        # indented line (test_toolkit.py::test_every_bullet_is_one_line_and_nests).
+        text = FileSystem.instructions(mounts={"shared": shared})
+        body = text.split("Conventions:\n", 1)[1]
+        for line in body.split("\n"):
+            if line:
+                assert line.startswith("  - "), line
+
+    def test_namespace_still_never_appears(self, shared):
+        # The mounted store's namespace is "global"; only the mount NAME may show.
+        text = FileSystem.instructions(mounts={"shared": shared})
+        assert "global" not in text
+        assert "namespace" not in text.lower()
+
+
+class TestAsyncTwins:
+    @pytest.mark.asyncio
+    async def test_async_write_and_read_through_a_mount(self, shared, rw_tools):
+        assert (await rw_tools.awrite_file("team/a.md", "async hello")).startswith("Wrote")
+        assert shared.read("a.md") == "async hello"
+        assert "async hello" in await rw_tools.aread_file("team/a.md")
+
+    @pytest.mark.asyncio
+    async def test_async_ro_enforcement(self, shared, ro_tools):
+        assert await ro_tools.aappend_file("shared/log.md", "rec-1") == RO_ERROR
+        assert shared.read("log.md") is None

--- a/libs/agno/tests/unit/fs/test_toolkit.py
+++ b/libs/agno/tests/unit/fs/test_toolkit.py
@@ -771,3 +771,14 @@ class TestConcurrentEditsInOneTurn:
 
         content = fs.read("notes/log.md")
         assert "REPLACED" in content and "appended" in content
+
+
+class TestToolkitName:
+    def test_default_name_is_filesystem(self, fs):
+        assert fs.tools().name == "filesystem"
+
+    def test_name_override(self, fs):
+        toolkit = fs.tools(name="agent_files")
+        assert toolkit.name == "agent_files"
+        # The override changes identity only; the tool surface is untouched.
+        assert "read_file" in toolkit.functions


### PR DESCRIPTION
## Summary

One agent can now see multiple namespaces through a single tool surface: `fs.tools(mounts={"shared": other_fs})` routes paths whose first segment names a mount to that mounted `FileSystem` — read-only by default (`Mount(fs, mode="rw")` to opt in). Until now this was impossible: every `FileSystemTools` registers the same tool names and the agent-level resolver drops duplicates, so a second file-like toolkit per agent was explicitly unsupported.

Spec posture preserved: cross-namespace access is developer-declared, never model-enumerated — mount *names* are discoverable (they surface as root directory entries in `list_files`, tagged ro/rw), namespaces never appear in any schema or instruction. Mounted filesystems may be templated (`{user_id}` etc.) and resolve per call exactly like the primary. Write-family tools on a ro mount return the standard error string before storage is touched; cross-store `move_file` is refused in v1 with a copy-instead hint; quotas stay per-filesystem.

## Changes
- `libs/agno/agno/fs/`: `types.py` (Mount), `errors.py` (ReadOnlyMountError), `_paths.py` (mount-name grammar), `fs.py` (coercion/validation, mounts-aware instructions), `toolkit.py` (routing, all nine tools), `__init__.py` exports
- Tests: `tests/unit/fs/test_mounts.py` (69 cases), `tests/integration/fs/test_mounts_over_db.py` (both dialects)

## Testing
- `tests/unit/fs/`: 408 passed (339 baseline + 69 new)
- `tests/integration/fs/`: 115 passed on SQLite and Postgres (pgvector container)
- ruff check / format clean; `mypy agno/fs`: clean (9 files)

## Known v1 edges (documented in commit body)
- `check_lines` at primary root cannot exclude a shadowed primary file (no per-file attribution in `ContainsResult`); listings and search do filter
- Async lock keys use the model-facing path, so two mounts aliasing the same store don't contend — matches existing single-toolkit behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)