### PR TITLE
feat: migrate existing eval tables to the user_id column

### DIFF
--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -1616,6 +1616,7 @@ class AsyncBaseDb(ABC):
         spans_table: Optional[str] = None,
         culture_table: Optional[str] = None,
         versions_table: Optional[str] = None,
+        components_table: Optional[str] = None,
         learnings_table: Optional[str] = None,
         schedules_table: Optional[str] = None,
         schedule_runs_table: Optional[str] = None,
@@ -1646,6 +1647,9 @@ class AsyncBaseDb(ABC):
         self.span_table_name = spans_table or "agno_spans"
         self.culture_table_name = culture_table or "agno_culture"
         self.versions_table_name = versions_table or "agno_schema_versions"
+        # Async adapters cannot read or write components yet, but they can still be asked to
+        # migrate a components table that a sync adapter created in the same database.
+        self.components_table_name = components_table or "agno_components"
         self.learnings_table_name = learnings_table or "agno_learnings"
         self.schedules_table_name = schedules_table or "agno_schedules"
         self.schedule_runs_table_name = schedule_runs_table or "agno_schedule_runs"

--- a/libs/agno/agno/db/migrations/V3_MIGRATION_GUIDE.md
+++ b/libs/agno/agno/db/migrations/V3_MIGRATION_GUIDE.md
@@ -113,6 +113,24 @@ v3.0 puts each run in its own item in a dedicated ``agno_runs`` table with a
 attribute on the session item is preserved by the migration; call
 ``db.cleanup_legacy_runs_field()`` to remove it once verified.
 
+### SingleStore note
+
+SingleStore requires every unique key to contain all shard-key columns, so the runs
+table uses `PRIMARY KEY (run_id, session_id)` with `SHARD KEY (session_id)`. A
+single-column `PRIMARY KEY (run_id)` is rejected outright with `ERROR 1744`, which
+means no SingleStore deployment can ever have had the narrower key — there is no data
+to migrate.
+
+The consequence to know about: on SingleStore `run_id` alone is **not** unique. If the
+same `run_id` is written under two different `session_id`s, both rows exist, and:
+
+- `get_run(run_id=...)` returns one of them, unordered
+- `upsert_run` with a new `session_id` inserts a second row rather than updating
+- `delete_run(run_id=...)` removes every copy, across sessions
+
+In normal use a `run_id` belongs to exactly one session, so none of this is reachable.
+The other SQL backends keep `PRIMARY KEY (run_id)` and are unaffected.
+
 ### SurrealDB note
 
 SurrealDB stores each run in a dedicated ``agno_runs`` table with indexes on the
@@ -198,6 +216,54 @@ table):
 ```python
 asyncio.run(MigrationManager(db).down(target_version="2.5.6"))
 ```
+
+## Eval runs: per-user isolation
+
+The same `v3.0.0` migration adds a `user_id` column (and its index) to the eval runs
+table (`agno_eval_runs` by default). It backs per-user isolation in AgentOS: with
+`user_isolation` enabled a caller only sees their own eval runs, while admins and
+unscoped deployments keep seeing everything.
+
+```
+agno_eval_runs
+├── run_id      TEXT PRIMARY KEY
+├── ...
+└── user_id     TEXT (indexed)   -- NULL for runs created before v3.0
+```
+
+Existing rows keep a `NULL` `user_id`. An unowned run stays visible to unscoped and
+admin callers and is invisible to a scoped one — nothing is deleted or reassigned.
+New runs are stamped with their owner right after the eval framework persists them.
+
+Schema-level work is only needed on the seven SQL adapters (`PostgresDb`,
+`AsyncPostgresDb`, `SqliteDb`, `AsyncSqliteDb`, `MySQLDb`, `AsyncMySQLDb`,
+`SingleStoreDb`). Every other adapter stores an eval run as a record and carries
+`user_id` without any schema change, so there is nothing for a migration to do —
+`MigrationManager` reports `No version found for table agno_eval_runs` and moves
+on without dispatching. `ClickhouseDb` is traces-only and implements no eval
+storage at all.
+
+It runs with the rest of the version — `MigrationManager(db).up()` — or on its own:
+
+```python
+asyncio.run(MigrationManager(db).up(table_type="evals"))
+```
+
+The column and index are added only when missing, so re-runs are safe. If the
+adapter schema for a table type does not declare `user_id`, that table is logged
+and skipped rather than failing the run.
+
+Reverting drops the index and then the column. **Every row survives, but the
+`user_id` values in that column are destroyed** — re-running `up()` afterwards
+restores the column with `NULL` everywhere, not the previous owners. Take a
+backup first if the ownership data matters:
+
+```python
+asyncio.run(MigrationManager(db).down(target_version="2.5.6", table_type="evals"))
+```
+
+SQLite reverts need SQLite 3.35+ for `ALTER TABLE ... DROP COLUMN`; on older
+builds the revert logs and skips instead, matching `v2.5.6`'s behaviour.
 
 ## Breaking changes
 

--- a/libs/agno/agno/db/migrations/manager.py
+++ b/libs/agno/agno/db/migrations/manager.py
@@ -52,6 +52,7 @@ class MigrationManager:
             "knowledge": "knowledge_table_name",
             "culture": "culture_table_name",
             "approvals": "approvals_table_name",
+            "components": "components_table_name",
         }
 
         # Select tables to migrate
@@ -146,6 +147,7 @@ class MigrationManager:
             "knowledge": "knowledge_table_name",
             "culture": "culture_table_name",
             "approvals": "approvals_table_name",
+            "components": "components_table_name",
         }
 
         # Select tables to migrate

--- a/libs/agno/agno/db/migrations/manager.py
+++ b/libs/agno/agno/db/migrations/manager.py
@@ -53,6 +53,8 @@ class MigrationManager:
             "culture": "culture_table_name",
             "approvals": "approvals_table_name",
             "components": "components_table_name",
+            "schedules": "schedules_table_name",
+            "schedule_runs": "schedule_runs_table_name",
         }
 
         # Select tables to migrate
@@ -148,6 +150,8 @@ class MigrationManager:
             "culture": "culture_table_name",
             "approvals": "approvals_table_name",
             "components": "components_table_name",
+            "schedules": "schedules_table_name",
+            "schedule_runs": "schedule_runs_table_name",
         }
 
         # Select tables to migrate

--- a/libs/agno/agno/db/migrations/versions/v3_0_0.py
+++ b/libs/agno/agno/db/migrations/versions/v3_0_0.py
@@ -1,6 +1,6 @@
-"""Migration v3.0.0: Normalize session runs into a dedicated runs table
+"""Migration v3.0.0: Normalize session runs into a runs table, isolate eval runs by user
 
-Changes:
+Sessions changes:
 - Create the runs table (one row per run, with the run payload as JSON)
 - Copy every run stored in the sessions table `runs` column into the runs table
 
@@ -11,6 +11,19 @@ The legacy `runs` column on `agno_sessions` is intentionally NOT dropped by this
 migration — it stays in place as a backup. New writes will null it as sessions
 are touched. When you have verified the migration and taken a backup, drop the
 column manually by calling ``db.cleanup_legacy_runs_column()``.
