### PR TITLE
[fix] pair unpaired tool calls with placeholder results across Chat Completions, Claude, and Gemini formatters

### DIFF
--- a/libs/agno/agno/models/google/gemini_interactions.py
+++ b/libs/agno/agno/models/google/gemini_interactions.py
@@ -363,6 +363,17 @@ class GeminiInteractions(Model):
         - VideoContentParam: {"type": "video", "data": base64, "mime_type": "video/mp4"}
         - DocumentContentParam: {"type": "document", "data": base64, "mime_type": "application/pdf"}
         """
+        from agno.utils.message import (
+            MISSING_TOOL_RESULT_PLACEHOLDER,
+            collect_recorded_tool_call_ids,
+        )
+
+        # Gemini requires every function_call step to be paired with a function_result
+        # step carrying the same call id. Sessions can hold runs whose tool result was
+        # never recorded, so collect the call_ids that have a formattable result and pair
+        # any unpaired function_call with a placeholder function_result at format time.
+        recorded_call_ids = collect_recorded_tool_call_ids(messages)
+
         steps: List[Dict[str, Any]] = []
 
         for message in messages:
@@ -422,14 +433,24 @@ class GeminiInteractions(Model):
                                 args = json.loads(args)
                             except json.JSONDecodeError:
                                 args = {}
+                        call_id = tool_call.get("id", str(uuid4()))
                         steps.append(
                             {
                                 "type": "function_call",
-                                "id": tool_call.get("id", str(uuid4())),
+                                "id": call_id,
                                 "name": func.get("name", ""),
                                 "arguments": args,
                             }
                         )
+                        if call_id not in recorded_call_ids:
+                            steps.append(
+                                {
+                                    "type": "function_result",
+                                    "call_id": call_id,
+                                    "name": func.get("name", ""),
+                                    "result": MISSING_TOOL_RESULT_PLACEHOLDER,
+                                }
+                            )
 
             # Tool result messages become FunctionResultSteps
             elif message.role == "tool" and message.tool_call_id:

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -381,12 +381,49 @@ class OpenAIChat(Model):
         self, messages: List[Message], compress_tool_results: bool = False
     ) -> List[Dict[str, Any]]:
         """Format all messages, remapping foreign tool call IDs to call_ prefix first."""
-        from agno.utils.message import normalize_tool_messages, reformat_tool_call_ids
+        from agno.utils.message import (
+            MISSING_TOOL_RESULT_PLACEHOLDER,
+            collect_recorded_tool_call_ids,
+            normalize_tool_messages,
+            reformat_tool_call_ids,
+        )
 
         # Backwards compat: expand old Gemini combined tool messages into individual canonical messages
         messages = normalize_tool_messages(messages)
         normalized = reformat_tool_call_ids(messages, provider="openai_chat")
-        return [self._format_message(m, compress_tool_results) for m in normalized]
+
+        # Chat Completions rejects an assistant message whose tool_calls are not followed by
+        # a tool message responding to each tool_call_id. Sessions can hold runs whose tool
+        # result was never recorded, so collect the call_ids that have a formattable result
+        # and pair any unpaired call with a placeholder result at format time.
+        recorded_call_ids = collect_recorded_tool_call_ids(normalized)
+
+        formatted_messages: List[Dict[str, Any]] = []
+        repaired_call_ids: List[str] = []
+        for message in normalized:
+            formatted_messages.append(self._format_message(message, compress_tool_results))
+            if message.role == "assistant" and message.tool_calls:
+                unpaired_call_ids: List[str] = []
+                for tool_call in message.tool_calls:
+                    call_id = tool_call.get("id")
+                    if call_id is not None and call_id not in recorded_call_ids:
+                        unpaired_call_ids.append(call_id)
+                for call_id in unpaired_call_ids:
+                    formatted_messages.append(
+                        {
+                            "role": self.role_map["tool"] if self.role_map else self.default_role_map["tool"],
+                            "tool_call_id": call_id,
+                            "content": MISSING_TOOL_RESULT_PLACEHOLDER,
+                        }
+                    )
+                    repaired_call_ids.append(call_id)
+
+        if repaired_call_ids:
+            log_warning(
+                f"No tool result was recorded for tool call(s) {repaired_call_ids}; "
+                "placeholder results were inserted to keep the request valid."
+            )
+        return formatted_messages
 
     def invoke(
         self,

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -382,12 +382,49 @@ class OpenAIChat(Model):
         self, messages: List[Message], compress_tool_results: bool = False
     ) -> List[Dict[str, Any]]:
         """Format all messages, remapping foreign tool call IDs to call_ prefix first."""
-        from agno.utils.message import normalize_tool_messages, reformat_tool_call_ids
+        from agno.utils.message import (
+            MISSING_TOOL_RESULT_PLACEHOLDER,
+            collect_recorded_tool_call_ids,
+            normalize_tool_messages,
+            reformat_tool_call_ids,
+        )
 
         # Backwards compat: expand old Gemini combined tool messages into individual canonical messages
         messages = normalize_tool_messages(messages)
         normalized = reformat_tool_call_ids(messages, provider="openai_chat")
-        return [self._format_message(m, compress_tool_results) for m in normalized]
+
+        # Chat Completions rejects an assistant message whose tool_calls are not followed by
+        # a tool message responding to each tool_call_id. Sessions can hold runs whose tool
+        # result was never recorded, so collect the call_ids that have a formattable result
+        # and pair any unpaired call with a placeholder result at format time.
+        recorded_call_ids = collect_recorded_tool_call_ids(normalized)
+
+        formatted_messages: List[Dict[str, Any]] = []
+        repaired_call_ids: List[str] = []
+        for message in normalized:
+            formatted_messages.append(self._format_message(message, compress_tool_results))
+            if message.role == "assistant" and message.tool_calls:
+                unpaired_call_ids: List[str] = []
+                for tool_call in message.tool_calls:
+                    call_id = tool_call.get("id")
+                    if call_id is not None and call_id not in recorded_call_ids:
+                        unpaired_call_ids.append(call_id)
+                for call_id in unpaired_call_ids:
+                    formatted_messages.append(
+                        {
+                            "role": self.role_map["tool"] if self.role_map else self.default_role_map["tool"],
+                            "tool_call_id": call_id,
+                            "content": MISSING_TOOL_RESULT_PLACEHOLDER,
+                        }
+                    )
+                    repaired_call_ids.append(call_id)
+
+        if repaired_call_ids:
+            log_warning(
+                f"No tool result was recorded for tool call(s) {repaired_call_ids}; "
+                "placeholder results were inserted to keep the request valid."
+            )
+        return formatted_messages
 
     def invoke(
         self,

--- a/libs/agno/agno/utils/message.py
+++ b/libs/agno/agno/utils/message.py
@@ -1,10 +1,29 @@
 from copy import deepcopy
-from typing import Dict, List, Optional, Sequence, Union
+from typing import Dict, List, Optional, Sequence, Set, Union
 
 from pydantic import BaseModel
 
 from agno.models.message import Message
 from agno.utils.log import log_debug
+
+# Placeholder result paired at format time with a tool call whose result was never
+# recorded, keeping the request valid while telling the model the call did not complete.
+MISSING_TOOL_RESULT_PLACEHOLDER = (
+    "Error: no result was recorded for this tool call (the run may have been interrupted)."
+)
+
+
+def collect_recorded_tool_call_ids(messages: Sequence[Message]) -> Set[str]:
+    """Return the tool_call_ids that have a recorded tool result.
+
+    A tool message counts as recorded when it carries a tool_call_id; formatters
+    always emit a result for such messages (even an empty one), so any tool message
+    present in the transcript answers its call. Formatters use this to detect
+    assistant tool calls whose result was never recorded (e.g. an interrupted run)
+    and pair them with a placeholder result at format time, because providers
+    reject requests that carry an unpaired tool call.
+    """
+    return {m.tool_call_id for m in messages if m.role == "tool" and m.tool_call_id}
 
 
 def safe_truncation_index(messages: Sequence[Message], requested_index: int) -> int:

--- a/libs/agno/agno/utils/message.py
+++ b/libs/agno/agno/utils/message.py
@@ -1,10 +1,29 @@
 from copy import deepcopy
-from typing import Dict, List, Optional, Sequence, Union
+from typing import Dict, List, Optional, Sequence, Set, Union
 
 from pydantic import BaseModel
 
 from agno.models.message import Message
 from agno.utils.log import log_debug
+
+# Placeholder result paired at format time with a tool call whose result was never
+# recorded, keeping the request valid while telling the model the call did not complete.
+MISSING_TOOL_RESULT_PLACEHOLDER = (
+    "Error: no result was recorded for this tool call (the run may have been interrupted)."
+)
+
+
+def collect_recorded_tool_call_ids(messages: Sequence[Message]) -> Set[str]:
+    """Return the tool_call_ids that have a recorded tool result.
+
+    A tool message counts as recorded when it carries a tool_call_id; formatters
+    always emit a result for such messages (even an empty one), so any tool message
+    present in the transcript answers its call. Formatters use this to detect
+    assistant tool calls whose result was never recorded (e.g. an interrupted run)
+    and pair them with a placeholder result at format time, because providers
+    reject requests that carry an unpaired tool call.
+    """
+    return {m.tool_call_id for m in messages if m.role == "tool" and m.tool_call_id}
 
 
 def copy_history_message(msg: Message) -> Message:

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -469,10 +469,21 @@ def format_messages(
     Returns:
         Tuple[List[Dict[str, Union[str, list]]], str]: A tuple containing the list of API messages and the concatenated system messages.
     """
