### PR TITLE
fix: run sync scheduler DB calls off the event loop

### DIFF
--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -566,10 +566,8 @@ def to_dict(agent: Agent) -> Dict[str, Any]:
         _claimed_names: Set[str] = set()
         for _tool in agent.tools:
             if isinstance(_tool, Toolkit):
-                # get_functions() rather than .functions: subclasses may expose
-                # a subset, and parse_tools serializes what get_functions()
-                # returns. Claimed by Function.name, not dict key: the two can
-                # differ, and the serialized dict carries the Function's name.
+                # get_functions() is what parse_tools serializes. Names are claimed
+                # by Function.name, which is what the serialized dict carries.
                 for _func in _tool.get_functions().values():
                     if _func.name in _claimed_names:
                         continue

--- a/libs/agno/agno/fs/toolkit.py
+++ b/libs/agno/agno/fs/toolkit.py
@@ -191,8 +191,8 @@ class FileSystemTools(Toolkit):
         async_tools = [(getattr(self, "a" + name), name) for name in registered]
 
         super().__init__(
-            # Overridable so multiple file toolkits (a shared store and a
-            # per-agent one, say) can coexist in a registry without colliding.
+            # A registry resolves a persisted tool by its toolkit name, so two file
+            # toolkits in one registry need distinct names to rebind correctly.
             name=kwargs.pop("name", "filesystem"),
             tools=sync_tools,
             async_tools=async_tools,

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -91,9 +91,8 @@ class Registry:
 
         for tool in self.tools:
             if isinstance(tool, Toolkit):
-                # get_functions() rather than .functions: subclasses may expose
-                # a subset, and only exposed functions are serialized or run --
-                # a hidden member must not claim a slot (or warn) here either.
+                # get_functions() is the exposed subset -- the only functions that
+                # are serialized or run, so only those claim a slot or warn here.
                 for func in tool.get_functions().values():
                     if func.entrypoint is not None:
                         register(func.name, func)

--- a/libs/agno/agno/scheduler/manager.py
+++ b/libs/agno/agno/scheduler/manager.py
@@ -72,7 +72,9 @@ class ScheduleManager:
             raise NotImplementedError(f"Database does not support {method_name}")
         if asyncio.iscoroutinefunction(fn):
             return await fn(*args, **kwargs)
-        return fn(*args, **kwargs)
+        # A sync adapter (SqliteDb, sync PostgresDb) would hold the event loop for the
+        # whole query, so it runs on a worker thread.
+        return await asyncio.to_thread(fn, *args, **kwargs)
 
     @staticmethod
     def _to_schedule(data: Any) -> Optional[Schedule]:

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -556,9 +556,8 @@ def to_dict(team: "Team") -> Dict[str, Any]:
                         func_dict["toolkit"] = tool.owning_toolkit
                     serialized_tools.append(func_dict)
                 elif isinstance(tool, Toolkit):
-                    # get_functions() rather than .functions: subclasses may
-                    # expose a subset, and the team runtime only ever calls
-                    # what get_functions() returns.
+                    # get_functions() is the exposed subset -- the only functions
+                    # the team runtime ever calls.
                     for func in tool.get_functions().values():
                         func_dict = func.to_dict()
                         # Record the owning toolkit so rehydration can re-bind

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -106,8 +106,7 @@ class StudioTools(Toolkit):
             enable_schedule, disable_schedule, delete_schedule). Defaults to
             False. Requires the optional scheduler dependencies (croniter and
             pytz -- ``pip install agno[scheduler]``); when they are missing,
