### PR TITLE
fix: toolkit-qualified tool rehydration for persisted components

### DIFF
--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -566,14 +566,21 @@ def to_dict(agent: Agent) -> Dict[str, Any]:
         _claimed_names: Set[str] = set()
         for _tool in agent.tools:
             if isinstance(_tool, Toolkit):
-                for _name in _tool.functions:
-                    if _name in _claimed_names:
+                # get_functions() rather than .functions: subclasses may expose
+                # a subset, and parse_tools serializes what get_functions()
+                # returns. Claimed by Function.name, not dict key: the two can
+                # differ, and the serialized dict carries the Function's name.
+                for _func in _tool.get_functions().values():
+                    if _func.name in _claimed_names:
                         continue
-                    _claimed_names.add(_name)
-                    if _tool.name:
-                        _owning_toolkit[_name] = _tool.name
+                    _claimed_names.add(_func.name)
+                    if isinstance(_tool.name, str) and _tool.name:
+                        _owning_toolkit[_func.name] = _tool.name
             elif isinstance(_tool, Function):
-                _claimed_names.add(_tool.name)
+                if _tool.name not in _claimed_names:
+                    _claimed_names.add(_tool.name)
+                    if _tool.owning_toolkit:
+                        _owning_toolkit[_tool.name] = _tool.owning_toolkit
             elif callable(_tool) and getattr(_tool, "__name__", None) is not None:
                 _claimed_names.add(_tool.__name__)
     if _tools:
