### PR TITLE
[fix] Restore nested team history lookup

### DIFF
--- a/libs/agno/agno/session/team.py
+++ b/libs/agno/agno/session/team.py
@@ -165,7 +165,29 @@ class TeamSession:
 
         # Filter by team_id and member_ids
         if team_id:
-            session_runs = [run for run in session_runs if hasattr(run, "team_id") and run.team_id == team_id]  # type: ignore
+            filtered_team_runs = []
+            seen_team_run_ids: set[str] = set()
+            visited_team_runs: set[int] = set()
+            pending_team_runs = list(reversed(session_runs))
+
+            while pending_team_runs:
+                run = pending_team_runs.pop()
+                run_identity = id(run)
+                if run_identity in visited_team_runs:
+                    continue
+                visited_team_runs.add(run_identity)
+
+                if getattr(run, "team_id", None) == team_id:
+                    run_id = getattr(run, "run_id", None)
+                    if not run_id or run_id not in seen_team_run_ids:
+                        filtered_team_runs.append(run)
+                        if run_id:
+                            seen_team_run_ids.add(run_id)
+
+                member_responses = getattr(run, "member_responses", None) or []
+                pending_team_runs.extend(reversed(member_responses))
+
+            session_runs = filtered_team_runs
         if member_ids:
             filtered_runs = []
             seen_run_ids: set[str] = set()

--- a/libs/agno/tests/unit/team/test_get_messages_dedup.py
+++ b/libs/agno/tests/unit/team/test_get_messages_dedup.py
@@ -105,6 +105,42 @@ def _nested_team_history_session() -> TeamSession:
     return session
 
 
+def _member_response_team_history_session() -> TeamSession:
+    """Build a three-level team run tree stored only through member responses."""
+    leaf_run = TeamRunOutput(
+        run_id="leaf-run",
+        team_id="leaf-team",
+        parent_run_id="middle-run",
+        status=RunStatus.completed,
+        messages=[
+            Message(role="user", content="Leaf request"),
+            Message(role="assistant", content="Leaf response"),
+        ],
+    )
+    middle_run = TeamRunOutput(
+        run_id="middle-run",
+        team_id="middle-team",
+        parent_run_id="root-run",
+        status=RunStatus.completed,
+        messages=[
+            Message(role="user", content="Middle request"),
+            Message(role="assistant", content="Middle response"),
+        ],
+        member_responses=[leaf_run],
+    )
+    root_run = TeamRunOutput(
+        run_id="root-run",
+        team_id="root-team",
+        status=RunStatus.completed,
+        messages=[
+            Message(role="user", content="Root request"),
+            Message(role="assistant", content="Root response"),
+        ],
+        member_responses=[middle_run],
+    )
+    return TeamSession(session_id="member-response-team-session", team_id="root-team", runs=[root_run])
+
+
 class TestGetMessagesMemberDedup:
     """Tests for deduplication when member runs appear in multiple locations."""
 
@@ -297,6 +333,32 @@ class TestNestedTeamHistory:
         history = _get_history_for_member_agent(parent_team, session, nested_team)
 
         assert [message.content for message in history] == ["Nested request", "Nested response"]
+
+    def test_team_id_filter_finds_team_in_member_responses(self):
+        """A nested team stored only as a member response remains queryable."""
+        session = _member_response_team_history_session()
+
+        messages = session.get_messages(team_id="middle-team")
+
+        assert [message.content for message in messages] == ["Middle request", "Middle response"]
+
+    def test_team_id_filter_finds_deeply_nested_team(self):
+        """Team history lookup traverses more than one member-response level."""
+        session = _member_response_team_history_session()
+
+        messages = session.get_messages(team_id="leaf-team")
+
+        assert [message.content for message in messages] == ["Leaf request", "Leaf response"]
+
+    def test_team_id_filter_deduplicates_flat_and_nested_run(self):
+        """Dual storage of a team run must not duplicate its history messages."""
+        session = _member_response_team_history_session()
+        leaf_run = session.runs[0].member_responses[0].member_responses[0]  # type: ignore[union-attr]
+        session.runs.append(leaf_run)
+
+        messages = session.get_messages(team_id="leaf-team")
+
+        assert [message.content for message in messages] == ["Leaf request", "Leaf response"]
 
 
 class TestGetTeamHistoryZeroCount:


### PR DESCRIPTION
## Summary

Fixes #9348.

TeamSession.get_messages(team_id=...) previously inspected only top-level session runs. Nested TeamRunOutput records are stored under their parent's member_responses, so delegated sub-team history disappeared and the member Team received an empty conversation.

This change:
- traverses member_responses at arbitrary nesting depth while preserving run order;
- prevents cycles by tracking visited run objects;
- deduplicates runs by run_id when storage contains both flat and nested copies;
- adds regression coverage for one-level nesting, three-level nesting, and dual storage.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (scripts/format.bat and scripts/validate.bat)
- [x] Self-review completed
- [ ] Documentation updated (not applicable; no public API or configuration change)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Adjacent PR #8515 changes member_ids filtering so nested Team IDs can be passed through that parameter. This PR addresses the separate team_id branch used by _get_history_for_member_agent for Team members; #8515 does not modify that branch and does not resolve #9348.

Validation:
- scripts/format.bat: 2,002 files unchanged; import checks passed
- scripts/validate.bat: Ruff passed; Mypy passed across 953 source files
- pytest libs/agno/tests/unit/team: 545 passed, 2 skipped
- focused TeamSession regression file: 17 passed

I also ran the existing TeamSession get_messages integration selection on Windows. All 15 test bodies passed, but its shared SQLite fixture raised WinError 32 while deleting each temporary database during teardown because the file handle remained open. The unit and validation gates above completed cleanly.