### PR TITLE
[fix] Allow combining Gemini built-in tools with custom functions

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -404,14 +404,15 @@ class Gemini(Model):
                 parallel_tool_config["custom_configs"] = self.parallel_config
             builtin_tools.append(Tool(parallel_ai_search=ToolParallelAiSearch(**parallel_tool_config)))
 
-        # Set tools in config
-        if builtin_tools:
-            if tools:
-                log_info("Built-in tools enabled. External tools will be disabled.")
-            config["tools"] = builtin_tools
-        elif tools:
-            config["tools"] = [format_function_definitions(tools)]
+        # Combine built-in tools and custom tools
+        all_tools = list(builtin_tools) if builtin_tools else []
+        if tools:
+            formatted_user_tools = format_function_definitions(tools)
+            if formatted_user_tools:
+                all_tools.append(formatted_user_tools)
 
+        if all_tools:
+            config["tools"] = all_tools
         if tool_choice is not None:
             if isinstance(tool_choice, str) and tool_choice.lower() == "auto":
                 config["tool_config"] = {"function_calling_config": {"mode": FunctionCallingConfigMode.AUTO}}
@@ -425,6 +426,14 @@ class Gemini(Model):
                 config["tool_config"] = {"function_calling_config": {"mode": tool_choice}}
 
         config = {k: v for k, v in config.items() if v is not None}
+        # Enable server-side tool invocations flag if mixing built-in tools and custom functions
+        if builtin_tools and tools:
+            tool_config = config.get("tool_config", {})
+            if isinstance(tool_config, dict):
+                tool_config["include_server_side_tool_invocations"] = True
+            else:
+                tool_config = {"include_server_side_tool_invocations": True}
+            config["tool_config"] = tool_config
 
         if config:
             request_params["config"] = GenerateContentConfig(**config)

--- a/libs/agno/tests/unit/models/google/test_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_gemini.py
@@ -634,20 +634,24 @@ def test_parallel_search_with_other_builtin_tools():
     assert "parallel_ai_search" in tool_types
 
 
-def test_parallel_search_with_external_tools_logs_warning():
-    """Test that parallel_search with external tools logs the builtin tools info."""
+def test_builtin_tools_combined_with_external_tools():
+    """Test that built-in tools and custom functions are combined successfully."""
     model = Gemini(
-        vertexai=True,
-        project_id="test-project",
-        location="test-location",
-        parallel_search=True,
-        parallel_api_key="test-key",
+        api_key="test-key",
+        search=True,
     )
 
+    custom_tools = [{"type": "function", "function": {"name": "test_custom_fn"}}]
+
     with patch("agno.models.google.gemini.genai.Client"):
-        with patch("agno.models.google.gemini.log_info") as mock_info:
-            model.get_request_params(tools=[{"type": "function", "function": {"name": "test_fn"}}])
-            mock_info.assert_called_once_with("Built-in tools enabled. External tools will be disabled.")
+        request_params = model.get_request_params(tools=custom_tools)
+
+    config = request_params["config"]
+
+    assert config.tools is not None
+    assert len(config.tools) == 2
+    assert config.tool_config is not None
+    assert getattr(config.tool_config, "include_server_side_tool_invocations", False) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR updates the Google Gemini model configuration to allow the simultaneous use of built-in tools (like Google Search) and user-provided custom function declarations. 

Previously in `agno\models\google\gemini`, enabling built-in tools would completely disable any external tools provided by the user. To fix this, `get_request_params` has been updated to:
1. Combine both `builtin_tools` and formatted custom `tools` into a single `all_tools` list.
2. Automatically set `tool_config["include_server_side_tool_invocations"] = True` in the `GenerateContentConfig` when mixing both, as required by the official Gemini API documentation.

(If applicable, issue number: #9329 )

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Tested successfully with `google-genai 2.16.0` and Gemini 3.5 / Gemma 4 models.
- Updated `test_gemini.py` to ensure `config.tools` correctly combines both sources and that the `include_server_side_tool_invocations` flag is properly injected into the request parameters.