+
+Per-user isolation changes:
+- Add the user_id column and its index to every table in ``USER_ID_TABLE_TYPES``
+
+The column backs per-user isolation: get / list / rename / delete scope by
+user_id when the caller is scoped, and stay global when it is None. Existing
+rows keep a NULL user_id, so they stay visible to admins and to unscoped
+deployments while a scoped caller sees none of them. Document backends store
+these records as documents and pick the field up without a schema change.
+
+To isolate another table, declare user_id on that table in each adapter schema
+and add its table type to ``USER_ID_TABLE_TYPES`` — the per-backend functions
+read the column type from the schema, so they need no change.
 """
 
 import json
@@ -31,8 +44,19 @@ except ImportError:
 BATCH_SIZE = 50
 
 
+# Table types that get a user_id column and index, so AgentOS can scope them per user.
+# Extend this tuple to isolate another table whose schema already declares user_id;
+# the per-backend functions need no change.
+USER_ID_TABLE_TYPES = ("evals",)
+
+
 def up(db: BaseDb, table_type: str, table_name: str) -> bool:
-    """Move session runs into the runs table and drop the sessions `runs` column.
+    """
+    Apply the following changes to the database:
+    - Move session runs out of the sessions `runs` column into the runs table
+    - Add a user_id column and index to the tables listed in USER_ID_TABLE_TYPES
+
+    Notice only the changes related to the given table_type are applied.
 
     Returns:
         bool: True if any migration was applied, False otherwise.
@@ -40,35 +64,32 @@ def up(db: BaseDb, table_type: str, table_name: str) -> bool:
     db_type = type(db).__name__
 
     try:
-        if table_type != "sessions":
-            return False
-
         if db_type == "PostgresDb":
-            return _migrate_postgres(db, table_name)
+            return _migrate_postgres(db, table_type, table_name)
         elif db_type == "SqliteDb":
-            return _migrate_sqlite(db, table_name)
+            return _migrate_sqlite(db, table_type, table_name)
         elif db_type in ("MySQLDb", "SingleStoreDb"):
-            return _migrate_mysql_like(db, table_name)
+            return _migrate_mysql_like(db, table_type, table_name)
         elif db_type == "MongoDb":
-            return _migrate_mongo(db, table_name)
+            return _migrate_mongo(db, table_type, table_name)
         elif db_type == "FirestoreDb":
-            return _migrate_firestore(db, table_name)
+            return _migrate_firestore(db, table_type, table_name)
         elif db_type == "RedisDb":
-            return _migrate_redis(db, table_name)
+            return _migrate_redis(db, table_type, table_name)
         elif db_type == "ValkeyDb":
-            return _migrate_valkey(db, table_name)
+            return _migrate_valkey(db, table_type, table_name)
         elif db_type == "JsonDb":
-            return _migrate_jsondb(db, table_name)
+            return _migrate_jsondb(db, table_type, table_name)
         elif db_type == "GcsJsonDb":
-            return _migrate_gcsjsondb(db, table_name)
+            return _migrate_gcsjsondb(db, table_type, table_name)
         elif db_type == "InMemoryDb":
-            return _migrate_inmemorydb(db, table_name)
+            return _migrate_inmemorydb(db, table_type, table_name)
         elif db_type == "DynamoDb":
-            return _migrate_dynamodb(db, table_name)
+            return _migrate_dynamodb(db, table_type, table_name)
         elif db_type == "SurrealDb":
-            return _migrate_surrealdb(db, table_name)
+            return _migrate_surrealdb(db, table_type, table_name)
         else:
-            log_info(f"Migration v3.0.0 is not implemented for {db_type}. Sessions will keep storing runs inline.")
+            log_info(f"Migration v3.0.0 is not implemented for {db_type}. Table '{table_name}' is left unchanged.")
         return False
     except Exception as e:
         log_error(f"Error running migration v3.0.0 for {db_type} on table {table_name}: {str(e)}")
@@ -76,7 +97,12 @@ def up(db: BaseDb, table_type: str, table_name: str) -> bool:
 
 
 async def async_up(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
-    """Move session runs into the runs table and drop the sessions `runs` column.
+    """
+    Apply the following changes to the database:
+    - Move session runs out of the sessions `runs` column into the runs table
+    - Add a user_id column and index to the tables listed in USER_ID_TABLE_TYPES
+
+    Notice only the changes related to the given table_type are applied.
 
     Returns:
         bool: True if any migration was applied, False otherwise.
@@ -84,19 +110,16 @@ async def async_up(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
     db_type = type(db).__name__
 
     try:
-        if table_type != "sessions":
-            return False
-
         if db_type == "AsyncPostgresDb":
-            return await _migrate_async_postgres(db, table_name)
+            return await _migrate_async_postgres(db, table_type, table_name)
         elif db_type == "AsyncSqliteDb":
-            return await _migrate_async_sqlite(db, table_name)
+            return await _migrate_async_sqlite(db, table_type, table_name)
         elif db_type == "AsyncMySQLDb":
-            return await _migrate_async_mysql(db, table_name)
+            return await _migrate_async_mysql(db, table_type, table_name)
         elif db_type == "AsyncMongoDb":
-            return await _migrate_async_mongo(db, table_name)
+            return await _migrate_async_mongo(db, table_type, table_name)
         else:
-            log_info(f"Migration v3.0.0 is not implemented for {db_type}. Sessions will keep storing runs inline.")
+            log_info(f"Migration v3.0.0 is not implemented for {db_type}. Table '{table_name}' is left unchanged.")
         return False
     except Exception as e:
         log_error(f"Error running migration v3.0.0 for {db_type} on table {table_name}: {str(e)}")
@@ -104,7 +127,12 @@ async def async_up(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
 
 
 def down(db: BaseDb, table_type: str, table_name: str) -> bool:
-    """Revert: move runs back into the sessions `runs` column and drop the runs table.
+    """
+    Revert the following changes to the database:
+    - Move runs back into the sessions `runs` column and drop the runs table
+    - Drop the user_id column and index from the tables listed in USER_ID_TABLE_TYPES
+
+    Notice only the changes related to the given table_type are reverted.
 
     Returns:
         bool: True if any migration was reverted, False otherwise.
@@ -112,33 +140,30 @@ def down(db: BaseDb, table_type: str, table_name: str) -> bool:
     db_type = type(db).__name__
 
     try:
-        if table_type != "sessions":
-            return False
-
         if db_type == "PostgresDb":
-            return _revert_postgres(db, table_name)
+            return _revert_postgres(db, table_type, table_name)
         elif db_type == "SqliteDb":
-            return _revert_sqlite(db, table_name)
+            return _revert_sqlite(db, table_type, table_name)
         elif db_type in ("MySQLDb", "SingleStoreDb"):
-            return _revert_mysql_like(db, table_name)
+            return _revert_mysql_like(db, table_type, table_name)
         elif db_type == "MongoDb":
-            return _revert_mongo(db, table_name)
+            return _revert_mongo(db, table_type, table_name)
         elif db_type == "FirestoreDb":
-            return _revert_firestore(db, table_name)
+            return _revert_firestore(db, table_type, table_name)
         elif db_type == "RedisDb":
-            return _revert_redis(db, table_name)
+            return _revert_redis(db, table_type, table_name)
         elif db_type == "ValkeyDb":
-            return _revert_valkey(db, table_name)
+            return _revert_valkey(db, table_type, table_name)
         elif db_type == "JsonDb":
-            return _revert_jsondb(db, table_name)
+            return _revert_jsondb(db, table_type, table_name)
         elif db_type == "GcsJsonDb":
-            return _revert_gcsjsondb(db, table_name)
+            return _revert_gcsjsondb(db, table_type, table_name)
         elif db_type == "InMemoryDb":
-            return _revert_inmemorydb(db, table_name)
+            return _revert_inmemorydb(db, table_type, table_name)
         elif db_type == "DynamoDb":
-            return _revert_dynamodb(db, table_name)
+            return _revert_dynamodb(db, table_type, table_name)
         elif db_type == "SurrealDb":
-            return _revert_surrealdb(db, table_name)
+            return _revert_surrealdb(db, table_type, table_name)
         else:
             log_info(f"Revert not implemented for {db_type}")
         return False
@@ -148,7 +173,12 @@ def down(db: BaseDb, table_type: str, table_name: str) -> bool:
 
 
 async def async_down(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
-    """Revert: move runs back into the sessions `runs` column and drop the runs table.
+    """
+    Revert the following changes to the database:
+    - Move runs back into the sessions `runs` column and drop the runs table
+    - Drop the user_id column and index from the tables listed in USER_ID_TABLE_TYPES
+
+    Notice only the changes related to the given table_type are reverted.
 
     Returns:
         bool: True if any migration was reverted, False otherwise.
@@ -156,23 +186,137 @@ async def async_down(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
     db_type = type(db).__name__
 
     try:
-        if table_type != "sessions":
-            return False
-
         if db_type == "AsyncPostgresDb":
-            return await _revert_async_postgres(db, table_name)
+            return await _revert_async_postgres(db, table_type, table_name)
         elif db_type == "AsyncSqliteDb":
-            return await _revert_async_sqlite(db, table_name)
+            return await _revert_async_sqlite(db, table_type, table_name)
         elif db_type == "AsyncMySQLDb":
-            return await _revert_async_mysql(db, table_name)
+            return await _revert_async_mysql(db, table_type, table_name)
         elif db_type == "AsyncMongoDb":
-            return await _revert_async_mongo(db, table_name)
+            return await _revert_async_mongo(db, table_type, table_name)
         else:
             log_info(f"Revert not implemented for {db_type}")
         return False
     except Exception as e:
         log_error(f"Error reverting migration v3.0.0 for {db_type} on table {table_name}: {str(e)}")
         raise
+
+
+# ---------------------------------------------------------------------------
+# Per-backend dispatch
+#
+# One entry per SQL backend, routing a table type to the work v3.0.0 does on it.
+# The document backends carry user_id without a schema change, so they only
+# implement the sessions half and return False for everything else.
+# ---------------------------------------------------------------------------
+
+
+def _migrate_postgres(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Apply the v3.0.0 changes for the given table type on PostgreSQL."""
+    if table_type == "sessions":
+        return _migrate_postgres_sessions(db, table_name)
+    if table_type in USER_ID_TABLE_TYPES:
+        return _migrate_postgres_user_id(db, table_type, table_name)
+    return False
+
+
+async def _migrate_async_postgres(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Apply the v3.0.0 changes for the given table type on async PostgreSQL."""
+    if table_type == "sessions":
+        return await _migrate_async_postgres_sessions(db, table_name)
+    if table_type in USER_ID_TABLE_TYPES:
+        return await _migrate_async_postgres_user_id(db, table_type, table_name)
+    return False
+
+
+def _migrate_sqlite(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Apply the v3.0.0 changes for the given table type on SQLite."""
+    if table_type == "sessions":
+        return _migrate_sqlite_sessions(db, table_name)
+    if table_type in USER_ID_TABLE_TYPES:
+        return _migrate_sqlite_user_id(db, table_type, table_name)
+    return False
+
+
+async def _migrate_async_sqlite(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Apply the v3.0.0 changes for the given table type on async SQLite."""
+    if table_type == "sessions":
+        return await _migrate_async_sqlite_sessions(db, table_name)
+    if table_type in USER_ID_TABLE_TYPES:
+        return await _migrate_async_sqlite_user_id(db, table_type, table_name)
+    return False
+
+
+def _migrate_mysql_like(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Apply the v3.0.0 changes for the given table type on MySQL or SingleStore."""
+    if table_type == "sessions":
+        return _migrate_mysql_like_sessions(db, table_name)
+    if table_type in USER_ID_TABLE_TYPES:
+        return _migrate_mysql_like_user_id(db, table_type, table_name)
+    return False
+
+
+async def _migrate_async_mysql(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Apply the v3.0.0 changes for the given table type on async MySQL."""
+    if table_type == "sessions":
+        return await _migrate_async_mysql_sessions(db, table_name)
+    if table_type in USER_ID_TABLE_TYPES:
+        return await _migrate_async_mysql_user_id(db, table_type, table_name)
+    return False
+
+
+def _revert_postgres(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Revert the v3.0.0 changes for the given table type on PostgreSQL."""
+    if table_type == "sessions":
+        return _revert_postgres_sessions(db, table_name)
+    if table_type in USER_ID_TABLE_TYPES:
+        return _revert_postgres_user_id(db, table_type, table_name)
+    return False
+
+
+async def _revert_async_postgres(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Revert the v3.0.0 changes for the given table type on async PostgreSQL."""
+    if table_type == "sessions":
+        return await _revert_async_postgres_sessions(db, table_name)
+    if table_type in USER_ID_TABLE_TYPES:
+        return await _revert_async_postgres_user_id(db, table_type, table_name)
+    return False
+
+
+def _revert_sqlite(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Revert the v3.0.0 changes for the given table type on SQLite."""
+    if table_type == "sessions":
+        return _revert_sqlite_sessions(db, table_name)
+    if table_type in USER_ID_TABLE_TYPES:
+        return _revert_sqlite_user_id(db, table_type, table_name)
+    return False
+
+
+async def _revert_async_sqlite(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Revert the v3.0.0 changes for the given table type on async SQLite."""
+    if table_type == "sessions":
+        return await _revert_async_sqlite_sessions(db, table_name)
+    if table_type in USER_ID_TABLE_TYPES:
+        return await _revert_async_sqlite_user_id(db, table_type, table_name)
+    return False
+
+
+def _revert_mysql_like(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Revert the v3.0.0 changes for the given table type on MySQL or SingleStore."""
+    if table_type == "sessions":
+        return _revert_mysql_like_sessions(db, table_name)
+    if table_type in USER_ID_TABLE_TYPES:
+        return _revert_mysql_like_user_id(db, table_type, table_name)
+    return False
+
+
+async def _revert_async_mysql(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Revert the v3.0.0 changes for the given table type on async MySQL."""
+    if table_type == "sessions":
+        return await _revert_async_mysql_sessions(db, table_name)
+    if table_type in USER_ID_TABLE_TYPES:
+        return await _revert_async_mysql_user_id(db, table_type, table_name)
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -225,12 +369,103 @@ def _build_run_rows(
     return rows
 
 
-def _column_exists_postgres(sess, db_schema: str, table_name: str, column_name: str) -> bool:
-    query = text(
-        "SELECT 1 FROM information_schema.columns "
-        "WHERE table_schema = :schema AND table_name = :table AND column_name = :column"
-    )
-    return sess.execute(query, {"schema": db_schema, "table": table_name, "column": column_name}).scalar() is not None
+def _forget_runs_table(db) -> None:
+    """Drop the runs table from the adapter's SQLAlchemy state after a revert.
+
+    ``DROP TABLE`` only removes the table from the database — the Table object
+    stays registered on ``db.metadata``, so a later up() in the same process
+    raises "Table is already defined for this MetaData instance" when it tries
+    to define it again.
+    """
+    metadata = getattr(db, "metadata", None)
+    runs_table_name = getattr(db, "runs_table_name", None)
+    if metadata is not None and runs_table_name is not None:
+        for table in list(metadata.tables.values()):
+            if table.name == runs_table_name:
+                metadata.remove(table)
+    if hasattr(db, "runs_table"):
+        db.runs_table = None
+
+
+def _decode_run_data(value: Any) -> Any:
+    """Decode a run_data payload read back through a raw SQL SELECT.
+
+    A raw select skips the column's JSON deserializer, so SQLite — which stores
+    the payload as a JSON string inside a JSON column — hands back both layers.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        value = value.decode()
+    if isinstance(value, str):
+        value = json.loads(value)
+    if isinstance(value, str):
+        value = json.loads(value)
+    return value
+
+
+def _column_exists(sess, db_schema: str, table_name: str, column_name: str, db_type: str) -> bool:
+    """Check if a column exists in a table."""
+    if db_type in ("PostgresDb", "AsyncPostgresDb"):
+        query = text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = :schema AND table_name = :table AND column_name = :column"
+        )
+    else:
+        # MySQL / SingleStore
+        query = text(
+            "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS "
+            "WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table AND COLUMN_NAME = :column"
+        )
+    result = sess.execute(query, {"schema": db_schema, "table": table_name, "column": column_name})
+    return result.scalar() is not None
+
+
+async def _async_column_exists(sess, db_schema: str, table_name: str, column_name: str, db_type: str) -> bool:
+    """Async version: check if a column exists in a table."""
+    if db_type in ("PostgresDb", "AsyncPostgresDb"):
+        query = text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = :schema AND table_name = :table AND column_name = :column"
+        )
+    else:
+        # MySQL / SingleStore
+        query = text(
+            "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS "
+            "WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table AND COLUMN_NAME = :column"
+        )
+    result = await sess.execute(query, {"schema": db_schema, "table": table_name, "column": column_name})
+    return result.scalar() is not None
+
+
+def _index_exists(sess, db_schema: str, table_name: str, index_name: str, db_type: str) -> bool:
+    """Check if an index exists on a table."""
+    if db_type in ("PostgresDb", "AsyncPostgresDb"):
+        query = text(
+            "SELECT 1 FROM pg_indexes WHERE schemaname = :schema AND tablename = :table AND indexname = :index"
+        )
+    else:
+        # MySQL / SingleStore
+        query = text(
+            "SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS "
+            "WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table AND INDEX_NAME = :index"
+        )
+    result = sess.execute(query, {"schema": db_schema, "table": table_name, "index": index_name})
+    return result.scalar() is not None
+
+
+async def _async_index_exists(sess, db_schema: str, table_name: str, index_name: str, db_type: str) -> bool:
+    """Async version: check if an index exists on a table."""
+    if db_type in ("PostgresDb", "AsyncPostgresDb"):
+        query = text(
+            "SELECT 1 FROM pg_indexes WHERE schemaname = :schema AND tablename = :table AND indexname = :index"
+        )
+    else:
+        # MySQL / SingleStore
+        query = text(
+            "SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS "
+            "WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table AND INDEX_NAME = :index"
+        )
+    result = await sess.execute(query, {"schema": db_schema, "table": table_name, "index": index_name})
+    return result.scalar() is not None
 
 
 # ---------------------------------------------------------------------------
@@ -238,7 +473,7 @@ def _column_exists_postgres(sess, db_schema: str, table_name: str, column_name: 
 # ---------------------------------------------------------------------------
 
 
-def _migrate_postgres(db: BaseDb, table_name: str) -> bool:
+def _migrate_postgres_sessions(db: BaseDb, table_name: str) -> bool:
     """Move session runs into the runs table and drop the `runs` column, for PostgreSQL."""
     db_schema = db.db_schema or "ai"  # type: ignore
     db_type = type(db).__name__
@@ -265,7 +500,7 @@ def _migrate_postgres(db: BaseDb, table_name: str) -> bool:
             log_info(f"Table {table_name} does not exist, skipping migration")
             return False
 
-        if not _column_exists_postgres(sess, db_schema, table_name, "runs"):
+        if not _column_exists(sess, db_schema, table_name, "runs", db_type):
             log_info(f"Table {table_name} has no runs column, skipping migration")
             return False
 
@@ -295,7 +530,7 @@ def _migrate_postgres(db: BaseDb, table_name: str) -> bool:
         return True
 
 
-async def _migrate_async_postgres(db: AsyncBaseDb, table_name: str) -> bool:
+async def _migrate_async_postgres_sessions(db: AsyncBaseDb, table_name: str) -> bool:
     """Move session runs into the runs table and drop the `runs` column, for async PostgreSQL."""
     db_schema = db.db_schema or "ai"  # type: ignore
     db_type = type(db).__name__
@@ -324,15 +559,7 @@ async def _migrate_async_postgres(db: AsyncBaseDb, table_name: str) -> bool:
             log_info(f"Table {table_name} does not exist, skipping migration")
             return False
 
-        column_exists = (
-            await sess.execute(
-                text(
-                    "SELECT 1 FROM information_schema.columns "
-                    "WHERE table_schema = :schema AND table_name = :table AND column_name = 'runs'"
-                ),
-                {"schema": db_schema, "table": table_name},
-            )
-        ).scalar() is not None
+        column_exists = await _async_column_exists(sess, db_schema, table_name, "runs", db_type)
         if not column_exists:
             log_info(f"Table {table_name} has no runs column, skipping migration")
             return False
@@ -368,7 +595,7 @@ async def _migrate_async_postgres(db: AsyncBaseDb, table_name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _migrate_sqlite(db: BaseDb, table_name: str) -> bool:
+def _migrate_sqlite_sessions(db: BaseDb, table_name: str) -> bool:
     """Move session runs into the runs table and drop the `runs` column, for SQLite."""
     # Ensure the runs table exists
     runs_table = db._get_table(table_type="runs", create_table_if_not_found=True)  # type: ignore
@@ -416,7 +643,7 @@ def _migrate_sqlite(db: BaseDb, table_name: str) -> bool:
         return True
 
 
-async def _migrate_async_sqlite(db: AsyncBaseDb, table_name: str) -> bool:
+async def _migrate_async_sqlite_sessions(db: AsyncBaseDb, table_name: str) -> bool:
     """Move session runs into the runs table and drop the `runs` column, for async SQLite."""
     # Ensure the runs table exists
     runs_table = await db._get_table(table_type="runs", create_table_if_not_found=True)  # type: ignore
@@ -471,7 +698,7 @@ async def _migrate_async_sqlite(db: AsyncBaseDb, table_name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _revert_postgres(db: BaseDb, table_name: str) -> bool:
+def _revert_postgres_sessions(db: BaseDb, table_name: str) -> bool:
     """Revert: move runs back into the sessions `runs` column and drop the runs table, for PostgreSQL."""
     db_schema = db.db_schema or "ai"  # type: ignore
     db_type = type(db).__name__
@@ -496,7 +723,7 @@ def _revert_postgres(db: BaseDb, table_name: str) -> bool:
             return False
 
         # Re-add the runs column if missing
-        if not _column_exists_postgres(sess, db_schema, table_name, "runs"):
+        if not _column_exists(sess, db_schema, table_name, "runs", db_type):
             log_info(f"-- Adding runs column back to {table_name}")
             sess.execute(text(f"ALTER TABLE {full_table} ADD COLUMN runs JSONB"))
 
@@ -516,11 +743,12 @@ def _revert_postgres(db: BaseDb, table_name: str) -> bool:
         # Drop the runs table
         log_info(f"-- Dropping runs table {runs_table_name}")
         sess.execute(text(f"DROP TABLE {quoted_runs_table}"))
+        _forget_runs_table(db)
 
         return True
 
 
-async def _revert_async_postgres(db: AsyncBaseDb, table_name: str) -> bool:
+async def _revert_async_postgres_sessions(db: AsyncBaseDb, table_name: str) -> bool:
     """Revert: move runs back into the sessions `runs` column and drop the runs table, for async PostgreSQL."""
     db_schema = db.db_schema or "ai"  # type: ignore
     db_type = type(db).__name__
@@ -547,15 +775,7 @@ async def _revert_async_postgres(db: AsyncBaseDb, table_name: str) -> bool:
             return False
 
         # Re-add the runs column if missing
-        column_exists = (
-            await sess.execute(
-                text(
-                    "SELECT 1 FROM information_schema.columns "
-                    "WHERE table_schema = :schema AND table_name = :table AND column_name = 'runs'"
-                ),
-                {"schema": db_schema, "table": table_name},
-            )
-        ).scalar() is not None
+        column_exists = await _async_column_exists(sess, db_schema, table_name, "runs", db_type)
         if not column_exists:
             log_info(f"-- Adding runs column back to {table_name}")
             await sess.execute(text(f"ALTER TABLE {full_table} ADD COLUMN runs JSONB"))
@@ -576,11 +796,12 @@ async def _revert_async_postgres(db: AsyncBaseDb, table_name: str) -> bool:
         # Drop the runs table
         log_info(f"-- Dropping runs table {runs_table_name}")
         await sess.execute(text(f"DROP TABLE {quoted_runs_table}"))
+        _forget_runs_table(db)
 
         return True
 
 
-def _revert_sqlite(db: BaseDb, table_name: str) -> bool:
+def _revert_sqlite_sessions(db: BaseDb, table_name: str) -> bool:
     """Revert: move runs back into the sessions `runs` column and drop the runs table, for SQLite."""
     runs_table_name = db.runs_table_name
 
@@ -610,7 +831,7 @@ def _revert_sqlite(db: BaseDb, table_name: str) -> bool:
                 ),
                 {"session_id": session_id},
             ).fetchall()
-            runs = [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in run_rows]
+            runs = [_decode_run_data(row[0]) for row in run_rows]
             sess.execute(
                 text(f"UPDATE {table_name} SET runs = :runs WHERE session_id = :session_id"),
                 {"runs": json.dumps(runs, cls=CustomJSONEncoder), "session_id": session_id},
@@ -619,11 +840,12 @@ def _revert_sqlite(db: BaseDb, table_name: str) -> bool:
         # Drop the runs table
         log_info(f"-- Dropping runs table {runs_table_name}")
         sess.execute(text(f"DROP TABLE {runs_table_name}"))
+        _forget_runs_table(db)
 
         return True
 
 
-async def _revert_async_sqlite(db: AsyncBaseDb, table_name: str) -> bool:
+async def _revert_async_sqlite_sessions(db: AsyncBaseDb, table_name: str) -> bool:
     """Revert: move runs back into the sessions `runs` column and drop the runs table, for async SQLite."""
     runs_table_name = db.runs_table_name
 
@@ -659,7 +881,7 @@ async def _revert_async_sqlite(db: AsyncBaseDb, table_name: str) -> bool:
                     {"session_id": session_id},
                 )
             ).fetchall()
-            runs = [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in run_rows]
+            runs = [_decode_run_data(row[0]) for row in run_rows]
             await sess.execute(
                 text(f"UPDATE {table_name} SET runs = :runs WHERE session_id = :session_id"),
                 {"runs": json.dumps(runs, cls=CustomJSONEncoder), "session_id": session_id},
@@ -668,6 +890,7 @@ async def _revert_async_sqlite(db: AsyncBaseDb, table_name: str) -> bool:
         # Drop the runs table
         log_info(f"-- Dropping runs table {runs_table_name}")
         await sess.execute(text(f"DROP TABLE {runs_table_name}"))
+        _forget_runs_table(db)
 
         return True
 
@@ -678,21 +901,22 @@ async def _revert_async_sqlite(db: AsyncBaseDb, table_name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _migrate_mysql_like(db: BaseDb, table_name: str) -> bool:
+def _migrate_mysql_like_sessions(db: BaseDb, table_name: str) -> bool:
     """Move session runs into the runs table for MySQL or SingleStore.
 
     Non-destructive: the legacy `runs` column is left in place. Call
     ``db.cleanup_legacy_runs_column()`` to drop it once you have verified
     the migration and taken a backup.
     """
-    db_schema = db.db_schema or "agno"  # type: ignore
-
     # Ensure the runs table exists
     runs_table = db._get_table(table_type="runs", create_table_if_not_found=True)  # type: ignore
     if runs_table is None:
         return False
 
     with db.Session() as sess, sess.begin():  # type: ignore
+        # SingleStore leaves db_schema as None and uses the connection's database
+        db_schema = db.db_schema or sess.execute(text("SELECT DATABASE()")).scalar()  # type: ignore
+
         # Does the sessions table exist?
         table_exists = sess.execute(
             text(
@@ -755,8 +979,8 @@ def _migrate_mysql_like(db: BaseDb, table_name: str) -> bool:
         return True
 
 
-async def _migrate_async_mysql(db: AsyncBaseDb, table_name: str) -> bool:
-    """Async MySQL variant of :func:`_migrate_mysql_like`."""
+async def _migrate_async_mysql_sessions(db: AsyncBaseDb, table_name: str) -> bool:
+    """Async MySQL variant of :func:`_migrate_mysql_like_sessions`."""
     db_schema = db.db_schema or "agno"  # type: ignore
 
     runs_table = await db._get_table(table_type="runs", create_table_if_not_found=True)  # type: ignore
@@ -820,12 +1044,14 @@ async def _migrate_async_mysql(db: AsyncBaseDb, table_name: str) -> bool:
         return True
 
 
-def _revert_mysql_like(db: BaseDb, table_name: str) -> bool:
+def _revert_mysql_like_sessions(db: BaseDb, table_name: str) -> bool:
     """Revert: rebuild blobs in `sessions.runs` from the runs table; drop the runs table."""
-    db_schema = db.db_schema or "agno"  # type: ignore
     runs_table_name = db.runs_table_name  # type: ignore
 
     with db.Session() as sess, sess.begin():  # type: ignore
+        # SingleStore leaves db_schema as None and uses the connection's database
+        db_schema = db.db_schema or sess.execute(text("SELECT DATABASE()")).scalar()  # type: ignore
+
         runs_table_exists = sess.execute(
             text(
                 "SELECT EXISTS ("
@@ -866,7 +1092,7 @@ def _revert_mysql_like(db: BaseDb, table_name: str) -> bool:
                 ),
                 {"session_id": session_id},
             ).fetchall()
-            runs = [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in run_rows]
+            runs = [_decode_run_data(row[0]) for row in run_rows]
             sess.execute(
                 text(f"UPDATE `{db_schema}`.`{table_name}` SET runs = :runs WHERE session_id = :session_id"),
                 {"runs": json.dumps(runs, cls=CustomJSONEncoder), "session_id": session_id},
@@ -875,12 +1101,13 @@ def _revert_mysql_like(db: BaseDb, table_name: str) -> bool:
         # Drop the runs table
         log_info(f"-- Dropping runs table {runs_table_name}")
         sess.execute(text(f"DROP TABLE `{db_schema}`.`{runs_table_name}`"))
+        _forget_runs_table(db)
 
         return True
 
 
-async def _revert_async_mysql(db: AsyncBaseDb, table_name: str) -> bool:
-    """Async MySQL variant of :func:`_revert_mysql_like`."""
+async def _revert_async_mysql_sessions(db: AsyncBaseDb, table_name: str) -> bool:
+    """Async MySQL variant of :func:`_revert_mysql_like_sessions`."""
     db_schema = db.db_schema or "agno"  # type: ignore
     runs_table_name = db.runs_table_name  # type: ignore
 
@@ -927,7 +1154,7 @@ async def _revert_async_mysql(db: AsyncBaseDb, table_name: str) -> bool:
                     {"session_id": session_id},
                 )
             ).fetchall()
-            runs = [json.loads(row[0]) if isinstance(row[0], str) else row[0] for row in run_rows]
+            runs = [_decode_run_data(row[0]) for row in run_rows]
             await sess.execute(
                 text(f"UPDATE `{db_schema}`.`{table_name}` SET runs = :runs WHERE session_id = :session_id"),
                 {"runs": json.dumps(runs, cls=CustomJSONEncoder), "session_id": session_id},
@@ -935,6 +1162,7 @@ async def _revert_async_mysql(db: AsyncBaseDb, table_name: str) -> bool:
 
         log_info(f"-- Dropping runs table {runs_table_name}")
         await sess.execute(text(f"DROP TABLE `{db_schema}`.`{runs_table_name}`"))
+        _forget_runs_table(db)
 
         return True
 
@@ -944,13 +1172,16 @@ async def _revert_async_mysql(db: AsyncBaseDb, table_name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _migrate_mongo(db: BaseDb, table_name: str) -> bool:
+def _migrate_mongo(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Copy runs from the legacy `runs` field on session documents into the runs collection.
 
     Non-destructive: the legacy `runs` field is left in place. Call
     ``db.cleanup_legacy_runs_field()`` to remove it once you have verified
     the migration and taken a backup.
     """
+    if table_type != "sessions":
+        return False
+
     sessions_collection = db._get_collection(table_type="sessions", create_collection_if_not_found=True)  # type: ignore
     if sessions_collection is None:
         log_info(f"Sessions collection {table_name} does not exist, skipping migration")
@@ -983,11 +1214,14 @@ def _migrate_mongo(db: BaseDb, table_name: str) -> bool:
     return True
 
 
-def _revert_mongo(db: BaseDb, table_name: str) -> bool:
+def _revert_mongo(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Revert: rebuild the legacy `runs` field on session documents from the runs collection.
 
     The runs collection is dropped at the end.
     """
+    if table_type != "sessions":
+        return False
+
     sessions_collection = db._get_collection(table_type="sessions", create_collection_if_not_found=True)  # type: ignore
     runs_collection_name = db.runs_table_name  # type: ignore
     runs_collection = db._get_collection(table_type="runs", create_collection_if_not_found=True)  # type: ignore
@@ -1015,8 +1249,11 @@ def _revert_mongo(db: BaseDb, table_name: str) -> bool:
     return True
 
 
-async def _migrate_async_mongo(db: AsyncBaseDb, table_name: str) -> bool:
+async def _migrate_async_mongo(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
     """Async variant of :func:`_migrate_mongo`."""
+    if table_type != "sessions":
+        return False
+
     sessions_collection = await db._get_collection(table_type="sessions", create_collection_if_not_found=True)  # type: ignore
     if sessions_collection is None:
         log_info(f"Sessions collection {table_name} does not exist, skipping migration")
@@ -1047,8 +1284,11 @@ async def _migrate_async_mongo(db: AsyncBaseDb, table_name: str) -> bool:
     return True
 
 
-async def _revert_async_mongo(db: AsyncBaseDb, table_name: str) -> bool:
+async def _revert_async_mongo(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
     """Async variant of :func:`_revert_mongo`."""
+    if table_type != "sessions":
+        return False
+
     sessions_collection = await db._get_collection(table_type="sessions", create_collection_if_not_found=True)  # type: ignore
     runs_collection_name = db.runs_table_name  # type: ignore
     runs_collection = await db._get_collection(table_type="runs", create_collection_if_not_found=True)  # type: ignore
@@ -1061,7 +1301,9 @@ async def _revert_async_mongo(db: AsyncBaseDb, table_name: str) -> bool:
         {"$sort": {"session_id": 1, "run_index": 1, "created_at": 1}},
         {"$group": {"_id": "$session_id", "runs": {"$push": "$run_data"}}},
     ]
-    async for group in runs_collection.aggregate(pipeline):
+    # PyMongo's async client returns a coroutine from aggregate(), Motor returns a
+    # cursor. _aggregate_to_list() is the adapter's helper that handles both.
+    for group in await db._aggregate_to_list(runs_collection, pipeline):  # type: ignore
         session_id = group["_id"]
         runs = group["runs"]
         await sessions_collection.update_one(
@@ -1079,12 +1321,15 @@ async def _revert_async_mongo(db: AsyncBaseDb, table_name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _migrate_firestore(db: BaseDb, table_name: str) -> bool:
+def _migrate_firestore(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Copy runs from the legacy `runs` field on session documents into the runs collection.
 
     Non-destructive: the legacy `runs` field is left in place. Call
     ``db.cleanup_legacy_runs_field()`` to remove it once verified.
     """
+    if table_type != "sessions":
+        return False
+
     sessions_ref = db._get_collection(table_type="sessions", create_collection_if_not_found=True)  # type: ignore
     if sessions_ref is None:
         log_info(f"Sessions collection {table_name} does not exist, skipping migration")
@@ -1130,11 +1375,14 @@ def _migrate_firestore(db: BaseDb, table_name: str) -> bool:
     return True
 
 
-def _revert_firestore(db: BaseDb, table_name: str) -> bool:
+def _revert_firestore(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Revert: rebuild the legacy `runs` field on session documents from the runs collection.
 
     The runs collection is deleted at the end.
     """
+    if table_type != "sessions":
+        return False
+
     from google.cloud.firestore import FieldFilter  # type: ignore[import-untyped]
 
     sessions_ref = db._get_collection(table_type="sessions", create_collection_if_not_found=True)  # type: ignore
@@ -1192,13 +1440,16 @@ def _revert_firestore(db: BaseDb, table_name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _migrate_redis(db: BaseDb, table_name: str) -> bool:
+def _migrate_redis(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Copy runs from the legacy `runs` field on session records into per-run keys.
 
     Non-destructive: the legacy `runs` field is left in place on the session
     record. Call ``db.cleanup_legacy_runs_field()`` once you have verified the
     migration to free the storage.
     """
+    if table_type != "sessions":
+        return False
+
     sessions = db._get_all_records("sessions")  # type: ignore
     migrated_runs = 0
     for session in sessions:
@@ -1228,8 +1479,11 @@ def _migrate_redis(db: BaseDb, table_name: str) -> bool:
     return True
 
 
-def _revert_redis(db: BaseDb, table_name: str) -> bool:
+def _revert_redis(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Revert: rebuild the legacy `runs` field on session records, then delete run keys."""
+    if table_type != "sessions":
+        return False
+
     from agno.db.redis.utils import generate_redis_key  # type: ignore
 
     # Collect runs per session
@@ -1274,13 +1528,16 @@ def _revert_redis(db: BaseDb, table_name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _migrate_valkey(db: BaseDb, table_name: str) -> bool:
+def _migrate_valkey(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Copy runs from the legacy `runs` field on session records into per-run keys.
 
     Non-destructive: the legacy `runs` field is left in place on the session
     record. Call ``db.cleanup_legacy_runs_field()`` once you have verified the
     migration to free the storage.
     """
+    if table_type != "sessions":
+        return False
+
     from glide_sync import ExpirySet, ExpiryType
 
     from agno.db.valkey.utils import generate_valkey_key, serialize_data  # type: ignore
@@ -1315,8 +1572,11 @@ def _migrate_valkey(db: BaseDb, table_name: str) -> bool:
     return True
 
 
-def _revert_valkey(db: BaseDb, table_name: str) -> bool:
+def _revert_valkey(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Revert: rebuild the legacy `runs` field on session records, then delete run keys."""
+    if table_type != "sessions":
+        return False
+
     from agno.db.valkey.utils import generate_valkey_key  # type: ignore
 
     # Collect runs per session
@@ -1364,13 +1624,16 @@ def _revert_valkey(db: BaseDb, table_name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _migrate_jsondb(db: BaseDb, table_name: str) -> bool:
+def _migrate_jsondb(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Copy runs from the legacy `runs` field on each session record into the runs file.
 
     Idempotent: reruns don't clobber fresh post-migration writes. Any run_id
     already present in the runs table wins — the legacy blob is only used
     to backfill run_ids that aren't there yet.
     """
+    if table_type != "sessions":
+        return False
+
     sessions = db._read_json_file(db.session_table_name, create_table_if_not_found=False)  # type: ignore
     if not sessions:
         log_info(f"Sessions file {table_name}.json is empty or missing, skipping migration")
@@ -1403,8 +1666,11 @@ def _migrate_jsondb(db: BaseDb, table_name: str) -> bool:
     return True
 
 
-def _revert_jsondb(db: BaseDb, table_name: str) -> bool:
+def _revert_jsondb(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Revert: rebuild the legacy `runs` field on each session record from the runs file."""
+    if table_type != "sessions":
+        return False
+
     sessions = db._read_json_file(db.session_table_name, create_table_if_not_found=False)  # type: ignore
     all_runs = db._read_runs_file(create_table_if_not_found=False)  # type: ignore
 
@@ -1428,12 +1694,15 @@ def _revert_jsondb(db: BaseDb, table_name: str) -> bool:
     return True
 
 
-def _migrate_gcsjsondb(db: BaseDb, table_name: str) -> bool:
+def _migrate_gcsjsondb(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Same shape as :func:`_migrate_jsondb` — both store sessions as a JSON list (file vs object).
 
     Idempotent: reruns don't clobber fresh post-migration writes. Any run_id
     already present in the runs table wins.
     """
+    if table_type != "sessions":
+        return False
+
     sessions = db._read_json_file(db.session_table_name, create_table_if_not_found=False)  # type: ignore
     if not sessions:
         log_info(f"Sessions object {table_name}.json is empty or missing, skipping migration")
@@ -1464,7 +1733,10 @@ def _migrate_gcsjsondb(db: BaseDb, table_name: str) -> bool:
     return True
 
 
-def _revert_gcsjsondb(db: BaseDb, table_name: str) -> bool:
+def _revert_gcsjsondb(db: BaseDb, table_type: str, table_name: str) -> bool:
+    if table_type != "sessions":
+        return False
+
     sessions = db._read_json_file(db.session_table_name, create_table_if_not_found=False)  # type: ignore
     all_runs = db._read_json_file(db.runs_table_name, create_table_if_not_found=False)  # type: ignore
 
@@ -1488,13 +1760,19 @@ def _revert_gcsjsondb(db: BaseDb, table_name: str) -> bool:
     return True
 
 
-def _migrate_inmemorydb(db: BaseDb, table_name: str) -> bool:
+def _migrate_inmemorydb(db: BaseDb, table_type: str, table_name: str) -> bool:
     """InMemoryDb is not normalized in v3.0; runs stay inline."""
+    if table_type != "sessions":
+        return False
+
     log_info("-- InMemoryDb does not split runs into a separate table; skipping migration.")
     return False
 
 
-def _revert_inmemorydb(db: BaseDb, table_name: str) -> bool:
+def _revert_inmemorydb(db: BaseDb, table_type: str, table_name: str) -> bool:
+    if table_type != "sessions":
+        return False
+
     return False
 
 
@@ -1560,8 +1838,11 @@ def _dynamo_put_run_with_retry(
     raise RuntimeError(f"Failed to migrate run into {table_name} after {max_retries} retries")
 
 
-def _migrate_dynamodb(db: BaseDb, table_name: str) -> bool:
+def _migrate_dynamodb(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Copy legacy `runs` blob from each session item into the agno_runs table."""
+    if table_type != "sessions":
+        return False
+
     import json as _json
 
     client = db.client  # type: ignore
@@ -1624,8 +1905,11 @@ def _migrate_dynamodb(db: BaseDb, table_name: str) -> bool:
     return migrated > 0
 
 
-def _revert_dynamodb(db: BaseDb, table_name: str) -> bool:
+def _revert_dynamodb(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Walk runs and re-attach to session items, then truncate the runs table."""
+    if table_type != "sessions":
+        return False
+
     import json as _json
 
     client = db.client  # type: ignore
@@ -1724,8 +2008,11 @@ def _serialize_to_dynamo_item_minimal(data: Dict[str, Any]) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _migrate_surrealdb(db: BaseDb, table_name: str) -> bool:
+def _migrate_surrealdb(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Copy legacy `runs` blob from each session record into the runs table."""
+    if table_type != "sessions":
+        return False
+
     from surrealdb import RecordID  # type: ignore
 
     from agno.db.surrealdb.models import serialize_run_row  # local import to avoid hard dep
@@ -1769,8 +2056,11 @@ def _migrate_surrealdb(db: BaseDb, table_name: str) -> bool:
     return migrated > 0
 
 
-def _revert_surrealdb(db: BaseDb, table_name: str) -> bool:
+def _revert_surrealdb(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Walk runs and rebuild the legacy `runs` blob on each session row."""
+    if table_type != "sessions":
+        return False
+
     from surrealdb import RecordID  # type: ignore
 
     runs_table = db.runs_table_name  # type: ignore
@@ -1830,3 +2120,544 @@ def _revert_surrealdb(db: BaseDb, table_name: str) -> bool:
             "blob rebuild failed; re-run down() after resolving the error."
         )
     return True
+
+
+# ---------------------------------------------------------------------------
+# user_id column
+# ---------------------------------------------------------------------------
+
+
+def _user_id_column_ddl(db, table_type: str) -> str:
+    """Compile the user_id column type from the adapter's own schema for this table.
+
+    Keeps a migrated table identical to one created fresh from the schema, so a
+    later migration reading INFORMATION_SCHEMA sees the same type either way.
+    """
+    db_type = type(db).__name__
+
+    schemas: Any
+    if db_type in ("PostgresDb", "AsyncPostgresDb"):
+        from agno.db.postgres import schemas
+    elif db_type in ("MySQLDb", "AsyncMySQLDb"):
+        from agno.db.mysql import schemas
+    elif db_type == "SingleStoreDb":
+        from agno.db.singlestore import schemas
+    else:
+        from agno.db.sqlite import schemas
+
+    column_type = schemas.get_table_schema_definition(table_type)["user_id"]["type"]
+    return column_type().compile(dialect=db.db_engine.dialect)
+
+
+def _migrate_postgres_user_id(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Add the user_id column to the given table for PostgreSQL."""
+    db_schema = db.db_schema or "ai"  # type: ignore
+    db_type = type(db).__name__
+    quoted_schema = quote_db_identifier(db_type, db_schema)
+    full_table = f"{quoted_schema}.{quote_db_identifier(db_type, table_name)}"
+    index_name = f"idx_{table_name}_user_id"
+    column_ddl = _user_id_column_ddl(db, table_type)
+
+    with db.Session() as sess, sess.begin():  # type: ignore
+        table_exists = sess.execute(
+            text(
+                "SELECT EXISTS ("
+                "  SELECT FROM information_schema.tables"
+                "  WHERE table_schema = :schema AND table_name = :table_name"
+                ")"
+            ),
+            {"schema": db_schema, "table_name": table_name},
+        ).scalar()
+        if not table_exists:
+            log_info(f"Table {table_name} does not exist, skipping migration")
+            return False
+
+        applied = False
+
+        if not _column_exists(sess, db_schema, table_name, "user_id", db_type):
+            log_info(f"-- Adding user_id column to {table_name}")
+            sess.execute(text(f"ALTER TABLE {full_table} ADD COLUMN user_id {column_ddl}"))
+            applied = True
+
+        if not _index_exists(sess, db_schema, table_name, index_name, db_type):
+            log_info(f"-- Adding index {index_name} on {table_name}")
+            sess.execute(text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {full_table} (user_id)"))
+            applied = True
+
+        return applied
+
+
+async def _migrate_async_postgres_user_id(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Async PostgreSQL variant of :func:`_migrate_postgres_user_id`."""
+    db_schema = db.db_schema or "ai"  # type: ignore
+    db_type = type(db).__name__
+    quoted_schema = quote_db_identifier(db_type, db_schema)
+    full_table = f"{quoted_schema}.{quote_db_identifier(db_type, table_name)}"
+    index_name = f"idx_{table_name}_user_id"
+    column_ddl = _user_id_column_ddl(db, table_type)
+
+    async with db.async_session_factory() as sess, sess.begin():  # type: ignore
+        result = await sess.execute(
+            text(
+                "SELECT EXISTS ("
+                "  SELECT FROM information_schema.tables"
+                "  WHERE table_schema = :schema AND table_name = :table_name"
+                ")"
+            ),
+            {"schema": db_schema, "table_name": table_name},
+        )
+        if not result.scalar():
+            log_info(f"Table {table_name} does not exist, skipping migration")
+            return False
+
+        applied = False
+
+        if not await _async_column_exists(sess, db_schema, table_name, "user_id", db_type):
+            log_info(f"-- Adding user_id column to {table_name}")
+            await sess.execute(text(f"ALTER TABLE {full_table} ADD COLUMN user_id {column_ddl}"))
+            applied = True
+
+        if not await _async_index_exists(sess, db_schema, table_name, index_name, db_type):
+            log_info(f"-- Adding index {index_name} on {table_name}")
+            await sess.execute(
+                text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {full_table} (user_id)")
+            )
+            applied = True
+
+        return applied
+
+
+def _migrate_mysql_like_user_id(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Add the user_id column to the given table for MySQL or SingleStore."""
+    db_type = type(db).__name__
+    index_name = f"idx_{table_name}_user_id"
+    column_ddl = _user_id_column_ddl(db, table_type)
+
+    with db.Session() as sess, sess.begin():  # type: ignore
+        # SingleStore leaves db_schema as None and uses the connection's database
+        db_schema = db.db_schema or sess.execute(text("SELECT DATABASE()")).scalar()  # type: ignore
+        quoted_schema = quote_db_identifier(db_type, db_schema)
+        full_table = f"{quoted_schema}.{quote_db_identifier(db_type, table_name)}"
+
+        table_exists = sess.execute(
+            text(
+                "SELECT EXISTS ("
+                "  SELECT 1 FROM INFORMATION_SCHEMA.TABLES"
+                "  WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table_name"
+                ")"
+            ),
+            {"schema": db_schema, "table_name": table_name},
+        ).scalar()
+        if not table_exists:
+            log_info(f"Table {table_name} does not exist, skipping migration")
+            return False
+
+        applied = False
+
+        if not _column_exists(sess, db_schema, table_name, "user_id", db_type):
+            log_info(f"-- Adding user_id column to {table_name}")
+            sess.execute(text(f"ALTER TABLE {full_table} ADD COLUMN `user_id` {column_ddl}"))
+            applied = True
+
+        if not _index_exists(sess, db_schema, table_name, index_name, db_type):
+            log_info(f"-- Adding index {index_name} on {table_name}")
+            sess.execute(text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {full_table} (`user_id`)"))
+            applied = True
+
+        return applied
+
+
+async def _migrate_async_mysql_user_id(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Async MySQL variant of :func:`_migrate_mysql_like_user_id`."""
+    db_type = type(db).__name__
+    index_name = f"idx_{table_name}_user_id"
+    column_ddl = _user_id_column_ddl(db, table_type)
+
+    async with db.async_session_factory() as sess, sess.begin():  # type: ignore
+        db_schema = db.db_schema or (await sess.execute(text("SELECT DATABASE()"))).scalar()  # type: ignore
+        quoted_schema = quote_db_identifier(db_type, db_schema)
+        full_table = f"{quoted_schema}.{quote_db_identifier(db_type, table_name)}"
+
+        table_exists = (
+            await sess.execute(
+                text(
+                    "SELECT EXISTS ("
+                    "  SELECT 1 FROM INFORMATION_SCHEMA.TABLES"
+                    "  WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table_name"
+                    ")"
+                ),
+                {"schema": db_schema, "table_name": table_name},
+            )
+        ).scalar()
+        if not table_exists:
+            log_info(f"Table {table_name} does not exist, skipping migration")
+            return False
+
+        applied = False
+
+        if not await _async_column_exists(sess, db_schema, table_name, "user_id", db_type):
+            log_info(f"-- Adding user_id column to {table_name}")
+            await sess.execute(text(f"ALTER TABLE {full_table} ADD COLUMN `user_id` {column_ddl}"))
+            applied = True
+
+        if not await _async_index_exists(sess, db_schema, table_name, index_name, db_type):
+            log_info(f"-- Adding index {index_name} on {table_name}")
+            await sess.execute(
+                text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {full_table} (`user_id`)")
+            )
+            applied = True
+
+        return applied
+
+
+def _migrate_sqlite_user_id(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Add the user_id column to the given table for SQLite."""
+    db_type = type(db).__name__
+    quoted_table = quote_db_identifier(db_type, table_name)
+    index_name = f"idx_{table_name}_user_id"
+    column_ddl = _user_id_column_ddl(db, table_type)
+
+    with db.Session() as sess, sess.begin():  # type: ignore
+        table_exists = sess.execute(
+            text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:table_name"),
+            {"table_name": table_name},
+        ).scalar()
+        if not table_exists:
+            log_info(f"Table {table_name} does not exist, skipping migration")
+            return False
+
+        applied = False
+
+        columns_info = sess.execute(text(f"PRAGMA table_info({quoted_table})")).fetchall()
+        if "user_id" not in {col[1] for col in columns_info}:
+            log_info(f"-- Adding user_id column to {table_name}")
+            sess.execute(text(f"ALTER TABLE {quoted_table} ADD COLUMN user_id {column_ddl}"))
+            applied = True
+
+        indexes = sess.execute(text(f"PRAGMA index_list({quoted_table})")).fetchall()
+        if index_name not in {idx[1] for idx in indexes}:
+            log_info(f"-- Adding index {index_name} on {table_name}")
+            sess.execute(text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {quoted_table} (user_id)"))
+            applied = True
+
+        return applied
+
+
+async def _migrate_async_sqlite_user_id(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Async SQLite variant of :func:`_migrate_sqlite_user_id`."""
+    db_type = type(db).__name__
+    quoted_table = quote_db_identifier(db_type, table_name)
+    index_name = f"idx_{table_name}_user_id"
+    column_ddl = _user_id_column_ddl(db, table_type)
+
+    async with db.async_session_factory() as sess, sess.begin():  # type: ignore
+        result = await sess.execute(
+            text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:table_name"),
+            {"table_name": table_name},
+        )
+        if not result.scalar():
+            log_info(f"Table {table_name} does not exist, skipping migration")
+            return False
+
+        applied = False
+
+        result = await sess.execute(text(f"PRAGMA table_info({quoted_table})"))
+        if "user_id" not in {col[1] for col in result.fetchall()}:
+            log_info(f"-- Adding user_id column to {table_name}")
+            await sess.execute(text(f"ALTER TABLE {quoted_table} ADD COLUMN user_id {column_ddl}"))
+            applied = True
+
+        result = await sess.execute(text(f"PRAGMA index_list({quoted_table})"))
+        if index_name not in {idx[1] for idx in result.fetchall()}:
+            log_info(f"-- Adding index {index_name} on {table_name}")
+            await sess.execute(
+                text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {quoted_table} (user_id)")
+            )
+            applied = True
+
+        return applied
+
+
+def _revert_postgres_user_id(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Drop the user_id column from the given table for PostgreSQL."""
+    db_schema = db.db_schema or "ai"  # type: ignore
+    db_type = type(db).__name__
+    quoted_schema = quote_db_identifier(db_type, db_schema)
+    full_table = f"{quoted_schema}.{quote_db_identifier(db_type, table_name)}"
+    index_name = f"idx_{table_name}_user_id"
+
+    with db.Session() as sess, sess.begin():  # type: ignore
+        table_exists = sess.execute(
+            text(
+                "SELECT EXISTS ("
+                "  SELECT FROM information_schema.tables"
+                "  WHERE table_schema = :schema AND table_name = :table_name"
+                ")"
+            ),
+            {"schema": db_schema, "table_name": table_name},
+        ).scalar()
+        if not table_exists:
+            log_info(f"Table {table_name} does not exist, skipping revert")
+            return False
+
+        applied = False
+
+        if _index_exists(sess, db_schema, table_name, index_name, db_type):
+            log_info(f"-- Dropping index {index_name} from {table_name}")
+            sess.execute(text(f"DROP INDEX {quoted_schema}.{quote_db_identifier(db_type, index_name)}"))
+            applied = True
+
+        if _column_exists(sess, db_schema, table_name, "user_id", db_type):
+            log_info(f"-- Dropping user_id column from {table_name}")
+            sess.execute(text(f"ALTER TABLE {full_table} DROP COLUMN user_id"))
+            applied = True
+
+        return applied
+
+
+async def _revert_async_postgres_user_id(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Async PostgreSQL variant of :func:`_revert_postgres_user_id`."""
+    db_schema = db.db_schema or "ai"  # type: ignore
+    db_type = type(db).__name__
+    quoted_schema = quote_db_identifier(db_type, db_schema)
+    full_table = f"{quoted_schema}.{quote_db_identifier(db_type, table_name)}"
+    index_name = f"idx_{table_name}_user_id"
+
+    async with db.async_session_factory() as sess, sess.begin():  # type: ignore
+        result = await sess.execute(
+            text(
+                "SELECT EXISTS ("
+                "  SELECT FROM information_schema.tables"
+                "  WHERE table_schema = :schema AND table_name = :table_name"
+                ")"
+            ),
+            {"schema": db_schema, "table_name": table_name},
+        )
+        if not result.scalar():
+            log_info(f"Table {table_name} does not exist, skipping revert")
+            return False
+
+        applied = False
+
+        if await _async_index_exists(sess, db_schema, table_name, index_name, db_type):
+            log_info(f"-- Dropping index {index_name} from {table_name}")
+            await sess.execute(text(f"DROP INDEX {quoted_schema}.{quote_db_identifier(db_type, index_name)}"))
+            applied = True
+
+        if await _async_column_exists(sess, db_schema, table_name, "user_id", db_type):
+            log_info(f"-- Dropping user_id column from {table_name}")
+            await sess.execute(text(f"ALTER TABLE {full_table} DROP COLUMN user_id"))
+            applied = True
+
+        return applied
+
+
+def _revert_mysql_like_user_id(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Drop the user_id column from the given table for MySQL or SingleStore."""
+    db_type = type(db).__name__
+    index_name = f"idx_{table_name}_user_id"
+
+    with db.Session() as sess, sess.begin():  # type: ignore
+        # SingleStore leaves db_schema as None and uses the connection's database
+        db_schema = db.db_schema or sess.execute(text("SELECT DATABASE()")).scalar()  # type: ignore
+        quoted_schema = quote_db_identifier(db_type, db_schema)
+        full_table = f"{quoted_schema}.{quote_db_identifier(db_type, table_name)}"
+
+        table_exists = sess.execute(
+            text(
+                "SELECT EXISTS ("
+                "  SELECT 1 FROM INFORMATION_SCHEMA.TABLES"
+                "  WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table_name"
+                ")"
+            ),
+            {"schema": db_schema, "table_name": table_name},
+        ).scalar()
+        if not table_exists:
+            log_info(f"Table {table_name} does not exist, skipping revert")
+            return False
+
+        applied = False
+
+        dropped_index = False
+        if _index_exists(sess, db_schema, table_name, index_name, db_type):
+            log_info(f"-- Dropping index {index_name} from {table_name}")
+            sess.execute(text(f"DROP INDEX {quote_db_identifier(db_type, index_name)} ON {full_table}"))
+            dropped_index = True
+            applied = True
+
+        if _column_exists(sess, db_schema, table_name, "user_id", db_type):
+            log_info(f"-- Dropping user_id column from {table_name}")
+            try:
+                sess.execute(text(f"ALTER TABLE {full_table} DROP COLUMN `user_id`"))
+            except Exception:
+                # MySQL and SingleStore commit DDL immediately, so the index drop
+                # above already stuck. Put it back rather than leave the column in
+                # place but unindexed.
+                if dropped_index:
+                    sess.execute(
+                        text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {full_table} (`user_id`)")
+                    )
+                raise
+            applied = True
+
+        return applied
+
+
+async def _revert_async_mysql_user_id(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Async MySQL variant of :func:`_revert_mysql_like_user_id`."""
+    db_type = type(db).__name__
+    index_name = f"idx_{table_name}_user_id"
+
+    async with db.async_session_factory() as sess, sess.begin():  # type: ignore
+        db_schema = db.db_schema or (await sess.execute(text("SELECT DATABASE()"))).scalar()  # type: ignore
+        quoted_schema = quote_db_identifier(db_type, db_schema)
+        full_table = f"{quoted_schema}.{quote_db_identifier(db_type, table_name)}"
+
+        table_exists = (
+            await sess.execute(
+                text(
+                    "SELECT EXISTS ("
+                    "  SELECT 1 FROM INFORMATION_SCHEMA.TABLES"
+                    "  WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table_name"
+                    ")"
+                ),
+                {"schema": db_schema, "table_name": table_name},
+            )
+        ).scalar()
+        if not table_exists:
+            log_info(f"Table {table_name} does not exist, skipping revert")
+            return False
+
+        applied = False
+
+        dropped_index = False
+        if await _async_index_exists(sess, db_schema, table_name, index_name, db_type):
+            log_info(f"-- Dropping index {index_name} from {table_name}")
+            await sess.execute(text(f"DROP INDEX {quote_db_identifier(db_type, index_name)} ON {full_table}"))
+            dropped_index = True
+            applied = True
+
+        if await _async_column_exists(sess, db_schema, table_name, "user_id", db_type):
+            log_info(f"-- Dropping user_id column from {table_name}")
+            try:
+                await sess.execute(text(f"ALTER TABLE {full_table} DROP COLUMN `user_id`"))
+            except Exception:
+                # MySQL commits DDL immediately, so the index drop above already
+                # stuck. Put it back rather than leave the column in place but
+                # unindexed.
+                if dropped_index:
+                    await sess.execute(
+                        text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {full_table} (`user_id`)")
+                    )
+                raise
+            applied = True
+
+        return applied
+
+
+def _revert_sqlite_user_id(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Drop the user_id column from the given table for SQLite.
+
+    ``DROP COLUMN`` needs SQLite 3.35+, and the index has to go first because
+    SQLite refuses to drop a column an index still references.
+    """
+    db_type = type(db).__name__
+    quoted_table = quote_db_identifier(db_type, table_name)
+    index_name = f"idx_{table_name}_user_id"
+
+    with db.Session() as sess, sess.begin():  # type: ignore
+        table_exists = sess.execute(
+            text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:table_name"),
+            {"table_name": table_name},
+        ).scalar()
+        if not table_exists:
+            log_info(f"Table {table_name} does not exist, skipping revert")
+            return False
+
+        import sqlite3
+
+        # DROP COLUMN landed in SQLite 3.35.0. Skip rather than drop the index
+        # and then fail on the column, which would leave user_id unindexed.
+        if sqlite3.sqlite_version_info < (3, 35, 0):
+            log_info(f"SQLite revert for {table_name}: DROP COLUMN needs SQLite >= 3.35.0, skipping")
+            return False
+
+        applied = False
+
+        dropped_index = False
+        indexes = sess.execute(text(f"PRAGMA index_list({quoted_table})")).fetchall()
+        if index_name in {idx[1] for idx in indexes}:
+            log_info(f"-- Dropping index {index_name} from {table_name}")
+            sess.execute(text(f"DROP INDEX {quote_db_identifier(db_type, index_name)}"))
+            dropped_index = True
+            applied = True
+
+        columns_info = sess.execute(text(f"PRAGMA table_info({quoted_table})")).fetchall()
+        if "user_id" in {col[1] for col in columns_info}:
+            log_info(f"-- Dropping user_id column from {table_name}")
+            try:
+                sess.execute(text(f"ALTER TABLE {quoted_table} DROP COLUMN user_id"))
+            except Exception:
+                # SQLite commits DDL outside the session transaction, so the index
+                # drop above already stuck. Put it back rather than leave the column
+                # in place but unindexed.
+                if dropped_index:
+                    sess.execute(
+                        text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {quoted_table} (user_id)")
+                    )
+                raise
+            applied = True
+
+        return applied
+
+
+async def _revert_async_sqlite_user_id(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Async SQLite variant of :func:`_revert_sqlite_user_id`."""
+    db_type = type(db).__name__
+    quoted_table = quote_db_identifier(db_type, table_name)
+    index_name = f"idx_{table_name}_user_id"
+
+    async with db.async_session_factory() as sess, sess.begin():  # type: ignore
+        result = await sess.execute(
+            text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:table_name"),
+            {"table_name": table_name},
+        )
+        if not result.scalar():
+            log_info(f"Table {table_name} does not exist, skipping revert")
+            return False
+
+        import sqlite3
+
+        # DROP COLUMN landed in SQLite 3.35.0. Skip rather than drop the index
+        # and then fail on the column, which would leave user_id unindexed.
+        if sqlite3.sqlite_version_info < (3, 35, 0):
+            log_info(f"SQLite revert for {table_name}: DROP COLUMN needs SQLite >= 3.35.0, skipping")
+            return False
+
+        applied = False
+
+        result = await sess.execute(text(f"PRAGMA index_list({quoted_table})"))
+        dropped_index = False
+        if index_name in {idx[1] for idx in result.fetchall()}:
+            log_info(f"-- Dropping index {index_name} from {table_name}")
+            await sess.execute(text(f"DROP INDEX {quote_db_identifier(db_type, index_name)}"))
+            dropped_index = True
+            applied = True
+
+        result = await sess.execute(text(f"PRAGMA table_info({quoted_table})"))
+        if "user_id" in {col[1] for col in result.fetchall()}:
+            log_info(f"-- Dropping user_id column from {table_name}")
+            try:
+                await sess.execute(text(f"ALTER TABLE {quoted_table} DROP COLUMN user_id"))
+            except Exception:
+                # SQLite commits DDL outside the session transaction, so the index
+                # drop above already stuck. Put it back rather than leave the column
+                # in place but unindexed.
+                if dropped_index:
+                    await sess.execute(
+                        text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {quoted_table} (user_id)")
+                    )
+                raise
+            applied = True
+
+        return applied

--- a/libs/agno/agno/db/migrations/versions/v3_0_0.py
+++ b/libs/agno/agno/db/migrations/versions/v3_0_0.py
@@ -21,9 +21,12 @@ rows keep a NULL user_id, so they stay visible to admins and to unscoped
 deployments while a scoped caller sees none of them. Document backends store
 these records as documents and pick the field up without a schema change.
 
-To isolate another table, declare user_id on that table in each adapter schema
-and add its table type to ``USER_ID_TABLE_TYPES`` — the per-backend functions
-read the column type from the schema, so they need no change.
+To isolate another table, declare user_id on that table in the adapter schemas
+that have it, register the table type in ``MigrationManager`` and add it to
+``USER_ID_TABLE_TYPES`` — the per-backend functions read the column type from
+the schema, so they need no change. A backend whose schema does not declare the
+column is skipped, so a table type that only some adapters support is safe to
+list here.
 """
 
 import json
@@ -45,9 +48,9 @@ BATCH_SIZE = 50
 
 
 # Table types that get a user_id column and index, so AgentOS can scope them per user.
-# Extend this tuple to isolate another table whose schema already declares user_id;
-# the per-backend functions need no change.
-USER_ID_TABLE_TYPES = ("evals",)
+# Extend this tuple to isolate another table; the per-backend functions need no change,
+# and backends whose schema does not declare the column skip it.
+USER_ID_TABLE_TYPES = ("evals", "components")
 
 
 def up(db: BaseDb, table_type: str, table_name: str) -> bool:
@@ -981,13 +984,14 @@ def _migrate_mysql_like_sessions(db: BaseDb, table_name: str) -> bool:
 
 async def _migrate_async_mysql_sessions(db: AsyncBaseDb, table_name: str) -> bool:
     """Async MySQL variant of :func:`_migrate_mysql_like_sessions`."""
-    db_schema = db.db_schema or "agno"  # type: ignore
-
     runs_table = await db._get_table(table_type="runs", create_table_if_not_found=True)  # type: ignore
     if runs_table is None:
         return False
 
     async with db.async_session_factory() as sess, sess.begin():  # type: ignore
+        # SingleStore leaves db_schema as None and uses the connection's database
+        db_schema = db.db_schema or (await sess.execute(text("SELECT DATABASE()"))).scalar()  # type: ignore
+
         table_exists = (
             await sess.execute(
                 text(
@@ -1108,10 +1112,12 @@ def _revert_mysql_like_sessions(db: BaseDb, table_name: str) -> bool:
 
 async def _revert_async_mysql_sessions(db: AsyncBaseDb, table_name: str) -> bool:
     """Async MySQL variant of :func:`_revert_mysql_like_sessions`."""
-    db_schema = db.db_schema or "agno"  # type: ignore
     runs_table_name = db.runs_table_name  # type: ignore
 
     async with db.async_session_factory() as sess, sess.begin():  # type: ignore
+        # SingleStore leaves db_schema as None and uses the connection's database
+        db_schema = db.db_schema or (await sess.execute(text("SELECT DATABASE()"))).scalar()  # type: ignore
+
         runs_table_exists = (
             await sess.execute(
                 text(
@@ -2127,11 +2133,16 @@ def _revert_surrealdb(db: BaseDb, table_type: str, table_name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _user_id_column_ddl(db, table_type: str) -> str:
+def _user_id_column_ddl(db, table_type: str) -> Optional[str]:
     """Compile the user_id column type from the adapter's own schema for this table.
 
     Keeps a migrated table identical to one created fresh from the schema, so a
     later migration reading INFORMATION_SCHEMA sees the same type either way.
+
+    Returns None when this adapter's schema has no such table, or has it without a
+    user_id column. Not every table type exists on every backend, and the SQL
+    adapters report an unknown table as version 2.0.0 rather than None, so the
+    migration is attempted there and has to bow out on its own.
     """
     db_type = type(db).__name__
 
@@ -2145,7 +2156,10 @@ def _user_id_column_ddl(db, table_type: str) -> str:
     else:
         from agno.db.sqlite import schemas
 
-    column_type = schemas.get_table_schema_definition(table_type)["user_id"]["type"]
+    try:
+        column_type = schemas.get_table_schema_definition(table_type)["user_id"]["type"]
+    except (ValueError, KeyError):
+        return None
     return column_type().compile(dialect=db.db_engine.dialect)
 
 
@@ -2157,6 +2171,8 @@ def _migrate_postgres_user_id(db: BaseDb, table_type: str, table_name: str) -> b
     full_table = f"{quoted_schema}.{quote_db_identifier(db_type, table_name)}"
     index_name = f"idx_{table_name}_user_id"
     column_ddl = _user_id_column_ddl(db, table_type)
+    if column_ddl is None:
+        return False
 
     with db.Session() as sess, sess.begin():  # type: ignore
         table_exists = sess.execute(
@@ -2195,6 +2211,8 @@ async def _migrate_async_postgres_user_id(db: AsyncBaseDb, table_type: str, tabl
     full_table = f"{quoted_schema}.{quote_db_identifier(db_type, table_name)}"
     index_name = f"idx_{table_name}_user_id"
     column_ddl = _user_id_column_ddl(db, table_type)
+    if column_ddl is None:
+        return False
 
     async with db.async_session_factory() as sess, sess.begin():  # type: ignore
         result = await sess.execute(
@@ -2232,6 +2250,8 @@ def _migrate_mysql_like_user_id(db: BaseDb, table_type: str, table_name: str) ->
     db_type = type(db).__name__
     index_name = f"idx_{table_name}_user_id"
     column_ddl = _user_id_column_ddl(db, table_type)
+    if column_ddl is None:
+        return False
 
     with db.Session() as sess, sess.begin():  # type: ignore
         # SingleStore leaves db_schema as None and uses the connection's database
@@ -2272,6 +2292,8 @@ async def _migrate_async_mysql_user_id(db: AsyncBaseDb, table_type: str, table_n
     db_type = type(db).__name__
     index_name = f"idx_{table_name}_user_id"
     column_ddl = _user_id_column_ddl(db, table_type)
+    if column_ddl is None:
+        return False
 
     async with db.async_session_factory() as sess, sess.begin():  # type: ignore
         db_schema = db.db_schema or (await sess.execute(text("SELECT DATABASE()"))).scalar()  # type: ignore
@@ -2316,6 +2338,8 @@ def _migrate_sqlite_user_id(db: BaseDb, table_type: str, table_name: str) -> boo
     quoted_table = quote_db_identifier(db_type, table_name)
     index_name = f"idx_{table_name}_user_id"
     column_ddl = _user_id_column_ddl(db, table_type)
+    if column_ddl is None:
+        return False
 
     with db.Session() as sess, sess.begin():  # type: ignore
         table_exists = sess.execute(
@@ -2349,6 +2373,8 @@ async def _migrate_async_sqlite_user_id(db: AsyncBaseDb, table_type: str, table_
     quoted_table = quote_db_identifier(db_type, table_name)
     index_name = f"idx_{table_name}_user_id"
     column_ddl = _user_id_column_ddl(db, table_type)
+    if column_ddl is None:
+        return False
 
     async with db.async_session_factory() as sess, sess.begin():  # type: ignore
         result = await sess.execute(

--- a/libs/agno/agno/db/migrations/versions/v3_0_0.py
+++ b/libs/agno/agno/db/migrations/versions/v3_0_0.py
@@ -50,7 +50,10 @@ BATCH_SIZE = 50
 # Table types that get a user_id column and index, so AgentOS can scope them per user.
 # Extend this tuple to isolate another table; the per-backend functions need no change,
 # and backends whose schema does not declare the column skip it.
-USER_ID_TABLE_TYPES = ("evals", "components")
+# - knowledge: declared on Postgres, SQLite, MySQL and SingleStore
+# - schedules / schedule_runs: declared on Postgres and SQLite (the only adapters
+#   with schedule schemas)
+USER_ID_TABLE_TYPES = ("evals", "components", "knowledge", "schedules", "schedule_runs")
 
 
 def up(db: BaseDb, table_type: str, table_name: str) -> bool:
@@ -2163,6 +2166,38 @@ def _user_id_column_ddl(db, table_type: str) -> Optional[str]:
     return column_type().compile(dialect=db.db_engine.dialect)
 
 
+def _user_id_composite_indexes(db, table_type: str, table_name: str) -> List[tuple]:
+    """Schema-declared composite indexes that include user_id, as (name, columns).
+
+    These cannot predate the column, so the migration creates them too — a
+    migrated table stays identical to one created fresh from the schema (the
+    schedules listing path, for one, relies on its (user_id, enabled,
+    next_run_at) index). The names follow the adapters' composite-index
+    convention: ``idx_{table}_{columns joined with _}``.
+    """
+    db_type = type(db).__name__
+
+    schemas: Any
+    if db_type in ("PostgresDb", "AsyncPostgresDb"):
+        from agno.db.postgres import schemas
+    elif db_type in ("MySQLDb", "AsyncMySQLDb"):
+        from agno.db.mysql import schemas
+    elif db_type == "SingleStoreDb":
+        from agno.db.singlestore import schemas
+    else:
+        from agno.db.sqlite import schemas
+
+    try:
+        composites = schemas.get_table_schema_definition(table_type).get("__composite_indexes__", [])
+    except (ValueError, KeyError):
+        return []
+    return [
+        (f"idx_{table_name}_{'_'.join(idx['columns'])}", list(idx["columns"]))
+        for idx in composites
+        if "user_id" in idx["columns"]
+    ]
+
+
 def _migrate_postgres_user_id(db: BaseDb, table_type: str, table_name: str) -> bool:
     """Add the user_id column to the given table for PostgreSQL."""
     db_schema = db.db_schema or "ai"  # type: ignore
@@ -2199,6 +2234,20 @@ def _migrate_postgres_user_id(db: BaseDb, table_type: str, table_name: str) -> b
             log_info(f"-- Adding index {index_name} on {table_name}")
             sess.execute(text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {full_table} (user_id)"))
             applied = True
+
+        for comp_name, comp_cols in _user_id_composite_indexes(db, table_type, table_name):
+            # A composite can reference other v3-only columns (e.g. linked_to)
+            # that a legacy table doesn't have yet — skip until they exist.
+            if not all(c == "user_id" or _column_exists(sess, db_schema, table_name, c, db_type) for c in comp_cols):
+                continue
+            if not _index_exists(sess, db_schema, table_name, comp_name, db_type):
+                log_info(f"-- Adding index {comp_name} on {table_name}")
+                sess.execute(
+                    text(
+                        f"CREATE INDEX {quote_db_identifier(db_type, comp_name)} ON {full_table} ({', '.join(comp_cols)})"
+                    )
+                )
+                applied = True
 
         return applied
 
@@ -2241,6 +2290,25 @@ async def _migrate_async_postgres_user_id(db: AsyncBaseDb, table_type: str, tabl
                 text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {full_table} (user_id)")
             )
             applied = True
+
+        for comp_name, comp_cols in _user_id_composite_indexes(db, table_type, table_name):
+            # A composite can reference other v3-only columns (e.g. linked_to)
+            # that a legacy table doesn't have yet — skip until they exist.
+            cols_present = True
+            for c in comp_cols:
+                if c != "user_id" and not await _async_column_exists(sess, db_schema, table_name, c, db_type):
+                    cols_present = False
+                    break
+            if not cols_present:
+                continue
+            if not await _async_index_exists(sess, db_schema, table_name, comp_name, db_type):
+                log_info(f"-- Adding index {comp_name} on {table_name}")
+                await sess.execute(
+                    text(
+                        f"CREATE INDEX {quote_db_identifier(db_type, comp_name)} ON {full_table} ({', '.join(comp_cols)})"
+                    )
+                )
+                applied = True
 
         return applied
 
@@ -2359,10 +2427,26 @@ def _migrate_sqlite_user_id(db: BaseDb, table_type: str, table_name: str) -> boo
             applied = True
 
         indexes = sess.execute(text(f"PRAGMA index_list({quoted_table})")).fetchall()
-        if index_name not in {idx[1] for idx in indexes}:
+        existing_indexes = {idx[1] for idx in indexes}
+        if index_name not in existing_indexes:
             log_info(f"-- Adding index {index_name} on {table_name}")
             sess.execute(text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {quoted_table} (user_id)"))
             applied = True
+
+        table_columns = {col[1] for col in columns_info} | {"user_id"}
+        for comp_name, comp_cols in _user_id_composite_indexes(db, table_type, table_name):
+            # A composite can reference other v3-only columns (e.g. linked_to)
+            # that a legacy table doesn't have yet — skip until they exist.
+            if not all(c in table_columns for c in comp_cols):
+                continue
+            if comp_name not in existing_indexes:
+                log_info(f"-- Adding index {comp_name} on {table_name}")
+                sess.execute(
+                    text(
+                        f"CREATE INDEX {quote_db_identifier(db_type, comp_name)} ON {quoted_table} ({', '.join(comp_cols)})"
+                    )
+                )
+                applied = True
 
         return applied
 
@@ -2394,12 +2478,29 @@ async def _migrate_async_sqlite_user_id(db: AsyncBaseDb, table_type: str, table_
             applied = True
 
         result = await sess.execute(text(f"PRAGMA index_list({quoted_table})"))
-        if index_name not in {idx[1] for idx in result.fetchall()}:
+        existing_indexes = {idx[1] for idx in result.fetchall()}
+        if index_name not in existing_indexes:
             log_info(f"-- Adding index {index_name} on {table_name}")
             await sess.execute(
                 text(f"CREATE INDEX {quote_db_identifier(db_type, index_name)} ON {quoted_table} (user_id)")
             )
             applied = True
+
+        result = await sess.execute(text(f"PRAGMA table_info({quoted_table})"))
+        table_columns = {col[1] for col in result.fetchall()} | {"user_id"}
+        for comp_name, comp_cols in _user_id_composite_indexes(db, table_type, table_name):
+            # A composite can reference other v3-only columns (e.g. linked_to)
+            # that a legacy table doesn't have yet — skip until they exist.
+            if not all(c in table_columns for c in comp_cols):
+                continue
+            if comp_name not in existing_indexes:
+                log_info(f"-- Adding index {comp_name} on {table_name}")
+                await sess.execute(
+                    text(
+                        f"CREATE INDEX {quote_db_identifier(db_type, comp_name)} ON {quoted_table} ({', '.join(comp_cols)})"
+                    )
+                )
+                applied = True
 
         return applied
 
@@ -2612,7 +2713,15 @@ def _revert_sqlite_user_id(db: BaseDb, table_type: str, table_name: str) -> bool
 
         dropped_index = False
         indexes = sess.execute(text(f"PRAGMA index_list({quoted_table})")).fetchall()
-        if index_name in {idx[1] for idx in indexes}:
+        existing_indexes = {idx[1] for idx in indexes}
+        # Composite indexes referencing user_id must go before the column:
+        # SQLite refuses to drop a column a multi-column index still covers.
+        for comp_name, _comp_cols in _user_id_composite_indexes(db, table_type, table_name):
+            if comp_name in existing_indexes:
+                log_info(f"-- Dropping index {comp_name} from {table_name}")
+                sess.execute(text(f"DROP INDEX {quote_db_identifier(db_type, comp_name)}"))
+                applied = True
+        if index_name in existing_indexes:
             log_info(f"-- Dropping index {index_name} from {table_name}")
             sess.execute(text(f"DROP INDEX {quote_db_identifier(db_type, index_name)}"))
             dropped_index = True
@@ -2663,8 +2772,16 @@ async def _revert_async_sqlite_user_id(db: AsyncBaseDb, table_type: str, table_n
         applied = False
 
         result = await sess.execute(text(f"PRAGMA index_list({quoted_table})"))
+        existing_indexes = {idx[1] for idx in result.fetchall()}
         dropped_index = False
-        if index_name in {idx[1] for idx in result.fetchall()}:
+        # Composite indexes referencing user_id must go before the column:
+        # SQLite refuses to drop a column a multi-column index still covers.
+        for comp_name, _comp_cols in _user_id_composite_indexes(db, table_type, table_name):
+            if comp_name in existing_indexes:
+                log_info(f"-- Dropping index {comp_name} from {table_name}")
+                await sess.execute(text(f"DROP INDEX {quote_db_identifier(db_type, comp_name)}"))
+                applied = True
+        if index_name in existing_indexes:
             log_info(f"-- Dropping index {index_name} from {table_name}")
             await sess.execute(text(f"DROP INDEX {quote_db_identifier(db_type, index_name)}"))
             dropped_index = True

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -575,15 +575,15 @@ class AsyncMongoDb(AsyncBaseDb):
             aggregate_cursor_or_coro = await aggregate_cursor_or_coro
         return await aggregate_cursor_or_coro.to_list(length=length)
 
-    def get_latest_schema_version(self, table_name: str = "") -> Optional[str]:
+    async def get_latest_schema_version(self, table_name: str = "") -> Optional[str]:
         """Get the latest version of the database schema.
 
         ``table_name`` is accepted for parity with the SQL adapters and the
-        ``BaseDb`` contract; MongoDB is schemaless so it is ignored.
+        ``AsyncBaseDb`` contract; MongoDB is schemaless so it is ignored.
         """
         return None
 
-    def upsert_schema_version(self, table_name: str = "", version: str = "") -> None:
+    async def upsert_schema_version(self, table_name: str = "", version: str = "") -> None:
         """Upsert the schema version. ``table_name`` is ignored — see
         ``get_latest_schema_version``."""
         pass
@@ -645,7 +645,7 @@ class AsyncMongoDb(AsyncBaseDb):
                 {"$sort": {"_ri": -1, "_ca": -1}},
                 {"$limit": limit},
             ]
-            docs = await runs_collection.aggregate(pipeline).to_list(length=limit)
+            docs = await self._aggregate_to_list(runs_collection, pipeline, length=limit)
             run_docs = [doc["run_data"] for doc in docs if "run_data" in doc]
             run_docs.reverse()  # back to chronological order
             return run_docs
@@ -655,7 +655,7 @@ class AsyncMongoDb(AsyncBaseDb):
             {"$addFields": {"_ri": {"$ifNull": ["$run_index", 0]}, "_ca": {"$ifNull": ["$created_at", 0]}}},
             {"$sort": {"_ri": 1, "_ca": 1}},
         ]
-        docs = await runs_collection.aggregate(pipeline).to_list(length=None)
+        docs = await self._aggregate_to_list(runs_collection, pipeline, length=None)
         return [doc["run_data"] for doc in docs if "run_data" in doc]
 
     async def _get_sessions_runs_docs(

--- a/libs/agno/agno/db/mongo/schemas.py
+++ b/libs/agno/agno/db/mongo/schemas.py
@@ -49,6 +49,7 @@ EVAL_COLLECTION_SCHEMA = [
     {"key": "team_id"},
     {"key": "workflow_id"},
     {"key": "model_id"},
+    {"key": "user_id"},
     {"key": "created_at"},
     {"key": "updated_at"},
 ]

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -110,6 +110,7 @@ class AsyncPostgresDb(AsyncBaseDb):
         traces_table: Optional[str] = None,
         spans_table: Optional[str] = None,
         versions_table: Optional[str] = None,
+        components_table: Optional[str] = None,
         learnings_table: Optional[str] = None,
         schedules_table: Optional[str] = None,
         schedule_runs_table: Optional[str] = None,
@@ -151,6 +152,7 @@ class AsyncPostgresDb(AsyncBaseDb):
             traces_table (Optional[str]): Name of the table to store run traces.
             spans_table (Optional[str]): Name of the table to store span events.
             versions_table (Optional[str]): Name of the table to store schema versions.
+            components_table (Optional[str]): Name of the table to store components.
             learnings_table (Optional[str]): Name of the table to store learnings.
             schedules_table (Optional[str]): Name of the table to store cron schedules.
             schedule_runs_table (Optional[str]): Name of the table to store schedule run history.
@@ -174,6 +176,7 @@ class AsyncPostgresDb(AsyncBaseDb):
             traces_table=traces_table,
             spans_table=spans_table,
             versions_table=versions_table,
+            components_table=components_table,
             learnings_table=learnings_table,
             schedules_table=schedules_table,
             schedule_runs_table=schedule_runs_table,

--- a/libs/agno/agno/db/postgres/schemas.py
+++ b/libs/agno/agno/db/postgres/schemas.py
@@ -114,6 +114,13 @@ KNOWLEDGE_TABLE_SCHEMA = {
     # ``(user_id = :uid OR user_id IS NULL)`` so the listing endpoint
     # (/knowledge/config) only surfaces the caller's content + shared rows.
     "user_id": {"type": String, "nullable": True, "index": True},
+    "__composite_indexes__": [
+        # Routes list "my content + shared" using
+        # ``WHERE (user_id = :uid OR user_id IS NULL) AND linked_to = :name``
+        # — covering both predicates speeds that up materially. Mirrors the
+        # SQLite schema, which already declares this index.
+        {"name": "ix_knowledge_user_linked_to", "columns": ["user_id", "linked_to"]},
+    ],
 }
 
 METRICS_TABLE_SCHEMA = {

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -327,15 +327,17 @@ class SingleStoreDb(BaseDb):
 
                         # Add primary key and shard key. The runs table is sharded by
                         # session_id (not run_id) so that all runs for a session live on
-                        # the same partition — keeps session reads cheap.
+                        # the same partition — keeps session reads cheap. SingleStore
+                        # requires every unique key to contain the whole shard key, so
+                        # the runs primary key carries session_id next to run_id.
                         if table_type == "sessions":
-                            pk_col, shard_col = "session_id", "session_id"
+                            pk_cols, shard_col = "session_id", "session_id"
                         else:
-                            pk_col, shard_col = "run_id", "session_id"
+                            pk_cols, shard_col = "run_id, session_id", "session_id"
 
                         table_sql = f"""CREATE TABLE IF NOT EXISTS {table_ref} (
                             {columns_def},
-                            PRIMARY KEY ({pk_col}),
+                            PRIMARY KEY ({pk_cols}),
                             SHARD KEY ({shard_col})
                         )"""
 

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -78,6 +78,7 @@ class AsyncSqliteDb(AsyncBaseDb):
         traces_table: Optional[str] = None,
         spans_table: Optional[str] = None,
         versions_table: Optional[str] = None,
+        components_table: Optional[str] = None,
         learnings_table: Optional[str] = None,
         schedules_table: Optional[str] = None,
         schedule_runs_table: Optional[str] = None,
@@ -109,6 +110,7 @@ class AsyncSqliteDb(AsyncBaseDb):
             traces_table (Optional[str]): Name of the table to store run traces.
             spans_table (Optional[str]): Name of the table to store span events.
             versions_table (Optional[str]): Name of the table to store schema versions.
+            components_table (Optional[str]): Name of the table to store components.
             learnings_table (Optional[str]): Name of the table to store learning records.
             schedules_table (Optional[str]): Name of the table to store cron schedules.
             schedule_runs_table (Optional[str]): Name of the table to store schedule run history.
@@ -133,6 +135,7 @@ class AsyncSqliteDb(AsyncBaseDb):
             traces_table=traces_table,
             spans_table=spans_table,
             versions_table=versions_table,
+            components_table=components_table,
             learnings_table=learnings_table,
             schedules_table=schedules_table,
             schedule_runs_table=schedule_runs_table,

--- a/libs/agno/agno/db/valkey/valkey.py
+++ b/libs/agno/agno/db/valkey/valkey.py
@@ -2132,11 +2132,12 @@ class ValkeyDb(BaseDb):
             log_error(f"Error deleting eval run {eval_run_id}: {str(e)}")
             raise
 
-    def delete_eval_runs(self, eval_run_ids: List[str]) -> None:
+    def delete_eval_runs(self, eval_run_ids: List[str], user_id: Optional[str] = None) -> None:
         """Delete multiple eval runs from Valkey using GLIDE Batch (pipeline) for reduced round trips.
 
         Args:
             eval_run_ids (List[str]): The IDs of the eval runs to delete.
+            user_id (Optional[str]): If set, only delete runs owned by this user.
 
         Raises:
             Exception: If any error occurs while deleting the eval runs.
@@ -2172,6 +2173,9 @@ class ValkeyDb(BaseDb):
 
                 record_data = deserialize_data(raw_str)
 
+                if user_id is not None and record_data.get("user_id") != user_id:
+                    continue
+
                 # Remove index entries
                 for field in index_fields:
                     if field in record_data and record_data[field] is not None:
@@ -2194,12 +2198,13 @@ class ValkeyDb(BaseDb):
             raise
 
     def get_eval_run(
-        self, eval_run_id: str, deserialize: Optional[bool] = True
+        self, eval_run_id: str, deserialize: Optional[bool] = True, user_id: Optional[str] = None
     ) -> Optional[Union[EvalRunRecord, Dict[str, Any]]]:
         """Get an eval run from Valkey.
 
         Args:
             eval_run_id (str): The ID of the eval run to get.
+            user_id (Optional[str]): If set, only return the run if owned by this user.
 
         Returns:
             Optional[EvalRunRecord]: The eval run if found, None otherwise.
@@ -2210,6 +2215,9 @@ class ValkeyDb(BaseDb):
         try:
             eval_run_raw = self._get_record("evals", eval_run_id)
             if eval_run_raw is None:
+                return None
+
+            if user_id is not None and eval_run_raw.get("user_id") != user_id:
                 return None
 
             if not deserialize:
@@ -2234,6 +2242,7 @@ class ValkeyDb(BaseDb):
         filter_type: Optional[EvalFilterType] = None,
         eval_type: Optional[List[EvalType]] = None,
         deserialize: Optional[bool] = True,
+        user_id: Optional[str] = None,
     ) -> Union[List[EvalRunRecord], Tuple[List[Dict[str, Any]], int]]:
         """Get all eval runs from Valkey.
 
@@ -2255,6 +2264,9 @@ class ValkeyDb(BaseDb):
             # Apply filters
             filtered_runs = []
             for run in all_eval_runs:
+                if user_id is not None and run.get("user_id") != user_id:
+                    continue
+
                 # Agent/team/workflow filters
                 if agent_id is not None and run.get("agent_id") != agent_id:
                     continue
@@ -2298,13 +2310,14 @@ class ValkeyDb(BaseDb):
             raise e
 
     def rename_eval_run(
-        self, eval_run_id: str, name: str, deserialize: Optional[bool] = True
+        self, eval_run_id: str, name: str, deserialize: Optional[bool] = True, user_id: Optional[str] = None
     ) -> Optional[Union[EvalRunRecord, Dict[str, Any]]]:
         """Update the name of an eval run in Valkey.
 
         Args:
             eval_run_id (str): The ID of the eval run to rename.
             name (str): The new name of the eval run.
+            user_id (Optional[str]): If set, only rename the run if owned by this user.
 
         Returns:
             Optional[Dict[str, Any]]: The updated eval run data if successful, None otherwise.
@@ -2315,6 +2328,9 @@ class ValkeyDb(BaseDb):
         try:
             eval_run_data = self._get_record("evals", eval_run_id)
             if eval_run_data is None:
+                return None
+
+            if user_id is not None and eval_run_data.get("user_id") != user_id:
                 return None
 
             eval_run_data["name"] = name
@@ -2333,6 +2349,25 @@ class ValkeyDb(BaseDb):
 
         except Exception as e:
             log_error(f"Error updating eval run name {eval_run_id}: {str(e)}")
+            raise
+
+    def update_eval_run_user_id(self, eval_run_id: str, user_id: str) -> None:
+        """Set the owner (user_id) on an existing eval run.
+
+        Args:
+            eval_run_id (str): The ID of the eval run to update.
+            user_id (str): The owner to set.
+        """
+        try:
+            eval_run_data = self._get_record("evals", eval_run_id)
+            if eval_run_data is None:
+                return
+
+            eval_run_data["user_id"] = user_id
+            self._store_record("evals", eval_run_id, eval_run_data)
+
+        except Exception as e:
+            log_error(f"Error setting owner on eval run {eval_run_id}: {str(e)}")
             raise
 
     # -- Cultural Knowledge methods --

--- a/libs/agno/tests/integration/db/postgres/test_migration_merge_order.py
+++ b/libs/agno/tests/integration/db/postgres/test_migration_merge_order.py
@@ -180,7 +180,7 @@ class TestPartialMigrationMergeOrder:
         legacy blob. get_session() must return [r0, r1, r2, r3]."""
         _seed_v2_session(postgres_db_real, ["r0", "r1", "r2", "r3"])
 
-        migrated = v3_0_0._migrate_postgres(postgres_db_real, "test_sessions")
+        migrated = v3_0_0._migrate_postgres(postgres_db_real, "sessions", "test_sessions")
         assert migrated is True
 
         assert set(_get_runs_table_ids(postgres_db_real)) == {"r0", "r1", "r2", "r3"}
@@ -200,7 +200,7 @@ class TestPartialMigrationMergeOrder:
     def test_leading_run_only_in_table(self, postgres_db_real: PostgresDb):
         """Only r0 in the runs table; r1, r2, r3 in blob only."""
         _seed_v2_session(postgres_db_real, ["r0", "r1", "r2", "r3"])
-        v3_0_0._migrate_postgres(postgres_db_real, "test_sessions")
+        v3_0_0._migrate_postgres(postgres_db_real, "sessions", "test_sessions")
         _delete_runs_from_table(postgres_db_real, ["r1", "r2", "r3"])
 
         merged = _read_merged_runs(postgres_db_real)
@@ -210,7 +210,7 @@ class TestPartialMigrationMergeOrder:
     def test_trailing_run_only_in_table(self, postgres_db_real: PostgresDb):
         """Only r3 in the runs table; r0, r1, r2 in blob only."""
         _seed_v2_session(postgres_db_real, ["r0", "r1", "r2", "r3"])
-        v3_0_0._migrate_postgres(postgres_db_real, "test_sessions")
+        v3_0_0._migrate_postgres(postgres_db_real, "sessions", "test_sessions")
         _delete_runs_from_table(postgres_db_real, ["r0", "r1", "r2"])
 
         merged = _read_merged_runs(postgres_db_real)
@@ -222,7 +222,7 @@ class TestPartialMigrationMergeOrder:
         counterpart in the legacy blob) is by definition newer than everything
         the blob knew about — it should appear at the tail."""
         _seed_v2_session(postgres_db_real, ["r0", "r1"])
-        v3_0_0._migrate_postgres(postgres_db_real, "test_sessions")
+        v3_0_0._migrate_postgres(postgres_db_real, "sessions", "test_sessions")
 
         with postgres_db_real.Session() as sess:
             sess.execute(
@@ -252,7 +252,7 @@ class TestPartialMigrationMergeOrder:
         """When the same run_id exists in both surfaces, the table wins on
         *content* but the legacy blob's position wins on *order*."""
         _seed_v2_session(postgres_db_real, ["r0", "r1", "r2"])
-        v3_0_0._migrate_postgres(postgres_db_real, "test_sessions")
+        v3_0_0._migrate_postgres(postgres_db_real, "sessions", "test_sessions")
 
         with postgres_db_real.Session() as sess:
             sess.execute(

--- a/libs/agno/tests/integration/db/postgres/test_migration_merge_order.py
+++ b/libs/agno/tests/integration/db/postgres/test_migration_merge_order.py
@@ -44,7 +44,7 @@ def cleanup_e2e_tables(postgres_db_real: PostgresDb):
     seeds raw SQL, so we can't rely on ORM-level cleanup."""
 
     def _wipe():
-        for table in ("test_sessions", "agno_runs"):
+        for table in ("test_sessions", postgres_db_real.runs_table_name):
             with postgres_db_real.Session() as sess:
                 try:
                     sess.execute(
@@ -124,7 +124,7 @@ def _delete_runs_from_table(postgres_db_real: PostgresDb, run_ids: List[str]) ->
         return
     with postgres_db_real.Session() as sess:
         sess.execute(
-            text("DELETE FROM test_schema.agno_runs WHERE run_id = ANY(:rids)"),
+            text(f"DELETE FROM test_schema.{postgres_db_real.runs_table_name} WHERE run_id = ANY(:rids)"),
             {"rids": run_ids},
         )
         sess.commit()
@@ -133,7 +133,10 @@ def _delete_runs_from_table(postgres_db_real: PostgresDb, run_ids: List[str]) ->
 def _get_runs_table_ids(postgres_db_real: PostgresDb) -> List[str]:
     with postgres_db_real.Session() as sess:
         rows = sess.execute(
-            text("SELECT run_id FROM test_schema.agno_runs WHERE session_id = :sid ORDER BY run_index"),
+            text(
+                f"SELECT run_id FROM test_schema.{postgres_db_real.runs_table_name} "
+                "WHERE session_id = :sid ORDER BY run_index"
+            ),
             {"sid": SESSION_ID},
         ).fetchall()
     return [r[0] for r in rows]
@@ -158,7 +161,10 @@ def _read_merged_runs(postgres_db_real: PostgresDb) -> List[dict]:
     on the ORM schema surfacing the (legacy) ``runs`` column."""
     with postgres_db_real.Session() as sess:
         table_rows = sess.execute(
-            text("SELECT run_data FROM test_schema.agno_runs WHERE session_id = :sid ORDER BY run_index"),
+            text(
+                f"SELECT run_data FROM test_schema.{postgres_db_real.runs_table_name} "
+                "WHERE session_id = :sid ORDER BY run_index"
+            ),
             {"sid": SESSION_ID},
         ).fetchall()
         table_runs = [r[0] for r in table_rows]
@@ -227,8 +233,8 @@ class TestPartialMigrationMergeOrder:
         with postgres_db_real.Session() as sess:
             sess.execute(
                 text(
-                    """
-                    INSERT INTO test_schema.agno_runs
+                    f"""
+                    INSERT INTO test_schema.{postgres_db_real.runs_table_name}
                     (run_id, session_id, run_type, agent_id, user_id, status, run_index, run_data, created_at, updated_at)
                     VALUES (:rid, :sid, 'agent', :aid, :uid, 'COMPLETED', 2, CAST(:data AS jsonb), :now, :now)
                     """
@@ -257,7 +263,7 @@ class TestPartialMigrationMergeOrder:
         with postgres_db_real.Session() as sess:
             sess.execute(
                 text(
-                    "UPDATE test_schema.agno_runs "
+                    f"UPDATE test_schema.{postgres_db_real.runs_table_name} "
                     "SET run_data = jsonb_set(run_data, '{content}', '\"table-fresh\"'::jsonb) "
                     "WHERE run_id = 'r1'"
                 )

--- a/libs/agno/tests/integration/db/postgres/test_runs_fk_cascade.py
+++ b/libs/agno/tests/integration/db/postgres/test_runs_fk_cascade.py
@@ -70,7 +70,7 @@ class TestFkConstraintExists:
                     f"""
                     SELECT conname, pg_get_constraintdef(oid) AS def
                     FROM pg_constraint
-                    WHERE conrelid = '{TEST_SCHEMA}.agno_runs'::regclass AND contype = 'f'
+                    WHERE conrelid = '{TEST_SCHEMA}.{pg_db.runs_table_name}'::regclass AND contype = 'f'
                     """
                 )
             ).fetchall()

--- a/libs/agno/tests/integration/db/valkey/test_user_isolation.py
+++ b/libs/agno/tests/integration/db/valkey/test_user_isolation.py
@@ -1,4 +1,4 @@
-"""Integration tests for per-user isolation on ValkeyDb metrics and knowledge.
+"""Integration tests for per-user isolation on ValkeyDb metrics, knowledge and eval runs.
 
 Requires a running Valkey instance on localhost:6379.
 Run with: pytest libs/agno/tests/integration/db/valkey/test_user_isolation.py -v
@@ -7,6 +7,7 @@ Run with: pytest libs/agno/tests/integration/db/valkey/test_user_isolation.py -v
 import time
 from typing import Optional
 
+from agno.db.schemas.evals import EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.valkey.valkey import ValkeyDb
 from agno.session import AgentSession
@@ -120,3 +121,59 @@ class TestKnowledgeVisibility:
 
         valkey_db.delete_knowledge_content("k_a", user_id="user_a")
         assert valkey_db.get_knowledge_content("k_a") is None
+
+
+class TestEvalRunsUserIsolation:
+    def _store(self, valkey_db: ValkeyDb, run_id: str, user_id: Optional[str] = None) -> None:
+        # The eval framework persists the run; the OS sets the owner afterwards.
+        valkey_db.create_eval_run(
+            EvalRunRecord(
+                run_id=run_id,
+                eval_type=EvalType.ACCURACY,
+                eval_data={"eval_status": "PASSED"},
+                eval_input={},
+            )
+        )
+        if user_id is not None:
+            valkey_db.update_eval_run_user_id(run_id, user_id)
+
+    def test_unowned_runs_visible_to_everyone(self, valkey_db: ValkeyDb):
+        self._store(valkey_db, "e_shared")
+
+        assert valkey_db.get_eval_run("e_shared") is not None
+        assert valkey_db.get_eval_run("e_shared", user_id="user_a") is None
+
+    def test_owned_run_hidden_from_other_users(self, valkey_db: ValkeyDb):
+        self._store(valkey_db, "e_a", user_id="user_a")
+
+        assert valkey_db.get_eval_run("e_a", user_id="user_b") is None
+        assert valkey_db.get_eval_run("e_a", user_id="user_a") is not None
+        assert valkey_db.get_eval_run("e_a") is not None
+
+    def test_get_eval_runs_scoped(self, valkey_db: ValkeyDb):
+        self._store(valkey_db, "e_shared")
+        self._store(valkey_db, "e_a", user_id="user_a")
+        self._store(valkey_db, "e_b", user_id="user_b")
+
+        rows, total = valkey_db.get_eval_runs(user_id="user_a", deserialize=False)
+        assert total == 1
+        assert {row["run_id"] for row in rows} == {"e_a"}
+
+        rows, total = valkey_db.get_eval_runs(deserialize=False)
+        assert total == 3
+
+    def test_rename_scoped_to_owner(self, valkey_db: ValkeyDb):
+        self._store(valkey_db, "e_a", user_id="user_a")
+
+        assert valkey_db.rename_eval_run("e_a", "hacked", user_id="user_b") is None
+        renamed = valkey_db.rename_eval_run("e_a", "mine", user_id="user_a")
+        assert renamed is not None and renamed.name == "mine"
+
+    def test_delete_scoped_to_owner(self, valkey_db: ValkeyDb):
+        self._store(valkey_db, "e_a", user_id="user_a")
+
+        valkey_db.delete_eval_runs(["e_a"], user_id="user_b")
+        assert valkey_db.get_eval_run("e_a") is not None
+
+        valkey_db.delete_eval_runs(["e_a"], user_id="user_a")
+        assert valkey_db.get_eval_run("e_a") is None

--- a/libs/agno/tests/unit/db/test_delete_run_scrubs_legacy_blob.py
+++ b/libs/agno/tests/unit/db/test_delete_run_scrubs_legacy_blob.py
@@ -49,7 +49,7 @@ def json_db_partially_migrated():
     sessions_file = os.path.join(tmp, "agno_sessions.json")
     with open(sessions_file, "w") as f:
         json.dump([session_row], f)
-    _migrate_jsondb(db, "agno_sessions")
+    _migrate_jsondb(db, "sessions", "agno_sessions")
     return db, tmp, sessions_file
 
 

--- a/libs/agno/tests/unit/db/test_evals_user_isolation.py
+++ b/libs/agno/tests/unit/db/test_evals_user_isolation.py
@@ -116,3 +116,71 @@ class TestNoCrossLeak:
         _, bob_total = db.get_eval_runs(user_id="bob", deserialize=False)
         _, grand_total = db.get_eval_runs(deserialize=False)
         assert (alice_total, bob_total, grand_total) == (3, 2, 5)
+
+
+# ---------------------------------------------------------------------------
+# Contract checks — no server needed, so every adapter is covered in CI
+# ---------------------------------------------------------------------------
+
+_EVAL_ADAPTERS: list[tuple[str, str]] = [
+    ("agno.db.json.json_db", "JsonDb"),
+    ("agno.db.gcs_json.gcs_json_db", "GcsJsonDb"),
+    ("agno.db.in_memory.in_memory_db", "InMemoryDb"),
+    ("agno.db.mongo.mongo", "MongoDb"),
+    ("agno.db.mongo.async_mongo", "AsyncMongoDb"),
+    ("agno.db.redis.redis", "RedisDb"),
+    ("agno.db.valkey.valkey", "ValkeyDb"),
+    ("agno.db.firestore.firestore", "FirestoreDb"),
+    ("agno.db.dynamo.dynamo", "DynamoDb"),
+    ("agno.db.surrealdb.surrealdb", "SurrealDb"),
+    ("agno.db.postgres.postgres", "PostgresDb"),
+    ("agno.db.postgres.async_postgres", "AsyncPostgresDb"),
+    ("agno.db.sqlite.sqlite", "SqliteDb"),
+    ("agno.db.sqlite.async_sqlite", "AsyncSqliteDb"),
+    ("agno.db.mysql.mysql", "MySQLDb"),
+    ("agno.db.mysql.async_mysql", "AsyncMySQLDb"),
+    ("agno.db.singlestore.singlestore", "SingleStoreDb"),
+]
+
+_SCOPED_METHODS = ["get_eval_run", "get_eval_runs", "delete_eval_runs", "rename_eval_run"]
+
+
+def _try_import_class(module_path: str, class_name: str):
+    """Some adapters have optional native drivers. Skip cleanly if one isn't
+    installed — the contract is what we're after, not runtime behavior."""
+    try:
+        module = __import__(module_path, fromlist=[class_name])
+        return getattr(module, class_name)
+    except Exception as e:
+        pytest.skip(f"skip {class_name}: driver unavailable ({type(e).__name__}: {e})")
+
+
+@pytest.mark.parametrize("module_path,class_name", _EVAL_ADAPTERS)
+@pytest.mark.parametrize("method_name", _SCOPED_METHODS)
+def test_eval_reads_accept_user_id(module_path: str, class_name: str, method_name: str):
+    """A scoped call must be expressible on every adapter.
+
+    Without the parameter the OS cannot scope the call at all, so a scoped
+    caller silently gets everyone's eval runs.
+    """
+    import inspect
+
+    cls = _try_import_class(module_path, class_name)
+    method = getattr(cls, method_name, None)
+    assert method is not None, f"{class_name}.{method_name} is missing"
+    assert "user_id" in inspect.signature(method).parameters, f"{class_name}.{method_name} does not accept user_id"
+
+
+@pytest.mark.parametrize("module_path,class_name", _EVAL_ADAPTERS)
+def test_update_eval_run_user_id_is_implemented(module_path: str, class_name: str):
+    """The owner has to be storable, not just filterable.
+
+    ``BaseDb.update_eval_run_user_id`` raises NotImplementedError, so inheriting
+    it leaves the adapter unable to record an owner at all.
+    """
+    from agno.db.base import AsyncBaseDb, BaseDb
+
+    cls = _try_import_class(module_path, class_name)
+    own = cls.update_eval_run_user_id
+    assert own is not BaseDb.update_eval_run_user_id, f"{class_name} inherits the BaseDb stub"
+    assert own is not AsyncBaseDb.update_eval_run_user_id, f"{class_name} inherits the AsyncBaseDb stub"

--- a/libs/agno/tests/unit/db/test_v3_dynamo_migration_retry.py
+++ b/libs/agno/tests/unit/db/test_v3_dynamo_migration_retry.py
@@ -124,12 +124,12 @@ class TestMigrateDynamodbPropagates:
 
         with patch("agno.db.migrations.versions.v3_0_0.time.sleep"):
             with pytest.raises(_ClientError):
-                _migrate_dynamodb(db, "agno_sessions")
+                _migrate_dynamodb(db, "sessions", "agno_sessions")
 
     def test_successful_run_is_migrated(self):
         client = _make_client()
         client.scan.return_value = {"Items": [self._session_item_with_one_run()]}
         db = self._make_db(client)
 
-        assert _migrate_dynamodb(db, "agno_sessions") is True
+        assert _migrate_dynamodb(db, "sessions", "agno_sessions") is True
         assert client.put_item.call_count == 1

--- a/libs/agno/tests/unit/db/test_v3_migration_compat.py
+++ b/libs/agno/tests/unit/db/test_v3_migration_compat.py
@@ -379,3 +379,29 @@ def test_cleanup_is_idempotent_when_no_legacy_column():
     db.upsert_session(AgentSession(session_id="seed", agent_id="agent-1", user_id="u1"))
 
     assert db.cleanup_legacy_runs_column() is False
+
+
+def test_down_then_up_in_the_same_process():
+    """A revert drops the runs table; a later up() in the same process must rebuild it.
+
+    The revert used to drop agno_runs from the database while leaving it registered
+    on db.metadata, so the next up() raised InvalidRequestError.
+    """
+    db, db_file = _new_db()
+    db.upsert_session(AgentSession(session_id="seed", agent_id="agent-1", user_id="u1"))
+    _add_legacy_runs_column(db_file)
+
+    runs = [_make_run(f"r{i}", "s8", f"c{i}").to_dict() for i in range(2)]
+    _insert_legacy_session(db_file, "s8", runs)
+
+    db = SqliteDb(db_file=db_file)
+    asyncio.run(MigrationManager(db).up())
+    asyncio.run(MigrationManager(db).down(target_version="2.5.6"))
+    asyncio.run(MigrationManager(db).up())
+
+    conn = sqlite3.connect(db_file)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM agno_runs WHERE session_id='s8'").fetchone()[0]
+        assert count == 2
+    finally:
+        conn.close()

--- a/libs/agno/tests/unit/db/test_v3_migration_idempotent.py
+++ b/libs/agno/tests/unit/db/test_v3_migration_idempotent.py
@@ -39,7 +39,7 @@ def partially_migrated_json_db():
     }
     with open(os.path.join(tmp, "agno_sessions.json"), "w") as f:
         json.dump([session_row], f)
-    _migrate_jsondb(db, "agno_sessions")
+    _migrate_jsondb(db, "sessions", "agno_sessions")
     return db
 
 
@@ -65,7 +65,7 @@ class TestJsonDbMigrationIdempotent:
         assert _content(db, "r0") == "FRESH-0"
 
         # Rerun the migration
-        _migrate_jsondb(db, "agno_sessions")
+        _migrate_jsondb(db, "sessions", "agno_sessions")
 
         assert _content(db, "r0") == "FRESH-0", (
             "post-migration writes must not be reverted by a migration rerun — "
@@ -95,7 +95,7 @@ class TestJsonDbMigrationIdempotent:
             json.dump(sessions, f)
 
         # Rerun migration
-        _migrate_jsondb(db, "agno_sessions")
+        _migrate_jsondb(db, "sessions", "agno_sessions")
 
         # r2 should now be in the runs table
         assert _content(db, "r2") == "NEW-from-legacy"
@@ -112,7 +112,7 @@ class TestJsonDbMigrationIdempotent:
         with open(runs_file) as f:
             before = json.load(f)
 
-        _migrate_jsondb(db, "agno_sessions")
+        _migrate_jsondb(db, "sessions", "agno_sessions")
 
         with open(runs_file) as f:
             after = json.load(f)
@@ -130,5 +130,5 @@ class TestJsonDbMigrationIdempotent:
             user_id="u1",
             run_index=1,
         )
-        _migrate_jsondb(db, "agno_sessions")
+        _migrate_jsondb(db, "sessions", "agno_sessions")
         assert _content(db, "r1") == "FRESH-1"

--- a/libs/agno/tests/unit/db/test_v3_revert_atomicity.py
+++ b/libs/agno/tests/unit/db/test_v3_revert_atomicity.py
@@ -55,7 +55,7 @@ class TestRevertDynamoPreservesRunsOnFailure:
         client.update_item.side_effect = update_item
         db = self._make_db(client)
 
-        assert _revert_dynamodb(db, "agno_sessions") is True
+        assert _revert_dynamodb(db, "sessions", "agno_sessions") is True
 
         deleted = {c.kwargs["Key"]["run_id"]["S"] for c in client.delete_item.call_args_list}
         assert "r1" in deleted, "successfully-reverted session's runs should be deleted"
@@ -67,7 +67,7 @@ class TestRevertDynamoPreservesRunsOnFailure:
         client.update_item.return_value = {}
         db = self._make_db(client)
 
-        assert _revert_dynamodb(db, "agno_sessions") is True
+        assert _revert_dynamodb(db, "sessions", "agno_sessions") is True
 
         deleted = {c.kwargs["Key"]["run_id"]["S"] for c in client.delete_item.call_args_list}
         assert deleted == {"r1", "r2"}

--- a/libs/agno/tests/unit/db/test_v3_user_id_migration.py
+++ b/libs/agno/tests/unit/db/test_v3_user_id_migration.py
@@ -222,6 +222,31 @@ def test_adding_a_table_type_needs_no_backend_changes(monkeypatch):
     assert v3_0_0.down(db, "memories", "agno_memories") is True
 
 
+def test_table_type_the_backend_does_not_have_is_skipped(monkeypatch):
+    """A table type only some adapters support must be skipped, not raise.
+
+    The SQL adapters report an unknown table as version 2.0.0 rather than None, so
+    MigrationManager runs the migration anyway and it has to bow out on its own.
+    """
+    from agno.db.migrations.versions import v3_0_0
+
+    db, _ = _new_db()
+    monkeypatch.setattr(v3_0_0, "USER_ID_TABLE_TYPES", ("evals", "not_a_real_table"))
+
+    assert v3_0_0.up(db, "not_a_real_table", "agno_not_a_real_table") is False
+    assert v3_0_0.down(db, "not_a_real_table", "agno_not_a_real_table") is False
+
+
+@pytest.mark.asyncio
+async def test_async_adapters_can_migrate_a_components_table():
+    """MigrationManager reads the table name off the db, so the async adapters need it
+    even though they cannot read or write components themselves."""
+    db = AsyncSqliteDb(db_file=os.path.join(tempfile.mkdtemp(), "test_components.db"))
+    assert db.components_table_name == "agno_components"
+
+    await MigrationManager(db).up()
+
+
 def test_document_backend_is_a_noop():
     """Document backends carry user_id without a schema change."""
     from agno.db.json import JsonDb

--- a/libs/agno/tests/unit/db/test_v3_user_id_migration.py
+++ b/libs/agno/tests/unit/db/test_v3_user_id_migration.py
@@ -175,7 +175,7 @@ def test_other_table_types_are_untouched():
     from agno.db.migrations.versions import v3_0_0
 
     db, _ = _new_db()
-    for table_type in ("memories", "metrics", "knowledge", "culture", "approvals"):
+    for table_type in ("memories", "metrics", "culture", "approvals"):
         assert v3_0_0.up(db, table_type, EVAL_TABLE) is False
         assert v3_0_0.down(db, table_type, EVAL_TABLE) is False
 
@@ -315,3 +315,125 @@ def test_failed_revert_leaves_the_index_in_place():
 
     assert "user_id" in _columns(db_file)
     assert EVAL_INDEX in _indexes(db_file), "the index must be restored when the column drop fails"
+
+
+# ---------------------------------------------------------------------------
+# schedules / schedule_runs / knowledge
+# ---------------------------------------------------------------------------
+
+SCHEDULES_TABLE = "agno_schedules"
+SCHEDULE_RUNS_TABLE = "agno_schedule_runs"
+KNOWLEDGE_TABLE = "agno_knowledge"
+SCHEDULES_COMPOSITE_INDEX = f"idx_{SCHEDULES_TABLE}_user_id_enabled_next_run_at"
+
+
+def _new_db_with(table_types: list[str]):
+    db_file = os.path.join(tempfile.mkdtemp(), "test.db")
+    db = SqliteDb(db_file=db_file)
+    for table_type in table_types:
+        db._get_table(table_type=table_type, create_table_if_not_found=True)
+    return db, db_file
+
+
+def _table_columns(db_file: str, table: str) -> set[str]:
+    conn = sqlite3.connect(db_file)
+    try:
+        return {c[1] for c in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+    finally:
+        conn.close()
+
+
+def _table_indexes(db_file: str, table: str) -> set[str]:
+    conn = sqlite3.connect(db_file)
+    try:
+        return {i[1] for i in conn.execute(f"PRAGMA index_list({table})").fetchall()}
+    finally:
+        conn.close()
+
+
+def _strip_user_id(db_file: str, table: str, indexes: list[str]) -> None:
+    """Mimic a pre-v3 table: drop the user_id indexes and column, rewind the version."""
+    conn = sqlite3.connect(db_file)
+    try:
+        for index in indexes:
+            conn.execute(f"DROP INDEX IF EXISTS {index}")
+        conn.execute(f"ALTER TABLE {table} DROP COLUMN user_id")
+        conn.execute("UPDATE agno_schema_versions SET version='2.5.6' WHERE table_name=?", (table,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_schedules_migration_restores_column_and_composite_index():
+    """Both schedule tables gain user_id, and schedules gets its composite index back."""
+    db, db_file = _new_db_with(["schedules", "schedule_runs"])
+    _strip_user_id(db_file, SCHEDULES_TABLE, [f"idx_{SCHEDULES_TABLE}_user_id", SCHEDULES_COMPOSITE_INDEX])
+    _strip_user_id(db_file, SCHEDULE_RUNS_TABLE, [f"idx_{SCHEDULE_RUNS_TABLE}_user_id"])
+    assert "user_id" not in _table_columns(db_file, SCHEDULES_TABLE)
+    assert "user_id" not in _table_columns(db_file, SCHEDULE_RUNS_TABLE)
+
+    asyncio.run(MigrationManager(db).up(table_type="schedules"))
+    asyncio.run(MigrationManager(db).up(table_type="schedule_runs"))
+
+    assert "user_id" in _table_columns(db_file, SCHEDULES_TABLE)
+    assert f"idx_{SCHEDULES_TABLE}_user_id" in _table_indexes(db_file, SCHEDULES_TABLE)
+    # A migrated table matches a fresh one: the (user_id, enabled, next_run_at)
+    # composite the listing path relies on is created too.
+    assert SCHEDULES_COMPOSITE_INDEX in _table_indexes(db_file, SCHEDULES_TABLE)
+    assert "user_id" in _table_columns(db_file, SCHEDULE_RUNS_TABLE)
+    assert f"idx_{SCHEDULE_RUNS_TABLE}_user_id" in _table_indexes(db_file, SCHEDULE_RUNS_TABLE)
+    assert db.get_latest_schema_version(SCHEDULES_TABLE) == "3.0.0"
+    assert db.get_latest_schema_version(SCHEDULE_RUNS_TABLE) == "3.0.0"
+
+
+def test_schedules_revert_drops_composite_before_column():
+    """SQLite refuses DROP COLUMN while a multi-column index covers it — the
+    revert must drop the composite first or fail."""
+    db, db_file = _new_db_with(["schedules"])
+    assert SCHEDULES_COMPOSITE_INDEX in _table_indexes(db_file, SCHEDULES_TABLE)
+
+    asyncio.run(MigrationManager(db).down(target_version="2.5.6", table_type="schedules"))
+
+    assert "user_id" not in _table_columns(db_file, SCHEDULES_TABLE)
+    assert SCHEDULES_COMPOSITE_INDEX not in _table_indexes(db_file, SCHEDULES_TABLE)
+    assert f"idx_{SCHEDULES_TABLE}_user_id" not in _table_indexes(db_file, SCHEDULES_TABLE)
+
+
+def test_schedules_up_after_down_restores_everything():
+    db, db_file = _new_db_with(["schedules"])
+    asyncio.run(MigrationManager(db).down(target_version="2.5.6", table_type="schedules"))
+    assert "user_id" not in _table_columns(db_file, SCHEDULES_TABLE)
+
+    asyncio.run(MigrationManager(db).up(table_type="schedules"))
+
+    assert "user_id" in _table_columns(db_file, SCHEDULES_TABLE)
+    assert SCHEDULES_COMPOSITE_INDEX in _table_indexes(db_file, SCHEDULES_TABLE)
+
+
+def test_knowledge_migration_adds_user_id():
+    db, db_file = _new_db_with(["knowledge"])
+    knowledge_composite = f"idx_{KNOWLEDGE_TABLE}_user_id_linked_to"
+    _strip_user_id(db_file, KNOWLEDGE_TABLE, [f"idx_{KNOWLEDGE_TABLE}_user_id", knowledge_composite])
+    assert "user_id" not in _table_columns(db_file, KNOWLEDGE_TABLE)
+
+    asyncio.run(MigrationManager(db).up(table_type="knowledge"))
+
+    assert "user_id" in _table_columns(db_file, KNOWLEDGE_TABLE)
+    assert f"idx_{KNOWLEDGE_TABLE}_user_id" in _table_indexes(db_file, KNOWLEDGE_TABLE)
+    # linked_to still exists on this table, so the (user_id, linked_to)
+    # composite comes back too.
+    assert knowledge_composite in _table_indexes(db_file, KNOWLEDGE_TABLE)
+    assert db.get_latest_schema_version(KNOWLEDGE_TABLE) == "3.0.0"
+
+
+def test_schedules_migration_is_idempotent():
+    db, db_file = _new_db_with(["schedules"])
+    _strip_user_id(db_file, SCHEDULES_TABLE, [f"idx_{SCHEDULES_TABLE}_user_id", SCHEDULES_COMPOSITE_INDEX])
+
+    asyncio.run(MigrationManager(db).up(table_type="schedules"))
+    before_cols = _table_columns(db_file, SCHEDULES_TABLE)
+    before_idx = _table_indexes(db_file, SCHEDULES_TABLE)
+    asyncio.run(MigrationManager(db).up(table_type="schedules", force=True))
+
+    assert _table_columns(db_file, SCHEDULES_TABLE) == before_cols
+    assert _table_indexes(db_file, SCHEDULES_TABLE) == before_idx

--- a/libs/agno/tests/unit/db/test_v3_user_id_migration.py
+++ b/libs/agno/tests/unit/db/test_v3_user_id_migration.py
@@ -1,0 +1,292 @@
+"""Tests for the v3.0.0 evals user_id migration: column add, idempotency, revert."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from agno.db.migrations.manager import MigrationManager
+from agno.db.schemas.evals import EvalRunRecord, EvalType
+from agno.db.sqlite import AsyncSqliteDb, SqliteDb
+
+EVAL_TABLE = "agno_eval_runs"
+EVAL_INDEX = f"idx_{EVAL_TABLE}_user_id"
+
+
+def _new_db():
+    db_file = os.path.join(tempfile.mkdtemp(), "test.db")
+    db = SqliteDb(db_file=db_file)
+    db._get_table(table_type="evals", create_table_if_not_found=True)
+    return db, db_file
+
+
+def _make_record(run_id: str) -> EvalRunRecord:
+    return EvalRunRecord(
+        run_id=run_id,
+        eval_type=EvalType.ACCURACY,
+        eval_data={"score": 8},
+        eval_input={"input": "2+2"},
+        name="baseline",
+        agent_id="agent-1",
+    )
+
+
+def _columns(db_file: str) -> set[str]:
+    conn = sqlite3.connect(db_file)
+    try:
+        return {c[1] for c in conn.execute(f"PRAGMA table_info({EVAL_TABLE})").fetchall()}
+    finally:
+        conn.close()
+
+
+def _column_type(db_file: str, column: str) -> str | None:
+    conn = sqlite3.connect(db_file)
+    try:
+        for col in conn.execute(f"PRAGMA table_info({EVAL_TABLE})").fetchall():
+            if col[1] == column:
+                return col[2]
+        return None
+    finally:
+        conn.close()
+
+
+def _indexes(db_file: str) -> set[str]:
+    conn = sqlite3.connect(db_file)
+    try:
+        return {i[1] for i in conn.execute(f"PRAGMA index_list({EVAL_TABLE})").fetchall()}
+    finally:
+        conn.close()
+
+
+def _make_legacy(db_file: str) -> None:
+    """Strip user_id and rewind the version row, mimicking a pre-v3 eval table."""
+    conn = sqlite3.connect(db_file)
+    try:
+        conn.execute(f"DROP INDEX IF EXISTS {EVAL_INDEX}")
+        conn.execute(f"ALTER TABLE {EVAL_TABLE} DROP COLUMN user_id")
+        conn.execute("UPDATE agno_schema_versions SET version='2.5.6' WHERE table_name=?", (EVAL_TABLE,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _insert_legacy_run(db_file: str, run_id: str) -> None:
+    """Insert a row the way a pre-v3 install would: no user_id column to fill."""
+    conn = sqlite3.connect(db_file)
+    try:
+        conn.execute(
+            f"INSERT INTO {EVAL_TABLE} (run_id, eval_type, eval_data, eval_input, name, created_at) "
+            "VALUES (?, 'accuracy', '{}', '{}', 'legacy', 1700000000)",
+            (run_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_up_adds_user_id_column_and_index():
+    db, db_file = _new_db()
+    _make_legacy(db_file)
+    assert "user_id" not in _columns(db_file)
+    assert EVAL_INDEX not in _indexes(db_file)
+
+    asyncio.run(MigrationManager(db).up(table_type="evals"))
+
+    assert "user_id" in _columns(db_file)
+    assert EVAL_INDEX in _indexes(db_file)
+    assert db.get_latest_schema_version(EVAL_TABLE) == "3.0.0"
+
+
+def test_migrated_column_type_matches_fresh_schema():
+    """A migrated table and a freshly created one must declare the same type."""
+    fresh, fresh_file = _new_db()
+    fresh_type = _column_type(fresh_file, "user_id")
+
+    db, db_file = _new_db()
+    _make_legacy(db_file)
+    asyncio.run(MigrationManager(db).up(table_type="evals"))
+
+    assert _column_type(db_file, "user_id") == fresh_type
+
+
+def test_up_is_idempotent():
+    db, db_file = _new_db()
+    _make_legacy(db_file)
+
+    asyncio.run(MigrationManager(db).up(table_type="evals"))
+    # force=True runs the migration again even though the version is already current
+    asyncio.run(MigrationManager(db).up(table_type="evals", force=True))
+
+    assert "user_id" in _columns(db_file)
+    assert len([i for i in _indexes(db_file) if i == EVAL_INDEX]) == 1
+
+
+def test_legacy_rows_survive_with_null_user_id():
+    db, db_file = _new_db()
+    _make_legacy(db_file)
+    _insert_legacy_run(db_file, "legacy-1")
+
+    asyncio.run(MigrationManager(db).up(table_type="evals"))
+
+    run = db.get_eval_run("legacy-1", deserialize=False)
+    assert run is not None
+    assert run["user_id"] is None
+    # An unowned run stays global: visible unscoped, invisible to a scoped caller
+    assert db.get_eval_run("legacy-1", deserialize=False, user_id="alice") is None
+
+
+def test_down_drops_column_and_index_preserving_rows():
+    db, db_file = _new_db()
+    _make_legacy(db_file)
+    _insert_legacy_run(db_file, "legacy-1")
+    asyncio.run(MigrationManager(db).up(table_type="evals"))
+    db.create_eval_run(_make_record("run-2"))
+
+    asyncio.run(MigrationManager(db).down(target_version="2.5.6", table_type="evals"))
+
+    assert "user_id" not in _columns(db_file)
+    assert EVAL_INDEX not in _indexes(db_file)
+    assert db.get_latest_schema_version(EVAL_TABLE) == "2.5.6"
+
+    conn = sqlite3.connect(db_file)
+    try:
+        assert conn.execute(f"SELECT COUNT(*) FROM {EVAL_TABLE}").fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_up_after_down_restores_the_column():
+    db, db_file = _new_db()
+    _make_legacy(db_file)
+    asyncio.run(MigrationManager(db).up(table_type="evals"))
+    asyncio.run(MigrationManager(db).down(target_version="2.5.6", table_type="evals"))
+    asyncio.run(MigrationManager(db).up(table_type="evals"))
+
+    assert "user_id" in _columns(db_file)
+    assert EVAL_INDEX in _indexes(db_file)
+
+
+def test_other_table_types_are_untouched():
+    """A table type outside USER_ID_TABLE_TYPES gets no user_id work."""
+    from agno.db.migrations.versions import v3_0_0
+
+    db, _ = _new_db()
+    for table_type in ("memories", "metrics", "knowledge", "culture", "approvals"):
+        assert v3_0_0.up(db, table_type, EVAL_TABLE) is False
+        assert v3_0_0.down(db, table_type, EVAL_TABLE) is False
+
+
+def test_adding_a_table_type_needs_no_backend_changes(monkeypatch):
+    """Isolating another table is a one-line change to USER_ID_TABLE_TYPES.
+
+    Uses 'memories' as the stand-in: it has a user_id column in every adapter
+    schema, so it exercises the same path a future table type would take.
+    """
+    from agno.db.migrations.versions import v3_0_0
+
+    db_file = os.path.join(tempfile.mkdtemp(), "test.db")
+    db = SqliteDb(db_file=db_file)
+    db._get_table(table_type="memories", create_table_if_not_found=True)
+
+    conn = sqlite3.connect(db_file)
+    try:
+        conn.execute("DROP INDEX IF EXISTS idx_agno_memories_user_id")
+        conn.execute("ALTER TABLE agno_memories DROP COLUMN user_id")
+        conn.commit()
+        cols = {c[1] for c in conn.execute("PRAGMA table_info(agno_memories)").fetchall()}
+        assert "user_id" not in cols
+    finally:
+        conn.close()
+
+    # Before: memories is not isolated, so the migration leaves it alone
+    assert v3_0_0.up(db, "memories", "agno_memories") is False
+
+    monkeypatch.setattr(v3_0_0, "USER_ID_TABLE_TYPES", ("evals", "memories"))
+
+    # After: the same backend functions add the column, with no other edit
+    assert v3_0_0.up(db, "memories", "agno_memories") is True
+
+    conn = sqlite3.connect(db_file)
+    try:
+        cols = {c[1] for c in conn.execute("PRAGMA table_info(agno_memories)").fetchall()}
+        idxs = {i[1] for i in conn.execute("PRAGMA index_list(agno_memories)").fetchall()}
+        assert "user_id" in cols
+        assert "idx_agno_memories_user_id" in idxs
+    finally:
+        conn.close()
+
+    assert v3_0_0.down(db, "memories", "agno_memories") is True
+
+
+def test_document_backend_is_a_noop():
+    """Document backends carry user_id without a schema change."""
+    from agno.db.json import JsonDb
+    from agno.db.migrations.versions import v3_0_0
+
+    db = JsonDb(db_path=tempfile.mkdtemp())
+    assert v3_0_0.up(db, "evals", EVAL_TABLE) is False
+    assert v3_0_0.down(db, "evals", EVAL_TABLE) is False
+
+    db.create_eval_run(_make_record("run-1"))
+    db.update_eval_run_user_id("run-1", "alice")
+    assert db.get_eval_run("run-1", user_id="alice") is not None
+    assert db.get_eval_run("run-1", user_id="bob") is None
+
+
+@pytest.mark.asyncio
+async def test_async_up_and_down():
+    db_file = os.path.join(tempfile.mkdtemp(), "test_async.db")
+    db = AsyncSqliteDb(db_file=db_file)
+    await db._get_table(table_type="evals", create_table_if_not_found=True)
+    _make_legacy(db_file)
+
+    await MigrationManager(db).up(table_type="evals")
+    assert "user_id" in _columns(db_file)
+    assert EVAL_INDEX in _indexes(db_file)
+
+    await db.create_eval_run(_make_record("alice-run"))
+    await db.update_eval_run_user_id("alice-run", "alice")
+    assert await db.get_eval_run("alice-run", user_id="alice") is not None
+    assert await db.get_eval_run("alice-run", user_id="bob") is None
+
+    await MigrationManager(db).down(target_version="2.5.6", table_type="evals")
+    assert "user_id" not in _columns(db_file)
+    assert EVAL_INDEX not in _indexes(db_file)
+
+
+def test_revert_skips_on_old_sqlite(monkeypatch):
+    """SQLite added DROP COLUMN in 3.35.0, so an older one must be left untouched."""
+    db, db_file = _new_db()
+    monkeypatch.setattr(sqlite3, "sqlite_version_info", (3, 34, 0))
+
+    asyncio.run(MigrationManager(db).down(target_version="2.5.6", table_type="evals"))
+
+    assert "user_id" in _columns(db_file)
+    assert EVAL_INDEX in _indexes(db_file)
+
+
+def test_failed_revert_leaves_the_index_in_place():
+    """A revert that cannot drop the column must not leave the column unindexed.
+
+    SQLite commits DDL outside the session transaction, so the index drop sticks
+    even when the column drop fails.
+    """
+    db, db_file = _new_db()
+
+    conn = sqlite3.connect(db_file)
+    try:
+        # a view over user_id makes DROP COLUMN fail
+        conn.execute(f"CREATE VIEW v_owner AS SELECT user_id FROM {EVAL_TABLE}")
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(Exception):
+        asyncio.run(MigrationManager(db).down(target_version="2.5.6", table_type="evals"))
+
+    assert "user_id" in _columns(db_file)
+    assert EVAL_INDEX in _indexes(db_file), "the index must be restored when the column drop fails"


### PR DESCRIPTION
## Summary

Per-user isolation for eval runs already landed on `feat/v3.0`: `user_id` is declared in the eval table schema and the SQL adapters scope `get` / `list` / `rename` / `delete` by it. What is missing is the upgrade path — the column only appears on a **freshly created** table, so an eval table that predates that work never gets it and the isolation silently has nothing to filter on.

This adds the migration for it, in the existing (unreleased) `v3_0_0` rather than a new version file. It also covers Valkey, the one adapter the original isolation work skipped, and three adapter bugs that stop the migration from running at all.

**Migration**

- `USER_ID_TABLE_TYPES = ("evals",)` drives the work. Isolating another table means adding its type to that tuple — the per-backend functions read the column type from the adapter schema, so none of them change.
- The four entry points (`up` / `down` / `async_up` / `async_down`) now dispatch on `db_type` only, matching `v2_3_0.py`. Each per-backend dispatcher then picks the work function from the table type. This keeps a future table type from having to edit the entry points again.
- Existing rows keep a `NULL` `user_id`, so they stay visible to unscoped/admin callers and invisible to a scoped one.

**Revert safety**

- SQLite, MySQL and SingleStore commit each DDL statement immediately, so a `DROP INDEX` that is followed by a failing `DROP COLUMN` used to leave the column in place and permanently unindexed — neither `up()` nor `force=True` restores it. The revert now rebuilds the index before re-raising.
- SQLite gained `DROP COLUMN` in 3.35.0 (Debian 11's Python 3.9 ships 3.34), so the SQLite revert skips instead of half-completing. Follows the existing check in `agno/fs/db.py:119`.
- Postgres is unchanged: it keeps DDL inside the transaction and rolls both statements back itself.

**Adapter fixes required to run the migration on these backends**

| File | Fix |
|---|---|
| `db/mongo/async_mongo.py` | `get_latest_schema_version` / `upsert_schema_version` were `def`, so `MigrationManager` raised `TypeError: object NoneType can't be used in 'await'` |
| `db/mongo/async_mongo.py` | `get_session` called `aggregate()` without awaiting the cursor — `AsyncMongoDb.get_session()` was broken end-to-end on pymongo-async |
| `db/singlestore/singlestore.py` | `agno_runs` needs a composite primary key containing the shard key; the old DDL was rejected with `ERROR 1744` |
| `db/valkey/valkey.py` | eval runs had no user scoping — added to match `redis.py` |
| `db/mongo/schemas.py` | index `user_id` on the eval collection |

## Type of change

- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes