### PR TITLE
fix: preserve toolkit instructions on rehydration

### DIFF
--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -11,6 +11,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Set,
     Union,
     cast,
 )
@@ -28,6 +29,12 @@ from agno.run.messages import RunMessages
 from agno.session import AgentSession
 from agno.tools import Toolkit
 from agno.tools.function import Function
+from agno.tools.toolkit import (
+    ToolkitKey,
+    _emits_toolkit_instructions,
+    _group_source_toolkits,
+    _toolkit_key,
+)
 from agno.utils.agent import (
     collect_joint_audios,
     collect_joint_files,
@@ -352,23 +359,29 @@ def parse_tools(
 ) -> List[Union[Function, dict]]:
     _function_names: List[str] = []
     _functions: List[Union[Function, dict]] = []
-    _toolkit_instruction_sources: set[int] = set()
-    _source_toolkit_last_indices = {
-        id(tool.source_toolkit): index
-        for index, tool in enumerate(tools)
-        if isinstance(tool, Function) and isinstance(tool.source_toolkit, Toolkit)
-    }
+    _toolkit_instruction_keys: Set[ToolkitKey] = set()
+    _live_toolkit_keys = {_toolkit_key(tool) for tool in tools if isinstance(tool, Toolkit)}
+    _source_toolkit_last_index, _source_toolkit_members = _group_source_toolkits(tools)
     agent._tool_instructions = []
 
     def add_toolkit_instructions(toolkit: Toolkit) -> None:
-        source_id = id(toolkit)
-        if source_id in _toolkit_instruction_sources:
+        key = _toolkit_key(toolkit)
+        if key in _toolkit_instruction_keys:
             return
         if toolkit.add_instructions and toolkit.instructions is not None:
             if agent._tool_instructions is None:
                 agent._tool_instructions = []
             agent._tool_instructions.append(toolkit.instructions)
-            _toolkit_instruction_sources.add(source_id)
+            _toolkit_instruction_keys.add(key)
+
+    def emits_toolkit_instructions(source_toolkit: Toolkit, index: int) -> bool:
+        return _emits_toolkit_instructions(
+            source_toolkit,
+            index,
+            live_toolkit_keys=_live_toolkit_keys,
+            last_index=_source_toolkit_last_index,
+            members=_source_toolkit_members,
+        )
 
     # Get output_schema from run_context
     output_schema = run_context.output_schema if run_context else None
@@ -424,12 +437,12 @@ def parse_tools(
 
         elif isinstance(tool, Function):
             source_toolkit = tool.source_toolkit if isinstance(tool.source_toolkit, Toolkit) else None
-            is_last_source_toolkit_function = (
-                source_toolkit is not None and _source_toolkit_last_indices.get(id(source_toolkit)) == tool_index
+            emit_toolkit_instructions = source_toolkit is not None and emits_toolkit_instructions(
+                source_toolkit, tool_index
             )
             if tool.name in _function_names:
                 log_warning(f"Duplicate tool name '{tool.name}' already registered on agent; skipping the duplicate.")
-                if is_last_source_toolkit_function and source_toolkit is not None:
+                if emit_toolkit_instructions and source_toolkit is not None:
                     add_toolkit_instructions(source_toolkit)
                 continue
             _function_names.append(tool.name)
@@ -457,7 +470,7 @@ def parse_tools(
             # Toolkit is restored by Registry.rehydrate_function; add its
             # guidance after all its member Functions, matching live Toolkit
             # instruction order, and only once.
-            if is_last_source_toolkit_function and source_toolkit is not None:
+            if emit_toolkit_instructions and source_toolkit is not None:
                 add_toolkit_instructions(source_toolkit)
 
         elif callable(tool):

--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -360,11 +360,19 @@ def parse_tools(
     _function_names: List[str] = []
     _functions: List[Union[Function, dict]] = []
     _toolkit_instruction_keys: Set[ToolkitKey] = set()
-    _source_toolkit_last_index, _source_toolkit_members = _group_source_toolkits(tools)
+    _source_toolkit_last_index, _source_toolkit_members, _toolkit_keys = _group_source_toolkits(tools)
     agent._tool_instructions = []
 
+    def toolkit_key(toolkit: Toolkit) -> ToolkitKey:
+        # The key folds the toolkit's whole function surface; memoized so one
+        # collection pass computes it once per toolkit, not once per member.
+        key = _toolkit_keys.get(id(toolkit))
+        if key is None:
+            key = _toolkit_keys[id(toolkit)] = _toolkit_key(toolkit)
+        return key
+
     def add_toolkit_instructions(toolkit: Toolkit) -> None:
-        key = _toolkit_key(toolkit)
+        key = toolkit_key(toolkit)
         if key in _toolkit_instruction_keys:
             return
         if toolkit.add_instructions and toolkit.instructions is not None:
@@ -377,6 +385,7 @@ def parse_tools(
         return _emits_toolkit_instructions(
             source_toolkit,
             index,
+            key=toolkit_key(source_toolkit),
             last_index=_source_toolkit_last_index,
             members=_source_toolkit_members,
             async_mode=async_mode,

--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -352,7 +352,23 @@ def parse_tools(
 ) -> List[Union[Function, dict]]:
     _function_names: List[str] = []
     _functions: List[Union[Function, dict]] = []
+    _toolkit_instruction_sources: set[int] = set()
+    _source_toolkit_last_indices = {
+        id(tool.source_toolkit): index
+        for index, tool in enumerate(tools)
+        if isinstance(tool, Function) and isinstance(tool.source_toolkit, Toolkit)
+    }
     agent._tool_instructions = []
+
+    def add_toolkit_instructions(toolkit: Toolkit) -> None:
+        source_id = id(toolkit)
+        if source_id in _toolkit_instruction_sources:
+            return
+        if toolkit.add_instructions and toolkit.instructions is not None:
+            if agent._tool_instructions is None:
+                agent._tool_instructions = []
+            agent._tool_instructions.append(toolkit.instructions)
+            _toolkit_instruction_sources.add(source_id)
 
     # Get output_schema from run_context
     output_schema = run_context.output_schema if run_context else None
@@ -367,7 +383,7 @@ def parse_tools(
     ):
         strict = True
 
-    for tool in tools:
+    for tool_index, tool in enumerate(tools):
         if isinstance(tool, Dict):
             # If a dict is passed, it is a builtin tool
             # that is run by the model provider and not the Agent
@@ -404,12 +420,17 @@ def parse_tools(
                     agent._tool_instructions.append(_func.instructions)
 
             # Add instructions from the toolkit
-            if tool.add_instructions and tool.instructions is not None:
-                agent._tool_instructions.append(tool.instructions)
+            add_toolkit_instructions(tool)
 
         elif isinstance(tool, Function):
+            source_toolkit = tool.source_toolkit if isinstance(tool.source_toolkit, Toolkit) else None
+            is_last_source_toolkit_function = (
+                source_toolkit is not None and _source_toolkit_last_indices.get(id(source_toolkit)) == tool_index
+            )
             if tool.name in _function_names:
                 log_warning(f"Duplicate tool name '{tool.name}' already registered on agent; skipping the duplicate.")
+                if is_last_source_toolkit_function and source_toolkit is not None:
+                    add_toolkit_instructions(source_toolkit)
                 continue
             _function_names.append(tool.name)
 
@@ -431,6 +452,13 @@ def parse_tools(
             # Add instructions from the Function
             if tool.add_instructions and tool.instructions is not None:
                 agent._tool_instructions.append(tool.instructions)
+
+            # DB-loaded toolkit members are bare Functions. Their live owning
+            # Toolkit is restored by Registry.rehydrate_function; add its
+            # guidance after all its member Functions, matching live Toolkit
+            # instruction order, and only once.
+            if is_last_source_toolkit_function and source_toolkit is not None:
+                add_toolkit_instructions(source_toolkit)
 
         elif callable(tool):
             try:

--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -379,6 +379,7 @@ def parse_tools(
             index,
             last_index=_source_toolkit_last_index,
             members=_source_toolkit_members,
+            async_mode=async_mode,
         )
 
     # Get output_schema from run_context

--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -360,7 +360,6 @@ def parse_tools(
     _function_names: List[str] = []
     _functions: List[Union[Function, dict]] = []
     _toolkit_instruction_keys: Set[ToolkitKey] = set()
-    _live_toolkit_keys = {_toolkit_key(tool) for tool in tools if isinstance(tool, Toolkit)}
     _source_toolkit_last_index, _source_toolkit_members = _group_source_toolkits(tools)
     agent._tool_instructions = []
 
@@ -378,7 +377,6 @@ def parse_tools(
         return _emits_toolkit_instructions(
             source_toolkit,
             index,
-            live_toolkit_keys=_live_toolkit_keys,
             last_index=_source_toolkit_last_index,
             members=_source_toolkit_members,
         )

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -5,7 +5,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Type, Union
 from uuid import uuid4
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from agno.db.base import BaseDb
 from agno.models.base import Model
@@ -118,30 +118,38 @@ class Registry:
             elif callable(tool):
                 yield None, tool.__name__, tool
 
-    def _owner_index(self) -> Dict[EntrypointKey, Tuple[Optional[Toolkit], EntrypointSource]]:
-        """The (toolkit, source) a fresh lookup build would leave in every slot.
+    def _owner_index(
+        self,
+    ) -> Tuple[Dict[EntrypointKey, Tuple[Optional[Toolkit], EntrypointSource]], Dict[int, Toolkit]]:
+        """Slot owners and toolkit provenance, replayed from the registrations.
 
-        Replayed from the same registrations the cached lookup was built from,
-        so comparing a cached entry against its slot's owner detects every way
-        the cache can go stale: a toolkit that rebuilt its functions dict (MCP
-        toolkits replace every Function on connect), a member deleted after the
-        cache was built, or a slot whose last-write-wins winner changed. A
-        miss-only check catches none of those, because the stale entry still
-        *hits*.
+        The first map holds the (toolkit, source) a fresh lookup build would
+        leave in every slot. Comparing a cached entry against its slot's owner
+        detects every way the cache can go stale: a toolkit that rebuilt its
+        functions dict (MCP toolkits replace every Function on connect), a
+        member deleted after the cache was built, or a slot whose
+        last-write-wins winner changed. A miss-only check catches none of
+        those, because the stale entry still *hits*.
 
-        The toolkit half is the attribution for ``source_toolkit``: the live
-        Toolkit whose registration owns the slot, or ``None`` for a Function or
-        plain callable registered directly.
+        The second map answers a different question: which live Toolkit holds
+        this exact Function object. Slot ownership cannot answer it -- a
+        toolkit member also registered directly owns its flat slot as a direct
+        registration, yet the toolkit still holds the object, and its guidance
+        still belongs to a component that loaded the member. Freshness is the
+        slot's; provenance is the object's.
 
         Built once per rehydration batch, so a component load pays one walk of
         the registrations rather than one per tool dict.
         """
         index: Dict[EntrypointKey, Tuple[Optional[Toolkit], EntrypointSource]] = {}
+        by_identity: Dict[int, Toolkit] = {}
         for toolkit, name, source in self._iter_entrypoint_sources():
             index[name] = (toolkit, source)
-            if toolkit is not None and isinstance(toolkit.name, str) and toolkit.name:
-                index[(toolkit.name, name)] = (toolkit, source)
-        return index
+            if toolkit is not None:
+                by_identity[id(source)] = toolkit
+                if isinstance(toolkit.name, str) and toolkit.name:
+                    index[(toolkit.name, name)] = (toolkit, source)
+        return index, by_identity
 
     def rehydrate_function(self, func_dict: Dict[str, Any]) -> Function:
         """Reconstruct a Function from dict, reattaching its entrypoint.
@@ -155,6 +163,26 @@ class Registry:
         """
         return self._rehydrate_function(func_dict, {"rebuilt": False})
 
+    @staticmethod
+    def _is_function_config(func_dict: Dict[str, Any]) -> bool:
+        """Whether ``Function.to_dict()`` could have written this dict.
+
+        Positive identification: ``name`` and ``parameters`` are always
+        written (``parameters`` has a non-None default, and ``to_dict`` only
+        drops None values), and no ``SERIALIZED_FIELDS`` key is ``type`` or
+        ``input_schema``. Provider-native tool dicts miss on one of these --
+        OpenAI-style builtins carry a top-level ``type``, Anthropic-style
+        custom tools carry ``input_schema`` and no ``parameters``. Anything
+        else in a tools list is the provider's to interpret, not ours to
+        parse.
+        """
+        return (
+            "name" in func_dict
+            and "parameters" in func_dict
+            and "type" not in func_dict
+            and "input_schema" not in func_dict
+        )
+
     def rehydrate_functions(self, func_dicts: List[Dict[str, Any]]) -> List[Union[Function, Dict[str, Any]]]:
         """Rehydrate a batch of persisted tool dicts, sharing one cache-rebuild budget.
 
@@ -162,18 +190,30 @@ class Registry:
         entrypoint lookup per batch is enough to pick up late-registered
         functions, so repeated misses within a load don't each pay a rebuild.
 
-        A tools list can also carry provider-builtin tools, persisted as plain
-        dicts. Those run inside the model provider, not the framework: there is
-        no entrypoint to reattach, so they pass through unchanged, in place. A
-        top-level ``type`` is what marks one -- every provider's builtin dicts
-        carry it, some alongside a ``name`` -- while a persisted Function dict
-        writes only ``SERIALIZED_FIELDS``, which has no ``type``.
+        A tools list can also carry provider-run tools persisted as plain
+        dicts. Those run inside the model provider, not the framework: there
+        is no entrypoint to reattach, so anything that is not positively a
+        serialized Function -- see ``_is_function_config`` -- passes through
+        unchanged, in place. A dict that looks like one but fails validation
+        passes through too: one unparseable tool must not take down the whole
+        component load.
         """
-        rebuild_state = {"rebuilt": False}
-        return [
-            func_dict if "type" in func_dict else self._rehydrate_function(func_dict, rebuild_state)
-            for func_dict in func_dicts
-        ]
+        rebuild_state: Dict[str, Any] = {"rebuilt": False}
+        rehydrated: List[Union[Function, Dict[str, Any]]] = []
+        for func_dict in func_dicts:
+            if not self._is_function_config(func_dict):
+                rehydrated.append(func_dict)
+                continue
+            try:
+                rehydrated.append(self._rehydrate_function(func_dict, rebuild_state))
+            except ValidationError as e:
+                log_warning(
+                    f"Registry: tool dict '{func_dict.get('name')}' looks like a serialized "
+                    f"Function but does not validate as one ({e.error_count()} error(s)); "
+                    "passing it through to the model provider unchanged."
+                )
+                rehydrated.append(func_dict)
+        return rehydrated
 
     def _rehydrate_function(self, func_dict: Dict[str, Any], rebuild_state: Dict[str, Any]) -> Function:
         func = Function.from_dict(func_dict)
@@ -184,9 +224,10 @@ class Registry:
             # bare Functions instead of Toolkits.
             func.owning_toolkit = toolkit_name
 
-        owners = rebuild_state.get("owners")
-        if owners is None:
-            owners = rebuild_state["owners"] = self._owner_index()
+        owner_maps = rebuild_state.get("owners")
+        if owner_maps is None:
+            owner_maps = rebuild_state["owners"] = self._owner_index()
+        owners, toolkit_by_identity = owner_maps
 
         def lookup(key: EntrypointKey) -> Tuple[Optional[EntrypointSource], Optional[Toolkit]]:
             # Resolution serves the slot's owner: the same answer a fresh cache
@@ -240,7 +281,13 @@ class Registry:
             # has left the registry binds the flat slot, which may belong to a
             # different toolkit, and that toolkit's guidance is not this
             # function's to carry.
-            source_toolkit = source_owner if resolved_as_recorded else None
+            #
+            # The slot's owner is the primary attribution; the identity map is
+            # the fallback for a flat slot owned by a direct registration of an
+            # object a Toolkit also holds -- provenance follows the object.
+            source_toolkit = source_owner if source_owner is not None else toolkit_by_identity.get(id(source))
+            if not resolved_as_recorded:
+                source_toolkit = None
             if source_toolkit is not None:
                 # Keep the exact live Toolkit available to instruction
                 # collection. Every member points to the same object, so the

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -155,15 +155,25 @@ class Registry:
         """
         return self._rehydrate_function(func_dict, {"rebuilt": False})
 
-    def rehydrate_functions(self, func_dicts: List[Dict[str, Any]]) -> List[Function]:
-        """Rehydrate a batch of function dicts, sharing one cache-rebuild budget.
+    def rehydrate_functions(self, func_dicts: List[Dict[str, Any]]) -> List[Union[Function, Dict[str, Any]]]:
+        """Rehydrate a batch of persisted tool dicts, sharing one cache-rebuild budget.
 
         A component load rehydrates every tool in its config; one rebuild of the
         entrypoint lookup per batch is enough to pick up late-registered
         functions, so repeated misses within a load don't each pay a rebuild.
+
+        A tools list can also carry provider-builtin tools, persisted as plain
+        dicts. Those run inside the model provider, not the framework: there is
+        no entrypoint to reattach, so they pass through unchanged, in place. A
+        top-level ``type`` is what marks one -- every provider's builtin dicts
+        carry it, some alongside a ``name`` -- while a persisted Function dict
+        writes only ``SERIALIZED_FIELDS``, which has no ``type``.
         """
         rebuild_state = {"rebuilt": False}
-        return [self._rehydrate_function(func_dict, rebuild_state) for func_dict in func_dicts]
+        return [
+            func_dict if "type" in func_dict else self._rehydrate_function(func_dict, rebuild_state)
+            for func_dict in func_dicts
+        ]
 
     def _rehydrate_function(self, func_dict: Dict[str, Any], rebuild_state: Dict[str, bool]) -> Function:
         func = Function.from_dict(func_dict)

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -109,49 +109,37 @@ class Registry:
                 register(tool.__name__, tool)
         return lookup
 
-    def _live_toolkit_for(
-        self, source: EntrypointSource, name: str, toolkit_name: Optional[str] = None
-    ) -> Tuple[Optional[Toolkit], bool, int]:
+    def _live_toolkit_for(self, source: EntrypointSource, name: str) -> Tuple[Optional[Toolkit], bool]:
         """Locate the live Toolkit that currently exposes ``source`` under ``name``.
 
-        Returns ``(toolkit, stale, exposures)``.
+        Returns ``(toolkit, stale)``. Matching is by object identity, so it
+        works for a config saved before tool names were toolkit-qualified and
+        for one whose toolkit was renamed: neither carries a name to match on.
 
         ``stale`` marks a resolved source that no Toolkit owns any more while a
         Toolkit does expose ``name`` with a different Function object. That is
         what a toolkit which rebuilt its functions dict looks like: MCP toolkits
         replace every Function on connect, and the cache entry written before
-        the rebuild still *hits*, so a plain miss check cannot catch it.
-
-        ``exposures`` counts the registry toolkits exposing ``name`` at all.
-        More than one means the flat slot's winner is arbitrary, so the
-        resolution must not be written back into a config.
-
-        ``toolkit_name`` restricts the search to same-named toolkits, for
-        sources resolved through a toolkit-qualified key.
+        the rebuild still *hits*, so a miss-only check cannot catch it.
         """
         if not isinstance(source, Function):
-            return None, False, 0
+            return None, False
 
-        owner: Optional[Toolkit] = None
-        exposures = 0
-        registered_directly = False
+        shadowed = False
         for tool in self.tools:
             if tool is source:
                 # Registered directly as a registry tool, so no toolkit owns it
                 # and a same-named toolkit member does not make it stale.
-                registered_directly = True
-                continue
+                return None, False
             if not isinstance(tool, Toolkit):
-                continue
-            if toolkit_name is not None and tool.name != toolkit_name:
                 continue
             current = tool.get_functions().get(name)
             if current is None:
                 continue
-            exposures += 1
             if current is source:
-                owner = tool
-        return owner, owner is None and exposures > 0 and not registered_directly, exposures
+                return tool, False
+            shadowed = True
+        return None, shadowed
 
     def rehydrate_function(self, func_dict: Dict[str, Any]) -> Function:
         """Reconstruct a Function from dict, reattaching its entrypoint.
@@ -234,22 +222,20 @@ class Registry:
             # has left the registry binds the flat slot, which may belong to a
             # different toolkit, and that toolkit's guidance is not this
             # function's to carry.
-            source_toolkit, _, exposures = (
-                self._live_toolkit_for(source, func.name) if resolved_as_recorded else (None, False, 0)
-            )
+            source_toolkit = self._live_toolkit_for(source, func.name)[0] if resolved_as_recorded else None
             if source_toolkit is not None:
                 # Keep the exact live Toolkit available to instruction
                 # collection. Every member points to the same object, so the
                 # collector can add toolkit-level guidance once without
                 # copying it into persisted Function dictionaries.
+                #
+                # The attribution is deliberately not written back onto an
+                # unqualified config. Identity resolution already reaches the
+                # Toolkit without a recorded name, and stamping one would tie
+                # the config to that name: a later rename would then take the
+                # qualified path, miss, and lose the guidance the unstamped
+                # config still finds.
                 func.source_toolkit = source_toolkit
-                if func.owning_toolkit is None and exposures == 1:
-                    # An unqualified config resolved unambiguously, so stamp the
-                    # attribution: a load -> save round trip then migrates it to
-                    # the qualified form. When several toolkits expose the name
-                    # the flat slot's winner is arbitrary and must not be made
-                    # permanent.
-                    func.owning_toolkit = source_toolkit.name
         else:
             func.entrypoint = source
         if func.entrypoint is None:

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -131,6 +131,22 @@ class Registry:
         rebuild_state = {"rebuilt": False}
         return [self._rehydrate_function(func_dict, rebuild_state) for func_dict in func_dicts]
 
+    def _toolkit_owning(self, source: Function) -> Optional[Toolkit]:
+        """The live Toolkit holding ``source``, matched by object identity.
+
+        Identity is what makes this work for a config saved before tool names
+        were toolkit-qualified, and for one whose toolkit was renamed: both
+        resolve through the flat name and carry no toolkit to match on. Slots
+        are last-write-wins, so the scan runs in reverse to return the Toolkit
+        that supplied the resolved source.
+        """
+        for tool in reversed(self.tools):
+            if not isinstance(tool, Toolkit):
+                continue
+            if any(tool_func is source for tool_func in tool.get_functions().values()):
+                return tool
+        return None
+
     def _rehydrate_function(self, func_dict: Dict[str, Any], rebuild_state: Dict[str, bool]) -> Function:
         func = Function.from_dict(func_dict)
         toolkit_name = func_dict.get("toolkit")
@@ -152,21 +168,13 @@ class Registry:
             return found
 
         source: Optional[EntrypointSource] = None
-        source_toolkit: Optional[Toolkit] = None
+        resolved_as_recorded = func.owning_toolkit is None
         if func.owning_toolkit is not None:
             # A qualified miss rebuilds before falling back to the flat name:
             # the flat slot may hold a same-named function from a *different*
             # toolkit while the right one simply hasn't populated the cache yet.
             source = lookup((func.owning_toolkit, func.name))
-            if isinstance(source, Function):
-                # Qualified slots are last-write-wins, so search in reverse to
-                # retain the exact Toolkit that supplied the resolved source.
-                for tool in reversed(self.tools):
-                    if not isinstance(tool, Toolkit) or tool.name != func.owning_toolkit:
-                        continue
-                    if any(tool_func is source for tool_func in tool.get_functions().values()):
-                        source_toolkit = tool
-                        break
+            resolved_as_recorded = source is not None
         if source is None:
             source = lookup(func.name)
             if source is not None and func.owning_toolkit is not None:
@@ -190,6 +198,12 @@ class Registry:
             # not be re-introspected at run time: processing would rebuild the
             # schema's `required` list from the proxy's signature.
             func.skip_entrypoint_processing = source.skip_entrypoint_processing
+            # Only when the bound function is the one the config named, or the
+            # config named no toolkit at all. A config whose recorded toolkit
+            # has left the registry binds the flat slot, which may belong to a
+            # different toolkit, and that toolkit's guidance is not this
+            # function's to carry.
+            source_toolkit = self._toolkit_owning(source) if resolved_as_recorded else None
             if source_toolkit is not None:
                 # Keep the exact live Toolkit available to instruction
                 # collection. Every member points to the same object, so the

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -152,11 +152,21 @@ class Registry:
             return found
 
         source: Optional[EntrypointSource] = None
+        source_toolkit: Optional[Toolkit] = None
         if func.owning_toolkit is not None:
             # A qualified miss rebuilds before falling back to the flat name:
             # the flat slot may hold a same-named function from a *different*
             # toolkit while the right one simply hasn't populated the cache yet.
             source = lookup((func.owning_toolkit, func.name))
+            if isinstance(source, Function):
+                # Qualified slots are last-write-wins, so search in reverse to
+                # retain the exact Toolkit that supplied the resolved source.
+                for tool in reversed(self.tools):
+                    if not isinstance(tool, Toolkit) or tool.name != func.owning_toolkit:
+                        continue
+                    if any(tool_func is source for tool_func in tool.get_functions().values()):
+                        source_toolkit = tool
+                        break
         if source is None:
             source = lookup(func.name)
             if source is not None and func.owning_toolkit is not None:
@@ -171,10 +181,21 @@ class Registry:
                 )
         if isinstance(source, Function):
             func.entrypoint = source.entrypoint
+            # Instruction settings are intentionally not serialized. Restore
+            # them from the live registry Function so registry edits apply on
+            # the next component load.
+            func.instructions = source.instructions
+            func.add_instructions = source.add_instructions
             # Entrypoints built for a fixed schema (e.g. MCP call proxies) must
             # not be re-introspected at run time: processing would rebuild the
             # schema's `required` list from the proxy's signature.
             func.skip_entrypoint_processing = source.skip_entrypoint_processing
+            if source_toolkit is not None:
+                # Keep the exact live Toolkit available to instruction
+                # collection. Every member points to the same object, so the
+                # collector can add toolkit-level guidance once without
+                # copying it into persisted Function dictionaries.
+                func.source_toolkit = source_toolkit
         else:
             func.entrypoint = source
         if func.entrypoint is None:

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Type, Union
 from uuid import uuid4
 
 from pydantic import BaseModel
@@ -89,76 +89,59 @@ class Registry:
                 )
             lookup[name] = source
 
-        for tool in self.tools:
-            if isinstance(tool, Toolkit):
-                # get_functions() is the exposed subset -- the only functions that
-                # are serialized or run, so only those claim a slot or warn here.
-                for func in tool.get_functions().values():
-                    if func.entrypoint is not None:
-                        register(func.name, func)
-                        if isinstance(tool.name, str) and tool.name:
-                            # A qualified slot collides only when two same-named
-                            # toolkits share a member name, and that collision has
-                            # already warned on the flat slot above -- so this
-                            # write stays silent (last wins).
-                            lookup[(tool.name, func.name)] = func
-            elif isinstance(tool, Function):
-                if tool.entrypoint is not None:
-                    register(tool.name, tool)
-            elif callable(tool):
-                register(tool.__name__, tool)
+        for toolkit, name, source in self._iter_entrypoint_sources():
+            register(name, source)
+            if toolkit is not None and isinstance(toolkit.name, str) and toolkit.name:
+                # A qualified slot collides only when two same-named toolkits
+                # share a member name, and that collision has already warned on
+                # the flat slot above -- so this write stays silent (last wins).
+                lookup[(toolkit.name, name)] = source
         return lookup
 
-    def _live_toolkit_for(
-        self, source: EntrypointSource, name: str, toolkit_name: Optional[str] = None
-    ) -> Tuple[Optional[Toolkit], bool]:
-        """Locate the live Toolkit that currently exposes ``source`` under ``name``.
+    def _iter_entrypoint_sources(self) -> Iterator[Tuple[Optional[Toolkit], str, EntrypointSource]]:
+        """Every (owning toolkit, name, source) registration, in order.
 
-        Returns ``(toolkit, stale)``. Matching is by object identity, so owner
-        resolution works for a config saved before tool names were
-        toolkit-qualified and for one whose toolkit was renamed: neither carries
-        a name to match on.
-
-        ``stale`` marks a resolved source that no Toolkit owns any more while a
-        Toolkit does expose ``name`` with a different Function object. That is
-        what a toolkit which rebuilt its functions dict looks like: MCP toolkits
-        replace every Function on connect, and the cache entry written before
-        the rebuild still *hits*, so a miss-only check cannot catch it.
-
-        ``toolkit_name`` narrows the search to same-named toolkits, for a
-        resolution that came from a toolkit-qualified key. Such a config named
-        the toolkit it wants, so only that toolkit can say whether the cached
-        entry is still fresh.
+        The single source of truth for what claims an entrypoint slot:
+        ``_entrypoint_lookup`` folds these into its dicts and ``_slot_owner``
+        replays them for one key, so the two can never disagree on a winner.
         """
-        if not isinstance(source, Function):
-            return None, False
-
-        shadowed = False
-        registered_directly = False
         for tool in self.tools:
-            if tool is source:
-                registered_directly = True
-                continue
-            if not isinstance(tool, Toolkit):
-                continue
-            if toolkit_name is not None and tool.name != toolkit_name:
-                continue
-            current = tool.get_functions().get(name)
-            if current is None:
-                continue
-            if current is source:
-                return tool, False
-            shadowed = True
+            if isinstance(tool, Toolkit):
+                # get_functions() is the exposed subset -- the only functions
+                # that are serialized or run, so only those claim a slot.
+                for func in tool.get_functions().values():
+                    if func.entrypoint is not None:
+                        yield tool, func.name, func
+            elif isinstance(tool, Function):
+                if tool.entrypoint is not None:
+                    yield None, tool.name, tool
+            elif callable(tool):
+                yield None, tool.__name__, tool
 
-        # A Function registered as a registry tool in its own right owns the
-        # flat slot legitimately, so a same-named toolkit member does not make
-        # it stale. That only holds for an unqualified resolution: a config that
-        # named a toolkit is asking that toolkit, and a standalone registration
-        # of the same object says nothing about whether the toolkit still holds
-        # it.
-        if toolkit_name is None and registered_directly:
-            return None, False
-        return None, shadowed
+    def _slot_owner(self, key: EntrypointKey) -> Tuple[Optional[Toolkit], Optional[EntrypointSource]]:
+        """The (toolkit, source) a fresh lookup build would leave in ``key``'s slot.
+
+        Replayed from the same registrations the cached lookup was built from,
+        so comparing a cached entry against this owner detects every way the
+        cache can go stale: a toolkit that rebuilt its functions dict (MCP
+        toolkits replace every Function on connect), a member deleted after the
+        cache was built, or a slot whose last-write-wins winner changed. A
+        miss-only check catches none of those, because the stale entry still
+        *hits*.
+
+        The toolkit half is the attribution for ``source_toolkit``: the live
+        Toolkit whose registration owns the slot, or ``None`` for a Function or
+        plain callable registered directly.
+        """
+        owner: Tuple[Optional[Toolkit], Optional[EntrypointSource]] = (None, None)
+        for toolkit, name, source in self._iter_entrypoint_sources():
+            if isinstance(key, tuple):
+                if toolkit is None or toolkit.name != key[0] or name != key[1]:
+                    continue
+            elif name != key:
+                continue
+            owner = (toolkit, source)
+        return owner
 
     def rehydrate_function(self, func_dict: Dict[str, Any]) -> Function:
         """Reconstruct a Function from dict, reattaching its entrypoint.
@@ -191,35 +174,39 @@ class Registry:
             # bare Functions instead of Toolkits.
             func.owning_toolkit = toolkit_name
 
-        def lookup(key: EntrypointKey) -> Optional[EntrypointSource]:
-            # Toolkits can gain functions after the lookup is first built -- MCP
-            # toolkits only register their functions once connected -- so a miss
-            # may just mean the cache is stale. A hit goes stale the same way: a
-            # toolkit that rebuilds its functions dict leaves the cache holding
-            # Function objects it no longer owns, and that entry still resolves.
-            # Rebuild once for either and retry.
-            # A qualified key is a question addressed to one toolkit, so its
-            # freshness is that toolkit's to answer.
-            qualified_toolkit = key[0] if isinstance(key, tuple) else None
+        def lookup(key: EntrypointKey) -> Tuple[Optional[EntrypointSource], Optional[Toolkit]]:
+            # The cache is fresh for this key only while it holds the same
+            # object a rebuild would produce -- the slot's replayed owner.
+            # Toolkits can gain functions after the lookup is first built (MCP
+            # toolkits only register their functions once connected), so a miss
+            # may just mean the cache is stale; a hit goes stale the same way
+            # when a toolkit rebuilds or drops its functions, or a slot's
+            # last-write-wins winner changes. Rebuild once per batch when the
+            # cache disagrees with the owner, and not at all when a rebuild
+            # could not help (the key has no owner, so it would miss too).
+            owner_toolkit, owner_source = self._slot_owner(key)
             found = self._entrypoint_lookup.get(key)
-            if not rebuild_state["rebuilt"] and (
-                found is None or self._live_toolkit_for(found, func.name, qualified_toolkit)[1]
-            ):
+            if not rebuild_state["rebuilt"] and found is not owner_source:
                 self.__dict__.pop("_entrypoint_lookup", None)
                 rebuild_state["rebuilt"] = True
                 found = self._entrypoint_lookup.get(key)
-            return found
+            # No disagreement is possible here: a rebuild folds the very
+            # registrations the replay walked, so once one has run this batch
+            # -- for this key or an earlier one -- the cached entry *is* the
+            # owner, and the fresh-check above covers the pre-rebuild path.
+            return found, owner_toolkit
 
         source: Optional[EntrypointSource] = None
+        source_owner: Optional[Toolkit] = None
         resolved_as_recorded = func.owning_toolkit is None
         if func.owning_toolkit is not None:
             # A qualified miss rebuilds before falling back to the flat name:
             # the flat slot may hold a same-named function from a *different*
             # toolkit while the right one simply hasn't populated the cache yet.
-            source = lookup((func.owning_toolkit, func.name))
+            source, source_owner = lookup((func.owning_toolkit, func.name))
             resolved_as_recorded = source is not None
         if source is None:
-            source = lookup(func.name)
+            source, source_owner = lookup(func.name)
             if source is not None and func.owning_toolkit is not None:
                 # The recorded toolkit could not be honored, so the flat slot's
                 # same-named function -- possibly from a different toolkit -- is
@@ -242,7 +229,7 @@ class Registry:
             # has left the registry binds the flat slot, which may belong to a
             # different toolkit, and that toolkit's guidance is not this
             # function's to carry.
-            source_toolkit = self._live_toolkit_for(source, func.name)[0] if resolved_as_recorded else None
+            source_toolkit = source_owner if resolved_as_recorded else None
             if source_toolkit is not None:
                 # Keep the exact live Toolkit available to instruction
                 # collection. Every member points to the same object, so the

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from agno.db.base import BaseDb
 from agno.models.base import Model
-from agno.tools.function import RUNTIME_ONLY_FIELDS, Function
+from agno.tools.function import RUNTIME_ONLY_FIELDS, Function, isolated_runtime_value
 from agno.tools.toolkit import Toolkit
 from agno.utils.log import log_warning
 from agno.vectordb.base import VectorDb
@@ -212,7 +212,7 @@ class Registry:
             # registry Function, so registry-side edits apply on the next
             # component load. See RUNTIME_ONLY_FIELDS for what and why.
             for field_name in RUNTIME_ONLY_FIELDS:
-                setattr(func, field_name, getattr(source, field_name))
+                setattr(func, field_name, isolated_runtime_value(getattr(source, field_name)))
             # Only when the bound function is the one the config named, or the
             # config named no toolkit at all. A config whose recorded toolkit
             # has left the registry binds the flat slot, which may belong to a

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from agno.db.base import BaseDb
 from agno.models.base import Model
-from agno.tools.function import Function
+from agno.tools.function import RUNTIME_ONLY_FIELDS, Function
 from agno.tools.toolkit import Toolkit
 from agno.utils.log import log_warning
 from agno.vectordb.base import VectorDb
@@ -208,15 +208,11 @@ class Registry:
                 )
         if isinstance(source, Function):
             func.entrypoint = source.entrypoint
-            # Instruction settings are intentionally not serialized. Restore
-            # them from the live registry Function so registry edits apply on
-            # the next component load.
-            func.instructions = source.instructions
-            func.add_instructions = source.add_instructions
-            # Entrypoints built for a fixed schema (e.g. MCP call proxies) must
-            # not be re-introspected at run time: processing would rebuild the
-            # schema's `required` list from the proxy's signature.
-            func.skip_entrypoint_processing = source.skip_entrypoint_processing
+            # Behavior the storage layer never writes comes from the live
+            # registry Function, so registry-side edits apply on the next
+            # component load. See RUNTIME_ONLY_FIELDS for what and why.
+            for field_name in RUNTIME_ONLY_FIELDS:
+                setattr(func, field_name, getattr(source, field_name))
             # Only when the bound function is the one the config named, or the
             # config named no toolkit at all. A config whose recorded toolkit
             # has left the registry binds the flat slot, which may belong to a

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -109,29 +109,39 @@ class Registry:
                 register(tool.__name__, tool)
         return lookup
 
-    def _live_toolkit_for(self, source: EntrypointSource, name: str) -> Tuple[Optional[Toolkit], bool]:
+    def _live_toolkit_for(
+        self, source: EntrypointSource, name: str, toolkit_name: Optional[str] = None
+    ) -> Tuple[Optional[Toolkit], bool]:
         """Locate the live Toolkit that currently exposes ``source`` under ``name``.
 
-        Returns ``(toolkit, stale)``. Matching is by object identity, so it
-        works for a config saved before tool names were toolkit-qualified and
-        for one whose toolkit was renamed: neither carries a name to match on.
+        Returns ``(toolkit, stale)``. Matching is by object identity, so owner
+        resolution works for a config saved before tool names were
+        toolkit-qualified and for one whose toolkit was renamed: neither carries
+        a name to match on.
 
         ``stale`` marks a resolved source that no Toolkit owns any more while a
         Toolkit does expose ``name`` with a different Function object. That is
         what a toolkit which rebuilt its functions dict looks like: MCP toolkits
         replace every Function on connect, and the cache entry written before
         the rebuild still *hits*, so a miss-only check cannot catch it.
+
+        ``toolkit_name`` narrows the search to same-named toolkits, for a
+        resolution that came from a toolkit-qualified key. Such a config named
+        the toolkit it wants, so only that toolkit can say whether the cached
+        entry is still fresh.
         """
         if not isinstance(source, Function):
             return None, False
 
         shadowed = False
+        registered_directly = False
         for tool in self.tools:
             if tool is source:
-                # Registered directly as a registry tool, so no toolkit owns it
-                # and a same-named toolkit member does not make it stale.
-                return None, False
+                registered_directly = True
+                continue
             if not isinstance(tool, Toolkit):
+                continue
+            if toolkit_name is not None and tool.name != toolkit_name:
                 continue
             current = tool.get_functions().get(name)
             if current is None:
@@ -139,6 +149,15 @@ class Registry:
             if current is source:
                 return tool, False
             shadowed = True
+
+        # A Function registered as a registry tool in its own right owns the
+        # flat slot legitimately, so a same-named toolkit member does not make
+        # it stale. That only holds for an unqualified resolution: a config that
+        # named a toolkit is asking that toolkit, and a standalone registration
+        # of the same object says nothing about whether the toolkit still holds
+        # it.
+        if toolkit_name is None and registered_directly:
+            return None, False
         return None, shadowed
 
     def rehydrate_function(self, func_dict: Dict[str, Any]) -> Function:
@@ -179,8 +198,13 @@ class Registry:
             # toolkit that rebuilds its functions dict leaves the cache holding
             # Function objects it no longer owns, and that entry still resolves.
             # Rebuild once for either and retry.
+            # A qualified key is a question addressed to one toolkit, so its
+            # freshness is that toolkit's to answer.
+            qualified_toolkit = key[0] if isinstance(key, tuple) else None
             found = self._entrypoint_lookup.get(key)
-            if not rebuild_state["rebuilt"] and (found is None or self._live_toolkit_for(found, func.name)[1]):
+            if not rebuild_state["rebuilt"] and (
+                found is None or self._live_toolkit_for(found, func.name, qualified_toolkit)[1]
+            ):
                 self.__dict__.pop("_entrypoint_lookup", None)
                 rebuild_state["rebuilt"] = True
                 found = self._entrypoint_lookup.get(key)

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -109,6 +109,50 @@ class Registry:
                 register(tool.__name__, tool)
         return lookup
 
+    def _live_toolkit_for(
+        self, source: EntrypointSource, name: str, toolkit_name: Optional[str] = None
+    ) -> Tuple[Optional[Toolkit], bool, int]:
+        """Locate the live Toolkit that currently exposes ``source`` under ``name``.
+
+        Returns ``(toolkit, stale, exposures)``.
+
+        ``stale`` marks a resolved source that no Toolkit owns any more while a
+        Toolkit does expose ``name`` with a different Function object. That is
+        what a toolkit which rebuilt its functions dict looks like: MCP toolkits
+        replace every Function on connect, and the cache entry written before
+        the rebuild still *hits*, so a plain miss check cannot catch it.
+
+        ``exposures`` counts the registry toolkits exposing ``name`` at all.
+        More than one means the flat slot's winner is arbitrary, so the
+        resolution must not be written back into a config.
+
+        ``toolkit_name`` restricts the search to same-named toolkits, for
+        sources resolved through a toolkit-qualified key.
+        """
+        if not isinstance(source, Function):
+            return None, False, 0
+
+        owner: Optional[Toolkit] = None
+        exposures = 0
+        registered_directly = False
+        for tool in self.tools:
+            if tool is source:
+                # Registered directly as a registry tool, so no toolkit owns it
+                # and a same-named toolkit member does not make it stale.
+                registered_directly = True
+                continue
+            if not isinstance(tool, Toolkit):
+                continue
+            if toolkit_name is not None and tool.name != toolkit_name:
+                continue
+            current = tool.get_functions().get(name)
+            if current is None:
+                continue
+            exposures += 1
+            if current is source:
+                owner = tool
+        return owner, owner is None and exposures > 0 and not registered_directly, exposures
+
     def rehydrate_function(self, func_dict: Dict[str, Any]) -> Function:
         """Reconstruct a Function from dict, reattaching its entrypoint.
 
@@ -131,22 +175,6 @@ class Registry:
         rebuild_state = {"rebuilt": False}
         return [self._rehydrate_function(func_dict, rebuild_state) for func_dict in func_dicts]
 
-    def _toolkit_owning(self, source: Function) -> Optional[Toolkit]:
-        """The live Toolkit holding ``source``, matched by object identity.
-
-        Identity is what makes this work for a config saved before tool names
-        were toolkit-qualified, and for one whose toolkit was renamed: both
-        resolve through the flat name and carry no toolkit to match on. Slots
-        are last-write-wins, so the scan runs in reverse to return the Toolkit
-        that supplied the resolved source.
-        """
-        for tool in reversed(self.tools):
-            if not isinstance(tool, Toolkit):
-                continue
-            if any(tool_func is source for tool_func in tool.get_functions().values()):
-                return tool
-        return None
-
     def _rehydrate_function(self, func_dict: Dict[str, Any], rebuild_state: Dict[str, bool]) -> Function:
         func = Function.from_dict(func_dict)
         toolkit_name = func_dict.get("toolkit")
@@ -159,9 +187,12 @@ class Registry:
         def lookup(key: EntrypointKey) -> Optional[EntrypointSource]:
             # Toolkits can gain functions after the lookup is first built -- MCP
             # toolkits only register their functions once connected -- so a miss
-            # may just mean the cache is stale. Rebuild once and retry.
+            # may just mean the cache is stale. A hit goes stale the same way: a
+            # toolkit that rebuilds its functions dict leaves the cache holding
+            # Function objects it no longer owns, and that entry still resolves.
+            # Rebuild once for either and retry.
             found = self._entrypoint_lookup.get(key)
-            if found is None and not rebuild_state["rebuilt"]:
+            if not rebuild_state["rebuilt"] and (found is None or self._live_toolkit_for(found, func.name)[1]):
                 self.__dict__.pop("_entrypoint_lookup", None)
                 rebuild_state["rebuilt"] = True
                 found = self._entrypoint_lookup.get(key)
@@ -203,13 +234,22 @@ class Registry:
             # has left the registry binds the flat slot, which may belong to a
             # different toolkit, and that toolkit's guidance is not this
             # function's to carry.
-            source_toolkit = self._toolkit_owning(source) if resolved_as_recorded else None
+            source_toolkit, _, exposures = (
+                self._live_toolkit_for(source, func.name) if resolved_as_recorded else (None, False, 0)
+            )
             if source_toolkit is not None:
                 # Keep the exact live Toolkit available to instruction
                 # collection. Every member points to the same object, so the
                 # collector can add toolkit-level guidance once without
                 # copying it into persisted Function dictionaries.
                 func.source_toolkit = source_toolkit
+                if func.owning_toolkit is None and exposures == 1:
+                    # An unqualified config resolved unambiguously, so stamp the
+                    # attribution: a load -> save round trip then migrates it to
+                    # the qualified form. When several toolkits expose the name
+                    # the flat slot's winner is arbitrary and must not be made
+                    # permanent.
+                    func.owning_toolkit = source_toolkit.name
         else:
             func.entrypoint = source
         if func.entrypoint is None:

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -102,8 +102,8 @@ class Registry:
         """Every (owning toolkit, name, source) registration, in order.
 
         The single source of truth for what claims an entrypoint slot:
-        ``_entrypoint_lookup`` folds these into its dicts and ``_slot_owner``
-        replays them for one key, so the two can never disagree on a winner.
+        ``_entrypoint_lookup`` folds these into its dicts and ``_owner_index``
+        replays them per batch, so the two can never disagree on a winner.
         """
         for tool in self.tools:
             if isinstance(tool, Toolkit):
@@ -118,12 +118,12 @@ class Registry:
             elif callable(tool):
                 yield None, tool.__name__, tool
 
-    def _slot_owner(self, key: EntrypointKey) -> Tuple[Optional[Toolkit], Optional[EntrypointSource]]:
-        """The (toolkit, source) a fresh lookup build would leave in ``key``'s slot.
+    def _owner_index(self) -> Dict[EntrypointKey, Tuple[Optional[Toolkit], EntrypointSource]]:
+        """The (toolkit, source) a fresh lookup build would leave in every slot.
 
         Replayed from the same registrations the cached lookup was built from,
-        so comparing a cached entry against this owner detects every way the
-        cache can go stale: a toolkit that rebuilt its functions dict (MCP
+        so comparing a cached entry against its slot's owner detects every way
+        the cache can go stale: a toolkit that rebuilt its functions dict (MCP
         toolkits replace every Function on connect), a member deleted after the
         cache was built, or a slot whose last-write-wins winner changed. A
         miss-only check catches none of those, because the stale entry still
@@ -132,16 +132,16 @@ class Registry:
         The toolkit half is the attribution for ``source_toolkit``: the live
         Toolkit whose registration owns the slot, or ``None`` for a Function or
         plain callable registered directly.
+
+        Built once per rehydration batch, so a component load pays one walk of
+        the registrations rather than one per tool dict.
         """
-        owner: Tuple[Optional[Toolkit], Optional[EntrypointSource]] = (None, None)
+        index: Dict[EntrypointKey, Tuple[Optional[Toolkit], EntrypointSource]] = {}
         for toolkit, name, source in self._iter_entrypoint_sources():
-            if isinstance(key, tuple):
-                if toolkit is None or toolkit.name != key[0] or name != key[1]:
-                    continue
-            elif name != key:
-                continue
-            owner = (toolkit, source)
-        return owner
+            index[name] = (toolkit, source)
+            if toolkit is not None and isinstance(toolkit.name, str) and toolkit.name:
+                index[(toolkit.name, name)] = (toolkit, source)
+        return index
 
     def rehydrate_function(self, func_dict: Dict[str, Any]) -> Function:
         """Reconstruct a Function from dict, reattaching its entrypoint.
@@ -175,7 +175,7 @@ class Registry:
             for func_dict in func_dicts
         ]
 
-    def _rehydrate_function(self, func_dict: Dict[str, Any], rebuild_state: Dict[str, bool]) -> Function:
+    def _rehydrate_function(self, func_dict: Dict[str, Any], rebuild_state: Dict[str, Any]) -> Function:
         func = Function.from_dict(func_dict)
         toolkit_name = func_dict.get("toolkit")
         if isinstance(toolkit_name, str) and toolkit_name:
@@ -184,27 +184,28 @@ class Registry:
             # bare Functions instead of Toolkits.
             func.owning_toolkit = toolkit_name
 
+        owners = rebuild_state.get("owners")
+        if owners is None:
+            owners = rebuild_state["owners"] = self._owner_index()
+
         def lookup(key: EntrypointKey) -> Tuple[Optional[EntrypointSource], Optional[Toolkit]]:
-            # The cache is fresh for this key only while it holds the same
-            # object a rebuild would produce -- the slot's replayed owner.
-            # Toolkits can gain functions after the lookup is first built (MCP
-            # toolkits only register their functions once connected), so a miss
-            # may just mean the cache is stale; a hit goes stale the same way
-            # when a toolkit rebuilds or drops its functions, or a slot's
-            # last-write-wins winner changes. Rebuild once per batch when the
-            # cache disagrees with the owner, and not at all when a rebuild
-            # could not help (the key has no owner, so it would miss too).
-            owner_toolkit, owner_source = self._slot_owner(key)
-            found = self._entrypoint_lookup.get(key)
-            if not rebuild_state["rebuilt"] and found is not owner_source:
+            # Resolution serves the slot's owner: the same answer a fresh cache
+            # build would give. The cached lookup is compared against it to
+            # decide when to rebuild -- Toolkits can gain functions after the
+            # lookup is first built (MCP toolkits only register their functions
+            # once connected), so a miss may just mean the cache is stale, and
+            # a hit goes stale the same way when a toolkit rebuilds or drops
+            # its functions, or a slot's last-write-wins winner changes.
+            # Rebuild once per batch when the cache disagrees, so collision
+            # warnings re-surface and later batches start warm, and not at all
+            # when a rebuild could not help (the key has no owner in the
+            # current registrations, so it would miss too).
+            owner_toolkit, owner_source = owners.get(key, (None, None))
+            if not rebuild_state["rebuilt"] and self._entrypoint_lookup.get(key) is not owner_source:
                 self.__dict__.pop("_entrypoint_lookup", None)
                 rebuild_state["rebuilt"] = True
-                found = self._entrypoint_lookup.get(key)
-            # No disagreement is possible here: a rebuild folds the very
-            # registrations the replay walked, so once one has run this batch
-            # -- for this key or an earlier one -- the cached entry *is* the
-            # owner, and the fresh-check above covers the pre-rebuild path.
-            return found, owner_toolkit
+                _ = self._entrypoint_lookup
+            return owner_source, owner_toolkit
 
         source: Optional[EntrypointSource] = None
         source_owner: Optional[Toolkit] = None

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -1148,7 +1148,7 @@ def _hydrate_from_graph(
         member_type = link_meta.get("type")
 
         if member_type == "agent":
-            agent = Agent.from_dict(child_config)
+            agent = Agent.from_dict(child_config, registry=registry)
             agent.id = child_graph["component"]["component_id"]
             if agent.db is None:
                 agent.db = db

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -351,6 +351,7 @@ def _determine_tools_for_model(
             index,
             last_index=_source_toolkit_last_index,
             members=_source_toolkit_members,
+            async_mode=async_mode,
         )
 
     # Get output_schema from run_context

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -324,7 +324,23 @@ def _determine_tools_for_model(
 
     _function_names = []
     _functions: List[Union[Function, dict]] = []
+    _toolkit_instruction_sources: set[int] = set()
+    _source_toolkit_last_indices = {
+        id(tool.source_toolkit): index
+        for index, tool in enumerate(_tools)
+        if isinstance(tool, Function) and isinstance(tool.source_toolkit, Toolkit)
+    }
     team._tool_instructions = []
+
+    def add_toolkit_instructions(toolkit: Toolkit) -> None:
+        source_id = id(toolkit)
+        if source_id in _toolkit_instruction_sources:
+            return
+        if toolkit.add_instructions and toolkit.instructions is not None:
+            if team._tool_instructions is None:
+                team._tool_instructions = []
+            team._tool_instructions.append(toolkit.instructions)
+            _toolkit_instruction_sources.add(source_id)
 
     # Get output_schema from run_context
     output_schema = run_context.output_schema if run_context else None
@@ -339,7 +355,7 @@ def _determine_tools_for_model(
     ):
         strict = True
 
-    for tool in _tools:
+    for tool_index, tool in enumerate(_tools):
         if isinstance(tool, Dict):
             # If a dict is passed, it is a builtin tool
             # that is run by the model provider and not the Agent
@@ -377,14 +393,17 @@ def _determine_tools_for_model(
                     team._tool_instructions.append(_func.instructions)
 
             # Add instructions from the toolkit
-            if tool.add_instructions and tool.instructions is not None:
-                if team._tool_instructions is None:
-                    team._tool_instructions = []
-                team._tool_instructions.append(tool.instructions)
+            add_toolkit_instructions(tool)
 
         elif isinstance(tool, Function):
+            source_toolkit = tool.source_toolkit if isinstance(tool.source_toolkit, Toolkit) else None
+            is_last_source_toolkit_function = (
+                source_toolkit is not None and _source_toolkit_last_indices.get(id(source_toolkit)) == tool_index
+            )
             if tool.name in _function_names:
                 log_warning(f"Duplicate tool name '{tool.name}' already registered on team; skipping the duplicate.")
+                if is_last_source_toolkit_function and source_toolkit is not None:
+                    add_toolkit_instructions(source_toolkit)
                 continue
             _function_names.append(tool.name)
             tool = tool.model_copy(deep=True)
@@ -404,6 +423,13 @@ def _determine_tools_for_model(
                 if team._tool_instructions is None:
                     team._tool_instructions = []
                 team._tool_instructions.append(tool.instructions)
+
+            # DB-loaded toolkit members are bare Functions. Their live owning
+            # Toolkit is restored by Registry.rehydrate_function; add its
+            # guidance after all its member Functions, matching live Toolkit
+            # instruction order, and only once.
+            if is_last_source_toolkit_function and source_toolkit is not None:
+                add_toolkit_instructions(source_toolkit)
 
         elif callable(tool):
             # We add the tools, which are callable functions

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -15,6 +15,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Union,
 )
@@ -33,6 +34,12 @@ from agno.run.team import (
 from agno.session import TeamSession
 from agno.tools import Toolkit
 from agno.tools.function import Function
+from agno.tools.toolkit import (
+    ToolkitKey,
+    _emits_toolkit_instructions,
+    _group_source_toolkits,
+    _toolkit_key,
+)
 from agno.utils.agent import (
     collect_joint_audios,
     collect_joint_files,
@@ -324,23 +331,29 @@ def _determine_tools_for_model(
 
     _function_names = []
     _functions: List[Union[Function, dict]] = []
-    _toolkit_instruction_sources: set[int] = set()
-    _source_toolkit_last_indices = {
-        id(tool.source_toolkit): index
-        for index, tool in enumerate(_tools)
-        if isinstance(tool, Function) and isinstance(tool.source_toolkit, Toolkit)
-    }
+    _toolkit_instruction_keys: Set[ToolkitKey] = set()
+    _live_toolkit_keys = {_toolkit_key(tool) for tool in _tools if isinstance(tool, Toolkit)}
+    _source_toolkit_last_index, _source_toolkit_members = _group_source_toolkits(_tools)
     team._tool_instructions = []
 
     def add_toolkit_instructions(toolkit: Toolkit) -> None:
-        source_id = id(toolkit)
-        if source_id in _toolkit_instruction_sources:
+        key = _toolkit_key(toolkit)
+        if key in _toolkit_instruction_keys:
             return
         if toolkit.add_instructions and toolkit.instructions is not None:
             if team._tool_instructions is None:
                 team._tool_instructions = []
             team._tool_instructions.append(toolkit.instructions)
-            _toolkit_instruction_sources.add(source_id)
+            _toolkit_instruction_keys.add(key)
+
+    def emits_toolkit_instructions(source_toolkit: Toolkit, index: int) -> bool:
+        return _emits_toolkit_instructions(
+            source_toolkit,
+            index,
+            live_toolkit_keys=_live_toolkit_keys,
+            last_index=_source_toolkit_last_index,
+            members=_source_toolkit_members,
+        )
 
     # Get output_schema from run_context
     output_schema = run_context.output_schema if run_context else None
@@ -397,12 +410,12 @@ def _determine_tools_for_model(
 
         elif isinstance(tool, Function):
             source_toolkit = tool.source_toolkit if isinstance(tool.source_toolkit, Toolkit) else None
-            is_last_source_toolkit_function = (
-                source_toolkit is not None and _source_toolkit_last_indices.get(id(source_toolkit)) == tool_index
+            emit_toolkit_instructions = source_toolkit is not None and emits_toolkit_instructions(
+                source_toolkit, tool_index
             )
             if tool.name in _function_names:
                 log_warning(f"Duplicate tool name '{tool.name}' already registered on team; skipping the duplicate.")
-                if is_last_source_toolkit_function and source_toolkit is not None:
+                if emit_toolkit_instructions and source_toolkit is not None:
                     add_toolkit_instructions(source_toolkit)
                 continue
             _function_names.append(tool.name)
@@ -428,7 +441,7 @@ def _determine_tools_for_model(
             # Toolkit is restored by Registry.rehydrate_function; add its
             # guidance after all its member Functions, matching live Toolkit
             # instruction order, and only once.
-            if is_last_source_toolkit_function and source_toolkit is not None:
+            if emit_toolkit_instructions and source_toolkit is not None:
                 add_toolkit_instructions(source_toolkit)
 
         elif callable(tool):

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -332,7 +332,6 @@ def _determine_tools_for_model(
     _function_names = []
     _functions: List[Union[Function, dict]] = []
     _toolkit_instruction_keys: Set[ToolkitKey] = set()
-    _live_toolkit_keys = {_toolkit_key(tool) for tool in _tools if isinstance(tool, Toolkit)}
     _source_toolkit_last_index, _source_toolkit_members = _group_source_toolkits(_tools)
     team._tool_instructions = []
 
@@ -350,7 +349,6 @@ def _determine_tools_for_model(
         return _emits_toolkit_instructions(
             source_toolkit,
             index,
-            live_toolkit_keys=_live_toolkit_keys,
             last_index=_source_toolkit_last_index,
             members=_source_toolkit_members,
         )

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -332,11 +332,19 @@ def _determine_tools_for_model(
     _function_names = []
     _functions: List[Union[Function, dict]] = []
     _toolkit_instruction_keys: Set[ToolkitKey] = set()
-    _source_toolkit_last_index, _source_toolkit_members = _group_source_toolkits(_tools)
+    _source_toolkit_last_index, _source_toolkit_members, _toolkit_keys = _group_source_toolkits(_tools)
     team._tool_instructions = []
 
+    def toolkit_key(toolkit: Toolkit) -> ToolkitKey:
+        # The key folds the toolkit's whole function surface; memoized so one
+        # collection pass computes it once per toolkit, not once per member.
+        key = _toolkit_keys.get(id(toolkit))
+        if key is None:
+            key = _toolkit_keys[id(toolkit)] = _toolkit_key(toolkit)
+        return key
+
     def add_toolkit_instructions(toolkit: Toolkit) -> None:
-        key = _toolkit_key(toolkit)
+        key = toolkit_key(toolkit)
         if key in _toolkit_instruction_keys:
             return
         if toolkit.add_instructions and toolkit.instructions is not None:
@@ -349,6 +357,7 @@ def _determine_tools_for_model(
         return _emits_toolkit_instructions(
             source_toolkit,
             index,
+            key=toolkit_key(source_toolkit),
             last_index=_source_toolkit_last_index,
             members=_source_toolkit_members,
             async_mode=async_mode,

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -250,13 +250,24 @@ class Function(BaseModel):
             approval_type=data.get("approval_type"),
         )
 
-    def __deepcopy__(self, memo: Dict[int, Any]) -> "Function":
-        """Deep-copy runtime state while retaining the live source Toolkit."""
+    def __deepcopy__(self, memo: Optional[Dict[int, Any]] = None) -> "Function":
+        """Deep-copy runtime state while retaining the live source Toolkit.
+
+        ``memo`` is optional because ``BaseModel.model_copy(deep=True)`` calls
+        ``__deepcopy__()`` with no argument.
+        """
+        if memo is None:
+            memo = {}
         if self.source_toolkit is not None:
             # AgentOS deep-copies each Function independently for request
-            # isolation. Sharing the registry Toolkit preserves its connections,
-            # current instructions, and one stable identity for deduplication.
-            memo[id(self.source_toolkit)] = self.source_toolkit
+            # isolation. Sharing the registry Toolkit keeps its connections and
+            # current instructions, and keeps the entrypoint bound to the live
+            # toolkit rather than to a detached clone of it.
+            #
+            # setdefault, not assignment: the memo belongs to the in-progress
+            # copy. Overwriting an entry it already made would leave one
+            # original with two stand-ins in the same object graph.
+            memo.setdefault(id(self.source_toolkit), self.source_toolkit)
         return super().__deepcopy__(memo)
 
     def model_copy(self, *, deep: bool = False) -> "Function":

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -189,15 +189,14 @@ def isolated_runtime_value(value: Any) -> Any:
 
     Lists are rebuilt rather than deep-copied, so callables such as tool hooks
     stay the same objects; only dataclass elements are copied, because those
-    are the ones written in place.
+    are the ones written in place. No RUNTIME_ONLY_FIELDS entry holds a dict,
+    so lists are the only containers handled.
     """
     from copy import copy
     from dataclasses import is_dataclass
 
     if isinstance(value, list):
         return [copy(item) if is_dataclass(item) else item for item in value]
-    if isinstance(value, dict):
-        return dict(value)
     return value
 
 

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -178,6 +178,29 @@ RUNTIME_ONLY_FIELDS = (
 )
 
 
+def isolated_runtime_value(value: Any) -> Any:
+    """A per-component copy of a value restored from a live registry Function.
+
+    Restoring by reference would let every component that loaded the same tool
+    share the registry Function's mutable state. ``user_input_schema`` is the
+    one that bites: the model layer writes the user's answer straight into its
+    ``UserInputField`` objects, so one run's input would be visible to every
+    other component holding that tool, and to the registry itself.
+
+    Lists are rebuilt rather than deep-copied, so callables such as tool hooks
+    stay the same objects; only dataclass elements are copied, because those
+    are the ones written in place.
+    """
+    from copy import copy
+    from dataclasses import is_dataclass
+
+    if isinstance(value, list):
+        return [copy(item) if is_dataclass(item) else item for item in value]
+    if isinstance(value, dict):
+        return dict(value)
+    return value
+
+
 class Function(BaseModel):
     """Model for storing functions that can be called by an agent."""
 

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -134,6 +134,50 @@ class UserFeedbackQuestion:
         )
 
 
+# What Function.to_dict() writes and from_dict() reads back: the choices that
+# belong to the saved component, so a later registry edit must not rewrite them.
+SERIALIZED_FIELDS = (
+    "name",
+    "description",
+    "parameters",
+    "strict",
+    "requires_confirmation",
+    "external_execution",
+    "approval_type",
+)
+
+# Fields Function.to_dict() deliberately omits and from_dict() cannot rebuild.
+# They describe how the tool behaves rather than what the saved component chose,
+# and several hold callables that do not serialize at all. Registry rehydration
+# copies them back from the live Function, so a reloaded component behaves like
+# the tool it was built from and picks up registry-side edits. The fields
+# to_dict() *does* carry stay as persisted: the saved config owns those.
+# Consumed by Registry._rehydrate_function.
+RUNTIME_ONLY_FIELDS = (
+    "instructions",
+    "add_instructions",
+    # Entrypoints built for a fixed schema (e.g. MCP call proxies) must not be
+    # re-introspected at run time: processing would rebuild the schema's
+    # `required` list from the proxy's signature.
+    "skip_entrypoint_processing",
+    "show_result",
+    "stop_after_tool_call",
+    "pre_hook",
+    "post_hook",
+    "tool_hooks",
+    # Without these, process_entrypoint stops excluding the user-supplied
+    # fields, so `required` lists a property the schema never defines and the
+    # gate that would have collected it is gone.
+    "requires_user_input",
+    "user_input_fields",
+    "user_input_schema",
+    "external_execution_silent",
+    "cache_results",
+    "cache_dir",
+    "cache_ttl",
+)
+
+
 class Function(BaseModel):
     """Model for storing functions that can be called by an agent."""
 
@@ -223,18 +267,7 @@ class Function(BaseModel):
     _files: Optional[Sequence[File]] = None
 
     def to_dict(self) -> Dict[str, Any]:
-        return self.model_dump(
-            exclude_none=True,
-            include={
-                "name",
-                "description",
-                "parameters",
-                "strict",
-                "requires_confirmation",
-                "external_execution",
-                "approval_type",
-            },
-        )
+        return self.model_dump(exclude_none=True, include=set(SERIALIZED_FIELDS))
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Function":

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -198,6 +198,10 @@ class Function(BaseModel):
     # to_dict: it is persisted via the storage layer's "toolkit" key and never
     # sent to models.
     owning_toolkit: Optional[str] = None
+    # Live Toolkit this function was flattened from during registry
+    # rehydration. It restores toolkit-level behavior without persisting the
+    # Toolkit or its instructions in component configs.
+    source_toolkit: Optional[Any] = Field(default=None, exclude=True, repr=False)
 
     # Caching configuration
     cache_results: bool = False
@@ -245,6 +249,15 @@ class Function(BaseModel):
             external_execution=data.get("external_execution", False),
             approval_type=data.get("approval_type"),
         )
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "Function":
+        """Deep-copy runtime state while retaining the live source Toolkit."""
+        if self.source_toolkit is not None:
+            # AgentOS deep-copies each Function independently for request
+            # isolation. Sharing the registry Toolkit preserves its connections,
+            # current instructions, and one stable identity for deduplication.
+            memo[id(self.source_toolkit)] = self.source_toolkit
+        return super().__deepcopy__(memo)
 
     def model_copy(self, *, deep: bool = False) -> "Function":
         """

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -349,8 +349,12 @@ class Function(BaseModel):
                 if field_name in shallow_fields:
                     # Shallow copy - just reference the same object
                     copied_data[field_name] = field_value
-                elif field_name == "parameters":
-                    # Deep copy the parameters dict
+                elif field_name in ("parameters", "user_input_schema"):
+                    # Deep copy the mutable run state. parse_tools hands the
+                    # model a per-run copy of each Function; the model layer
+                    # then writes the user's answers into user_input_schema in
+                    # place, so an aliased schema carries one run's input into
+                    # every later run of the same component.
                     from copy import deepcopy
 
                     copied_data[field_name] = deepcopy(field_value)

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -51,6 +51,7 @@ def _emits_toolkit_instructions(
     index: int,
     last_index: Dict[ToolkitKey, int],
     members: Dict[ToolkitKey, Set[str]],
+    async_mode: bool = False,
 ) -> bool:
     """Whether the bare Function at ``index`` should emit its toolkit's guidance.
 
@@ -68,7 +69,10 @@ def _emits_toolkit_instructions(
     key = _toolkit_key(source_toolkit)
     if last_index.get(key) != index:
         return False
-    exposed = set(source_toolkit.get_functions())
+    # Measured against the set this run would actually deliver: in async mode a
+    # live Toolkit contributes its async variants too, and the registry cannot
+    # rehydrate those, so an async-only member always leaves a gap here.
+    exposed = set(source_toolkit.get_async_functions() if async_mode else source_toolkit.get_functions())
     present = members.get(key, set())
     if not exposed <= present:
         log_debug(

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -44,27 +44,23 @@ def _group_source_toolkits(tools: Sequence[Any]) -> Tuple[Dict[ToolkitKey, int],
 def _emits_toolkit_instructions(
     source_toolkit: "Toolkit",
     index: int,
-    live_toolkit_keys: Set[ToolkitKey],
     last_index: Dict[ToolkitKey, int],
     members: Dict[ToolkitKey, Set[str]],
 ) -> bool:
     """Whether the bare Function at ``index`` should emit its toolkit's guidance.
 
     Guidance belongs after all of the toolkit's member guidance, so only the
-    last member emits it. Two cases suppress it entirely:
+    last member emits it, and only when the component holds every function the
+    toolkit exposes. Persistence records one dict per function, so a component
+    built from a whole toolkit and one built from a single member are
+    indistinguishable on reload; resolving that ambiguity as "whole toolkit"
+    would hand the model guidance naming tools it was not given.
 
-    - A live Toolkit carrying the same guidance is in the same tools list. It
-      emits at its own index, after its own members, which is where the
-      guidance would have gone had nothing been flattened.
-    - The component holds only some of the toolkit's functions. Persistence
-      records one dict per function, so a component built from a whole toolkit
-      and one built from a single member are indistinguishable on reload;
-      resolving that ambiguity as "whole toolkit" would hand the model guidance
-      naming tools it was not given.
+    A live Toolkit for the same guidance elsewhere in the list needs no special
+    case: whichever representation reaches its emission point first wins, and
+    :func:`_toolkit_key` makes the caller's dedup collapse the two.
     """
     key = _toolkit_key(source_toolkit)
-    if key in live_toolkit_keys:
-        return False
     if last_index.get(key) != index:
         return False
     exposed = set(source_toolkit.get_functions())

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -1,12 +1,81 @@
 from collections import OrderedDict
 from inspect import iscoroutinefunction
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, cast, get_type_hints
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union, cast, get_type_hints
 
 from agno.exceptions import PathSecurityError
 from agno.tools.function import Function
 from agno.utils.log import log_debug, log_warning
 from agno.utils.path_safety import safe_join_relative_path
+
+
+# Groups a Toolkit by the guidance it emits rather than by object identity.
+# Agent.deep_copy / Team.deep_copy clone a Toolkit list entry while the
+# rehydrated Functions that came from it keep pointing at the live registry
+# Toolkit, so identity splits one logical toolkit into two. Two toolkits that
+# agree on all three fields emit the same text, so collapsing them is correct.
+ToolkitKey = Tuple[str, Optional[str], bool]
+
+
+def _toolkit_key(toolkit: "Toolkit") -> ToolkitKey:
+    return (toolkit.name, toolkit.instructions, toolkit.add_instructions)
+
+
+def _group_source_toolkits(tools: Sequence[Any]) -> Tuple[Dict[ToolkitKey, int], Dict[ToolkitKey, Set[str]]]:
+    """Index the bare Functions that a live Toolkit was flattened into.
+
+    Returns the last index each toolkit's members occupy in ``tools`` and the
+    member names present, both keyed by :func:`_toolkit_key`.
+    """
+    last_index: Dict[ToolkitKey, int] = {}
+    members: Dict[ToolkitKey, Set[str]] = {}
+    for index, tool in enumerate(tools):
+        if not isinstance(tool, Function):
+            continue
+        source_toolkit = tool.source_toolkit
+        if not isinstance(source_toolkit, Toolkit):
+            continue
+        key = _toolkit_key(source_toolkit)
+        last_index[key] = index
+        members.setdefault(key, set()).add(tool.name)
+    return last_index, members
+
+
+def _emits_toolkit_instructions(
+    source_toolkit: "Toolkit",
+    index: int,
+    live_toolkit_keys: Set[ToolkitKey],
+    last_index: Dict[ToolkitKey, int],
+    members: Dict[ToolkitKey, Set[str]],
+) -> bool:
+    """Whether the bare Function at ``index`` should emit its toolkit's guidance.
+
+    Guidance belongs after all of the toolkit's member guidance, so only the
+    last member emits it. Two cases suppress it entirely:
+
+    - A live Toolkit carrying the same guidance is in the same tools list. It
+      emits at its own index, after its own members, which is where the
+      guidance would have gone had nothing been flattened.
+    - The component holds only some of the toolkit's functions. Persistence
+      records one dict per function, so a component built from a whole toolkit
+      and one built from a single member are indistinguishable on reload;
+      resolving that ambiguity as "whole toolkit" would hand the model guidance
+      naming tools it was not given.
+    """
+    key = _toolkit_key(source_toolkit)
+    if key in live_toolkit_keys:
+        return False
+    if last_index.get(key) != index:
+        return False
+    exposed = set(source_toolkit.get_functions())
+    present = members.get(key, set())
+    if not exposed <= present:
+        log_debug(
+            f"Toolkit '{source_toolkit.name}' instructions skipped: the component holds "
+            f"{len(present)} of its {len(exposed)} functions."
+        )
+        return False
+    return True
 
 
 class Toolkit:

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -13,11 +13,17 @@ from agno.utils.path_safety import safe_join_relative_path
 # rehydrated Functions that came from it keep pointing at the live registry
 # Toolkit, so identity splits one logical toolkit into two. Two toolkits that
 # agree on all three fields emit the same text, so collapsing them is correct.
-ToolkitKey = Tuple[str, Optional[str], bool]
+ToolkitKey = Tuple[str, Any, bool]
 
 
 def _toolkit_key(toolkit: "Toolkit") -> ToolkitKey:
-    return (toolkit.name, toolkit.instructions, toolkit.add_instructions)
+    instructions = toolkit.instructions
+    if instructions is not None and not isinstance(instructions, str):
+        # `instructions` is declared Optional[str] but nothing enforces it, and
+        # a list would make this key unhashable. Fall back to identity for that
+        # toolkit rather than raise: grouping degrades, the run does not fail.
+        return (toolkit.name, id(toolkit), toolkit.add_instructions)
+    return (toolkit.name, instructions, toolkit.add_instructions)
 
 
 def _group_source_toolkits(tools: Sequence[Any]) -> Tuple[Dict[ToolkitKey, int], Dict[ToolkitKey, Set[str]]]:

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -8,22 +8,29 @@ from agno.tools.function import Function
 from agno.utils.log import log_debug, log_warning
 from agno.utils.path_safety import safe_join_relative_path
 
-# Groups a Toolkit by the guidance it emits rather than by object identity.
+# Groups a Toolkit by what it contributes rather than by object identity.
 # Agent.deep_copy / Team.deep_copy clone a Toolkit list entry while the
 # rehydrated Functions that came from it keep pointing at the live registry
-# Toolkit, so identity splits one logical toolkit into two. Two toolkits that
-# agree on all three fields emit the same text, so collapsing them is correct.
-ToolkitKey = Tuple[str, Any, bool]
+# Toolkit, so identity splits one logical toolkit into two. A clone agrees with
+# its original on every part of this key, so the two regroup.
+#
+# The function surface is part of the key because the coverage check reads it:
+# two same-named toolkits carrying the same guidance but exposing different
+# functions would otherwise pool their members, and one toolkit's coverage would
+# be judged against the other's function set.
+ToolkitKey = Tuple[str, Any, bool, frozenset]
 
 
 def _toolkit_key(toolkit: "Toolkit") -> ToolkitKey:
+    # Both dicts, so the key does not shift between sync and async collection.
+    surface = frozenset(toolkit.get_functions()) | frozenset(toolkit.get_async_functions())
     instructions = toolkit.instructions
     if instructions is not None and not isinstance(instructions, str):
         # `instructions` is declared Optional[str] but nothing enforces it, and
         # a list would make this key unhashable. Fall back to identity for that
         # toolkit rather than raise: grouping degrades, the run does not fail.
-        return (toolkit.name, id(toolkit), toolkit.add_instructions)
-    return (toolkit.name, instructions, toolkit.add_instructions)
+        return (toolkit.name, id(toolkit), toolkit.add_instructions, surface)
+    return (toolkit.name, instructions, toolkit.add_instructions, surface)
 
 
 def _group_source_toolkits(tools: Sequence[Any]) -> Tuple[Dict[ToolkitKey, int], Dict[ToolkitKey, Set[str]]]:

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -17,20 +17,23 @@ from agno.utils.path_safety import safe_join_relative_path
 # The function surface is part of the key because the coverage check reads it:
 # two same-named toolkits carrying the same guidance but exposing different
 # functions would otherwise pool their members, and one toolkit's coverage would
-# be judged against the other's function set.
-ToolkitKey = Tuple[str, Any, bool, frozenset]
+# be judged against the other's function set. The sync and async surfaces stay
+# separate parts of the key: coverage is measured per mode, and two toolkits
+# whose surfaces agree only as a union would pool members that mode-specific
+# coverage then judges against the wrong function set.
+ToolkitKey = Tuple[str, Any, bool, frozenset, frozenset]
 
 
 def _toolkit_key(toolkit: "Toolkit") -> ToolkitKey:
-    # Both dicts, so the key does not shift between sync and async collection.
-    surface = frozenset(toolkit.get_functions()) | frozenset(toolkit.get_async_functions())
+    sync_surface = frozenset(toolkit.get_functions())
+    async_surface = frozenset(toolkit.get_async_functions())
     instructions = toolkit.instructions
     if instructions is not None and not isinstance(instructions, str):
         # `instructions` is declared Optional[str] but nothing enforces it, and
         # a list would make this key unhashable. Fall back to identity for that
         # toolkit rather than raise: grouping degrades, the run does not fail.
-        return (toolkit.name, id(toolkit), toolkit.add_instructions, surface)
-    return (toolkit.name, instructions, toolkit.add_instructions, surface)
+        return (toolkit.name, id(toolkit), toolkit.add_instructions, sync_surface, async_surface)
+    return (toolkit.name, instructions, toolkit.add_instructions, sync_surface, async_surface)
 
 
 def _group_source_toolkits(tools: Sequence[Any]) -> Tuple[Dict[ToolkitKey, int], Dict[ToolkitKey, Set[str]]]:

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -36,29 +36,39 @@ def _toolkit_key(toolkit: "Toolkit") -> ToolkitKey:
     return (toolkit.name, instructions, toolkit.add_instructions, sync_surface, async_surface)
 
 
-def _group_source_toolkits(tools: Sequence[Any]) -> Tuple[Dict[ToolkitKey, int], Dict[ToolkitKey, Set[str]]]:
+def _group_source_toolkits(
+    tools: Sequence[Any],
+) -> Tuple[Dict[ToolkitKey, int], Dict[ToolkitKey, Set[str]], Dict[int, ToolkitKey]]:
     """Index the bare Functions that a live Toolkit was flattened into.
 
     Returns the last index each toolkit's members occupy in ``tools`` and the
-    member names present, both keyed by :func:`_toolkit_key`.
+    member names present, both keyed by :func:`_toolkit_key`, plus the key
+    itself memoized per live Toolkit object. The key folds the toolkit's whole
+    function surface, so rebuilding it per member Function would make one
+    collection pass quadratic in the toolkit's size; every later key read must
+    come from the memo.
     """
     last_index: Dict[ToolkitKey, int] = {}
     members: Dict[ToolkitKey, Set[str]] = {}
+    keys_by_id: Dict[int, ToolkitKey] = {}
     for index, tool in enumerate(tools):
         if not isinstance(tool, Function):
             continue
         source_toolkit = tool.source_toolkit
         if not isinstance(source_toolkit, Toolkit):
             continue
-        key = _toolkit_key(source_toolkit)
+        key = keys_by_id.get(id(source_toolkit))
+        if key is None:
+            key = keys_by_id[id(source_toolkit)] = _toolkit_key(source_toolkit)
         last_index[key] = index
         members.setdefault(key, set()).add(tool.name)
-    return last_index, members
+    return last_index, members, keys_by_id
 
 
 def _emits_toolkit_instructions(
     source_toolkit: "Toolkit",
     index: int,
+    key: ToolkitKey,
     last_index: Dict[ToolkitKey, int],
     members: Dict[ToolkitKey, Set[str]],
     async_mode: bool = False,
@@ -72,11 +82,14 @@ def _emits_toolkit_instructions(
     indistinguishable on reload; resolving that ambiguity as "whole toolkit"
     would hand the model guidance naming tools it was not given.
 
+    ``key`` is ``_toolkit_key(source_toolkit)``, passed in from the caller's
+    memo rather than rebuilt here: the key folds the toolkit's whole function
+    surface, and this check runs once per member Function.
+
     A live Toolkit for the same guidance elsewhere in the list needs no special
     case: whichever representation reaches its emission point first wins, and
     :func:`_toolkit_key` makes the caller's dedup collapse the two.
     """
-    key = _toolkit_key(source_toolkit)
     if last_index.get(key) != index:
         return False
     # Measured against the set this run would actually deliver: in async mode a

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -8,7 +8,6 @@ from agno.tools.function import Function
 from agno.utils.log import log_debug, log_warning
 from agno.utils.path_safety import safe_join_relative_path
 
-
 # Groups a Toolkit by the guidance it emits rather than by object identity.
 # Agent.deep_copy / Team.deep_copy clone a Toolkit list entry while the
 # rehydrated Functions that came from it keep pointing at the live registry

--- a/libs/agno/tests/unit/agent/test_team_tool_propagation.py
+++ b/libs/agno/tests/unit/agent/test_team_tool_propagation.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 from agno.agent._tools import parse_tools
 from agno.agent.agent import Agent
+from agno.registry import Registry
 from agno.tools import tool
 from agno.tools.function import Function
 from agno.tools.toolkit import Toolkit
@@ -190,3 +191,85 @@ def test_toolkit_function_without_instructions_does_not_append_none():
     parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
 
     assert agent._tool_instructions == []
+
+
+# -- Rehydrated toolkit members ----------------------------------------------
+
+
+def _guided_toolkit() -> Toolkit:
+    def first_tool() -> str:
+        return "first"
+
+    def second_tool() -> str:
+        return "second"
+
+    toolkit = Toolkit(
+        name="my_toolkit",
+        tools=[first_tool, second_tool],
+        instructions="toolkit-level-rule",
+        add_instructions=True,
+    )
+    toolkit.functions["first_tool"].instructions = "first-rule"
+    toolkit.functions["second_tool"].instructions = "second-rule"
+    return toolkit
+
+
+def _rehydrate(registry: Registry, toolkit: Toolkit, only: Any = None) -> Any:
+    stored = []
+    for name, function in toolkit.get_functions().items():
+        if only is not None and name not in only:
+            continue
+        function_dict = function.to_dict()
+        function_dict["toolkit"] = toolkit.name
+        stored.append(function_dict)
+    return registry.rehydrate_functions(stored)
+
+
+def test_rehydrated_toolkit_instructions_reach_agent_once():
+    toolkit = _guided_toolkit()
+    registry = Registry(tools=[toolkit])
+
+    agent = Agent(tools=_rehydrate(registry, toolkit))
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+
+    assert agent._tool_instructions == ["first-rule", "second-rule", "toolkit-level-rule"]
+
+
+def test_rehydrated_subset_does_not_get_the_whole_toolkits_guidance():
+    """A component that persisted one member of a toolkit must not be handed
+    guidance naming the members it was not given."""
+    toolkit = _guided_toolkit()
+    registry = Registry(tools=[toolkit])
+
+    agent = Agent(tools=_rehydrate(registry, toolkit, only={"first_tool"}))
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+
+    assert agent._tool_instructions == ["first-rule"]
+
+
+def test_live_toolkit_beside_rehydrated_members_emits_guidance_once_and_last():
+    """A tools list holding both representations of one toolkit must read the
+    same as the live Toolkit alone -- before and after deep_copy, which clones
+    the Toolkit entry while the Functions keep the live one."""
+    toolkit = _guided_toolkit()
+    registry = Registry(tools=[toolkit])
+    mixed = _rehydrate(registry, toolkit, only={"first_tool"}) + [toolkit]
+
+    agent = Agent(tools=mixed)
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+    assert agent._tool_instructions == ["first-rule", "second-rule", "toolkit-level-rule"]
+
+    copied = Agent(tools=mixed).deep_copy()
+    parse_tools(agent=copied, tools=copied.tools, model=_mock_model())
+    assert copied._tool_instructions == ["first-rule", "second-rule", "toolkit-level-rule"]
+
+
+def test_rehydrated_toolkit_guidance_survives_deep_copy():
+    toolkit = _guided_toolkit()
+    registry = Registry(tools=[toolkit])
+
+    copied = Agent(tools=_rehydrate(registry, toolkit)).deep_copy()
+    assert all(tool.source_toolkit is toolkit for tool in copied.tools)
+    parse_tools(agent=copied, tools=copied.tools, model=_mock_model())
+
+    assert copied._tool_instructions == ["first-rule", "second-rule", "toolkit-level-rule"]

--- a/libs/agno/tests/unit/agent/test_team_tool_propagation.py
+++ b/libs/agno/tests/unit/agent/test_team_tool_propagation.py
@@ -273,3 +273,20 @@ def test_rehydrated_toolkit_guidance_survives_deep_copy():
     parse_tools(agent=copied, tools=copied.tools, model=_mock_model())
 
     assert copied._tool_instructions == ["first-rule", "second-rule", "toolkit-level-rule"]
+
+
+def test_cloned_toolkit_and_its_rehydrated_members_are_one_toolkit():
+    """deep_copy clones the Toolkit list entry while the rehydrated members keep
+    the live one. Grouping by object identity would see two toolkits here and
+    emit the guidance twice."""
+    toolkit = _guided_toolkit()
+    registry = Registry(tools=[toolkit])
+    mixed = [toolkit] + _rehydrate(registry, toolkit)
+
+    copied = Agent(tools=mixed).deep_copy()
+    # The premise: the copy really did split the object.
+    assert copied.tools[0] is not toolkit
+    assert copied.tools[1].source_toolkit is toolkit
+
+    parse_tools(agent=copied, tools=copied.tools, model=_mock_model())
+    assert copied._tool_instructions == ["first-rule", "second-rule", "toolkit-level-rule"]

--- a/libs/agno/tests/unit/agent/test_team_tool_propagation.py
+++ b/libs/agno/tests/unit/agent/test_team_tool_propagation.py
@@ -308,6 +308,34 @@ def test_two_toolkits_are_not_collapsed_by_the_grouping_key():
     assert agent._tool_instructions == ["rule"]
 
 
+def test_toolkits_sharing_guidance_text_are_still_grouped_apart():
+    """Two toolkits can carry the same guidance and still be different
+    toolkits. Pooling their members would let one toolkit's functions satisfy
+    the other's coverage check, so a fully-loaded toolkit loses its guidance to
+    a partially-loaded neighbour."""
+
+    def a_one() -> str:
+        return "a1"
+
+    def a_two() -> str:
+        return "a2"
+
+    def b_one() -> str:
+        return "b1"
+
+    alpha = Toolkit(name="alpha", tools=[a_one, a_two], instructions="shared-rule", add_instructions=True)
+    beta = Toolkit(name="beta", tools=[b_one], instructions="shared-rule", add_instructions=True)
+    registry = Registry(tools=[alpha, beta])
+
+    # beta is complete, alpha is a subset, and alpha's member comes last.
+    tools = _rehydrate(registry, beta) + _rehydrate(registry, alpha, only={"a_one"})
+    agent = Agent(tools=tools)
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+
+    # beta earns its guidance; alpha does not, and cannot borrow beta's members.
+    assert agent._tool_instructions == ["shared-rule"]
+
+
 def test_async_only_members_are_counted_when_checking_coverage():
     """In async mode a live Toolkit contributes its async variants too, and the
     registry cannot rehydrate those. The component is genuinely short a tool, so

--- a/libs/agno/tests/unit/agent/test_team_tool_propagation.py
+++ b/libs/agno/tests/unit/agent/test_team_tool_propagation.py
@@ -336,6 +336,35 @@ def test_toolkits_sharing_guidance_text_are_still_grouped_apart():
     assert agent._tool_instructions == ["shared-rule"]
 
 
+def test_same_named_toolkits_do_not_pool_their_members():
+    """Same name, same guidance, different functions: still two toolkits. Pooling
+    them judges one toolkit's coverage against the other's function set, so a
+    fully-loaded toolkit is silenced by a partially-loaded namesake."""
+
+    def a_one() -> str:
+        return "a1"
+
+    def a_two() -> str:
+        return "a2"
+
+    def b_one() -> str:
+        return "b1"
+
+    def b_two() -> str:
+        return "b2"
+
+    first = Toolkit(name="shared", tools=[a_one, a_two], instructions="shared-rule", add_instructions=True)
+    second = Toolkit(name="shared", tools=[b_one, b_two], instructions="shared-rule", add_instructions=True)
+    registry = Registry(tools=[first, second])
+
+    tools = _rehydrate(registry, first) + _rehydrate(registry, second, only={"b_one"})
+    agent = Agent(tools=tools)
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+
+    # `first` is complete and keeps its guidance; the partial `second` adds none.
+    assert agent._tool_instructions == ["shared-rule"]
+
+
 def test_async_only_members_are_counted_when_checking_coverage():
     """In async mode a live Toolkit contributes its async variants too, and the
     registry cannot rehydrate those. The component is genuinely short a tool, so

--- a/libs/agno/tests/unit/agent/test_team_tool_propagation.py
+++ b/libs/agno/tests/unit/agent/test_team_tool_propagation.py
@@ -275,6 +275,22 @@ def test_rehydrated_toolkit_guidance_survives_deep_copy():
     assert copied._tool_instructions == ["first-rule", "second-rule", "toolkit-level-rule"]
 
 
+def test_non_string_toolkit_instructions_do_not_break_the_run():
+    """`instructions` is declared Optional[str] but nothing enforces it. Grouping
+    toolkits by their guidance must not turn a list into a hard failure."""
+    toolkit = Toolkit(
+        name="my_toolkit",
+        tools=[lambda: "x"],
+        instructions=["rule one", "rule two"],
+        add_instructions=True,
+    )
+
+    agent = Agent(tools=[toolkit])
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+
+    assert agent._tool_instructions == [["rule one", "rule two"]]
+
+
 def test_cloned_toolkit_and_its_rehydrated_members_are_one_toolkit():
     """deep_copy clones the Toolkit list entry while the rehydrated members keep
     the live one. Grouping by object identity would see two toolkits here and

--- a/libs/agno/tests/unit/agent/test_team_tool_propagation.py
+++ b/libs/agno/tests/unit/agent/test_team_tool_propagation.py
@@ -275,6 +275,69 @@ def test_rehydrated_toolkit_guidance_survives_deep_copy():
     assert copied._tool_instructions == ["first-rule", "second-rule", "toolkit-level-rule"]
 
 
+def test_two_toolkits_are_not_collapsed_by_the_grouping_key():
+    """Grouping is by emitted guidance, so toolkits that differ in any part of
+    that must stay separate. Without this, one key for everything still passes
+    the single-toolkit tests."""
+
+    def a_tool() -> str:
+        return "a"
+
+    def b_tool() -> str:
+        return "b"
+
+    # Different names, different guidance: two blocks.
+    first = Toolkit(name="first", tools=[a_tool], instructions="first-rule", add_instructions=True)
+    second = Toolkit(name="second", tools=[b_tool], instructions="second-rule", add_instructions=True)
+    agent = Agent(tools=[first, second])
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+    assert agent._tool_instructions == ["first-rule", "second-rule"]
+
+    # Same name, different guidance: still two blocks.
+    same_name_a = Toolkit(name="shared", tools=[a_tool], instructions="rule-a", add_instructions=True)
+    same_name_b = Toolkit(name="shared", tools=[b_tool], instructions="rule-b", add_instructions=True)
+    agent = Agent(tools=[same_name_a, same_name_b])
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+    assert agent._tool_instructions == ["rule-a", "rule-b"]
+
+    # Same guidance, one opted out: only the opted-in toolkit emits.
+    opted_in = Toolkit(name="shared", tools=[a_tool], instructions="rule", add_instructions=True)
+    opted_out = Toolkit(name="shared", tools=[b_tool], instructions="rule", add_instructions=False)
+    agent = Agent(tools=[opted_out, opted_in])
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+    assert agent._tool_instructions == ["rule"]
+
+
+def test_async_only_members_are_counted_when_checking_coverage():
+    """In async mode a live Toolkit contributes its async variants too, and the
+    registry cannot rehydrate those. The component is genuinely short a tool, so
+    the toolkit's guidance must not describe it."""
+
+    def sync_tool() -> str:
+        return "sync"
+
+    async def async_only_tool() -> str:
+        return "async"
+
+    toolkit = Toolkit(
+        name="my_toolkit",
+        tools=[sync_tool, async_only_tool],
+        instructions="toolkit-level-rule",
+        add_instructions=True,
+    )
+    registry = Registry(tools=[toolkit])
+    rehydrated = _rehydrate(registry, toolkit)
+    assert [tool.name for tool in rehydrated] == ["sync_tool"]
+
+    agent = Agent(tools=list(rehydrated))
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+    assert agent._tool_instructions == ["toolkit-level-rule"]
+
+    agent = Agent(tools=list(rehydrated))
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model(), async_mode=True)
+    assert agent._tool_instructions == []
+
+
 def test_non_string_toolkit_instructions_do_not_break_the_run():
     """`instructions` is declared Optional[str] but nothing enforces it. Grouping
     toolkits by their guidance must not turn a list into a hard failure."""

--- a/libs/agno/tests/unit/agent/test_team_tool_propagation.py
+++ b/libs/agno/tests/unit/agent/test_team_tool_propagation.py
@@ -411,6 +411,86 @@ def test_non_string_toolkit_instructions_do_not_break_the_run():
     assert agent._tool_instructions == [["rule one", "rule two"]]
 
 
+def test_swapped_sync_async_surfaces_are_not_pooled():
+    """Coverage is measured per mode, so the sync and async surfaces are
+    separate parts of the grouping key. Two same-named toolkits whose surfaces
+    agree only as a union would otherwise pool their members, and a complete
+    toolkit's guidance would be judged against -- and silenced by -- its
+    namesake's function set."""
+
+    def make_first() -> Toolkit:
+        def a() -> str:
+            return "a"
+
+        def b() -> str:
+            return "b"
+
+        async def c() -> str:
+            return "c"
+
+        async def d() -> str:
+            return "d"
+
+        return Toolkit(name="shared", tools=[a, b, c, d], instructions="rule", add_instructions=True)
+
+    def make_second() -> Toolkit:
+        def c() -> str:
+            return "c"
+
+        def d() -> str:
+            return "d"
+
+        async def a() -> str:
+            return "a"
+
+        async def b() -> str:
+            return "b"
+
+        return Toolkit(name="shared", tools=[c, d, a, b], instructions="rule", add_instructions=True)
+
+    first, second = make_first(), make_second()
+    registry = Registry(tools=[first, second])
+
+    # All of first, plus one member of second: first earned the guidance.
+    tools = _rehydrate(registry, first) + _rehydrate(registry, second, only={"c"})
+    agent = Agent(tools=tools)
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+
+    assert agent._tool_instructions == ["rule"]
+
+
+def test_user_input_does_not_leak_between_runs_of_a_rehydrated_agent():
+    """parse_tools hands the model a per-run copy of each Function, and the
+    model layer writes the user's answer into that copy's user_input_schema in
+    place. The copy must not alias the loaded component's schema, or one run's
+    input reappears in the next run -- and nothing purges it in between."""
+
+    def send_email(to: str, subject: str, body: str) -> str:
+        """Send an email."""
+        return "sent"
+
+    live = Function.from_callable(send_email)
+    live.requires_user_input = True
+    live.user_input_fields = ["body"]
+    live.process_entrypoint()
+    live.skip_entrypoint_processing = True
+
+    registry = Registry(tools=[live])
+    agent = Agent(tools=registry.rehydrate_functions([live.to_dict()]))
+
+    first_run = parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+    first_fn = next(f for f in first_run if isinstance(f, Function))
+    assert first_fn.user_input_schema
+    for input_field in first_fn.user_input_schema:
+        input_field.value = "secret-from-run-1"
+
+    second_run = parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+    second_fn = next(f for f in second_run if isinstance(f, Function))
+    assert second_fn.user_input_schema
+    assert all(input_field.value is None for input_field in second_fn.user_input_schema)
+    assert all(input_field.value is None for input_field in live.user_input_schema or [])
+
+
 def test_cloned_toolkit_and_its_rehydrated_members_are_one_toolkit():
     """deep_copy clones the Toolkit list entry while the rehydrated members keep
     the live one. Grouping by object identity would see two toolkits here and

--- a/libs/agno/tests/unit/agent/test_team_tool_propagation.py
+++ b/libs/agno/tests/unit/agent/test_team_tool_propagation.py
@@ -411,6 +411,37 @@ def test_non_string_toolkit_instructions_do_not_break_the_run():
     assert agent._tool_instructions == [["rule one", "rule two"]]
 
 
+def test_duplicate_last_member_still_emits_toolkit_guidance():
+    """Guidance is emitted at the toolkit's last list position. When that
+    position holds a duplicate-named member, the duplicate is skipped as a
+    tool but the position still owes the toolkit its guidance."""
+    toolkit = _guided_toolkit()
+    registry = Registry(tools=[toolkit])
+    rehydrated = _rehydrate(registry, toolkit)
+    second_again = registry.rehydrate_functions([rehydrated[1].to_dict() | {"toolkit": toolkit.name}])
+
+    agent = Agent(tools=rehydrated + second_again)
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+
+    assert agent._tool_instructions == ["first-rule", "second-rule", "toolkit-level-rule"]
+
+
+def test_junk_source_toolkit_is_ignored():
+    """source_toolkit is typed Any and travels through copies; a value that is
+    not a live Toolkit must not crash collection or fabricate guidance."""
+
+    def lone_tool() -> str:
+        return "lone"
+
+    function = Function.from_callable(lone_tool)
+    function.source_toolkit = "junk"
+
+    agent = Agent(tools=[function])
+    parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+
+    assert agent._tool_instructions == []
+
+
 def test_swapped_sync_async_surfaces_are_not_pooled():
     """Coverage is measured per mode, so the sync and async surfaces are
     separate parts of the grouping key. Two same-named toolkits whose surfaces

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -568,6 +568,7 @@ class TestToolkitQualifiedRehydration:
         rehydrated = reg.rehydrate_function(func_dict)
 
         assert rehydrated.entrypoint is self._agent_read
+        assert rehydrated.source_toolkit is None
         assert any("gone_files" in w for w in warnings)
 
     def test_qualified_lookup_rebuilds_stale_cache(self):
@@ -605,6 +606,32 @@ class TestToolkitQualifiedRehydration:
         assert unqualified.owning_toolkit is None
         # owning_toolkit never leaks into the model-facing schema
         assert "owning_toolkit" not in rehydrated.to_dict()
+
+    def test_qualified_rehydration_restores_live_function_instruction_settings(self):
+        """Instruction settings come from the live registry Function, not the
+        serialized component config."""
+
+        source = Function(
+            name="search_docs",
+            entrypoint=search_function,
+            instructions="Creation-time function guidance.",
+        )
+        toolkit = Toolkit(name="agno_docs")
+        toolkit.functions[source.name] = source
+        reg = Registry(tools=[toolkit])
+
+        func_dict = source.to_dict()
+        func_dict["toolkit"] = toolkit.name
+        assert "instructions" not in func_dict
+        assert "add_instructions" not in func_dict
+
+        source.instructions = "Use the live registry search conventions."
+        source.add_instructions = False
+        rehydrated = reg.rehydrate_function(func_dict)
+
+        assert rehydrated.instructions == source.instructions
+        assert rehydrated.add_instructions is False
+        assert rehydrated.source_toolkit is toolkit
 
     def test_same_named_toolkits_warn_once_per_collision(self, monkeypatch):
         """Two same-named toolkits sharing a member name collide on both the

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -633,6 +633,30 @@ class TestToolkitQualifiedRehydration:
         assert rehydrated.add_instructions is False
         assert rehydrated.source_toolkit is toolkit
 
+    def test_unqualified_dict_still_gets_its_live_toolkit(self):
+        """A config saved before tool names carried a toolkit resolves through
+        the flat name, and still reaches the Toolkit that owns the bound
+        function, so toolkit-level guidance is restored too."""
+
+        source = Function(
+            name="search_docs",
+            entrypoint=search_function,
+            instructions="Creation-time function guidance.",
+        )
+        toolkit = Toolkit(name="agno_docs", instructions="Toolkit guidance.", add_instructions=True)
+        toolkit.functions[source.name] = source
+        reg = Registry(tools=[toolkit])
+
+        func_dict = source.to_dict()
+        assert "toolkit" not in func_dict
+
+        source.instructions = "Use the live registry search conventions."
+        rehydrated = reg.rehydrate_function(func_dict)
+
+        assert rehydrated.entrypoint is search_function
+        assert rehydrated.instructions == source.instructions
+        assert rehydrated.source_toolkit is toolkit
+
     def test_same_named_toolkits_warn_once_per_collision(self, monkeypatch):
         """Two same-named toolkits sharing a member name collide on both the
         flat and the qualified slot, but only the flat registration warns --

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -17,7 +17,7 @@ import pytest
 from pydantic import BaseModel
 
 from agno.registry.registry import Registry
-from agno.tools.function import Function
+from agno.tools.function import RUNTIME_ONLY_FIELDS, SERIALIZED_FIELDS, Function
 from agno.tools.toolkit import Toolkit
 
 # =============================================================================
@@ -736,6 +736,106 @@ class TestToolkitQualifiedRehydration:
 
         assert len(warnings) == 1
         assert "read_file" in warnings[0]
+
+
+class TestRuntimeOnlyFieldRestoration:
+    """Behavior the storage layer never writes comes back from the live Function."""
+
+    def test_every_unserialized_field_is_restored(self):
+        """The invariant, so a new Function field cannot be silently dropped on
+        reload: every field to_dict() omits is either restored from the live
+        source or handled explicitly."""
+        explicit = {"entrypoint", "owning_toolkit", "source_toolkit"}
+
+        unaccounted = set(Function.model_fields) - set(SERIALIZED_FIELDS) - explicit - set(RUNTIME_ONLY_FIELDS)
+
+        assert unaccounted == set(), (
+            f"Function fields {sorted(unaccounted)} are neither serialized by to_dict() nor "
+            "restored by RUNTIME_ONLY_FIELDS, so they are lost on reload."
+        )
+
+    def test_user_input_settings_survive_a_round_trip(self):
+        """Without these, process_entrypoint stops excluding the user-supplied
+        field, so the model is handed a `required` entry the schema never
+        defines and nothing is left to collect it."""
+
+        def send_email(to: str, subject: str, body: str) -> str:
+            """Send an email."""
+            return "sent"
+
+        live = Function.from_callable(send_email)
+        live.requires_user_input = True
+        live.user_input_fields = ["body"]
+        live.process_entrypoint()
+        assert sorted(live.parameters["required"]) == ["subject", "to"]
+
+        reg = Registry(tools=[live])
+        rehydrated = reg.rehydrate_function(live.to_dict())
+        rehydrated.process_entrypoint()
+
+        assert rehydrated.requires_user_input is True
+        assert rehydrated.user_input_fields == ["body"]
+        assert set(rehydrated.parameters["required"]) <= set(rehydrated.parameters["properties"])
+
+    def test_control_flow_and_cache_settings_survive_a_round_trip(self):
+        def note(text: str) -> str:
+            """Note."""
+            return text
+
+        live = Function.from_callable(note)
+        live.show_result = True
+        live.stop_after_tool_call = True
+        live.external_execution_silent = True
+        live.cache_results = True
+        live.cache_dir = "/tmp/agno-cache"
+        live.cache_ttl = 60
+
+        rehydrated = Registry(tools=[live]).rehydrate_function(live.to_dict())
+
+        assert rehydrated.show_result is True
+        assert rehydrated.stop_after_tool_call is True
+        assert rehydrated.external_execution_silent is True
+        assert rehydrated.cache_results is True
+        assert rehydrated.cache_dir == "/tmp/agno-cache"
+        assert rehydrated.cache_ttl == 60
+
+    def test_hooks_are_restored_by_reference(self):
+        """Hooks are callables the storage layer cannot write at all."""
+
+        def note(text: str) -> str:
+            """Note."""
+            return text
+
+        def a_hook(function_call):
+            return None
+
+        live = Function.from_callable(note)
+        live.pre_hook = a_hook
+        live.post_hook = a_hook
+        live.tool_hooks = [a_hook]
+
+        rehydrated = Registry(tools=[live]).rehydrate_function(live.to_dict())
+
+        assert rehydrated.pre_hook is a_hook
+        assert rehydrated.post_hook is a_hook
+        assert rehydrated.tool_hooks == [a_hook]
+
+    def test_serialized_fields_keep_the_saved_value(self):
+        """The saved config owns what to_dict() carries: a later registry edit
+        to those must not silently rewrite an existing component."""
+
+        def note(text: str) -> str:
+            """Note."""
+            return text
+
+        live = Function.from_callable(note)
+        live.requires_confirmation = True
+        func_dict = live.to_dict()
+
+        live.requires_confirmation = False
+        rehydrated = Registry(tools=[live]).rehydrate_function(func_dict)
+
+        assert rehydrated.requires_confirmation is True
 
 
 class TestRehydrateFunctionsBatch:

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -9,7 +9,8 @@ Tests cover:
 """
 
 import os
-from typing import Optional
+from functools import cached_property
+from typing import List, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -656,6 +657,48 @@ class TestToolkitQualifiedRehydration:
         assert rehydrated.entrypoint is search_function
         assert rehydrated.instructions == source.instructions
         assert rehydrated.source_toolkit is toolkit
+        # Re-stamped, so the next save writes the "toolkit" key and the config
+        # stops depending on the flat slot.
+        assert rehydrated.owning_toolkit == "agno_docs"
+
+    def test_legacy_dict_with_an_ambiguous_name_is_not_restamped(self):
+        """Two toolkits exposing the name make the flat slot's winner arbitrary,
+        so the resolution must not be written back into the config."""
+        reg, _, agent_files = self._registry_with_shared_names()
+
+        rehydrated = reg.rehydrate_function({"name": "read_file", "parameters": {}})
+
+        # The bound source is still identified exactly, so its guidance applies.
+        assert rehydrated.source_toolkit is agent_files
+        assert rehydrated.owning_toolkit is None
+
+    def test_rebuilt_toolkit_functions_are_not_served_from_the_stale_cache(self):
+        """A toolkit that replaces its Function objects -- what MCPTools does on
+        every connect -- leaves cache entries that still hit. Rehydration must
+        detect that and rebuild rather than serve the old entrypoint."""
+
+        toolkit = Toolkit(name="agno_docs", instructions="Toolkit guidance.", add_instructions=True)
+        toolkit.functions["search_docs"] = Function(
+            name="search_docs", entrypoint=search_function, instructions="Stale guidance."
+        )
+        reg = Registry(tools=[toolkit])
+
+        func_dict = toolkit.functions["search_docs"].to_dict()
+        func_dict["toolkit"] = toolkit.name
+        reg.rehydrate_function(func_dict)  # warms the cached lookup
+
+        def rebuilt_entrypoint() -> str:
+            return "rebuilt"
+
+        toolkit.functions["search_docs"] = Function(
+            name="search_docs", entrypoint=rebuilt_entrypoint, instructions="Fresh guidance."
+        )
+
+        rehydrated = reg.rehydrate_function(func_dict)
+
+        assert rehydrated.entrypoint is rebuilt_entrypoint
+        assert rehydrated.instructions == "Fresh guidance."
+        assert rehydrated.source_toolkit is toolkit
 
     def test_same_named_toolkits_warn_once_per_collision(self, monkeypatch):
         """Two same-named toolkits sharing a member name collide on both the
@@ -685,19 +728,23 @@ class TestRehydrateFunctionsBatch:
         return f"read:{path}"
 
     def _counting_registry(self):
-        """Registry whose lookup builds are observable via tools iterations."""
-        builds = []
+        """Registry that records every build of the cached entrypoint lookup.
 
-        class CountingList(list):
-            def __iter__(self):
+        Counts the cached_property's own evaluations rather than iterations of
+        ``reg.tools``: rehydration walks ``tools`` for other reasons too, so an
+        iteration count would not isolate rebuilds.
+        """
+        builds: List[int] = []
+
+        class CountingRegistry(Registry):
+            @cached_property
+            def _entrypoint_lookup(self):
                 builds.append(1)
-                return super().__iter__()
+                return Registry._entrypoint_lookup.func(self)
 
         kit = Toolkit(name="agent_files")
         kit.functions["read_file"] = Function(name="read_file", entrypoint=self._read)
-        reg = Registry()
-        reg.tools = CountingList([kit])
-        return reg, builds
+        return CountingRegistry(tools=[kit]), builds
 
     def test_batch_shares_single_rebuild(self):
         """N dicts whose toolkit is missing from the registry trigger at most

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -820,6 +820,36 @@ class TestRuntimeOnlyFieldRestoration:
         assert rehydrated.post_hook is a_hook
         assert rehydrated.tool_hooks == [a_hook]
 
+    def test_mutable_restored_fields_are_not_shared(self):
+        """The model layer writes the user's answer into UserInputField objects
+        in place. Restoring them by reference would put one run's input into
+        every other component holding the tool, and into the registry."""
+
+        def send(to: str, body: str) -> str:
+            """Send."""
+            return "ok"
+
+        live = Function.from_callable(send)
+        live.requires_user_input = True
+        live.user_input_fields = ["body"]
+        live.process_entrypoint()
+        # A toolkit-decorated tool keeps its parsed schema, because processing
+        # is skipped -- the case where the sharing survives to run time.
+        live.skip_entrypoint_processing = True
+        assert live.user_input_schema
+
+        reg = Registry(tools=[live])
+        first = reg.rehydrate_function(live.to_dict())
+        second = reg.rehydrate_function(live.to_dict())
+
+        assert first.user_input_schema is not second.user_input_schema
+        assert first.user_input_schema is not live.user_input_schema
+        assert first.user_input_fields is not live.user_input_fields
+
+        first.user_input_schema[0].value = "answer for the first component"
+        assert second.user_input_schema[0].value is None
+        assert live.user_input_schema[0].value is None
+
     def test_serialized_fields_keep_the_saved_value(self):
         """The saved config owns what to_dict() carries: a later registry edit
         to those must not silently rewrite an existing component."""

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -718,6 +718,64 @@ class TestToolkitQualifiedRehydration:
         assert rehydrated.instructions == "Fresh guidance."
         assert rehydrated.source_toolkit is toolkit
 
+    def test_members_without_entrypoints_do_not_claim_slots(self):
+        """A member whose entrypoint is None cannot be executed, so it must
+        not claim a slot: a later toolkit holding an unbound namesake would
+        otherwise shadow the executable one."""
+        bound = Toolkit(name="bound_kit")
+        bound.functions["search_docs"] = Function(name="search_docs", entrypoint=search_function)
+        unbound = Toolkit(name="unbound_kit")
+        unbound.functions["search_docs"] = Function(name="search_docs")
+        reg = Registry(tools=[bound, unbound])
+
+        rehydrated = reg.rehydrate_function({"name": "search_docs", "parameters": {}})
+
+        assert rehydrated.entrypoint is search_function
+        assert rehydrated.source_toolkit is bound
+
+    def test_deleted_function_is_not_served_from_the_stale_cache(self):
+        """A member deleted after the cache was built leaves an entry that
+        still hits. Serving it would execute a function the registry no longer
+        offers; the cache must agree with what a fresh build would say:
+        nothing."""
+        toolkit = Toolkit(name="agno_docs")
+        toolkit.functions["search_docs"] = Function(name="search_docs", entrypoint=search_function)
+        reg = Registry(tools=[toolkit])
+
+        func_dict = toolkit.functions["search_docs"].to_dict()
+        func_dict["toolkit"] = toolkit.name
+        warm = reg.rehydrate_function(dict(func_dict))
+        assert warm.entrypoint is search_function  # warms the cached lookup
+
+        del toolkit.functions["search_docs"]
+        rehydrated = reg.rehydrate_function(dict(func_dict))
+
+        assert rehydrated.entrypoint is None
+        assert rehydrated.source_toolkit is None
+
+    def test_direct_registration_does_not_mask_the_toolkits_flat_slot(self):
+        """The same object can be registered directly and owned by a later
+        toolkit. The toolkit's registration wins the flat slot, so when the
+        toolkit rebuilds the member, the cached flat entry is stale even though
+        the direct registration still exists."""
+        member = Function(name="search_docs", entrypoint=search_function)
+        toolkit = Toolkit(name="agno_docs", instructions="Toolkit guidance.", add_instructions=True)
+        toolkit.functions["search_docs"] = member
+        reg = Registry(tools=[member, toolkit])
+
+        flat_dict = {"name": "search_docs", "parameters": {}}
+        warm = reg.rehydrate_function(dict(flat_dict))
+        assert warm.entrypoint is search_function  # warms the cached lookup
+
+        def rebuilt_entrypoint() -> str:
+            return "rebuilt"
+
+        toolkit.functions["search_docs"] = Function(name="search_docs", entrypoint=rebuilt_entrypoint)
+        rehydrated = reg.rehydrate_function(dict(flat_dict))
+
+        assert rehydrated.entrypoint is rebuilt_entrypoint
+        assert rehydrated.source_toolkit is toolkit
+
     def test_direct_registration_does_not_mask_a_rebuilt_toolkit(self):
         """A Function can be both a toolkit member and a registry tool in its
         own right. A qualified config named the toolkit, so the toolkit alone
@@ -920,8 +978,28 @@ class TestRehydrateFunctionsBatch:
         return CountingRegistry(tools=[kit]), builds
 
     def test_batch_shares_single_rebuild(self):
-        """N dicts whose toolkit is missing from the registry trigger at most
-        one lookup rebuild for the whole batch, not one per dict."""
+        """N dicts naming a function registered after the cache was primed
+        trigger at most one lookup rebuild for the whole batch, not one per
+        dict."""
+        reg, builds = self._counting_registry()
+        kit = reg.tools[0]
+        _ = reg._entrypoint_lookup  # prime while write_file is unregistered
+
+        def _write(path: str) -> str:
+            return f"write:{path}"
+
+        kit.functions["write_file"] = Function(name="write_file", entrypoint=_write)
+        dicts = [{"name": "write_file", "parameters": {}, "toolkit": "agent_files"} for _ in range(5)]
+        rehydrated = reg.rehydrate_functions(dicts)
+
+        assert all(f.entrypoint is _write for f in rehydrated)
+        assert sum(builds) == 2  # the priming build plus one shared rebuild
+
+    def test_unresolvable_batch_spends_no_rebuild(self):
+        """A rebuild is skipped when it could not help: a key with no owner in
+        the current registrations misses before and after a rebuild, so dicts
+        naming a missing toolkit resolve through the flat fallback without
+        spending the batch's budget."""
         reg, builds = self._counting_registry()
         _ = reg._entrypoint_lookup  # prime the cache
 
@@ -929,7 +1007,7 @@ class TestRehydrateFunctionsBatch:
         rehydrated = reg.rehydrate_functions(dicts)
 
         assert all(f.entrypoint is self._read for f in rehydrated)
-        assert sum(builds) == 2  # the priming build plus one shared rebuild
+        assert sum(builds) == 1  # the priming build only
 
     def test_directly_registered_function_does_not_look_stale(self):
         """A Function registered as a registry tool in its own right owns the
@@ -992,16 +1070,20 @@ class TestRehydrateFunctionsBatch:
         kit = reg.tools[0]
         _ = reg._entrypoint_lookup  # prime the cache
 
-        first = reg.rehydrate_functions([{"name": "read_file", "parameters": {}, "toolkit": "renamed_kit"}])
-        assert first[0].entrypoint is self._read  # spent this batch's rebuild
-
         def _write(path: str) -> str:
             return f"write:{path}"
 
         kit.functions["write_file"] = Function(name="write_file", entrypoint=_write)
-        second = reg.rehydrate_functions([{"name": "write_file", "parameters": {}, "toolkit": "agent_files"}])
+        first = reg.rehydrate_functions([{"name": "write_file", "parameters": {}, "toolkit": "agent_files"}])
+        assert first[0].entrypoint is _write  # spent this batch's rebuild
 
-        assert second[0].entrypoint is _write
+        def _more(path: str) -> str:
+            return f"more:{path}"
+
+        kit.functions["more_file"] = Function(name="more_file", entrypoint=_more)
+        second = reg.rehydrate_functions([{"name": "more_file", "parameters": {}, "toolkit": "agent_files"}])
+
+        assert second[0].entrypoint is _more
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -657,18 +657,36 @@ class TestToolkitQualifiedRehydration:
         assert rehydrated.entrypoint is search_function
         assert rehydrated.instructions == source.instructions
         assert rehydrated.source_toolkit is toolkit
-        # Re-stamped, so the next save writes the "toolkit" key and the config
-        # stops depending on the flat slot.
-        assert rehydrated.owning_toolkit == "agno_docs"
+        # The attribution is not invented. Stamping the toolkit's current name
+        # would tie the config to it -- see the rename test below.
+        assert rehydrated.owning_toolkit is None
 
-    def test_legacy_dict_with_an_ambiguous_name_is_not_restamped(self):
-        """Two toolkits exposing the name make the flat slot's winner arbitrary,
-        so the resolution must not be written back into the config."""
+    def test_unqualified_dict_survives_a_toolkit_rename(self):
+        """Identity resolution is what makes an unqualified config rename-proof.
+        Recording the toolkit's name on load would take that away: the next load
+        would go through the qualified key, miss, and lose the guidance."""
+        toolkit = Toolkit(name="old_name", instructions="Toolkit guidance.", add_instructions=True)
+        toolkit.functions["search_docs"] = Function(name="search_docs", entrypoint=search_function)
+        legacy_dict = toolkit.functions["search_docs"].to_dict()
+
+        renamed = Toolkit(name="new_name", instructions="Toolkit guidance.", add_instructions=True)
+        renamed.functions["search_docs"] = Function(name="search_docs", entrypoint=search_function)
+        reg = Registry(tools=[renamed])
+
+        rehydrated = reg.rehydrate_function(legacy_dict)
+
+        assert rehydrated.source_toolkit is renamed
+        assert rehydrated.owning_toolkit is None
+
+    def test_ambiguous_flat_name_still_resolves_to_the_bound_toolkit(self):
+        """Two toolkits expose the name, so the flat slot's winner is arbitrary,
+        but the Toolkit carried forward is the one that owns the bound
+        function -- not merely one that shares its name."""
         reg, _, agent_files = self._registry_with_shared_names()
 
         rehydrated = reg.rehydrate_function({"name": "read_file", "parameters": {}})
 
-        # The bound source is still identified exactly, so its guidance applies.
+        assert rehydrated.entrypoint is self._agent_read
         assert rehydrated.source_toolkit is agent_files
         assert rehydrated.owning_toolkit is None
 

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -718,6 +718,31 @@ class TestToolkitQualifiedRehydration:
         assert rehydrated.instructions == "Fresh guidance."
         assert rehydrated.source_toolkit is toolkit
 
+    def test_direct_registration_does_not_mask_a_rebuilt_toolkit(self):
+        """A Function can be both a toolkit member and a registry tool in its
+        own right. A qualified config named the toolkit, so the toolkit alone
+        decides whether the cached entry is still fresh -- the standalone
+        registration must not vouch for it."""
+        toolkit = Toolkit(name="agno_docs", instructions="Toolkit guidance.", add_instructions=True)
+        member = Function(name="search_docs", entrypoint=search_function)
+        toolkit.functions["search_docs"] = member
+        # The same object, registered both ways.
+        reg = Registry(tools=[toolkit, member])
+
+        func_dict = member.to_dict()
+        func_dict["toolkit"] = toolkit.name
+        reg.rehydrate_function(dict(func_dict))  # warms the cached lookup
+
+        def rebuilt_entrypoint() -> str:
+            return "rebuilt"
+
+        toolkit.functions["search_docs"] = Function(name="search_docs", entrypoint=rebuilt_entrypoint)
+
+        rehydrated = reg.rehydrate_function(dict(func_dict))
+
+        assert rehydrated.entrypoint is rebuilt_entrypoint
+        assert rehydrated.source_toolkit is toolkit
+
     def test_same_named_toolkits_warn_once_per_collision(self, monkeypatch):
         """Two same-named toolkits sharing a member name collide on both the
         flat and the qualified slot, but only the flat registration warns --

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -758,6 +758,20 @@ class TestRehydrateFunctionsBatch:
         assert all(f.entrypoint is self._read for f in rehydrated)
         assert sum(builds) == 2  # the priming build plus one shared rebuild
 
+    def test_directly_registered_function_does_not_look_stale(self):
+        """A Function registered as a registry tool in its own right owns the
+        flat slot legitimately. A toolkit member sharing its name must not read
+        as a rebuilt-toolkit cache entry and force a rebuild on every batch."""
+        reg, builds = self._counting_registry()
+        bare = Function(name="read_file", entrypoint=self._read)
+        reg.tools.append(bare)
+        _ = reg._entrypoint_lookup  # prime the cache
+
+        rehydrated = reg.rehydrate_functions([{"name": "read_file", "parameters": {}} for _ in range(3)])
+
+        assert all(f.entrypoint is self._read for f in rehydrated)
+        assert sum(builds) == 1  # the priming build only
+
     def test_batch_resolves_mixed_dicts(self):
         """Qualified, legacy-unqualified, and unknown dicts resolve in one batch."""
         reg, _ = self._counting_registry()

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -753,6 +753,23 @@ class TestToolkitQualifiedRehydration:
         assert rehydrated.entrypoint is None
         assert rehydrated.source_toolkit is None
 
+    def test_direct_registration_does_not_strip_toolkit_provenance(self):
+        """A toolkit member also registered directly owns its flat slot as the
+        direct registration, but the toolkit still holds the object, and its
+        guidance still belongs to a component that loaded the member.
+        Freshness follows the slot; provenance follows the object."""
+        toolkit = Toolkit(name="agno_docs", instructions="Toolkit guidance.", add_instructions=True)
+        member = Function(name="search_docs", entrypoint=search_function)
+        toolkit.functions["search_docs"] = member
+        # AgentOS component collection appends a loaded component's Functions
+        # directly, after the toolkit that owns them.
+        reg = Registry(tools=[toolkit, member])
+
+        rehydrated = reg.rehydrate_function({"name": "search_docs", "parameters": {}})
+
+        assert rehydrated.entrypoint is search_function
+        assert rehydrated.source_toolkit is toolkit
+
     def test_direct_registration_does_not_mask_the_toolkits_flat_slot(self):
         """The same object can be registered directly and owned by a later
         toolkit. The toolkit's registration wins the flat slot, so when the
@@ -1045,27 +1062,62 @@ class TestRehydrateFunctionsBatch:
         assert rehydrated[1].entrypoint is self._read
         assert rehydrated[2].entrypoint is None
 
-    def test_provider_builtin_dicts_pass_through_unchanged(self):
-        """Builtin tools run inside the model provider and persist as plain
-        dicts. Parsing one as a Function config raised a ValidationError that
-        took the whole component load down. They pass through in place; a
-        top-level ``type`` marks one, including provider dicts that also carry
-        a ``name``."""
+    def test_provider_tool_dicts_pass_through_unchanged(self):
+        """Provider-run tools persist as plain dicts. Parsing one as a
+        Function config raised a ValidationError that took the whole component
+        load down. Only a dict that Function.to_dict() could have written is
+        rehydrated -- name and parameters present, no provider marker --
+        and every other dict passes through in place."""
         reg, _ = self._counting_registry()
-        openai_style = {"type": "web_search"}
-        anthropic_style = {"type": "web_search_20250305", "name": "web_search", "max_uses": 3}
+        openai_builtin = {"type": "web_search"}
+        anthropic_builtin = {"type": "web_search_20250305", "name": "web_search", "max_uses": 3}
+        anthropic_custom = {"name": "get_weather", "description": "Weather", "input_schema": {"type": "object"}}
+        marked_but_parametered = {"name": "get_time", "parameters": {}, "input_schema": {"type": "object"}}
+        # The OpenAI Responses custom-function shape carries name AND
+        # parameters, so the type marker alone keeps it out of rehydration.
+        openai_responses_fn = {"type": "function", "name": "get_news", "parameters": {"type": "object"}}
 
         rehydrated = reg.rehydrate_functions(
             [
-                openai_style,
+                openai_builtin,
                 {"name": "read_file", "parameters": {}, "toolkit": "agent_files"},
-                anthropic_style,
+                anthropic_builtin,
+                anthropic_custom,
+                marked_but_parametered,
+                openai_responses_fn,
             ]
         )
 
-        assert rehydrated[0] is openai_style
+        assert rehydrated[0] is openai_builtin
         assert isinstance(rehydrated[1], Function) and rehydrated[1].entrypoint is self._read
-        assert rehydrated[2] is anthropic_style
+        assert rehydrated[2] is anthropic_builtin
+        assert rehydrated[3] is anthropic_custom
+        assert rehydrated[4] is marked_but_parametered
+        assert rehydrated[5] is openai_responses_fn
+
+    def test_unparseable_function_looking_dict_passes_through(self, monkeypatch):
+        """A dict that looks like a serialized Function but fails validation
+        must not abort the component load: it is warned about and handed to
+        the model provider unchanged."""
+        import agno.registry.registry as registry_module
+
+        warnings = []
+        monkeypatch.setattr(registry_module, "log_warning", warnings.append)
+        reg, _ = self._counting_registry()
+        broken = {"name": 123, "parameters": {}}
+
+        rehydrated = reg.rehydrate_functions([broken, {"name": "read_file", "parameters": {}}])
+
+        assert rehydrated[0] is broken
+        assert isinstance(rehydrated[1], Function) and rehydrated[1].entrypoint is self._read
+        assert any("does not validate" in w for w in warnings)
+
+        # A dict without ``parameters`` cannot be a to_dict() product, so it
+        # is not a near-miss worth a warning: it passes through silently.
+        warnings.clear()
+        plain = {"name": "solo_dict"}
+        assert reg.rehydrate_functions([plain]) == [plain]
+        assert warnings == []
 
     def test_batch_rebuild_still_finds_late_functions(self):
         """The shared budget still covers the late-connecting toolkit case:

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -837,6 +837,12 @@ class TestRuntimeOnlyFieldRestoration:
             "restored by RUNTIME_ONLY_FIELDS, so they are lost on reload."
         )
 
+        # And the other direction: a field removed from the model but left in
+        # a list would make rehydration setattr/getattr a missing attribute,
+        # crashing every component load.
+        stale = (set(SERIALIZED_FIELDS) | set(RUNTIME_ONLY_FIELDS)) - set(Function.model_fields)
+        assert stale == set(), f"{sorted(stale)} are listed but no longer Function fields."
+
     def test_user_input_settings_survive_a_round_trip(self):
         """Without these, process_entrypoint stops excluding the user-supplied
         field, so the model is handed a `required` entry the schema never
@@ -1038,6 +1044,28 @@ class TestRehydrateFunctionsBatch:
         assert rehydrated[0].entrypoint is self._read
         assert rehydrated[1].entrypoint is self._read
         assert rehydrated[2].entrypoint is None
+
+    def test_provider_builtin_dicts_pass_through_unchanged(self):
+        """Builtin tools run inside the model provider and persist as plain
+        dicts. Parsing one as a Function config raised a ValidationError that
+        took the whole component load down. They pass through in place; a
+        top-level ``type`` marks one, including provider dicts that also carry
+        a ``name``."""
+        reg, _ = self._counting_registry()
+        openai_style = {"type": "web_search"}
+        anthropic_style = {"type": "web_search_20250305", "name": "web_search", "max_uses": 3}
+
+        rehydrated = reg.rehydrate_functions(
+            [
+                openai_style,
+                {"name": "read_file", "parameters": {}, "toolkit": "agent_files"},
+                anthropic_style,
+            ]
+        )
+
+        assert rehydrated[0] is openai_style
+        assert isinstance(rehydrated[1], Function) and rehydrated[1].entrypoint is self._read
+        assert rehydrated[2] is anthropic_style
 
     def test_batch_rebuild_still_finds_late_functions(self):
         """The shared budget still covers the late-connecting toolkit case:

--- a/libs/agno/tests/unit/team/test_get_tool_names.py
+++ b/libs/agno/tests/unit/team/test_get_tool_names.py
@@ -277,6 +277,67 @@ def test_rehydrated_toolkit_instructions_reach_team_once():
     assert team._tool_instructions == ["first-function-rule", "second-function-rule", "toolkit-level-rule"]
 
 
+def test_rehydrated_subset_does_not_get_the_whole_toolkits_guidance_team():
+    """A team that persisted one member of a toolkit must not be handed guidance
+    naming the members it was not given."""
+
+    def first_tool() -> str:
+        return "first"
+
+    def second_tool() -> str:
+        return "second"
+
+    toolkit = Toolkit(
+        name="my_toolkit",
+        tools=[first_tool, second_tool],
+        instructions="toolkit-level-rule",
+        add_instructions=True,
+    )
+    toolkit.functions["first_tool"].instructions = "first-function-rule"
+    registry = Registry(tools=[toolkit])
+    stored = toolkit.get_functions()["first_tool"].to_dict()
+    stored["toolkit"] = toolkit.name
+
+    team = Team(name="t", members=[], tools=registry.rehydrate_functions([stored]))
+    _resolve(team)
+
+    assert team._tool_instructions == ["first-function-rule"]
+
+
+def test_live_toolkit_beside_rehydrated_members_emits_guidance_once_team():
+    """Both representations of one toolkit in a team's tools list must read the
+    same as the live Toolkit alone, including after deep_copy."""
+
+    def first_tool() -> str:
+        return "first"
+
+    def second_tool() -> str:
+        return "second"
+
+    toolkit = Toolkit(
+        name="my_toolkit",
+        tools=[first_tool, second_tool],
+        instructions="toolkit-level-rule",
+        add_instructions=True,
+    )
+    toolkit.functions["first_tool"].instructions = "first-function-rule"
+    toolkit.functions["second_tool"].instructions = "second-function-rule"
+    registry = Registry(tools=[toolkit])
+    stored = toolkit.get_functions()["first_tool"].to_dict()
+    stored["toolkit"] = toolkit.name
+    mixed = registry.rehydrate_functions([stored]) + [toolkit]
+
+    expected = ["first-function-rule", "second-function-rule", "toolkit-level-rule"]
+
+    team = Team(name="t", members=[], tools=mixed)
+    _resolve(team)
+    assert team._tool_instructions == expected
+
+    copied = Team(name="t", members=[], tools=mixed).deep_copy()
+    _resolve(copied)
+    assert copied._tool_instructions == expected
+
+
 def test_toolkit_per_function_add_instructions_false_is_respected_team():
     class MyToolkit(Toolkit):
         def __init__(self):

--- a/libs/agno/tests/unit/team/test_get_tool_names.py
+++ b/libs/agno/tests/unit/team/test_get_tool_names.py
@@ -10,6 +10,7 @@ Regression test for: https://github.com/agno-agi/agno/issues/7039
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from agno.registry import Registry
 from agno.run.base import RunContext
 from agno.run.team import TeamRunOutput
 from agno.session import TeamSession
@@ -244,6 +245,36 @@ def test_toolkit_level_and_per_function_instructions_both_reach_team():
     _resolve(team)
 
     assert team._tool_instructions == ["toolkit-func-rule", "toolkit-level-rule"]
+
+
+def test_rehydrated_toolkit_instructions_reach_team_once():
+    def first_tool() -> str:
+        return "first"
+
+    def second_tool() -> str:
+        return "second"
+
+    toolkit = Toolkit(
+        name="my_toolkit",
+        tools=[first_tool, second_tool],
+        instructions="toolkit-level-rule",
+        add_instructions=True,
+    )
+    toolkit.functions["first_tool"].instructions = "first-function-rule"
+    toolkit.functions["second_tool"].instructions = "second-function-rule"
+    registry = Registry(tools=[toolkit])
+    stored_tools = []
+    for function in toolkit.get_functions().values():
+        function_dict = function.to_dict()
+        function_dict["toolkit"] = toolkit.name
+        stored_tools.append(function_dict)
+
+    team = Team(name="t", members=[], tools=registry.rehydrate_functions(stored_tools)).deep_copy()
+    assert team.tools is not None
+    assert all(isinstance(tool, Function) and tool.source_toolkit is toolkit for tool in team.tools)
+    _resolve(team)
+
+    assert team._tool_instructions == ["first-function-rule", "second-function-rule", "toolkit-level-rule"]
 
 
 def test_toolkit_per_function_add_instructions_false_is_respected_team():

--- a/libs/agno/tests/unit/team/test_get_tool_names.py
+++ b/libs/agno/tests/unit/team/test_get_tool_names.py
@@ -277,6 +277,36 @@ def test_rehydrated_toolkit_instructions_reach_team_once():
     assert team._tool_instructions == ["first-function-rule", "second-function-rule", "toolkit-level-rule"]
 
 
+def test_duplicate_last_member_still_emits_toolkit_guidance_team():
+    """Guidance is emitted at the toolkit's last list position; a duplicate
+    there is skipped as a tool but still owes the toolkit its guidance."""
+
+    def first_tool() -> str:
+        return "first"
+
+    def second_tool() -> str:
+        return "second"
+
+    toolkit = Toolkit(
+        name="my_toolkit",
+        tools=[first_tool, second_tool],
+        instructions="toolkit-level-rule",
+        add_instructions=True,
+    )
+    registry = Registry(tools=[toolkit])
+    stored = []
+    for function in toolkit.get_functions().values():
+        function_dict = function.to_dict()
+        function_dict["toolkit"] = toolkit.name
+        stored.append(function_dict)
+    stored.append(dict(stored[-1]))
+
+    team = Team(name="t", members=[], tools=registry.rehydrate_functions(stored))
+    _resolve(team)
+
+    assert team._tool_instructions == ["toolkit-level-rule"]
+
+
 def test_rehydrated_subset_does_not_get_the_whole_toolkits_guidance_team():
     """A team that persisted one member of a toolkit must not be handed guidance
     naming the members it was not given."""

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -951,6 +951,22 @@ class TestTeamLoad:
         # And the toolkit came with them, so its guidance survives the reload.
         assert member_tools[0].source_toolkit is toolkit
 
+    def test_load_passes_member_builtin_dict_tools_through(self, tmp_path):
+        """Provider-builtin tools persist as plain dicts. Rehydrating one as a
+        Function config raised a ValidationError that took the whole team load
+        down; it must ride through the member's tools untouched instead."""
+        from agno.models.openai import OpenAIResponses
+
+        model = OpenAIResponses(id="gpt-5.5")
+        db = SqliteDb(db_file=str(tmp_path / "team_builtin_tools.db"))
+        member = Agent(id="builtin-member", name="Member", model=model, tools=[{"type": "web_search"}])
+        Team(id="builtin-team", name="Builtin Team", model=model, members=[member]).save(db=db)
+
+        loaded = Team.load(id="builtin-team", db=db, registry=Registry(models=[model]))
+
+        assert loaded is not None
+        assert loaded.members[0].tools == [{"type": "web_search"}]
+
 
 # =============================================================================
 # delete() Tests

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -919,6 +919,38 @@ class TestTeamLoad:
         assert len(loaded.members) == 1
         assert loaded.members[0].id == "rt-agent"
 
+    def test_load_rehydrates_member_agent_tools(self, tmp_path):
+        """A member agent's tools must be rehydrated against the same registry
+        the team was loaded with. Without it Agent.from_dict takes its
+        no-registry branch, drops the tools outright, and the member comes back
+        with none -- the nested-team branch already forwards the registry."""
+        from agno.models.openai import OpenAIResponses
+        from agno.tools.toolkit import Toolkit
+
+        def search_web(query: str) -> str:
+            """Search the web."""
+            return "results"
+
+        toolkit = Toolkit(
+            name="web",
+            tools=[search_web],
+            instructions="Cite every source.",
+            add_instructions=True,
+        )
+        model = OpenAIResponses(id="gpt-5.5")
+        db = SqliteDb(db_file=str(tmp_path / "team_member_tools.db"))
+        member = Agent(id="member", name="Member", model=model, tools=[toolkit])
+        Team(id="tool-team", name="Tool Team", model=model, members=[member]).save(db=db)
+
+        loaded = Team.load(id="tool-team", db=db, registry=Registry(tools=[toolkit], models=[model]))
+
+        assert loaded is not None
+        member_tools = loaded.members[0].tools or []
+        assert [tool.name for tool in member_tools] == ["search_web"]
+        assert member_tools[0].entrypoint is not None
+        # And the toolkit came with them, so its guidance survives the reload.
+        assert member_tools[0].source_toolkit is toolkit
+
 
 # =============================================================================
 # delete() Tests

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -951,21 +951,26 @@ class TestTeamLoad:
         # And the toolkit came with them, so its guidance survives the reload.
         assert member_tools[0].source_toolkit is toolkit
 
-    def test_load_passes_member_builtin_dict_tools_through(self, tmp_path):
-        """Provider-builtin tools persist as plain dicts. Rehydrating one as a
-        Function config raised a ValidationError that took the whole team load
-        down; it must ride through the member's tools untouched instead."""
+    def test_load_passes_member_provider_dict_tools_through(self, tmp_path):
+        """Provider-run tools persist as plain dicts, typed builtins and
+        untyped custom shapes alike. Rehydrating one as a Function config
+        raised a ValidationError that took the whole team load down; they must
+        ride through the member's tools untouched instead."""
         from agno.models.openai import OpenAIResponses
 
+        provider_dicts = [
+            {"type": "web_search"},
+            {"name": "get_weather", "description": "Weather", "input_schema": {"type": "object"}},
+        ]
         model = OpenAIResponses(id="gpt-5.5")
         db = SqliteDb(db_file=str(tmp_path / "team_builtin_tools.db"))
-        member = Agent(id="builtin-member", name="Member", model=model, tools=[{"type": "web_search"}])
+        member = Agent(id="builtin-member", name="Member", model=model, tools=list(provider_dicts))
         Team(id="builtin-team", name="Builtin Team", model=model, members=[member]).save(db=db)
 
         loaded = Team.load(id="builtin-team", db=db, registry=Registry(models=[model]))
 
         assert loaded is not None
-        assert loaded.members[0].tools == [{"type": "web_search"}]
+        assert loaded.members[0].tools == provider_dicts
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1228,3 +1228,26 @@ def test_tool_hook_receives_messages_via_run_context():
     # Verify it's a copy (not the same reference), so hook mutations don't affect the run
     assert captured_messages is not run_context.messages
     assert captured_messages == run_context.messages
+
+
+def test_model_copy_deep_isolates_user_input_schema():
+    """model_copy(deep=True) is the per-run copy parse_tools hands the model,
+    and the model layer writes the user's answers into user_input_schema in
+    place. An aliased schema would carry one run's input into every later run
+    of the same component."""
+
+    def send_email(to: str, subject: str, body: str) -> str:
+        """Send an email."""
+        return "sent"
+
+    func = Function.from_callable(send_email)
+    func.requires_user_input = True
+    func.user_input_fields = ["body"]
+    func.process_entrypoint()
+    assert func.user_input_schema
+
+    copied = func.model_copy(deep=True)
+    assert copied.user_input_schema is not func.user_input_schema
+
+    copied.user_input_schema[0].value = "run-scoped answer"
+    assert func.user_input_schema[0].value is None

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -548,6 +548,30 @@ class TestToolNameResolution:
 
 
 class TestToolkitInstructionPersistence:
+    def test_source_toolkit_survives_every_copy_path(self):
+        """The live Toolkit must survive both copy entry points, including
+        pydantic's own model_copy(deep=True), which calls __deepcopy__() with
+        no memo."""
+        from copy import deepcopy
+
+        from pydantic import BaseModel
+
+        def read_file(path: str) -> str:
+            return path
+
+        toolkit = Toolkit(name="agent_files", tools=[read_file])
+        function = toolkit.get_functions()["read_file"].model_copy()
+        function.source_toolkit = toolkit
+
+        assert deepcopy(function).source_toolkit is toolkit
+        assert function.model_copy(deep=True).source_toolkit is toolkit
+        assert BaseModel.model_copy(function, deep=True).source_toolkit is toolkit
+
+        # The pin must not overwrite a stand-in the in-progress copy already
+        # made: one original may not end up with two stand-ins.
+        copied_toolkit, copied_function = deepcopy([toolkit, function])
+        assert copied_function.source_toolkit is copied_toolkit
+
     def test_db_loaded_agent_includes_live_toolkit_guidance_once(self, db):
         creation_guidance = "CREATION_TOOLKIT_GUIDANCE"
         live_guidance = "LIVE_TOOLKIT_GUIDANCE"

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -13,9 +13,11 @@ from typing import Any, Dict
 import pytest
 
 from agno.agent import Agent
+from agno.agent._tools import parse_tools
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.registry import Registry
+from agno.session import AgentSession
 from agno.tools.calculator import CalculatorTools
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.function import Function
@@ -543,6 +545,75 @@ class TestToolNameResolution:
 
         assert isinstance(member, Function)
         assert member.owning_toolkit == "agent_files"
+
+
+class TestToolkitInstructionPersistence:
+    def test_db_loaded_agent_includes_live_toolkit_guidance_once(self, db):
+        creation_guidance = "CREATION_TOOLKIT_GUIDANCE"
+        live_guidance = "LIVE_TOOLKIT_GUIDANCE"
+        first_guidance = "FIRST_FUNCTION_GUIDANCE"
+        second_guidance = "SECOND_FUNCTION_GUIDANCE"
+
+        def first_tool() -> str:
+            return "first"
+
+        def second_tool() -> str:
+            return "second"
+
+        toolkit = Toolkit(
+            name="guided_tools",
+            tools=[first_tool, second_tool],
+            instructions=creation_guidance,
+            add_instructions=True,
+        )
+        toolkit.functions["first_tool"].instructions = first_guidance
+        toolkit.functions["second_tool"].instructions = second_guidance
+        registry = Registry(
+            tools=[toolkit],
+            models=[OpenAIResponses(id="gpt-5.5")],
+            dbs=[db],
+        )
+        studio = StudioTools(registry=registry, db=db)
+
+        result = _loads(
+            studio.create_agent(
+                name="guided-agent",
+                instructions="Base agent guidance.",
+                model_id="gpt-5.5",
+                tool_names=[toolkit.name],
+            )
+        )
+        assert result["status"] == "created"
+
+        persisted_tools = db.get_config("guided-agent")["config"]["tools"]
+        assert len(persisted_tools) == 2
+        assert all(tool["toolkit"] == toolkit.name for tool in persisted_tools)
+        assert all("instructions" not in tool for tool in persisted_tools)
+        assert all("add_instructions" not in tool for tool in persisted_tools)
+
+        # A registry edit after persistence must be visible on the next load.
+        toolkit.instructions = live_guidance
+
+        loaded = studio._load_agent_from_db("guided-agent")
+        assert loaded is not None
+        # AgentOS request resolution deep-copies DB-loaded components.
+        loaded = loaded.deep_copy()
+        assert loaded.tools is not None
+        assert loaded.model is not None
+        assert all(isinstance(tool, Function) for tool in loaded.tools)
+        assert all(tool.source_toolkit is toolkit for tool in loaded.tools if isinstance(tool, Function))
+
+        model_tools = parse_tools(agent=loaded, tools=loaded.tools, model=loaded.model)
+        assert loaded._tool_instructions == [first_guidance, second_guidance, live_guidance]
+        message = loaded.get_system_message(
+            session=AgentSession(session_id="test-session", agent_id=loaded.id),
+            tools=model_tools,
+        )
+
+        assert message is not None
+        assert isinstance(message.content, str)
+        assert creation_guidance not in message.content
+        assert message.content.count(live_guidance) == 1
 
 
 class TestMCPToolkitPersistence:


### PR DESCRIPTION
## Summary

Fix Studio component rehydration so toolkit usage guidance survives database reloads while the live registry remains the source of truth.

- Restore per-function `instructions` and `add_instructions` from the live registry Function during rehydration.
- Retain an excluded runtime reference to the live source Toolkit, including across AgentOS deep copies.
- Add toolkit-level guidance exactly once, after its member-function guidance, for both Agents and Teams.
- Add registry, SQLite Studio reload, and Team regression coverage.

The root cause was that persisted Function dictionaries intentionally omit instruction fields, but registry rehydration restored only the entrypoint. DB-loaded toolkit members therefore reached instruction collection as bare Functions with no way to recover the Toolkit-level guidance.

No instruction text is added to persisted component data. Registry-side function instructions are read at load; toolkit-level instructions are read from the live Toolkit at run time.

## Review round two

A review of the first implementation found four further defects. All were reproduced, fixed, and pinned by tests.

**Configs saved before tool dicts carried a `toolkit` key got nothing.** `source_toolkit` was computed only inside the qualified-lookup branch, so a legacy config restored its per-function instructions but not the toolkit's. The `toolkit` key shipped in 2.8.7, and `StudioTools` shipped in June, so every component persisted in between is affected. The owning Toolkit is now found by object identity, which needs no recorded name and therefore also survives a toolkit rename. The attribution is deliberately not written back into the config: see the round-three note below.

**A toolkit that rebuilt its functions dict was served from a stale cache.** `_entrypoint_lookup` is a `cached_property` that was rebuilt only on a lookup *miss*. `MCPTools.build_tools()` replaces every `Function` object on connect, so entries written before the rebuild still *hit* — and returned the old entrypoint, the old instructions, and no toolkit at all, silently. The cache now also rebuilds when a hit resolves to a Function its toolkit no longer owns.

**A component holding one member of a toolkit was given the whole toolkit's guidance.** `StudioTools._resolve_tools` resolves individual toolkit functions, and persistence records one dict per function, so a whole-toolkit selection and a single-member selection are indistinguishable on reload. The first implementation resolved that as always-full-toolkit, which put guidance naming five absent tools into a one-tool agent's prompt. Toolkit-level guidance is now emitted only when the component holds every function the toolkit exposes.

**Toolkit guidance duplicated, and landed out of order, after `deep_copy`.** Grouping keyed on `id(toolkit)`, but `deep_copy` clones a Toolkit list entry while its rehydrated members keep pointing at the live one — one toolkit, two ids, guidance twice. Grouping now keys on what a toolkit contributes rather than its identity: two toolkits that agree on every part of the key emit the same text, so collapsing them is correct, and a clone can no longer split from its original. (The key grew in later rounds: round three added the function surface so same-guidance toolkits cannot pool their members, and round four split that surface per mode.)

Two smaller items from the same review:

- `Function.__deepcopy__` made `memo` a required positional, but `BaseModel.model_copy(deep=True)` calls `__deepcopy__()` with no argument. It is now optional, and the toolkit is pinned with `setdefault` so the override cannot overwrite an entry the in-progress copy already made.
- The `reversed(self.tools)` scan was redundant: the loop body already disambiguates by object identity, and `Toolkit.register` builds a distinct `Function` per toolkit. Replaced by a single-pass, dict-indexed helper.

Behaviour worth calling out, because it is not obvious from the diff: pinning the toolkit in the memo also keeps a rehydrated function's `entrypoint` bound to the **live** toolkit. Previously `deepcopy` rebound it to a detached clone, which broke DB-loaded MCP toolkits — `deep_copy_field` inspects `type(tool).__mro__` and cannot recognise MCP once a toolkit is flattened to bare Functions. The trade-off is that `create_fresh=True` runs now share one live toolkit instead of a per-run clone.

Known limitation, unchanged: a tools list that *interleaves* two toolkits' members emits each toolkit's guidance after its own last member, so one block can land inside another's. Persistence writes members grouped by toolkit, so this needs a hand-built list.

## Review round three

Two PR comments from @harshsinha03, both reproduced and fixed:

- **`Team.load()` never passed its registry to `Agent.from_dict`** (`team/_storage.py:1151`), so a member agent took the no-registry branch, had its tools deleted, and came back with none. The nested-team branch two lines below already forwarded it. No rehydrated toolkit setting could reach a team member at all.
- **Instruction settings were not the only behaviour the storage layer drops.** `to_dict()` carries seven fields; the other fifteen describe how the tool behaves, and several hold callables that cannot serialize. Losing `requires_user_input` and `user_input_fields` corrupted the schema outright: a round trip handed the model `required: ['body','subject','to']` against `properties: ['subject','to']`, with `body` required, never defined, and no gate left to supply it. `show_result`, `stop_after_tool_call`, the cache settings and the hooks were dropped the same way. Both halves are now named lists, `SERIALIZED_FIELDS` and `RUNTIME_ONLY_FIELDS`, and a test asserts they partition `Function`'s fields, so a new field cannot be added and silently lost.

An adversarial review of the round-two code then found four more, all fixed:

- **The `owning_toolkit` re-stamp was reverted.** Writing the resolved toolkit's name back onto a legacy config traded a rename-proof state for a brittle one: identity resolution reaches the Toolkit with no recorded name, so an unstamped config survives a rename while a stamped one takes the qualified key, misses, and loses the guidance. A migration to qualified names, if wanted, belongs in an explicit opt-in migration rather than as a side effect of loading.
- **A non-string `Toolkit.instructions` crashed every run.** Grouping toolkits by their guidance put `instructions` into a dict key. It is declared `Optional[str]` but nothing enforces it, so a list made the key unhashable. Now falls back to object identity for that toolkit.
- **Restored mutable fields were aliased, not copied.** The model layer writes a user's answer straight into the `UserInputField` objects of `user_input_schema`, so one run's input became visible to every other component holding that tool and to the registry itself. Reachable through any `@tool(requires_user_input=...)` method on a Toolkit, because `skip_entrypoint_processing` stops `process_entrypoint` rebuilding the schema that would otherwise dissolve the sharing.
- **The coverage guard measured the sync function set in both modes.** In async mode a live Toolkit contributes its async variants too, and the registry cannot rehydrate those, so an async-only member left the component genuinely short a tool while still receiving guidance describing it.

An external review of round three then found two more, both reproduced and fixed:

- **A standalone registration masked a rebuilt toolkit.** A `Function` can be both a toolkit member and a registry tool in its own right, and `Registry.add_tool` accepts it either way. The staleness check treated that standalone registration as proof the cached entry was fresh, so a toolkit-qualified config whose toolkit had since rebuilt its functions kept receiving the old entrypoint and lost the live toolkit. Staleness for a qualified key is now the named toolkit's to answer; the standalone guard applies to unqualified resolution alone.
- **The grouping key omitted the toolkit's function set.** Two same-named toolkits carrying identical guidance pooled their members, so each was judged against the other's coverage. A component holding all of one and part of the other emitted no guidance at all, when the shared guidance was earned once.

## Review round four

An external review of the round-three head found three more. Each was reproduced by execution before it was fixed.

- **One run's user input leaked into the next run of a reloaded component.** `Function.model_copy(deep=True)` deep-copied `parameters` but aliased everything else, including `user_input_schema` — and that is the per-run copy `parse_tools` hands the model on every run. The round-three isolation protected the registry, but the loaded Agent's own Functions still shared their `UserInputField` objects with each run's copy, so an answer written in run one was visible in run two. The schema is now deep-copied alongside `parameters`.
- **The grouping key folded the sync and async surfaces into one union.** Coverage is measured per mode, so two same-named toolkits whose surfaces agree only as a union pooled their members, and a complete toolkit's guidance was judged against — and silenced by — its namesake's function set. The key now carries the two surfaces separately.
- **The stale-cache recovery was still history-dependent.** A member deleted after the cache was warmed kept serving its old entrypoint, because staleness only looked for a *different* current owner; and a standalone registration vouched for a flat slot that a later toolkit's registration actually owned under last-write-wins. Staleness is now exact by construction: one shared walker yields every registration in order, the cached lookup folds it, and a per-key replay names the slot's owner, so the cache is fresh only while it holds the object a rebuild would produce. The replayed owner doubles as the `source_toolkit` attribution, and a rebuild is skipped when the key has no owner at all — it could only miss too.

A parallel multi-agent review of the same head found one more, reproduced on both the head and the merge base:

- **A member's provider-builtin dict tool crashed the whole team load.** Builtin tools persist as plain dicts, and `rehydrate_functions` parsed every entry as a Function config — a builtin dict has no `name`, so the ValidationError took the load down. On the team path this was a regression introduced by the round-three registry forward: a member that used to come back with its tools silently dropped now failed to load at all. (`Agent.load` crashed the same way before this branch.) Builtin dicts now pass through unchanged, in place: a top-level `type` marks one, while a persisted Function dict writes only `SERIALIZED_FIELDS`, which has no `type`. The partition test also pins its reverse direction now, so a field removed from `Function` but left in either list cannot crash every load on the missing attribute.

The adversarial verification pass over that review confirmed one further finding and killed eight as pre-existing, fail-safe, or mischaracterized:

- **The exact-staleness replay walked every registration once per key.** A 40-tool load against a 2,000-registration registry spent 6.5 ms scanning — 91% of `Agent.from_dict` — where the old cache read cost microseconds. The replay now folds into an owner index built once per rehydration batch: same owners, same staleness answers, one walk instead of one per tool dict. 1.1 ms on the same benchmark; sub-0.2 ms at realistic registry sizes.

A mutation audit of the earlier rounds' guards also found four that no test pinned: the duplicate-name path that still emits toolkit guidance when a toolkit's last list position holds a duplicate (agent and team), the isinstance narrowing that keeps a junk `source_toolkit` value from crashing collection, and `isolated_runtime_value`'s dict branch, which no `RUNTIME_ONLY_FIELDS` entry can reach. The first three are now pinned; the dead branch is removed.

The mutation audit was repeated for this round: every new guard, reverted individually, fails at least one test.

## Review round five

An external review of the round-four head found two blockers and one scalability concern. All three reproduced by execution, all three fixed.

- **Untyped provider tool dicts aborted the component load.** The round-four pass-through keyed on a top-level `type`, so a provider-native shape like Anthropic's `{name, description, input_schema}` was parsed as a Function config and raised a ValidationError — and with the registry now forwarded into member loading, the whole `Team.load` failed. Identification is now positive: only a dict `Function.to_dict()` could have written — `name` and `parameters` present, no `type`, no `input_schema` — is rehydrated; every other dict is the provider's to interpret and passes through in place. A dict that looks like a Function config but fails validation is warned about and passed through too: one unparseable tool must not take down the load.
- **Flat-slot ownership erased toolkit provenance.** A toolkit member also registered directly — what AgentOS component collection produces — owns its flat slot as the direct registration, so an unqualified config resolved its entrypoint but lost `source_toolkit`, contradicting the legacy-config promise from round two. The owner index now also carries an identity map: freshness follows the slot, provenance follows the object.
- **Toolkit-key construction was quadratic in toolkit size.** `_toolkit_key` folds the toolkit's whole function surface and was rebuilt once per member Function, so one collection pass over a 2,000-function toolkit spent 0.93 s in key construction. The key is now memoized per live Toolkit for the pass: 0.19 s, and linear. Together with round four's per-batch owner index, the reviewer's 5,000-function scenario (~8 s on the round-three head) is now sub-second end to end.

The mutation audit was repeated: each of the six new guards, reverted individually, fails at least one test — including one pinned by the OpenAI Responses custom-function shape, which carries `type`, `name`, and `parameters` together.

## Known limitations

- A component that holds only some of a toolkit's functions gets no toolkit-level guidance, because persistence records one dict per function and cannot distinguish a deliberate subset from a toolkit that has since grown. A toolkit that gains a function therefore drops its guidance from already-saved components. This is never worse than 2.8.7, which gave rehydrated components no toolkit guidance at all. Removing the guesswork needs a completeness marker written at save time, which is a config-format change and belongs in its own PR.
- A tools list that interleaves two toolkits' members emits each toolkit's guidance after its own last member, so one block can land inside another's. Persistence writes members grouped by toolkit, so this needs a hand-built list.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (not applicable; no public API change)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Target release: 2.8.8.

PR #9371 also touches Studio component loading, but it does not restore or deduplicate toolkit instruction guidance. This PR is the narrow registry and instruction-collection fix.

Validation:

- 2771 tests pass across `unit/registry`, `unit/tools`, `unit/agent`, and `unit/team` after round five; the only failures and collection errors also occur on the merge base and come from missing optional dependencies
- Full `libs/agno/tests/unit` run A/B'd against the merge base: identical failure sets (100 pre-existing failures, all missing optional dependencies), so this branch introduces none
- Every production line added by this PR is mutation-tested: reverting any one guard individually — across all five rounds — fails at least one test; the round-four audit also caught and pinned four guards from earlier rounds that no test had covered
- `./scripts/format.sh` passed
- `./scripts/validate.sh` passed, including mypy over 955 core source files
