### PR TITLE
fix: disable forced tool choice after call limit

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -719,7 +719,7 @@ class Model(ABC):
                 model_response=model_response,
                 response_format=response_format,
                 tools=_tool_dicts,
-                tool_choice=tool_choice or self._tool_choice,
+                tool_choice=self._get_tool_choice_for_call(tool_choice, function_call_count, tool_call_limit),
                 run_response=run_response,
                 compress_tool_results=_compress_tool_results,
             )
@@ -941,7 +941,7 @@ class Model(ABC):
                 model_response=model_response,
                 response_format=response_format,
                 tools=_tool_dicts,
-                tool_choice=tool_choice or self._tool_choice,
+                tool_choice=self._get_tool_choice_for_call(tool_choice, function_call_count, tool_call_limit),
                 run_response=run_response,
                 compress_tool_results=_compress_tool_results,
             )
@@ -1449,7 +1449,7 @@ class Model(ABC):
                         stream_data=stream_data,
                         response_format=response_format,
                         tools=_tool_dicts,
-                        tool_choice=tool_choice or self._tool_choice,
+                        tool_choice=self._get_tool_choice_for_call(tool_choice, function_call_count, tool_call_limit),
                         run_response=run_response,
                         compress_tool_results=_compress_tool_results,
                     ):
@@ -1474,7 +1474,7 @@ class Model(ABC):
                     model_response=model_response,
                     response_format=response_format,
                     tools=_tool_dicts,
-                    tool_choice=tool_choice or self._tool_choice,
+                    tool_choice=self._get_tool_choice_for_call(tool_choice, function_call_count, tool_call_limit),
                     run_response=run_response,
                     compress_tool_results=_compress_tool_results,
                 )
@@ -1728,7 +1728,7 @@ class Model(ABC):
                         stream_data=stream_data,
                         response_format=response_format,
                         tools=_tool_dicts,
-                        tool_choice=tool_choice or self._tool_choice,
+                        tool_choice=self._get_tool_choice_for_call(tool_choice, function_call_count, tool_call_limit),
                         run_response=run_response,
                         compress_tool_results=_compress_tool_results,
                     ):
@@ -1753,7 +1753,7 @@ class Model(ABC):
                     model_response=model_response,
                     response_format=response_format,
                     tools=_tool_dicts,
-                    tool_choice=tool_choice or self._tool_choice,
+                    tool_choice=self._get_tool_choice_for_call(tool_choice, function_call_count, tool_call_limit),
                     run_response=run_response,
                     compress_tool_results=_compress_tool_results,
                 )
@@ -2129,6 +2129,16 @@ class Model(ABC):
             tool_args=function_call.arguments,
             tool_call_error=True,
         )
+
+    def _get_tool_choice_for_call(
+        self,
+        tool_choice: Optional[Union[str, Dict[str, Any]]],
+        function_call_count: int,
+        tool_call_limit: Optional[int],
+    ) -> Optional[Union[str, Dict[str, Any]]]:
+        if tool_call_limit is not None and function_call_count >= tool_call_limit:
+            return "none"
+        return tool_choice or self._tool_choice
 
     def run_function_call(
         self,

--- a/libs/agno/tests/unit/models/test_tool_call_limit.py
+++ b/libs/agno/tests/unit/models/test_tool_call_limit.py
@@ -1,0 +1,35 @@
+from typing import Any, AsyncIterator, Iterator
+
+from agno.models.base import Model
+from agno.models.response import ModelResponse
+
+
+class StubModel(Model):
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        raise NotImplementedError
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        raise NotImplementedError
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        raise NotImplementedError
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        raise NotImplementedError
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        raise NotImplementedError
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        raise NotImplementedError
+
+
+def test_tool_choice_is_disabled_after_tool_call_limit():
+    model = StubModel(id="stub")
+    forced_tool = {"type": "function", "function": {"name": "search"}}
+    model._tool_choice = forced_tool
+
+    assert model._get_tool_choice_for_call(forced_tool, function_call_count=0, tool_call_limit=3) == forced_tool
+    assert model._get_tool_choice_for_call(forced_tool, function_call_count=2, tool_call_limit=3) == forced_tool
+    assert model._get_tool_choice_for_call(forced_tool, function_call_count=3, tool_call_limit=3) == "none"
+    assert model._get_tool_choice_for_call(forced_tool, function_call_count=4, tool_call_limit=None) == forced_tool


### PR DESCRIPTION
## Problem
When a model is forced to use a function and tool_call_limit is reached, the next request still receives the forced tool_choice. The model can keep producing tool calls instead of terminating, resulting in an infinite loop.

## Root Cause
The response and streaming loops reused the original tool_choice for every model request, without changing it after the accumulated function-call count reached the configured limit.

## Solution
Use a per-call tool choice that becomes none once the limit is reached, while preserving the configured choice before the limit and when no limit is configured.

## Changes
- Apply the limit-aware tool choice to synchronous, asynchronous, and streaming response loops.
- Add unit coverage for below-limit, at-limit, and unlimited behavior.

## Testing
- python -m pytest tests/unit/models/test_tool_call_limit.py -q — passed (1 passed).
- python -m pytest tests/unit/models -q — not fully verified: collection requires optional packages (boto3, ollama, google.genai) unavailable in this environment.
- Ruff check — passed.
- git diff --check — passed.
- Ruff format check — blocked by CRLF/baseline formatting differences in the upstream file; no unrelated formatting changes were included.

## Compatibility/Risk
The change only affects calls after tool_call_limit is reached. Existing forced tool choice behavior is preserved before the limit and when no limit is configured. The risk is limited to response-loop termination semantics.

## Notes for Reviewer
Please review the six sync/async/streaming call sites and confirm that none is the desired provider-compatible value after the limit.

## Linked Issue
Fixes #9385