-    from agno.utils.message import normalize_tool_messages
+    from agno.utils.message import (
+        MISSING_TOOL_RESULT_PLACEHOLDER,
+        collect_recorded_tool_call_ids,
+        normalize_tool_messages,
+    )
+
 
     # Backwards compat: expand old Gemini combined tool messages into individual canonical messages
     messages = normalize_tool_messages(messages)
+
+    # Anthropic rejects a tool_use block that has no corresponding tool_result block.
+    # Sessions can hold runs whose tool result was never recorded, so collect the call_ids
+    # that have a formattable result and pair any unpaired tool_use with a placeholder
+    # tool_result at format time.
+    recorded_call_ids = collect_recorded_tool_call_ids(messages)
 
     chat_messages: List[Dict[str, Union[str, list]]] = []
     system_messages: List[str] = []
@@ -559,6 +570,7 @@ def format_messages(
             elif isinstance(message.content, str) and message.content and len(message.content.strip()) > 0:
                 content.append(TextBlock(text=message.content, type="text"))
 
+            unpaired_tool_use_ids: List[str] = []
             if message.tool_calls:
                 for tool_call in message.tool_calls:
                     content.append(
@@ -571,6 +583,8 @@ def format_messages(
                             type="tool_use",
                         )
                     )
+                    if tool_call["id"] not in recorded_call_ids:
+                        unpaired_tool_use_ids.append(tool_call["id"])
         elif message.role == "tool":
             content = []
 
@@ -603,6 +617,24 @@ def format_messages(
             continue
 
         chat_messages.append({"role": ROLE_MAP[message.role], "content": content})  # type: ignore
+
+        # Tool use blocks whose result was never recorded get a placeholder tool_result,
+        # appended as their own user message so the request stays valid. The merge step
+        # below folds it into a following tool result message when one exists.
+        if message.role == "assistant" and unpaired_tool_use_ids:
+            chat_messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": call_id,
+                            "content": MISSING_TOOL_RESULT_PLACEHOLDER,
+                        }
+                        for call_id in unpaired_tool_use_ids
+                    ],
+                }
+            )
 
     # Merge consecutive messages with the same role (Claude requires alternating user/assistant roles).
     # This happens when multiple tool results (mapped to "user") appear in sequence, or when a tool

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -552,10 +552,20 @@ def format_messages(
     Returns:
         Tuple[List[Dict[str, Union[str, list]]], str]: A tuple containing the list of API messages and the concatenated system messages.
     """
-    from agno.utils.message import normalize_tool_messages
+    from agno.utils.message import (
+        MISSING_TOOL_RESULT_PLACEHOLDER,
+        collect_recorded_tool_call_ids,
+        normalize_tool_messages,
+    )
 
     # Backwards compat: expand old Gemini combined tool messages into individual canonical messages
     messages = normalize_tool_messages(messages)
+
+    # Anthropic rejects a tool_use block that has no corresponding tool_result block.
+    # Sessions can hold runs whose tool result was never recorded, so collect the call_ids
+    # that have a formattable result and pair any unpaired tool_use with a placeholder
+    # tool_result at format time.
+    recorded_call_ids = collect_recorded_tool_call_ids(messages)
 
     chat_messages: List[Dict[str, Union[str, list]]] = []
     system_messages: List[str] = []
@@ -664,6 +674,7 @@ def format_messages(
                 elif isinstance(message.content, str) and message.content and len(message.content.strip()) > 0:
                     content.append(TextBlock(text=message.content, type="text"))
 
+                unpaired_tool_use_ids: List[str] = []
                 if message.tool_calls:
                     for tool_call in message.tool_calls:
                         content.append(
@@ -676,6 +687,8 @@ def format_messages(
                                 type="tool_use",
                             )
                         )
+                        if tool_call["id"] not in recorded_call_ids:
+                            unpaired_tool_use_ids.append(tool_call["id"])
         elif message.role == "tool":
             content = []
 
@@ -708,6 +721,24 @@ def format_messages(
             continue
 
         chat_messages.append({"role": ROLE_MAP[message.role], "content": content})  # type: ignore
+
+        # Tool use blocks whose result was never recorded get a placeholder tool_result,
+        # appended as their own user message so the request stays valid. The merge step
+        # below folds it into a following tool result message when one exists.
+        if message.role == "assistant" and unpaired_tool_use_ids:
+            chat_messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": call_id,
+                            "content": MISSING_TOOL_RESULT_PLACEHOLDER,
+                        }
+                        for call_id in unpaired_tool_use_ids
+                    ],
+                }
+            )
 
     # Merge consecutive messages with the same role (Claude requires alternating user/assistant roles).
     # This happens when multiple tool results (mapped to "user") appear in sequence, or when a tool

--- a/libs/agno/tests/unit/models/google/test_gemini_interactions.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_interactions.py
@@ -166,11 +166,15 @@ class TestBuildInput:
             )
         ]
         steps = model._build_input(messages)
-        assert len(steps) == 1
+        # A function_call with no recorded result is paired with a placeholder
+        # function_result so the request stays valid.
+        assert len(steps) == 2
         assert steps[0]["type"] == "function_call"
         assert steps[0]["id"] == "call_123"
         assert steps[0]["name"] == "get_weather"
         assert steps[0]["arguments"] == {"city": "Paris"}
+        assert steps[1]["type"] == "function_result"
+        assert steps[1]["call_id"] == "call_123"
 
     def test_tool_result_message(self):
         model = self._make_model()

--- a/libs/agno/tests/unit/models/google/test_gemini_interactions_unpaired_tool_calls.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_interactions_unpaired_tool_calls.py
@@ -1,0 +1,108 @@
+"""Unpaired function_call steps must be paired with a placeholder function_result.
+
+Gemini's Interactions API expects every ``function_call`` step to be followed by a
+``function_result`` step carrying the same call id. Sessions can hold runs whose tool
+result was never recorded (e.g. a run that was interrupted mid-tool-execution).
+Formatting pairs such calls with a placeholder function_result so the session stays
+usable and the model can see the call never completed.
+"""
+
+import pytest
+
+pytest.importorskip("google.genai")
+
+from typing import Any, Dict, List
+
+from agno.models.google.gemini_interactions import GeminiInteractions
+from agno.models.message import Message
+from agno.utils.message import MISSING_TOOL_RESULT_PLACEHOLDER
+
+# Shape observed in affected sessions: uuid id, no call_id.
+DELEGATE_CALL_ID = "d4f8a1b2-3c5e-4a91-b7d2-8e6f0a1c2b3d"
+
+
+def _delegate_tool_call(call_id: str = DELEGATE_CALL_ID) -> Dict[str, Any]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": "delegate_task_to_member",
+            "arguments": '{"member_id": "researcher", "task": "Research X"}',
+        },
+    }
+
+
+def _steps_of_type(steps: List[Dict[str, Any]], step_type: str) -> List[Dict[str, Any]]:
+    return [s for s in steps if s.get("type") == step_type]
+
+
+class TestUnpairedToolCalls:
+    def _make_model(self):
+        return GeminiInteractions(api_key="test-key")
+
+    def test_complete_turn_is_preserved(self):
+        """A call with its result must still be sent — both halves, correctly paired."""
+        model = self._make_model()
+
+        steps = model._build_input(
+            messages=[
+                Message(role="user", content="Research X"),
+                Message(role="assistant", content="", tool_calls=[_delegate_tool_call()]),
+                Message(
+                    role="tool",
+                    tool_call_id=DELEGATE_CALL_ID,
+                    tool_name="delegate_task_to_member",
+                    content="Researcher: findings for X",
+                ),
+            ]
+        )
+
+        calls = _steps_of_type(steps, "function_call")
+        results = _steps_of_type(steps, "function_result")
+        assert len(calls) == 1
+        assert len(results) == 1
+        assert results[0]["call_id"] == DELEGATE_CALL_ID
+        assert results[0]["result"] == "Researcher: findings for X"
+
+    def test_call_with_no_recorded_result_gets_placeholder(self):
+        """The reported bug: a run persisted with a tool call and no tool message."""
+        model = self._make_model()
+
+        steps = model._build_input(
+            messages=[
+                Message(role="user", content="Research X"),
+                Message(role="assistant", content="", tool_calls=[_delegate_tool_call()]),
+                # No tool message was ever recorded for the call above.
+                Message(role="assistant", content="Here are the findings."),
+            ]
+        )
+
+        calls = _steps_of_type(steps, "function_call")
+        results = _steps_of_type(steps, "function_result")
+        assert len(calls) == 1, "the call must still be sent"
+        assert len(results) == 1
+        assert results[0]["call_id"] == calls[0]["id"]
+        assert results[0]["result"] == MISSING_TOOL_RESULT_PLACEHOLDER
+
+    def test_mixed_turn_pairs_real_and_placeholder_results(self):
+        """A mixed turn: one recorded result and one missing result both stay valid."""
+        model = self._make_model()
+        paired_id = "call_paired"
+        unpaired_id = "call_unpaired"
+
+        steps = model._build_input(
+            messages=[
+                Message(role="user", content="Do both tasks"),
+                Message(
+                    role="assistant",
+                    content="",
+                    tool_calls=[_delegate_tool_call(paired_id), _delegate_tool_call(unpaired_id)],
+                ),
+                Message(role="tool", tool_call_id=paired_id, tool_name="delegate_task_to_member", content="Paired result"),
+            ]
+        )
+
+        results = _steps_of_type(steps, "function_result")
+        by_call_id = {r["call_id"]: r for r in results}
+        assert by_call_id[paired_id]["result"] == "Paired result"
+        assert by_call_id[unpaired_id]["result"] == MISSING_TOOL_RESULT_PLACEHOLDER

--- a/libs/agno/tests/unit/models/openai/test_openai_chat_unpaired_tool_calls.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_chat_unpaired_tool_calls.py
@@ -1,0 +1,149 @@
+"""Unpaired tool calls must be paired with a placeholder tool message at format time.
+
+Chat Completions rejects an assistant message whose ``tool_calls`` are not followed by
+tool messages responding to each ``tool_call_id``:
+
+    An assistant message with 'tool_calls' must be followed by tool messages
+    responding to each tool_call_id.
+
+Sessions can hold runs whose tool result was never recorded (e.g. a run that was
+interrupted mid-tool-execution). Formatting pairs such calls with a placeholder tool
+message so the session stays usable and the model can see the call never completed.
+"""
+
+from typing import Any, Dict, List
+
+from agno.models.message import Message
+from agno.models.openai.chat import OpenAIChat
+from agno.utils.message import MISSING_TOOL_RESULT_PLACEHOLDER
+
+# Shape observed in affected sessions: uuid id, no call_id.
+DELEGATE_CALL_ID = "d4f8a1b2-3c5e-4a91-b7d2-8e6f0a1c2b3d"
+
+
+def _delegate_tool_call(call_id: str = DELEGATE_CALL_ID) -> Dict[str, Any]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": "delegate_task_to_member",
+            "arguments": '{"member_id": "researcher", "task": "Research X"}',
+        },
+    }
+
+
+def _placeholder_messages(formatted: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [m for m in formatted if m.get("content") == MISSING_TOOL_RESULT_PLACEHOLDER]
+
+
+class TestUnpairedToolCalls:
+    def test_complete_turn_is_preserved(self):
+        """A call with its result must still be sent — both halves, correctly paired."""
+        model = OpenAIChat(id="gpt-4o-mini")
+
+        formatted = model._format_all_messages(
+            messages=[
+                Message(role="user", content="Research X"),
+                Message(role="assistant", content="", tool_calls=[_delegate_tool_call()]),
+                Message(
+                    role="tool",
+                    tool_call_id=DELEGATE_CALL_ID,
+                    tool_name="delegate_task_to_member",
+                    content="Researcher: findings for X",
+                ),
+                Message(role="assistant", content="Here are the findings."),
+            ]
+        )
+
+        assistant_with_calls = [m for m in formatted if m.get("tool_calls")]
+        tool_messages = [m for m in formatted if m.get("role") == "tool"]
+        assert len(assistant_with_calls) == 1
+        assert len(tool_messages) == 1
+        # IDs are reformatted to the call_ prefix; the tool message must answer the emitted call.
+        emitted_id = assistant_with_calls[0]["tool_calls"][0]["id"]
+        assert tool_messages[0]["tool_call_id"] == emitted_id
+        assert tool_messages[0]["content"] == "Researcher: findings for X"
+        assert _placeholder_messages(formatted) == []
+
+    def test_call_with_no_recorded_result_gets_placeholder(self):
+        """The reported bug: a run persisted with a tool call and no tool message."""
+        model = OpenAIChat(id="gpt-4o-mini")
+
+        formatted = model._format_all_messages(
+            messages=[
+                Message(role="user", content="Research X"),
+                Message(role="assistant", content="", tool_calls=[_delegate_tool_call()]),
+                # No tool message was ever recorded for the call above.
+                Message(role="assistant", content="Here are the findings."),
+            ]
+        )
+
+        assistant_with_calls = [m for m in formatted if m.get("tool_calls")]
+        assert len(assistant_with_calls) == 1, "the call must still be sent"
+        assert assistant_with_calls[0]["tool_calls"][0]["function"]["name"] == "delegate_task_to_member"
+        placeholders = _placeholder_messages(formatted)
+        assert len(placeholders) == 1
+        # The placeholder tool message answers the emitted call.
+        emitted_id = assistant_with_calls[0]["tool_calls"][0]["id"]
+        assert placeholders[0]["tool_call_id"] == emitted_id
+        # The recorded tool message must not be placeholder-repaired.
+        tool_messages = [m for m in formatted if m.get("role") == "tool"]
+        assert len(tool_messages) == 1  # only the placeholder
+
+    def test_result_without_tool_call_id_gets_placeholder(self):
+        """A tool result that cannot be formatted is dropped; its call gets a placeholder."""
+        model = OpenAIChat(id="gpt-4o-mini")
+
+        formatted = model._format_all_messages(
+            messages=[
+                Message(role="user", content="Research X"),
+                Message(role="assistant", content="", tool_calls=[_delegate_tool_call()]),
+                Message(role="tool", tool_call_id=None, tool_name="delegate_task_to_member", content="findings"),
+            ]
+        )
+
+        assistant_with_calls = [m for m in formatted if m.get("tool_calls")]
+        assert len(assistant_with_calls) == 1
+        emitted_id = assistant_with_calls[0]["tool_calls"][0]["id"]
+        placeholders = _placeholder_messages(formatted)
+        assert len(placeholders) == 1
+        assert placeholders[0]["tool_call_id"] == emitted_id
+
+    def test_tool_message_with_none_content_counts_as_recorded(self):
+        """A tool message with a call id and None content is still emitted (as ""), so its
+        call must not get a duplicate placeholder result."""
+        model = OpenAIChat(id="gpt-4o-mini")
+
+        formatted = model._format_all_messages(
+            messages=[
+                Message(role="user", content="Research X"),
+                Message(role="assistant", content="", tool_calls=[_delegate_tool_call()]),
+                Message(role="tool", tool_call_id=DELEGATE_CALL_ID, tool_name="delegate_task_to_member", content=None),
+            ]
+        )
+
+        assert _placeholder_messages(formatted) == []
+
+    def test_mixed_turn_pairs_real_and_placeholder_results(self):
+        """A mixed turn: one recorded result and one missing result both stay valid."""
+        model = OpenAIChat(id="gpt-4o-mini")
+        paired_id = "call_paired"
+        unpaired_id = "call_unpaired"
+
+        formatted = model._format_all_messages(
+            messages=[
+                Message(role="user", content="Do both tasks"),
+                Message(
+                    role="assistant",
+                    content="",
+                    tool_calls=[_delegate_tool_call(paired_id), _delegate_tool_call(unpaired_id)],
+                ),
+                Message(role="tool", tool_call_id=paired_id, tool_name="delegate_task_to_member", content="Paired result"),
+                Message(role="assistant", content="Done."),
+            ]
+        )
+
+        tool_messages = [m for m in formatted if m.get("role") == "tool"]
+        by_id = {m["tool_call_id"]: m for m in tool_messages}
+        assert by_id[paired_id]["content"] == "Paired result"
+        assert by_id[unpaired_id]["content"] == MISSING_TOOL_RESULT_PLACEHOLDER

--- a/libs/agno/tests/unit/utils/test_claude_unpaired_tool_calls.py
+++ b/libs/agno/tests/unit/utils/test_claude_unpaired_tool_calls.py
@@ -1,0 +1,129 @@
+"""Unpaired tool use blocks must be paired with a placeholder tool_result at format time.
+
+Anthropic rejects a ``tool_use`` block that has no corresponding ``tool_result`` block:
+
+    Each tool_use block must have a corresponding tool_result block.
+
+Sessions can hold runs whose tool result was never recorded (e.g. a run that was
+interrupted mid-tool-execution). Formatting pairs such calls with a placeholder
+tool_result so the session stays usable and the model can see the call never completed.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from agno.models.message import Message
+from agno.utils.message import MISSING_TOOL_RESULT_PLACEHOLDER
+from agno.utils.models.claude import format_messages
+
+# Shape observed in affected sessions: uuid id, no call_id.
+DELEGATE_CALL_ID = "d4f8a1b2-3c5e-4a91-b7d2-8e6f0a1c2b3d"
+
+
+def _delegate_tool_call(call_id: str = DELEGATE_CALL_ID) -> Dict[str, Any]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": "delegate_task_to_member",
+            "arguments": '{"member_id": "researcher", "task": "Research X"}',
+        },
+    }
+
+
+def _block_type(block: Any) -> Optional[str]:
+    if isinstance(block, dict):
+        return block.get("type")
+    return getattr(block, "type", None)
+
+
+def _block_id(block: Any) -> Optional[str]:
+    if isinstance(block, dict):
+        return block.get("id") or block.get("tool_use_id")
+    return getattr(block, "id", None)
+
+
+def _block_content(block: Any) -> Any:
+    if isinstance(block, dict):
+        return block.get("content")
+    return getattr(block, "content", None)
+
+
+def _all_blocks(chat_messages: List[Dict[str, Any]]) -> List[Any]:
+    return [block for message in chat_messages for block in message["content"]]
+
+
+def _tool_results(chat_messages: List[Dict[str, Any]]) -> List[Any]:
+    return [b for b in _all_blocks(chat_messages) if _block_type(b) == "tool_result"]
+
+
+def _tool_uses(chat_messages: List[Dict[str, Any]]) -> List[Any]:
+    return [b for b in _all_blocks(chat_messages) if _block_type(b) == "tool_use"]
+
+
+class TestUnpairedToolCalls:
+    def test_complete_turn_is_preserved(self):
+        """A call with its result must still be sent — both halves, correctly paired."""
+        formatted, _ = format_messages(
+            messages=[
+                Message(role="user", content="Research X"),
+                Message(role="assistant", content="", tool_calls=[_delegate_tool_call()]),
+                Message(
+                    role="tool",
+                    tool_call_id=DELEGATE_CALL_ID,
+                    tool_name="delegate_task_to_member",
+                    content="Researcher: findings for X",
+                ),
+                Message(role="assistant", content="Here are the findings."),
+            ]
+        )
+
+        tool_uses = _tool_uses(formatted)
+        tool_results = _tool_results(formatted)
+        assert len(tool_uses) == 1
+        assert _block_id(tool_uses[0]) == DELEGATE_CALL_ID
+        assert len(tool_results) == 1
+        assert tool_results[0]["tool_use_id"] == DELEGATE_CALL_ID
+        assert tool_results[0]["content"] == "Researcher: findings for X"
+
+    def test_call_with_no_recorded_result_gets_placeholder(self):
+        """The reported bug: a run persisted with a tool call and no tool message."""
+        formatted, _ = format_messages(
+            messages=[
+                Message(role="user", content="Research X"),
+                Message(role="assistant", content="", tool_calls=[_delegate_tool_call()]),
+                # No tool message was ever recorded for the call above.
+                Message(role="assistant", content="Here are the findings."),
+            ]
+        )
+
+        tool_uses = _tool_uses(formatted)
+        tool_results = _tool_results(formatted)
+        assert len(tool_uses) == 1, "the call must still be sent"
+        assert len(tool_results) == 1
+        assert tool_results[0]["tool_use_id"] == _block_id(tool_uses[0])
+        assert tool_results[0]["content"] == MISSING_TOOL_RESULT_PLACEHOLDER
+
+    def test_mixed_turn_pairs_real_and_placeholder_results(self):
+        """A mixed turn: one recorded result and one missing result both stay valid."""
+        paired_id = "call_paired"
+        unpaired_id = "call_unpaired"
+
+        formatted, _ = format_messages(
+            messages=[
+                Message(role="user", content="Do both tasks"),
+                Message(
+                    role="assistant",
+                    content="",
+                    tool_calls=[_delegate_tool_call(paired_id), _delegate_tool_call(unpaired_id)],
+                ),
+                Message(role="tool", tool_call_id=paired_id, tool_name="delegate_task_to_member", content="Paired result"),
+                Message(role="assistant", content="Done."),
+            ]
+        )
+
+        tool_uses = _tool_uses(formatted)
+        tool_results = _tool_results(formatted)
+        assert len(tool_uses) == 2
+        by_use_id = {r["tool_use_id"]: r for r in tool_results}
+        assert by_use_id[paired_id]["content"] == "Paired result"
+        assert by_use_id[unpaired_id]["content"] == MISSING_TOOL_RESULT_PLACEHOLDER


