### PR TITLE
fix: tool result caching - per-user keys, ToolResult round-trip, hooks on cache hits

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -31,10 +31,15 @@ from agno.utils.log import log_debug, log_exception, log_warning
 
 T = TypeVar("T")
 
+# The media the caller attached to the run. Unlike the other injected names these
+# carry the call's input rather than framework plumbing, so they decide whether a
+# call can be cached at all (see _has_injected_media).
+MEDIA_INJECTED_PARAMS = ("images", "videos", "audios", "files")
+
 # Parameter names the framework fills in itself (see FunctionCall._build_entrypoint_args).
 # They are kept out of the model-facing schema, and a model-supplied value for one of
 # them is discarded in favour of the injected object.
-FRAMEWORK_INJECTED_PARAMS = ("agent", "team", "run_context", "images", "videos", "audios", "files")
+FRAMEWORK_INJECTED_PARAMS = ("agent", "team", "run_context", *MEDIA_INJECTED_PARAMS)
 
 # The `_agno_`-prefixed channels, used by wrappers whose tools may have arguments
 # legitimately named "agent", "team" or "run_context" (e.g. MCP tools).
@@ -60,6 +65,194 @@ def _identity_injected_types() -> tuple:
     return (Agent, Team, RunContext)
 
 
+# What a cache entry holds. Bump this whenever the meaning of a stored value
+# changes: entries written under any other version are discarded unread, which
+# costs one re-execution and keeps a stale reading from reaching a model.
+# Version 2 stores the entrypoint's own return, where version 1 stored whatever
+# the tool_hook chain made of it.
+CACHE_FORMAT = 2
+
+
+class _StaleCacheEntry(Exception):
+    """A cache entry that no longer matches what the code returns."""
+
+
+def _make_private_dir(directory: Any) -> None:
+    """Create the cache directory, and refuse one somebody else can write.
+
+    The default location is a shared temporary directory under a predictable
+    name, so a directory already there may not be ours. Raising leaves the tool
+    call itself alone: the caller treats an unusable cache directory as a
+    reason to stop caching, not a reason to fail."""
+    import os
+    import stat
+
+    missing = []
+    probe = directory
+    while not probe.exists():
+        missing.append(probe)
+        if probe.parent == probe:
+            break
+        probe = probe.parent
+    for level in reversed(missing):
+        try:
+            level.mkdir(mode=0o700)
+        except FileExistsError:
+            pass
+
+    if not hasattr(os, "geteuid"):
+        # Ownership and permission bits mean nothing here: every directory
+        # reports the same mode, so there is nothing to read them for.
+        return
+
+    owner = os.geteuid()
+    for level in (directory, directory.parent, directory.parent.parent):
+        info = level.stat()
+        if info.st_uid != owner:
+            raise PermissionError(f"Refusing a cache directory owned by another user: {level}")
+        if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            # These three levels are ours to keep, and an earlier release made
+            # them with whatever the umask allowed. Close them rather than
+            # refuse them, so upgrading does not cost a caller its caching.
+            level.chmod(info.st_mode & ~(stat.S_IWGRP | stat.S_IWOTH))
+
+
+def _has_injected_media(entrypoint_args: Dict[str, Any]) -> bool:
+    """True when the call carries attached media.
+
+    Media is the input the tool computes over, and it contributes nothing to
+    the cache key, so two calls over different documents look identical to it.
+    Such a call is neither served from the cache nor written to it."""
+    return any(entrypoint_args.get(name) for name in MEDIA_INJECTED_PARAMS)
+
+
+# Stands in for an entrypoint call that left no value the cache can keep: one
+# that raised, and one whose return could not be copied. Recording it keeps the
+# count of entrypoint calls honest while making the call uncacheable.
+_NO_RESULT = object()
+
+
+def _start_entrypoint_call(raw_results: List[Any]) -> int:
+    """Count an entrypoint call that is about to run, and return its slot.
+
+    The slot is claimed before the call, so a call that raises still counts. A
+    hook that retried past a failure ran the tool twice, and what the retry
+    returned does not stand for the call."""
+    raw_results.append(_NO_RESULT)
+    return len(raw_results) - 1
+
+
+def _detached(value: Any) -> Any:
+    """A copy of a cached value for one entrypoint call to keep.
+
+    A hook may call the entrypoint more than once, and on a miss each call
+    returns its own object. Handing every call the same stored object would let
+    one call's edits show up in the next."""
+    from copy import deepcopy
+
+    try:
+        return deepcopy(value)
+    except Exception:
+        return value
+
+
+def _carries_media(value: Any, depth: int = 0) -> bool:
+    """Whether a ToolResult holding media sits anywhere inside this value.
+
+    Media never reaches a cache file, so a stored value that holds some did not
+    come from here, and one about to be stored would lose it. The walk follows
+    types rather than names, so an ordinary dict with an "images" key is not
+    mistaken for one."""
+    if depth > 32:
+        return False
+    if isinstance(value, ToolResult):
+        if value.images or value.videos or value.audios or value.files:
+            return True
+    if isinstance(value, BaseModel):
+        parts: Any = list(value.__dict__.values()) + list((value.__pydantic_extra__ or {}).values())
+    elif isinstance(value, dict):
+        parts = list(value.values())
+    elif isinstance(value, (list, tuple, set)):
+        parts = list(value)
+    else:
+        return False
+    return any(_carries_media(part, depth + 1) for part in parts)
+
+
+def _shares_a_reference(value: Any, seen: Optional[List[int]] = None, depth: int = 0) -> bool:
+    """Whether one object sits in more than one place inside this value.
+
+    JSON keeps no record of that sharing, so a value written with it comes back
+    with as many separate objects as it had places."""
+    if depth > 32:
+        return False
+    if isinstance(value, BaseModel):
+        parts: Any = list(value.__dict__.values())
+    elif isinstance(value, dict):
+        parts = list(value.values())
+    elif isinstance(value, (list, tuple, set)):
+        parts = list(value)
+    else:
+        return False
+    seen = [] if seen is None else seen
+    if id(value) in seen:
+        return True
+    seen.append(id(value))
+    return any(_shares_a_reference(part, seen, depth + 1) for part in parts)
+
+
+def _faithful(original: Any, rebuilt: Any, depth: int = 0) -> bool:
+    """Whether a value read back from the cache is the value that was stored.
+
+    Equality alone is too weak: an IntEnum member equals the plain integer it
+    was written as, and a hook that reads .name off it would work on the miss
+    and fail on the hit. Every node has to come back as its own type."""
+    if depth > 32:
+        return original == rebuilt
+    if type(original) is not type(rebuilt):
+        return False
+    if isinstance(original, BaseModel):
+        return all(
+            key in rebuilt.__dict__ and _faithful(value, rebuilt.__dict__[key], depth + 1)
+            for key, value in original.__dict__.items()
+        )
+    if isinstance(original, dict):
+        if set(map(type, original)) != set(map(type, rebuilt)) or original.keys() != rebuilt.keys():
+            return False
+        return all(_faithful(value, rebuilt[key], depth + 1) for key, value in original.items())
+    if isinstance(original, (list, tuple)):
+        if len(original) != len(rebuilt):
+            return False
+        return all(_faithful(a, b, depth + 1) for a, b in zip(original, rebuilt))
+    return bool(original == rebuilt)
+
+
+def _record_entrypoint_result(raw_results: List[Any], slot: int, result: Any) -> None:
+    """Record what the entrypoint returned, detached from the caller.
+
+    The hooks run after this and may edit the result in place, so the cache
+    must keep a copy rather than the object itself."""
+    from copy import deepcopy
+
+    try:
+        snapshot = deepcopy(result)
+    except Exception as e:
+        log_debug(f"Result could not be copied for the cache, so this call is not cacheable: {e}")
+        return
+    if snapshot is result and isinstance(result, (dict, list, set, BaseModel)):
+        # A value may answer deepcopy with itself. The hooks run next and may
+        # edit it, and those edits would reach what the cache keeps.
+        log_debug(f"Result did not detach from a copy, so this call is not cacheable: {type(result).__name__}")
+        return
+    if _shares_a_reference(result):
+        # Two fields backed by one object come back as two on the far side of a
+        # JSON round trip, and a hook that edits one would then see a different
+        # value from the one the miss gave it.
+        log_debug("Result holds the same object in more than one place, so this call is not cacheable")
+        return
+    raw_results[slot] = snapshot
+
+
 def _unwrap_annotation(hint: Any) -> Any:
     """The annotation a type alias stands for (PEP 695 ``type X = ...``), else
     the annotation itself. get_type_hints leaves an alias unresolved.
@@ -71,6 +264,11 @@ def _unwrap_annotation(hint: Any) -> Any:
     reuse."""
     seen: List[Any] = []
     while True:
+        if isinstance(hint, types.GenericAlias) and hasattr(get_origin(hint), "__value__"):
+            # A subscripted generic alias (``Maybe[Weather]``) keeps what it was
+            # given only while it stays subscripted. Its __value__ is the body
+            # with the parameter still loose, so following it loses the Weather.
+            return hint
         # A PEP 695 alias carries __value__; typing.NewType carries
         # __supertype__ and is just as transparent to pydantic, which builds
         # the supertype from a model-supplied dict either way.
@@ -81,6 +279,63 @@ def _unwrap_annotation(hint: Any) -> Any:
             return hint
         seen.append(hint)
         hint = unwrapped
+
+
+def _mentions_base_model(hint: Any, seen: Optional[List[Any]] = None) -> bool:
+    """True when the annotation is a BaseModel or holds one, at any depth.
+
+    Cached results are only rebuilt into a declared type when the code says it
+    returns a model. A tool annotated str or dict keeps handing back exactly
+    what the cache file holds, so an annotation the tool does not honour costs
+    nothing.
+
+    An alias may name itself (``type JSON = str | list[JSON]``), so the seen
+    list stops the walk from following one round and round."""
+    hint = _unwrap_annotation(hint)
+    if isinstance(hint, type):
+        try:
+            return issubclass(hint, BaseModel)
+        except TypeError:
+            return False
+    seen = [] if seen is None else seen
+    if any(hint is s for s in seen):
+        return False
+    seen.append(hint)
+    return any(_mentions_base_model(arg, seen) for arg in get_args(hint))
+
+
+def _dump_for_cache(model: BaseModel) -> Any:
+    """What _save_to_cache writes for this model, as JSON gives it back.
+
+    A round trip turns tuples into lists and dates into strings, so a rebuilt
+    value can only be compared with a stored one on the far side of one."""
+    import json
+
+    return json.loads(json.dumps(model.model_dump(), default=str))
+
+
+def _validate_by_field_name(adapter: Any, payload: Any) -> Any:
+    """Rebuild a value this cache wrote.
+
+    Entries are written with model_dump(), which emits field names, so a model
+    whose fields carry aliases has to be validated by name or it would never be
+    readable. Older pydantic releases take no such argument and accept field
+    names anyway."""
+    try:
+        return adapter.validate_python(payload, by_name=True)
+    except TypeError:
+        return adapter.validate_python(payload)
+
+
+@lru_cache(maxsize=256)
+def _return_type_adapter(hint: Any) -> Any:
+    """A validator for a return annotation, or None when one cannot be built."""
+    from pydantic import TypeAdapter
+
+    try:
+        return TypeAdapter(hint)
+    except Exception:
+        return None
 
 
 def _is_union(hint: Any) -> bool:
@@ -1176,22 +1431,66 @@ class Function(BaseModel):
             and name not in AGNO_INJECTED_PARAMS
         ]
 