-            the first schedule tool call that needs them returns an error JSON
-            instead of raising at import time.
+            the first schedule tool call that needs them returns an error JSON.
     """
 
     def __init__(
@@ -205,7 +204,7 @@ class StudioTools(Toolkit):
                 ]
             )
 
-        # Schedules target existing components of any enabled type; opt-in.
+        # Schedules target an existing component by id; opt-in.
         if self._scheduler_tools is not None:
             tools.extend(
                 [

--- a/libs/agno/tests/unit/scheduler/test_cron.py
+++ b/libs/agno/tests/unit/scheduler/test_cron.py
@@ -60,23 +60,28 @@ class TestValidateTimezone:
 
 
 class TestComputeNextRun:
+    # compute_next_run reads the clock itself to apply its monotonicity guard.
+    # Sampling time before the call keeps the comparison true across a second
+    # boundary landing mid-call; sampling after makes the bound one too high.
     def test_returns_future_time(self):
+        before = int(time.time())
         result = compute_next_run("* * * * *")
-        assert result > int(time.time())
+        assert result > before
 
     def test_monotonicity_guard(self):
         # Even if we provide an after_epoch in the distant past, the result
         # should still be >= now + 1
-        result = compute_next_run("* * * * *", after_epoch=0)
         minimum = int(time.time()) + 1
+        result = compute_next_run("* * * * *", after_epoch=0)
         assert result >= minimum
 
     def test_respects_timezone(self):
         # Both should return valid future timestamps
+        before = int(time.time())
         utc_result = compute_next_run("0 12 * * *", "UTC")
         ny_result = compute_next_run("0 12 * * *", "America/New_York")
-        assert utc_result > int(time.time())
-        assert ny_result > int(time.time())
+        assert utc_result > before
+        assert ny_result > before
         # They should differ (different timezones, different absolute times)
         # But edge cases exist, so we just check they're both valid
         assert isinstance(utc_result, int)

--- a/libs/agno/tests/unit/tools/test_scheduler.py
+++ b/libs/agno/tests/unit/tools/test_scheduler.py
@@ -1,6 +1,9 @@
 """Unit tests for SchedulerTools toolkit."""
 
+import asyncio
 import json
+import threading
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -481,3 +484,61 @@ class TestAsyncTriggerSchedule:
         assert "error" in result
         assert "disabled" in result["error"]
         tools.manager.aupdate.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestAsyncDbCallsRunOffThread:
+    """A sync DB adapter must not run on the event loop thread."""
+
+    async def test_sync_adapter_runs_on_worker_thread(self):
+        from agno.scheduler.manager import ScheduleManager
+
+        loop_thread = threading.get_ident()
+        seen = {}
+
+        db = MagicMock()
+
+        def get_schedules(**kwargs):
+            seen["thread"] = threading.get_ident()
+            return []
+
+        db.get_schedules = get_schedules
+        manager = ScheduleManager(db=db)
+
+        await manager._acall("get_schedules")
+
+        assert seen["thread"] != loop_thread
+
+    async def test_async_adapter_is_awaited_directly(self):
+        from agno.scheduler.manager import ScheduleManager
+
+        db = MagicMock()
+        db.get_schedules = AsyncMock(return_value=[])
+        manager = ScheduleManager(db=db)
+
+        assert await manager._acall("get_schedules") == []
+        db.get_schedules.assert_awaited_once()
+
+    async def test_sync_adapter_does_not_stall_the_loop(self):
+        from agno.scheduler.manager import ScheduleManager
+
+        db = MagicMock()
+        db.get_schedules = lambda **kwargs: (time.sleep(0.3), [])[1]
+        manager = ScheduleManager(db=db)
+
+        gaps = []
+
+        async def heartbeat():
+            last = time.perf_counter()
+            while True:
+                await asyncio.sleep(0.005)
+                now = time.perf_counter()
+                gaps.append(now - last)
+                last = now
+
+        beat = asyncio.create_task(heartbeat())
+        await manager._acall("get_schedules")
+        beat.cancel()
+
+        assert gaps, "the heartbeat never ran: the loop was blocked for the whole query"
+        assert max(gaps) < 0.2


### PR DESCRIPTION
## Summary

Two 2.8.7 follow-ups found while reviewing the release set. Neither blocks the tag; both are worth landing before it.

**`ScheduleManager._acall` ran sync DB adapters on the event loop.** It awaited a coroutine adapter but called a sync one inline, so every schedule query against `SqliteDb` or a sync `PostgresDb` held the loop for the duration of the query. Measured with a 0.5s query and a 5ms heartbeat task: one `alist_schedules` produced a 0.509s loop gap. The sync twin `_call` already bridges the opposite direction through a thread pool, so this was an oversight rather than a design choice; `_acall` now uses `asyncio.to_thread`.

This has been reachable through `SchedulerTools` since it shipped — `_acall` is byte-identical at `2e7739979`. #9352 widened it: `StudioTools`' async schedule tools previously went through `_run_sync_tool` (`asyncio.to_thread`) and now reach `_acall` directly, so the whole async schedule surface was blocking. One fix covers both.

**Six comments described something other than the final state.** The `fs/toolkit.py` one was also inaccurate: it claimed distinct toolkit names let two file toolkits "coexist in a registry without colliding". Verified against merged `main` with #9358 in — a qualified config (2.8.7+) rebinds correctly to both toolkits, but a pre-2.8.7 config still binds last-wins, and `Registry` still logs a collision warning per shared function name telling you to give them distinct names when they already are. The comment now states what the registry actually does.

The others: `agent/_storage.py` asserted a Function's dict key and `Function.name` can differ (no path in the repo produces that); `studio.py` described error-JSON as chosen "instead of raising at import time" and claimed schedules target "any enabled type" when `_resolve_schedule_target` never reads the enable flags; `registry.py` and `team/_storage.py` explained `get_functions()` by what it is not.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Testing

- `tests/unit/tools/test_scheduler.py`: 47 passed (44 baseline + 3 new)
- Sweep across every touched area — `test_scheduler.py`, `test_studio.py`, `tests/unit/scheduler`, `tests/unit/registry`, `tests/unit/fs`, `test_agent_config.py`, `test_team_config.py`, `tests/unit/run`: **1018 passed**
- The three new tests fail on `main` without the fix (two by assertion, one because the heartbeat never runs at all) and pass with it, so they are not vacuous
- `ruff check` / `ruff format --check` clean; `mypy` clean on all six touched modules

## Additional Notes

Known and deliberately not fixed here, for separate PRs:

- `StudioTools._normalize_tool_names` maps function names to toolkits with a last-registration-wins dict and never reads the `owning_toolkit` field #9358 added, so `get_agent` can misreport which toolkit an agent uses and the documented `get_agent` → `edit_agent` echo loop can rewrite the persisted config to the wrong store. Pre-existing, but it is the last gap around #9358 and should be the next follow-up.
- `trigger_schedule` reports `{"status": "triggered"}` without checking that `manager.update` landed, and a nudge arriving while a run is in flight is overwritten by the executor's `finally`.
- `next_run_at` is absent from `list_schedules` and `get_schedule`, so a trigger is unobservable.
- `schedules=True` has no cookbook coverage, unlike its sibling `versions=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)