### PR TITLE
fix: propagate top-level user_input/user_feedback resolutions to tool_execution

### DIFF
--- a/libs/agno/agno/run/requirement.py
+++ b/libs/agno/agno/run/requirement.py
@@ -307,4 +307,56 @@ class RunRequirement:
                     rebuilt_feedback.append(UserFeedbackQuestion.from_dict(item))
             requirement.user_feedback_schema = rebuilt_feedback if rebuilt_feedback else None
 
+        # The same rule applies to the schema lanes: to_dict ships each schema
+        # both at the requirement level and inside tool_execution, but dispatch
+        # reads only tool_execution's copy - values filled on the requirement-level
+        # copy must reach it. Merging mirrors provide_user_input and
+        # provide_user_feedback; a value already set on the nested copy stays
+        # authoritative. answered is inferred only when this merge resolves the
+        # last open field: a paused schema can arrive with every value pre-filled
+        # by the model, so a plain reload of a stored pause must never read as
+        # answered.
+        if requirement.tool_execution is not None:
+            if requirement.user_input_schema:
+                tool_input_schema = requirement.tool_execution.user_input_schema
+                if tool_input_schema is None:
+                    requirement.tool_execution.user_input_schema = requirement.user_input_schema
+                else:
+                    input_values = {f.name: f.value for f in requirement.user_input_schema if f.value is not None}
+                    input_merged = False
+                    for tool_field in tool_input_schema:
+                        if tool_field.value is None and tool_field.name in input_values:
+                            tool_field.value = input_values[tool_field.name]
+                            input_merged = True
+                    if (
+                        input_merged
+                        and requirement.tool_execution.answered is None
+                        and all(f.value is not None for f in tool_input_schema)
+                    ):
+                        requirement.tool_execution.answered = True
+            if requirement.user_feedback_schema:
+                tool_feedback_schema = requirement.tool_execution.user_feedback_schema
+                if tool_feedback_schema is None:
+                    requirement.tool_execution.user_feedback_schema = requirement.user_feedback_schema
+                else:
+                    selections = {
+                        q.question: q.selected_options
+                        for q in requirement.user_feedback_schema
+                        if q.selected_options is not None
+                    }
+                    feedback_merged = False
+                    for tool_question in tool_feedback_schema:
+                        if tool_question.selected_options is None and tool_question.question in selections:
+                            tool_question.selected_options = selections[tool_question.question]
+                            if tool_question.options:
+                                for opt in tool_question.options:
+                                    opt.selected = opt.label in tool_question.selected_options
+                            feedback_merged = True
+                    if (
+                        feedback_merged
+                        and requirement.tool_execution.answered is None
+                        and all(q.selected_options is not None for q in tool_feedback_schema)
+                    ):
+                        requirement.tool_execution.answered = True
+
         return requirement

--- a/libs/agno/tests/unit/run/test_requirement.py
+++ b/libs/agno/tests/unit/run/test_requirement.py
@@ -1,6 +1,6 @@
 """Unit tests for agno.run.requirement — RunRequirement serialization round-trips."""
 
-from agno.models.response import ToolExecution
+from agno.models.response import ToolExecution, UserInputField
 from agno.run.requirement import RunRequirement
 
 # =============================================================================
@@ -21,6 +21,54 @@ def build_confirmation_requirement_dict(**overrides) -> dict:
     }
     data.update(overrides)
     return data
+
+
+def build_input_field_dict(name: str, value=None) -> dict:
+    return {"name": name, "field_type": "str", "description": None, "value": value}
+
+
+def build_user_input_requirement_dict(top_values: dict, nested_values: dict) -> dict:
+    """A stored requirement dict for a tool call awaiting user input.
+
+    Carries the schema twice — requirement level and inside tool_execution —
+    exactly as to_dict() ships it over the wire.
+    """
+    return {
+        "id": "req-input",
+        "tool_execution": {
+            "tool_name": "send_email",
+            "tool_args": {},
+            "tool_call_id": "call-input",
+            "requires_user_input": True,
+            "user_input_schema": [build_input_field_dict(name, value) for name, value in nested_values.items()],
+        },
+        "user_input_schema": [build_input_field_dict(name, value) for name, value in top_values.items()],
+    }
+
+
+def build_feedback_question_dict(question: str, labels: list, selected_options=None) -> dict:
+    return {
+        "question": question,
+        "header": None,
+        "multi_select": False,
+        "selected_options": selected_options,
+        "options": [{"label": label, "description": None, "selected": False} for label in labels],
+    }
+
+
+def build_user_feedback_requirement_dict(top_questions: list, nested_questions: list) -> dict:
+    """A stored requirement dict for an ask_user tool call awaiting feedback."""
+    return {
+        "id": "req-feedback",
+        "tool_execution": {
+            "tool_name": "ask_user",
+            "tool_args": {},
+            "tool_call_id": "call-feedback",
+            "requires_user_input": True,
+            "user_feedback_schema": nested_questions,
+        },
+        "user_feedback_schema": top_questions,
+    }
 
 
 # =============================================================================
