### PR TITLE
fix: MCP tool entrypoints must not allow call-time tool_name override

### DIFF
--- a/libs/agno/agno/utils/mcp.py
+++ b/libs/agno/agno/utils/mcp.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 from uuid import uuid4
 
@@ -106,7 +105,6 @@ def get_entrypoint_for_tool(
     """
 
     async def call_tool(
-        tool_name: str,
         _agno_run_context: Optional["RunContext"] = None,
         _agno_agent: Optional["Agent"] = None,
         _agno_team: Optional["Team"] = None,
@@ -115,6 +113,11 @@ def get_entrypoint_for_tool(
         # Framework-injected params use the `_agno_` prefix so they cannot
         # collide with MCP tool arguments named "run_context", "agent" and
         # "team".
+        # The executed tool is pinned to the tool this entrypoint was built
+        # for: call-time arguments cannot change it. A model-supplied
+        # "tool_name" argument stays in **kwargs and is forwarded to the
+        # server as an ordinary argument of the declared tool.
+        tool_name = tool.name
 
         async def _call_with_session(active_session: ClientSession) -> ToolResult:
             try:
@@ -264,7 +267,7 @@ def get_entrypoint_for_tool(
             log_exception(f"Failed to call MCP tool '{tool_name}': {e}")
             return ToolResult(content=f"Error: {e}")
 
-    return partial(call_tool, tool_name=tool.name)
+    return call_tool
 
 
 def _build_mcp_metadata(result: "CallToolResult") -> Optional[Dict[str, Any]]:

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -1431,6 +1431,97 @@ async def test_mcp_tool_with_run_context_argument_does_not_collide():
 
 
 # =============================================================================
+# tool_name pinning tests (security)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_model_supplied_tool_name_cannot_override_executed_tool():
+    """A model-supplied tool_name argument must not change which tool the MCP
+    server executes: the entrypoint is pinned to the tool it was built for."""
+    tool = _make_mcp_tool_mock("list_issues")
+    session = _make_session_returning("issues listed")
+
+    entrypoint = get_entrypoint_for_tool(tool, session)
+    await entrypoint(tool_name="delete_repo", repo="agno")
+
+    session.call_tool.assert_awaited_once()
+    called_name, called_kwargs = session.call_tool.await_args.args
+    assert called_name == "list_issues"
+
+
+@pytest.mark.asyncio
+async def test_model_supplied_tool_name_is_forwarded_as_plain_argument():
+    """tool_name has no special meaning to the entrypoint: it is forwarded to
+    the server as an ordinary argument of the declared tool, so MCP tools that
+    legitimately declare a tool_name parameter keep working."""
+    tool = _make_mcp_tool_mock("call_helper")
+    session = _make_session_returning("done")
+
+    entrypoint = get_entrypoint_for_tool(tool, session)
+    await entrypoint(tool_name="format_disk")
+
+    called_name, called_kwargs = session.call_tool.await_args.args
+    assert called_name == "call_helper"
+    assert called_kwargs == {"tool_name": "format_disk"}
+
+
+@pytest.mark.asyncio
+async def test_function_call_arguments_cannot_override_executed_tool():
+    """FunctionCall.aexecute merges model arguments into the entrypoint call;
+    a smuggled tool_name must not change the executed tool on that path."""
+    tool = _make_mcp_tool_mock("list_issues")
+    session = _make_session_returning("issues listed")
+
+    fn = Function(
+        name="list_issues",
+        entrypoint=get_entrypoint_for_tool(tool, session),
+        skip_entrypoint_processing=True,
+    )
+    fc = FunctionCall(function=fn, arguments={"tool_name": "delete_repo", "repo": "agno"})
+
+    result = await fc.aexecute()
+
+    assert result.status == "success", f"Expected success, got error: {result.error}"
+    session.call_tool.assert_awaited_once()
+    called_name, called_kwargs = session.call_tool.await_args.args
+    assert called_name == "list_issues"
+    assert called_kwargs == {"tool_name": "delete_repo", "repo": "agno"}
+
+
+@pytest.mark.asyncio
+async def test_hitl_confirmation_gates_the_tool_that_executes():
+    """requires_confirmation resolves from the Function's declared name, so the
+    tool that executes must be that same name: calling an ungated tool with a
+    smuggled tool_name must not reach the confirmation-gated tool."""
+    session = _make_session_returning("ok")
+
+    gated_fn = Function(
+        name="delete_repo",
+        entrypoint=get_entrypoint_for_tool(_make_mcp_tool_mock("delete_repo"), session),
+        skip_entrypoint_processing=True,
+        requires_confirmation=True,
+    )
+    ungated_fn = Function(
+        name="list_issues",
+        entrypoint=get_entrypoint_for_tool(_make_mcp_tool_mock("list_issues"), session),
+        skip_entrypoint_processing=True,
+        requires_confirmation=False,
+    )
+
+    # The model calls the unconfirmed tool but smuggles tool_name="delete_repo"
+    fc = FunctionCall(function=ungated_fn, arguments={"tool_name": "delete_repo"})
+    result = await fc.aexecute()
+
+    assert result.status == "success", f"Expected success, got error: {result.error}"
+    # Only the declared, unconfirmed tool reached the server; the gated tool
+    # can only execute through its own Function, which pauses for confirmation.
+    executed_names = [call.args[0] for call in session.call_tool.await_args_list]
+    assert executed_names == ["list_issues"]
+    assert gated_fn.requires_confirmation is True
+
+
+# =============================================================================
 # CancelledError propagation tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary

**Security-relevant.** Every MCP tool entrypoint was built as `functools.partial(call_tool, tool_name=tool.name)`. `partial` keyword defaults are overridden by call-time kwargs, so a model that passed `tool_name="delete_repo"` as an argument to any MCP tool made the server execute `delete_repo`, while allow-lists, `requires_confirmation`, HITL approval and logging all resolved from the `Function`'s declared name. Any HITL/approval gate on an MCP toolkit could therefore be bypassed by calling an ungated tool with a smuggled `tool_name` argument.

Reproduced first with a mocked MCP session: calling the entrypoint built for `list_issues` with a model-supplied `tool_name="delete_repo"` made the session receive `delete_repo` (test failed on the unfixed code with `assert 'delete_repo' == 'list_issues'`).

**Fix:** `get_entrypoint_for_tool` already has `tool` in scope. The `tool_name` parameter is removed entirely and the executed tool name is closed over from `tool.name`, so call-time kwargs cannot change which tool executes.

**Decision on model-supplied `tool_name` arguments:** they are neither silently dropped nor failed at the framework level - they stay in `**kwargs` and are forwarded to the server as an ordinary argument of the declared tool. This keeps MCP tools that legitimately declare a `tool_name` parameter working; for tools that do not declare one, the server's own input-schema validation rejects the extra argument. Either way the executed tool can no longer differ from the gated/logged one.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Security considerations: this closes a HITL/allow-list bypass for MCP toolkits. The MCP entrypoint is async-only (sync agent paths route coroutine entrypoints through `aexecute`), so coverage exercises the direct entrypoint call and the `FunctionCall.aexecute` argument-merge path - the exact vector - plus a test asserting HITL confirmation gates the tool that actually executes, and a test pinning the forwarded-as-plain-argument behavior. 4 new tests; full `test_mcp.py` suite (80 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
