### PR TITLE
[fix] drop orphaned function_call_output items in OpenAI Responses formatter (#9372)

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple, Type, Union
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Set, Tuple, Type, Union
 
 import httpx
 from pydantic import BaseModel
@@ -633,6 +633,27 @@ class OpenAIResponses(Model):
 
         fc_id_to_call_id = self._build_fc_id_to_call_id_map(messages)
 
+        # Whether this request chains from a previous response (reasoning models). In that
+        # mode the API holds the conversation state server-side, so function_call_output
+        # items are intentionally emitted without their matching function_call items.
+        is_chaining = self._using_reasoning_model() and previous_response_id is not None
+
+        # Collect the call_ids that will be emitted as function_call items in this request.
+        # Used to detect orphaned function_call_output items (tool results whose matching
+        # function_call was truncated out of the history), which the Responses API rejects
+        # with "No tool call found for function call output with call_id ...".
+        emitted_call_ids: Set[str] = set()
+        if not is_chaining:
+            for msg in messages_to_format:
+                if msg.role != "assistant":
+                    continue
+                tool_calls = getattr(msg, "tool_calls", None)
+                if tool_calls:
+                    for tc in tool_calls:
+                        call_id = tc.get("call_id") or tc.get("id")
+                        if isinstance(call_id, str):
+                            emitted_call_ids.add(call_id)
+
         for message in messages_to_format:
             if message.role in ["user", "system"]:
                 message_dict: Dict[str, Any] = {
@@ -679,6 +700,19 @@ class OpenAIResponses(Model):
                         call_id_value = fc_id_to_call_id[function_call_id]
                     else:
                         call_id_value = function_call_id
+
+                    # Drop orphaned function_call_output items. When history truncation cuts
+                    # out the assistant's function_call but keeps its tool result, emitting
+                    # the output alone makes the Responses API reject the whole request.
+                    # The previous_response_id path is exempt: the API holds that state
+                    # server-side and expects outputs without their calls.
+                    if not is_chaining and call_id_value not in emitted_call_ids:
+                        log_warning(
+                            f"Skipping orphaned function_call_output with call_id {call_id_value}: "
+                            "no matching function_call in this request"
+                        )
+                        continue
+
                     formatted_messages.append(
                         {"type": "function_call_output", "call_id": call_id_value, "output": tool_result}
                     )

--- a/libs/agno/tests/unit/models/openai/test_openai_responses_orphaned_outputs.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_responses_orphaned_outputs.py
@@ -1,0 +1,145 @@
+"""Regression tests for issue #9372: orphaned function_call_output items.
+
+The OpenAI Responses API rejects a request containing a `function_call_output`
+whose `call_id` has no matching `function_call` in the request:
+`No tool call found for function call output with call_id ...`.
+
+History truncation (e.g. `num_history_messages`) can cut between an assistant
+tool-call message and its tool result, leaving an orphaned output. The tool-result
+branch of `_format_messages` must drop those outputs — except on the
+`previous_response_id` chaining path (reasoning models), where the API holds the
+conversation state server-side and outputs are deliberately sent without their calls.
+"""
+
+from typing import Any, List, Optional
+
+from agno.models.message import Message
+from agno.models.openai.responses import OpenAIResponses
+
+
+def _assistant_with_tool_call(call_id: str = "call_def456", fc_id: str = "fc_abc123") -> Message:
+    return Message(
+        role="assistant",
+        tool_calls=[
+            {
+                "id": fc_id,
+                "call_id": call_id,
+                "type": "function",
+                "function": {"name": "execute_shell_command", "arguments": '{"command": "ls -la"}'},
+            }
+        ],
+    )
+
+
+def test_format_messages_drops_orphaned_function_call_output():
+    """A tool result whose function_call was truncated out of the history must not be emitted."""
+    model = OpenAIResponses(id="gpt-4.1-mini")
+
+    # The assistant's tool-call message is gone (truncated); only the tool result survives.
+    orphaned_tool_output = Message(role="tool", tool_call_id="call_def456", content="ok")
+
+    fm = model._format_messages(
+        messages=[
+            Message(role="system", content="s"),
+            Message(role="user", content="u"),
+            orphaned_tool_output,
+        ]
+    )
+
+    out_items = [x for x in fm if isinstance(x, dict) and x.get("type") == "function_call_output"]
+    fc_items = [x for x in fm if isinstance(x, dict) and x.get("type") == "function_call"]
+
+    assert out_items == []
+    assert fc_items == []
+
+
+def test_format_messages_drops_orphaned_output_with_fc_id():
+    """Same, when the tool message references the assistant call by its fc_* id."""
+    model = OpenAIResponses(id="gpt-4.1-mini")
+
+    orphaned_tool_output = Message(role="tool", tool_call_id="fc_abc123", content="ok")
+
+    fm = model._format_messages(
+        messages=[
+            Message(role="system", content="s"),
+            Message(role="user", content="u"),
+            orphaned_tool_output,
+        ]
+    )
+
+    out_items = [x for x in fm if isinstance(x, dict) and x.get("type") == "function_call_output"]
+    assert out_items == []
+
+
+def test_format_messages_keeps_output_when_call_present():
+    """Paired call + output must still be emitted (existing behavior preserved)."""
+    model = OpenAIResponses(id="gpt-4.1-mini")
+
+    tool_output = Message(role="tool", tool_call_id="call_def456", content="ok")
+
+    fm = model._format_messages(
+        messages=[
+            Message(role="system", content="s"),
+            Message(role="user", content="u"),
+            _assistant_with_tool_call(),
+            tool_output,
+        ]
+    )
+
+    fc_items = [x for x in fm if isinstance(x, dict) and x.get("type") == "function_call"]
+    out_items = [x for x in fm if isinstance(x, dict) and x.get("type") == "function_call_output"]
+
+    assert len(fc_items) == 1
+    assert len(out_items) == 1
+    assert out_items[0]["call_id"] == "call_def456"
+
+
+def test_format_messages_truncation_keeps_output_when_call_still_emitted():
+    """Truncation that keeps the assistant call (e.g. limit=4) must still emit the output."""
+    model = OpenAIResponses(id="gpt-4.1-mini")
+
+    tool_output = Message(role="tool", tool_call_id="call_def456", content="ok")
+    final_assistant = Message(role="assistant", content="done")
+
+    fm = model._format_messages(
+        messages=[
+            Message(role="system", content="s"),
+            Message(role="user", content="u"),
+            _assistant_with_tool_call(),
+            tool_output,
+            final_assistant,
+        ]
+    )
+
+    out_items = [x for x in fm if isinstance(x, dict) and x.get("type") == "function_call_output"]
+    assert len(out_items) == 1
+    assert out_items[0]["call_id"] == "call_def456"
+
+
+def test_reasoning_chaining_keeps_outputs_without_calls(monkeypatch):
+    """The previous_response_id chaining path must keep emitting outputs without calls."""
+    model = OpenAIResponses(id="o4-mini")  # reasoning
+    monkeypatch.setattr(model, "_using_reasoning_model", lambda: True)
+
+    assistant_with_prev = Message(role="assistant")
+    assistant_with_prev.provider_data = {"response_id": "resp_123"}  # type: ignore[attr-defined]
+
+    # Tool output for a call made in the *previous* response — no function_call in this request.
+    tool_output = Message(role="tool", tool_call_id="call_prev001", content="ok")
+
+    fm = model._format_messages(
+        messages=[
+            Message(role="system", content="s"),
+            Message(role="user", content="u"),
+            assistant_with_prev,
+            tool_output,
+        ]
+    )
+
+    out_items = [x for x in fm if isinstance(x, dict) and x.get("type") == "function_call_output"]
+    fc_items = [x for x in fm if isinstance(x, dict) and x.get("type") == "function_call"]
+
+    # Output must survive; no function_call items are re-sent on the chaining path.
+    assert len(out_items) == 1
+    assert out_items[0]["call_id"] == "call_prev001"
+    assert fc_items == []


### PR DESCRIPTION
## Summary

Fixes #9372 — the OpenAI Responses API rejects requests containing an **orphaned `function_call_output`**: a tool result whose matching `function_call` was truncated out of the history (e.g. by `num_history_messages` cutting between an assistant tool-call message and its result, or a half-persisted run). The API error is `No tool call found for function call output with call_id ...`.

`_format_messages` now collects the `call_id`s that will actually be emitted as `function_call` items in this request, and drops `function_call_output` items whose call has no matching `function_call` (logging a warning). This is the counterpart of #9361 / #9375, which repair the reverse direction (an orphaned tool *call* with no result).

**Constraint respected:** the guard is **not** applied on the `previous_response_id` chaining path (reasoning models such as `o4-mini`/`gpt-5`), where the API holds the conversation state server-side and `function_call_output` items are deliberately emitted without their calls.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff` clean on changed lines; mypy clean on changed files)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — **Yes, AI-generated.** This PR was written with AI assistance; it has been manually reviewed, includes a regression test for each behavior change, and passes the local test suite (9/9 in the new + id-handling files; the 3 failures in `test_openai_responses_background.py` are pre-existing — missing `pytest-asyncio` mark registration, verified on baseline).

---

## Additional Notes

**Tests added** (`tests/unit/models/openai/test_openai_responses_orphaned_outputs.py`):
- orphaned output dropped (both `call_*` and `fc_*` id forms)
- paired call + output still emitted (no regression)
- truncation that keeps the assistant call still emits the output
- reasoning `previous_response_id` chaining path keeps outputs without calls (exemption verified)

**Why drop instead of a placeholder:** on the Responses API, `function_call_output` must reference a `function_call` issued in the conversation. Unlike the Chat Completions repair (#9375), where a placeholder *result* can be synthesized for an orphaned call, synthesizing a fake `function_call` here would fabricate tool invocations the model never made; dropping the orphaned output (whose call the model never saw anyway) preserves the exact server-side conversation state.