@@ -114,3 +162,139 @@ class TestFromDictExternalExecutionResultPropagation:
         req = RunRequirement.from_dict(data)
         assert req.tool_execution is not None
         assert req.tool_execution.result == "nested result"
+
+
+# =============================================================================
+# from_dict: user_input_schema values propagate to tool_execution
+# =============================================================================
+
+
+class TestFromDictUserInputSchemaPropagation:
+    def test_top_level_values_reach_tool_execution(self):
+        """Values filled on the requirement-level schema copy must reach tool_execution."""
+        data = build_user_input_requirement_dict(
+            top_values={"to": "a@b.com", "body": "hello"},
+            nested_values={"to": None, "body": None},
+        )
+        req = RunRequirement.from_dict(data)
+        assert req.tool_execution is not None
+        assert req.tool_execution.user_input_schema is not None
+        nested = {f.name: f.value for f in req.tool_execution.user_input_schema}
+        assert nested == {"to": "a@b.com", "body": "hello"}
+        assert req.tool_execution.answered is True
+        assert req.needs_user_input is False
+
+    def test_partial_fill_does_not_mark_answered(self):
+        data = build_user_input_requirement_dict(
+            top_values={"to": "a@b.com", "body": None},
+            nested_values={"to": None, "body": None},
+        )
+        req = RunRequirement.from_dict(data)
+        assert req.tool_execution is not None
+        assert req.tool_execution.user_input_schema is not None
+        nested = {f.name: f.value for f in req.tool_execution.user_input_schema}
+        assert nested == {"to": "a@b.com", "body": None}
+        assert req.tool_execution.answered is None
+        assert req.needs_user_input is True
+
+    def test_nested_value_stays_authoritative(self):
+        data = build_user_input_requirement_dict(
+            top_values={"to": "other@x.com"},
+            nested_values={"to": "ops@x.com"},
+        )
+        req = RunRequirement.from_dict(data)
+        assert req.tool_execution is not None
+        assert req.tool_execution.user_input_schema is not None
+        assert req.tool_execution.user_input_schema[0].value == "ops@x.com"
+
+    def test_prefilled_pause_reload_stays_unanswered(self):
+        """A stored pause can carry model-prefilled values in both copies; reloading it must not read as answered."""
+        data = build_user_input_requirement_dict(
+            top_values={"to": "model@guess.com", "body": "model draft"},
+            nested_values={"to": "model@guess.com", "body": "model draft"},
+        )
+        req = RunRequirement.from_dict(data)
+        assert req.tool_execution is not None
+        assert req.tool_execution.answered is None
+        assert req.needs_user_input is True
+
+    def test_missing_nested_schema_gets_requirement_copy(self):
+        data = build_user_input_requirement_dict(top_values={"to": "a@b.com"}, nested_values={})
+        del data["tool_execution"]["user_input_schema"]
+        req = RunRequirement.from_dict(data)
+        assert req.tool_execution is not None
+        assert req.tool_execution.user_input_schema is req.user_input_schema
+        assert req.tool_execution.answered is None
+
+    def test_round_trip_preserves_provide_user_input(self):
+        requirement = RunRequirement(
+            tool_execution=ToolExecution(
+                tool_name="send_email",
+                tool_args={},
+                tool_call_id="call-input",
+                requires_user_input=True,
+                user_input_schema=[
+                    UserInputField(name="to", field_type=str),
+                    UserInputField(name="body", field_type=str),
+                ],
+            )
+        )
+        requirement.provide_user_input({"to": "a@b.com", "body": "hello"})
+        restored = RunRequirement.from_dict(requirement.to_dict())
+        assert restored.tool_execution is not None
+        assert restored.tool_execution.user_input_schema is not None
+        nested = {f.name: f.value for f in restored.tool_execution.user_input_schema}
+        assert nested == {"to": "a@b.com", "body": "hello"}
+        assert restored.tool_execution.answered is True
+        assert restored.needs_user_input is False
+
+
+# =============================================================================
+# from_dict: user_feedback_schema selections propagate to tool_execution
+# =============================================================================
+
+
+class TestFromDictUserFeedbackSchemaPropagation:
+    def test_top_level_selections_reach_tool_execution(self):
+        data = build_user_feedback_requirement_dict(
+            top_questions=[build_feedback_question_dict("Ship it?", ["yes", "no"], selected_options=["yes"])],
+            nested_questions=[build_feedback_question_dict("Ship it?", ["yes", "no"])],
+        )
+        req = RunRequirement.from_dict(data)
+        assert req.tool_execution is not None
+        assert req.tool_execution.user_feedback_schema is not None
+        question = req.tool_execution.user_feedback_schema[0]
+        assert question.selected_options == ["yes"]
+        assert question.options is not None
+        assert {opt.label: opt.selected for opt in question.options} == {"yes": True, "no": False}
+        assert req.tool_execution.answered is True
+        assert req.needs_user_feedback is False
+
+    def test_nested_selections_stay_authoritative(self):
+        data = build_user_feedback_requirement_dict(
+            top_questions=[build_feedback_question_dict("Ship it?", ["yes", "no"], selected_options=["yes"])],
+            nested_questions=[build_feedback_question_dict("Ship it?", ["yes", "no"], selected_options=["no"])],
+        )
+        req = RunRequirement.from_dict(data)
+        assert req.tool_execution is not None
+        assert req.tool_execution.user_feedback_schema is not None
+        assert req.tool_execution.user_feedback_schema[0].selected_options == ["no"]
+
+    def test_partial_selections_do_not_mark_answered(self):
+        data = build_user_feedback_requirement_dict(
+            top_questions=[
+                build_feedback_question_dict("Ship it?", ["yes", "no"], selected_options=["yes"]),
+                build_feedback_question_dict("Which env?", ["dev", "prod"]),
+            ],
+            nested_questions=[
+                build_feedback_question_dict("Ship it?", ["yes", "no"]),
+                build_feedback_question_dict("Which env?", ["dev", "prod"]),
+            ],
+        )
+        req = RunRequirement.from_dict(data)
+        assert req.tool_execution is not None
+        assert req.tool_execution.user_feedback_schema is not None
+        assert req.tool_execution.user_feedback_schema[0].selected_options == ["yes"]
+        assert req.tool_execution.user_feedback_schema[1].selected_options is None
+        assert req.tool_execution.answered is None
+        assert req.needs_user_feedback is True