### PR DESCRIPTION
## Summary

Sessions can hold an assistant tool call whose tool result was never recorded (e.g. a run interrupted mid-tool-execution). Replaying such a session was rejected by every provider:

- **Chat Completions** rejects: *"An assistant message with 'tool_calls' must be followed by tool messages responding to each tool_call_id"* — affects everything inheriting `OpenAIChat`/`OpenAILike` (~30 providers: azure, xai, together, deepseek, ...).
- **Anthropic** rejects: *"Each tool_use block must have a corresponding tool_result block"*.
- **Gemini Interactions** rejects unpaired `function_call` steps.

This PR repairs such sessions at format time: every unpaired call is still emitted, but paired with a neutral placeholder result so the request stays valid and the model can see the call never completed. It mirrors the Responses-API repair in #9361 and, per the issue's suggestion, routes the placeholder text and pairing conditions through a shared helper so they stay consistent across providers.

## Changes

- `agno/utils/message.py` — adds `MISSING_TOOL_RESULT_PLACEHOLDER` and a shared `collect_recorded_tool_call_ids()` helper.
- `agno/models/openai/chat.py` — `_format_all_messages` appends a placeholder tool message after an assistant message whose tool_call_id has no recorded result (respects `role_map`).
- `agno/utils/models/claude.py` — `format_messages` appends a user message with placeholder `tool_result` blocks for unpaired `tool_use` ids; the existing merge step folds them with any following results.
- `agno/models/google/gemini_interactions.py` — `_build_input` appends a placeholder `function_result` step for unpaired `function_call` steps.
- Tests: three new test files (one per formatter) covering complete turns, missing results, results without a tool_call_id, `None`-content tool messages, and mixed turns; the existing `test_tool_call_message` was updated to assert the new paired behavior.

## Validation

- `pytest tests/unit/models/openai/ tests/unit/utils/ tests/unit/models/anthropic/ tests/unit/models/google/test_gemini_interactions.py` — all new tests pass (10 new tests + updated one); only pre-existing failures remain (missing optional deps like boto3/litellm on the baseline).
- `mypy` — no new errors on the changed files.
- `ruff` (E501, 120-col) — no new violations.

Fixes #9373

## AI disclosure

This PR was authored with assistance from an AI coding tool. The changes have been reviewed and understood by the author, include tests, and pass the local validation described above.