@@ -816,7 +823,7 @@ def from_dict(cls: Type[Agent], data: Dict[str, Any], registry: Optional[Registr
     # --- Handle tools reconstruction ---
     if "tools" in config and config["tools"]:
         if registry:
-            config["tools"] = [registry.rehydrate_function(t) for t in config["tools"]]
+            config["tools"] = registry.rehydrate_functions(config["tools"])
         else:
             log_warning("No registry provided, tools will not be rehydrated.")
             del config["tools"]

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -8,6 +8,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Set,
     Type,
     Union,
     cast,
@@ -27,6 +28,7 @@ from agno.registry.registry import Registry
 from agno.run.agent import RunOutput
 from agno.session import AgentSession, TeamSession, WorkflowSession
 from agno.tools.function import Function
+from agno.tools.toolkit import Toolkit
 from agno.utils.agent import (
     aget_last_run_output_util,
     aget_run_output_util,
@@ -550,18 +552,40 @@ def to_dict(agent: Agent) -> Dict[str, Any]:
     # --- Tools ---
     # Serialize tools to their dictionary representations (skip callable factories)
     _tools: List[Union[Function, dict]] = []
+    # Which toolkit each flattened function came from, so rehydration can
+    # re-bind same-named functions to the right toolkit (see
+    # Registry.rehydrate_function). Mirrors the parse_tools walk: tools are
+    # processed in declaration order and the first one to claim a name wins.
+    _owning_toolkit: Dict[str, str] = {}
     if agent.model is not None and agent.tools and isinstance(agent.tools, list):
         _tools = parse_tools(
             agent,
             model=agent.model,
             tools=agent.tools,
         )
+        _claimed_names: Set[str] = set()
+        for _tool in agent.tools:
+            if isinstance(_tool, Toolkit):
+                for _name in _tool.functions:
+                    if _name in _claimed_names:
+                        continue
+                    _claimed_names.add(_name)
+                    if _tool.name:
+                        _owning_toolkit[_name] = _tool.name
+            elif isinstance(_tool, Function):
+                _claimed_names.add(_tool.name)
+            elif callable(_tool) and getattr(_tool, "__name__", None) is not None:
+                _claimed_names.add(_tool.__name__)
     if _tools:
         serialized_tools = []
         for tool in _tools:
             try:
                 if isinstance(tool, Function):
-                    serialized_tools.append(tool.to_dict())
+                    tool_dict = tool.to_dict()
+                    _toolkit_name = _owning_toolkit.get(tool.name)
+                    if _toolkit_name is not None:
+                        tool_dict["toolkit"] = _toolkit_name
+                    serialized_tools.append(tool_dict)
                 else:
                     serialized_tools.append(tool)
             except Exception as e:

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Type
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 from uuid import uuid4
 
 from pydantic import BaseModel
@@ -17,6 +17,11 @@ from agno.vectordb.base import VectorDb
 if TYPE_CHECKING:
     from agno.agent import Agent
     from agno.team import Team
+
+# A flat function name, or a (toolkit name, function name) qualified pair.
+EntrypointKey = Union[str, Tuple[str, str]]
+# The Function that owns the entrypoint, or the registered plain callable itself.
+EntrypointSource = Union[Function, Callable]
 
 
 def _model_identity(model: Model) -> tuple:
@@ -54,7 +59,7 @@ class Registry:
     teams: List[Team] = field(default_factory=list)
 
     @cached_property
-    def _entrypoint_lookup(self) -> Dict[Any, Any]:
+    def _entrypoint_lookup(self) -> Dict[EntrypointKey, EntrypointSource]:
         # Maps function name -> source: the Function that owns the entrypoint
         # (for Toolkit and Function tools) or the plain callable itself.
         # Toolkit functions are additionally indexed under a toolkit-qualified
@@ -64,12 +69,12 @@ class Registry:
         # toolkits share member names. A tuple never equals a string, so
         # qualified keys cannot collide with flat names -- including function
         # names that contain characters like dots.
-        lookup: Dict[Any, Any] = {}
+        lookup: Dict[EntrypointKey, EntrypointSource] = {}
 
-        def _entrypoint(source: Any) -> Optional[Callable]:
+        def _entrypoint(source: EntrypointSource) -> Optional[Callable]:
             return source.entrypoint if isinstance(source, Function) else source
 
-        def register(name: str, source: Any) -> None:
+        def register(name: str, source: EntrypointSource) -> None:
             # The flat slot is keyed by name only, so two genuinely different
             # tools that share a name collapse to one slot (last wins). Dicts
             # qualified with their toolkit's name still resolve correctly, but
@@ -136,7 +141,7 @@ class Registry:
             # bare Functions instead of Toolkits.
             func.owning_toolkit = toolkit_name
 
-        def lookup(key: Any) -> Optional[Any]:
+        def lookup(key: EntrypointKey) -> Optional[EntrypointSource]:
             # Toolkits can gain functions after the lookup is first built -- MCP
             # toolkits only register their functions once connected -- so a miss
             # may just mean the cache is stale. Rebuild once and retry.
@@ -147,7 +152,7 @@ class Registry:
                 found = self._entrypoint_lookup.get(key)
             return found
 
-        source: Optional[Any] = None
+        source: Optional[EntrypointSource] = None
         if func.owning_toolkit is not None:
             # A qualified miss rebuilds before falling back to the flat name:
             # the flat slot may hold a same-named function from a *different*

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -54,16 +54,17 @@ class Registry:
     teams: List[Team] = field(default_factory=list)
 
     @cached_property
-    def _entrypoint_lookup(self) -> Dict[str, Any]:
+    def _entrypoint_lookup(self) -> Dict[Any, Any]:
         # Maps function name -> source: the Function that owns the entrypoint
         # (for Toolkit and Function tools) or the plain callable itself.
         # Toolkit functions are additionally indexed under a toolkit-qualified
-        # key ("<toolkit name>.<function name>") so serialized dicts that carry
-        # their owning toolkit's name (the "toolkit" key written at
+        # tuple key (<toolkit name>, <function name>) so serialized dicts that
+        # carry their owning toolkit's name (the "toolkit" key written at
         # serialization) resolve to the right toolkit even when two registry
-        # toolkits share member names. Function names cannot contain dots, so
-        # qualified keys never collide with flat ones.
-        lookup: Dict[str, Any] = {}
+        # toolkits share member names. A tuple never equals a string, so
+        # qualified keys cannot collide with flat names -- including function
+        # names that contain characters like dots.
+        lookup: Dict[Any, Any] = {}
 
         def _entrypoint(source: Any) -> Optional[Callable]:
             return source.entrypoint if isinstance(source, Function) else source
@@ -85,11 +86,18 @@ class Registry:
 
         for tool in self.tools:
             if isinstance(tool, Toolkit):
-                for func in tool.functions.values():
+                # get_functions() rather than .functions: subclasses may expose
+                # a subset, and only exposed functions are serialized or run --
+                # a hidden member must not claim a slot (or warn) here either.
+                for func in tool.get_functions().values():
                     if func.entrypoint is not None:
                         register(func.name, func)
-                        if tool.name:
-                            register(f"{tool.name}.{func.name}", func)
+                        if isinstance(tool.name, str) and tool.name:
+                            # A qualified slot collides only when two same-named
+                            # toolkits share a member name, and that collision has
+                            # already warned on the flat slot above -- so this
+                            # write stays silent (last wins).
+                            lookup[(tool.name, func.name)] = func
             elif isinstance(tool, Function):
                 if tool.entrypoint is not None:
                     register(tool.name, tool)
@@ -107,31 +115,56 @@ class Registry:
         saved before qualification and for functions whose toolkit is no longer
         in the registry.
         """
+        return self._rehydrate_function(func_dict, {"rebuilt": False})
+
+    def rehydrate_functions(self, func_dicts: List[Dict[str, Any]]) -> List[Function]:
+        """Rehydrate a batch of function dicts, sharing one cache-rebuild budget.
+
+        A component load rehydrates every tool in its config; one rebuild of the
+        entrypoint lookup per batch is enough to pick up late-registered
+        functions, so repeated misses within a load don't each pay a rebuild.
+        """
+        rebuild_state = {"rebuilt": False}
+        return [self._rehydrate_function(func_dict, rebuild_state) for func_dict in func_dicts]
+
+    def _rehydrate_function(self, func_dict: Dict[str, Any], rebuild_state: Dict[str, bool]) -> Function:
         func = Function.from_dict(func_dict)
         toolkit_name = func_dict.get("toolkit")
+        if isinstance(toolkit_name, str) and toolkit_name:
+            # Keep the attribution on the object so a load -> save round trip
+            # re-stamps the "toolkit" key even though the loaded component holds
+            # bare Functions instead of Toolkits.
+            func.owning_toolkit = toolkit_name
 
-        rebuilt = False
-
-        def lookup(key: str) -> Optional[Any]:
+        def lookup(key: Any) -> Optional[Any]:
             # Toolkits can gain functions after the lookup is first built -- MCP
             # toolkits only register their functions once connected -- so a miss
             # may just mean the cache is stale. Rebuild once and retry.
-            nonlocal rebuilt
             found = self._entrypoint_lookup.get(key)
-            if found is None and not rebuilt:
+            if found is None and not rebuild_state["rebuilt"]:
                 self.__dict__.pop("_entrypoint_lookup", None)
-                rebuilt = True
+                rebuild_state["rebuilt"] = True
                 found = self._entrypoint_lookup.get(key)
             return found
 
         source: Optional[Any] = None
-        if isinstance(toolkit_name, str) and toolkit_name:
+        if func.owning_toolkit is not None:
             # A qualified miss rebuilds before falling back to the flat name:
             # the flat slot may hold a same-named function from a *different*
             # toolkit while the right one simply hasn't populated the cache yet.
-            source = lookup(f"{toolkit_name}.{func.name}")
+            source = lookup((func.owning_toolkit, func.name))
         if source is None:
             source = lookup(func.name)
+            if source is not None and func.owning_toolkit is not None:
+                # The recorded toolkit could not be honored, so the flat slot's
+                # same-named function -- possibly from a different toolkit -- is
+                # being bound instead.
+                log_warning(
+                    f"Registry: toolkit '{func.owning_toolkit}' does not provide '{func.name}' "
+                    "in this registry; binding the same-named function found under the flat "
+                    "name instead. If the toolkit was renamed, update the registry or re-save "
+                    "the component."
+                )
         if isinstance(source, Function):
             func.entrypoint = source.entrypoint
             # Entrypoints built for a fixed schema (e.g. MCP call proxies) must

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -57,16 +57,23 @@ class Registry:
     def _entrypoint_lookup(self) -> Dict[str, Any]:
         # Maps function name -> source: the Function that owns the entrypoint
         # (for Toolkit and Function tools) or the plain callable itself.
+        # Toolkit functions are additionally indexed under a toolkit-qualified
+        # key ("<toolkit name>.<function name>") so serialized dicts that carry
+        # their owning toolkit's name (the "toolkit" key written at
+        # serialization) resolve to the right toolkit even when two registry
+        # toolkits share member names. Function names cannot contain dots, so
+        # qualified keys never collide with flat ones.
         lookup: Dict[str, Any] = {}
 
         def _entrypoint(source: Any) -> Optional[Callable]:
             return source.entrypoint if isinstance(source, Function) else source
 
         def register(name: str, source: Any) -> None:
-            # This lookup is keyed by name only, so two genuinely different tools
-            # that share a name collapse to one slot (last wins). We can't resolve
-            # that from a serialized function name alone, but we can surface it so
-            # the user can give the tools distinct names.
+            # The flat slot is keyed by name only, so two genuinely different
+            # tools that share a name collapse to one slot (last wins). Dicts
+            # qualified with their toolkit's name still resolve correctly, but
+            # unqualified ones (legacy configs, plain callables) can't, so we
+            # surface the collision for the user to disambiguate.
             existing = lookup.get(name)
             if existing is not None and existing is not source and _entrypoint(existing) is not _entrypoint(source):
                 log_warning(
@@ -81,6 +88,8 @@ class Registry:
                 for func in tool.functions.values():
                     if func.entrypoint is not None:
                         register(func.name, func)
+                        if tool.name:
+                            register(f"{tool.name}.{func.name}", func)
             elif isinstance(tool, Function):
                 if tool.entrypoint is not None:
                     register(tool.name, tool)
@@ -89,15 +98,40 @@ class Registry:
         return lookup
 
     def rehydrate_function(self, func_dict: Dict[str, Any]) -> Function:
-        """Reconstruct a Function from dict, reattaching its entrypoint."""
+        """Reconstruct a Function from dict, reattaching its entrypoint.
+
+        Dicts that carry their owning toolkit's name (the "toolkit" key written
+        at serialization) resolve via the toolkit-qualified key first, so
+        same-named functions from different toolkits bind to the right
+        entrypoint. The flat function name stays as the fallback for configs
+        saved before qualification and for functions whose toolkit is no longer
+        in the registry.
+        """
         func = Function.from_dict(func_dict)
-        source = self._entrypoint_lookup.get(func.name)
-        if source is None:
+        toolkit_name = func_dict.get("toolkit")
+
+        rebuilt = False
+
+        def lookup(key: str) -> Optional[Any]:
             # Toolkits can gain functions after the lookup is first built -- MCP
             # toolkits only register their functions once connected -- so a miss
             # may just mean the cache is stale. Rebuild once and retry.
-            self.__dict__.pop("_entrypoint_lookup", None)
-            source = self._entrypoint_lookup.get(func.name)
+            nonlocal rebuilt
+            found = self._entrypoint_lookup.get(key)
+            if found is None and not rebuilt:
+                self.__dict__.pop("_entrypoint_lookup", None)
+                rebuilt = True
+                found = self._entrypoint_lookup.get(key)
+            return found
+
+        source: Optional[Any] = None
+        if isinstance(toolkit_name, str) and toolkit_name:
+            # A qualified miss rebuilds before falling back to the flat name:
+            # the flat slot may hold a same-named function from a *different*
+            # toolkit while the right one simply hasn't populated the cache yet.
+            source = lookup(f"{toolkit_name}.{func.name}")
+        if source is None:
+            source = lookup(func.name)
         if isinstance(source, Function):
             func.entrypoint = source.entrypoint
             # Entrypoints built for a fixed schema (e.g. MCP call proxies) must

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -549,14 +549,22 @@ def to_dict(team: "Team") -> Dict[str, Any]:
         for tool in team.tools:
             try:
                 if isinstance(tool, Function):
-                    serialized_tools.append(tool.to_dict())
+                    func_dict = tool.to_dict()
+                    # A rehydrated team holds bare Functions; re-stamp the
+                    # attribution they carry so it survives the round trip.
+                    if tool.owning_toolkit:
+                        func_dict["toolkit"] = tool.owning_toolkit
+                    serialized_tools.append(func_dict)
                 elif isinstance(tool, Toolkit):
-                    for func in tool.functions.values():
+                    # get_functions() rather than .functions: subclasses may
+                    # expose a subset, and the team runtime only ever calls
+                    # what get_functions() returns.
+                    for func in tool.get_functions().values():
                         func_dict = func.to_dict()
                         # Record the owning toolkit so rehydration can re-bind
                         # same-named functions to the right toolkit (see
                         # Registry.rehydrate_function).
-                        if tool.name:
+                        if isinstance(tool.name, str) and tool.name:
                             func_dict["toolkit"] = tool.name
                         serialized_tools.append(func_dict)
                 elif callable(tool):
@@ -826,7 +834,7 @@ def from_dict(
     # --- Handle tools reconstruction ---
     if "tools" in config and config["tools"]:
         if registry:
-            config["tools"] = [registry.rehydrate_function(t) for t in config["tools"]]
+            config["tools"] = registry.rehydrate_functions(config["tools"])
         else:
             log_warning("No registry provided, tools will not be rehydrated.")
             del config["tools"]

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -552,7 +552,13 @@ def to_dict(team: "Team") -> Dict[str, Any]:
                     serialized_tools.append(tool.to_dict())
                 elif isinstance(tool, Toolkit):
                     for func in tool.functions.values():
-                        serialized_tools.append(func.to_dict())
+                        func_dict = func.to_dict()
+                        # Record the owning toolkit so rehydration can re-bind
+                        # same-named functions to the right toolkit (see
+                        # Registry.rehydrate_function).
+                        if tool.name:
+                            func_dict["toolkit"] = tool.name
+                        serialized_tools.append(func_dict)
                 elif callable(tool):
                     func = Function.from_callable(tool)
                     serialized_tools.append(func.to_dict())

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -192,6 +192,13 @@ class Function(BaseModel):
     # Set via the @approval decorator, not directly via @tool().
     approval_type: Optional[str] = None
 
+    # Name of the Toolkit this function was flattened from, if any. Set by
+    # Registry.rehydrate_function and read by the agent/team storage serializers
+    # so toolkit attribution survives load -> save round trips. Excluded from
+    # to_dict: it is persisted via the storage layer's "toolkit" key and never
+    # sent to models.
+    owning_toolkit: Optional[str] = None
+
     # Caching configuration
     cache_results: bool = False
     cache_dir: Optional[str] = None

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -298,7 +298,12 @@ class StudioTools(Toolkit):
                 if tool.name == name:
                     matches.append(tool)
                 elif name in tool.functions:
-                    function_matches.append(tool.functions[name])
+                    member = tool.functions[name]
+                    # Stamp the attribution so a component saved with this bare
+                    # Function keeps its "toolkit" key (see Registry.rehydrate_function).
+                    if isinstance(tool.name, str) and tool.name:
+                        member.owning_toolkit = tool.name
+                    function_matches.append(member)
             elif isinstance(tool, Function):
                 if tool.name == name:
                     matches.append(tool)

--- a/libs/agno/tests/unit/agent/test_agent_config.py
+++ b/libs/agno/tests/unit/agent/test_agent_config.py
@@ -218,6 +218,39 @@ class TestAgentToDict:
         assert config["user_id"] == "user-123"
         assert config["session_id"] == "session-456"
 
+    def test_to_dict_records_owning_toolkit(self):
+        """Functions flattened from a toolkit carry the toolkit's name so
+        rehydration can re-bind same-named functions to the right toolkit
+        (see Registry.rehydrate_function). Plain tools stay unqualified."""
+        from agno.models.openai import OpenAIChat
+        from agno.tools.toolkit import Toolkit
+
+        def read_file(path: str) -> str:
+            """Read a file."""
+            return path
+
+        def write_file(path: str, content: str) -> str:
+            """Write a file."""
+            return path
+
+        def plain_tool(x: int) -> int:
+            """A plain callable tool."""
+            return x
+
+        toolkit = Toolkit(name="agent_files", tools=[read_file, write_file])
+        agent = Agent(
+            id="toolkit-agent",
+            model=OpenAIChat(id="gpt-4o-mini"),
+            tools=[toolkit, plain_tool],
+        )
+
+        config = agent.to_dict()
+
+        tools_by_name = {t["name"]: t for t in config["tools"]}
+        assert tools_by_name["read_file"]["toolkit"] == "agent_files"
+        assert tools_by_name["write_file"]["toolkit"] == "agent_files"
+        assert "toolkit" not in tools_by_name["plain_tool"]
+
 
 # =============================================================================
 # from_dict() Tests

--- a/libs/agno/tests/unit/agent/test_agent_config.py
+++ b/libs/agno/tests/unit/agent/test_agent_config.py
@@ -251,6 +251,73 @@ class TestAgentToDict:
         assert tools_by_name["write_file"]["toolkit"] == "agent_files"
         assert "toolkit" not in tools_by_name["plain_tool"]
 
+    def test_to_dict_round_trip_preserves_toolkit(self):
+        """A rehydrated agent holds bare Functions, not Toolkits; their
+        owning_toolkit re-stamps the "toolkit" key so the attribution
+        survives load -> save (e.g. a Studio edit)."""
+        from agno.models.openai import OpenAIChat
+        from agno.registry import Registry
+        from agno.tools.toolkit import Toolkit
+
+        def read_file(path: str) -> str:
+            """Read a file."""
+            return path
+
+        toolkit = Toolkit(name="agent_files", tools=[read_file])
+        agent = Agent(
+            id="round-trip-agent",
+            model=OpenAIChat(id="gpt-4o-mini"),
+            tools=[toolkit],
+        )
+        registry = Registry(tools=[toolkit])
+
+        config = agent.to_dict()
+        assert config["tools"][0]["toolkit"] == "agent_files"
+
+        loaded = Agent.from_dict(config, registry=registry)
+        assert loaded.tools[0].entrypoint is read_file
+
+        config_resaved = loaded.to_dict()
+
+        tools_by_name = {t["name"]: t for t in config_resaved["tools"]}
+        assert tools_by_name["read_file"]["toolkit"] == "agent_files"
+
+    def test_to_dict_stamps_toolkit_per_get_functions(self):
+        """The stamping walk reads get_functions() -- what parse_tools
+        actually serializes -- so a toolkit subclass exposing a subset never
+        claims a name it hides."""
+        from agno.models.openai import OpenAIChat
+        from agno.tools.toolkit import Toolkit
+
+        def only_a(x: str) -> str:
+            """Tool a."""
+            return x
+
+        def _make_search(tag):
+            def search(q: str) -> str:
+                """Search."""
+                return f"{tag}:{q}"
+
+            return search
+
+        class GatedToolkit(Toolkit):
+            def get_functions(self):
+                return {name: f for name, f in self.functions.items() if name != "search"}
+
+        alpha = GatedToolkit(name="alpha", tools=[only_a, _make_search("alpha")])
+        beta = Toolkit(name="beta", tools=[_make_search("beta")])
+        agent = Agent(
+            id="gated-agent",
+            model=OpenAIChat(id="gpt-4o-mini"),
+            tools=[alpha, beta],
+        )
+
+        config = agent.to_dict()
+
+        tools_by_name = {t["name"]: t for t in config["tools"]}
+        assert tools_by_name["only_a"]["toolkit"] == "alpha"
+        assert tools_by_name["search"]["toolkit"] == "beta"
+
 
 # =============================================================================
 # from_dict() Tests
@@ -347,20 +414,23 @@ class TestAgentFromDict:
             assert agent.db == mock_db
 
     def test_from_dict_with_registry_tools(self):
-        """Test from_dict uses registry to rehydrate tools."""
-        config = {
-            "id": "tools-agent",
-            "tools": [{"name": "search", "description": "Search the web"}],
-        }
+        """from_dict rehydrates the whole tools list in ONE batch call, so a
+        component load shares a single lookup-rebuild budget."""
+        tool_dicts = [
+            {"name": "search", "description": "Search the web"},
+            {"name": "read_file", "description": "Read a file"},
+            {"name": "write_file", "description": "Write a file"},
+        ]
+        config = {"id": "tools-agent", "tools": list(tool_dicts)}
 
         mock_registry = MagicMock()
-        mock_tool = MagicMock()
-        mock_registry.rehydrate_function.return_value = mock_tool
+        mock_tools = [MagicMock(), MagicMock(), MagicMock()]
+        mock_registry.rehydrate_functions.return_value = mock_tools
 
         agent = Agent.from_dict(config, registry=mock_registry)
 
-        mock_registry.rehydrate_function.assert_called_once()
-        assert agent.tools == [mock_tool]
+        mock_registry.rehydrate_functions.assert_called_once_with(tool_dicts)
+        assert agent.tools == mock_tools
 
     def test_from_dict_without_registry_removes_tools(self):
         """Test from_dict removes tools when no registry is provided."""
@@ -616,12 +686,12 @@ class TestAgentLoad:
         mock_db.get_config.return_value = {"config": {"id": "registry-agent", "tools": [{"name": "search"}]}}
 
         mock_registry = MagicMock()
-        mock_registry.rehydrate_function.return_value = MagicMock()
+        mock_registry.rehydrate_functions.return_value = [MagicMock()]
 
         agent = Agent.load(id="registry-agent", db=mock_db, registry=mock_registry)
 
         assert agent is not None
-        mock_registry.rehydrate_function.assert_called()
+        mock_registry.rehydrate_functions.assert_called()
 
     def test_load_returns_none_when_not_found(self, mock_db):
         """Test load returns None when agent not found."""
@@ -763,7 +833,7 @@ class TestGetAgentById:
         mock_db.get_config.return_value = {"config": {"id": "registry-agent", "tools": [{"name": "calc"}]}}
 
         mock_registry = MagicMock()
-        mock_registry.rehydrate_function.return_value = MagicMock()
+        mock_registry.rehydrate_functions.return_value = [MagicMock()]
 
         agent = get_agent_by_id(db=mock_db, id="registry-agent", registry=mock_registry)
 
@@ -851,7 +921,7 @@ class TestGetAgents:
         mock_db.get_config.return_value = {"config": {"id": "tools-agent", "tools": [{"name": "search"}]}}
 
         mock_registry = MagicMock()
-        mock_registry.rehydrate_function.return_value = MagicMock()
+        mock_registry.rehydrate_functions.return_value = [MagicMock()]
 
         agents = get_agents(db=mock_db, registry=mock_registry)
 

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -113,6 +113,9 @@ def function_tool():
 def mock_toolkit():
     """Create a mock Toolkit with functions."""
     toolkit = MagicMock(spec=Toolkit)
+    # Toolkit.name is an instance attribute, so spec=Toolkit doesn't provide it
+    # (and the MagicMock constructor reserves the "name" kwarg).
+    toolkit.name = "mock_toolkit"
 
     func1 = MagicMock(spec=Function)
     func1.name = "toolkit_func_1"
@@ -313,6 +316,30 @@ class TestEntrypointLookup:
         # Should return the same cached object
         assert lookup1 is lookup2
 
+    def test_entrypoint_lookup_indexes_toolkit_qualified_keys(self):
+        """Toolkit functions are also indexed under '<toolkit>.<function>' so
+        serialized dicts carrying their owning toolkit's name can resolve to
+        the right toolkit when two toolkits share member names."""
+
+        def shared_read(path: str) -> str:
+            return f"shared:{path}"
+
+        def agent_read(path: str) -> str:
+            return f"agent:{path}"
+
+        shared = Toolkit(name="filesystem")
+        shared.functions["read_file"] = Function(name="read_file", entrypoint=shared_read)
+        agent_files = Toolkit(name="agent_files")
+        agent_files.functions["read_file"] = Function(name="read_file", entrypoint=agent_read)
+        reg = Registry(tools=[shared, agent_files])
+
+        lookup = reg._entrypoint_lookup
+
+        assert lookup["filesystem.read_file"].entrypoint is shared_read
+        assert lookup["agent_files.read_file"].entrypoint is agent_read
+        # The flat slot still exists (last registration wins) for legacy configs
+        assert lookup["read_file"].entrypoint is agent_read
+
 
 # =============================================================================
 # rehydrate_function() Tests
@@ -446,6 +473,93 @@ class TestRehydrateFunction:
 
         assert rehydrated.entrypoint is call_proxy
         assert rehydrated.skip_entrypoint_processing is True
+
+
+class TestToolkitQualifiedRehydration:
+    """Tests for toolkit-qualified entrypoint resolution.
+
+    A DB-persisted function dict carries no toolkit attribution beyond the
+    optional "toolkit" key, so when two registry toolkits share member names
+    the flat name lookup alone would silently bind the wrong toolkit's
+    entrypoint (e.g. two FileSystem toolkits both exposing read_file).
+    """
+
+    @staticmethod
+    def _shared_read(path: str) -> str:
+        return f"shared:{path}"
+
+    @staticmethod
+    def _agent_read(path: str) -> str:
+        return f"agent:{path}"
+
+    def _registry_with_shared_names(self):
+        shared = Toolkit(name="filesystem")
+        shared.functions["read_file"] = Function(name="read_file", entrypoint=self._shared_read)
+        agent_files = Toolkit(name="agent_files")
+        agent_files.functions["read_file"] = Function(name="read_file", entrypoint=self._agent_read)
+        return Registry(tools=[shared, agent_files]), shared, agent_files
+
+    def test_qualified_dict_binds_to_its_own_toolkit(self):
+        """A dict qualified with its toolkit's name binds to that toolkit's
+        entrypoint even when another toolkit's member shares the name."""
+        reg, shared, agent_files = self._registry_with_shared_names()
+
+        func_dict = agent_files.functions["read_file"].to_dict()
+        func_dict["toolkit"] = "agent_files"
+        rehydrated = reg.rehydrate_function(func_dict)
+        assert rehydrated.entrypoint is self._agent_read
+
+        # And the first toolkit's dict binds to the first toolkit -- even
+        # though the flat slot holds the last-registered entrypoint.
+        func_dict = shared.functions["read_file"].to_dict()
+        func_dict["toolkit"] = "filesystem"
+        rehydrated = reg.rehydrate_function(func_dict)
+        assert rehydrated.entrypoint is self._shared_read
+
+    def test_unqualified_dict_resolves_via_flat_name(self):
+        """A legacy dict without the "toolkit" key resolves via the flat name
+        exactly as before qualification existed (last registration wins)."""
+        reg, shared, _ = self._registry_with_shared_names()
+
+        func_dict = shared.functions["read_file"].to_dict()
+        assert "toolkit" not in func_dict
+
+        rehydrated = reg.rehydrate_function(func_dict)
+
+        assert rehydrated.entrypoint is self._agent_read
+
+    def test_qualified_dict_with_missing_toolkit_falls_back_to_flat(self):
+        """A dict whose toolkit has left the registry falls back to the flat
+        name so the function still gets an entrypoint."""
+        reg, _, agent_files = self._registry_with_shared_names()
+
+        func_dict = agent_files.functions["read_file"].to_dict()
+        func_dict["toolkit"] = "gone_files"
+
+        rehydrated = reg.rehydrate_function(func_dict)
+
+        assert rehydrated.entrypoint is self._agent_read
+
+    def test_qualified_lookup_rebuilds_stale_cache(self):
+        """A qualified miss rebuilds the cached lookup before falling back to
+        the flat name: the flat slot may hold a same-named function from a
+        different toolkit while the right toolkit (e.g. an MCP toolkit that
+        connects late) simply hasn't populated the cache yet."""
+        shared = Toolkit(name="filesystem")
+        shared.functions["read_file"] = Function(name="read_file", entrypoint=self._shared_read)
+        agent_files = Toolkit(name="agent_files")
+        reg = Registry(tools=[shared, agent_files])
+
+        # Prime the cache while agent_files is still "unconnected"
+        assert "agent_files.read_file" not in reg._entrypoint_lookup
+
+        agent_files.functions["read_file"] = Function(name="read_file", entrypoint=self._agent_read)
+        func_dict = agent_files.functions["read_file"].to_dict()
+        func_dict["toolkit"] = "agent_files"
+
+        rehydrated = reg.rehydrate_function(func_dict)
+
+        assert rehydrated.entrypoint is self._agent_read
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -129,6 +129,7 @@ def mock_toolkit():
         "toolkit_func_1": func1,
         "toolkit_func_2": func2,
     }
+    toolkit.get_functions.return_value = toolkit.functions
     return toolkit
 
 
@@ -317,9 +318,9 @@ class TestEntrypointLookup:
         assert lookup1 is lookup2
 
     def test_entrypoint_lookup_indexes_toolkit_qualified_keys(self):
-        """Toolkit functions are also indexed under '<toolkit>.<function>' so
-        serialized dicts carrying their owning toolkit's name can resolve to
-        the right toolkit when two toolkits share member names."""
+        """Toolkit functions are also indexed under a (toolkit, function) tuple
+        key so serialized dicts carrying their owning toolkit's name can resolve
+        to the right toolkit when two toolkits share member names."""
 
         def shared_read(path: str) -> str:
             return f"shared:{path}"
@@ -335,10 +336,32 @@ class TestEntrypointLookup:
 
         lookup = reg._entrypoint_lookup
 
-        assert lookup["filesystem.read_file"].entrypoint is shared_read
-        assert lookup["agent_files.read_file"].entrypoint is agent_read
+        assert lookup[("filesystem", "read_file")].entrypoint is shared_read
+        assert lookup[("agent_files", "read_file")].entrypoint is agent_read
         # The flat slot still exists (last registration wins) for legacy configs
         assert lookup["read_file"].entrypoint is agent_read
+
+    def test_qualified_keys_cannot_collide_with_dotted_function_names(self):
+        """Function names are not validated, so a name like "browser.navigate"
+        can reach the registry (e.g. verbatim from an MCP server). The tuple
+        qualified keys must not displace such a flat name, in either
+        declaration order."""
+
+        def dotted_ep(path: str) -> str:
+            return f"dotted:{path}"
+
+        def toolkit_ep(path: str) -> str:
+            return f"toolkit:{path}"
+
+        dotted = Function(name="browser.navigate", entrypoint=dotted_ep)
+        browser = Toolkit(name="browser")
+        browser.functions["navigate"] = Function(name="navigate", entrypoint=toolkit_ep)
+
+        for tools in ([dotted, browser], [browser, dotted]):
+            reg = Registry(tools=tools)
+            rehydrated = reg.rehydrate_function({"name": "browser.navigate", "parameters": {}})
+            assert rehydrated.entrypoint is dotted_ep
+            assert reg._entrypoint_lookup[("browser", "navigate")].entrypoint is toolkit_ep
 
 
 # =============================================================================
@@ -528,9 +551,15 @@ class TestToolkitQualifiedRehydration:
 
         assert rehydrated.entrypoint is self._agent_read
 
-    def test_qualified_dict_with_missing_toolkit_falls_back_to_flat(self):
+    def test_qualified_dict_with_missing_toolkit_falls_back_to_flat(self, monkeypatch):
         """A dict whose toolkit has left the registry falls back to the flat
-        name so the function still gets an entrypoint."""
+        name so the function still gets an entrypoint, and warns that the
+        recorded attribution could not be honored."""
+        import agno.registry.registry as registry_module
+
+        warnings = []
+        monkeypatch.setattr(registry_module, "log_warning", lambda msg, *a, **k: warnings.append(msg))
+
         reg, _, agent_files = self._registry_with_shared_names()
 
         func_dict = agent_files.functions["read_file"].to_dict()
@@ -539,6 +568,7 @@ class TestToolkitQualifiedRehydration:
         rehydrated = reg.rehydrate_function(func_dict)
 
         assert rehydrated.entrypoint is self._agent_read
+        assert any("gone_files" in w for w in warnings)
 
     def test_qualified_lookup_rebuilds_stale_cache(self):
         """A qualified miss rebuilds the cached lookup before falling back to
@@ -551,7 +581,7 @@ class TestToolkitQualifiedRehydration:
         reg = Registry(tools=[shared, agent_files])
 
         # Prime the cache while agent_files is still "unconnected"
-        assert "agent_files.read_file" not in reg._entrypoint_lookup
+        assert ("agent_files", "read_file") not in reg._entrypoint_lookup
 
         agent_files.functions["read_file"] = Function(name="read_file", entrypoint=self._agent_read)
         func_dict = agent_files.functions["read_file"].to_dict()
@@ -560,6 +590,133 @@ class TestToolkitQualifiedRehydration:
         rehydrated = reg.rehydrate_function(func_dict)
 
         assert rehydrated.entrypoint is self._agent_read
+
+    def test_rehydrated_function_carries_owning_toolkit(self):
+        """The dict's toolkit attribution lands on the Function object so a
+        load -> save round trip can re-stamp the "toolkit" key."""
+        reg, _, agent_files = self._registry_with_shared_names()
+
+        func_dict = agent_files.functions["read_file"].to_dict()
+        func_dict["toolkit"] = "agent_files"
+        rehydrated = reg.rehydrate_function(func_dict)
+        assert rehydrated.owning_toolkit == "agent_files"
+
+        unqualified = reg.rehydrate_function({"name": "read_file", "parameters": {}})
+        assert unqualified.owning_toolkit is None
+        # owning_toolkit never leaks into the model-facing schema
+        assert "owning_toolkit" not in rehydrated.to_dict()
+
+    def test_same_named_toolkits_warn_once_per_collision(self, monkeypatch):
+        """Two same-named toolkits sharing a member name collide on both the
+        flat and the qualified slot, but only the flat registration warns --
+        the same single warning main emitted before qualified keys existed."""
+        import agno.registry.registry as registry_module
+
+        warnings = []
+        monkeypatch.setattr(registry_module, "log_warning", lambda msg, *a, **k: warnings.append(msg))
+
+        kit_a = Toolkit(name="filesystem")
+        kit_a.functions["read_file"] = Function(name="read_file", entrypoint=self._shared_read)
+        kit_b = Toolkit(name="filesystem")
+        kit_b.functions["read_file"] = Function(name="read_file", entrypoint=self._agent_read)
+
+        _ = Registry(tools=[kit_a, kit_b])._entrypoint_lookup
+
+        assert len(warnings) == 1
+        assert "read_file" in warnings[0]
+
+
+class TestRehydrateFunctionsBatch:
+    """rehydrate_functions shares one cache-rebuild budget across a load."""
+
+    @staticmethod
+    def _read(path: str) -> str:
+        return f"read:{path}"
+
+    def _counting_registry(self):
+        """Registry whose lookup builds are observable via tools iterations."""
+        builds = []
+
+        class CountingList(list):
+            def __iter__(self):
+                builds.append(1)
+                return super().__iter__()
+
+        kit = Toolkit(name="agent_files")
+        kit.functions["read_file"] = Function(name="read_file", entrypoint=self._read)
+        reg = Registry()
+        reg.tools = CountingList([kit])
+        return reg, builds
+
+    def test_batch_shares_single_rebuild(self):
+        """N dicts whose toolkit is missing from the registry trigger at most
+        one lookup rebuild for the whole batch, not one per dict."""
+        reg, builds = self._counting_registry()
+        _ = reg._entrypoint_lookup  # prime the cache
+
+        dicts = [{"name": "read_file", "parameters": {}, "toolkit": "renamed_kit"} for _ in range(5)]
+        rehydrated = reg.rehydrate_functions(dicts)
+
+        assert all(f.entrypoint is self._read for f in rehydrated)
+        assert sum(builds) == 2  # the priming build plus one shared rebuild
+
+    def test_batch_resolves_mixed_dicts(self):
+        """Qualified, legacy-unqualified, and unknown dicts resolve in one batch."""
+        reg, _ = self._counting_registry()
+
+        rehydrated = reg.rehydrate_functions(
+            [
+                {"name": "read_file", "parameters": {}, "toolkit": "agent_files"},
+                {"name": "read_file", "parameters": {}},
+                {"name": "missing_tool", "parameters": {}},
+            ]
+        )
+
+        assert rehydrated[0].entrypoint is self._read
+        assert rehydrated[1].entrypoint is self._read
+        assert rehydrated[2].entrypoint is None
+
+    def test_batch_rebuild_still_finds_late_functions(self):
+        """The shared budget still covers the late-connecting toolkit case:
+        a function registered after the cache was primed is found via the
+        batch's one rebuild."""
+        reg, _ = self._counting_registry()
+        kit = reg.tools[0]
+        _ = reg._entrypoint_lookup  # prime while write_file is unregistered
+
+        def _write(path: str) -> str:
+            return f"write:{path}"
+
+        kit.functions["write_file"] = Function(name="write_file", entrypoint=_write)
+        rehydrated = reg.rehydrate_functions(
+            [
+                {"name": "write_file", "parameters": {}, "toolkit": "agent_files"},
+                {"name": "read_file", "parameters": {}, "toolkit": "agent_files"},
+            ]
+        )
+
+        assert rehydrated[0].entrypoint is _write
+        assert rehydrated[1].entrypoint is self._read
+
+    def test_rebuild_budget_resets_per_batch(self):
+        """Each rehydrate_functions call gets a fresh rebuild budget: a batch
+        that spent its rebuild must not starve the next batch's ability to
+        pick up functions registered in between (e.g. successive component
+        loads while an MCP toolkit connects)."""
+        reg, _ = self._counting_registry()
+        kit = reg.tools[0]
+        _ = reg._entrypoint_lookup  # prime the cache
+
+        first = reg.rehydrate_functions([{"name": "read_file", "parameters": {}, "toolkit": "renamed_kit"}])
+        assert first[0].entrypoint is self._read  # spent this batch's rebuild
+
+        def _write(path: str) -> str:
+            return f"write:{path}"
+
+        kit.functions["write_file"] = Function(name="write_file", entrypoint=_write)
+        second = reg.rehydrate_functions([{"name": "write_file", "parameters": {}, "toolkit": "agent_files"}])
+
+        assert second[0].entrypoint is _write
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -291,6 +291,33 @@ class TestTeamToDict:
         assert config["mode"] == "coordinate"
         assert "max_iterations" not in config  # default=10 should not be serialized
 
+    def test_to_dict_records_owning_toolkit(self):
+        """Functions flattened from a toolkit carry the toolkit's name so
+        rehydration can re-bind same-named functions to the right toolkit
+        (see Registry.rehydrate_function). Plain tools stay unqualified."""
+        from agno.tools.toolkit import Toolkit
+
+        def read_file(path: str) -> str:
+            """Read a file."""
+            return path
+
+        def plain_tool(x: int) -> int:
+            """A plain callable tool."""
+            return x
+
+        toolkit = Toolkit(name="agent_files", tools=[read_file])
+        team = Team(
+            id="toolkit-team",
+            members=[],
+            tools=[toolkit, plain_tool],
+        )
+
+        config = team.to_dict()
+
+        tools_by_name = {t["name"]: t for t in config["tools"]}
+        assert tools_by_name["read_file"]["toolkit"] == "agent_files"
+        assert "toolkit" not in tools_by_name["plain_tool"]
+
 
 # =============================================================================
 # from_dict() Tests

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -318,6 +318,61 @@ class TestTeamToDict:
         assert tools_by_name["read_file"]["toolkit"] == "agent_files"
         assert "toolkit" not in tools_by_name["plain_tool"]
 
+    def test_to_dict_round_trip_preserves_toolkit(self):
+        """A rehydrated team holds bare Functions, not Toolkits; their
+        owning_toolkit re-stamps the "toolkit" key so the attribution
+        survives load -> save (e.g. a Studio edit)."""
+        from agno.registry import Registry
+        from agno.tools.toolkit import Toolkit
+
+        def read_file(path: str) -> str:
+            """Read a file."""
+            return path
+
+        toolkit = Toolkit(name="agent_files", tools=[read_file])
+        team = Team(id="round-trip-team", members=[], tools=[toolkit])
+        registry = Registry(tools=[toolkit])
+
+        config = team.to_dict()
+        assert config["tools"][0]["toolkit"] == "agent_files"
+
+        loaded = Team.from_dict(config, registry=registry)
+        assert loaded.tools[0].entrypoint is read_file
+
+        config_resaved = loaded.to_dict()
+
+        tools_by_name = {t["name"]: t for t in config_resaved["tools"]}
+        assert tools_by_name["read_file"]["toolkit"] == "agent_files"
+
+    def test_to_dict_serializes_per_get_functions(self):
+        """The team serializer reads get_functions() -- what the team runtime
+        exposes -- so a toolkit subclass hiding a member never persists it."""
+        from agno.tools.toolkit import Toolkit
+
+        def only_a(x: str) -> str:
+            """Tool a."""
+            return x
+
+        def _make_search(tag):
+            def search(q: str) -> str:
+                """Search."""
+                return f"{tag}:{q}"
+
+            return search
+
+        class GatedToolkit(Toolkit):
+            def get_functions(self):
+                return {name: f for name, f in self.functions.items() if name != "search"}
+
+        alpha = GatedToolkit(name="alpha", tools=[only_a, _make_search("alpha")])
+        beta = Toolkit(name="beta", tools=[_make_search("beta")])
+        team = Team(id="gated-team", members=[], tools=[alpha, beta])
+
+        config = team.to_dict()
+
+        serialized = {(t["name"], t.get("toolkit")) for t in config["tools"]}
+        assert serialized == {("only_a", "alpha"), ("search", "beta")}
+
 
 # =============================================================================
 # from_dict() Tests
@@ -406,20 +461,23 @@ class TestTeamFromDict:
             assert team.db == mock_db
 
     def test_from_dict_with_registry_tools(self):
-        """Test from_dict uses registry to rehydrate tools."""
-        config = {
-            "id": "tools-team",
-            "tools": [{"name": "search", "description": "Search the web"}],
-        }
+        """from_dict rehydrates the whole tools list in ONE batch call, so a
+        component load shares a single lookup-rebuild budget."""
+        tool_dicts = [
+            {"name": "search", "description": "Search the web"},
+            {"name": "read_file", "description": "Read a file"},
+            {"name": "write_file", "description": "Write a file"},
+        ]
+        config = {"id": "tools-team", "tools": list(tool_dicts)}
 
         mock_registry = MagicMock()
-        mock_tool = MagicMock()
-        mock_registry.rehydrate_function.return_value = mock_tool
+        mock_tools = [MagicMock(), MagicMock(), MagicMock()]
+        mock_registry.rehydrate_functions.return_value = mock_tools
 
         team = Team.from_dict(config, registry=mock_registry)
 
-        mock_registry.rehydrate_function.assert_called_once()
-        assert team.tools == [mock_tool]
+        mock_registry.rehydrate_functions.assert_called_once_with(tool_dicts)
+        assert team.tools == mock_tools
 
     def test_from_dict_without_registry_removes_tools(self):
         """Test from_dict removes tools when no registry is provided."""
@@ -967,7 +1025,7 @@ class TestGetTeamById:
         mock_db.get_config.return_value = {"config": {"id": "registry-team", "tools": [{"name": "calc"}]}}
 
         mock_registry = MagicMock()
-        mock_registry.rehydrate_function.return_value = MagicMock()
+        mock_registry.rehydrate_functions.return_value = [MagicMock()]
 
         team = get_team_by_id(db=mock_db, id="registry-team", registry=mock_registry)
 
@@ -1055,7 +1113,7 @@ class TestGetTeams:
         mock_db.get_config.return_value = {"config": {"id": "tools-team", "tools": [{"name": "search"}]}}
 
         mock_registry = MagicMock()
-        mock_registry.rehydrate_function.return_value = MagicMock()
+        mock_registry.rehydrate_functions.return_value = [MagicMock()]
 
         teams = get_teams(db=mock_db, registry=mock_registry)
 

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -403,6 +403,28 @@ class TestToolNameResolution:
         assert "error" in out
         assert "ambiguous" in out["error"]
 
+    def test_find_tool_by_function_name_stamps_owning_toolkit(self, db):
+        """Selecting a toolkit member by its function name hands back a bare
+        Function; it must carry its toolkit attribution so a component saved
+        with it keeps the "toolkit" key (see Registry.rehydrate_function)."""
+
+        def read_file(path: str) -> str:
+            """Read a file."""
+            return path
+
+        registry = Registry(
+            name="Stamp Registry",
+            tools=[Toolkit(name="agent_files", tools=[read_file])],
+            models=[OpenAIResponses(id="gpt-5.5")],
+            dbs=[db],
+        )
+        studio = StudioTool(registry=registry, db=db)
+
+        member = studio._find_tool("read_file")
+
+        assert isinstance(member, Function)
+        assert member.owning_toolkit == "agent_files"
+
 
 class TestMCPToolkitPersistence:
     """Registry MCP toolkits must persist their functions and survive rehydration.


### PR DESCRIPTION
## Summary

**The bug (live-reproduced):** a DB-persisted component stores its tools as flat function dicts (name/parameters/description) with no toolkit attribution, and `Registry.rehydrate_function` resolves entrypoints via a lookup keyed by function name alone. When two registry toolkits share member names, rehydration silently binds the wrong one. Repro: a registry holding two FileSystem toolkits — a shared-notes one named `filesystem` and a per-agent one named `agent_files`, both exposing `read_file`/`write_file`/... An agent created via Studio with `tool_names=["agent_files"]` persisted correctly, but every run rehydrated its `read_file`/`write_file` to the `filesystem` toolkit's entrypoints and wrote to the wrong store. Code-defined components are unaffected (entrypoints bound directly); only DB-rehydrated ones hit this.

**The fix** threads toolkit attribution through the round trip:

- **Serialization** (`agent/_storage.py`, `team/_storage.py`): each function dict flattened from a `Toolkit` now records its owner as `"toolkit": "<toolkit name>"`. Plain `Function`/callable tools stay unqualified unless they carry attribution themselves (see durability below). The agent path mirrors `parse_tools`' declaration-order, first-claim-wins walk, so the recorded owner is the toolkit whose function was actually serialized. Both serializers and the registry index read `Toolkit.get_functions()` — the same view `parse_tools` and the runtimes use — so subclasses that hide members can't have them claimed, persisted, or rehydrated back to life.
- **Registry** (`registry/registry.py`): `_entrypoint_lookup` additionally indexes toolkit functions under a `(toolkit name, function name)` tuple key. A tuple can never equal a string, so qualified keys are structurally collision-free against flat names — including function names that contain dots (reachable via `@tool(name=...)` or verbatim MCP server tool names, which no validator rejects). `rehydrate_function` tries the qualified key first when the dict carries `"toolkit"`, then falls back to the flat name, warning when the recorded toolkit can't be honored. The stale-cache rebuild-and-retry is preserved on both paths; a qualified miss rebuilds *before* falling back, since the flat slot may hold a same-named function from a different toolkit while the right one (e.g. an MCP toolkit that connects late) hasn't populated the cache yet.
- **Round-trip durability**: rehydrated `Function`s carry their attribution in a new `owning_toolkit` field (excluded from `to_dict`, never sent to models). The agent/team serializers re-stamp it, and Studio's `_find_tool` sets it when selecting a toolkit member by function name — so the `"toolkit"` key survives load → save cycles (e.g. Studio edits) instead of silently reverting the config to ambiguous flat-name resolution.
- **Batched rehydration**: new `Registry.rehydrate_functions` shares one cache-rebuild budget per component load (fresh per batch); agent/team `from_dict` use it, so a config whose toolkit is missing or renamed costs one lookup rebuild per load instead of one per tool.

**Backward compatibility:** dicts without the key resolve through the flat path exactly as today; a qualified dict whose toolkit left the registry falls back to the flat name (now with a warning); `Function.from_dict` ignores unknown keys, so old and new configs round-trip without schema or validation changes. Same-named-toolkit collisions emit the same single warning as before (qualified tuple writes are silent, since any qualified collision already warned on the flat slot).

## Changes

- `libs/agno/agno/registry/registry.py` — `(toolkit, function)` tuple index in `_entrypoint_lookup` built from `get_functions()`; qualified-first resolution with warned flat fallback; `rehydrate_functions` batch API with per-batch rebuild budget.
- `libs/agno/agno/agent/_storage.py` — `to_dict` records the owning toolkit on each flattened function dict via a `get_functions()`-based, first-claim-wins walk keyed by `Function.name`; bare `Function` tools re-stamp their `owning_toolkit`; `from_dict` uses the batch API.
- `libs/agno/agno/team/_storage.py` — same for the team flatten and load.
- `libs/agno/agno/tools/function.py` — `owning_toolkit` field (excluded from `to_dict`).
- `libs/agno/agno/tools/studio.py` — `_find_tool` stamps `owning_toolkit` when resolving a toolkit member by function name.
- Tests: tuple-key indexing; dotted-name non-collision in both declaration orders; qualified dict binds to its own toolkit under name collision; legacy unqualified dict unchanged; missing-toolkit fallback warns; stale-cache rebuild on the qualified path; batch shares one rebuild with a per-batch budget reset; `from_dict` wiring pinned to the batch call; agent/team `to_dict` record the `toolkit` key per `get_functions()`; round trips preserve attribution and entrypoint binding; same-named toolkits warn once; Studio `_find_tool` stamping.

## Testing

- `tests/unit/agent` + `tests/unit/team` + `tests/unit/registry` + `tests/unit/os` (minus the telegram files, which fail collection on clean `main` for a missing optional dep) + `tests/unit/tools/test_studio.py`: **2851 passed, 2 skipped**
- `ruff check` + `ruff format --check` clean on all touched files; `mypy` (repo config) clean on the five touched source modules.
- Both commits were adversarially reviewed by multi-agent workflows (find → refute with live reproductions against this branch and `main`); all confirmed findings are folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)