### PR DESCRIPTION
## Summary

Completes the invariant established in #9351 for the two remaining HITL resolution lanes. `RunRequirement.from_dict` rebuilt the requirement-level `user_input_schema` and `user_feedback_schema` but never merged the values into `tool_execution` — the only copy the continue paths rebuild run tools from and the only copy dispatch reads (`handle_user_input_update` copies `tool.user_input_schema` values into `tool_args`; `handle_ask_user_tool_update` reports `tool.user_feedback_schema` to the model).

Since `to_dict()` ships each schema twice (requirement level and nested, identical), a client that filled the requirement-level copy — the sibling of the `confirmation` field #9351 just made authoritative — had its input silently discarded: the tool executed with null arguments (`send_email(to=None, body=None)`), and `ask_user` reported an empty selection to the model. Worse than the confirmation drop, which at least failed safe as a rejection.

The merge mirrors `provide_user_input`/`provide_user_feedback`: values match by field name / question text, a value already set on the nested copy stays authoritative (same rule as #9351), and `option.selected` flags are synced for copied selections. If `tool_execution` lacks the schema entirely, the requirement-level list is assigned to it, restoring the constructor's aliasing.

`answered` is inferred only when the merge itself resolves the last open field. This gate is load-bearing: when a `requires_user_input` tool pauses, `models/base.py` pre-fills `user_input_schema[].value` from the model's own `fc.arguments`, so for a bare `@tool(requires_user_input=True)` (no `user_input_fields`) the paused schema arrives fully filled with the model's guesses. An unconditional "all values present → answered" inference would mark such a run resolved on any session load — AG-UI resume would then skip `provide_user_input` and the tool would execute with the model's invented arguments under an "approved" audit record. Gating on the merge means a plain reload of a stored pause (identical copies, nothing to merge) can never flip `answered`, while a genuine client fill still resolves cleanly.

## Changes

- `libs/agno/agno/run/requirement.py` — schema-lane merge block at the end of `from_dict` (+45)
- `libs/agno/tests/unit/run/test_requirement.py` — 9 new tests: top-level fill reaches `tool_execution` (input + feedback), partial fill leaves `answered` unset, nested values/selections stay authoritative, model-prefilled pause reload stays unanswered, missing nested schema gets the requirement copy, `provide_user_input` round-trip, `option.selected` flag sync

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Stacked on #9351 (`fix/continue-run-bare-confirmation`); retarget/merge after it lands.

Testing:
- `tests/unit/run/`: 104 passed (95 post-#9351 baseline + 9 new)
- Negative control: with the fix reverted, exactly the 6 propagation tests fail; the 3 pinning pre-existing behavior (nested-wins, round-trip) pass
- HITL-adjacent sweep (agui resume, unified continue, team requirement/continue/persistence, workflow hitl): 365 passed
- End-to-end through the real MCP funnel (`parse_run_requirements` → continue-path tool rebuild → `handle_tool_call_updates`): a top-level-only fill now executes `send_email` with the human's values (was `None`/`None` pre-fix) and resolves `ask_user` with the selection intact (was `selected: []`)
- Reload shapes verified end to end: an untouched stored pause and a model-prefilled pause both stay `needs_user_input=True` / unresolved after `from_dict` (real `@tool` decorator + SQLite session round-trip + AG-UI resume helper)
- `./scripts/format.sh` and `./scripts/validate.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
