### PR TITLE
[fix] Keep each concurrent delegation's own child_run_id (#9359)

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -547,17 +547,32 @@ def _get_delegate_task_function(
         member_agent: Union[Agent, "Team"],
         member_agent_task: Union[str, Message],
         member_session_state_copy: Dict[str, Any],
+        delegation_tool_args: Optional[Dict[str, Any]] = None,
     ):
         # Add team run id to the member run
 
         if member_agent_run_response is not None:
             member_agent_run_response.parent_run_id = run_response.run_id  # type: ignore
 
-        # Update the top-level team run_response tool call to have the run_id of the member run
-        if run_response.tools is not None and member_agent_run_response is not None:
+        # Update the top-level team run_response tool call to have the run_id of the member run.
+        # A single model turn can issue several delegate_task_to_member calls that then run
+        # concurrently, so match the arguments this delegation was called with and skip entries
+        # another delegation already linked, otherwise the last one to finish would overwrite
+        # the child_run_id of every other delegation in the turn.
+        if (
+            run_response.tools is not None
+            and member_agent_run_response is not None
+            and delegation_tool_args is not None
+        ):
             for tool in run_response.tools:
-                if tool.tool_name and tool.tool_name.lower() == "delegate_task_to_member":
+                if (
+                    tool.tool_name
+                    and tool.tool_name.lower() == "delegate_task_to_member"
+                    and tool.child_run_id is None
+                    and tool.tool_args == delegation_tool_args
+                ):
                     tool.child_run_id = member_agent_run_response.run_id  # type: ignore
+                    break
 
         # Update the team run context
         member_name = member_agent.name if member_agent.name else member_agent.id if member_agent.id else "Unknown"
@@ -724,6 +739,7 @@ def _get_delegate_task_function(
                 member_agent,
                 member_agent_task,  # type: ignore
                 member_session_state_copy,  # type: ignore
+                delegation_tool_args={"member_id": member_id, "task": task},
             )
             raise
 
@@ -736,6 +752,7 @@ def _get_delegate_task_function(
                 member_agent,
                 member_agent_task,  # type: ignore
                 member_session_state_copy,  # type: ignore
+                delegation_tool_args={"member_id": member_id, "task": task},
             )
             yield f"Member '{member_agent.name}' requires human input before continuing."
             return
