### PR TITLE
fix(ollama): honor response_format on streaming calls

### DIFF
--- a/libs/agno/agno/models/ollama/chat.py
+++ b/libs/agno/agno/models/ollama/chat.py
@@ -308,13 +308,19 @@ class Ollama(Model):
 
         messages = normalize_tool_messages(messages)
 
+        # Keep parity with invoke/ainvoke: stream must honor response_format
+        # (Ollama `format`) for structured outputs.
+        request_kwargs = self._prepare_request_kwargs_for_invoke(
+            response_format=response_format, tools=tools
+        )
+
         assistant_message.metrics.start_timer()
 
         for chunk in self.get_client().chat(
             model=self.id,
             messages=[self._format_message(m, compress_tool_results) for m in messages],  # type: ignore
             stream=True,
-            **self.get_request_params(tools=tools),
+            **request_kwargs,
         ):
             yield self._parse_provider_response_delta(chunk)
 
@@ -337,13 +343,17 @@ class Ollama(Model):
 
         messages = normalize_tool_messages(messages)
 
+        request_kwargs = self._prepare_request_kwargs_for_invoke(
+            response_format=response_format, tools=tools
+        )
+
         assistant_message.metrics.start_timer()
 
         async for chunk in await self.get_async_client().chat(
             model=self.id.strip(),
             messages=[self._format_message(m, compress_tool_results) for m in messages],  # type: ignore
             stream=True,
-            **self.get_request_params(tools=tools),
+            **request_kwargs,
         ):
             yield self._parse_provider_response_delta(chunk)
 

--- a/libs/agno/tests/unit/models/ollama/test_ollama_stream_response_format.py
+++ b/libs/agno/tests/unit/models/ollama/test_ollama_stream_response_format.py
@@ -1,0 +1,50 @@
+"""Streaming Ollama calls must pass response_format like non-stream invoke."""
+
+from __future__ import annotations
+
+from typing import Iterator
+from unittest.mock import MagicMock
+
+from pydantic import BaseModel
+
+from agno.models.message import Message
+from agno.models.ollama.chat import Ollama
+
+
+class _Out(BaseModel):
+    answer: str
+
+
+def test_invoke_stream_forwards_response_format_via_prepare_kwargs(monkeypatch) -> None:
+    model = Ollama(id="llama3.2")
+    captured: dict[str, object] = {}
+
+    def fake_prepare(*, response_format=None, tools=None):
+        captured["response_format"] = response_format
+        captured["tools"] = tools
+        return {"format": "json"}
+
+    class _Client:
+        def chat(self, **kwargs):
+            captured["chat_kwargs"] = kwargs
+
+            def _gen() -> Iterator[dict]:
+                yield {"message": {"role": "assistant", "content": "{}"}}
+
+            return _gen()
+
+    monkeypatch.setattr(model, "_prepare_request_kwargs_for_invoke", fake_prepare)
+    monkeypatch.setattr(model, "get_client", lambda: _Client())
+
+    assistant = Message(role="assistant", content="")
+    list(
+        model.invoke_stream(
+            messages=[Message(role="user", content="hi")],
+            assistant_message=assistant,
+            response_format=_Out,
+        )
+    )
+
+    assert captured["response_format"] is _Out
+    assert captured["chat_kwargs"]["stream"] is True
+    assert captured["chat_kwargs"]["format"] == "json"


### PR DESCRIPTION
## Summary
Ollama streaming ignored `response_format` / `output_schema` because `invoke_stream` / `ainvoke_stream` did not call `_prepare_request_kwargs_for_invoke`.

## Changes
- Use the same request-kwargs helper as non-stream invoke
- Add unit coverage

Fixes #9262

## Test plan
- [x] `pytest libs/agno/tests/unit/models/ollama/test_ollama_stream_response_format.py`
