### PR TITLE
fix: honor label in load_component_graph on SQLite and Postgres

### DIFF
--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -941,7 +941,7 @@ class BaseDb(ABC):
         Args:
             component_id: The component ID.
             version: Specific version or None for current.
-            label: Optional label of the component.
+            label: Config label to resolve. Ignored if version is provided.
 
         Returns:
             Dictionary with component, config, children, and resolved_versions.

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -4589,7 +4589,7 @@ class PostgresDb(BaseDb):
         Args:
             component_id: The component ID.
             version: Specific version or None for current.
-            label: Optional label of the component.
+            label: Config label to resolve. Ignored if version is provided.
             _visited: Internal cycle tracking (do not pass).
             _max_depth: Internal depth limit (do not pass).
 
@@ -4605,7 +4605,14 @@ class PostgresDb(BaseDb):
             if component is None:
                 return None
 
-            resolved_version = self._resolve_version(component_id, version)
+            # Resolve version (a label resolves through its config row; version wins over label)
+            if version is None and label is not None:
+                labeled_config = self.get_config(component_id, label=label)
+                if labeled_config is None:
+                    return None
+                resolved_version = labeled_config["version"]
+            else:
+                resolved_version = self._resolve_version(component_id, version)
             if resolved_version is None:
                 return None
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -4460,7 +4460,7 @@ class SqliteDb(BaseDb):
         Args:
             component_id: The component ID.
             version: Specific version or None for current.
-            label: Optional label of the component.
+            label: Config label to resolve. Ignored if version is provided.
 
         Returns:
             Dictionary with component, config, links, and resolved children.
@@ -4471,8 +4471,14 @@ class SqliteDb(BaseDb):
             if component is None:
                 return None
 
