### PR TITLE
feat: safe retries - fence the run row and event stream, retire the experimental gate

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -6040,7 +6040,8 @@ def flush_in_flight_messages_on_error(
     and were deleted rather than left implying coverage. A background run
     that errors at the WRAPPER level (outside the inner run's own error
     handling) persists without its in-flight conversation. Threading the
-    real flush out to the wrappers is the item-33 test target.
+    real flush out to the wrappers - with a wrapper-level-error test -
+    is a known follow-up.
     """
     if run_messages is None:
         return

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -254,6 +254,12 @@ def upsert_run(
     try:
         if not agent.db:
             return
+        from agno.run.status_persist import persist_worker_owned_run
+
+        # Queue-worker-owned runs save through the attempt-fenced primitive;
+        # a zombie attempt's write is refused instead of clobbering the row
+        if persist_worker_owned_run(agent.db, run, session_id=session_id, user_id=user_id):
+            return
         agent.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr]
     except NotImplementedError:
         # Adapter has not been ported to v3 storage; runs are persisted inline
@@ -293,6 +299,12 @@ async def aupsert_run(
 
     try:
         if not agent.db:
+            return
+        from agno.run.status_persist import apersist_worker_owned_run
+
+        # Queue-worker-owned runs save through the attempt-fenced primitive;
+        # a zombie attempt's write is refused instead of clobbering the row
+        if await apersist_worker_owned_run(agent.db, run, session_id=session_id, user_id=user_id):
             return
         if _init.has_async_db(agent):
             await agent.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr,misc]

--- a/libs/agno/agno/job_queue/config.py
+++ b/libs/agno/agno/job_queue/config.py
@@ -91,14 +91,11 @@ class QueueConfig:
     max_queue_depth: int = 1000
     # At most this many executions ever, under any failure mode (reclaim
     # included). 1 = a crashed run is failed visibly, never silently re-run.
+    # Values > 1 are safe: a swept-but-alive attempt's writes are fenced on
+    # every surface - the ticket (CAS on locked_by/attempt), the run row
+    # (worker-owned saves route through the attempt-fenced primitive), and
+    # the event stream (per-run writer generations).
     max_attempts: int = 1
-    # EXPERIMENTAL gate for max_attempts > 1. Re-execution is where the
-    # two-live-producer races live: the happy-path completion save and the
-    # stream writes are not yet generation-fenced (the P1 program's items),
-    # so a swept-but-alive attempt and its retry can interleave writes on
-    # the same run row and stream. Until that fencing lands, multi-attempt
-    # is opt-in with this flag - a warning is not a control.
-    allow_multi_attempt_experimental: bool = False
     # BASE retry delay: attempt N waits up to base * 2**(N-1) with full
     # jitter (capped at 10x base) - see QueueWorker._retry_delay
     retry_delay_seconds: int = 30
@@ -134,13 +131,6 @@ class QueueConfig:
         # not as mysterious runtime behavior
         if self.max_attempts < 1:
             raise ValueError("QueueConfig.max_attempts must be >= 1 (every run needs at least one attempt)")
-        if self.max_attempts > 1 and not self.allow_multi_attempt_experimental:
-            raise ValueError(
-                "QueueConfig.max_attempts > 1 requires allow_multi_attempt_experimental=True: "
-                "re-execution can race a swept-but-alive attempt's writes on the same run row "
-                "and event stream (their generation fencing is still on the roadmap). Until "
-                "then, multi-attempt is an explicit experimental opt-in."
-            )
         if self.poll_interval <= 0:
             raise ValueError("QueueConfig.poll_interval must be > 0 seconds")
         if self.lock_grace_seconds < 3:

--- a/libs/agno/agno/os/event_streams/base.py
+++ b/libs/agno/agno/os/event_streams/base.py
@@ -53,7 +53,7 @@ class BaseEventStream(ABC):
         """
 
     @abstractmethod
-    async def set_run_status(self, run_id: str, status: RunStatus) -> None:
+    async def set_run_status(self, run_id: str, status: RunStatus, generation: Optional[int] = None) -> None:
         """Update the status of a registered run (e.g. PENDING -> RUNNING)."""
 
     @abstractmethod
@@ -61,11 +61,17 @@ class BaseEventStream(ABC):
         """Return the run's status, or None if the run is unknown to the stream."""
 
     @abstractmethod
-    async def complete_run(self, run_id: str, status: RunStatus) -> None:
+    async def complete_run(self, run_id: str, status: RunStatus, generation: Optional[int] = None) -> None:
         """Mark a run terminal (completed/error/cancelled/paused) and wake all tails.
 
         After this call every active and future ``tail()`` for the run must
         finish once it has yielded the remaining buffered events.
+
+        ``generation``: like ``add_event`` - when given and OLDER than the
+        stream's recorded writer generation, the terminal write is refused
+        (a zombie attempt's sentinel must not close the live attempt's
+        tails). Equal or newer passes: a same-attempt late completion is the
+        finished-work-wins intent, and a newer writer self-heals forward.
         """
 
     async def reopen_run(self, run_id: str, include_error: bool = False, floor: Optional[int] = None) -> bool:
@@ -119,7 +125,7 @@ class BaseEventStream(ABC):
         """Drop all stored state for a run (called after the retention period)."""
 
     @abstractmethod
-    async def reset_run_events(self, run_id: str) -> None:
+    async def reset_run_events(self, run_id: str, generation: Optional[int] = None) -> None:
         """Drop a run's buffered events but PRESERVE its index counter and
         registration.
 
@@ -128,14 +134,33 @@ class BaseEventStream(ABC):
         across attempts - a client that saw indices 0..N on attempt 1 and
         reconnects with last_event_index=N must receive the retry's events
         (which start at N+1), not filter them all out. Index gaps across the
-        attempt boundary are covered by the not-gapless contract."""
+        attempt boundary are covered by the not-gapless contract.
+
+        ``generation``: when given and OLDER than the recorded writer
+        generation, the reset is refused - a worker that stalled before its
+        leg entry and woke after a reclaim must not delete the reclaiming
+        attempt's events."""
 
     # ------------------------------------------------------------------
     # Events
     # ------------------------------------------------------------------
 
+    async def begin_attempt(self, run_id: str, generation: int) -> None:
+        """Declare that attempt ``generation`` now owns this run's stream.
+
+        Monotonic CAS: the stored generation only moves FORWARD (a late call
+        from an older attempt never regresses it). Once a newer generation is
+        recorded, ``add_event`` calls carrying an older one are refused - the
+        zombie-writer fence. Queue attempts pass their ticket ``attempt``
+        (monotonic per run by construction); the same-generation continuation
+        legs share their attempt's generation.
+
+        Default is a no-op so implementations without multi-writer exposure
+        (or custom streams) keep working; both built-ins implement it.
+        """
+
     @abstractmethod
-    async def add_event(self, run_id: str, event: Any) -> int:
+    async def add_event(self, run_id: str, event: Any, generation: Optional[int] = None) -> int:
         """Append an event, assign its index, and publish it to live tails.
 
         The implementation owns index assignment (the SSE payload embeds the
@@ -145,12 +170,20 @@ class BaseEventStream(ABC):
         Args:
             run_id: The run the event belongs to.
             event: The structured event object.
+            generation: The writer's attempt generation from ``begin_attempt``.
+                When given and it no longer matches the stream's recorded
+                generation, the event is REFUSED and -1 returned: a zombie
+                attempt's output must not interleave into the live attempt's
+                stream. ``None`` bypasses the fence (single-writer inline
+                producers). A refusal may consume an index - gaps are covered
+                by the monotonic-not-gapless contract.
 
         Returns:
-            The monotonic event index assigned to this event. Callers that also
-            deliver the event on a local channel (e.g. the primary SSE queue)
-            format their own copy with this index — the formatter is
-            deterministic, so both copies are identical.
+            The monotonic event index assigned to this event, or -1 when the
+            generation fence refused it. Callers that also deliver the event
+            on a local channel (e.g. the primary SSE queue) format their own
+            copy with this index — the formatter is deterministic, so both
+            copies are identical.
         """
 
     @abstractmethod

--- a/libs/agno/agno/os/event_streams/in_memory.py
+++ b/libs/agno/agno/os/event_streams/in_memory.py
@@ -38,21 +38,51 @@ class InMemoryEventStream(BaseEventStream):
             subscriber_manager = subscriber_manager if subscriber_manager is not None else sse_subscriber_manager
         self._buffer = events_buffer
         self._subscribers = subscriber_manager
+        # Per-run writer generation (item 5): begin_attempt records the newest
+        # attempt; add_event calls carrying an older generation are refused.
+        # Process-local like the buffer itself - single-process is this
+        # backend's whole contract.
+        self._generations: dict = {}
 
     # ------------------------------------------------------------------
     # Run lifecycle
     # ------------------------------------------------------------------
 
+    def _generation_stale(self, run_id: str, generation: Optional[int]) -> bool:
+        """Monotonic fence rule (matches the Redis twin): refuse only when the
+        writer's generation is OLDER than the recorded one. Equal passes
+        (same-attempt finished-work-wins); newer self-heals the record
+        forward; None bypasses (unfenced single-writer callers)."""
+        if generation is None:
+            return False
+        current = self._generations.get(run_id)
+        if current is None or generation > current:
+            self._generations[run_id] = generation
+            return False
+        if generation < current:
+            from agno.utils.log import log_warning
+
+            log_warning(
+                f"Event stream: refused write for run {run_id} from stale generation "
+                f"{generation} (current {current}) - zombie writer fenced out"
+            )
+            return True
+        return False
+
     async def register_run(self, run_id: str, status: RunStatus = RunStatus.pending) -> None:
         self._buffer.register_run(run_id, status)
 
-    async def set_run_status(self, run_id: str, status: RunStatus) -> None:
+    async def set_run_status(self, run_id: str, status: RunStatus, generation: Optional[int] = None) -> None:
+        if self._generation_stale(run_id, generation):
+            return
         self._buffer.set_run_status(run_id, status)
 
     async def get_run_status(self, run_id: str) -> Optional[RunStatus]:
         return self._buffer.get_run_status(run_id)
 
-    async def complete_run(self, run_id: str, status: RunStatus) -> None:
+    async def complete_run(self, run_id: str, status: RunStatus, generation: Optional[int] = None) -> None:
+        if self._generation_stale(run_id, generation):
+            return  # a zombie's sentinel must not close the live attempt's tails
         if status not in (RunStatus.completed, RunStatus.error, RunStatus.cancelled, RunStatus.paused):
             # Contract: this call MARKS TERMINAL. A non-terminal argument
             # (producer raced mid-transition) must still end tails - coerce
@@ -69,13 +99,23 @@ class InMemoryEventStream(BaseEventStream):
         # the buffer came up empty under a paused run's continue.
         return bool(self._buffer.reopen_run(run_id, include_error=include_error, floor=floor))
 
+    async def begin_attempt(self, run_id: str, generation: int) -> None:
+        # Monotonic: a late begin from an older attempt never regresses the
+        # recorded generation (its subsequent adds stay fenced out)
+        current = self._generations.get(run_id)
+        if current is None or generation > current:
+            self._generations[run_id] = generation
+
     async def cleanup_run(self, run_id: str) -> None:
+        self._generations.pop(run_id, None)
         self._buffer.cleanup_run(run_id)
 
-    async def reset_run_events(self, run_id: str) -> None:
+    async def reset_run_events(self, run_id: str, generation: Optional[int] = None) -> None:
         # Events go; the index counter and registration stay (monotonic
         # indices across retry attempts). Empty the list IN PLACE: popping the
         # key would make the buffer's add_event re-zero the counter.
+        if self._generation_stale(run_id, generation):
+            return  # a pre-entry-stalled zombie must not delete the reclaim's events
         if run_id in self._buffer.events:
             self._buffer.events[run_id] = []
 
@@ -83,11 +123,13 @@ class InMemoryEventStream(BaseEventStream):
     # Events
     # ------------------------------------------------------------------
 
-    async def add_event(self, run_id: str, event: Any) -> int:
+    async def add_event(self, run_id: str, event: Any, generation: Optional[int] = None) -> int:
         import contextlib
 
         from agno.os.utils import format_sse_event_with_index
 
+        if self._generation_stale(run_id, generation):
+            return -1
         event_index: int = self._buffer.add_event(run_id, event)
         # Stamp the index onto the event OBJECT (see the Redis twin): the
         # component's session save persists the real index with the stored

--- a/libs/agno/agno/os/event_streams/in_memory.py
+++ b/libs/agno/agno/os/event_streams/in_memory.py
@@ -38,7 +38,7 @@ class InMemoryEventStream(BaseEventStream):
             subscriber_manager = subscriber_manager if subscriber_manager is not None else sse_subscriber_manager
         self._buffer = events_buffer
         self._subscribers = subscriber_manager
-        # Per-run writer generation (item 5): begin_attempt records the newest
+        # Per-run writer generation: begin_attempt records the newest
         # attempt; add_event calls carrying an older generation are refused.
         # Process-local like the buffer itself - single-process is this
         # backend's whole contract.

--- a/libs/agno/agno/os/event_streams/redis.py
+++ b/libs/agno/agno/os/event_streams/redis.py
@@ -28,7 +28,36 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional, Tupl
 
 from agno.os.event_streams.base import BaseEventStream
 from agno.run.base import RunStatus
-from agno.utils.log import log_warning
+from agno.utils.log import log_debug, log_warning
+
+# Item 5 fence scripts. The INCR script refuses when the stored generation is
+# NEWER than the writer's, establishes it when absent (first fenced writer, or
+# an expired key - fail-open restamp; the TTL hazard predates the fence), and
+# self-heals forward when the writer's is newer. The XADD script re-checks at
+# append time: index INCR and XADD are separate roundtrips (the SSE payload
+# embeds the index and is formatted client-side), and a newer attempt can
+# begin between them - a refused append leaves an index gap, covered by the
+# monotonic-not-gapless contract.
+_FENCED_INCR_LUA = """
+local gen = redis.call('GET', KEYS[1])
+if gen == false then
+  redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[2]))
+elseif tonumber(gen) > tonumber(ARGV[1]) then
+  return -1
+elseif tonumber(gen) < tonumber(ARGV[1]) then
+  redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[2]))
+end
+return redis.call('INCR', KEYS[2])
+"""
+
+_FENCED_XADD_LUA = """
+local gen = redis.call('GET', KEYS[1])
+if gen ~= false and tonumber(gen) > tonumber(ARGV[1]) then
+  return 0
+end
+redis.call('XADD', KEYS[2], 'MAXLEN', '~', ARGV[2], '*', 'idx', ARGV[3], 'sse', ARGV[4])
+return 1
+"""
 
 _redis_available = True
 _redis_import_error: Optional[str] = None
@@ -117,6 +146,15 @@ class RedisEventStream(BaseEventStream):
         # runs remain active.
         self._active_runs: set = set()
         self._refresher_task: Optional["asyncio.Task"] = None
+        # Item 5 generation fence: Lua gives gen-check + INCR (and gen-check +
+        # XADD) single-roundtrip atomicity on the hot per-event path. Scripts
+        # register lazily; a server without scripting (fakeredis, restricted
+        # managed Redis) degrades FAIL-OPEN to the unfenced legacy path with
+        # one warning - the stream is coordination, not truth.
+        self._fenced_incr_script: Optional[Any] = None
+        self._fenced_xadd_script: Optional[Any] = None
+        self._scripting_unavailable = False
+        self._fence_refusals_logged: set = set()
 
     # ------------------------------------------------------------------
     # Keys
@@ -135,6 +173,12 @@ class RedisEventStream(BaseEventStream):
     def _counter_key(self, run_id: str) -> str:
         return f"{self._prefix}{run_id}:idx"
 
+    def _gen_key(self, run_id: str) -> str:
+        # The stream's writer generation (item 5): the newest attempt that
+        # called begin_attempt. add_event calls carrying an older generation
+        # are refused atomically in Lua.
+        return f"{self._prefix}{run_id}:gen"
+
     # ------------------------------------------------------------------
     # Run lifecycle
     # ------------------------------------------------------------------
@@ -149,9 +193,49 @@ class RedisEventStream(BaseEventStream):
         # set_run_status(RUNNING) / add_event.
         await self._redis.set(self._status_key(run_id), status.value, nx=True, ex=self._ttl)
 
-    async def set_run_status(self, run_id: str, status: RunStatus) -> None:
-        await self._redis.set(self._status_key(run_id), status.value, ex=self._ttl)
-        if status == RunStatus.running:
+    async def _fenced_lifecycle(self, run_id: str, generation: Optional[int], build) -> bool:
+        """Run a lifecycle mutation atomically UNDER the generation fence.
+
+        WATCH the gen key; refuse (False) when the stored writer generation
+        is NEWER than the caller's; otherwise queue ``build(pipe)`` after
+        MULTI and execute - the WATCH aborts if a newer attempt began in
+        between. Equal generations pass (same-attempt finished-work-wins);
+        a newer caller's generation is recorded forward. generation=None
+        runs the mutation unfenced (legacy single-writer callers)."""
+        from redis.exceptions import WatchError
+
+        gen_key = self._gen_key(run_id)
+        if generation is None:
+            pipe = self._redis.pipeline()
+            build(pipe)
+            await pipe.execute()
+            return True
+        for _ in range(10):
+            try:
+                async with self._redis.pipeline(transaction=True) as pipe:
+                    await pipe.watch(gen_key)
+                    raw = _to_str(await pipe.get(gen_key))
+                    if raw is not None and int(raw) > generation:
+                        await pipe.unwatch()
+                        self._log_fence_refusal(run_id, generation)
+                        return False
+                    pipe.multi()
+                    if raw is None or int(raw) < generation:
+                        pipe.set(gen_key, generation, ex=self._ttl)
+                    build(pipe)
+                    await pipe.execute()
+                    return True
+            except WatchError:
+                continue
+        return False
+
+    async def set_run_status(self, run_id: str, status: RunStatus, generation: Optional[int] = None) -> None:
+        applied = await self._fenced_lifecycle(
+            run_id,
+            generation,
+            lambda pipe: pipe.set(self._status_key(run_id), status.value, ex=self._ttl),
+        )
+        if applied and status == RunStatus.running:
             # The transition to RUNNING happens on the executing replica: this
             # process is the producer, so it owns keeping the keys alive
             self._active_runs.add(run_id)
@@ -208,6 +292,7 @@ class RedisEventStream(BaseEventStream):
                     pipe.expire(self._stream_key(run_id), self._ttl)
                     pipe.expire(self._status_key(run_id), self._ttl)
                     pipe.expire(self._counter_key(run_id), self._ttl)
+                    pipe.expire(self._gen_key(run_id), self._ttl)
                     await pipe.execute()
                 except Exception:
                     # Fail-open on Redis faults: keep the run enrolled and let
@@ -225,10 +310,29 @@ class RedisEventStream(BaseEventStream):
                 pass
             self._refresher_task = None
 
-    async def complete_run(self, run_id: str, status: RunStatus) -> None:
+    async def complete_run(self, run_id: str, status: RunStatus, generation: Optional[int] = None) -> None:
         if status not in (RunStatus.completed, RunStatus.error, RunStatus.cancelled, RunStatus.paused):
             # Contract: this call MARKS TERMINAL (see in-memory twin)
             status = RunStatus.completed
+
+        # Status first, then the sentinel: a tail woken by the sentinel must
+        # observe the terminal status. Under the generation fence: a zombie
+        # attempt's sentinel must not close the live attempt's tails (equal
+        # generations pass - same-attempt finished-work-wins).
+        def build(pipe: Any) -> None:
+            pipe.set(self._status_key(run_id), status.value, ex=self._ttl)
+            pipe.xadd(
+                self._stream_key(run_id),
+                {"terminal": status.value},
+                maxlen=self._maxlen,
+                approximate=True,
+            )
+            pipe.expire(self._stream_key(run_id), self._ttl)
+            pipe.expire(self._counter_key(run_id), self._ttl)
+
+        applied = await self._fenced_lifecycle(run_id, generation, build)
+        if not applied:
+            return
         if status == RunStatus.paused:
             # Paused is terminal-for-the-stream but resumable: keep refreshing
             # its keys so the counter/stream survive until the approval, else
@@ -241,19 +345,6 @@ class RedisEventStream(BaseEventStream):
             # Bookkeeping dies with the run: without this, per-run refresh
             # timestamps accumulate for the process lifetime
             self._last_ttl_refresh.pop(run_id, None)
-        # Status first, then the sentinel: a tail woken by the sentinel must
-        # observe the terminal status.
-        pipe = self._redis.pipeline()
-        pipe.set(self._status_key(run_id), status.value, ex=self._ttl)
-        pipe.xadd(
-            self._stream_key(run_id),
-            {"terminal": status.value},
-            maxlen=self._maxlen,
-            approximate=True,
-        )
-        pipe.expire(self._stream_key(run_id), self._ttl)
-        pipe.expire(self._counter_key(run_id), self._ttl)
-        await pipe.execute()
 
     async def reopen_run(self, run_id: str, include_error: bool = False, floor: Optional[int] = None) -> bool:
         """Atomically reopen a PAUSED run for a continuation leg.
@@ -320,26 +411,120 @@ class RedisEventStream(BaseEventStream):
     async def cleanup_run(self, run_id: str) -> None:
         self._last_ttl_refresh.pop(run_id, None)
         self._active_runs.discard(run_id)
+        self._fence_refusals_logged.discard(run_id)
         await self._redis.delete(
             self._stream_key(run_id),
             self._status_key(run_id),
             self._counter_key(run_id),
+            self._gen_key(run_id),
         )
 
-    async def reset_run_events(self, run_id: str) -> None:
+    async def reset_run_events(self, run_id: str, generation: Optional[int] = None) -> None:
         # Events go; counter and status stay - indices remain monotonic across
-        # retry attempts (see BaseEventStream.reset_run_events)
-        await self._redis.delete(self._stream_key(run_id))
+        # retry attempts (see BaseEventStream.reset_run_events). Fenced: a
+        # worker that stalled before its leg entry and woke after a reclaim
+        # must not delete the reclaiming attempt's events.
+        await self._fenced_lifecycle(run_id, generation, lambda pipe: pipe.delete(self._stream_key(run_id)))
 
     # ------------------------------------------------------------------
     # Events
     # ------------------------------------------------------------------
 
-    async def add_event(self, run_id: str, event: Any) -> int:
+    async def begin_attempt(self, run_id: str, generation: int) -> None:
+        """Record this attempt as the stream's writer generation (monotonic
+        CAS - an older attempt's late begin never regresses it)."""
+        from redis.exceptions import WatchError
+
+        gen_key = self._gen_key(run_id)
+        for _ in range(10):
+            try:
+                async with self._redis.pipeline(transaction=True) as pipe:
+                    await pipe.watch(gen_key)
+                    current_raw = _to_str(await pipe.get(gen_key))
+                    if current_raw is not None and int(current_raw) >= generation:
+                        await pipe.unwatch()
+                        with contextlib.suppress(Exception):
+                            await self._redis.expire(gen_key, self._ttl)
+                        return
+                    pipe.multi()
+                    pipe.set(gen_key, generation, ex=self._ttl)
+                    await pipe.execute()
+                    return
+            except WatchError:
+                continue
+
+    def _log_fence_refusal(self, run_id: str, generation: int) -> None:
+        # First refusal per run at WARNING; a streaming zombie can produce
+        # hundreds more - those go to DEBUG
+        if run_id not in self._fence_refusals_logged:
+            self._fence_refusals_logged.add(run_id)
+            log_warning(
+                f"Event stream: refused event for run {run_id} from stale generation "
+                f"{generation} - zombie writer fenced out (further refusals logged at DEBUG)"
+            )
+        else:
+            log_debug(f"Event stream: refused event for run {run_id} from stale generation {generation}")
+
+    async def _fenced_add_event(self, run_id: str, event: Any, generation: int) -> Optional[int]:
+        """Lua path: gen-check + INCR, then gen-check + XADD. Returns the
+        index, -1 (refused), or None when scripting is unavailable and the
+        caller must degrade to the unfenced legacy path."""
+        from redis.exceptions import ResponseError
+
+        from agno.os.utils import format_sse_event_with_index
+
+        try:
+            if self._fenced_incr_script is None:
+                self._fenced_incr_script = self._redis.register_script(_FENCED_INCR_LUA)
+                self._fenced_xadd_script = self._redis.register_script(_FENCED_XADD_LUA)
+            next_count = await self._fenced_incr_script(
+                keys=[self._gen_key(run_id), self._counter_key(run_id)],
+                args=[generation, self._ttl],
+            )
+        except ResponseError as e:
+            message = str(e).lower()
+            if "unknown command" in message or "not supported" in message or "unsupported" in message:
+                self._scripting_unavailable = True
+                log_warning(
+                    "Event stream: Redis server does not support scripting - the writer "
+                    "generation fence is DISABLED (events publish unfenced, legacy behavior)"
+                )
+                return None
+            raise
+        if int(next_count) == -1:
+            self._log_fence_refusal(run_id, generation)
+            return -1
+        event_index = int(next_count) - 1
+        with contextlib.suppress(Exception):
+            event.event_index = event_index
+        sse_data = format_sse_event_with_index(event, event_index=event_index, run_id=run_id)
+        appended = await self._fenced_xadd_script(  # type: ignore[misc]
+            keys=[self._gen_key(run_id), self._stream_key(run_id)],
+            args=[generation, self._maxlen, event_index, sse_data],
+        )
+        if self._ttl_refresh_due(run_id):
+            pipe = self._redis.pipeline()
+            pipe.expire(self._stream_key(run_id), self._ttl)
+            pipe.expire(self._status_key(run_id), self._ttl)
+            pipe.expire(self._counter_key(run_id), self._ttl)
+            pipe.expire(self._gen_key(run_id), self._ttl)
+            await pipe.execute()
+        if int(appended) == 0:
+            self._log_fence_refusal(run_id, generation)
+            return -1
+        return event_index
+
+    async def add_event(self, run_id: str, event: Any, generation: Optional[int] = None) -> int:
         if run_id not in self._active_runs:
             self._active_runs.add(run_id)
             self._ensure_refresher()
         from agno.os.utils import format_sse_event_with_index
+
+        if generation is not None and not self._scripting_unavailable:
+            fenced = await self._fenced_add_event(run_id, event, generation)
+            if fenced is not None:
+                return fenced
+            # Scripting unavailable: fall through to the unfenced legacy path
 
         # INCR assigns the monotonic index atomically (single producer today;
         # safe for multi-attempt producers later).

--- a/libs/agno/agno/os/event_streams/redis.py
+++ b/libs/agno/agno/os/event_streams/redis.py
@@ -30,7 +30,7 @@ from agno.os.event_streams.base import BaseEventStream
 from agno.run.base import RunStatus
 from agno.utils.log import log_debug, log_warning
 
-# Item 5 fence scripts. The INCR script refuses when the stored generation is
+# Writer-generation fence scripts. The INCR script refuses when the stored generation is
 # NEWER than the writer's, establishes it when absent (first fenced writer, or
 # an expired key - fail-open restamp; the TTL hazard predates the fence), and
 # self-heals forward when the writer's is newer. The XADD script re-checks at
@@ -146,7 +146,7 @@ class RedisEventStream(BaseEventStream):
         # runs remain active.
         self._active_runs: set = set()
         self._refresher_task: Optional["asyncio.Task"] = None
-        # Item 5 generation fence: Lua gives gen-check + INCR (and gen-check +
+        # Writer-generation fence: Lua gives gen-check + INCR (and gen-check +
         # XADD) single-roundtrip atomicity on the hot per-event path. Scripts
         # register lazily; a server without scripting (fakeredis, restricted
         # managed Redis) degrades FAIL-OPEN to the unfenced legacy path with
@@ -174,7 +174,7 @@ class RedisEventStream(BaseEventStream):
         return f"{self._prefix}{run_id}:idx"
 
     def _gen_key(self, run_id: str) -> str:
-        # The stream's writer generation (item 5): the newest attempt that
+        # The stream's writer generation: the newest attempt that
         # called begin_attempt. add_event calls carrying an older generation
         # are refused atomically in Lua.
         return f"{self._prefix}{run_id}:gen"

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -555,7 +555,7 @@ class QueueWorker:
 
         stream_generation = job.get("attempt", 1)
         with contextlib.suppress(Exception):
-            # Item 5: this attempt takes the stream's writer generation FIRST,
+            # This attempt takes the stream's writer generation FIRST,
             # before any stream mutation. A zombie attempt still publishing
             # from an older claim is refused per-mutation by the backend - its
             # events cannot interleave, its sentinel cannot close this leg's
@@ -1904,7 +1904,7 @@ async def aticket_poll_fallback(
 
 def warn_unfenced_session_stores(agent_os: Any) -> None:
     """Loud-degrade for durable queues over session stores without the atomic
-    run-persistence primitives (phase-6 item 24, option A).
+    run-persistence primitives.
 
     The fencing architecture - zombie/attempt fences, the worker's RUNNING
     and attempt stamps, the terminal-row guard's atomic path - lives in the

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -553,6 +553,18 @@ class QueueWorker:
         payload = job.get("payload") or {}
         is_continuation = bool(payload.get("continue"))
 
+        stream_generation = job.get("attempt", 1)
+        with contextlib.suppress(Exception):
+            # Item 5: this attempt takes the stream's writer generation FIRST,
+            # before any stream mutation. A zombie attempt still publishing
+            # from an older claim is refused per-mutation by the backend - its
+            # events cannot interleave, its sentinel cannot close this leg's
+            # tails, and (if it stalled before its own leg entry) its reset
+            # cannot delete this leg's events. Continuation legs pass their
+            # ticket attempt too: each continue CASes the SAME ticket to a
+            # new attempt, so the generation stays monotonic per run.
+            await event_stream.begin_attempt(job_id, stream_generation)
+
         if job.get("attempt", 1) > 1 and not is_continuation:
             # Drop the contradicted attempt's events but keep the index
             # counter: reconnecting clients filter by last_event_index, and a
@@ -563,7 +575,7 @@ class QueueWorker:
             # leave the crashed leg-attempt's partial events in the view - the
             # stream is the best-effort view, the run row stays authoritative.
             with contextlib.suppress(Exception):
-                await event_stream.reset_run_events(job_id)
+                await event_stream.reset_run_events(job_id, generation=stream_generation)
         if is_continuation:
             # Belt-and-braces sentinel invalidation (the seam already reopened
             # on accept, fail-open): covers a seam-side Redis blip AND the
@@ -589,7 +601,7 @@ class QueueWorker:
             # Fail-open: a Redis blip here must not burn the attempt budget -
             # execution can proceed; tails degrade to the DB view
             await event_stream.register_run(job_id, RunStatus.pending)
-            await event_stream.set_run_status(job_id, RunStatus.running)
+            await event_stream.set_run_status(job_id, RunStatus.running, generation=stream_generation)
 
         final_output: Any = None
         is_workflow = job.get("component_type") == "workflow"
@@ -638,7 +650,7 @@ class QueueWorker:
                     final_output = event  # the terminal RunOutput
                     continue
                 with contextlib.suppress(Exception):
-                    await event_stream.add_event(job_id, event)
+                    await event_stream.add_event(job_id, event, generation=stream_generation)
             if final_output is None and is_workflow:
                 with contextlib.suppress(Exception):
                     final_output = await component.aget_run_output(
@@ -666,7 +678,7 @@ class QueueWorker:
             will_retry = status == RunStatus.error and job.get("attempt", 1) < job.get("max_attempts", 1)
             if not will_retry:
                 with contextlib.suppress(Exception):
-                    await asyncio.shield(event_stream.complete_run(job_id, status))
+                    await asyncio.shield(event_stream.complete_run(job_id, status, generation=stream_generation))
         return final_output
 
     async def _terminate_stream_view(self, job: Dict[str, Any], status: str = "error") -> None:
@@ -680,10 +692,16 @@ class QueueWorker:
         from agno.run.base import RunStatus
 
         # The TRUE status: a cancelled run's SSE terminal must not claim ERROR
-        # while the poll surface says CANCELLED
+        # while the poll surface says CANCELLED. Stamped with the SWEPT
+        # attempt's generation: if that attempt is actually alive (a false
+        # death diagnosis), its own later terminal carries the same
+        # generation and passes - finished-work-wins - while a reclaim at a
+        # newer attempt fences this close out entirely.
         terminal = RunStatus.cancelled if status == "cancelled" else RunStatus.error
         with contextlib.suppress(Exception):
-            await asyncio.shield(get_event_stream().complete_run(job["id"], terminal))
+            await asyncio.shield(
+                get_event_stream().complete_run(job["id"], terminal, generation=job.get("attempt"))
+            )
 
     async def _persist_run_error(self, job: Dict[str, Any], error: str, status: str = "error") -> bool:
         """Persist a terminal status on the run row so pollers see it, never a

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -699,9 +699,7 @@ class QueueWorker:
         # newer attempt fences this close out entirely.
         terminal = RunStatus.cancelled if status == "cancelled" else RunStatus.error
         with contextlib.suppress(Exception):
-            await asyncio.shield(
-                get_event_stream().complete_run(job["id"], terminal, generation=job.get("attempt"))
-            )
+            await asyncio.shield(get_event_stream().complete_run(job["id"], terminal, generation=job.get("attempt")))
 
     async def _persist_run_error(self, job: Dict[str, Any], error: str, status: str = "error") -> bool:
         """Persist a terminal status on the run row so pollers see it, never a

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -1486,19 +1486,22 @@ def get_agent_router(
         else:
             if background:
                 # background=true + stream=false reached the NON-durable path
-                # (no paused ticket - or fork/regenerate/remote/factory). The
-                # old fallthrough silently ran the continuation INLINE,
-                # blocking the request for the entire leg while the caller
-                # asked for background semantics - a lie that only held until
-                # a proxy or client timeout killed the connection mid-leg.
-                # Workflow-door parity: background non-stream continues are
-                # the durable door, full stop (the background param is new in
-                # this PR - no back-compat cost).
-                raise HTTPException(
-                    status_code=409,
-                    detail="background=true continuation is only available for durably-submitted "
-                    "runs (no paused ticket for this run). Continue without background, or "
-                    "submit with background=true and a durable queue.",
+                # (no paused ticket - or fork/regenerate/remote/factory).
+                # Pre-queue clients rely on this exact fallthrough (the
+                # background form param predates the durable queue, and its
+                # non-stream branch always ran inline), so it stays for
+                # back-compat: the continuation executes INLINE-BLOCKING on
+                # this replica and the response returns when the leg
+                # finishes. That is not real background semantics - it does
+                # not survive client disconnect - hence the warning; a
+                # durable queue (QueueConfig(durable=True)) is the real
+                # background door. Workflows differ deliberately: their
+                # continue endpoint never had the param, so the durable door
+                # is its only contract there and refuses instead.
+                log_warning(
+                    f"background=true continue for run {run_id} has no durable ticket: executing "
+                    "INLINE-BLOCKING on this replica (legacy behavior; does not survive client "
+                    "disconnect). Enable QueueConfig(durable=True) for durable background continuation."
                 )
             # Build extra kwargs for remote agent auth
             extra_kwargs: dict = {}

--- a/libs/agno/agno/os/routers/job_queue/router.py
+++ b/libs/agno/agno/os/routers/job_queue/router.py
@@ -112,19 +112,21 @@ def get_queue_router(os: "AgentOS", settings: AgnoAPISettings = AgnoAPISettings(
     )
     async def requeue_job(request: Request, job_id: str, clear_cancellation: bool = False, force: bool = False):
         store = _get_store(request)
-        # Live-zombie gate (the other half of the multi-attempt experimental
-        # gate): a job FAILED within the last lock_grace was, in the worst
+        # Live-zombie gate, kept as OPS HYGIENE now that the write fences
+        # exist: a job FAILED within the last lock_grace was, in the worst
         # case, swept while its worker was actually alive - the sweep only
         # proves heartbeats stopped, not that execution did (the documented
-        # event-loop-starvation mode). Requeueing inside that window can put
-        # a second live producer on the same run row and event stream, whose
-        # writes are not yet generation-fenced. Refuse with 409 until the
-        # grace elapses, unless the operator explicitly forces. Heuristic by
-        # construction: completed_at is DB time on Postgres and this compares
-        # against app time, so clock skew shifts the refusal window - never
-        # ownership, which does not depend on this gate. Cancelled jobs skip
-        # the gate: cancellation only tombstones waiting tickets, so no
-        # zombie attempt can exist.
+        # event-loop-starvation mode). The fences make a requeue inside that
+        # window SAFE (the zombie's row/stream writes are refused once the
+        # new attempt begins), but not free: it burns an attempt re-running
+        # work that may be about to finish, and the finished-work-wins
+        # outcome the operator probably wants arrives by simply waiting.
+        # Refuse with 409 until the grace elapses, unless the operator
+        # explicitly forces. Heuristic by construction: completed_at is DB
+        # time on Postgres and this compares against app time, so clock skew
+        # shifts the refusal window - never ownership, which does not depend
+        # on this gate. Cancelled jobs skip the gate: cancellation only
+        # tombstones waiting tickets, so no zombie attempt can exist.
         gate_job = await store.get_job(job_id)
         if gate_job is not None and gate_job.get("status") == "failed" and not force:
             import time as _time

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -1444,14 +1444,13 @@ def get_team_router(
             )
         else:
             if background:
-                # background=true + stream=false reached the NON-durable path
-                # - see the agent twin. Workflow-door parity: background
-                # non-stream continues are the durable door, full stop.
-                raise HTTPException(
-                    status_code=409,
-                    detail="background=true continuation is only available for durably-submitted "
-                    "runs (no paused ticket for this run). Continue without background, or "
-                    "submit with background=true and a durable queue.",
+                # background=true + stream=false reached the NON-durable path:
+                # legacy inline-blocking fallthrough kept for back-compat -
+                # see the agent twin for the full rationale
+                log_warning(
+                    f"background=true continue for run {run_id} has no durable ticket: executing "
+                    "INLINE-BLOCKING on this replica (legacy behavior; does not survive client "
+                    "disconnect). Enable QueueConfig(durable=True) for durable background continuation."
                 )
             # Build extra kwargs for remote team auth
             extra_kwargs: dict = {}

--- a/libs/agno/agno/run/status_persist.py
+++ b/libs/agno/agno/run/status_persist.py
@@ -7,9 +7,11 @@ falling back to the fresh-read + whole-session save mitigation otherwise.
 
 This is the write path for status TRANSITIONS (RUNNING, CANCELLED, ERROR)
 made outside a run's own execution: background task bodies, the queue
-worker's sweep and error persists. A run's own final save (inside arun's
-cleanup) still writes the full session; fencing that path end-to-end is the
-remaining scope documented in the design note.
+worker's sweep and error persists. A run's OWN saves are fenced too when
+the run executes under the queue worker: ``apersist_worker_owned_run`` /
+``persist_worker_owned_run`` intercept the per-run save helpers while the
+worker's ownership registration is live, so a zombie attempt's writes are
+refused by the primitive instead of clobbering through bare upsert_run.
 """
 
 import asyncio
@@ -187,3 +189,150 @@ async def apersist_run_transition(
         else:
             component.save_run(run=run_response, session_id=session_id, user_id=user_id)
             component.save_session(session=workflow_session)
+
+
+def _coerce_outcome(result: Any, expected_attempt: Optional[int]) -> "RunPersistOutcome":
+    """Map a legacy bool-returning third-party adapter onto the typed
+    outcomes, using the same historical decisions as apersist_run_status."""
+    if isinstance(result, RunPersistOutcome):
+        return result
+    if result is True:
+        return RunPersistOutcome.UPDATED
+    if expected_attempt is not None:
+        return RunPersistOutcome.STALE_ATTEMPT
+    return RunPersistOutcome.MISSING
+
+
+async def _acall_update(method: Any, kwargs: Dict[str, Any]) -> Any:
+    if inspect.iscoroutinefunction(method):
+        return await method(**kwargs)
+    return await asyncio.to_thread(method, **kwargs)
+
+
+async def apersist_worker_owned_run(
+    db: Any,
+    run: Any,
+    session_id: str,
+    user_id: Optional[str] = None,
+) -> bool:
+    """Fence a worker-owned run's save through the atomic primitive.
+
+    The queue worker registers (worker_id, attempt) for exactly the span of
+    each execution (agno.run.concurrency.worker_managed_execution). While
+    that registration is live, every per-run DB save in this process for
+    that run_id carries the attempt fence: a zombie attempt's write - a late
+    terminal save OR a mid-run flush landing after a newer attempt claimed
+    the row - is refused by the row-locked primitive instead of clobbering
+    wholesale through bare ``upsert_run``. This closes the "run's own final
+    save is unfenced" gap the module docstring describes.
+
+    Returns True when the save was handled here: applied, or finally refused
+    by the fence/terminal guard (refusals are dropped by design - retrying
+    them unfenced is exactly the clobber the fence exists to stop). Returns
+    False when the caller should fall through to the unfenced ``upsert_run``:
+    the run is not worker-owned in this process, the adapter lacks the
+    primitive (the unfenced-store startup warning covers that deployment),
+    or neither the row nor its session exists yet.
+    """
+    from agno.run.concurrency import get_worker_ownership
+    from agno.utils.log import log_warning
+
+    run_id = getattr(run, "run_id", None)
+    if run_id is None or db is None:
+        return False
+    ownership = get_worker_ownership(run_id)
+    if ownership is None or not ownership.attempt:
+        return False
+    method = getattr(db, "update_run_in_session", None)
+    if not callable(method):
+        return False
+    fields = dict(run.to_dict())
+    kwargs: Dict[str, Any] = dict(
+        session_id=session_id,
+        run_id=run_id,
+        fields=fields,
+        expected_attempt=ownership.attempt,
+        user_id=user_id,
+    )
+    outcome = _coerce_outcome(await _acall_update(method, kwargs), ownership.attempt)
+    if outcome is RunPersistOutcome.MISSING:
+        append = getattr(db, "append_run_to_session_if_absent", None)
+        if not callable(append):
+            return False
+        run_dict = dict(fields)
+        # Keep the fresh row fence-stamped: without the attempt on it, the
+        # next fence compare passes vacuously against stored None
+        run_dict["queue_attempt"] = ownership.attempt
+        if inspect.iscoroutinefunction(append):
+            appended = await append(session_id=session_id, run_dict=run_dict, user_id=user_id)
+        else:
+            appended = await asyncio.to_thread(append, session_id=session_id, run_dict=run_dict, user_id=user_id)
+        if appended is None:
+            return False  # no session row / no primitive: the legacy path decides
+        if appended is True:
+            return True
+        # A concurrent writer landed the row between check and append:
+        # re-drive the fenced update once against it
+        outcome = _coerce_outcome(await _acall_update(method, kwargs), ownership.attempt)
+        if outcome is RunPersistOutcome.MISSING:
+            return False
+    if outcome in (RunPersistOutcome.STALE_ATTEMPT, RunPersistOutcome.TERMINAL_REFUSED):
+        log_warning(
+            f"Dropped fenced-out run save: run {run_id} attempt {ownership.attempt} "
+            f"({outcome.value}) - a newer attempt or a terminal row owns it"
+        )
+    return True
+
+
+def persist_worker_owned_run(
+    db: Any,
+    run: Any,
+    session_id: str,
+    user_id: Optional[str] = None,
+) -> bool:
+    """Sync twin of ``apersist_worker_owned_run`` for the sync save helpers.
+
+    Async-only adapters return False here (the sync-save-with-async-db guard
+    raises upstream before this matters).
+    """
+    from agno.run.concurrency import get_worker_ownership
+    from agno.utils.log import log_warning
+
+    run_id = getattr(run, "run_id", None)
+    if run_id is None or db is None:
+        return False
+    ownership = get_worker_ownership(run_id)
+    if ownership is None or not ownership.attempt:
+        return False
+    method = getattr(db, "update_run_in_session", None)
+    if not callable(method) or inspect.iscoroutinefunction(method):
+        return False
+    fields = dict(run.to_dict())
+    kwargs: Dict[str, Any] = dict(
+        session_id=session_id,
+        run_id=run_id,
+        fields=fields,
+        expected_attempt=ownership.attempt,
+        user_id=user_id,
+    )
+    outcome = _coerce_outcome(method(**kwargs), ownership.attempt)
+    if outcome is RunPersistOutcome.MISSING:
+        append = getattr(db, "append_run_to_session_if_absent", None)
+        if not callable(append) or inspect.iscoroutinefunction(append):
+            return False
+        run_dict = dict(fields)
+        run_dict["queue_attempt"] = ownership.attempt
+        appended = append(session_id=session_id, run_dict=run_dict, user_id=user_id)
+        if appended is None:
+            return False
+        if appended is True:
+            return True
+        outcome = _coerce_outcome(method(**kwargs), ownership.attempt)
+        if outcome is RunPersistOutcome.MISSING:
+            return False
+    if outcome in (RunPersistOutcome.STALE_ATTEMPT, RunPersistOutcome.TERMINAL_REFUSED):
+        log_warning(
+            f"Dropped fenced-out run save: run {run_id} attempt {ownership.attempt} "
+            f"({outcome.value}) - a newer attempt or a terminal row owns it"
+        )
+    return True

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -4763,7 +4763,7 @@ def flush_in_flight_messages_on_error_team(
     KNOWN GAP (tombstone): see the agent twin - the detached background
     wrappers never had run_messages in scope, their locals().get calls were
     no-ops and are deleted; wrapper-level errors persist without in-flight
-    conversation (item-33 test target).
+    conversation. Threading the real flush out is a known follow-up.
     """
     if run_messages is None:
         return

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -237,6 +237,13 @@ def _upsert_run(
     try:
         if not team.db:
             return
+        from agno.run.status_persist import persist_worker_owned_run
+
+        # Queue-worker-owned runs save through the attempt-fenced primitive;
+        # member-run saves pass through untouched (their run_ids are never
+        # registered - a zombie leg's member writes orphan, not clobber)
+        if persist_worker_owned_run(team.db, run, session_id=session_id, user_id=user_id):
+            return
         team.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr]
     except NotImplementedError:
         log_debug(f"{type(team.db).__name__} does not implement upsert_run; skipping per-run write")
@@ -256,6 +263,12 @@ async def _aupsert_run(
 
     try:
         if not team.db:
+            return
+        from agno.run.status_persist import apersist_worker_owned_run
+
+        # Queue-worker-owned runs save through the attempt-fenced primitive;
+        # member-run saves pass through untouched (see _upsert_run)
+        if await apersist_worker_owned_run(team.db, run, session_id=session_id, user_id=user_id):
             return
         if _has_async_db(team):
             await team.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr,misc]

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -1638,6 +1638,12 @@ class Workflow:
         if not self.db:
             return
         try:
+            from agno.run.status_persist import persist_worker_owned_run
+
+            # Queue-worker-owned runs save through the attempt-fenced
+            # primitive; a zombie attempt's write is refused, not applied
+            if persist_worker_owned_run(self.db, run, session_id=session_id, user_id=user_id):
+                return
             self.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr]
         except NotImplementedError:
             log_debug(f"{type(self.db).__name__} does not implement upsert_run; skipping per-run write")
@@ -1655,6 +1661,12 @@ class Workflow:
         if not self.db:
             return
         try:
+            from agno.run.status_persist import apersist_worker_owned_run
+
+            # Queue-worker-owned runs save through the attempt-fenced
+            # primitive; a zombie attempt's write is refused, not applied
+            if await apersist_worker_owned_run(self.db, run, session_id=session_id, user_id=user_id):
+                return
             if self._has_async_db():
                 await self.db.upsert_run(run=run, session_id=session_id, user_id=user_id, run_index=run_index)  # type: ignore[union-attr,misc]
             else:

--- a/libs/agno/tests/integration/db/async_postgres/test_prepare_atomicity.py
+++ b/libs/agno/tests/integration/db/async_postgres/test_prepare_atomicity.py
@@ -1,6 +1,6 @@
 """Integration tests for the atomic queued-run prepare on real Postgres.
 
-Phase-3 item 9 (lean): aprepare_queued_run must never whole-session-save.
+aprepare_queued_run must never whole-session-save.
 The fresh-session path used to be an unlocked read-check-save, and a worker
 that claimed, created the session, and COMPLETED the run inside that window
 was clobbered back to PENDING by the accepting request's stale save. The

--- a/libs/agno/tests/integration/db/async_postgres/test_worker_owned_fencing.py
+++ b/libs/agno/tests/integration/db/async_postgres/test_worker_owned_fencing.py
@@ -1,0 +1,181 @@
+"""Item 4 on real Postgres: the zombie-clobber the fence exists to stop.
+
+A worker declared dead (but still executing) writes its result AFTER a newer
+attempt has claimed and completed the run. Before the fence, that write went
+through bare ``upsert_run`` and overwrote the newer attempt's terminal row
+wholesale. Now the save helpers route worker-owned runs through the
+row-locked ``update_run_in_session`` with ``expected_attempt`` - the zombie
+is typed STALE_ATTEMPT (or TERMINAL_REFUSED) and dropped.
+"""
+
+import time
+import uuid
+
+import pytest
+
+from agno.agent import Agent
+from agno.db.postgres import AsyncPostgresDb
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.concurrency import mark_worker_managed, unmark_worker_managed
+
+DB_URL = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+
+def _pg_available() -> bool:
+    import socket
+
+    try:
+        with socket.create_connection(("localhost", 5532), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _pg_available(), reason="Postgres not available on localhost:5532")
+
+
+@pytest.fixture()
+def db() -> AsyncPostgresDb:
+    suffix = uuid.uuid4().hex[:8]
+    return AsyncPostgresDb(db_url=DB_URL, session_table=f"test_wof_{suffix}", runs_table=f"test_wof_runs_{suffix}")
+
+
+@pytest.fixture(autouse=True)
+def cleanup(db):
+    registered: list = []
+    yield registered
+    for rid in registered:
+        unmark_worker_managed(rid)
+    import sqlalchemy
+
+    engine = sqlalchemy.create_engine(DB_URL)
+    with engine.begin() as conn:
+        conn.execute(sqlalchemy.text(f'DROP TABLE IF EXISTS {db.db_schema}."{db.runs_table_name}"'))
+        conn.execute(sqlalchemy.text(f'DROP TABLE IF EXISTS {db.db_schema}."{db.session_table_name}"'))
+    engine.dispose()
+
+
+async def seed_completed_run(db, session_id: str, run_id: str, attempt: int) -> None:
+    """The NEWER attempt's settled state: COMPLETED row stamped with its
+    queue_attempt, exactly as the worker's up-front stamp + fenced terminal
+    save leave it."""
+    table = await db._get_table(table_type="sessions", create_table_if_not_found=True)
+    runs_table = await db._get_table(table_type="runs", create_table_if_not_found=True)
+    async with db.async_session_factory() as sess:
+        async with sess.begin():
+            await sess.execute(
+                table.insert().values(session_id=session_id, session_type="agent", created_at=int(time.time()))
+            )
+            await sess.execute(
+                runs_table.insert().values(
+                    run_id=run_id,
+                    session_id=session_id,
+                    run_type="agent",
+                    status="COMPLETED",
+                    run_index=0,
+                    run_data={
+                        "run_id": run_id,
+                        "status": "COMPLETED",
+                        "content": "the real output",
+                        "queue_attempt": attempt,
+                    },
+                    created_at=int(time.time()),
+                )
+            )
+
+
+async def read_run(db, run_id: str) -> dict:
+    from sqlalchemy import select
+
+    runs_table = await db._get_table(table_type="runs")
+    async with db.async_session_factory() as sess:
+        row = (await sess.execute(select(runs_table.c.run_data).where(runs_table.c.run_id == run_id))).fetchone()
+    return dict(row[0]) if row else {}
+
+
+class TestZombieSaveCannotClobber:
+    @pytest.mark.asyncio
+    async def test_stale_attempt_terminal_save_is_dropped(self, db, cleanup):
+        """The canonical zombie: attempt 1 was swept, attempt 2 completed.
+        Attempt 1's late ERROR save must bounce off the fence."""
+        from agno.agent._session import asave_run
+
+        session_id, run_id = f"s-{uuid.uuid4().hex[:8]}", f"r-{uuid.uuid4().hex[:8]}"
+        await seed_completed_run(db, session_id, run_id, attempt=2)
+        agent = Agent(id="fence-agent", name="Fence Agent", db=db)
+
+        mark_worker_managed(run_id, worker_id="zombie", attempt=1)
+        cleanup.append(run_id)
+        zombie_result = RunOutput(
+            run_id=run_id, session_id=session_id, status=RunStatus.error, content="zombie garbage"
+        )
+        await asave_run(agent, run=zombie_result, session_id=session_id)
+
+        row = await read_run(db, run_id)
+        assert row["status"] == "COMPLETED", (
+            f"zombie attempt 1 clobbered the newer attempt's terminal row: {row['status']}"
+        )
+        assert row["content"] == "the real output"
+        assert row["queue_attempt"] == 2
+
+    @pytest.mark.asyncio
+    async def test_stale_attempt_midrun_flush_is_dropped(self, db, cleanup):
+        """Not just terminal saves: a zombie's mid-run RUNNING flush landing
+        after the newer attempt completed must also be refused (the census
+        rider - bare upsert_run overwrites status unconditionally)."""
+        from agno.agent._session import asave_run
+
+        session_id, run_id = f"s-{uuid.uuid4().hex[:8]}", f"r-{uuid.uuid4().hex[:8]}"
+        await seed_completed_run(db, session_id, run_id, attempt=2)
+        agent = Agent(id="fence-agent", name="Fence Agent", db=db)
+
+        mark_worker_managed(run_id, worker_id="zombie", attempt=1)
+        cleanup.append(run_id)
+        midrun = RunOutput(run_id=run_id, session_id=session_id, status=RunStatus.running, content="partial")
+        await asave_run(agent, run=midrun, session_id=session_id)
+
+        row = await read_run(db, run_id)
+        assert row["status"] == "COMPLETED" and row["content"] == "the real output"
+
+    @pytest.mark.asyncio
+    async def test_live_attempt_save_applies(self, db, cleanup):
+        """The fence must not block the CURRENT attempt: a newer attempt's
+        own terminal save goes through and restamps the row."""
+        from agno.agent._session import asave_run
+
+        session_id, run_id = f"s-{uuid.uuid4().hex[:8]}", f"r-{uuid.uuid4().hex[:8]}"
+        await seed_completed_run(db, session_id, run_id, attempt=2)
+        agent = Agent(id="fence-agent", name="Fence Agent", db=db)
+
+        mark_worker_managed(run_id, worker_id="live", attempt=3)
+        cleanup.append(run_id)
+        newer = RunOutput(run_id=run_id, session_id=session_id, status=RunStatus.completed, content="attempt 3 output")
+        await asave_run(agent, run=newer, session_id=session_id)
+
+        row = await read_run(db, run_id)
+        assert row["content"] == "attempt 3 output"
+        assert row["queue_attempt"] == 3
+
+    @pytest.mark.asyncio
+    async def test_owned_save_with_missing_row_creates_stamped_row(self, db, cleanup):
+        """MISSING falls to the atomic append, which stamps queue_attempt so
+        the very next fence compare is armed."""
+        from agno.agent._session import asave_run
+        from agno.session import AgentSession
+
+        session_id, run_id = f"s-{uuid.uuid4().hex[:8]}", f"r-{uuid.uuid4().hex[:8]}"
+        agent = Agent(id="fence-agent", name="Fence Agent", db=db)
+        await db._get_table(table_type="runs", create_table_if_not_found=True)
+        assert await db.insert_session_if_absent(
+            AgentSession(session_id=session_id, agent_id="fence-agent", runs=[], created_at=int(time.time()))
+        )
+
+        mark_worker_managed(run_id, worker_id="w1", attempt=1)
+        cleanup.append(run_id)
+        result = RunOutput(run_id=run_id, session_id=session_id, status=RunStatus.completed, content="first landing")
+        await asave_run(agent, run=result, session_id=session_id)
+
+        row = await read_run(db, run_id)
+        assert row.get("content") == "first landing"
+        assert row.get("queue_attempt") == 1, "fresh row must carry the attempt stamp"

--- a/libs/agno/tests/integration/db/async_postgres/test_worker_owned_fencing.py
+++ b/libs/agno/tests/integration/db/async_postgres/test_worker_owned_fencing.py
@@ -1,4 +1,4 @@
-"""Item 4 on real Postgres: the zombie-clobber the fence exists to stop.
+"""On real Postgres: the zombie-clobber the save fence exists to stop.
 
 A worker declared dead (but still executing) writes its result AFTER a newer
 attempt has claimed and completed the run. Before the fence, that write went
@@ -122,8 +122,9 @@ class TestZombieSaveCannotClobber:
     @pytest.mark.asyncio
     async def test_stale_attempt_midrun_flush_is_dropped(self, db, cleanup):
         """Not just terminal saves: a zombie's mid-run RUNNING flush landing
-        after the newer attempt completed must also be refused (the census
-        rider - bare upsert_run overwrites status unconditionally)."""
+        after the newer attempt completed must also be refused - bare
+        upsert_run overwrites status unconditionally, so an unfenced flush
+        is the same clobber as an unfenced terminal write."""
         from agno.agent._session import asave_run
 
         session_id, run_id = f"s-{uuid.uuid4().hex[:8]}", f"r-{uuid.uuid4().hex[:8]}"

--- a/libs/agno/tests/integration/db/test_queue_store_parity.py
+++ b/libs/agno/tests/integration/db/test_queue_store_parity.py
@@ -1,4 +1,4 @@
-"""Phase-6 item 26: the store-contract PARITY matrix.
+"""The store-contract PARITY matrix.
 
 One scenario set, executed identically against every queue store: in-memory,
 Redis over fakeredis, Redis over a REAL server (the WATCH-sensitive rows -

--- a/libs/agno/tests/unit/agent/test_acontinue_run_background_stream.py
+++ b/libs/agno/tests/unit/agent/test_acontinue_run_background_stream.py
@@ -235,7 +235,7 @@ class TestRePausedContinueFinalStatus:
 
 
 class TestRunIdOnlyContinuePersistsStatus:
-    """Phase-4 item 16: HITL continues arrive with run_response=None (the
+    """HITL continues arrive with run_response=None (the
     router passes only run_id), and both persistence points sat behind
     `if run_response:` - the run executed fine while the DB read PAUSED for
     the entire leg. The producer must load the run from the session it

--- a/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
+++ b/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
@@ -178,14 +178,17 @@ class TestHelperUnits:
         assert await aticket_poll_fallback(worker, "r1", "s1", "agent", "a1", "bob") is None
 
 
-class TestBackgroundContinueRequiresDurableDoor:
-    """continue(background=true, stream=false) previously
-    diverged three ways - 202 with a ticket, a silent INLINE-BLOCKING 200 on
-    agents/teams without one, and a 409 on workflows. The silent inline run
-    was the lie: the caller asked for background semantics and got a request
-    that blocked for the whole continuation leg. Now all three components
-    refuse identically without a ticket; the durable 202 body was already
-    uniform (cbeb8e8)."""
+class TestBackgroundContinueCompatFallthrough:
+    """continue(background=true, stream=false) without a durable ticket.
+
+    Agents and teams keep their PRE-QUEUE behavior for back-compat: the
+    background form param predates the durable queue on those endpoints and
+    its non-stream branch always ran the continuation INLINE-BLOCKING, so
+    existing clients depend on it. The fallthrough now logs a loud warning
+    pointing at QueueConfig(durable=True) - real background continuation is
+    the durable door. Workflows differ deliberately: their continue endpoint
+    never had the param, so the durable door is its only contract and it
+    refuses with 409 instead."""
 
     @pytest.fixture()
     def continue_harness(self, tmp_path):
@@ -195,38 +198,85 @@ class TestBackgroundContinueRequiresDurableDoor:
         from agno.db.sqlite import SqliteDb
         from agno.os import AgentOS
         from agno.team import Team
+        from agno.workflow import Workflow
 
         db = SqliteDb(db_file=str(tmp_path / "t.db"))
         agent = Agent(id="qa-agent", name="QA Agent", db=db)
         team = Team(id="qa-team", name="QA Team", members=[], db=db)
-        app = AgentOS(agents=[agent], teams=[team], telemetry=False).get_app()
+        workflow = Workflow(id="qa-wf", name="QA Workflow", db=db, steps=[])
+        app = AgentOS(agents=[agent], teams=[team], workflows=[workflow], telemetry=False).get_app()
         return TestClient(app, raise_server_exceptions=False)
 
-    def test_agent_background_continue_without_ticket_409s(self, continue_harness):
-        resp = continue_harness.post(
-            "/agents/qa-agent/runs/r-nope/continue",
-            data={"background": "true", "stream": "false", "session_id": "s1"},
-        )
-        assert resp.status_code == 409, (
-            f"got {resp.status_code} - the old fallthrough ran the continuation inline while "
-            "claiming background semantics"
-        )
-        assert "durably-submitted" in resp.json()["detail"]
+    def test_agent_background_continue_without_ticket_runs_inline(self, continue_harness, caplog):
+        import logging
 
-    def test_team_background_continue_without_ticket_409s(self, continue_harness):
+        with caplog.at_level(logging.WARNING, logger="agno"):
+            resp = continue_harness.post(
+                "/agents/qa-agent/runs/r-nope/continue",
+                data={"background": "true", "stream": "false", "session_id": "s1"},
+            )
+        assert resp.status_code != 409, (
+            f"got 409 - the legacy inline fallthrough must survive for back-compat: {resp.json()}"
+        )
+        assert any("INLINE-BLOCKING" in r.message for r in caplog.records), (
+            "the compat fallthrough must warn that background semantics are not real here"
+        )
+
+    def test_team_background_continue_without_ticket_runs_inline(self, continue_harness, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="agno"):
+            resp = continue_harness.post(
+                "/teams/qa-team/runs/r-nope/continue",
+                data={"background": "true", "stream": "false", "session_id": "s1"},
+            )
+        assert resp.status_code != 409
+        assert any("INLINE-BLOCKING" in r.message for r in caplog.records)
+
+    def test_workflow_background_continue_without_ticket_409s(self, continue_harness, tmp_path):
+        """The workflow continue endpoint gained the background param WITH
+        the durable queue - there is no legacy client to protect, so the
+        honest refusal stands. A real PAUSED run is seeded (the endpoint
+        404s nonexistent runs before the gate)."""
+        import json as _json
+        import time as _time
+
+        from agno.db.sqlite import SqliteDb
+
+        seed_db = SqliteDb(db_file=str(tmp_path / "t.db"))
+        sessions_table = seed_db._get_table(table_type="sessions", create_table_if_not_found=True)
+        runs_table = seed_db._get_table(table_type="runs", create_table_if_not_found=True)
+        with seed_db.Session() as sess, sess.begin():
+            sess.execute(
+                sessions_table.insert().values(session_id="s1", session_type="workflow", created_at=int(_time.time()))
+            )
+            sess.execute(
+                runs_table.insert().values(
+                    run_id="r-paused",
+                    session_id="s1",
+                    run_type="workflow",
+                    workflow_id="qa-wf",
+                    status="PAUSED",
+                    run_index=0,
+                    run_data=_json.dumps(
+                        {"run_id": "r-paused", "session_id": "s1", "workflow_id": "qa-wf", "status": "PAUSED"}
+                    ),
+                    created_at=int(_time.time()),
+                )
+            )
+
         resp = continue_harness.post(
-            "/teams/qa-team/runs/r-nope/continue",
+            "/workflows/qa-wf/runs/r-paused/continue",
             data={"background": "true", "stream": "false", "session_id": "s1"},
         )
-        assert resp.status_code == 409
+        assert resp.status_code == 409, f"got {resp.status_code}: {resp.json()}"
         assert "durably-submitted" in resp.json()["detail"]
 
     def test_inline_continue_without_background_is_not_refused(self, continue_harness):
-        """background=false continues keep the inline path: whatever the
-        inline machinery does with this run, the durable-door refusal must
-        not fire - it is scoped strictly to the background flag."""
+        """background=false continues keep the inline path untouched - no
+        warning, no refusal keyed on the durable door."""
         resp = continue_harness.post(
             "/agents/qa-agent/runs/r-nope/continue",
             data={"background": "false", "stream": "false", "session_id": "s1"},
         )
-        assert resp.status_code != 409, f"the 409 must key on background=true only: {resp.json()}"
+        assert resp.status_code != 409, f"nothing here should 409: {resp.json()}"

--- a/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
+++ b/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
@@ -280,3 +280,39 @@ class TestBackgroundContinueCompatFallthrough:
             data={"background": "false", "stream": "false", "session_id": "s1"},
         )
         assert resp.status_code != 409, f"nothing here should 409: {resp.json()}"
+
+
+class TestSubmitBackgroundBodyParity:
+    """background=true + stream=false submits answer with the SAME body shape
+    whether or not the durable queue is wired: 202 and exactly
+    {run_id, session_id, status}. The durable seam's body is pinned by
+    TestPrepareFailureTruthfulness/TestTicketPollFallback above; this pins
+    the NON-durable detached path for all three components, so a client
+    written against one deployment mode works unchanged on the other."""
+
+    @pytest.fixture()
+    def submit_harness(self, tmp_path):
+        from fastapi.testclient import TestClient
+
+        from agno.agent import Agent
+        from agno.db.sqlite import SqliteDb
+        from agno.os import AgentOS
+        from agno.team import Team
+        from agno.workflow import Workflow
+
+        db = SqliteDb(db_file=str(tmp_path / "t.db"))
+        agent = Agent(id="qa-agent", name="QA Agent", db=db)
+        team = Team(id="qa-team", name="QA Team", members=[], db=db)
+        workflow = Workflow(id="qa-wf", name="QA Workflow", db=db, steps=[])
+        app = AgentOS(agents=[agent], teams=[team], workflows=[workflow], telemetry=False).get_app()
+        return TestClient(app, raise_server_exceptions=False)
+
+    @pytest.mark.parametrize("path", ["/agents/qa-agent/runs", "/teams/qa-team/runs", "/workflows/qa-wf/runs"])
+    def test_non_durable_body_matches_durable_contract(self, submit_harness, path):
+        resp = submit_harness.post(path, data={"message": "hi", "stream": "false", "background": "true"})
+        assert resp.status_code == 202, f"{path}: {resp.status_code} {resp.text[:200]}"
+        body = resp.json()
+        assert set(body.keys()) == {"run_id", "session_id", "status"}, (
+            f"{path}: the non-durable 202 body must match the durable seam's shape exactly, got {body}"
+        )
+        assert body["status"] in ("PENDING", "RUNNING")

--- a/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
+++ b/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
@@ -1,4 +1,4 @@
-"""Behavioral tests for the acceptance invariant (phase-3 item 10).
+"""Behavioral tests for the acceptance invariant.
 
 After the queue ticket commits, every response must either ACKNOWLEDGE the
 durable acceptance (202/tail) or first make the ticket permanently
@@ -179,7 +179,7 @@ class TestHelperUnits:
 
 
 class TestBackgroundContinueRequiresDurableDoor:
-    """Phase-7 item 32: continue(background=true, stream=false) previously
+    """continue(background=true, stream=false) previously
     diverged three ways - 202 with a ticket, a silent INLINE-BLOCKING 200 on
     agents/teams without one, and a 409 on workflows. The silent inline run
     was the lie: the caller asked for background semantics and got a request

--- a/libs/agno/tests/unit/os/test_continue_seam.py
+++ b/libs/agno/tests/unit/os/test_continue_seam.py
@@ -579,8 +579,8 @@ class TestAcceptSideEffects:
         await acancel_run("r1")
 
         endpoint, request = self._requeue_endpoint(store)
-        # force=True: the job JUST failed, and the zombie gate (phase-7
-        # guard) refuses fresh failures without it - orthogonal to the
+        # force=True: the job JUST failed, and the requeue zombie gate
+        # refuses fresh failures without it - orthogonal to the
         # intent semantics this test pins
         result = await endpoint(request, "r1", force=True)
         assert result["status"] == "queued"
@@ -644,8 +644,8 @@ class TestAcceptSideEffects:
         await acancel_run("r1")
 
         endpoint, request = self._requeue_endpoint(store)
-        # force=True: fresh failure, zombie gate refused otherwise (phase-7
-        # guard) - orthogonal to the clear-failure semantics under test
+        # force=True: fresh failure, the requeue zombie gate refuses
+        # otherwise - orthogonal to the clear-failure semantics under test
         with patch("agno.run.cancel.acleanup_run", side_effect=RuntimeError("redis down")):
             with pytest.raises(HTTPException) as exc:
                 await endpoint(request, "r1", clear_cancellation=True, force=True)
@@ -723,7 +723,7 @@ class TestContinueStreamEventsPrecedence:
 
 
 class TestInlineContinueReopensStream:
-    """Phase-4 item 15: the INLINE continue path (amark_continue_stream_running)
+    """The INLINE continue path (amark_continue_stream_running)
     must invalidate the settled pause the same way the durable path does.
     PAUSED is tail-terminal in the stream twice over - the status key AND a
     sentinel event - and the old helper only rewrote the status: a client
@@ -801,7 +801,7 @@ class TestInlineContinueReopensStream:
 
 
 class TestInlineContinueSeedsExpiredCounter:
-    """Phase-5 item 20, inline door: an inline continue of a paused run whose
+    """Inline door: an inline continue of a paused run whose
     stream state expired (deploy/restart) must seed the counter from the run
     row's stored indices - the floor read happens ONLY when the counter is
     gone, never on the hot path."""

--- a/libs/agno/tests/unit/os/test_db_replay_fallback.py
+++ b/libs/agno/tests/unit/os/test_db_replay_fallback.py
@@ -1,4 +1,4 @@
-"""Phase-5 item 21: the DB replay fallback (PATH-3) must honor the client's
+"""The DB replay fallback (PATH-3) must honor the client's
 last_event_index using the events' REAL stream indices.
 
 Substrate: the event stream stamps event_index onto the event OBJECT at

--- a/libs/agno/tests/unit/os/test_event_streams.py
+++ b/libs/agno/tests/unit/os/test_event_streams.py
@@ -213,7 +213,7 @@ class TestInMemoryRetryIndexContinuity:
 
 
 class TestReopenSeedsCounterFromFloor:
-    """Phase-5 item 20 (in-memory twin): after a process restart the buffer
+    """In-memory twin of the Redis floor-seeding tests: after a process restart the buffer
     comes up empty under a paused run's continue - the seeded floor keeps
     indices monotonic for resuming clients."""
 

--- a/libs/agno/tests/unit/os/test_event_streams_redis.py
+++ b/libs/agno/tests/unit/os/test_event_streams_redis.py
@@ -589,7 +589,7 @@ class TestDeadProducerGate:
 
 
 class TestEventCountExcludesMarkers:
-    """Phase-5 item 23: coordination markers - pause/terminal sentinels and
+    """Coordination markers - pause/terminal sentinels and
     reopen markers, including stale mid-stream ones - are stream entries but
     not client-facing events. The old XLEN-minus-trailing-sentinel count
     inflated by 2+ per pause/continue cycle; anything consuming the count for
@@ -620,7 +620,7 @@ class TestEventCountExcludesMarkers:
 
 
 class TestBatchBoundarySentinel:
-    """Phase-5 item 22: XREAD reads count-bounded batches (100), and the old
+    """XREAD reads count-bounded batches (100), and the old
     tail honored a sentinel that was merely BATCH-final - a lagging consumer
     whose batch happened to end exactly on a stale pause sentinel was closed
     even though the reopen marker and continuation events sat in the very
@@ -674,7 +674,7 @@ class TestBatchBoundarySentinel:
 
 
 class TestReopenSeedsCounterFromFloor:
-    """Phase-5 item 20: a paused run outliving the TTL (HITL across a
+    """A paused run outliving the TTL (HITL across a
     deploy) loses its counter; reopen_run accepted the missing state and
     INCR restarted indices at 0 - resuming clients, which dedup by index,
     silently discarded every post-approval event."""
@@ -728,7 +728,7 @@ class TestReopenSeedsCounterFromFloor:
 
 
 class TestClusterRejection:
-    """Phase-6 item 25: the stream's per-run keys are not hash-tagged, so its
+    """The stream's per-run keys are not hash-tagged, so its
     WATCH/MULTI and multi-key pipelines are cross-slot - reject cluster
     clients at construction like the job-queue store does, instead of
     failing confusingly at runtime mid-continuation. The cancellation
@@ -746,7 +746,7 @@ class TestClusterRejection:
 
 
 class TestIdleProbeResilience:
-    """Phase-7 item 28: the status probe on the idle path was the one
+    """The status probe on the idle path was the one
     unguarded call in the tail loop - a Redis blip there escaped the loop
     (client sees an error close) instead of riding through like the same
     outage one line earlier at the XREAD. And when a connection fails FAST,

--- a/libs/agno/tests/unit/os/test_queue_wiring.py
+++ b/libs/agno/tests/unit/os/test_queue_wiring.py
@@ -271,7 +271,7 @@ class TestQueueAdminGate:
 
 
 class TestUnfencedSessionStoreWarning:
-    """Phase-6 item 24-as-A: a durable queue over a session store without the
+    """A durable queue over a session store without the
     atomic run-persistence primitives must degrade LOUDLY - the fencing
     architecture silently does not exist there. Option B (implement the
     primitive family per adapter) is parked, evidence-gated."""
@@ -320,7 +320,7 @@ class TestUnfencedSessionStoreWarning:
 
 
 class TestQueueLifespanCleanup:
-    """Phase-7 item 27: an exception in the app body must not leak a running
+    """An exception in the app body must not leak a running
     worker or a stale active-worker registration - the inline-door admission
     gate consults that registration, and a leaked one points at a dead
     worker's store forever."""

--- a/libs/agno/tests/unit/os/test_queue_worker.py
+++ b/libs/agno/tests/unit/os/test_queue_worker.py
@@ -1015,17 +1015,16 @@ class TestConfigValidation:
             with pytest.raises(ValueError):
                 QueueConfig(durable=True, **{k: v for k, v in kwargs.items() if k != "durable"})
 
-    def test_multi_attempt_requires_experimental_opt_in(self):
-        """The interim two-producer guard, config half: re-execution reaches
-        the unfenced happy-path-save and stream-write races (P1 items), so
-        max_attempts > 1 is an explicit experimental opt-in - a log warning
-        is not a control."""
+    def test_multi_attempt_is_first_class(self):
+        """The interim experimental opt-in is GONE: items 4+5 fenced the
+        two-producer races (run-row saves and stream writes), so
+        max_attempts > 1 constructs plainly. The at-most-once default is
+        untouched - retries are a choice, not a surprise."""
         from agno.job_queue.config import QueueConfig
 
-        with pytest.raises(ValueError, match="allow_multi_attempt_experimental"):
-            QueueConfig(durable=True, max_attempts=3)
-        config = QueueConfig(durable=True, max_attempts=3, allow_multi_attempt_experimental=True)
+        config = QueueConfig(durable=True, max_attempts=3)
         assert config.max_attempts == 3
+        assert not hasattr(config, "allow_multi_attempt_experimental"), "the flag must be fully deleted"
         assert QueueConfig(durable=True).max_attempts == 1  # default untouched
 
 

--- a/libs/agno/tests/unit/os/test_queue_worker.py
+++ b/libs/agno/tests/unit/os/test_queue_worker.py
@@ -1016,7 +1016,7 @@ class TestConfigValidation:
                 QueueConfig(durable=True, **{k: v for k, v in kwargs.items() if k != "durable"})
 
     def test_multi_attempt_is_first_class(self):
-        """The interim experimental opt-in is GONE: items 4+5 fenced the
+        """The interim experimental opt-in is GONE: the save and stream fences closed the
         two-producer races (run-row saves and stream writes), so
         max_attempts > 1 constructs plainly. The at-most-once default is
         untouched - retries are a choice, not a surprise."""
@@ -1760,7 +1760,7 @@ class TestForegroundCancelPersistGuard:
 
 
 class TestWorkerEnsuresRunRow:
-    """Phase-3 item 9 (lean): a claimed run's row is guaranteed durable BEFORE
+    """A claimed run's row is guaranteed durable BEFORE
     execution - the accepting request's prepare can fail or die after the
     ticket committed, and the old worker executed rowless (pollers 404ed a
     real run until its terminal save; the accept grace only narrowed the
@@ -1952,7 +1952,7 @@ class TestClosingLedger:
 
 
 class TestWorkerPathIndexStamp:
-    """Phase-5 item 21 tripwire: the DB-fallback substrate assumes the events
+    """Tripwire: the DB-fallback substrate assumes the events
     the worker PUBLISHES are the same objects the component ACCUMULATES for
     its session save. If that shared-reference assumption ever breaks (a
     copy, a reconstruction), indices silently stop reaching storage and the
@@ -2022,7 +2022,7 @@ class TestWorkerPathIndexStamp:
 
 
 class TestWorkerRedriveSeedsExpiredCounter:
-    """Phase-5 item 20, durable door: the worker's continuation reopen seeds
+    """Durable door: the worker's continuation reopen seeds
     an EXPIRED counter from the run row before the leg's first event - the
     seam's accept-time reopen is deliberately floorless (nothing publishes
     before the worker's reopen), so this is the one seat that must seed."""
@@ -2092,7 +2092,7 @@ class TestWorkerRedriveSeedsExpiredCounter:
 
 
 class TestDrainLifecycle:
-    """Phase-7 item 29: the drain's three defects - heartbeat dying at drain
+    """The drain's three defects - heartbeat dying at drain
     start (peer sweeps a healthily-draining run as dead), the double-cancel
     (a second cancel landing inside except CancelledError interrupts the
     drain's own shielded persist-before-requeue), and the warned-not-enforced

--- a/libs/agno/tests/unit/os/test_requeue_zombie_gate.py
+++ b/libs/agno/tests/unit/os/test_requeue_zombie_gate.py
@@ -1,4 +1,4 @@
-"""Phase-7 commit #1: the interim two-producer guard, requeue half.
+"""The requeue zombie gate.
 
 A job FAILED within the last lock_grace was, in the worst case, swept while
 its worker was actually alive (a sweep proves lost heartbeats, not stopped

--- a/libs/agno/tests/unit/os/test_stream_expired_close.py
+++ b/libs/agno/tests/unit/os/test_stream_expired_close.py
@@ -1,4 +1,4 @@
-"""Phase-5 item 19-lite: the honest close.
+"""The honest close.
 
 A tail that ends because the stream state expired (run queued past the TTL,
 or a dead producer) while the durable ticket still vouches for the run used

--- a/libs/agno/tests/unit/os/test_stream_generation_fence.py
+++ b/libs/agno/tests/unit/os/test_stream_generation_fence.py
@@ -1,4 +1,4 @@
-"""Item 5: per-run stream writer generations.
+"""Per-run stream writer generations.
 
 ``begin_attempt`` records the newest attempt as the stream's writer
 generation (monotonic CAS); ``add_event(generation=...)`` from an older

--- a/libs/agno/tests/unit/os/test_stream_generation_fence.py
+++ b/libs/agno/tests/unit/os/test_stream_generation_fence.py
@@ -1,0 +1,316 @@
+"""Item 5: per-run stream writer generations.
+
+``begin_attempt`` records the newest attempt as the stream's writer
+generation (monotonic CAS); ``add_event(generation=...)`` from an older
+generation is REFUSED - a zombie attempt's output can no longer interleave
+into the live attempt's stream. Redis does the check atomically in Lua
+(gen-check+INCR, gen-check+XADD); in-memory checks under the event loop; a
+Redis server without scripting degrades fail-open to unfenced publishing
+with a warning (the stream is coordination, not truth).
+"""
+
+import socket
+import uuid
+
+import pytest
+
+from agno.run.agent import RunContentEvent
+from agno.run.base import RunStatus
+
+
+def make_event(run_id: str, content: str) -> RunContentEvent:
+    return RunContentEvent(content=content, run_id=run_id)
+
+
+def _port_open(port: int) -> bool:
+    try:
+        with socket.create_connection(("localhost", port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# In-memory backend
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mem_stream():
+    from agno.os.event_streams import InMemoryEventStream
+    from agno.os.managers import EventsBuffer, SSESubscriberManager
+
+    return InMemoryEventStream(events_buffer=EventsBuffer(), subscriber_manager=SSESubscriberManager())
+
+
+class TestInMemoryGenerationFence:
+    @pytest.mark.asyncio
+    async def test_stale_generation_is_refused(self, mem_stream):
+        await mem_stream.register_run("r1", RunStatus.running)
+        await mem_stream.begin_attempt("r1", 1)
+        assert await mem_stream.add_event("r1", make_event("r1", "live-1"), generation=1) == 0
+
+        await mem_stream.begin_attempt("r1", 2)  # the reclaim
+        assert await mem_stream.add_event("r1", make_event("r1", "zombie"), generation=1) == -1, (
+            "attempt 1's event landed after attempt 2 took the stream"
+        )
+        assert await mem_stream.add_event("r1", make_event("r1", "live-2"), generation=2) >= 0
+
+        replayed = await mem_stream.replay("r1")
+        contents = [getattr(e, "content", None) for _, e in replayed]
+        assert "zombie" not in contents
+        assert await mem_stream.get_event_count("r1") == 2
+
+    @pytest.mark.asyncio
+    async def test_old_begin_never_regresses(self, mem_stream):
+        await mem_stream.begin_attempt("r1", 2)
+        await mem_stream.begin_attempt("r1", 1)  # zombie's late begin
+        assert await mem_stream.add_event("r1", make_event("r1", "z"), generation=1) == -1
+        assert await mem_stream.add_event("r1", make_event("r1", "ok"), generation=2) >= 0
+
+    @pytest.mark.asyncio
+    async def test_unfenced_add_bypasses(self, mem_stream):
+        """Inline single-writer producers pass no generation - legacy path."""
+        await mem_stream.begin_attempt("r1", 5)
+        assert await mem_stream.add_event("r1", make_event("r1", "inline")) == 0
+
+    @pytest.mark.asyncio
+    async def test_first_fenced_writer_establishes_generation(self, mem_stream):
+        """No begin_attempt happened (e.g. process restart lost it): the
+        first fenced add establishes the generation instead of refusing."""
+        assert await mem_stream.add_event("r1", make_event("r1", "a"), generation=3) == 0
+        assert await mem_stream.add_event("r1", make_event("r1", "b"), generation=2) == -1
+
+    @pytest.mark.asyncio
+    async def test_cleanup_clears_generation(self, mem_stream):
+        await mem_stream.begin_attempt("r1", 9)
+        await mem_stream.cleanup_run("r1")
+        assert await mem_stream.add_event("r1", make_event("r1", "fresh"), generation=1) == 0
+
+
+# ---------------------------------------------------------------------------
+# Redis backend - Lua path on a real server
+# ---------------------------------------------------------------------------
+
+redis_required = pytest.mark.skipif(not _port_open(6379), reason="Redis not available on localhost:6379")
+
+
+@redis_required
+class TestRedisGenerationFence:
+    @pytest.fixture()
+    async def redis_stream(self):
+        import redis.asyncio as aioredis
+
+        from agno.os.event_streams.redis import RedisEventStream
+
+        client = aioredis.Redis.from_url("redis://localhost:6379")
+        stream = RedisEventStream(client, key_prefix=f"agno:test:fence:{uuid.uuid4().hex[:8]}:", block_ms=100)
+        yield stream
+        for rid in ("r1",):
+            await stream.cleanup_run(rid)
+        await stream.aclose()
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_stale_generation_is_refused_atomically(self, redis_stream):
+        await redis_stream.register_run("r1", RunStatus.running)
+        await redis_stream.begin_attempt("r1", 1)
+        assert await redis_stream.add_event("r1", make_event("r1", "live-1"), generation=1) == 0
+
+        await redis_stream.begin_attempt("r1", 2)
+        assert await redis_stream.add_event("r1", make_event("r1", "zombie"), generation=1) == -1
+        live_idx = await redis_stream.add_event("r1", make_event("r1", "live-2"), generation=2)
+        assert live_idx >= 1
+
+        replayed = await redis_stream.replay("r1")
+        assert all("zombie" not in (sse or "") for _, sse in replayed), replayed
+        assert await redis_stream.get_event_count("r1") == 2
+
+    @pytest.mark.asyncio
+    async def test_old_begin_never_regresses(self, redis_stream):
+        await redis_stream.begin_attempt("r1", 2)
+        await redis_stream.begin_attempt("r1", 1)
+        assert await redis_stream.add_event("r1", make_event("r1", "z"), generation=1) == -1
+        assert await redis_stream.add_event("r1", make_event("r1", "ok"), generation=2) >= 0
+
+    @pytest.mark.asyncio
+    async def test_unfenced_add_unchanged(self, redis_stream):
+        await redis_stream.begin_attempt("r1", 5)
+        assert await redis_stream.add_event("r1", make_event("r1", "inline")) == 0
+
+    @pytest.mark.asyncio
+    async def test_newer_writer_self_heals_generation(self, redis_stream):
+        """A fenced add from a NEWER generation than stored (its begin was
+        lost) updates the stored generation and lands."""
+        await redis_stream.begin_attempt("r1", 1)
+        assert await redis_stream.add_event("r1", make_event("r1", "new"), generation=4) == 0
+        assert await redis_stream.add_event("r1", make_event("r1", "old"), generation=1) == -1
+
+
+# ---------------------------------------------------------------------------
+# Degradation: a server without scripting fails OPEN
+# ---------------------------------------------------------------------------
+
+
+class TestScriptingUnavailableDegradation:
+    @pytest.mark.asyncio
+    async def test_fenced_add_publishes_unfenced_on_fakeredis(self):
+        fakeredis = pytest.importorskip("fakeredis", reason="fakeredis not installed")
+        from agno.os.event_streams.redis import RedisEventStream
+
+        stream = RedisEventStream(fakeredis.FakeAsyncRedis(), block_ms=100)
+        try:
+            await stream.register_run("r1", RunStatus.running)
+            # fakeredis has no EVAL: the fence must degrade to publishing
+            # unfenced (fail-open), never to dropping the event
+            idx = await stream.add_event("r1", make_event("r1", "a"), generation=1)
+            assert idx == 0
+            assert stream._scripting_unavailable is True
+            # And it stays on the legacy path afterwards
+            assert await stream.add_event("r1", make_event("r1", "b"), generation=99) == 1
+        finally:
+            await stream.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Worker wiring: the attempt is the generation
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerStampsGeneration:
+    @pytest.mark.asyncio
+    async def test_execute_streaming_takes_generation_and_fences_zombie(self):
+        import agno.os.event_streams as es_mod
+        from agno.job_queue.config import QueueConfig
+        from agno.job_queue.store import InMemoryQueueStore
+        from agno.os.event_streams import InMemoryEventStream, set_event_stream
+        from agno.os.job_queue import QueueWorker
+        from agno.os.managers import EventsBuffer, SSESubscriberManager
+
+        original = es_mod._event_stream
+        stream = InMemoryEventStream(events_buffer=EventsBuffer(), subscriber_manager=SSESubscriberManager())
+        set_event_stream(stream)
+        try:
+
+            class FakeOutput:
+                run_id = "sr1"
+                status = RunStatus.completed
+
+            class FakeAgent:
+                id = "a1"
+                db = None
+
+                async def arun(self, **kwargs):
+                    yield make_event("sr1", "live")
+                    yield FakeOutput()
+
+            worker = QueueWorker(
+                store=InMemoryQueueStore(),
+                resolve_component=lambda t, i: FakeAgent(),
+                config=QueueConfig(durable=True),
+            )
+            job = {"id": "sr1", "attempt": 2, "session_id": "s1", "payload": {"input": "x", "stream": True}}
+            await worker._execute_streaming(FakeAgent(), job)
+
+            # The leg took generation 2; a zombie publish from attempt 1 is
+            # refused while the leg's own event landed
+            assert await stream.add_event("sr1", make_event("sr1", "zombie"), generation=1) == -1
+            replayed = await stream.replay("sr1")
+            contents = [getattr(e, "content", None) for _, e in replayed]
+            assert contents == ["live"]
+        finally:
+            es_mod._event_stream = original
+
+
+class TestInMemoryLifecycleFence:
+    """The fence covers lifecycle mutations too: a zombie's terminal sentinel
+    must not close the live attempt's tails, and a pre-entry-stalled zombie's
+    reset must not delete the reclaim's events."""
+
+    @pytest.mark.asyncio
+    async def test_stale_complete_run_refused(self, mem_stream):
+        await mem_stream.register_run("r1", RunStatus.running)
+        await mem_stream.begin_attempt("r1", 2)
+        await mem_stream.add_event("r1", make_event("r1", "b-1"), generation=2)
+        await mem_stream.complete_run("r1", RunStatus.error, generation=1)  # zombie sentinel
+        assert await mem_stream.get_run_status("r1") == RunStatus.running, (
+            "the zombie's terminal write closed the live attempt's stream"
+        )
+        await mem_stream.complete_run("r1", RunStatus.completed, generation=2)
+        assert await mem_stream.get_run_status("r1") == RunStatus.completed
+
+    @pytest.mark.asyncio
+    async def test_same_generation_complete_passes(self, mem_stream):
+        """Finished-work-wins: a same-attempt late completion (worker falsely
+        swept, then finishing) overwrites the sweeper's ERROR close."""
+        await mem_stream.register_run("r1", RunStatus.running)
+        await mem_stream.begin_attempt("r1", 1)
+        await mem_stream.complete_run("r1", RunStatus.error, generation=1)  # the sweep
+        await mem_stream.complete_run("r1", RunStatus.completed, generation=1)  # the "dead" worker finishing
+        assert await mem_stream.get_run_status("r1") == RunStatus.completed
+
+    @pytest.mark.asyncio
+    async def test_stale_reset_refused(self, mem_stream):
+        await mem_stream.register_run("r1", RunStatus.running)
+        await mem_stream.begin_attempt("r1", 2)
+        await mem_stream.add_event("r1", make_event("r1", "b-1"), generation=2)
+        await mem_stream.reset_run_events("r1", generation=1)  # pre-entry-stalled zombie waking
+        assert await mem_stream.get_event_count("r1") == 1, "the zombie's reset deleted the reclaim's events"
+
+    @pytest.mark.asyncio
+    async def test_stale_set_run_status_refused(self, mem_stream):
+        await mem_stream.register_run("r1", RunStatus.running)
+        await mem_stream.begin_attempt("r1", 2)
+        await mem_stream.complete_run("r1", RunStatus.completed, generation=2)
+        await mem_stream.set_run_status("r1", RunStatus.running, generation=1)  # zombie's leg entry
+        assert await mem_stream.get_run_status("r1") == RunStatus.completed, (
+            "the zombie's RUNNING flip re-opened a completed stream (tails would hang)"
+        )
+
+
+@redis_required
+class TestRedisLifecycleFence:
+    @pytest.fixture()
+    async def redis_stream(self):
+        import redis.asyncio as aioredis
+
+        from agno.os.event_streams.redis import RedisEventStream
+
+        client = aioredis.Redis.from_url("redis://localhost:6379")
+        stream = RedisEventStream(client, key_prefix=f"agno:test:fence:{uuid.uuid4().hex[:8]}:", block_ms=100)
+        yield stream
+        await stream.cleanup_run("r1")
+        await stream.aclose()
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_stale_complete_run_refused(self, redis_stream):
+        await redis_stream.register_run("r1", RunStatus.running)
+        await redis_stream.begin_attempt("r1", 2)
+        await redis_stream.add_event("r1", make_event("r1", "b-1"), generation=2)
+        await redis_stream.complete_run("r1", RunStatus.error, generation=1)
+        assert await redis_stream.get_run_status("r1") == RunStatus.running
+
+    @pytest.mark.asyncio
+    async def test_same_generation_complete_passes(self, redis_stream):
+        await redis_stream.register_run("r1", RunStatus.running)
+        await redis_stream.begin_attempt("r1", 1)
+        await redis_stream.complete_run("r1", RunStatus.error, generation=1)
+        await redis_stream.complete_run("r1", RunStatus.completed, generation=1)
+        assert await redis_stream.get_run_status("r1") == RunStatus.completed
+
+    @pytest.mark.asyncio
+    async def test_stale_reset_refused(self, redis_stream):
+        await redis_stream.register_run("r1", RunStatus.running)
+        await redis_stream.begin_attempt("r1", 2)
+        await redis_stream.add_event("r1", make_event("r1", "b-1"), generation=2)
+        await redis_stream.reset_run_events("r1", generation=1)
+        assert await redis_stream.get_event_count("r1") == 1
+
+    @pytest.mark.asyncio
+    async def test_stale_set_run_status_refused(self, redis_stream):
+        await redis_stream.register_run("r1", RunStatus.running)
+        await redis_stream.begin_attempt("r1", 2)
+        await redis_stream.complete_run("r1", RunStatus.completed, generation=2)
+        await redis_stream.set_run_status("r1", RunStatus.running, generation=1)
+        assert await redis_stream.get_run_status("r1") == RunStatus.completed

--- a/libs/agno/tests/unit/os/test_zombie_acceptance.py
+++ b/libs/agno/tests/unit/os/test_zombie_acceptance.py
@@ -153,13 +153,7 @@ class TestZombieReclaimAcceptance:
                         yield Out(RUN_ID)
 
             comp = Component()
-            cfg = QueueConfig(
-                durable=True,
-                max_attempts=2,
-                lock_grace_seconds=3,
-                retry_delay_seconds=0,
-                allow_multi_attempt_experimental=True,
-            )
+            cfg = QueueConfig(durable=True, max_attempts=2, lock_grace_seconds=3, retry_delay_seconds=0)
             worker_a = QueueWorker(
                 store=store, resolve_component=lambda t, i: comp, config=cfg, worker_id="A", stop_timeout=0.2
             )

--- a/libs/agno/tests/unit/os/test_zombie_acceptance.py
+++ b/libs/agno/tests/unit/os/test_zombie_acceptance.py
@@ -1,9 +1,9 @@
-"""The two parked zombie acceptance repros, ported to the fenced world.
+"""Zombie-worker acceptance scenarios, end to end against the fences.
 
-Scenarios preserved verbatim from .context/pr9079-review/repros/
-(zombie_stream_demo.py, sweep_vs_live_worker_demo.py); only the assertions
-changed - they now pin the FENCED outcomes instead of demonstrating the
-corruption. Timings match the demos (lock_grace floor is 3s).
+Both scenarios reproduce a worker that stalls past lock_grace (heartbeats
+stop, execution does not - the event-loop-starvation mode) and then wakes.
+They originally demonstrated the corruption; the assertions now pin the
+fenced outcomes. Timings sit at the lock_grace floor (3s).
 
 Scenario 1 (multi-attempt reclaim): a worker stalls past lock_grace, a second
 worker reclaims at attempt 2, the first wakes and keeps publishing. Fenced:

--- a/libs/agno/tests/unit/os/test_zombie_acceptance.py
+++ b/libs/agno/tests/unit/os/test_zombie_acceptance.py
@@ -1,0 +1,296 @@
+"""The two parked zombie acceptance repros, ported to the fenced world.
+
+Scenarios preserved verbatim from .context/pr9079-review/repros/
+(zombie_stream_demo.py, sweep_vs_live_worker_demo.py); only the assertions
+changed - they now pin the FENCED outcomes instead of demonstrating the
+corruption. Timings match the demos (lock_grace floor is 3s).
+
+Scenario 1 (multi-attempt reclaim): a worker stalls past lock_grace, a second
+worker reclaims at attempt 2, the first wakes and keeps publishing. Fenced:
+the zombie's post-wakeup events and terminal sentinel are refused; the
+reclaiming attempt's stream and ticket are untouched.
+
+Scenario 2 (DEFAULT config, the sweep-vs-live race): max_attempts=1, the
+stalled worker is falsely swept as dead, then finishes. Fenced intent is
+FINISHED-WORK-WINS: the ticket keeps the sweep's failure (at-most-once
+bookkeeping, the requeue gate guards re-execution), but the run row and the
+stream both end COMPLETED with the real result - the zombie holds the SAME
+attempt the sweeper stamped, and same-generation writes pass by design.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+import agno.os.event_streams as es_mod
+from agno.job_queue.config import QueueConfig
+from agno.job_queue.store import InMemoryQueueStore
+from agno.os.event_streams import InMemoryEventStream, set_event_stream
+from agno.os.job_queue import QueueWorker
+from agno.os.managers import EventsBuffer, SSESubscriberManager
+from agno.run.base import RunStatus
+from agno.run.status_persist import RunPersistOutcome
+
+
+class Ev:
+    def __init__(self, name: str, run_id: str):
+        self.event = name
+        self.run_id = run_id
+        self.content = name
+
+    def to_dict(self):
+        return {"event": self.event, "content": self.content, "run_id": self.run_id}
+
+
+class Out:
+    def __init__(self, run_id: str):
+        self.status = RunStatus.completed
+        self.run_id = run_id
+
+    def to_dict(self):
+        return {"status": "completed", "run_id": self.run_id}
+
+
+class FencedFakeDb:
+    """In-memory db implementing the fenced primitive's real contract:
+    attempt fence (stale writers refused), terminal guard, queue_attempt
+    stamping. Enough for the worker's persist paths and the item-4 choke
+    point to behave exactly as against Postgres."""
+
+    def __init__(self):
+        self.rows: dict = {}
+
+    async def append_run_to_session_if_absent(self, session_id, run_dict, user_id=None):
+        rid = run_dict.get("run_id")
+        if rid in self.rows:
+            return False  # row already landed - the worker's claim-time ensure is satisfied
+        self.rows[rid] = dict(run_dict)
+        return True
+
+    async def update_run_in_session(self, session_id, run_id, fields, expected_attempt=None, user_id=None, **kw):
+        row = self.rows.get(run_id)
+        if row is None:
+            return RunPersistOutcome.MISSING
+        stored_attempt = row.get("queue_attempt")
+        if expected_attempt is not None and stored_attempt is not None and stored_attempt > expected_attempt:
+            return RunPersistOutcome.STALE_ATTEMPT
+        stored_status = str(row.get("status") or "").lower()
+        incoming = str(fields.get("status") or "").lower()
+        if stored_status in ("completed", "cancelled") and incoming and incoming != stored_status:
+            return RunPersistOutcome.TERMINAL_REFUSED
+        row.update(fields)
+        if expected_attempt is not None:
+            row["queue_attempt"] = expected_attempt
+        if kw.get("content_if_absent") is not None and not row.get("content"):
+            row["content"] = kw["content_if_absent"]
+        return RunPersistOutcome.UPDATED
+
+
+def fresh_stream() -> InMemoryEventStream:
+    return InMemoryEventStream(events_buffer=EventsBuffer(), subscriber_manager=SSESubscriberManager())
+
+
+def make_ticket(run_id: str, max_attempts: int) -> dict:
+    now = int(time.time())
+    return {
+        "id": run_id,
+        "job_type": "run",
+        "status": "queued",
+        "component_type": "agent",
+        "component_id": "comp-1",
+        "session_id": "s1",
+        "user_id": None,
+        "payload": {"stream": True, "input": "hi"},
+        "attempt": 0,
+        "max_attempts": max_attempts,
+        "available_at": now,
+        "created_at": now,
+        "updated_at": now,
+        "idempotency_key": None,
+        "deployment_id": None,
+    }
+
+
+class TestZombieReclaimAcceptance:
+    """Scenario 1: multi-attempt reclaim. The zombie's stream mutations are
+    fenced out; the reclaiming attempt owns every surface."""
+
+    @pytest.mark.asyncio
+    async def test_zombie_events_and_sentinel_fenced_after_reclaim(self):
+        RUN_ID = "run-zombie-1"
+        original = es_mod._event_stream
+        stream = fresh_stream()
+        set_event_stream(stream)
+        try:
+            store = InMemoryQueueStore()
+
+            class Component:
+                db = None
+                id = "comp-1"
+
+                def __init__(self):
+                    self.calls = 0
+
+                def arun(self, **kwargs):
+                    self.calls += 1
+                    return self._gen(self.calls)
+
+                async def _gen(self, call_no):
+                    if call_no == 1:
+                        # Attempt 1: two events, then a stall past lock_grace
+                        yield Ev("A-1", RUN_ID)
+                        yield Ev("A-2", RUN_ID)
+                        await asyncio.sleep(5.0)
+                        yield Ev("A-3-after-wakeup", RUN_ID)
+                        yield Out(RUN_ID)
+                    else:
+                        # Attempt 2 (the reclaim): finishes AFTER A wakes, so
+                        # the zombie's writes interleave mid-leg
+                        for i in range(1, 6):
+                            yield Ev(f"B-{i}", RUN_ID)
+                            await asyncio.sleep(0.5)
+                        yield Out(RUN_ID)
+
+            comp = Component()
+            cfg = QueueConfig(
+                durable=True,
+                max_attempts=2,
+                lock_grace_seconds=3,
+                retry_delay_seconds=0,
+                allow_multi_attempt_experimental=True,
+            )
+            worker_a = QueueWorker(
+                store=store, resolve_component=lambda t, i: comp, config=cfg, worker_id="A", stop_timeout=0.2
+            )
+            worker_b = QueueWorker(
+                store=store, resolve_component=lambda t, i: comp, config=cfg, worker_id="B", stop_timeout=0.2
+            )
+            await store.enqueue_job(make_ticket(RUN_ID, max_attempts=2))
+
+            job_a = await store.claim_job("A", cfg.lock_grace_seconds)
+            assert job_a is not None and job_a["attempt"] == 1
+            task_a = asyncio.create_task(worker_a._execute_claimed(job_a))
+
+            await asyncio.sleep(3.5)  # past lock_grace; A stalled mid-execution
+            job_b = await store.claim_job("B", cfg.lock_grace_seconds)
+            assert job_b is not None and job_b["attempt"] == 2, f"reclaim failed: {job_b}"
+            task_b = asyncio.create_task(worker_b._execute_claimed(job_b))
+
+            # A live tail attaches after the reclaim (a client watching the retry)
+            tail_names = []
+
+            async def tail():
+                async for _idx, sse in stream.tail(RUN_ID, last_event_index=None):
+                    tail_names.append(sse)
+
+            await asyncio.sleep(0.2)
+            tail_task = asyncio.create_task(tail())
+            await asyncio.gather(task_a, task_b)
+            await asyncio.wait_for(tail_task, timeout=10)
+
+            # The zombie's post-wakeup event is NOT in the durable view
+            replay_names = [str(getattr(e, "event", e)) for _, e in await stream.replay(RUN_ID)]
+            assert not any("A-3" in n for n in replay_names), replay_names
+            # The reclaiming attempt's full output is
+            assert sum(1 for n in replay_names if n.startswith("B-")) == 5, replay_names
+
+            # The zombie's terminal sentinel did not close B's stream early:
+            # the tail saw every B event before the (B-issued) close
+            assert sum(1 for s in tail_names if "B-" in s) == 5, tail_names
+
+            # Stream and ticket both belong to attempt 2's outcome
+            assert await stream.get_run_status(RUN_ID) == RunStatus.completed
+            ticket = await store.get_job(RUN_ID)
+            assert ticket["status"] == "completed" and ticket["attempt"] == 2
+        finally:
+            es_mod._event_stream = original
+
+
+class TestSweepVsLiveWorkerAcceptance:
+    """Scenario 2: DEFAULT config. A falsely swept worker finishes anyway.
+    Finished-work-wins: ticket keeps the sweep's failure (the requeue gate
+    guards re-execution), but the run row and stream carry the REAL result."""
+
+    @pytest.mark.asyncio
+    async def test_finished_work_wins_on_false_sweep(self):
+        RUN_ID = "run-swept-1"
+        original = es_mod._event_stream
+        stream = fresh_stream()
+        set_event_stream(stream)
+        try:
+            store = InMemoryQueueStore()
+            db = FencedFakeDb()
+            db.rows[RUN_ID] = {"run_id": RUN_ID, "status": "PENDING"}
+
+            class Component:
+                id = "comp-1"
+
+                def __init__(self):
+                    self.db = db
+                    self.finished = False
+
+                def arun(self, **kwargs):
+                    return self._gen()
+
+                async def _gen(self):
+                    from types import SimpleNamespace
+
+                    from agno.agent._storage import aupsert_run
+
+                    yield Ev("A-1", RUN_ID)
+                    await asyncio.sleep(5.0)  # swept as dead in here
+                    yield Ev("A-2-after-stall", RUN_ID)
+                    self.finished = True
+                    # The real agent's own terminal save (the item-4 choke
+                    # point): worker ownership is live, so this routes through
+                    # the fenced primitive - same attempt, finished-work-wins
+                    from agno.run.agent import RunOutput
+
+                    await aupsert_run(
+                        SimpleNamespace(db=db),
+                        RunOutput(run_id=RUN_ID, session_id="s1", status=RunStatus.completed, content="real output"),
+                        session_id="s1",
+                    )
+                    yield Out(RUN_ID)
+
+            comp = Component()
+            cfg = QueueConfig(durable=True, max_attempts=1, lock_grace_seconds=3)
+            worker_a = QueueWorker(
+                store=store, resolve_component=lambda t, i: comp, config=cfg, worker_id="A", stop_timeout=0.2
+            )
+            worker_b = QueueWorker(
+                store=store, resolve_component=lambda t, i: comp, config=cfg, worker_id="B", stop_timeout=0.2
+            )
+            await store.enqueue_job(make_ticket(RUN_ID, max_attempts=1))
+
+            job = await store.claim_job("A", cfg.lock_grace_seconds)
+            task_a = asyncio.create_task(worker_a._execute_claimed(job))
+
+            await asyncio.sleep(3.5)  # past lock_grace; A is mid-stall
+            await worker_b._sweep_exhausted()
+
+            ticket = await store.get_job(RUN_ID)
+            assert ticket["status"] == "failed", "the sweep must fail the ticket of a stale worker"
+            assert str(db.rows[RUN_ID]["status"]).upper() == "ERROR", "the sweep terminalizes the row"
+            assert await stream.get_run_status(RUN_ID) == RunStatus.error
+
+            await task_a  # A wakes and finishes
+
+            # FINISHED-WORK-WINS: the user surfaces carry the real result
+            assert comp.finished is True
+            row = db.rows[RUN_ID]
+            assert str(row["status"]).upper() == "COMPLETED", (
+                f"the falsely swept worker's real completion must overwrite the sweep's presumption: {row}"
+            )
+            assert row["content"] == "real output"
+            assert await stream.get_run_status(RUN_ID) == RunStatus.completed, (
+                "the same-generation terminal must pass (finished-work-wins)"
+            )
+            # The ticket keeps the sweep's bookkeeping: at-most-once was
+            # honored (no second execution), and the requeue zombie gate
+            # (409 without force) guards operators from re-driving it
+            ticket = await store.get_job(RUN_ID)
+            assert ticket["status"] == "failed"
+        finally:
+            es_mod._event_stream = original

--- a/libs/agno/tests/unit/run/test_queue_store_logging.py
+++ b/libs/agno/tests/unit/run/test_queue_store_logging.py
@@ -1,4 +1,4 @@
-"""Phase-7 item 30: a dead database must be LOUD, not indistinguishable from
+"""A dead database must be LOUD, not indistinguishable from
 an empty queue. The queue sections' catches logged at DEBUG - production logs
 showed nothing while every claim, heartbeat, and settlement silently failed.
 Claims and fenced/terminal writes now log at ERROR, pure reads at WARNING,

--- a/libs/agno/tests/unit/run/test_shutdown_repause_guard.py
+++ b/libs/agno/tests/unit/run/test_shutdown_repause_guard.py
@@ -1,4 +1,4 @@
-"""Phase-4 item 14: task-level shutdown must not destroy a paused run.
+"""Task-level shutdown must not destroy a paused run.
 
 A run that PAUSED for human input parked valid, continuable HITL state, and
 the leg's own persistence wrote the PAUSED row. The shutdown branches in the

--- a/libs/agno/tests/unit/run/test_worker_owned_save_fencing.py
+++ b/libs/agno/tests/unit/run/test_worker_owned_save_fencing.py
@@ -1,4 +1,4 @@
-"""Item 4: a run's OWN saves are fenced while it executes under the queue
+"""A run's OWN saves are fenced while it executes under the queue
 worker.
 
 The per-run save helpers (agent/team/workflow, sync and async) consult the

--- a/libs/agno/tests/unit/run/test_worker_owned_save_fencing.py
+++ b/libs/agno/tests/unit/run/test_worker_owned_save_fencing.py
@@ -1,0 +1,176 @@
+"""Item 4: a run's OWN saves are fenced while it executes under the queue
+worker.
+
+The per-run save helpers (agent/team/workflow, sync and async) consult the
+worker-ownership registry before writing. A registered run saves through
+``update_run_in_session`` with ``expected_attempt`` - so a zombie attempt's
+write (late terminal save or mid-run flush after a newer attempt claimed
+the row) is refused by the primitive and DROPPED, never retried through the
+bare ``upsert_run`` clobber path. Unregistered runs and adapters without
+the primitive keep the exact legacy behavior.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.concurrency import mark_worker_managed, unmark_worker_managed
+from agno.run.status_persist import RunPersistOutcome
+
+RUN_ID = "r-fence"
+SESSION_ID = "s-fence"
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    yield
+    unmark_worker_managed(RUN_ID)
+
+
+def make_run() -> RunOutput:
+    return RunOutput(run_id=RUN_ID, session_id=SESSION_ID, status=RunStatus.completed, content="done")
+
+
+def make_sync_db(outcome=RunPersistOutcome.UPDATED):
+    db = MagicMock(name="sync_db")
+    db.update_run_in_session = MagicMock(return_value=outcome)
+    return db
+
+
+def make_async_db(outcome=RunPersistOutcome.UPDATED):
+    db = MagicMock(name="async_db")
+    db.update_run_in_session = AsyncMock(return_value=outcome)
+    db.upsert_run = AsyncMock()
+    return db
+
+
+class TestFenceHelperCore:
+    @pytest.mark.asyncio
+    async def test_unmanaged_run_falls_through(self):
+        from agno.run.status_persist import apersist_worker_owned_run
+
+        db = make_async_db()
+        assert await apersist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is False
+        db.update_run_in_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_managed_run_saves_fenced(self):
+        from agno.run.status_persist import apersist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=3)
+        db = make_async_db(RunPersistOutcome.UPDATED)
+        assert await apersist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is True
+        call = db.update_run_in_session.call_args.kwargs
+        assert call["expected_attempt"] == 3
+        assert call["run_id"] == RUN_ID
+        assert call["fields"]["status"] == "COMPLETED"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("outcome", [RunPersistOutcome.STALE_ATTEMPT, RunPersistOutcome.TERMINAL_REFUSED])
+    async def test_fence_refusal_is_dropped_not_retried(self, outcome):
+        """The refusal is FINAL: handled=True so no caller falls through to
+        the unfenced upsert_run - that retry is exactly the clobber."""
+        from agno.run.status_persist import apersist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="zombie", attempt=1)
+        db = make_async_db(outcome)
+        assert await apersist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is True
+
+    @pytest.mark.asyncio
+    async def test_missing_row_appends_with_attempt_stamp(self):
+        from agno.run.status_persist import apersist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
+        db = make_async_db(RunPersistOutcome.MISSING)
+        db.append_run_to_session_if_absent = AsyncMock(return_value=True)
+        assert await apersist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is True
+        appended = db.append_run_to_session_if_absent.call_args.kwargs
+        assert appended["run_dict"]["queue_attempt"] == 2, (
+            "a fresh row without the attempt stamp lets the next fence compare pass vacuously"
+        )
+
+    @pytest.mark.asyncio
+    async def test_adapter_without_primitive_falls_through(self):
+        from agno.run.status_persist import apersist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
+        db = SimpleNamespace()  # no update_run_in_session at all
+        assert await apersist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is False
+
+    def test_sync_twin_fences_managed_run(self):
+        from agno.run.status_persist import persist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=4)
+        db = make_sync_db(RunPersistOutcome.UPDATED)
+        assert persist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is True
+        assert db.update_run_in_session.call_args.kwargs["expected_attempt"] == 4
+
+    def test_sync_twin_skips_async_only_adapter(self):
+        from agno.run.status_persist import persist_worker_owned_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=4)
+        db = MagicMock()
+        db.update_run_in_session = AsyncMock()
+        assert persist_worker_owned_run(db, make_run(), session_id=SESSION_ID) is False
+
+
+class TestChokePointWiring:
+    """The three components' save helpers actually consult the fence: a
+    managed run's save must NOT reach bare upsert_run."""
+
+    @pytest.mark.asyncio
+    async def test_agent_async_save_is_fenced(self):
+        from agno.agent._storage import aupsert_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
+        db = make_async_db(RunPersistOutcome.STALE_ATTEMPT)
+        agent = SimpleNamespace(db=db)
+        await aupsert_run(agent, make_run(), session_id=SESSION_ID)
+        db.upsert_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_agent_async_save_unmanaged_uses_upsert(self):
+        from agno.agent._storage import aupsert_run
+
+        db = make_async_db()
+        agent = SimpleNamespace(db=db)
+        await aupsert_run(agent, make_run(), session_id=SESSION_ID)
+        db.upsert_run.assert_called_once()
+        db.update_run_in_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_team_async_save_is_fenced(self):
+        from agno.run.team import TeamRunOutput
+        from agno.team._storage import _aupsert_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
+        db = make_async_db(RunPersistOutcome.STALE_ATTEMPT)
+        team = SimpleNamespace(db=db)
+        run = TeamRunOutput(run_id=RUN_ID, session_id=SESSION_ID, status=RunStatus.completed)
+        await _aupsert_run(team, run, session_id=SESSION_ID)
+        db.upsert_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_workflow_async_save_is_fenced(self):
+        from agno.run.workflow import WorkflowRunOutput
+        from agno.workflow.workflow import Workflow
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
+        db = make_async_db(RunPersistOutcome.STALE_ATTEMPT)
+        workflow = Workflow(id="wf-fence", name="WF", db=db, steps=[])
+        run = WorkflowRunOutput(run_id=RUN_ID, session_id=SESSION_ID, status=RunStatus.completed)
+        await workflow.asave_run(run=run, session_id=SESSION_ID)
+        db.upsert_run.assert_not_called()
+
+    def test_agent_sync_save_is_fenced(self):
+        from agno.agent._storage import upsert_run as sync_upsert_run
+
+        mark_worker_managed(RUN_ID, worker_id="w1", attempt=2)
+        db = make_sync_db(RunPersistOutcome.STALE_ATTEMPT)
+        db.upsert_run = MagicMock()
+        agent = SimpleNamespace(db=db)
+        sync_upsert_run(agent, make_run(), session_id=SESSION_ID)
+        db.upsert_run.assert_not_called()

--- a/libs/agno/tests/unit/team/test_acontinue_run_background_stream.py
+++ b/libs/agno/tests/unit/team/test_acontinue_run_background_stream.py
@@ -464,7 +464,7 @@ class TestQueuedCancelWithoutRunResponse:
 
 
 class TestRunIdOnlyContinuePersistsStatus:
-    """Phase-4 item 16 (team twin): run-ID-only continues must persist
+    """Team twin of the agent test: run-ID-only continues must persist
     PENDING then RUNNING from the session-loaded run; the dispatch still
     receives run_response=None. See the agent twin for the full story."""
 

--- a/libs/agno/tests/unit/workflow/test_workflow_agent_background_runs.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_agent_background_runs.py
@@ -117,7 +117,7 @@ async def test_background_workflow_agent_cancel_lands_a_run_row(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_background_workflow_agent_run_visible_while_executing(monkeypatch):
-    """Phase-4 item 17: the 202'd run id must be poll-visible from acceptance,
+    """The 202'd run id must be poll-visible from acceptance,
     not only after execution writes. The skip removed with the 9079 safety net
     made non-durable WorkflowAgent background runs fully invisible while
     queued/executing - polls 404ed and tenant-scoped cancel had nothing to


### PR DESCRIPTION
## Summary

The safe-retries closing block for #9079 (P1 items 4 and 5): fences the last two surfaces a swept-but-alive worker could corrupt, ports the parked zombie acceptance repros as the proof, and deletes the interim `allow_multi_attempt_experimental` gate now that the races it guarded are closed.

One commit per item, in dependency order:

- **`merge: record feat/v3.0 ancestry`** - carries the ancestry-restoring merge commit already on the head branch (tree-identical, no content).
- **Item 4 (`b746817`)** - worker-owned run saves route through the attempt-fenced `update_run_in_session`. Writer census first: every run-row DB write funnels through six choke points (agent/team/workflow, sync/async); all six now consult the worker-ownership registry. STALE_ATTEMPT / TERMINAL_REFUSED are final (dropped with a warning, never retried through bare `upsert_run`); MISSING falls to the atomic append with the attempt stamped; non-worker contexts and unfenced adapters keep exact legacy behavior. Covers mid-run flushes, not just terminal saves. Option (a) from the plan: pure consumption of the ported primitive.
- **Item 5 (`3a87203`)** - per-run stream writer generations. `begin_attempt` is a monotonic CAS; `add_event`, `complete_run`, `reset_run_events`, and `set_run_status` all refuse older generations. Redis fences the per-event path atomically in Lua (gen-check+INCR, gen-check+XADD) and lifecycle mutations via WATCH/MULTI; servers without scripting degrade fail-open with one warning. Equal generations pass deliberately - that is the finished-work-wins intent for the default single-attempt config (the sweeper's close stamps the swept attempt, so a falsely-swept worker's own completion overwrites it).
- **Acceptance tests (`ccb7863`)** - the two parked repros from the review program, scenarios preserved verbatim, assertions re-pointed at the fenced outcomes. Both fail against the pre-fence source.
- **Flag deletion (`9d34ec6`)** - `allow_multi_attempt_experimental` and its validation are gone; `max_attempts > 1` constructs plainly; the at-most-once default is untouched. The requeue force gate stays, reframed as ops hygiene (requeueing a just-failed job is now safe but wasteful).

**Deliberate decisions to review:**
- Finished-work-wins for same-attempt writes (row and stream) - the falsely-swept worker's real result beats the sweeper's presumption of death; the ticket keeps the failure as at-most-once bookkeeping.
- Fail-open degradation of the per-event Lua fence on servers without scripting - the stream is coordination, not truth.
- Member-run saves stay unfenced - their run_ids are never registered, so a zombie team leg's member writes orphan rather than clobber.

## Type of change

- [x] New feature
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Every fix commit's tests were proven to fail on the unfixed source (stash/parent-tree runs); the zombie acceptance pair fails on the pre-fence tree specifically.
- Full sweep: 3,350 unit + 201 integration tests green; the only integration failures are the four known pre-existing metrics/span-sanitization ones on the base.
- Validation output carries two pre-existing marks unrelated to this diff: the ambient `_genai_compat.py` mypy errors and an E402 from an uncommitted local cookbook file.
- Merge guidance: land with **squash or rebase into the head branch** - this PR contains a merge commit only as inherited history; squashing INTO `claude/agentos-request-queue-621b2a` is fine (the ancestry merge is already on the head branch itself).