@@ -776,6 +793,7 @@ def _get_delegate_task_function(
             member_agent,
             member_agent_task,  # type: ignore
             member_session_state_copy,  # type: ignore
+            delegation_tool_args={"member_id": member_id, "task": task},
         )
 
     async def adelegate_task_to_member(
@@ -910,6 +928,7 @@ def _get_delegate_task_function(
                 member_agent,
                 member_agent_task,  # type: ignore
                 member_session_state_copy,  # type: ignore
+                delegation_tool_args={"member_id": member_id, "task": task},
             )
             raise
 
@@ -922,6 +941,7 @@ def _get_delegate_task_function(
                 member_agent,
                 member_agent_task,  # type: ignore
                 member_session_state_copy,  # type: ignore
+                delegation_tool_args={"member_id": member_id, "task": task},
             )
             yield f"Member '{member_agent.name}' requires human input before continuing."
             return
@@ -959,6 +979,7 @@ def _get_delegate_task_function(
             member_agent,
             member_agent_task,  # type: ignore
             member_session_state_copy,  # type: ignore
+            delegation_tool_args={"member_id": member_id, "task": task},
         )
 
     # When the task should be delegated to all members

--- a/libs/agno/tests/unit/team/test_delegate_child_run_id.py
+++ b/libs/agno/tests/unit/team/test_delegate_child_run_id.py
@@ -1,0 +1,94 @@
+"""Regression tests for child_run_id linking on concurrent member delegations.
+
+A single model turn can emit several ``delegate_task_to_member`` tool calls, which the
+team then runs concurrently. Each tool execution recorded on the team run must keep the
+run id of the member it delegated to, rather than the run id of whichever member
+happened to finish last.
+"""
+
+import asyncio
+from typing import List
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.models.response import ToolExecution
+from agno.run.agent import RunOutput
+from agno.run.base import RunContext
+from agno.run.team import TeamRunOutput
+from agno.session.team import TeamSession
+from agno.team._default_tools import _get_delegate_task_function
+from agno.team.team import Team
+
+
+def _member(index: int, delay: float) -> Agent:
+    """A member whose run takes ``delay`` seconds and returns a distinct run id."""
+    member = Agent(name=f"Worker{index}", id=f"worker-{index}")
+
+    async def fake_arun(*args, **kwargs):
+        await asyncio.sleep(delay)
+        return RunOutput(
+            run_id=f"member-run-{index}",
+            agent_id=f"worker-{index}",
+            agent_name=f"Worker{index}",
+            content=f"Response from Worker{index}",
+        )
+
+    member.arun = fake_arun  # type: ignore[method-assign]
+    return member
+
+
+def _delegation_tools(count: int) -> List[ToolExecution]:
+    return [
+        ToolExecution(
+            tool_call_id=f"call_{index}",
+            tool_name="delegate_task_to_member",
+            tool_args={"member_id": f"worker-{index}", "task": f"task {index}"},
+        )
+        for index in range(1, count + 1)
+    ]
+
+
+async def _run_delegations(team: Team, run_response: TeamRunOutput) -> None:
+    delegate_function = _get_delegate_task_function(
+        team=team,
+        run_response=run_response,
+        run_context=RunContext(run_id="team-run-1", session_id="session-1", session_state={}),
+        session=TeamSession(session_id="session-1", team_id="team-1"),
+        team_run_context={},
+        async_mode=True,
+    )
+
+    async def delegate(tool: ToolExecution) -> None:
+        async for _ in delegate_function.entrypoint(**tool.tool_args):  # type: ignore[misc]
+            pass
+
+    await asyncio.gather(*(delegate(tool) for tool in run_response.tools or []))
+
+
+@pytest.mark.asyncio
+async def test_concurrent_delegations_keep_their_own_child_run_id():
+    """The slowest member must not overwrite the child_run_id of the other delegations."""
+    # Worker1 finishes last, so under the previous name-only match it won every entry.
+    members = [_member(1, 0.05), _member(2, 0.0)]
+    team = Team(name="Test Team", id="team-1", members=members)
+    run_response = TeamRunOutput(
+        run_id="team-run-1", team_id="team-1", session_id="session-1", tools=_delegation_tools(2)
+    )
+
+    await _run_delegations(team, run_response)
+
+    assert [tool.child_run_id for tool in run_response.tools] == ["member-run-1", "member-run-2"]
+
+
+@pytest.mark.asyncio
+async def test_single_delegation_still_links_its_child_run_id():
+    """The common case of one delegation per turn is unchanged."""
+    team = Team(name="Test Team", id="team-1", members=[_member(1, 0.0)])
+    run_response = TeamRunOutput(
+        run_id="team-run-1", team_id="team-1", session_id="session-1", tools=_delegation_tools(1)
+    )
+
+    await _run_delegations(team, run_response)
+
+    assert run_response.tools[0].child_run_id == "member-run-1"


### PR DESCRIPTION
## Summary

Fixes #9359.

When the model emits several `delegate_task_to_member` tool calls in one turn, the team runs
them concurrently through `asyncio.gather`. `_process_delegate_task_to_member` then walked
`run_response.tools` and matched entries on `tool_name` alone:

```python
for tool in run_response.tools:
    if tool.tool_name and tool.tool_name.lower() == "delegate_task_to_member":
        tool.child_run_id = member_agent_run_response.run_id
```

So every finishing delegation stamped its own run id onto *all* delegation entries of the
turn, and whichever member finished last won. Parent-child linking then pointed at the wrong
member run — silently, with no error and a well-formed-looking run output.

The fix passes the arguments the delegation was invoked with down to
`_process_delegate_task_to_member` and matches on them, skipping entries another delegation
has already linked:

```python
if (
    tool.tool_name
    and tool.tool_name.lower() == "delegate_task_to_member"
    and tool.child_run_id is None
    and tool.tool_args == delegation_tool_args
):
    tool.child_run_id = member_agent_run_response.run_id
    break
```

`tool_args` is the raw argument dict the model sent (`models/base.py` sets
`tool_args=function_call.arguments`), so it is exactly `{"member_id": ..., "task": ...}` for
this tool and identifies the tool call uniquely.

Scope notes:

- Only the singular `delegate_task_to_member` / `adelegate_task_to_member` paths pass
  `delegation_tool_args` (6 call sites). The `delegate_task_to_members` path leaves it at
  `None`; its tool is registered under a different name (`delegate_task_to_members`), so it
  never matched this loop in the first place and its behaviour is unchanged.
- Single-delegation turns behave exactly as before.

### Verification

Reproduced on `2.8.7` with two members where the *first* one is the slower, so it finishes
last:

```
before:  call_1 -> member-run-1 ,  call_2 -> member-run-1   # overwritten
after :  call_1 -> member-run-1 ,  call_2 -> member-run-2
```

Added `libs/agno/tests/unit/team/test_delegate_child_run_id.py` (two tests: concurrent
delegations keep their own ids; the single-delegation case is unchanged). The first test
fails on `main` and passes with this change.

Full `libs/agno/tests/unit/team` suite: **539 passed** before, **541 passed** after (the two
new tests); the same 6 pre-existing failures on both runs (`test_acontinue_run_background_stream`
x2, `test_remote_team` x2, `test_team_checkpointing`, `test_team_skills` — all unrelated,
environment/path-dependent).

`ruff 0.15.20` check + format clean on both files; `mypy 2.1.0` reports nothing new.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (ruff 0.15.20 check + format, mypy 2.1.0)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

AI-assisted (Claude Code), human reviewed. The reproduction, the full unit-suite before/after
runs, and the lint/type checks above were executed locally against `agno 2.8.7`, whose
`_default_tools.py` is byte-identical to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