-            # Resolve version
-            resolved_version = self.resolve_version(component_id, version)
+            # Resolve version (a label resolves through its config row; version wins over label)
+            if version is None and label is not None:
+                labeled_config = self.get_config(component_id, label=label)
+                if labeled_config is None:
+                    return None
+                resolved_version = labeled_config["version"]
+            else:
+                resolved_version = self.resolve_version(component_id, version)
             if resolved_version is None:
                 return None
 

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -1188,7 +1188,7 @@ def load(
     Args:
         id: The id of the team to load.
         db: The database to load the team from.
-        label: The label of the team to load.
+        label: The label of the team version to load. Ignored if version is provided.
 
     Returns:
         The team loaded from the database with hydrated members, or None if not found.

--- a/libs/agno/tests/integration/db/postgres/test_db.py
+++ b/libs/agno/tests/integration/db/postgres/test_db.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from sqlalchemy import text
 
+from agno.db.base import ComponentType
 from agno.db.postgres.postgres import PostgresDb
 
 
@@ -151,3 +152,22 @@ def test_full_workflow(postgres_db_real):
 
         assert result is not None
         assert result.session_type == "agent"
+
+
+def test_load_component_graph_honors_label(postgres_db_real):
+    """load_component_graph(label=...) resolves the labeled version, not current."""
+    postgres_db_real.upsert_component("lbl-comp", component_type=ComponentType.TEAM, name="Labeled")
+    postgres_db_real.upsert_config("lbl-comp", config={"name": "Version One"}, label="stable", stage="published")
+    postgres_db_real.upsert_config("lbl-comp", config={"name": "Version Two"}, stage="published")
+
+    labeled = postgres_db_real.load_component_graph("lbl-comp", label="stable")
+    assert labeled is not None
+    assert labeled["config"]["version"] == 1
+    assert labeled["config"]["config"]["name"] == "Version One"
+
+    missing = postgres_db_real.load_component_graph("lbl-comp", label="no-such-label")
+    assert missing is None
+
+    version_wins = postgres_db_real.load_component_graph("lbl-comp", version=2, label="stable")
+    assert version_wins is not None
+    assert version_wins["config"]["version"] == 2

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -834,6 +834,45 @@ class TestTeamLoad:
         assert len(loaded.members) == 1
         assert loaded.members[0].id == "rt-agent"
 
+    def test_load_with_label_returns_labeled_version_on_real_sqlite_db(self, tmp_path):
+        """Test load(label=...) returns the labeled version, with members pinned to it."""
+        db = SqliteDb(db_file=str(tmp_path / "team_label.db"))
+        member = Agent(id="lbl-agent", name="Member One")
+        team = Team(id="lbl-team", name="Version One", members=[member])
+        team.save(db=db, label="stable")
+        team.name = "Version Two"
+        member.name = "Member Two"
+        team.save(db=db)
+
+        loaded = Team.load(id="lbl-team", db=db, label="stable")
+
+        assert loaded is not None
+        assert loaded.name == "Version One"
+        assert loaded.members[0].name == "Member One"
+
+    def test_load_with_unknown_label_returns_none_on_real_sqlite_db(self, tmp_path):
+        """Test load(label=...) returns None when no version carries the label."""
+        db = SqliteDb(db_file=str(tmp_path / "team_label_miss.db"))
+        team = Team(id="miss-team", name="Current", members=[Agent(id="miss-agent", name="Member")])
+        team.save(db=db, label="stable")
+
+        loaded = Team.load(id="miss-team", db=db, label="no-such-label")
+
+        assert loaded is None
+
+    def test_load_with_version_and_label_prefers_version_on_real_sqlite_db(self, tmp_path):
+        """Test load(version=..., label=...) resolves by version, matching get_config precedence."""
+        db = SqliteDb(db_file=str(tmp_path / "team_label_prec.db"))
+        team = Team(id="prec-team", name="Version One", members=[Agent(id="prec-agent", name="Member")])
+        team.save(db=db, label="stable")
+        team.name = "Version Two"
+        team.save(db=db)
+
+        loaded = Team.load(id="prec-team", db=db, version=2, label="stable")
+
+        assert loaded is not None
+        assert loaded.name == "Version Two"
+
 
 # =============================================================================
 # delete() Tests


### PR DESCRIPTION
## Summary

Follow-up to #9337, which fixed the `Team.load()` crash on SQLite and flagged this: `load_component_graph` **accepted `label` and ignored it** on both backends, so `Team.load(label="production")` silently loaded the **current** version.

```
before                                            after
──────                                            ─────
Team.load(id, db=db, label="stable")              Team.load(id, db=db, label="stable")
  └─ load_component_graph(id, label="stable")       └─ load_component_graph(id, label="stable")
       ├─ resolve_version(id, None)                      ├─ get_config(id, label="stable")
       │    └─ components.current_version  ← label       │    └─ the labeled config row  ← label
       │       dies here                                 │       resolves the root version
       └─ get_config(id, version=current)                └─ get_config(id, version=resolved)
```

`get_config` on both backends already supports label lookup (`version > label > current > latest`); the graph loader just never passed it through. The fix is one branch per backend: when `version is None and label is not None`, fetch the root config by label and derive the resolved version from the returned row. Everything downstream (`get_links`, `resolved_versions`, child recursion) already keys off the resolved version and is untouched.

| File | Change |
|---|---|
| `db/sqlite/sqlite.py` | label branch in `load_component_graph` |
| `db/postgres/postgres.py` | same branch, placed **before** the cycle-detection key so `_visited` keys on the label-resolved version |
| `db/base.py`, `team/_storage.py` | docstrings aligned with the real contract ("Ignored if version is provided") |
| `tests/unit/team/test_team_config.py` | 3 real-`SqliteDb` effect tests in `TestTeamLoad` |
| `tests/integration/db/postgres/test_db.py` | direct `load_component_graph` label test |

### Behavior changes (intentional)

- `Team.load(label="stable")` now returns the **labeled** version (was: current version, silently).
- `Team.load(label="no-such-label")` now returns **`None`** (was: current version, silently). This matches `get_config`'s contract and the resolution order `get_team_by_id` already documents — `Team.load` now behaves like its documented sibling.
- Precedence is unchanged from `get_config`: if `version` is passed, `label` is ignored.

### What label does NOT do (by design)

`label` selects the **root** version only. Children are pinned numerically by `component_links.child_version` (links have no label column, and the write path requires a numeric `child_version`), so the labeled root loads exactly the member versions it was saved with. Verified through a 2-level nested-team graph and through Postgres's cycle-detection path.

### Why no test caught this before

Every existing label test asserts the kwarg was *forwarded* to a `MagicMock` — none asserts label had an *effect*. The new tests save two versions (one labeled) against real backends and assert the labeled one comes back, with a member rename proving child pinning survives label resolution.

Note for reviewers: the Postgres integration test needs the live test database (`localhost:5532`, same as the rest of `tests/integration/db/postgres/`). A default unit-only CI run exercises the SQLite branch; the Postgres test was run locally against a live server, along with the full sqlite+postgres integration suites (235 passed).

Related, not touched here: `Workflow.load` has a `TODO` (workflow.py) to switch from `get_config` to `load_component_graph` — before this fix, executing that TODO would have silently broken `Workflow.load(label=...)`; after it, the switch is safe label-wise.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: (not applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Async backends need no change: their component methods are `NotImplementedError` stubs that already declare `label`. No other backend implements the component surface.
- `validate.sh` mypy baseline on `main` is 26 pre-existing errors; the error set is byte-identical before and after this change. Full unit tree: 8938 passed; the 48 failures are pre-existing optional-dependency issues, verified identical at `main`'s tip.
