### PR TITLE
fix: require confirmation for Resend email sends

### DIFF
--- a/cookbook/91_tools/resend_tools.py
+++ b/cookbook/91_tools/resend_tools.py
@@ -3,6 +3,10 @@ Resend Tools
 =============================
 
 Demonstrates resend tools.
+
+The send_email tool requires user confirmation by default. Pass
+require_send_email_confirmation=False to ResendTools only if you intentionally
+want agents to send emails without confirmation.
 """
 
 from agno.agent import Agent

--- a/libs/agno/agno/tools/resend.py
+++ b/libs/agno/agno/tools/resend.py
@@ -16,9 +16,22 @@ class ResendTools(Toolkit):
         api_key: Optional[str] = None,
         from_email: Optional[str] = None,
         enable_send_email: bool = True,
+        require_send_email_confirmation: bool = True,
         all: bool = False,
         **kwargs,
     ):
+        """
+        Initialize ResendTools.
+
+        Args:
+            api_key: Resend API key. Defaults to the RESEND_API_KEY environment variable.
+            from_email: Email address to send from.
+            enable_send_email: Whether to register the send_email tool.
+            require_send_email_confirmation: Whether send_email should require user confirmation before execution.
+                Disabling this allows agents to send emails without confirmation.
+            all: Whether to enable all tools.
+            **kwargs: Additional Toolkit options.
+        """
         self.from_email = from_email
         self.api_key = api_key or getenv("RESEND_API_KEY")
         if not self.api_key:
@@ -28,7 +41,19 @@ class ResendTools(Toolkit):
         if all or enable_send_email:
             tools.append(self.send_email)
 
-        super().__init__(name="resend_tools", tools=tools, **kwargs)
+        requires_confirmation_tools = kwargs.pop("requires_confirmation_tools", None)
+        if require_send_email_confirmation and (all or enable_send_email):
+            if requires_confirmation_tools is None:
+                requires_confirmation_tools = ["send_email"]
+            elif "send_email" not in requires_confirmation_tools:
+                requires_confirmation_tools = [*requires_confirmation_tools, "send_email"]
+
+        super().__init__(
+            name="resend_tools",
+            tools=tools,
+            requires_confirmation_tools=requires_confirmation_tools,
+            **kwargs,
+        )
 
     def send_email(self, to_email: str, subject: str, body: str) -> str:
         """Send an email using the Resend API. Returns if the email was sent successfully or an error message.

--- a/libs/agno/tests/unit/tools/test_resend.py
+++ b/libs/agno/tests/unit/tools/test_resend.py
@@ -1,0 +1,45 @@
+import sys
+from importlib import import_module
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock
+
+resend_module = ModuleType("resend")
+setattr(resend_module, "Emails", SimpleNamespace(send=Mock()))
+sys.modules.setdefault("resend", resend_module)
+
+
+def get_resend_tools_class():
+    return import_module("agno.tools.resend").ResendTools
+
+
+def test_send_email_is_registered():
+    ResendTools = get_resend_tools_class()
+    resend_tools = ResendTools(api_key="test-api-key")
+
+    assert "send_email" in resend_tools.functions
+
+
+def test_send_email_requires_confirmation_by_default():
+    ResendTools = get_resend_tools_class()
+    resend_tools = ResendTools(api_key="test-api-key")
+
+    assert resend_tools.functions["send_email"].requires_confirmation is True
+
+
+def test_send_email_confirmation_can_be_disabled():
+    ResendTools = get_resend_tools_class()
+    resend_tools = ResendTools(api_key="test-api-key", require_send_email_confirmation=False)
+
+    assert resend_tools.functions["send_email"].requires_confirmation is False
+
+
+def test_existing_requires_confirmation_tools_are_preserved_when_default_is_disabled():
+    ResendTools = get_resend_tools_class()
+    resend_tools = ResendTools(
+        api_key="test-api-key",
+        require_send_email_confirmation=False,
+        requires_confirmation_tools=["send_email"],
+    )
+
+    assert resend_tools.requires_confirmation_tools == ["send_email"]
+    assert resend_tools.functions["send_email"].requires_confirmation is True


### PR DESCRIPTION
## Summary

- Require confirmation for `ResendTools.send_email` by default.
- Add `require_send_email_confirmation=False` for users who intentionally need automated sends without confirmation.
- Preserve caller-provided `requires_confirmation_tools`.
- Add focused unit tests for Resend tool registration and confirmation behavior.
- Update the Resend cookbook note.

Fixes #8847

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Validation

- `pytest libs/agno/tests/unit/tools/test_resend.py`
- `ruff check libs/agno/agno/tools/resend.py libs/agno/tests/unit/tools/test_resend.py cookbook/91_tools/resend_tools.py`
- `mypy libs/agno/agno/tools/resend.py libs/agno/tests/unit/tools/test_resend.py --config-file libs/agno/pyproject.toml`

Note: `./scripts/validate.sh` was run and reports existing unrelated mypy errors in Redis/MCP files.
This PR was AI-assisted with Codex. I reviewed the implementation, tests, and validation results.