+    @staticmethod
+    def _get_run_context_identity(entrypoint_args: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Stable identity fields a run context contributes to the cache key.
+
+        Both injection channels ("run_context" and "_agno_run_context", the
+        latter used by internal wrappers such as the MCP entrypoints)
+        contribute the same fields. Only user_id and session_id are
+        contributed: run_id stays out so a result cached for a user and session
+        is reusable across their runs. Returns None when the entrypoint takes
+        no run context, so key composition for run-context-free tools is
+        unchanged.
+
+        Only those two fields enter the key. A run context also carries
+        metadata, dependencies, session_state and knowledge_filters, and none of
+        them scope an entry, so two calls that differ only there share one. A
+        tool that reads them, rather than taking the same information as an
+        argument the model supplies, is not safely cacheable.
+
+        Reuse across runs holds for the "run_context" spelling alone.
+        _get_cache_key removes only FRAMEWORK_INJECTED_PARAMS from the key
+        material, so an injected "_agno_run_context" object is also serialized
+        into the key with run_id and every other live field. Entries on that
+        channel are therefore scoped to one run context, not to a user and
+        session, until those channels are removed from the key material too.
+        """
+        run_context = entrypoint_args.get("run_context") or entrypoint_args.get("_agno_run_context")
+        if run_context is None:
+            return None
+        return {
+            "user_id": getattr(run_context, "user_id", None),
+            "session_id": getattr(run_context, "session_id", None),
+        }
+
     def _get_cache_key(self, entrypoint_args: Dict[str, Any], call_args: Optional[Dict[str, Any]] = None) -> str:
-        """Generate a cache key based on function name and arguments."""
+        """Generate a cache key based on function name, caller identity and arguments."""
         import json
         from hashlib import md5
 
+        identity = self._get_run_context_identity(entrypoint_args)
+
         copy_entrypoint_args = entrypoint_args.copy()
         # Injected framework objects are not part of a call's identity for caching
-        # purposes. NOTE: this means a `cache_results` tool that reads run_context serves
-        # one user's result to another -- pre-existing, tracked separately.
+        # purposes; a run context contributes the caller's identity below. An
+        # injected agent or team contributes none, so a cache_results tool that
+        # reads agent.user_id still shares entries across users. Tracked as a
+        # follow-up.
         for param_name in FRAMEWORK_INJECTED_PARAMS:
             copy_entrypoint_args.pop(param_name, None)
         # Use json.dumps with sort_keys=True to ensure consistent ordering regardless of dict key order
         args_str = json.dumps(copy_entrypoint_args, sort_keys=True, default=str)
 
         kwargs_str = str(sorted((call_args or {}).items()))
-        key_str = f"{self.name}:{args_str}:{kwargs_str}"
+        if identity is not None:
+            # A run context contributes the caller's identity instead of being
+            # dropped: results cached for one user or session must never be
+            # served to another.
+            identity_str = json.dumps(identity, sort_keys=True, default=str)
+            key_str = f"{self.name}:{identity_str}:{args_str}:{kwargs_str}"
+        else:
+            key_str = f"{self.name}:{args_str}:{kwargs_str}"
         return md5(key_str.encode()).hexdigest()
 
     def _get_cache_file_path(self, cache_key: str) -> str:
@@ -1200,13 +1499,18 @@ class Function(BaseModel):
         from tempfile import gettempdir
 
         base_cache_dir = self.cache_dir or Path(gettempdir()) / "agno_cache"
-        func_cache_dir = Path(base_cache_dir) / "functions" / self.name
-        func_cache_dir.mkdir(parents=True, exist_ok=True)
+        # The version names the directory, not just the payload. A stored value
+        # means different things to different versions of this code, and a
+        # reader that predates a change would otherwise find an entry it cannot
+        # read correctly and would have no way to tell.
+        func_cache_dir = Path(base_cache_dir) / "functions" / f"v{CACHE_FORMAT}" / self.name
+        _make_private_dir(func_cache_dir)
         return str(func_cache_dir / f"{cache_key}.json")
 
     def _get_cached_result(self, cache_file: str) -> Optional[Any]:
         """Retrieve cached result if valid."""
         import json
+        import os
         from pathlib import Path
         from time import time
 
@@ -1215,31 +1519,150 @@ class Function(BaseModel):
             return None
 
         try:
-            with cache_path.open("r", encoding="utf-8") as f:
+            # Never follow a link out of the cache directory. The path is
+            # predictable, so a symlink planted there would otherwise choose
+            # the file a cache hit reads.
+            fd = os.open(cache_file, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+            with os.fdopen(fd, "r", encoding="utf-8") as f:
+                entry_id = os.fstat(f.fileno()).st_ino
                 cache_data = json.load(f)
 
             timestamp = cache_data.get("timestamp", 0)
-            result = cache_data.get("result")
 
             if time() - timestamp <= self.cache_ttl:
-                return result
+                try:
+                    if cache_data.get("cache_format") != CACHE_FORMAT:
+                        raise _StaleCacheEntry("the entry was written in an earlier cache format")
+                    return self._cached_value(cache_data.get("result"), cache_data.get("result_type"))
+                except _StaleCacheEntry as e:
+                    log_debug(f"Discarding the cache entry for {self.name}: {e}")
 
-            # Remove expired entry
-            cache_path.unlink()
+            # Remove the entry that was read, not whatever stands at that
+            # name now: a writer replaces the file whole, and unlinking by name
+            # alone would throw away an entry written since the read.
+            if cache_path.stat().st_ino == entry_id:
+                cache_path.unlink()
         except Exception:
             log_exception("Error reading cache")
 
         return None
 
+    def _survives_the_cache(self, cache_data: Dict[str, Any], result: Any) -> bool:
+        """Whether reading this entry back gives what the tool just returned."""
+        try:
+            return _faithful(result, self._cached_value(cache_data.get("result"), cache_data.get("result_type")))
+        except Exception:
+            return False
+
+    def _cached_value(self, payload: Any, result_type: Optional[str]) -> Any:
+        """The cached payload as the type the entrypoint declares it returns.
+
+        The class comes from the code's return annotation, never from the cache
+        file, so an entry cannot choose which class gets built. Raises
+        _StaleCacheEntry when the payload no longer matches what the code
+        returns, so the caller re-executes rather than hand back a value of the
+        wrong shape.
+        """
+        value = payload
+        return_type = self._declared_return_type()
+
+        if return_type is not None and _mentions_base_model(return_type):
+            try:
+                adapter = _return_type_adapter(return_type)
+            except TypeError:  # an annotation that cannot be memoised
+                adapter = None
+            if adapter is not None:
+                try:
+                    value = _validate_by_field_name(adapter, payload)
+                except Exception as e:
+                    raise _StaleCacheEntry(f"the payload no longer rebuilds into {return_type}: {e}")
+                if isinstance(value, BaseModel) and _dump_for_cache(value) != payload:
+                    raise _StaleCacheEntry(
+                        f"{return_type} cannot hold everything the entry carries, so the entry no longer stands "
+                        "for what the tool returns"
+                    )
+        elif result_type == "ToolResult":
+            if return_type is not None:
+                raise _StaleCacheEntry(f"the entry holds a ToolResult but the tool returns {return_type}")
+            # Nothing in the code says what this tool returns, so the entry's
+            # own tag is the only thing left to go on.
+            try:
+                value = ToolResult.model_validate(payload)
+            except Exception as e:
+                raise _StaleCacheEntry(f"the payload is not a valid ToolResult: {e}")
+
+        if _carries_media(value):
+            # Media is never written to the cache, so an entry carrying it did
+            # not come from here. Rebuilding it would hand the model media that
+            # a cache file chose.
+            raise _StaleCacheEntry("a cached result must not carry media")
+
+        return value
+
+    def _declared_return_type(self) -> Any:
+        """The entrypoint's return annotation, or None when it declares none."""
+        if self.entrypoint is None:
+            return None
+        try:
+            hint = get_type_hints(self.entrypoint).get("return")
+        except Exception:
+            return None
+        if hint is None or hint is type(None):
+            return None
+        return _unwrap_annotation(hint)
+
     def _save_to_cache(self, cache_file: str, result: Any):
         """Save result to cache."""
         import json
+        import os
+        from tempfile import mkstemp
         from time import time
 
         try:
-            serializable_result = result.model_dump() if isinstance(result, BaseModel) else result
-            with open(cache_file, "w", encoding="utf-8") as f:
-                json.dump({"timestamp": time(), "result": serializable_result}, f)
+            cache_data: Dict[str, Any] = {"timestamp": time(), "cache_format": CACHE_FORMAT}
+            if _carries_media(result):
+                # The cache holds JSON, and it excludes media by design: media
+                # is forwarded from the live result rather than rebuilt from a
+                # file. Skipping the write keeps the media intact on every call
+                # at the cost of re-executing.
+                log_debug(f"Skipping cache for {self.name}: a result carrying media is not cacheable")
+                return
+            if isinstance(result, ToolResult):
+                # Tag the entry so a cache hit restores a ToolResult instead of
+                # handing the model loop a plain dict.
+                cache_data["result"] = result.model_dump()
+                cache_data["result_type"] = "ToolResult"
+            elif isinstance(result, BaseModel):
+                cache_data["result"] = result.model_dump()
+            else:
+                cache_data["result"] = result
+            # Serialize before writing anything: a result that cannot be
+            # encoded must leave no half-written file for the next call to read.
+            payload = json.dumps(cache_data)
+            checks_round_trip = bool(self.tool_hooks) or self._declared_return_type() is not None
+            if checks_round_trip and not self._survives_the_cache(json.loads(payload), result):
+                # A hit hands this value back in the tool's place, so what
+                # comes back has to be what the tool returned: a tuple comes
+                # back a list, and a union picks its first matching member
+                # rather than the one the tool chose. A tool that says nothing
+                # about what it returns, and has no hooks to read it, keeps the
+                # older behaviour of handing the model whatever was stored.
+                log_debug(f"Skipping cache for {self.name}: the result does not survive being stored")
+                return
+            # Write a new file and move it into place. The cache path is
+            # predictable and the default directory is shared, so writing
+            # through the target would follow a symlink someone else planted
+            # and would keep whatever mode that file already had. mkstemp
+            # creates with 0600, and the rename is atomic, so a reader sees
+            # either the previous entry or this one.
+            fd, tmp_path = mkstemp(dir=os.path.dirname(cache_file), suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(payload)
+                os.replace(tmp_path, cache_file)
+            except Exception:
+                os.unlink(tmp_path)
+                raise
         except Exception:
             log_exception("Error writing cache")
 
@@ -1594,21 +2017,44 @@ class FunctionCall(BaseModel):
             hook_args["arguments"] = args
         return hook_args
 
-    def _build_nested_execution_chain(self, entrypoint_args: Dict[str, Any]):
+    def _build_nested_execution_chain(
+        self,
+        entrypoint_args: Dict[str, Any],
+        cached_result: Optional[Any] = None,
+        raw_results: Optional[List[Any]] = None,
+        cache_key: Optional[str] = None,
+    ):
         """Build a nested chain of hook executions with the entrypoint at the center.
 
         This creates a chain where each hook wraps the next one, with the function call
         at the innermost level. Returns bubble back up through each hook.
+
+        On a cache hit, cached_result stands in for the entrypoint call only
+        while the call still asks what the key names: a hook may rewrite an
+        argument before the entrypoint is reached, and the stored value answers
+        the earlier question. When that happens the tool runs for real, so the
+        hooks run over the value the entrypoint gave them on the miss and what
+        the caller gets back is what the miss produced. Entrypoint returns are
+        recorded in raw_results, detached so a hook that edits one in place
+        cannot reach the copy the cache keeps, and the caller stores that value
+        rather than the chain's: the hooks run again on a hit, and storing their
+        output would apply a result-transforming hook twice.
         """
         from functools import reduce
         from inspect import iscoroutinefunction
 
         def execute_entrypoint(name, func, args):
             """Execute the entrypoint function."""
+            if cached_result is not None and not self._moved_its_key(cache_key, entrypoint_args):
+                return _detached(cached_result)
             arguments = entrypoint_args.copy()
             if self.arguments is not None:
                 arguments.update(self.arguments)
-            return self.function.entrypoint(**arguments)  # type: ignore
+            slot = _start_entrypoint_call(raw_results) if raw_results is not None else -1
+            result = self.function.entrypoint(**arguments)  # type: ignore
+            if raw_results is not None:
+                _record_entrypoint_result(raw_results, slot, result)
+            return result
 
         # If no hooks, just return the entrypoint execution function
         if not self.function.tool_hooks:
@@ -1642,6 +2088,65 @@ class FunctionCall(BaseModel):
         chain = reduce(create_hook_wrapper, hooks, execute_entrypoint)
         return chain
 
+    def _moved_its_key(self, cache_key: Optional[str], entrypoint_args: Dict[str, Any]) -> bool:
+        """Whether anything the key is built from changed since the lookup.
+
+        Hooks hold the live arguments and the run context, so by the time the
+        entrypoint is reached the call may be asking something other than what
+        the key names. Such a call is neither answered from the entry under
+        that key nor stored under it.
+        """
+        if cache_key is None:
+            return False
+        return self.function._get_cache_key(entrypoint_args, self.arguments) != cache_key
+
+    def _save_entrypoint_result(
+        self, cache_key: str, cache_file: str, entrypoint_args: Dict[str, Any], raw_results: List[Any]
+    ) -> None:
+        """Store what the entrypoint returned, so a hit replays the hooks over
+        the same value the miss handed them.
+
+        A chain that called the entrypoint anything but once leaves no such
+        value: a hook that retried produced several and a hook that answered by
+        itself produced none, and replaying over either would not reproduce the
+        miss. Those calls stay uncached.
+
+        The caller passes the key and file the lookup used. The tool and its
+        hooks can reach the run context and the arguments the key is built
+        from, and a hook that rewrites an argument in place changes what the
+        tool was actually asked. Storing under the key the lookup used would
+        then answer a later call from a different question, and storing under a
+        key worked out afterwards would file the result under whatever the call
+        left behind. Neither is safe, so a call that moved its own key is not
+        cached at all.
+        """
+        from inspect import isasyncgen, isgenerator
+
+        if self.function.tool_hooks is not None:
+            if len(raw_results) != 1:
+                log_debug(
+                    f"Skipping cache for {self.function.name}: its hooks ran the tool "
+                    f"{len(raw_results)} times, so no single result stands for the call"
+                )
+                return
+            result_to_cache = raw_results[0]
+            if result_to_cache is _NO_RESULT:
+                return
+        else:
+            result_to_cache = self.result
+
+        if isgenerator(result_to_cache) or isasyncgen(result_to_cache):
+            return
+
+        if self._moved_its_key(cache_key, entrypoint_args):
+            log_debug(
+                f"Skipping cache for {self.function.name}: the call changed what it was asked, "
+                "so the result does not answer the question the key names"
+            )
+            return
+
+        self.function._save_to_cache(cache_file, result_to_cache)
+
     def execute(self) -> FunctionExecutionResult:
         """Runs the function call."""
         from inspect import isgenerator, isgeneratorfunction
@@ -1660,25 +2165,44 @@ class FunctionCall(BaseModel):
         self._handle_pre_hook()
 
         # Check cache if enabled and not a generator function
-        if self.function.cache_results and not isgeneratorfunction(self.function.entrypoint):
-            cache_key = self.function._get_cache_key(entrypoint_args, self.arguments)
-            cache_file = self.function._get_cache_file_path(cache_key)
-            cached_result = self.function._get_cached_result(cache_file)
-
-            if cached_result is not None:
-                log_debug(f"Cache hit for: {self.get_call_str()}")
-                self.result = cached_result
-                return FunctionExecutionResult(status="success", result=cached_result)
+        cached_result = None
+        cacheable = self.function.cache_results and not isgeneratorfunction(self.function.entrypoint)
+        if cacheable and _has_injected_media(entrypoint_args):
+            log_debug(f"Skipping cache for {self.function.name}: the call carries attached media")
+            cacheable = False
+        if cacheable:
+            try:
+                cache_key = self.function._get_cache_key(entrypoint_args, self.arguments)
+                cache_file = self.function._get_cache_file_path(cache_key)
+                cached_result = self.function._get_cached_result(cache_file)
+                if cached_result is not None:
+                    log_debug(f"Cache hit for: {self.get_call_str()}")
+            except Exception:
+                # An unusable cache directory must cost the tool its caching,
+                # not the run.
+                log_exception("Error reading cache")
+                cacheable = False
+        # A cache hit still runs tool_hooks and post_hook, so audit hooks see
+        # every tool call.
+        from_cache = cached_result is not None
 
         # Execute function
         execution_result: FunctionExecutionResult
         exception_to_raise = None
 
+        raw_results: List[Any] = []
         try:
             # Build and execute the nested chain of hooks
             if self.function.tool_hooks is not None:
-                execution_chain = self._build_nested_execution_chain(entrypoint_args=entrypoint_args)
+                execution_chain = self._build_nested_execution_chain(
+                    entrypoint_args=entrypoint_args,
+                    cached_result=cached_result,
+                    raw_results=raw_results if cacheable else None,
+                    cache_key=cache_key if cacheable else None,
+                )
                 result = execution_chain(self.function.name, self.function.entrypoint, self.arguments or {})
+            elif from_cache:
+                result = cached_result
             else:
                 if self.arguments is None or self.arguments == {}:
                     result = self.function.entrypoint(**entrypoint_args)
@@ -1697,11 +2221,10 @@ class FunctionCall(BaseModel):
                 )
             else:
                 self.result = result
-                # Only cache non-generator results
-                if self.function.cache_results:
-                    cache_key = self.function._get_cache_key(entrypoint_args, self.arguments)
-                    cache_file = self.function._get_cache_file_path(cache_key)
-                    self.function._save_to_cache(cache_file, self.result)
+                # Only cache non-generator results, and never re-save a result
+                # that was just served from cache
+                if cacheable and not from_cache:
+                    self._save_entrypoint_result(cache_key, cache_file, entrypoint_args, raw_results)
 
                 updated_session_state = None
                 run_context = entrypoint_args.get("run_context") or entrypoint_args.get("_agno_run_context")
@@ -1796,31 +2319,49 @@ class FunctionCall(BaseModel):
                 log_warning(f"Error in post-hook callback: {str(e)}")
                 log_exception(e)
 
-    async def _build_nested_execution_chain_async(self, entrypoint_args: Dict[str, Any]):
+    async def _build_nested_execution_chain_async(
+        self,
+        entrypoint_args: Dict[str, Any],
+        cached_result: Optional[Any] = None,
+        raw_results: Optional[List[Any]] = None,
+        cache_key: Optional[str] = None,
+    ):
         """Build a nested chain of async hook executions with the entrypoint at the center.
 
-        Similar to _build_nested_execution_chain but for async execution.
+        Similar to _build_nested_execution_chain but for async execution, and
+        with the same treatment of cached_result and raw_results.
         """
         from functools import reduce
         from inspect import isasyncgenfunction, iscoroutinefunction
 
         async def execute_entrypoint_async(name, func, args):
             """Execute the entrypoint function asynchronously."""
+            if cached_result is not None and not self._moved_its_key(cache_key, entrypoint_args):
+                return _detached(cached_result)
             arguments = entrypoint_args.copy()
             if self.arguments is not None:
                 arguments.update(self.arguments)
 
+            slot = _start_entrypoint_call(raw_results) if raw_results is not None else -1
             result = self.function.entrypoint(**arguments)  # type: ignore
             if iscoroutinefunction(self.function.entrypoint) and not isasyncgenfunction(self.function.entrypoint):
                 result = await result
+            if raw_results is not None:
+                _record_entrypoint_result(raw_results, slot, result)
             return result
 
         def execute_entrypoint(name, func, args):
             """Execute the entrypoint function synchronously."""
+            if cached_result is not None and not self._moved_its_key(cache_key, entrypoint_args):
+                return _detached(cached_result)
             arguments = entrypoint_args.copy()
             if self.arguments is not None:
                 arguments.update(self.arguments)
-            return self.function.entrypoint(**arguments)  # type: ignore
+            slot = _start_entrypoint_call(raw_results) if raw_results is not None else -1
+            result = self.function.entrypoint(**arguments)  # type: ignore
+            if raw_results is not None:
+                _record_entrypoint_result(raw_results, slot, result)
+            return result
 
         # If no hooks, just return the async entrypoint execution function
         if not self.function.tool_hooks:
@@ -1880,26 +2421,46 @@ class FunctionCall(BaseModel):
             self._handle_pre_hook()
 
         # Check cache if enabled and not a generator function
-        if self.function.cache_results and not (
+        cached_result = None
+        cacheable = self.function.cache_results and not (
             isasyncgenfunction(self.function.entrypoint) or isgeneratorfunction(self.function.entrypoint)
-        ):
-            cache_key = self.function._get_cache_key(entrypoint_args, self.arguments)
-            cache_file = self.function._get_cache_file_path(cache_key)
-            cached_result = self.function._get_cached_result(cache_file)
-            if cached_result is not None:
-                log_debug(f"Cache hit for: {self.get_call_str()}")
-                self.result = cached_result
-                return FunctionExecutionResult(status="success", result=cached_result)
+        )
+        if cacheable and _has_injected_media(entrypoint_args):
+            log_debug(f"Skipping cache for {self.function.name}: the call carries attached media")
+            cacheable = False
+        if cacheable:
+            try:
+                cache_key = self.function._get_cache_key(entrypoint_args, self.arguments)
+                cache_file = self.function._get_cache_file_path(cache_key)
+                cached_result = self.function._get_cached_result(cache_file)
+                if cached_result is not None:
+                    log_debug(f"Cache hit for: {self.get_call_str()}")
+            except Exception:
+                # An unusable cache directory must cost the tool its caching,
+                # not the run.
+                log_exception("Error reading cache")
+                cacheable = False
+        # A cache hit still runs tool_hooks and post_hook, so audit hooks see
+        # every tool call.
+        from_cache = cached_result is not None
 
         # Execute function
         execution_result: FunctionExecutionResult
         exception_to_raise = None
 
+        raw_results: List[Any] = []
         try:
             # Build and execute the nested chain of hooks
             if self.function.tool_hooks is not None:
-                execution_chain = await self._build_nested_execution_chain_async(entrypoint_args)
+                execution_chain = await self._build_nested_execution_chain_async(
+                    entrypoint_args,
+                    cached_result=cached_result,
+                    raw_results=raw_results if cacheable else None,
+                    cache_key=cache_key if cacheable else None,
+                )
                 self.result = await execution_chain(self.function.name, self.function.entrypoint, self.arguments or {})
+            elif from_cache:
+                self.result = cached_result
             else:
                 if self.arguments is None or self.arguments == {}:
                     result = self.function.entrypoint(**entrypoint_args)
@@ -1916,11 +2477,10 @@ class FunctionCall(BaseModel):
                 else:
                     self.result = result  # Sync function, result is already computed
 
-            # Only cache if not a generator
-            if self.function.cache_results and not (isgenerator(self.result) or isasyncgen(self.result)):
-                cache_key = self.function._get_cache_key(entrypoint_args, self.arguments)
-                cache_file = self.function._get_cache_file_path(cache_key)
-                self.function._save_to_cache(cache_file, self.result)
+            # Only cache if not a generator, and never re-save a result that
+            # was just served from cache
+            if cacheable and not from_cache:
+                self._save_entrypoint_result(cache_key, cache_file, entrypoint_args, raw_results)
 
             # For generators, don't capture updated_session_state -
             # session_state is passed by reference, so mutations made during

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import pytest
 from pydantic import BaseModel, ValidationError
@@ -9,7 +9,7 @@ from agno.models.message import Message
 from agno.run.base import RunContext
 from agno.tools import Toolkit
 from agno.tools.decorator import tool
-from agno.tools.function import Function, FunctionCall
+from agno.tools.function import Function, FunctionCall, ToolResult
 
 
 def test_function_initialization():
@@ -386,7 +386,9 @@ def test_function_cache_file_path(tmp_path):
 
     cache_key = "test_key"
     cache_file = func._get_cache_file_path(cache_key)
-    assert cache_file == os.path.join(str(tmp_path), "functions", "test_func", "test_key.json")
+    assert cache_file == os.path.join(
+        str(tmp_path), "functions", f"v{function_module.CACHE_FORMAT}", "test_func", "test_key.json"
+    )
 
 
 def test_function_cache_operations(tmp_path):
@@ -2708,3 +2710,1510 @@ def test_framework_return_annotation_keeps_argument_validation():
     result = FunctionCall(function=func, arguments={"count": "3"}).execute()
     assert result.status == "success", f"Expected success, got: {result.error}"
     assert result.result.name == "agent-3"
+
+
+# =============================================================================
+# Cache key identity tests
+# =============================================================================
+
+
+def test_cached_results_do_not_leak_across_users(tmp_path):
+    """A cache_results tool that takes run_context must key per user: one
+    user's cached result must never be served to another user."""
+    executions = []
+
+    def whoami(run_context: RunContext) -> str:
+        executions.append(run_context.user_id)
+        return f"secret for {run_context.user_id}"
+
+    func = Function(name="whoami", entrypoint=whoami, cache_results=True, cache_dir=str(tmp_path))
+
+    func._run_context = RunContext(run_id="r1", session_id="s-alice", user_id="alice")
+    result_alice = FunctionCall(function=func).execute()
+
+    func._run_context = RunContext(run_id="r2", session_id="s-bob", user_id="bob")
+    result_bob = FunctionCall(function=func).execute()
+
+    assert result_alice.result == "secret for alice"
+    assert result_bob.result == "secret for bob"
+    assert executions == ["alice", "bob"]
+
+
+@pytest.mark.asyncio
+async def test_cached_results_do_not_leak_across_users_async(tmp_path):
+    """Async variant: per-user cache keys through aexecute."""
+    executions = []
+
+    async def whoami(run_context: RunContext) -> str:
+        executions.append(run_context.user_id)
+        return f"secret for {run_context.user_id}"
+
+    func = Function(name="whoami", entrypoint=whoami, cache_results=True, cache_dir=str(tmp_path))
+
+    func._run_context = RunContext(run_id="r1", session_id="s-alice", user_id="alice")
+    result_alice = await FunctionCall(function=func).aexecute()
+
+    func._run_context = RunContext(run_id="r2", session_id="s-bob", user_id="bob")
+    result_bob = await FunctionCall(function=func).aexecute()
+
+    assert result_alice.result == "secret for alice"
+    assert result_bob.result == "secret for bob"
+    assert executions == ["alice", "bob"]
+
+
+def test_cache_hits_across_runs_for_same_user_and_session(tmp_path):
+    """run_id must stay out of the cache key: the same user and session hit
+    the cache across runs."""
+    executions = []
+
+    def whoami(run_context: RunContext) -> str:
+        executions.append(run_context.user_id)
+        return f"secret for {run_context.user_id}"
+
+    func = Function(name="whoami", entrypoint=whoami, cache_results=True, cache_dir=str(tmp_path))
+
+    func._run_context = RunContext(run_id="r1", session_id="s1", user_id="alice")
+    FunctionCall(function=func).execute()
+
+    func._run_context = RunContext(run_id="r2", session_id="s1", user_id="alice")
+    result = FunctionCall(function=func).execute()
+
+    assert result.result == "secret for alice"
+    assert executions == ["alice"]
+
+
+@pytest.mark.asyncio
+async def test_cache_hits_across_runs_for_same_user_and_session_async(tmp_path):
+    """Async variant: run_id stays out of the cache key."""
+    executions = []
+
+    async def whoami(run_context: RunContext) -> str:
+        executions.append(run_context.user_id)
+        return f"secret for {run_context.user_id}"
+
+    func = Function(name="whoami", entrypoint=whoami, cache_results=True, cache_dir=str(tmp_path))
+
+    func._run_context = RunContext(run_id="r1", session_id="s1", user_id="alice")
+    await FunctionCall(function=func).aexecute()
+
+    func._run_context = RunContext(run_id="r2", session_id="s1", user_id="alice")
+    result = await FunctionCall(function=func).aexecute()
+
+    assert result.result == "secret for alice"
+    assert executions == ["alice"]
+
+
+# =============================================================================
+# Cached ToolResult round-trip tests
+# =============================================================================
+
+
+def test_cached_tool_result_round_trips_as_tool_result(tmp_path):
+    """A cached ToolResult must come back as a ToolResult on a hit, not as a
+    plain dict."""
+
+    def get_data() -> ToolResult:
+        return ToolResult(content="hello", metadata={"structured_content": {"k": "v"}})
+
+    func = Function(name="get_data", entrypoint=get_data, cache_results=True, cache_dir=str(tmp_path))
+
+    first = FunctionCall(function=func).execute()
+    second = FunctionCall(function=func).execute()
+
+    assert isinstance(first.result, ToolResult)
+    assert isinstance(second.result, ToolResult)
+    assert second.result.content == "hello"
+    assert second.result.metadata == {"structured_content": {"k": "v"}}
+
+
+@pytest.mark.asyncio
+async def test_cached_tool_result_round_trips_as_tool_result_async(tmp_path):
+    """Async variant: cached ToolResult round-trips through aexecute."""
+
+    async def get_data() -> ToolResult:
+        return ToolResult(content="hello", metadata={"structured_content": {"k": "v"}})
+
+    func = Function(name="get_data", entrypoint=get_data, cache_results=True, cache_dir=str(tmp_path))
+
+    first = await FunctionCall(function=func).aexecute()
+    second = await FunctionCall(function=func).aexecute()
+
+    assert isinstance(first.result, ToolResult)
+    assert isinstance(second.result, ToolResult)
+    assert second.result.content == "hello"
+    assert second.result.metadata == {"structured_content": {"k": "v"}}
+
+
+def test_tool_result_with_media_is_not_cached(tmp_path):
+    """Media bytes do not survive a JSON round trip; a ToolResult carrying
+    media is executed every time instead of being served media-stripped."""
+    from agno.media import Image
+
+    executions = []
+
+    def get_image() -> ToolResult:
+        executions.append(1)
+        return ToolResult(content="image attached", images=[Image(content=b"\x89PNG raw")])
+
+    func = Function(name="get_image", entrypoint=get_image, cache_results=True, cache_dir=str(tmp_path))
+
+    FunctionCall(function=func).execute()
+    second = FunctionCall(function=func).execute()
+
+    assert len(executions) == 2
+    assert isinstance(second.result, ToolResult)
+    assert second.result.images[0].content == b"\x89PNG raw"
+
+
+@pytest.mark.asyncio
+async def test_tool_result_with_media_is_not_cached_async(tmp_path):
+    """Async variant: media-bearing ToolResults are never served from cache."""
+    from agno.media import Image
+
+    executions = []
+
+    async def get_image() -> ToolResult:
+        executions.append(1)
+        return ToolResult(content="image attached", images=[Image(content=b"\x89PNG raw")])
+
+    func = Function(name="get_image", entrypoint=get_image, cache_results=True, cache_dir=str(tmp_path))
+
+    await FunctionCall(function=func).aexecute()
+    second = await FunctionCall(function=func).aexecute()
+
+    assert len(executions) == 2
+    assert isinstance(second.result, ToolResult)
+    assert second.result.images[0].content == b"\x89PNG raw"
+
+
+# =============================================================================
+# Hooks on cache hit tests
+# =============================================================================
+
+
+def test_hooks_run_on_cache_hit(tmp_path):
+    """tool_hooks and post_hook must run on a cache hit, with the cached
+    result substituted for the entrypoint call, so audit hooks never miss a
+    tool call."""
+    events = []
+
+    def audit_hook(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        events.append("tool_hook")
+        return function_call(**arguments)
+
+    def post_hook():
+        events.append("post_hook")
+
+    def compute(x: int) -> str:
+        events.append("entrypoint")
+        return f"value {x}"
+
+    func = Function(
+        name="compute",
+        entrypoint=compute,
+        cache_results=True,
+        cache_dir=str(tmp_path),
+        tool_hooks=[audit_hook],
+        post_hook=post_hook,
+    )
+
+    first = FunctionCall(function=func, arguments={"x": 1}).execute()
+    assert first.result == "value 1"
+    assert events == ["tool_hook", "entrypoint", "post_hook"]
+
+    events.clear()
+    second = FunctionCall(function=func, arguments={"x": 1}).execute()
+    assert second.result == "value 1"
+    assert events == ["tool_hook", "post_hook"]
+
+
+@pytest.mark.asyncio
+async def test_hooks_run_on_cache_hit_async(tmp_path):
+    """Async variant: hooks run on cache hits through aexecute."""
+    events = []
+
+    async def audit_hook(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        events.append("tool_hook")
+        return await function_call(**arguments)
+
+    async def post_hook():
+        events.append("post_hook")
+
+    async def compute(x: int) -> str:
+        events.append("entrypoint")
+        return f"value {x}"
+
+    func = Function(
+        name="compute",
+        entrypoint=compute,
+        cache_results=True,
+        cache_dir=str(tmp_path),
+        tool_hooks=[audit_hook],
+        post_hook=post_hook,
+    )
+
+    first = await FunctionCall(function=func, arguments={"x": 1}).aexecute()
+    assert first.result == "value 1"
+    assert events == ["tool_hook", "entrypoint", "post_hook"]
+
+    events.clear()
+    second = await FunctionCall(function=func, arguments={"x": 1}).aexecute()
+    assert second.result == "value 1"
+    assert events == ["tool_hook", "post_hook"]
+
+
+# =============================================================================
+# Cache key identity: each field on its own
+# =============================================================================
+
+
+def test_cached_results_do_not_leak_across_users_in_one_session(tmp_path):
+    """user_id must reach the key on its own. Two callers can share a session
+    id, so a key built from the session alone serves one user's result to
+    another."""
+    executions = []
+
+    def get_secret(run_context: RunContext) -> str:
+        executions.append(run_context.user_id)
+        return f"secret for {run_context.user_id}"
+
+    func = Function(name="get_secret", entrypoint=get_secret, cache_results=True, cache_dir=str(tmp_path))
+
+    func._run_context = RunContext(run_id="r1", session_id="shared", user_id="alice")
+    assert FunctionCall(function=func).execute().result == "secret for alice"
+
+    func._run_context = RunContext(run_id="r2", session_id="shared", user_id="bob")
+    assert FunctionCall(function=func).execute().result == "secret for bob"
+    assert executions == ["alice", "bob"]
+
+
+def test_cached_results_do_not_leak_across_sessions_for_one_user(tmp_path):
+    """session_id must reach the key on its own, so one user's two sessions do
+    not share an entry."""
+    executions = []
+
+    def read_scratch(run_context: RunContext) -> str:
+        executions.append(run_context.session_id)
+        return f"notes in {run_context.session_id}"
+
+    func = Function(name="read_scratch", entrypoint=read_scratch, cache_results=True, cache_dir=str(tmp_path))
+
+    func._run_context = RunContext(run_id="r1", session_id="s1", user_id="alice")
+    assert FunctionCall(function=func).execute().result == "notes in s1"
+
+    func._run_context = RunContext(run_id="r2", session_id="s2", user_id="alice")
+    assert FunctionCall(function=func).execute().result == "notes in s2"
+    assert executions == ["s1", "s2"]
+
+
+# =============================================================================
+# Cache hits reproduce what the miss returned
+# =============================================================================
+
+
+def test_hook_mutating_the_result_is_not_applied_twice_on_a_cache_hit(tmp_path):
+    """A hook that edits the result in place is an ordinary way to write one.
+    The hit must return what the miss returned, not the hook's edit applied to
+    its own earlier output."""
+    executions = []
+
+    def enrich(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        result = function_call(**arguments)
+        result["items"].append("enriched")
+        return result
+
+    def load(x: int) -> dict:
+        executions.append(x)
+        return {"items": ["raw"]}
+
+    func = Function(name="load", entrypoint=load, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[enrich])
+
+    first = FunctionCall(function=func, arguments={"x": 1}).execute()
+    second = FunctionCall(function=func, arguments={"x": 1}).execute()
+
+    assert first.result == {"items": ["raw", "enriched"]}
+    assert second.result == first.result
+    assert executions == [1]
+
+
+@pytest.mark.asyncio
+async def test_hook_mutating_the_result_is_not_applied_twice_on_a_cache_hit_async(tmp_path):
+    """Async variant of the in-place mutation case."""
+    executions = []
+
+    async def enrich(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        result = await function_call(**arguments)
+        result["items"].append("enriched")
+        return result
+
+    async def load(x: int) -> dict:
+        executions.append(x)
+        return {"items": ["raw"]}
+
+    func = Function(
+        name="load_async", entrypoint=load, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[enrich]
+    )
+
+    first = await FunctionCall(function=func, arguments={"x": 1}).aexecute()
+    second = await FunctionCall(function=func, arguments={"x": 1}).aexecute()
+
+    assert first.result == {"items": ["raw", "enriched"]}
+    assert second.result == first.result
+    assert executions == [1]
+
+
+def test_a_hook_reading_the_result_still_gets_the_tools_shape_on_a_hit(tmp_path):
+    """A hook receives what the tool returned, on a hit as on a miss. A hook
+    that reads the tool's own shape would break on anything else."""
+    executions = []
+
+    def render(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        rows = function_call(**arguments)
+        return "\n".join(f"{row['title']} ({row['score']})" for row in rows)
+
+    def search(query: str) -> List[Dict[str, Any]]:
+        executions.append(query)
+        return [{"title": "alpha", "score": 0.9}, {"title": "beta", "score": 0.7}]
+
+    func = Function(
+        name="search_rows", entrypoint=search, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[render]
+    )
+
+    first = FunctionCall(function=func, arguments={"query": "q"}).execute()
+    second = FunctionCall(function=func, arguments={"query": "q"}).execute()
+
+    assert first.status == "success"
+    assert second.status == "success"
+    assert second.result == first.result == "alpha (0.9)\nbeta (0.7)"
+    assert executions == ["q"]
+
+
+def test_a_hook_whose_output_depends_on_the_caller_still_decides_on_a_hit(tmp_path):
+    """The hooks run again on a hit, so a hook that redacts for the current
+    caller keeps deciding rather than replaying the first caller's answer."""
+    viewer = {"role": "admin"}
+
+    def redact(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        summary = function_call(**arguments)
+        if viewer["role"] != "admin":
+            summary = summary.replace("4111111111111111", "****")
+        return summary
+
+    def account_summary() -> str:
+        return "card=4111111111111111"
+
+    func = Function(
+        name="account_summary",
+        entrypoint=account_summary,
+        cache_results=True,
+        cache_dir=str(tmp_path),
+        tool_hooks=[redact],
+    )
+
+    assert FunctionCall(function=func, arguments={}).execute().result == "card=4111111111111111"
+
+    viewer["role"] = "support"
+    assert FunctionCall(function=func, arguments={}).execute().result == "card=****"
+
+
+def test_a_hook_calling_the_entrypoint_twice_is_not_cached(tmp_path):
+    """No single return stands for a call whose hooks ran the tool more than
+    once, so there is nothing to replay the hooks over and the call is not
+    cached."""
+    counter = iter(range(1, 99))
+
+    def compare(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        return f"{function_call(**arguments)}|{function_call(**arguments)}"
+
+    def attempt() -> str:
+        return f"value-{next(counter)}"
+
+    func = Function(
+        name="attempt", entrypoint=attempt, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[compare]
+    )
+
+    first = FunctionCall(function=func, arguments={}).execute()
+    second = FunctionCall(function=func, arguments={}).execute()
+
+    assert first.result == "value-1|value-2"
+    assert second.result == "value-3|value-4"
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+def test_a_hook_that_answers_without_the_entrypoint_is_not_cached(tmp_path):
+    """A hook that recovers from an error, or refuses before the tool runs,
+    produced no result of the tool's own. Caching its answer would keep
+    answering for the tool long after the condition passed."""
+    available = {"ok": False}
+
+    def recover(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        try:
+            return f"[ok] {function_call(**arguments)}"
+        except Exception as e:
+            return f"[error] {e}"
+
+    def upstream() -> str:
+        if not available["ok"]:
+            raise ValueError("upstream down")
+        return "fresh data"
+
+    func = Function(
+        name="upstream", entrypoint=upstream, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[recover]
+    )
+
+    assert FunctionCall(function=func, arguments={}).execute().result == "[error] upstream down"
+    assert list(tmp_path.rglob("*.json")) == []
+
+    available["ok"] = True
+    assert FunctionCall(function=func, arguments={}).execute().result == "[ok] fresh data"
+
+
+def test_a_hook_can_still_refuse_a_call_served_from_cache(tmp_path):
+    """Hooks run on hits so a policy hook governs cached calls too."""
+    calls = []
+
+    def rate_limit(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        calls.append(1)
+        if len(calls) > 1:
+            raise PermissionError("rate limit exceeded")
+        return function_call(**arguments)
+
+    def lookup() -> str:
+        return "sensitive"
+
+    func = Function(
+        name="lookup", entrypoint=lookup, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[rate_limit]
+    )
+
+    assert FunctionCall(function=func, arguments={}).execute().status == "success"
+    refused = FunctionCall(function=func, arguments={}).execute()
+    assert refused.status == "failure"
+    assert "rate limit exceeded" in refused.error
+
+
+def test_post_hook_and_session_state_still_run_on_a_hit_without_tool_hooks(tmp_path):
+    """Most cached tools declare no tool_hooks. The hit must not short-circuit
+    past post_hook or past the session state the run context collected."""
+    events = []
+
+    def post_hook():
+        events.append("post_hook")
+
+    def remember(run_context: RunContext) -> str:
+        events.append("entrypoint")
+        run_context.session_state["seen"] = 1
+        return "noted"
+
+    func = Function(
+        name="remember", entrypoint=remember, cache_results=True, cache_dir=str(tmp_path), post_hook=post_hook
+    )
+    func._run_context = RunContext(run_id="r1", session_id="s1", user_id="alice", session_state={})
+
+    FunctionCall(function=func).execute()
+    events.clear()
+
+    func._run_context = RunContext(run_id="r2", session_id="s1", user_id="alice", session_state={})
+    hit = FunctionCall(function=func).execute()
+
+    assert events == ["post_hook"]
+    assert hit.result == "noted"
+
+
+@pytest.mark.asyncio
+async def test_sync_entrypoint_with_hooks_is_cached_under_aexecute(tmp_path):
+    """A sync tool called through aexecute takes its own branch of the async
+    hook chain, and caching must work there too."""
+    executions = []
+
+    async def audit(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        return await function_call(**arguments)
+
+    def compute(x: int) -> str:
+        executions.append(x)
+        return f"value {x}"
+
+    func = Function(
+        name="compute_sync_async",
+        entrypoint=compute,
+        cache_results=True,
+        cache_dir=str(tmp_path),
+        tool_hooks=[audit],
+    )
+
+    first = await FunctionCall(function=func, arguments={"x": 1}).aexecute()
+    second = await FunctionCall(function=func, arguments={"x": 1}).aexecute()
+
+    assert first.result == "value 1"
+    assert second.result == "value 1"
+    assert executions == [1]
+
+
+# =============================================================================
+# What the cache file may hold
+# =============================================================================
+
+
+def test_a_sanitizing_hook_redacts_the_hit_as_well_as_the_miss(tmp_path):
+    """The entry holds the tool's own return, so a hook that strips a secret
+    keeps stripping it on every hit. The stripped value reaches the cache file,
+    which is why entries are readable by their owner alone."""
+    import json
+
+    def redact(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        result = function_call(**arguments)
+        return {k: v for k, v in result.items() if k != "card"}
+
+    def profile() -> dict:
+        return {"name": "Ada", "card": "4111111111111111"}
+
+    func = Function(
+        name="profile", entrypoint=profile, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[redact]
+    )
+
+    assert FunctionCall(function=func, arguments={}).execute().result == {"name": "Ada"}
+    assert FunctionCall(function=func, arguments={}).execute().result == {"name": "Ada"}
+
+    written = list(tmp_path.rglob("*.json"))
+    assert len(written) == 1
+    assert json.loads(written[0].read_text())["result"] == {"name": "Ada", "card": "4111111111111111"}
+
+
+def test_cache_files_are_readable_by_their_owner_only(tmp_path):
+    """The default cache directory is shared, and an entry holds the caller's
+    data."""
+    import stat
+
+    def compute() -> str:
+        return "value"
+
+    func = Function(name="compute_mode", entrypoint=compute, cache_results=True, cache_dir=str(tmp_path))
+    FunctionCall(function=func, arguments={}).execute()
+
+    written = list(tmp_path.rglob("*.json"))
+    assert len(written) == 1
+    assert stat.S_IMODE(written[0].stat().st_mode) == 0o600
+
+
+def test_a_result_that_cannot_be_copied_is_not_cached(tmp_path):
+    """The cache keeps a copy of the tool's return because the hooks run after
+    it and may edit it in place. A value too deeply nested to copy leaves
+    nothing safe to keep, so the call is not cached rather than cached with the
+    hook's edit folded in."""
+
+    def enrich(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        result = function_call(**arguments)
+        result["items"].append("enriched")
+        return result
+
+    def nested() -> dict:
+        deep: Any = []
+        for _ in range(600):
+            deep = [deep]
+        return {"items": ["raw"], "deep": deep}
+
+    func = Function(name="nested", entrypoint=nested, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[enrich])
+
+    reported = []
+    original = function_module.log_exception
+    function_module.log_exception = lambda *args, **kwargs: reported.append(args)
+    try:
+        first = FunctionCall(function=func, arguments={}).execute()
+        second = FunctionCall(function=func, arguments={}).execute()
+    finally:
+        function_module.log_exception = original
+
+    assert first.result["items"] == ["raw", "enriched"]
+    assert second.result["items"] == ["raw", "enriched"]
+    assert list(tmp_path.rglob("*.json")) == []
+    # A result the cache cannot keep is an ordinary outcome, not a failure.
+    assert reported == []
+
+
+def test_a_result_that_cannot_be_serialized_leaves_no_cache_file(tmp_path):
+    """A half-written file would fail to parse on every later call, and the
+    expiry path never reaches it."""
+    import threading
+
+    def handle() -> dict:
+        return {"lock": threading.Lock()}
+
+    func = Function(name="handle", entrypoint=handle, cache_results=True, cache_dir=str(tmp_path))
+    assert FunctionCall(function=func, arguments={}).execute().status == "success"
+
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+def test_calls_carrying_attached_media_are_not_cached(tmp_path):
+    """Attached media is the input the tool reads, and it is not part of the
+    key, so two documents would otherwise share one entry."""
+    from agno.media import File as MediaFile
+
+    reads = []
+
+    def summarize(question: str, files: Optional[List[Any]] = None) -> str:
+        content = files[0].content if files else b""
+        reads.append(content)
+        return f"summary of {content.decode()}"
+
+    func = Function(name="summarize", entrypoint=summarize, cache_results=True, cache_dir=str(tmp_path))
+
+    func._files = [MediaFile(content=b"DOC-A")]
+    first = FunctionCall(function=func, arguments={"question": "what is this"}).execute()
+    func._files = [MediaFile(content=b"DOC-B")]
+    second = FunctionCall(function=func, arguments={"question": "what is this"}).execute()
+
+    assert first.result == "summary of DOC-A"
+    assert second.result == "summary of DOC-B"
+    assert reads == [b"DOC-A", b"DOC-B"]
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+# =============================================================================
+# Entries that no longer match the code
+# =============================================================================
+
+
+def test_an_entry_from_an_earlier_cache_format_is_discarded(tmp_path):
+    """An earlier version stored what the hooks made of the result. Replaying
+    the hooks over that would apply them twice, so entries without the current
+    format are discarded unread and the tool runs again."""
+    import json
+    from time import time
+
+    executions = []
+
+    def verify(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        return f"[verified] {function_call(**arguments)}"
+
+    def balance() -> str:
+        executions.append(1)
+        return "balance = 100"
+
+    func = Function(
+        name="balance", entrypoint=balance, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[verify]
+    )
+
+    cache_file = func._get_cache_file_path(func._get_cache_key({}, {}))
+    with open(cache_file, "w", encoding="utf-8") as f:
+        json.dump({"timestamp": time(), "result": "[verified] balance = 100"}, f)
+
+    assert FunctionCall(function=func, arguments={}).execute().result == "[verified] balance = 100"
+    assert executions == [1]
+
+    # The entry it wrote in passing is in the current format, so the next call hits.
+    assert FunctionCall(function=func, arguments={}).execute().result == "[verified] balance = 100"
+    assert executions == [1]
+
+
+def test_an_entry_claiming_a_tool_result_the_tool_does_not_return_is_discarded(tmp_path):
+    """The declared return type decides what a hit rebuilds, so an entry cannot
+    choose the class and hand the model loop media it named itself."""
+    import json
+    from time import time
+
+    executions = []
+
+    def get_price(symbol: str) -> str:
+        executions.append(symbol)
+        return "100"
+
+    func = Function(name="get_price", entrypoint=get_price, cache_results=True, cache_dir=str(tmp_path))
+
+    cache_file = func._get_cache_file_path(func._get_cache_key({}, {"symbol": "AGNO"}))
+    with open(cache_file, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "timestamp": time(),
+                "cache_format": function_module.CACHE_FORMAT,
+                "result_type": "ToolResult",
+                "result": {"content": "owned", "images": [{"id": "x", "filepath": "/etc/passwd"}]},
+            },
+            f,
+        )
+
+    result = FunctionCall(function=func, arguments={"symbol": "AGNO"}).execute()
+    assert result.result == "100"
+    assert executions == ["AGNO"]
+
+
+def test_an_entry_typed_against_the_declared_return_is_discarded_without_media(tmp_path):
+    """The declared return type alone settles it. An entry naming a class the
+    tool does not return is discarded whether or not it carries media."""
+    import json
+    from time import time
+
+    executions = []
+
+    def get_note(key: str) -> str:
+        executions.append(key)
+        return "the real note"
+
+    func = Function(name="get_note", entrypoint=get_note, cache_results=True, cache_dir=str(tmp_path))
+
+    cache_file = func._get_cache_file_path(func._get_cache_key({}, {"key": "k"}))
+    with open(cache_file, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "timestamp": time(),
+                "cache_format": function_module.CACHE_FORMAT,
+                "result_type": "ToolResult",
+                "result": {"content": "planted"},
+            },
+            f,
+        )
+
+    result = FunctionCall(function=func, arguments={"key": "k"}).execute()
+    assert result.result == "the real note"
+    assert executions == ["k"]
+
+
+def test_an_entry_a_tool_result_cannot_carry_is_discarded(tmp_path):
+    """Media is never written to the cache, so an entry holding it did not come
+    from here."""
+    import json
+    from time import time
+
+    executions = []
+
+    def report() -> ToolResult:
+        executions.append(1)
+        return ToolResult(content="clean")
+
+    func = Function(name="report", entrypoint=report, cache_results=True, cache_dir=str(tmp_path))
+
+    from agno.media import Image
+
+    # A complete dump, so the entry rebuilds cleanly and only the media in it
+    # can be what makes it unusable.
+    planted = ToolResult(content="owned", images=[Image(id="x", filepath="/etc/passwd")]).model_dump()
+    cache_file = func._get_cache_file_path(func._get_cache_key({}, {}))
+    with open(cache_file, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "timestamp": time(),
+                "cache_format": function_module.CACHE_FORMAT,
+                "result_type": "ToolResult",
+                "result": planted,
+            },
+            f,
+        )
+
+    result = FunctionCall(function=func, arguments={}).execute()
+    assert isinstance(result.result, ToolResult)
+    assert result.result.content == "clean"
+    assert result.result.images is None
+    assert executions == [1]
+
+
+def test_optional_model_return_stays_typed_on_a_cache_hit(tmp_path):
+    """A union spelling is the ordinary way to annotate a tool that may return
+    nothing, and the hit must not hand back a plain dict."""
+
+    class Weather(BaseModel):
+        city: str
+        temp_c: int
+
+    def forecast(city: str) -> Optional[Weather]:
+        return Weather(city=city, temp_c=21)
+
+    func = Function(name="forecast", entrypoint=forecast, cache_results=True, cache_dir=str(tmp_path))
+
+    first = FunctionCall(function=func, arguments={"city": "Paris"}).execute()
+    second = FunctionCall(function=func, arguments={"city": "Paris"}).execute()
+
+    assert isinstance(first.result, Weather)
+    assert isinstance(second.result, Weather)
+    assert second.result.city == "Paris"
+
+
+def test_a_result_the_declared_return_type_cannot_hold_is_recomputed(tmp_path):
+    """A tool may return a richer subclass than it declares. Rebuilding the
+    declared type would drop the extra fields, so the entry is discarded and
+    the call runs again with every field intact."""
+
+    class SearchResult(BaseModel):
+        title: str
+
+    class RichSearchResult(SearchResult):
+        url: str
+
+    executions = []
+
+    def search(q: str) -> SearchResult:
+        executions.append(q)
+        return RichSearchResult(title="Agno", url="https://agno.com")
+
+    func = Function(name="search", entrypoint=search, cache_results=True, cache_dir=str(tmp_path))
+
+    first = FunctionCall(function=func, arguments={"q": "agno"}).execute()
+    second = FunctionCall(function=func, arguments={"q": "agno"}).execute()
+
+    assert first.result.url == "https://agno.com"
+    assert second.result.url == "https://agno.com"
+    assert executions == ["agno", "agno"]
+
+
+def test_result_transforming_hook_not_applied_twice_on_cache_hit(tmp_path):
+    """The cache must store the raw entrypoint return, not the hook-chain
+    output: hooks run again on a hit, so caching their output would apply a
+    result-transforming hook twice."""
+    executions = []
+
+    def redacting_hook(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        return f"[audited] {function_call(**arguments)}"
+
+    def compute(x: int) -> str:
+        executions.append(x)
+        return f"value {x}"
+
+    func = Function(
+        name="compute",
+        entrypoint=compute,
+        cache_results=True,
+        cache_dir=str(tmp_path),
+        tool_hooks=[redacting_hook],
+    )
+
+    first = FunctionCall(function=func, arguments={"x": 1}).execute()
+    second = FunctionCall(function=func, arguments={"x": 1}).execute()
+
+    assert first.result == "[audited] value 1"
+    assert second.result == "[audited] value 1"
+    assert executions == [1]
+
+
+@pytest.mark.asyncio
+async def test_result_transforming_hook_not_applied_twice_on_cache_hit_async(tmp_path):
+    """Async variant: raw entrypoint return cached, hook applied once per call."""
+    executions = []
+
+    async def redacting_hook(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        return f"[audited] {await function_call(**arguments)}"
+
+    async def compute(x: int) -> str:
+        executions.append(x)
+        return f"value {x}"
+
+    func = Function(
+        name="compute",
+        entrypoint=compute,
+        cache_results=True,
+        cache_dir=str(tmp_path),
+        tool_hooks=[redacting_hook],
+    )
+
+    first = await FunctionCall(function=func, arguments={"x": 1}).aexecute()
+    second = await FunctionCall(function=func, arguments={"x": 1}).aexecute()
+
+    assert first.result == "[audited] value 1"
+    assert second.result == "[audited] value 1"
+    assert executions == [1]
+
+
+def test_cached_base_model_revalidates_against_return_annotation(tmp_path):
+    """A cached BaseModel result is validated back into the entrypoint's
+    declared return type on a hit, instead of coming back as a plain dict."""
+
+    class Weather(BaseModel):
+        city: str
+        temp_c: int
+
+    def get_weather(city: str) -> Weather:
+        return Weather(city=city, temp_c=20)
+
+    func = Function(name="get_weather", entrypoint=get_weather, cache_results=True, cache_dir=str(tmp_path))
+
+    first = FunctionCall(function=func, arguments={"city": "Paris"}).execute()
+    second = FunctionCall(function=func, arguments={"city": "Paris"}).execute()
+
+    assert isinstance(first.result, Weather)
+    assert isinstance(second.result, Weather)
+    assert second.result == first.result
+
+
+@pytest.mark.asyncio
+async def test_cached_base_model_revalidates_against_return_annotation_async(tmp_path):
+    """Async variant of the BaseModel cache round-trip."""
+
+    class Weather(BaseModel):
+        city: str
+        temp_c: int
+
+    async def get_weather(city: str) -> Weather:
+        return Weather(city=city, temp_c=20)
+
+    func = Function(name="get_weather", entrypoint=get_weather, cache_results=True, cache_dir=str(tmp_path))
+
+    first = await FunctionCall(function=func, arguments={"city": "Paris"}).aexecute()
+    second = await FunctionCall(function=func, arguments={"city": "Paris"}).aexecute()
+
+    assert isinstance(first.result, Weather)
+    assert isinstance(second.result, Weather)
+    assert second.result == first.result
+
+
+# =============================================================================
+# Calls the cache must refuse
+# =============================================================================
+
+
+def test_a_hook_retrying_past_a_failure_is_not_cached(tmp_path):
+    """A hook that retries has run the tool twice even though only the second
+    attempt returned. Neither attempt stands for the call, so caching the one
+    that succeeded would make the hit take a path the miss never took."""
+    attempts = []
+    counter = iter(range(1, 99))
+
+    def retry(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        try:
+            return f"primary:{function_call(**arguments)}"
+        except Exception:
+            return f"recovered:{function_call(**arguments)}"
+
+    def flaky() -> str:
+        n = next(counter)
+        attempts.append(n)
+        if n == 1:
+            raise RuntimeError("transient")
+        return f"value-{n}"
+
+    func = Function(name="flaky", entrypoint=flaky, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[retry])
+
+    assert FunctionCall(function=func, arguments={}).execute().result == "recovered:value-2"
+    assert attempts == [1, 2]
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+@pytest.mark.asyncio
+async def test_a_hook_retrying_past_a_failure_is_not_cached_async(tmp_path):
+    """Async variant: the attempt that raised still counts."""
+    attempts = []
+    counter = iter(range(1, 99))
+
+    async def retry(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        try:
+            return f"primary:{await function_call(**arguments)}"
+        except Exception:
+            return f"recovered:{await function_call(**arguments)}"
+
+    async def flaky() -> str:
+        n = next(counter)
+        attempts.append(n)
+        if n == 1:
+            raise RuntimeError("transient")
+        return f"value-{n}"
+
+    func = Function(
+        name="flaky_async", entrypoint=flaky, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[retry]
+    )
+
+    result = await FunctionCall(function=func, arguments={}).aexecute()
+    assert result.result == "recovered:value-2"
+    assert attempts == [1, 2]
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+def test_a_hook_recovering_from_the_only_attempt_is_not_reported_as_an_error(tmp_path):
+    """The tool ran once and returned nothing, so there is nothing to store.
+    That is an ordinary outcome of a recovering hook, not a failure to report."""
+
+    def recover(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        try:
+            return function_call(**arguments)
+        except Exception as e:
+            return f"[error] {e}"
+
+    def upstream() -> str:
+        raise ValueError("upstream down")
+
+    func = Function(
+        name="single_failure", entrypoint=upstream, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[recover]
+    )
+
+    reported = []
+    original = function_module.log_exception
+    function_module.log_exception = lambda *args, **kwargs: reported.append(args)
+    try:
+        result = FunctionCall(function=func, arguments={}).execute()
+    finally:
+        function_module.log_exception = original
+
+    assert result.result == "[error] upstream down"
+    assert list(tmp_path.rglob("*.json")) == []
+    assert reported == []
+
+
+def test_a_result_a_hook_could_not_read_back_is_not_cached(tmp_path):
+    """A hit hands the stored value to the hooks in the tool's place, so a
+    value a JSON round trip changes is not stored at all. A tuple would come
+    back a list, and the hook that unpacks it would be reading something the
+    tool never returned."""
+
+    def unpack(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        low, high = function_call(**arguments)
+        return f"{low}..{high}"
+
+    def span() -> tuple:
+        return (1, 9)
+
+    func = Function(name="span", entrypoint=span, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[unpack])
+
+    first = FunctionCall(function=func, arguments={}).execute()
+    second = FunctionCall(function=func, arguments={}).execute()
+
+    assert first.status == "success"
+    assert second.status == "success"
+    assert second.result == first.result == "1..9"
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+def test_an_entry_that_no_longer_rebuilds_into_the_return_type_is_discarded(tmp_path):
+    """A model that gained a required field between deploys leaves entries the
+    code can no longer read. Handing back the old shape would give the caller a
+    value its own annotation says it cannot receive."""
+    import json
+    from time import time
+
+    class Forecast(BaseModel):
+        city: str
+        country: str
+
+    executions = []
+
+    def forecast() -> Forecast:
+        executions.append(1)
+        return Forecast(city="oslo", country="no")
+
+    func = Function(name="forecast", entrypoint=forecast, cache_results=True, cache_dir=str(tmp_path))
+
+    cache_file = func._get_cache_file_path(func._get_cache_key({}, {}))
+    with open(cache_file, "w", encoding="utf-8") as f:
+        json.dump({"timestamp": time(), "cache_format": function_module.CACHE_FORMAT, "result": {"city": "oslo"}}, f)
+
+    result = FunctionCall(function=func, arguments={}).execute()
+    assert isinstance(result.result, Forecast)
+    assert result.result.country == "no"
+    assert executions == [1]
+
+
+def test_a_model_whose_fields_carry_aliases_still_caches(tmp_path):
+    """Entries are written with field names, so reading one back has to accept
+    field names. Otherwise an ordinary aliased model would re-execute forever."""
+    from pydantic import Field
+
+    executions = []
+
+    class Profile(BaseModel):
+        user_name: str = Field(alias="userName")
+
+    def whoami() -> Profile:
+        executions.append(1)
+        return Profile(userName="ada")
+
+    func = Function(name="whoami", entrypoint=whoami, cache_results=True, cache_dir=str(tmp_path))
+
+    first = FunctionCall(function=func, arguments={}).execute()
+    second = FunctionCall(function=func, arguments={}).execute()
+
+    assert isinstance(first.result, Profile)
+    assert isinstance(second.result, Profile)
+    assert second.result.user_name == "ada"
+    assert executions == [1]
+
+
+def test_the_cache_directory_is_private_to_its_owner(tmp_path):
+    """The default location is a shared temporary directory under a
+    predictable name."""
+    import stat
+    from pathlib import Path
+
+    def compute() -> str:
+        return "value"
+
+    func = Function(name="private_dir", entrypoint=compute, cache_results=True, cache_dir=str(tmp_path / "cache"))
+    FunctionCall(function=func, arguments={}).execute()
+
+    leaf = Path(func._get_cache_file_path(func._get_cache_key({}, {}))).parent
+    for level in (leaf, leaf.parent, leaf.parent.parent):
+        assert stat.S_IMODE(level.stat().st_mode) == 0o700, level
+
+
+def test_a_link_planted_at_the_cache_path_is_not_read(tmp_path):
+    """The cache path is predictable, so a link left there must not choose the
+    file a hit reads."""
+    import json
+    from pathlib import Path
+    from time import time
+
+    executions = []
+
+    def get_note() -> str:
+        executions.append(1)
+        return "the real note"
+
+    func = Function(name="linked", entrypoint=get_note, cache_results=True, cache_dir=str(tmp_path / "cache"))
+
+    planted = tmp_path / "planted.json"
+    planted.write_text(json.dumps({"timestamp": time(), "cache_format": function_module.CACHE_FORMAT, "result": "x"}))
+    cache_path = Path(func._get_cache_file_path(func._get_cache_key({}, {})))
+    cache_path.symlink_to(planted)
+
+    result = FunctionCall(function=func, arguments={}).execute()
+    assert result.result == "the real note"
+    assert executions == [1]
+
+
+def test_a_cache_directory_others_can_write_is_closed(tmp_path):
+    """An earlier release made these directories with whatever the umask
+    allowed. They are ours to keep, so they are closed rather than refused: a
+    caller must not lose its caching by upgrading."""
+    import stat
+
+    open_dir = tmp_path / "cache" / "functions" / f"v{function_module.CACHE_FORMAT}" / "widely_open"
+    open_dir.mkdir(parents=True)
+    open_dir.chmod(0o777)
+
+    executions = []
+
+    def compute() -> str:
+        executions.append(1)
+        return "value"
+
+    func = Function(name="widely_open", entrypoint=compute, cache_results=True, cache_dir=str(tmp_path / "cache"))
+
+    first = FunctionCall(function=func, arguments={}).execute()
+    second = FunctionCall(function=func, arguments={}).execute()
+
+    assert first.status == "success"
+    assert second.result == "value"
+    assert executions == [1]
+    assert not stat.S_IMODE(open_dir.stat().st_mode) & (stat.S_IWGRP | stat.S_IWOTH)
+
+
+def test_a_tool_that_changes_the_caller_cannot_store_under_the_new_identity(tmp_path):
+    """The key is decided before the tool runs. A tool that edits the run
+    context would otherwise file its result under whoever it left behind, and
+    the next caller would be served it."""
+    executions = []
+
+    def leaky(run_context: RunContext) -> str:
+        executions.append(run_context.user_id)
+        secret = f"secret for {run_context.user_id}"
+        run_context.user_id = "bob"
+        return secret
+
+    func = Function(name="leaky", entrypoint=leaky, cache_results=True, cache_dir=str(tmp_path))
+
+    func._run_context = RunContext(run_id="r1", session_id="s1", user_id="alice")
+    assert FunctionCall(function=func).execute().result == "secret for alice"
+
+    func._run_context = RunContext(run_id="r2", session_id="s1", user_id="bob")
+    assert FunctionCall(function=func).execute().result == "secret for bob"
+    assert executions == ["alice", "bob"]
+
+
+def test_a_stored_value_must_come_back_as_its_own_type(tmp_path):
+    """Equality is too weak. An IntEnum member equals the integer it is written
+    as, so a hook reading its name would work on the miss and fail on the hit."""
+    from enum import IntEnum
+
+    class Status(IntEnum):
+        READY = 1
+
+    def read_name(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        return f"status={function_call(**arguments).name}"
+
+    def status() -> Status:
+        return Status.READY
+
+    func = Function(
+        name="status", entrypoint=status, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[read_name]
+    )
+
+    first = FunctionCall(function=func, arguments={}).execute()
+    second = FunctionCall(function=func, arguments={}).execute()
+
+    assert first.status == "success"
+    assert second.status == "success"
+    assert second.result == first.result == "status=READY"
+
+
+def test_each_entrypoint_call_on_a_hit_gets_its_own_value(tmp_path):
+    """A hook may call the tool more than once, and on a miss each call returns
+    its own object. One shared object would let the first call's edits show up
+    in the second."""
+
+    def payload() -> dict:
+        return {"items": ["raw"]}
+
+    seen = []
+
+    def twice(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        first = function_call(**arguments)
+        second = function_call(**arguments)
+        seen.append(first is second)
+        first["items"].append("A")
+        second["items"].append("B")
+        return {"a": first["items"], "b": second["items"]}
+
+    # A single-call path writes the entry, so the two-call hook meets a warm one.
+    warm = Function(name="twice_over", entrypoint=payload, cache_results=True, cache_dir=str(tmp_path))
+    FunctionCall(function=warm, arguments={}).execute()
+
+    hooked = Function(
+        name="twice_over", entrypoint=payload, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[twice]
+    )
+    result = FunctionCall(function=hooked, arguments={}).execute()
+
+    assert seen == [False]
+    assert result.result == {"a": ["raw", "A"], "b": ["raw", "B"]}
+
+
+def test_media_anywhere_inside_a_result_keeps_it_out_of_the_cache(tmp_path):
+    """The cache excludes media wherever it sits, not only at the top."""
+    from agno.media import Image
+
+    class Wrapper(BaseModel):
+        inner: ToolResult
+
+    executions = []
+
+    def wrapped() -> Wrapper:
+        executions.append(1)
+        return Wrapper(inner=ToolResult(content="see it", images=[Image(filepath="/tmp/secret.png")]))
+
+    func = Function(name="wrapped", entrypoint=wrapped, cache_results=True, cache_dir=str(tmp_path))
+
+    FunctionCall(function=func, arguments={}).execute()
+    FunctionCall(function=func, arguments={}).execute()
+
+    assert executions == [1, 1]
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+def test_an_entry_holding_media_below_the_top_level_is_discarded(tmp_path):
+    """An entry carrying media did not come from here, however deeply it is
+    buried."""
+    import json
+    from time import time
+
+    from agno.media import Image
+
+    executions = []
+
+    def listed() -> List[ToolResult]:
+        executions.append(1)
+        return [ToolResult(content="clean")]
+
+    func = Function(name="listed", entrypoint=listed, cache_results=True, cache_dir=str(tmp_path))
+
+    planted = [ToolResult(content="planted", images=[Image(filepath="/etc/passwd")]).model_dump()]
+    cache_file = func._get_cache_file_path(func._get_cache_key({}, {}))
+    with open(cache_file, "w", encoding="utf-8") as f:
+        json.dump({"timestamp": time(), "cache_format": function_module.CACHE_FORMAT, "result": planted}, f)
+
+    result = FunctionCall(function=func, arguments={}).execute()
+    assert result.result[0].content == "clean"
+    assert result.result[0].images is None
+    assert executions == [1]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP 695 type alias syntax needs 3.12")
+def test_a_generic_alias_return_keeps_what_it_was_given(tmp_path):
+    """A subscripted generic alias holds its argument only while it stays
+    subscripted. Unwrapping it to the alias body loses the model, and the hit
+    would hand back a plain dict where the miss returned one."""
+
+    class Weather(BaseModel):
+        city: str
+
+    namespace: Dict[str, Any] = {}
+    exec("type Maybe[T] = T | None", namespace)
+
+    executions = []
+
+    def forecast():
+        executions.append(1)
+        return Weather(city="Lisbon")
+
+    forecast.__annotations__["return"] = namespace["Maybe"][Weather]
+
+    func = Function(name="generic_forecast", entrypoint=forecast, cache_results=True, cache_dir=str(tmp_path))
+
+    first = FunctionCall(function=func, arguments={}).execute()
+    second = FunctionCall(function=func, arguments={}).execute()
+
+    assert isinstance(first.result, Weather)
+    assert isinstance(second.result, Weather)
+    assert second.result.city == "Lisbon"
+    # Losing the argument would leave the annotation unreadable, and the entry
+    # would be refused as unfaithful rather than served.
+    assert executions == [1]
+
+
+def test_entries_live_under_a_versioned_directory(tmp_path):
+    """A stored value means different things to different versions of this
+    code. A reader from another version must not find these entries at all,
+    because nothing in an entry would tell it that it cannot read one."""
+
+    def compute() -> str:
+        return "value"
+
+    func = Function(name="versioned", entrypoint=compute, cache_results=True, cache_dir=str(tmp_path))
+    FunctionCall(function=func, arguments={}).execute()
+
+    written = list(tmp_path.rglob("*.json"))
+    assert len(written) == 1
+    assert written[0].parent.parent.name == f"v{function_module.CACHE_FORMAT}"
+
+
+def test_a_union_return_keeps_the_member_the_tool_chose(tmp_path):
+    """Rebuilding a union takes its first matching member, which need not be
+    the one the tool returned. A tool that says it may return either must not
+    hand back the other on a hit."""
+    executions = []
+
+    def report() -> Union[dict, ToolResult]:
+        executions.append(1)
+        return ToolResult(content="done", metadata={"k": "v"})
+
+    func = Function(name="union_report", entrypoint=report, cache_results=True, cache_dir=str(tmp_path))
+
+    first = FunctionCall(function=func, arguments={}).execute()
+    second = FunctionCall(function=func, arguments={}).execute()
+
+    assert isinstance(first.result, ToolResult)
+    assert isinstance(second.result, ToolResult)
+    assert executions == [1, 1]
+
+
+def test_a_hook_that_rewrites_an_argument_makes_the_call_uncacheable(tmp_path):
+    """A hook receives the live arguments and may replace one from state, which
+    cookbook/91_tools/tool_hooks/tool_hook_in_toolkit_with_state.py does. The
+    key names the question the caller asked, not the one the tool answered, so
+    the answer must not be stored under it."""
+    profiles = {"123": "profile-v1"}
+    executions = []
+
+    def resolve(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        arguments["customer"] = profiles[arguments["customer"]]
+        return function_call(**arguments)
+
+    def lookup(customer: str) -> str:
+        executions.append(customer)
+        return f"data for {customer}"
+
+    func = Function(name="lookup", entrypoint=lookup, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[resolve])
+
+    first = FunctionCall(function=func, arguments={"customer": "123"}).execute()
+    profiles["123"] = "profile-v2"
+    second = FunctionCall(function=func, arguments={"customer": "123"}).execute()
+
+    assert first.result == "data for profile-v1"
+    assert second.result == "data for profile-v2"
+    assert executions == ["profile-v1", "profile-v2"]
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+def test_a_result_holding_one_object_twice_is_not_cached(tmp_path):
+    """Two fields backed by one list come back as two lists, so a hook editing
+    one would see a different value on the hit than the miss gave it."""
+
+    def edit(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        result = function_call(**arguments)
+        result["a"].append("hook")
+        return {"a": result["a"], "b": result["b"]}
+
+    def shared(x: int) -> dict:
+        both: List[str] = []
+        return {"a": both, "b": both}
+
+    func = Function(name="shared", entrypoint=shared, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[edit])
+
+    first = FunctionCall(function=func, arguments={"x": 1}).execute()
+    second = FunctionCall(function=func, arguments={"x": 1}).execute()
+
+    assert first.result == {"a": ["hook"], "b": ["hook"]}
+    assert second.result == first.result
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+def test_a_result_that_answers_a_copy_with_itself_is_not_cached(tmp_path):
+    """The snapshot has to be the cache's own. A value that hands back itself
+    would keep whatever the hooks then did to it."""
+
+    class Sticky(BaseModel):
+        items: List[str] = []
+
+        def __deepcopy__(self, memo):
+            return self
+
+    def append(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        result = function_call(**arguments)
+        result.items.append("hook")
+        return f"items={result.items}"
+
+    def sticky(x: int) -> Sticky:
+        return Sticky(items=["raw"])
+
+    func = Function(name="sticky", entrypoint=sticky, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[append])
+
+    outputs = [FunctionCall(function=func, arguments={"x": 1}).execute().result for _ in range(3)]
+
+    assert outputs == ["items=['raw', 'hook']"] * 3
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+def test_a_warm_entry_is_not_served_once_a_hook_rewrites_the_argument(tmp_path):
+    """A hook may leave the arguments alone on one call and rewrite them on the
+    next. The stored value answers the question the key names, so once the call
+    stops asking that question the tool has to run."""
+    rewriting = {"on": False}
+    executions = []
+
+    def resolve(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        if rewriting["on"]:
+            arguments["customer"] = "profile-v2"
+        return function_call(**arguments)
+
+    def lookup(customer: str) -> str:
+        executions.append(customer)
+        return f"data for {customer}"
+
+    func = Function(name="lookup", entrypoint=lookup, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[resolve])
+
+    first = FunctionCall(function=func, arguments={"customer": "123"}).execute()
+    rewriting["on"] = True
+    second = FunctionCall(function=func, arguments={"customer": "123"}).execute()
+
+    assert first.result == "data for 123"
+    assert second.result == "data for profile-v2"
+    assert executions == ["123", "profile-v2"]
+
+
+@pytest.mark.asyncio
+async def test_a_warm_entry_is_not_served_once_a_hook_rewrites_the_argument_async(tmp_path):
+    """Async variant of the warm entry a later call no longer asks for."""
+    rewriting = {"on": False}
+    executions = []
+
+    async def resolve(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        if rewriting["on"]:
+            arguments["customer"] = "profile-v2"
+        return await function_call(**arguments)
+
+    async def lookup(customer: str) -> str:
+        executions.append(customer)
+        return f"data for {customer}"
+
+    func = Function(
+        name="lookup_async", entrypoint=lookup, cache_results=True, cache_dir=str(tmp_path), tool_hooks=[resolve]
+    )
+
+    first = await FunctionCall(function=func, arguments={"customer": "123"}).aexecute()
+    rewriting["on"] = True
+    second = await FunctionCall(function=func, arguments={"customer": "123"}).aexecute()
+
+    assert first.result == "data for 123"
+    assert second.result == "data for profile-v2"
+    assert executions == ["123", "profile-v2"]

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -1710,3 +1710,69 @@ async def test_agent_refresh_does_not_call_build_tools_after_reconnect():
     # No forced reconnect; build_tools() called to refresh definitions
     assert not any(call.kwargs.get("force") for call in alive_tool.connect.await_args_list)
     alive_tool.build_tools.assert_awaited_once()
+
+
+# =============================================================================
+# Cache identity tests (_agno_run_context channel)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_mcp_cached_results_key_per_user_and_stay_per_run(tmp_path):
+    """MCP entrypoints receive identity via _agno_run_context, so the cache
+    keys per user. The injected object stays in the key material, so an MCP
+    cache entry is scoped to its run: a header provider that reads the agent,
+    the team, or run-context metadata cannot serve one caller's result to
+    another."""
+    from agno.run.base import RunContext
+
+    tool = _make_mcp_tool_mock("get_data")
+    session = _make_session_returning("payload")
+
+    fn = Function(
+        name="get_data",
+        entrypoint=get_entrypoint_for_tool(tool, session),
+        skip_entrypoint_processing=True,
+        cache_results=True,
+        cache_dir=str(tmp_path),
+    )
+
+    fn._run_context = RunContext(run_id="r1", session_id="s1", user_id="alice")
+    await FunctionCall(function=fn).aexecute()
+
+    # A different user must execute again, not be served alice's result
+    fn._run_context = RunContext(run_id="r2", session_id="s2", user_id="bob")
+    await FunctionCall(function=fn).aexecute()
+    assert session.call_tool.await_count == 2
+
+    # A new run executes again: the run's own context is part of the key
+    fn._run_context = RunContext(run_id="r3", session_id="s1", user_id="alice")
+    result = await FunctionCall(function=fn).aexecute()
+    assert session.call_tool.await_count == 3
+    assert result.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_mcp_cached_hit_returns_tool_result(tmp_path):
+    """A cache hit for an MCP tool must return a ToolResult, not the plain
+    dict it was serialized to, so downstream result handling keeps working."""
+    from agno.run.base import RunContext
+
+    tool = _make_mcp_tool_mock("get_data")
+    session = _make_session_returning("payload")
+
+    fn = Function(
+        name="get_data",
+        entrypoint=get_entrypoint_for_tool(tool, session),
+        skip_entrypoint_processing=True,
+        cache_results=True,
+        cache_dir=str(tmp_path),
+    )
+    fn._run_context = RunContext(run_id="r1", session_id="s1", user_id="alice")
+
+    await FunctionCall(function=fn).aexecute()
+    second = await FunctionCall(function=fn).aexecute()
+
+    assert session.call_tool.await_count == 1
+    assert isinstance(second.result, ToolResult)
+    assert second.result.content == "payload"


### PR DESCRIPTION
## Summary

Correctness fixes for the tool result cache (`cache_results=True`), each reproduced with a failing test before the fix.

**1. Cross-user cache leak (security-relevant).** `_get_cache_key` deleted the `run_context` entry from the key material outright, so any cached tool whose entrypoint takes `run_context` (e.g. MemoryTools) computed identical keys for different users, and cache files live in a shared tempdir keyed by function name. One user's result was served to the next. A run context now contributes stable identity fields (`user_id`, `session_id`) to the key through one shared helper (`_get_run_context_identity`) that reads the `run_context` and `_agno_run_context` channels. `run_id` stays out of the identity fields so caching remains useful across a user's runs, and key composition for tools with no run-context parameter is unchanged.

The injected objects themselves stay in the key material for the `_agno_` channel, so an MCP cache entry remains scoped to its own run. That is deliberate: dropping them would make `MCPTools(cache_results=True)` hit across runs for the first time, and a `header_provider` that reads the agent, the team, or `run_context.metadata` (as `cookbook/91_tools/mcp/dynamic_headers` does) would then serve one caller's result to another. Widening the MCP cache safely needs those dimensions in the identity fields first, and is left to a follow-up.

**2. Cached `ToolResult`s came back as plain dicts.** Cached results round-trip through JSON, so a tool returning a `ToolResult` got a dict back on a hit: the model received `str(dict)` and media/metadata handling downstream was skipped. `ToolResult` entries are tagged and rebuilt on read. `ToolResult`s carrying media are not cached at all, and the cache excludes media by design: an entry holds JSON, and media is forwarded from the live result rather than rebuilt from a file.

**3. Hooks silently missed cached calls.** On a cache hit, `execute()`/`aexecute()` returned before `tool_hooks` and `post_hook` ran, so audit and policy hooks never saw cached calls. The hit no longer short-circuits: the chain runs on every call, and a policy hook can refuse a call that would have been served from cache.

**4. A cache hit now reproduces the miss, and the cache file is no longer trusted.** This is the review response; details below.

## Review response

Two reviews found the same defect from opposite directions, and it is not fixable by choosing which value to store.

Storing what the `tool_hook` chain returned means a hit replays the hooks over their own earlier output. A hook that appends to the result appends again (`[1, 2]` then `[1, 2, 2]`), and a hook that reads the tool's shape fails outright on every hit for the rest of the entry's life. The sanitizing hook in `cookbook/91_tools/tool_hooks/tool_hooks_in_toolkit_nested.py` is exactly that shape, and it raised `KeyError` on the second call. Storing the entrypoint's return instead fixed those, but wrote the value a sanitizing hook had just stripped, kept the very object the hook then edited in place, had nothing to store when a hook recovered from an error or answered by itself, and stored one attempt of several when a hook retried.

The entry now holds **what the entrypoint returned**, copied at the moment it returned so a later in-place edit cannot reach it, and a hit hands that value to the chain in the entrypoint's place. The hooks see on a hit exactly what they saw on the miss, so they produce the same answer and keep deciding: a hook that redacts for the current caller still redacts, and a hook that refuses still refuses. A call whose hooks ran the tool anything but once is not cached, because no single value stands for it. That also stops a hook that answered from an error path from answering for the tool until the entry expires.

Entries carry a format version, because earlier versions stored the chain's output under the same key and replaying hooks over that is the bug above. Entries from any other version are discarded unread, at the cost of one re-execution.

On the read side the declared return type decides what a hit rebuilds, not the tag in the file. Reconstruction covers the union and alias spellings a tool uses to say it may return nothing, so `-> Optional[Weather]` no longer returns a model on the miss and a dict on the hit. An entry is discarded and recomputed when it carries fields the declared type would drop, when its tag names a class the tool does not return, or when it holds a `ToolResult` carrying media, which is never written and so never ours to rebuild. A payload that simply fails to validate is handed back as stored, since a tool may not return what it says it returns.

A call carrying attached media is not cached. Media is the input the tool reads and contributes nothing to the key, so two calls over different documents shared one entry and the second was answered from the first. This needed no multi-tenancy: attach document A and ask a question, attach document B and ask the same question, and the second answer described document A.

Entries are serialized before anything is written and then moved into place, so a result that cannot be encoded leaves no half-written file, a reader sees one entry or the other, and a predictable path that someone else created first is not written through. `mkstemp` creates them readable by their owner alone, since the default cache directory is shared.

### Second review round

Six more blockers were raised. Two were regressions in the first round and are fixed; four reproduce but are pre-existing, with base-branch controls run for each.

**Fixed.** A hook that retried past a failure was cached: the attempt was recorded only once the entrypoint returned, so an attempt that raised never counted and the retry looked like the call's one result. The miss returned `recovered:value-2` and the hit `primary:value-2`. The slot is now claimed before the call. Separately, a hooked tool now stores only a value it can hand back unchanged, so a tuple that would come back a list is not cached at all; an entry that no longer rebuilds into the declared return type is discarded rather than served in whatever shape it has; and entries are read back by field name, so an ordinary aliased model stays cacheable.

**Hardened.** The cache directory is created private to its owner and refused when another user owns it or can write to it, and reads no longer follow a link out of it. A planted symlink was being read in place of the entry.

**Left as follow-ups, with controls showing the base behaves the same.** A run context contributes only `user_id` and `session_id`, so `metadata`, `dependencies` and `session_state` do not scope an entry. An injected `agent` or `team` contributes no identity. Both are now stated in the code where the key is built. The base shares entries on those dimensions too; what changed here is that `user_id` and `session_id` went from shared to separate, so the key only narrowed.

**Declined, with measurements.** Disabling caching whenever `tool_hooks` are present was measured to cost every cached tool of any agent that sets one hook, because an agent-level hook is copied onto every function. Nested field loss under a declared base-model return happens at serialization time and predates this branch; the base returned the same value as an untyped dict.

### Third review round

Eight more findings. Six are fixed, two are documentation.

**Fixed.** The cache key was worked out twice, once for the lookup and again for the write, so a tool that changed `run_context.user_id` filed its result under the next user's name and that user was served it without the tool running. The lookup's file now carries through to the write. A stored value only had to compare equal to what it came from, so an `IntEnum` member survived as a plain integer and a hook reading its name failed on every hit; the check now requires each node to come back as its own type. On a hit every entrypoint call in a chain shared one object where a miss gives each its own. Media is refused wherever it sits, not only at the top of a `ToolResult`; a model holding a media-bearing `ToolResult` was being written, and a planted entry holding one inside a list was rebuilt and handed to a hook. A subscripted generic alias lost its argument, so the hit returned a dict where the miss returned the model. Expiry removed the entry by name, so a reader could delete an entry another writer had just placed there.

**Not changed, with measurements.** Making a sanitizing hook uncacheable was prototyped: it fails seven of the suite's tests, permanently stops every transforming hook from caching, and still writes the raw value for the caller-dependent redaction case that motivates the concern, because serving per-caller redaction from a cache requires the raw value at rest. The boundary is the Unix account: files are 0600, and a directory owned by another user or writable by others is refused. A deployment sharing one account across tenants should set a per-tenant `cache_dir`, or leave `cache_results` off for tools that return secrets.

Legacy entries written before this branch use a different filename once the key carries identity, so the format gate never sees them and they remain at their original mode. A versioned cache root was considered and rejected: it removes nothing, orphans every current entry, and disables the cleanup that does work today. Delete `<tmpdir>/agno_cache`, or your `cache_dir`, when upgrading.

### Fourth review round

Three findings. Two are fixed, one I could not reproduce.

**Fixed.** The cache format version lived in the entry rather than in its name, so it only protected a newer reader from an older entry. A reader from an older version found a newer entry at the same path and read it as the value that version stored: the tool returned `raw`, the hooks made it `[hook] raw`, and the older reader answered `raw` without running the tool. The version now names the directory. Entries from before this change are left where they are, so delete the cache directory when upgrading.

**Fixed.** The round trip was checked only for tools carrying hooks. That missed a tool that declares what it returns: rebuilding a union takes its first matching member, so a tool declared `dict | ToolResult` returned a `ToolResult` on the miss and a `dict` on the hit. The check now covers any tool that declares a return type, and a value is stored only if it comes back as itself. A tool that declares nothing and carries no hooks keeps the older behaviour.

**Could not reproduce.** The report that hooks rewrite arguments after the key is fixed does not hold in this codebase: a hook receives a copy of the arguments, and the keyword arguments it passes to `function_call` are discarded before the entrypoint runs, so a hook cannot change either the effective arguments or the key. I tried the copy form, the in-place form, and a tool reading and writing session state, on this branch and on the base, and every pair matched. If there is a repro I am missing, please share it.

### Fifth review round

Three findings, all real and all fixed. One of them I had wrongly rejected in the previous round.

**A hook that rewrites an argument now makes the call uncacheable.** A hook receives the live arguments dict rather than a copy, and the entrypoint call is rebuilt from it, so replacing an argument in place changes what the tool is actually asked. `cookbook/91_tools/tool_hooks/tool_hook_in_toolkit_with_state.py` does exactly this, swapping a customer id for the profile behind it. The key names the question the caller asked, so storing the answer under it served a later caller a result computed from an earlier profile. Storing under a key worked out after the call is the other half of the same problem, since a tool that edits the run context would file its result under whoever it left behind. A call that moved anything the key is built from is now not cached.

I rejected this last round after failing to reproduce it. My repro passed empty arguments, and `self.arguments or {}` substitutes a fresh dict when the arguments are empty, so the hook was mutating a throwaway. With non-empty arguments it reproduces exactly as reported.

**A value that answers a copy with itself is no longer cached.** A `__deepcopy__` returning `self` left the snapshot aliased to the value the hooks then edited, so the miss appended once and every hit appended twice.

**A result holding one object in two places is no longer cached.** JSON keeps no record of that sharing, so two fields backed by one list came back as two lists, and a hook appending to one saw it in both on the miss and in one on the hit.

**Follow-up, not fixed here.** A cached `None` cannot be told apart from a miss, so such a tool re-executes despite having an entry. For an ordinary `None` result this is pre-existing and behaves the same on the base. Where a hook turns a `None` result into a non-`None` answer, the base executes once and this branch executes twice, so the cost is real but is a wasted execution rather than a wrong answer. Fixing it means threading an explicit hit flag through both execute paths and the hook chain, which is a larger change than the cost it removes.

### Sixth review round

A warm entry could still be served to a call that had moved its own key. The previous round kept such a call out of the cache but still let it read from one: a hook that leaves the arguments alone on one call and rewrites them on the next found the entry chosen before it ran, so the tool never saw the rewritten value and the caller got the answer to the earlier question. The check now also runs at the entrypoint boundary, after the hooks have had their say. A stored value stands in for the tool only while the call still asks what the key names; otherwise the tool runs for real and that call is not cached either. Sync and async both covered, each with a regression test.

### Final confirmation pass

A cold read of the finished change, plus a run through the real agent path, found one thing worth fixing and confirmed the rest.

**Fixed.** The cache refused any of the three directories it owns when others could write to them. An earlier release created those directories with whatever the umask allowed, so on a system whose umask is 002 an upgrade left them group-writable and the refusal was permanent: every call lost its caching and logged an error. Those directories are the cache's own, so one owned by the caller is now closed to others rather than refused. A directory owned by somebody else is still refused. The check also returns early where there is no ownership to read, since Windows reports the same mode for every directory and the refusal fired on all of them.

**Also removed** a disabled branch inside `_save_to_cache`, where an earlier `ToolResult`-only media refusal sat behind a literal false after the general one replaced it.

**Confirmed by execution rather than argument.** Every rule holds identically on `execute` and `aexecute`, across all three entrypoint variants. A sweep of 19 return shapes against annotated and unannotated tools, with and without hooks, on both paths, produced no escaping exception and no failed call. Through the real agent path, built with `determine_tools_for_model` so the framework does the injection: two users do not share an entry, the same user and session hits across runs, a different session misses, and an agent-level `tool_hook` runs on a hit and can still refuse the call three different ways.

Two behaviours are unchanged from the base and left alone: a hook that rewrites an argument and restores it before returning is still stored under the original key, and a tool taking an `fc` parameter is not cacheable. Both were verified to behave identically before this branch.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Release note:** every existing cache entry is discarded once after upgrade, because entries now carry a format version and hold a different value than before. That costs one re-execution per key. Cache keys for run-context-bearing tools also gain `user_id` and `session_id`. Three behaviours change for everyone using `cache_results=True`: a call carrying attached media is not cached, a call whose `tool_hooks` ran the tool anything but once is not cached, and a tool that declares a model return but hands back a richer subclass is recomputed rather than served narrowed. The cache file now holds the tool's own return, before any result-transforming hook, so entries are created readable by their owner alone.

Security: item 1 stops cross-user data disclosure through the shared tool-result cache. Item 3 closes an audit-hook blind spot for cached calls, and item 4 keeps it closed: a hook that gates or refuses a call runs on a hit and still decides. Item 4 also stops the cache file from choosing which class a hit constructs, and from handing the model media that a file named.

One deliberate trade to note when reviewing: replaying the hooks faithfully requires storing the value the hooks were given, which is the tool's return **before** any redaction a hook applies. That value reaches the cache file. Storing the redacted value instead is what broke the shapes above, so the file is created readable by its owner alone and moved into place rather than written through a predictable path. A hook that redacts for the model does not redact the cache.

Tests: 20 new tests in this round on top of the earlier ones, covering each identity field on its own, every hook shape that behaves differently on a hit, both the sync and async paths, the file mode, the media gate, and five kinds of entry that no longer match the code. Every fix in this round is mutation-tested: reverting any one of the fifteen makes a named test fail.

Based on `feat/studio-runner-tools` (#9371) and retargets to `main` when that merges. Rebased onto the current base; note that the base now restores `cache_results`, `cache_dir`, `cache_ttl` and the hooks onto rehydrated components, so this code path is reachable for persisted AgentOS components and not only for code-defined agents.

**Known and deliberately left to follow-ups:**

- Identity carried by an injected `agent` or `team` rather than a run context is still absent from the key. `initialize_session` does not write the resolved identity back onto the agent, so the fix is to read `Function._run_context`, which is set on every Function regardless of signature.
- The `_agno_*` channels are still in the key material, so MCP entries stay scoped to a run. Popping them and contributing identity must land together, matching `RunContext` by value so union, alias and string-annotation spellings are all covered.
- A type-injected `ctx: RunContext` parameter is popped by neither list, so it keys the cache by object repr.
- Two instances of the same toolkit class share entries, because `_get_cache_file_path` namespaces by function name and the bound `self` never reaches the key material. The fix belongs in the directory, not the key, so existing entries survive.
- A tool whose key can never repeat writes one cache file per call and nothing reclaims the directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)