### PR TITLE
feat: allow overriding the FileSystemTools toolkit name

### DIFF
--- a/libs/agno/agno/fs/toolkit.py
+++ b/libs/agno/agno/fs/toolkit.py
@@ -191,7 +191,9 @@ class FileSystemTools(Toolkit):
         async_tools = [(getattr(self, "a" + name), name) for name in registered]
 
         super().__init__(
-            name="filesystem",
+            # Overridable so multiple file toolkits (a shared store and a
+            # per-agent one, say) can coexist in a registry without colliding.
+            name=kwargs.pop("name", "filesystem"),
             tools=sync_tools,
             async_tools=async_tools,
             instructions=instructions,

--- a/libs/agno/tests/unit/fs/test_toolkit.py
+++ b/libs/agno/tests/unit/fs/test_toolkit.py
@@ -771,3 +771,14 @@ class TestConcurrentEditsInOneTurn:
 
         content = fs.read("notes/log.md")
         assert "REPLACED" in content and "appended" in content
+
+
+class TestToolkitName:
+    def test_default_name_is_filesystem(self, fs):
+        assert fs.tools().name == "filesystem"
+
+    def test_name_override(self, fs):
+        toolkit = fs.tools(name="agent_files")
+        assert toolkit.name == "agent_files"
+        # The override changes identity only; the tool surface is untouched.
+        assert "read_file" in toolkit.functions


### PR DESCRIPTION
## Summary

One line: `FileSystemTools` passes a hardcoded `name="filesystem"` to `Toolkit.__init__`, so two file toolkits cannot coexist in one registry — lookups collide on the toolkit name. Now overridable via the standard `name=` kwarg (`fs.tools(name="agent_files")`), default unchanged.

Concrete consumer: the AgentOS template registry ships a shared team-notes toolkit alongside a per-agent one built over a templated namespace (`{agent_id}`); they need distinct names.

Split out of #9353 so it can ship independently — the mounts work there is not needed by any current consumer and can be reviewed without release pressure.

## Changes
- `libs/agno/agno/fs/toolkit.py` — `name=kwargs.pop("name", "filesystem")` (+comment)
- `libs/agno/tests/unit/fs/test_toolkit.py` — default-name and override tests

## Testing
`tests/unit/fs/test_toolkit.py`: 133 passed (131 baseline + 2 new); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
