### PR TITLE
feat(tools): add OutageDeck status toolkit

### DIFF
--- a/cookbook/91_tools/outagedeck_tools.py
+++ b/cookbook/91_tools/outagedeck_tools.py
@@ -18,7 +18,7 @@ agent = Agent(
     instructions=[
         "Always use OutageDeck before making claims about current provider or service status.",
         "Summarize active incidents with severity, state, and last update time.",
-        "Include the OutageDeck URL returned by the tool so the reader can inspect the live status page.",
+        "Include the OutageDeck URL returned by the tool so the reader can inspect the provider status page.",
     ],
     markdown=True,
 )

--- a/cookbook/91_tools/outagedeck_tools.py
+++ b/cookbook/91_tools/outagedeck_tools.py
@@ -1,4 +1,4 @@
-"""OutageDeck Tools - Live operational status without credentials.
+"""OutageDeck Tools - Vendor-published operational status without credentials.
 
 This example gives an agent current provider status, active and historical
 incidents, and individual service health through OutageDeck's public API.

--- a/cookbook/91_tools/outagedeck_tools.py
+++ b/cookbook/91_tools/outagedeck_tools.py
@@ -1,0 +1,43 @@
+"""OutageDeck Tools - Live operational status without credentials.
+
+This example gives an agent current provider status, active and historical
+incidents, and individual service health through OutageDeck's public API.
+No OutageDeck account or API key is required.
+
+API documentation:
+https://outagedeck.com/docs/api?utm_source=agno&utm_medium=integration&utm_campaign=agno_toolkit
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.outagedeck import OutageDeckTools
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[OutageDeckTools()],
+    instructions=[
+        "Always use OutageDeck before making claims about current provider or service status.",
+        "Summarize active incidents with severity, state, and last update time.",
+        "Include the OutageDeck URL returned by the tool so the reader can inspect the live status page.",
+    ],
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    print("=== Provider status ===")
+    agent.print_response(
+        "Is GitHub operational right now? Include active incidents and affected services.",
+        stream=True,
+    )
+
+    print("\n=== Active incidents ===")
+    agent.print_response(
+        "List active major or critical incidents across all providers.",
+        stream=True,
+    )
+
+    print("\n=== Service status ===")
+    agent.print_response(
+        "Check the current status of GitHub Actions and summarize its latest incidents.",
+        stream=True,
+    )

--- a/libs/agno/agno/tools/outagedeck.py
+++ b/libs/agno/agno/tools/outagedeck.py
@@ -1,0 +1,414 @@
+"""OutageDeck toolkit for live provider, incident, and service status.
+
+OutageDeck (https://outagedeck.com) aggregates operational status and incident
+history for infrastructure providers. Its public API does not require an API
+key, so this toolkit works without setup or credentials.
+
+API documentation:
+https://outagedeck.com/docs/api?utm_source=agno&utm_medium=integration&utm_campaign=agno_toolkit
+"""
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlencode
+
+try:
+    import httpx
+except ImportError:
+    raise ImportError("`httpx` not installed. Please install it via `pip install httpx`.")
+
+from agno.tools import Toolkit
+from agno.utils.log import log_info, logger
+
+API_BASE_URL = "https://outagedeck.com/api/v1"
+SITE_BASE_URL = "https://outagedeck.com"
+USER_AGENT = "Agno-OutageDeck/1.0"
+ATTRIBUTION_PARAMS = {
+    "utm_source": "agno",
+    "utm_medium": "integration",
+    "utm_campaign": "agno_toolkit",
+}
+SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+VALID_INCIDENT_STATES = {"active", "resolved"}
+VALID_SEVERITIES = {"minor", "major", "critical", "maintenance"}
+
+
+class OutageDeckTools(Toolkit):
+    """Toolkit for checking live operational status through OutageDeck.
+
+    Args:
+        timeout (float): Per-request HTTP timeout in seconds. Default is 20.
+        enable_provider_status (bool): Enable `get_provider_status`. Default is True.
+        enable_incidents (bool): Enable `list_incidents`. Default is True.
+        enable_service_status (bool): Enable `get_service_status`. Default is True.
+        all (bool): Enable all tools regardless of individual flags. Default is False.
+    """
+
+    def __init__(
+        self,
+        timeout: float = 20.0,
+        enable_provider_status: bool = True,
+        enable_incidents: bool = True,
+        enable_service_status: bool = True,
+        all: bool = False,
+        **kwargs,
+    ):
+        self.timeout = httpx.Timeout(timeout)
+
+        tools: List[Any] = []
+        async_tools: List[Tuple[Any, str]] = []
+
+        if all or enable_provider_status:
+            tools.append(self.get_provider_status)
+            async_tools.append((self.aget_provider_status, "get_provider_status"))
+        if all or enable_incidents:
+            tools.append(self.list_incidents)
+            async_tools.append((self.alist_incidents, "list_incidents"))
+        if all or enable_service_status:
+            tools.append(self.get_service_status)
+            async_tools.append((self.aget_service_status, "get_service_status"))
+
+        name = kwargs.pop("name", "outagedeck_tools")
+        super().__init__(name=name, tools=tools, async_tools=async_tools, **kwargs)
+
+    @staticmethod
+    def _headers() -> Dict[str, str]:
+        return {"Accept": "application/json", "User-Agent": USER_AGENT}
+
+    @staticmethod
+    def _slug(value: str, kind: str) -> Tuple[Optional[str], Optional[Dict[str, str]]]:
+        slug = value.strip().lower()
+        if not SLUG_PATTERN.fullmatch(slug):
+            return None, {"error": f"Invalid {kind} slug. Use lowercase letters, numbers, and single hyphens only."}
+        return slug, None
+
+    @staticmethod
+    def _attributed_url(path: str) -> str:
+        return f"{SITE_BASE_URL}{path}?{urlencode(ATTRIBUTION_PARAMS)}"
+
+    @staticmethod
+    def _http_error(exc: "httpx.HTTPStatusError", resource: str) -> Dict[str, str]:
+        status = exc.response.status_code
+        if status == 404:
+            return {"error": f"OutageDeck could not find {resource}."}
+        if status == 429:
+            return {"error": "OutageDeck rate limit exceeded. Try again later."}
+        if status in (401, 403):
+            return {"error": "OutageDeck rejected the request."}
+        return {"error": f"OutageDeck API error: HTTP {status}."}
+
+    @staticmethod
+    def _request_error(exc: Exception) -> Dict[str, str]:
+        logger.exception("Error requesting OutageDeck")
+        return {"error": f"Could not reach OutageDeck: {exc}"}
+
+    @staticmethod
+    def _response_error(exc: ValueError) -> Dict[str, str]:
+        logger.exception("Invalid response from OutageDeck")
+        return {"error": f"OutageDeck returned an invalid JSON response: {exc}"}
+
+    @staticmethod
+    def _data(payload: Any) -> Optional[Dict[str, Any]]:
+        if not isinstance(payload, dict):
+            return None
+        data = payload.get("data")
+        return data if isinstance(data, dict) else None
+
+    @classmethod
+    def _incident(cls, incident: Any) -> Optional[Dict[str, Any]]:
+        if not isinstance(incident, dict):
+            return None
+        provider = incident.get("provider")
+        affected_services = incident.get("affectedServices")
+        slug = incident.get("slug")
+        result = {
+            "slug": slug,
+            "title": incident.get("title"),
+            "summary": incident.get("summary"),
+            "status": incident.get("status"),
+            "severity": incident.get("severity"),
+            "started_at": incident.get("startedAt"),
+            "updated_at": incident.get("updatedAt"),
+            "resolved_at": incident.get("resolvedAt"),
+            "provider": {
+                "slug": provider.get("slug"),
+                "name": provider.get("name"),
+            }
+            if isinstance(provider, dict)
+            else None,
+            "affected_services": [
+                {"slug": service.get("slug"), "name": service.get("name")}
+                for service in affected_services
+                if isinstance(service, dict)
+            ]
+            if isinstance(affected_services, list)
+            else [],
+        }
+        if isinstance(slug, str) and SLUG_PATTERN.fullmatch(slug):
+            result["outagedeck_url"] = cls._attributed_url(f"/incidents/{slug}")
+        return result
+
+    @classmethod
+    def _parse_provider(cls, payload: Any) -> Dict[str, Any]:
+        data = cls._data(payload)
+        if data is None:
+            return {"error": "OutageDeck returned an unexpected provider response."}
+
+        status = data.get("currentStatus")
+        counts = data.get("counts")
+        services = data.get("services")
+        incidents = data.get("activeIncidents")
+        slug = data.get("slug")
+        if not isinstance(status, dict) or not isinstance(slug, str):
+            return {"error": "OutageDeck returned an unexpected provider response."}
+
+        return {
+            "provider": {"slug": slug, "name": data.get("name")},
+            "status": {
+                "code": status.get("code"),
+                "label": status.get("label"),
+                "headline": status.get("headline"),
+                "summary": status.get("summary"),
+                "captured_at": status.get("capturedAt"),
+            },
+            "counts": counts if isinstance(counts, dict) else {},
+            "services": [
+                {
+                    "slug": service.get("slug"),
+                    "name": service.get("name"),
+                    "category": service.get("category"),
+                    "status": service.get("status"),
+                    "summary": service.get("summary"),
+                }
+                for service in services
+                if isinstance(service, dict)
+            ]
+            if isinstance(services, list)
+            else [],
+            "active_incidents": [parsed for item in incidents if (parsed := cls._incident(item)) is not None][:10]
+            if isinstance(incidents, list)
+            else [],
+            "outagedeck_url": cls._attributed_url(f"/providers/{slug}"),
+        }
+
+    @classmethod
+    def _parse_incidents(cls, payload: Any) -> Dict[str, Any]:
+        data = cls._data(payload)
+        if data is None or not isinstance(data.get("incidents"), list):
+            return {"error": "OutageDeck returned an unexpected incident response."}
+
+        incidents = [parsed for item in data["incidents"] if (parsed := cls._incident(item)) is not None]
+        return {
+            "count": data.get("count", len(incidents)),
+            "page": data.get("page"),
+            "total_pages": data.get("totalPages"),
+            "total_incidents": data.get("totalIncidents"),
+            "incidents": incidents,
+            "outagedeck_url": cls._attributed_url("/incidents"),
+        }
+
+    @classmethod
+    def _parse_service(cls, payload: Any) -> Dict[str, Any]:
+        data = cls._data(payload)
+        if data is None:
+            return {"error": "OutageDeck returned an unexpected service response."}
+
+        slug = data.get("slug")
+        provider = data.get("provider")
+        incidents = data.get("incidents")
+        if not isinstance(slug, str) or not isinstance(provider, dict):
+            return {"error": "OutageDeck returned an unexpected service response."}
+
+        return {
+            "service": {
+                "slug": slug,
+                "name": data.get("name"),
+                "category": data.get("category"),
+                "status": data.get("status"),
+                "summary": data.get("summary"),
+            },
+            "provider": {"slug": provider.get("slug"), "name": provider.get("name")},
+            "counts": data.get("counts") if isinstance(data.get("counts"), dict) else {},
+            "recent_incidents": [parsed for item in incidents if (parsed := cls._incident(item)) is not None][:10]
+            if isinstance(incidents, list)
+            else [],
+            "outagedeck_url": cls._attributed_url(f"/services/{slug}"),
+        }
+
+    def get_provider_status(self, provider_slug: str) -> Dict[str, Any]:
+        """Get the current status, services, and active incidents for a provider.
+
+        Args:
+            provider_slug (str): OutageDeck provider slug, for example `github`, `openai`, or `cloudflare`.
+
+        Returns:
+            Dict[str, Any]: Current provider status and active incidents, or an error.
+        """
+        slug, invalid = self._slug(provider_slug, "provider")
+        if invalid:
+            return invalid
+        log_info(f"Checking OutageDeck provider status: {slug}")
+        try:
+            with httpx.Client(timeout=self.timeout) as client:
+                response = client.get(f"{API_BASE_URL}/providers/{slug}", headers=self._headers())
+                response.raise_for_status()
+                return self._parse_provider(response.json())
+        except httpx.HTTPStatusError as exc:
+            return self._http_error(exc, f"provider '{slug}'")
+        except httpx.RequestError as exc:
+            return self._request_error(exc)
+        except ValueError as exc:
+            return self._response_error(exc)
+
+    async def aget_provider_status(self, provider_slug: str) -> Dict[str, Any]:
+        """Get current provider status and active incidents asynchronously."""
+        slug, invalid = self._slug(provider_slug, "provider")
+        if invalid:
+            return invalid
+        log_info(f"Checking OutageDeck provider status: {slug}")
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(f"{API_BASE_URL}/providers/{slug}", headers=self._headers())
+                response.raise_for_status()
+                return self._parse_provider(response.json())
+        except httpx.HTTPStatusError as exc:
+            return self._http_error(exc, f"provider '{slug}'")
+        except httpx.RequestError as exc:
+            return self._request_error(exc)
+        except ValueError as exc:
+            return self._response_error(exc)
+
+    def list_incidents(
+        self,
+        provider: Optional[str] = None,
+        state: Optional[str] = None,
+        severity: Optional[str] = None,
+        page: int = 1,
+        limit: int = 20,
+    ) -> Dict[str, Any]:
+        """List current or historical incidents, optionally filtered by provider.
+
+        Args:
+            provider (Optional[str]): Provider slug, such as `github` or `openai`.
+            state (Optional[str]): Lifecycle filter: `active` or `resolved`.
+            severity (Optional[str]): `minor`, `major`, `critical`, or `maintenance`.
+            page (int): 1-based result page. Default is 1.
+            limit (int): Results per page from 1 through 100. Default is 20.
+
+        Returns:
+            Dict[str, Any]: Paginated incidents and metadata, or an error.
+        """
+        params, invalid = self._incident_params(provider, state, severity, page, limit)
+        if invalid:
+            return invalid
+        log_info("Listing OutageDeck incidents")
+        try:
+            with httpx.Client(timeout=self.timeout) as client:
+                response = client.get(f"{API_BASE_URL}/incidents", params=params, headers=self._headers())
+                response.raise_for_status()
+                return self._parse_incidents(response.json())
+        except httpx.HTTPStatusError as exc:
+            return self._http_error(exc, "the requested incidents")
+        except httpx.RequestError as exc:
+            return self._request_error(exc)
+        except ValueError as exc:
+            return self._response_error(exc)
+
+    async def alist_incidents(
+        self,
+        provider: Optional[str] = None,
+        state: Optional[str] = None,
+        severity: Optional[str] = None,
+        page: int = 1,
+        limit: int = 20,
+    ) -> Dict[str, Any]:
+        """List incidents asynchronously with optional provider and lifecycle filters."""
+        params, invalid = self._incident_params(provider, state, severity, page, limit)
+        if invalid:
+            return invalid
+        log_info("Listing OutageDeck incidents")
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(f"{API_BASE_URL}/incidents", params=params, headers=self._headers())
+                response.raise_for_status()
+                return self._parse_incidents(response.json())
+        except httpx.HTTPStatusError as exc:
+            return self._http_error(exc, "the requested incidents")
+        except httpx.RequestError as exc:
+            return self._request_error(exc)
+        except ValueError as exc:
+            return self._response_error(exc)
+
+    @classmethod
+    def _incident_params(
+        cls,
+        provider: Optional[str],
+        state: Optional[str],
+        severity: Optional[str],
+        page: int,
+        limit: int,
+    ) -> Tuple[Dict[str, Any], Optional[Dict[str, str]]]:
+        params: Dict[str, Any] = {"page": page, "limit": limit}
+        if isinstance(page, bool) or not isinstance(page, int) or page < 1:
+            return params, {"error": "Page must be an integer greater than or equal to 1."}
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
+            return params, {"error": "Limit must be an integer from 1 through 100."}
+        if provider is not None:
+            slug, invalid = cls._slug(provider, "provider")
+            if invalid:
+                return params, invalid
+            params["provider"] = slug
+        if state is not None:
+            normalized_state = state.strip().lower()
+            if normalized_state not in VALID_INCIDENT_STATES:
+                return params, {"error": "State must be 'active' or 'resolved'."}
+            params["state"] = normalized_state
+        if severity is not None:
+            normalized_severity = severity.strip().lower()
+            if normalized_severity not in VALID_SEVERITIES:
+                return params, {"error": "Severity must be 'minor', 'major', 'critical', or 'maintenance'."}
+            params["severity"] = normalized_severity
+        return params, None
+
+    def get_service_status(self, service_slug: str) -> Dict[str, Any]:
+        """Get current status and recent incidents for a provider service.
+
+        Args:
+            service_slug (str): OutageDeck service slug, for example `github-actions` or `openai-api`.
+
+        Returns:
+            Dict[str, Any]: Service status, provider, counts, and up to 10 recent incidents, or an error.
+        """
+        slug, invalid = self._slug(service_slug, "service")
+        if invalid:
+            return invalid
+        log_info(f"Checking OutageDeck service status: {slug}")
+        try:
+            with httpx.Client(timeout=self.timeout) as client:
+                response = client.get(f"{API_BASE_URL}/services/{slug}", headers=self._headers())
+                response.raise_for_status()
+                return self._parse_service(response.json())
+        except httpx.HTTPStatusError as exc:
+            return self._http_error(exc, f"service '{slug}'")
+        except httpx.RequestError as exc:
+            return self._request_error(exc)
+        except ValueError as exc:
+            return self._response_error(exc)
+
+    async def aget_service_status(self, service_slug: str) -> Dict[str, Any]:
+        """Get current service status and recent incidents asynchronously."""
+        slug, invalid = self._slug(service_slug, "service")
+        if invalid:
+            return invalid
+        log_info(f"Checking OutageDeck service status: {slug}")
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(f"{API_BASE_URL}/services/{slug}", headers=self._headers())
+                response.raise_for_status()
+                return self._parse_service(response.json())
+        except httpx.HTTPStatusError as exc:
+            return self._http_error(exc, f"service '{slug}'")
+        except httpx.RequestError as exc:
+            return self._request_error(exc)
+        except ValueError as exc:
+            return self._response_error(exc)

--- a/libs/agno/agno/tools/outagedeck.py
+++ b/libs/agno/agno/tools/outagedeck.py
@@ -34,7 +34,7 @@ VALID_SEVERITIES = {"minor", "major", "critical", "maintenance"}
 
 
 class OutageDeckTools(Toolkit):
-    """Toolkit for checking live operational status through OutageDeck.
+    """Toolkit for checking vendor-published operational status through OutageDeck.
 
     Args:
         timeout (float): Per-request HTTP timeout in seconds. Default is 20.

--- a/libs/agno/agno/tools/outagedeck.py
+++ b/libs/agno/agno/tools/outagedeck.py
@@ -1,4 +1,4 @@
-"""OutageDeck toolkit for live provider, incident, and service status.
+"""OutageDeck toolkit for vendor-published provider, incident, and service status.
 
 OutageDeck (https://outagedeck.com) aggregates operational status and incident
 history for infrastructure providers. Its public API does not require an API

--- a/libs/agno/tests/unit/tools/test_outagedeck.py
+++ b/libs/agno/tests/unit/tools/test_outagedeck.py
@@ -1,0 +1,274 @@
+"""Unit tests for OutageDeckTools."""
+
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+
+from agno.tools.outagedeck import API_BASE_URL, USER_AGENT, OutageDeckTools
+
+
+@pytest.fixture
+def tools():
+    return OutageDeckTools(timeout=7)
+
+
+def _response(payload, status_code=200):
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _provider_payload():
+    return {
+        "data": {
+            "slug": "github",
+            "name": "GitHub",
+            "currentStatus": {
+                "code": "degraded",
+                "label": "Degraded Performance",
+                "headline": "Some systems are degraded",
+                "summary": "GitHub reports degraded performance.",
+                "capturedAt": "2026-08-05T12:00:00Z",
+            },
+            "counts": {"services": 3, "activeIncidents": 1, "incidents": 10},
+            "services": [
+                {
+                    "slug": "github-actions",
+                    "name": "GitHub Actions",
+                    "category": "ci-cd",
+                    "status": "degraded",
+                    "summary": "Workflow execution.",
+                }
+            ],
+            "activeIncidents": [_incident_payload()],
+        }
+    }
+
+
+def _incident_payload():
+    return {
+        "slug": "github-actions-delays-2026-08-05",
+        "title": "Actions delays",
+        "summary": "Some workflow runs are delayed.",
+        "status": "monitoring",
+        "severity": "major",
+        "startedAt": "2026-08-05T10:00:00Z",
+        "updatedAt": "2026-08-05T11:00:00Z",
+        "resolvedAt": None,
+        "provider": {"slug": "github", "name": "GitHub"},
+        "affectedServices": [{"slug": "github-actions", "name": "GitHub Actions"}],
+    }
+
+
+def _service_payload():
+    return {
+        "data": {
+            "slug": "github-actions",
+            "name": "GitHub Actions",
+            "category": "ci-cd",
+            "status": "degraded",
+            "summary": "Workflow execution.",
+            "provider": {"slug": "github", "name": "GitHub"},
+            "counts": {"incidents": 12, "activeIncidents": 1},
+            "incidents": [_incident_payload()] * 12,
+        }
+    }
+
+
+def test_registers_all_tools_and_async_variants(tools):
+    assert set(tools.functions) == {"get_provider_status", "list_incidents", "get_service_status"}
+    assert set(tools.async_functions) == {"get_provider_status", "list_incidents", "get_service_status"}
+
+
+def test_selective_registration():
+    tools = OutageDeckTools(
+        enable_provider_status=False,
+        enable_incidents=True,
+        enable_service_status=False,
+    )
+    assert set(tools.functions) == {"list_incidents"}
+    assert set(tools.async_functions) == {"list_incidents"}
+
+
+@pytest.mark.parametrize(
+    "method,value",
+    [
+        ("get_provider_status", "../admin"),
+        ("get_provider_status", "github/status"),
+        ("get_provider_status", "github?limit=100"),
+        ("get_service_status", "-github-actions"),
+        ("get_service_status", "github--actions"),
+        ("get_service_status", ""),
+    ],
+)
+def test_rejects_invalid_slugs_without_network(tools, method, value):
+    with patch("agno.tools.outagedeck.httpx.Client") as client:
+        result = getattr(tools, method)(value)
+    assert "error" in result
+    client.assert_not_called()
+
+
+def test_get_provider_status_sends_exact_request_and_parses_response(tools):
+    with patch("agno.tools.outagedeck.httpx.Client") as client:
+        instance = client.return_value.__enter__.return_value
+        instance.get.return_value = _response(_provider_payload())
+        result = tools.get_provider_status(" GitHub ")
+
+    instance.get.assert_called_once_with(
+        f"{API_BASE_URL}/providers/github",
+        headers={"Accept": "application/json", "User-Agent": USER_AGENT},
+    )
+    assert result["status"]["code"] == "degraded"
+    assert result["services"][0]["slug"] == "github-actions"
+    assert result["active_incidents"][0]["severity"] == "major"
+    assert "utm_campaign=agno_toolkit" in result["outagedeck_url"]
+
+
+def test_list_incidents_sends_filters_and_parses_pagination(tools):
+    payload = {
+        "data": {
+            "count": 1,
+            "page": 2,
+            "totalPages": 4,
+            "totalIncidents": 7,
+            "incidents": [_incident_payload()],
+        }
+    }
+    with patch("agno.tools.outagedeck.httpx.Client") as client:
+        instance = client.return_value.__enter__.return_value
+        instance.get.return_value = _response(payload)
+        result = tools.list_incidents(" GitHub ", state="ACTIVE", severity="Major", page=2, limit=5)
+
+    instance.get.assert_called_once_with(
+        f"{API_BASE_URL}/incidents",
+        params={"page": 2, "limit": 5, "provider": "github", "state": "active", "severity": "major"},
+        headers={"Accept": "application/json", "User-Agent": USER_AGENT},
+    )
+    assert result["total_pages"] == 4
+    assert result["incidents"][0]["affected_services"][0]["slug"] == "github-actions"
+    assert "utm_source=agno" in result["incidents"][0]["outagedeck_url"]
+
+
+@pytest.mark.parametrize(
+    "kwargs,error",
+    [
+        ({"page": 0}, "Page"),
+        ({"page": True}, "Page"),
+        ({"limit": 101}, "Limit"),
+        ({"limit": False}, "Limit"),
+        ({"state": "investigating"}, "State"),
+        ({"severity": "catastrophic"}, "Severity"),
+        ({"provider": "github/api"}, "slug"),
+    ],
+)
+def test_list_incidents_validates_filters_without_network(tools, kwargs, error):
+    with patch("agno.tools.outagedeck.httpx.Client") as client:
+        result = tools.list_incidents(**kwargs)
+    assert error in result["error"]
+    client.assert_not_called()
+
+
+def test_get_service_status_caps_incidents_for_agent_context(tools):
+    with patch("agno.tools.outagedeck.httpx.Client") as client:
+        instance = client.return_value.__enter__.return_value
+        instance.get.return_value = _response(_service_payload())
+        result = tools.get_service_status("github-actions")
+
+    assert result["service"]["status"] == "degraded"
+    assert result["provider"] == {"slug": "github", "name": "GitHub"}
+    assert len(result["recent_incidents"]) == 10
+    assert "utm_medium=integration" in result["outagedeck_url"]
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [(404, "could not find"), (429, "rate limit"), (500, "HTTP 500")],
+)
+def test_http_errors_are_actionable(tools, status, expected):
+    request = httpx.Request("GET", f"{API_BASE_URL}/providers/missing")
+    response = httpx.Response(status, request=request)
+    error = httpx.HTTPStatusError("failed", request=request, response=response)
+    with patch("agno.tools.outagedeck.httpx.Client") as client:
+        instance = client.return_value.__enter__.return_value
+        instance.get.return_value.raise_for_status.side_effect = error
+        result = tools.get_provider_status("missing")
+    assert expected.lower() in result["error"].lower()
+
+
+def test_network_error_is_actionable(tools):
+    request = httpx.Request("GET", f"{API_BASE_URL}/incidents")
+    with patch("agno.tools.outagedeck.httpx.Client") as client:
+        instance = client.return_value.__enter__.return_value
+        instance.get.side_effect = httpx.ConnectError("connection refused", request=request)
+        result = tools.list_incidents()
+    assert "Could not reach OutageDeck" in result["error"]
+
+
+def test_invalid_json_is_actionable(tools):
+    with patch("agno.tools.outagedeck.httpx.Client") as client:
+        instance = client.return_value.__enter__.return_value
+        response = _response({})
+        response.json.side_effect = ValueError("invalid JSON")
+        instance.get.return_value = response
+        result = tools.get_provider_status("github")
+    assert "invalid JSON response" in result["error"]
+
+
+@pytest.mark.parametrize("method", ["get_provider_status", "list_incidents", "get_service_status"])
+def test_unexpected_response_shape_is_actionable(tools, method):
+    with patch("agno.tools.outagedeck.httpx.Client") as client:
+        instance = client.return_value.__enter__.return_value
+        instance.get.return_value = _response({"data": []})
+        result = getattr(tools, method)("github" if method != "list_incidents" else None)
+    assert "unexpected" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_async_provider_status_matches_sync_behavior(tools):
+    async def get(*args, **kwargs):
+        return _response(_provider_payload())
+
+    with patch("agno.tools.outagedeck.httpx.AsyncClient") as client:
+        instance = client.return_value.__aenter__.return_value
+        instance.get.side_effect = get
+        result = await tools.aget_provider_status("github")
+
+    instance.get.assert_called_once_with(
+        f"{API_BASE_URL}/providers/github",
+        headers={"Accept": "application/json", "User-Agent": USER_AGENT},
+    )
+    assert result["provider"]["name"] == "GitHub"
+
+
+@pytest.mark.asyncio
+async def test_async_incidents_matches_sync_behavior(tools):
+    payload = {
+        "data": {"count": 1, "page": 1, "totalPages": 1, "totalIncidents": 1, "incidents": [_incident_payload()]}
+    }
+
+    async def get(*args, **kwargs):
+        return _response(payload)
+
+    with patch("agno.tools.outagedeck.httpx.AsyncClient") as client:
+        instance = client.return_value.__aenter__.return_value
+        instance.get.side_effect = get
+        result = await tools.alist_incidents(provider="github", state="active", limit=1)
+
+    assert result["count"] == 1
+    assert result["incidents"][0]["title"] == "Actions delays"
+
+
+@pytest.mark.asyncio
+async def test_async_service_status_matches_sync_behavior(tools):
+    async def get(*args, **kwargs):
+        return _response(_service_payload())
+
+    with patch("agno.tools.outagedeck.httpx.AsyncClient") as client:
+        instance = client.return_value.__aenter__.return_value
+        instance.get.side_effect = get
+        result = await tools.aget_service_status("github-actions")
+
+    assert result["service"]["name"] == "GitHub Actions"


### PR DESCRIPTION
## Summary

Adds a keyless `OutageDeckTools` integration so Agno agents can check vendor-published infrastructure status instead of guessing from stale model knowledge.

Closes #9368.

- adds sync and async tools for provider status, filtered incidents, and individual service status
- fixes requests to the public OutageDeck API origin, validates all path slugs and filters, and returns compact normalized results suitable for agent context
- includes attributed provider-status links so users can inspect the underlying OutageDeck page
- adds 29 focused unit tests covering registration, request construction, parsing, input rejection, HTTP/network/JSON errors, and sync/async parity
- adds a runnable cookbook example; no OutageDeck account or API key is required

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

This contribution was entirely AI-generated and then self-reviewed against the repository guidelines and the live public API contract.

Validation completed:

- `pytest -q libs/agno/tests/unit/tools/test_outagedeck.py`: 29 passed
- `./scripts/format.sh`: passed across all repository targets
- `./scripts/validate.sh`: Ruff passed; MyPy passed across 956 Agno and 21 Agnoctl source files; cookbook checks passed
- sync and async smoke calls passed for all three API methods
- wheel and source distribution builds both include `agno/tools/outagedeck.py`

The integration is read-only, uses only GET requests, requires no credentials, and does not expose a configurable API origin.
