### PR TITLE
fix: persist paused member runs so team HITL resume survives a session reload

### DIFF
--- a/libs/agno/agno/os/managers.py
+++ b/libs/agno/agno/os/managers.py
@@ -232,6 +232,13 @@ class EventsBuffer:
                 "created_at": current_time,
                 "last_updated": current_time,
             }
+        elif self.run_metadata.get(run_id, {}).get("status") == RunStatus.paused:
+            # A continue reuses the paused run's id, so an event arriving on a
+            # paused entry means a new producer took the run over. The pause's
+            # status and completed_at would let the cleanup pass reclaim a live
+            # run and would route /resume to replay instead of subscribing.
+            self.run_metadata[run_id]["status"] = RunStatus.running
+            self.run_metadata[run_id].pop("completed_at", None)
 
         self.events[run_id].append(event)
         self.run_metadata[run_id]["last_updated"] = current_time

--- a/libs/agno/agno/os/managers.py
+++ b/libs/agno/agno/os/managers.py
@@ -328,8 +328,10 @@ class EventsBuffer:
         runs_to_cleanup = []
 
         for run_id, metadata in self.run_metadata.items():
-            # Only cleanup completed runs
-            if metadata["status"] in [RunStatus.completed, RunStatus.error, RunStatus.cancelled]:
+            # Terminal runs, plus paused runs: a pause can wait on an approval
+            # forever, and a reclaimed paused entry is rebuilt by add_event
+            # when the run is eventually continued.
+            if metadata["status"] in [RunStatus.completed, RunStatus.error, RunStatus.cancelled, RunStatus.paused]:
                 completed_at = metadata.get("completed_at", metadata["last_updated"])
                 if current_time - completed_at > self.cleanup_interval:
                     runs_to_cleanup.append(run_id)

--- a/libs/agno/agno/os/managers.py
+++ b/libs/agno/agno/os/managers.py
@@ -226,7 +226,9 @@ class EventsBuffer:
 
         if run_id not in self.events:
             self.events[run_id] = []
-            self._next_index[run_id] = 0
+            # A reclaimed paused run keeps its index; a continuation must not
+            # recycle event indices a client has already seen.
+            self._next_index.setdefault(run_id, 0)
             self.run_metadata[run_id] = {
                 "status": RunStatus.running,
                 "created_at": current_time,
@@ -324,7 +326,11 @@ class EventsBuffer:
         """Remove buffer for a completed run (called after retention period)"""
         if run_id in self.events:
             del self.events[run_id]
-        self._next_index.pop(run_id, None)
+        # A paused run can be continued later under the same id: its monotonic
+        # index survives the reclaim, so the continuation's event indices keep
+        # ascending past every index a client has already seen.
+        if (self.run_metadata.get(run_id) or {}).get("status") != RunStatus.paused:
+            self._next_index.pop(run_id, None)
         if run_id in self.run_metadata:
             del self.run_metadata[run_id]
         log_debug(f"Cleaned up event buffer for run {run_id}")

--- a/libs/agno/agno/run/approval.py
+++ b/libs/agno/agno/run/approval.py
@@ -440,20 +440,37 @@ def _collect_all_approval_tools(run_response: Any) -> List[Any]:
     return result
 
 
+_AMBIGUOUS_OWNER = "__ambiguous_owner__"
+
+
 def _member_run_id_for_tool(run_response: Any, tool: Any) -> Optional[str]:
-    """The member run_id that owns this tool execution, if it came in via a requirement."""
+    """The member run_id that owns this tool execution, if it came in via a requirement.
+
+    An identity match is authoritative. A value match (tool_call_id + tool_name)
+    that fits requirements of MORE THAN ONE member is ambiguous and returns
+    _AMBIGUOUS_OWNER, so the tool resolves no record and the continue blocks:
+    provider-local tool_call_ids can collide across members, and a wrong owner
+    would let one member's approval execute another member's tool."""
+    value_matches: List[str] = []
     for req in getattr(run_response, "requirements", None) or []:
         te = getattr(req, "tool_execution", None)
         if te is None:
             continue
-        if te is tool or (
+        if te is tool:
+            return getattr(req, "member_run_id", None)
+        if (
             getattr(te, "tool_call_id", None) is not None
             and getattr(te, "tool_call_id", None) == getattr(tool, "tool_call_id", None)
             and getattr(te, "tool_name", None) == getattr(tool, "tool_name", None)
         ):
             mid = getattr(req, "member_run_id", None)
             if mid:
-                return mid
+                value_matches.append(mid)
+    distinct = set(value_matches)
+    if len(distinct) > 1:
+        return _AMBIGUOUS_OWNER
+    if value_matches:
+        return value_matches[0]
     return None
 
 
@@ -464,9 +481,8 @@ def _group_tools_by_approval(db: Any, run_id: str, run_response: Any, tools: Lis
     speak for another member's tool. Resolution order per tool:
       1. the approval_id stamped on the tool execution at pause time,
       2. the owning member_run_id,
-      3. the run-level lookup (team run_id first, then any member run_id) -- the
-         pre-existing behaviour, kept so single-member and team-level runs whose
-         tools carry no approval_id still resolve.
+      3. the run-level lookup (team run_id first, then any member run_id),
+         which serves tools carrying no approval_id and no owning member run.
     """
     cache: Dict[str, Optional[Dict[str, Any]]] = {}
     fallback_used = False
@@ -485,11 +501,23 @@ def _group_tools_by_approval(db: Any, run_id: str, run_response: Any, tools: Lis
         mid: Optional[str] = None
         if record is None:
             mid = _member_run_id_for_tool(run_response, tool)
+            if mid == _AMBIGUOUS_OWNER:
+                # No record can be paired safely; the continue blocks.
+                pairs.append((tool, None))
+                continue
             if mid:
                 key = f"run:{mid}"
                 if key not in cache:
                     cache[key] = _get_approval_for_run(db, mid)
                 record = cache[key]
+        if record is None and aid and not mid:
+            # A tool whose stamped record is gone and that owns no member run
+            # resolves within its own run only: a record re-issued under this
+            # run id counts, a sibling member's record never does.
+            key = f"run:{run_id}"
+            if key not in cache:
+                cache[key] = _get_approval_for_run(db, run_id)
+            record = cache[key]
         if record is None and not aid and not mid:
             # The run-level lookup serves only tools with no scoped identity.
             # A tool whose own record is gone stays unresolved: pairing it with
@@ -527,11 +555,23 @@ async def _agroup_tools_by_approval(db: Any, run_id: str, run_response: Any, too
         mid: Optional[str] = None
         if record is None:
             mid = _member_run_id_for_tool(run_response, tool)
+            if mid == _AMBIGUOUS_OWNER:
+                # No record can be paired safely; the continue blocks.
+                pairs.append((tool, None))
+                continue
             if mid:
                 key = f"run:{mid}"
                 if key not in cache:
                     cache[key] = await _aget_approval_for_run(db, mid)
                 record = cache[key]
+        if record is None and aid and not mid:
+            # A tool whose stamped record is gone and that owns no member run
+            # resolves within its own run only: a record re-issued under this
+            # run id counts, a sibling member's record never does.
+            key = f"run:{run_id}"
+            if key not in cache:
+                cache[key] = await _aget_approval_for_run(db, run_id)
+            record = cache[key]
         if record is None and not aid and not mid:
             # The run-level lookup serves only tools with no scoped identity.
             # A tool whose own record is gone stays unresolved: pairing it with
@@ -638,7 +678,6 @@ async def acheck_and_apply_approval_resolution(db: Any, run_id: str, run_respons
     if not any(getattr(t, "approval_type", None) == "required" for t in all_approval_tools):
         return
 
-    # Search by team run_id first, then fall back to member run_ids
     pairs = await _agroup_tools_by_approval(db, run_id, run_response, all_approval_tools)
     if any(record is None for _, record in pairs):
         raise RuntimeError(

--- a/libs/agno/agno/run/approval.py
+++ b/libs/agno/agno/run/approval.py
@@ -49,12 +49,12 @@ def _stamp_approval_id_on_tools(
     """Stamp approval_id on every tool that has approval_type set."""
     if tools:
         for tool in tools:
-            if getattr(tool, "approval_type", None) is not None:
+            if getattr(tool, "approval_type", None) is not None and getattr(tool, "approval_id", None) is None:
                 tool.approval_id = approval_id
     if requirements:
         for req in requirements:
             te = getattr(req, "tool_execution", None)
-            if te and getattr(te, "approval_type", None) is not None:
+            if te and getattr(te, "approval_type", None) is not None and getattr(te, "approval_id", None) is None:
                 te.approval_id = approval_id
 
 
@@ -482,6 +482,7 @@ def _group_tools_by_approval(db: Any, run_id: str, run_response: Any, tools: Lis
                 except (NotImplementedError, Exception):
                     cache[aid] = None
             record = cache[aid]
+        mid: Optional[str] = None
         if record is None:
             mid = _member_run_id_for_tool(run_response, tool)
             if mid:
@@ -489,7 +490,10 @@ def _group_tools_by_approval(db: Any, run_id: str, run_response: Any, tools: Lis
                 if key not in cache:
                     cache[key] = _get_approval_for_run(db, mid)
                 record = cache[key]
-        if record is None:
+        if record is None and not aid and not mid:
+            # The run-level lookup serves only tools with no scoped identity.
+            # A tool whose own record is gone stays unresolved: pairing it with
+            # a sibling's record would let that sibling's approval execute it.
             if not fallback_used:
                 fallback_used = True
                 for rid in _collect_all_run_ids(run_id, run_response):
@@ -520,6 +524,7 @@ async def _agroup_tools_by_approval(db: Any, run_id: str, run_response: Any, too
                 except (NotImplementedError, Exception):
                     cache[aid] = None
             record = cache[aid]
+        mid: Optional[str] = None
         if record is None:
             mid = _member_run_id_for_tool(run_response, tool)
             if mid:
@@ -527,7 +532,10 @@ async def _agroup_tools_by_approval(db: Any, run_id: str, run_response: Any, too
                 if key not in cache:
                     cache[key] = await _aget_approval_for_run(db, mid)
                 record = cache[key]
-        if record is None:
+        if record is None and not aid and not mid:
+            # The run-level lookup serves only tools with no scoped identity.
+            # A tool whose own record is gone stays unresolved: pairing it with
+            # a sibling's record would let that sibling's approval execute it.
             if not fallback_used:
                 fallback_used = True
                 for rid in _collect_all_run_ids(run_id, run_response):

--- a/libs/agno/agno/run/approval.py
+++ b/libs/agno/agno/run/approval.py
@@ -440,7 +440,106 @@ def _collect_all_approval_tools(run_response: Any) -> List[Any]:
     return result
 
 
-def _sync_requirements_after_approval(run_response: Any, approval_status: str) -> None:
+def _member_run_id_for_tool(run_response: Any, tool: Any) -> Optional[str]:
+    """The member run_id that owns this tool execution, if it came in via a requirement."""
+    for req in getattr(run_response, "requirements", None) or []:
+        te = getattr(req, "tool_execution", None)
+        if te is None:
+            continue
+        if te is tool or (
+            getattr(te, "tool_call_id", None) is not None
+            and getattr(te, "tool_call_id", None) == getattr(tool, "tool_call_id", None)
+            and getattr(te, "tool_name", None) == getattr(tool, "tool_name", None)
+        ):
+            mid = getattr(req, "member_run_id", None)
+            if mid:
+                return mid
+    return None
+
+
+def _group_tools_by_approval(db: Any, run_id: str, run_response: Any, tools: List[Any]) -> List[tuple]:
+    """Pair every approval tool with ITS OWN approval record.
+
+    Each paused member creates its own approval record, so one record must not
+    speak for another member's tool. Resolution order per tool:
+      1. the approval_id stamped on the tool execution at pause time,
+      2. the owning member_run_id,
+      3. the run-level lookup (team run_id first, then any member run_id) -- the
+         pre-existing behaviour, kept so single-member and team-level runs whose
+         tools carry no approval_id still resolve.
+    """
+    cache: Dict[str, Optional[Dict[str, Any]]] = {}
+    fallback_used = False
+    fallback: Optional[Dict[str, Any]] = None
+    pairs: List[tuple] = []
+    for tool in tools:
+        record: Optional[Dict[str, Any]] = None
+        aid = getattr(tool, "approval_id", None)
+        if aid:
+            if aid not in cache:
+                try:
+                    cache[aid] = db.get_approval(aid)
+                except (NotImplementedError, Exception):
+                    cache[aid] = None
+            record = cache[aid]
+        if record is None:
+            mid = _member_run_id_for_tool(run_response, tool)
+            if mid:
+                key = f"run:{mid}"
+                if key not in cache:
+                    cache[key] = _get_approval_for_run(db, mid)
+                record = cache[key]
+        if record is None:
+            if not fallback_used:
+                fallback_used = True
+                for rid in _collect_all_run_ids(run_id, run_response):
+                    fallback = _get_approval_for_run(db, rid)
+                    if fallback is not None:
+                        break
+            record = fallback
+        pairs.append((tool, record))
+    return pairs
+
+
+async def _agroup_tools_by_approval(db: Any, run_id: str, run_response: Any, tools: List[Any]) -> List[tuple]:
+    """Async variant of _group_tools_by_approval."""
+    from inspect import iscoroutinefunction
+
+    cache: Dict[str, Optional[Dict[str, Any]]] = {}
+    fallback_used = False
+    fallback: Optional[Dict[str, Any]] = None
+    pairs: List[tuple] = []
+    get_one = getattr(db, "get_approval", None)
+    for tool in tools:
+        record: Optional[Dict[str, Any]] = None
+        aid = getattr(tool, "approval_id", None)
+        if aid and get_one is not None:
+            if aid not in cache:
+                try:
+                    cache[aid] = await get_one(aid) if iscoroutinefunction(get_one) else get_one(aid)
+                except (NotImplementedError, Exception):
+                    cache[aid] = None
+            record = cache[aid]
+        if record is None:
+            mid = _member_run_id_for_tool(run_response, tool)
+            if mid:
+                key = f"run:{mid}"
+                if key not in cache:
+                    cache[key] = await _aget_approval_for_run(db, mid)
+                record = cache[key]
+        if record is None:
+            if not fallback_used:
+                fallback_used = True
+                for rid in _collect_all_run_ids(run_id, run_response):
+                    fallback = await _aget_approval_for_run(db, rid)
+                    if fallback is not None:
+                        break
+            record = fallback
+        pairs.append((tool, record))
+    return pairs
+
+
+def _sync_requirements_after_approval(run_response: Any, approval_status: str, only_tool: Any = None) -> None:
     """Mirror an applied approval resolution onto the RunRequirement objects.
 
     _apply_approval_to_tools writes ToolExecution fields only, while a
@@ -452,6 +551,8 @@ def _sync_requirements_after_approval(run_response: Any, approval_status: str) -
     for req in getattr(run_response, "requirements", None) or []:
         te = getattr(req, "tool_execution", None)
         if te is None or getattr(te, "approval_type", None) != "required":
+            continue
+        if only_tool is not None and te is not only_tool:
             continue
         if approval_status == "approved":
             if getattr(te, "requires_confirmation", False) and te.confirmed is True:
@@ -504,26 +605,20 @@ def check_and_apply_approval_resolution(db: Any, run_id: str, run_response: Any)
     if not any(getattr(t, "approval_type", None) == "required" for t in all_approval_tools):
         return
 
-    all_run_ids = _collect_all_run_ids(run_id, run_response)
-    approval = None
-    for rid in all_run_ids:
-        approval = _get_approval_for_run(db, rid)
-        if approval is not None:
-            break
-    if approval is None:
+    pairs = _group_tools_by_approval(db, run_id, run_response, all_approval_tools)
+    if any(record is None for _, record in pairs):
         raise RuntimeError(
             "No approval record found for this run. Cannot continue a run that requires external approval."
         )
-
-    status = approval.get("status", "pending")
-    if status == "pending":
+    if any((record or {}).get("status", "pending") == "pending" for _, record in pairs):
         raise RuntimeError("Approval is still pending. Resolve the approval before continuing this run.")
 
-    resolution_data = approval.get("resolution_data")
-    _apply_approval_to_tools(all_approval_tools, status, resolution_data)
-    _sync_requirements_after_approval(run_response, status)
+    for tool, record in pairs:
+        assert record is not None
+        _apply_approval_to_tools([tool], record.get("status", "pending"), record.get("resolution_data"))
+        _sync_requirements_after_approval(run_response, record.get("status", "pending"), only_tool=tool)
 
-    _attach_resolved_approval(run_response, approval)
+    _attach_resolved_approval(run_response, pairs[0][1])
 
 
 async def acheck_and_apply_approval_resolution(db: Any, run_id: str, run_response: Any) -> None:
@@ -536,26 +631,20 @@ async def acheck_and_apply_approval_resolution(db: Any, run_id: str, run_respons
         return
 
     # Search by team run_id first, then fall back to member run_ids
-    all_run_ids = _collect_all_run_ids(run_id, run_response)
-    approval = None
-    for rid in all_run_ids:
-        approval = await _aget_approval_for_run(db, rid)
-        if approval is not None:
-            break
-    if approval is None:
+    pairs = await _agroup_tools_by_approval(db, run_id, run_response, all_approval_tools)
+    if any(record is None for _, record in pairs):
         raise RuntimeError(
             "No approval record found for this run. Cannot continue a run that requires external approval."
         )
-
-    status = approval.get("status", "pending")
-    if status == "pending":
+    if any((record or {}).get("status", "pending") == "pending" for _, record in pairs):
         raise RuntimeError("Approval is still pending. Resolve the approval before continuing this run.")
 
-    resolution_data = approval.get("resolution_data")
-    _apply_approval_to_tools(all_approval_tools, status, resolution_data)
-    _sync_requirements_after_approval(run_response, status)
+    for tool, record in pairs:
+        assert record is not None
+        _apply_approval_to_tools([tool], record.get("status", "pending"), record.get("resolution_data"))
+        _sync_requirements_after_approval(run_response, record.get("status", "pending"), only_tool=tool)
 
-    _attach_resolved_approval(run_response, approval)
+    _attach_resolved_approval(run_response, pairs[0][1])
 
 
 async def acreate_audit_approval(

--- a/libs/agno/agno/run/approval.py
+++ b/libs/agno/agno/run/approval.py
@@ -432,8 +432,10 @@ def _collect_all_approval_tools(run_response: Any) -> List[Any]:
     for req in getattr(run_response, "requirements", None) or []:
         te = getattr(req, "tool_execution", None)
         if te and getattr(te, "approval_type", None) is not None:
-            # Avoid duplicates (same tool_call_id already in result)
-            if not any(getattr(r, "tool_call_id", None) == te.tool_call_id for r in result):
+            # Dedupe by object identity: after a DB reload, run_response.tools
+            # and the requirement hold DISTINCT copies of the same tool call,
+            # and the resolution must land on both.
+            if not any(r is te for r in result):
                 result.append(te)
     return result
 
@@ -461,11 +463,20 @@ def _sync_requirements_after_approval(run_response: Any, approval_status: str) -
                     for rf in req.user_input_schema:
                         if rf.name in by_name:
                             rf.value = by_name[rf.name]
-                if fields and all(f.value is not None for f in fields):
+                if all(f.value is not None for f in fields):
                     te.answered = True
             if getattr(te, "external_execution_required", False) and te.result is not None:
                 req.external_execution_result = te.result
         elif approval_status == "rejected":
+            if getattr(te, "requires_user_input", False) or getattr(te, "external_execution_required", False):
+                # A rejected tool is routed through the reject lane the
+                # dispatchers already handle: nothing left to answer,
+                # execution refused.
+                te.answered = True
+                te.requires_user_input = False
+                te.external_execution_required = False
+                te.requires_confirmation = True
+                te.confirmed = False
             if te.confirmed is False:
                 req.confirmation = False
 

--- a/libs/agno/agno/run/approval.py
+++ b/libs/agno/agno/run/approval.py
@@ -438,6 +438,38 @@ def _collect_all_approval_tools(run_response: Any) -> List[Any]:
     return result
 
 
+def _sync_requirements_after_approval(run_response: Any, approval_status: str) -> None:
+    """Mirror an applied approval resolution onto the RunRequirement objects.
+
+    _apply_approval_to_tools writes ToolExecution fields only, while a
+    requirement's needs_* properties read `answered`, `confirmation` and
+    `external_execution_result`. A requirement counts as answered only when
+    every user-input field carries a value, the same rule as
+    RunRequirement.provide_user_input.
+    """
+    for req in getattr(run_response, "requirements", None) or []:
+        te = getattr(req, "tool_execution", None)
+        if te is None or getattr(te, "approval_type", None) != "required":
+            continue
+        if approval_status == "approved":
+            if getattr(te, "requires_confirmation", False) and te.confirmed is True:
+                req.confirmation = True
+            if getattr(te, "requires_user_input", False):
+                fields = te.user_input_schema or []
+                if req.user_input_schema is not None and req.user_input_schema is not fields:
+                    by_name = {f.name: f.value for f in fields}
+                    for rf in req.user_input_schema:
+                        if rf.name in by_name:
+                            rf.value = by_name[rf.name]
+                if fields and all(f.value is not None for f in fields):
+                    te.answered = True
+            if getattr(te, "external_execution_required", False) and te.result is not None:
+                req.external_execution_result = te.result
+        elif approval_status == "rejected":
+            if te.confirmed is False:
+                req.confirmation = False
+
+
 def _attach_resolved_approval(run_response: Any, approval: Dict[str, Any]) -> None:
     """Expose the resolved approval record to post-hooks via run_response.metadata["approval"]."""
     if run_response.metadata is None:
@@ -478,6 +510,7 @@ def check_and_apply_approval_resolution(db: Any, run_id: str, run_response: Any)
 
     resolution_data = approval.get("resolution_data")
     _apply_approval_to_tools(all_approval_tools, status, resolution_data)
+    _sync_requirements_after_approval(run_response, status)
 
     _attach_resolved_approval(run_response, approval)
 
@@ -509,6 +542,7 @@ async def acheck_and_apply_approval_resolution(db: Any, run_id: str, run_respons
 
     resolution_data = approval.get("resolution_data")
     _apply_approval_to_tools(all_approval_tools, status, resolution_data)
+    _sync_requirements_after_approval(run_response, status)
 
     _attach_resolved_approval(run_response, approval)
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -8138,11 +8138,14 @@ async def _acontinue_run_background_stream(
         ):
             raise RunNotContinuableError(
                 f"Cannot continue run {_run_id}: the stored run has status {status_before_takeover.value} "
-                "and cannot be continued in place. Pass fork=True to branch off a finished run. "
-                "The stored run is unchanged."
+                "and cannot be continued in place. Use acontinue_run(run_id=..., fork=True) to branch off a "
+                "finished run. The stored run is unchanged."
             )
-        run_response.status = RunStatus.running
-        team_session.upsert_run(run_response=run_response)
+        # A fork or regenerate executes under a NEW run id; writing RUNNING
+        # under the original id would strand the original run at RUNNING.
+        if not (fork or regenerate):
+            run_response.status = RunStatus.running
+            team_session.upsert_run(run_response=run_response)
     await asave_session(team, session=team_session)
 
     log_info(f"Background continue-run stream {_run_id} persisted with RUNNING status")

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -16,6 +16,7 @@ from typing import (
     Literal,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Type,
     Union,
@@ -5311,35 +5312,68 @@ def _merge_tools_preserving_approval(
     return merged
 
 
+def _merge_requirement_decision(stored: Any, wire: Any) -> None:
+    """Copy the client's decision state onto the canonical stored requirement.
+
+    Only decision fields cross over: confirmation, user input and feedback
+    answers, and — solely for external-execution tools — the result. Identity
+    and routing (tool_execution, tool_args, member provenance) stay the
+    stored requirement's own; a result on a non-external tool is dropped
+    because honoring it would suppress the confirmed tool's execution.
+    """
+    for attr in ("confirmation", "confirmation_note"):
+        if getattr(wire, attr, None) is not None:
+            setattr(stored, attr, getattr(wire, attr))
+    if getattr(wire, "user_input_schema", None) is not None:
+        stored.user_input_schema = wire.user_input_schema
+    if getattr(wire, "user_feedback_schema", None) is not None:
+        stored.user_feedback_schema = wire.user_feedback_schema
+    stored_te = getattr(stored, "tool_execution", None)
+    wire_te = getattr(wire, "tool_execution", None)
+    if stored_te is not None and wire_te is not None:
+        for attr in ("confirmed", "confirmation_note", "answered"):
+            if getattr(wire_te, attr, None) is not None:
+                setattr(stored_te, attr, getattr(wire_te, attr))
+        if getattr(wire_te, "user_input_schema", None) is not None:
+            stored_te.user_input_schema = wire_te.user_input_schema
+        if getattr(wire_te, "user_feedback_schema", None) is not None:
+            stored_te.user_feedback_schema = wire_te.user_feedback_schema
+        if getattr(stored_te, "external_execution_required", None) and getattr(wire_te, "result", None) is not None:
+            stored_te.result = wire_te.result
+    if (
+        stored_te is not None
+        and getattr(stored_te, "external_execution_required", None)
+        and getattr(wire, "external_execution_result", None) is not None
+    ):
+        stored.external_execution_result = wire.external_execution_result
+
+
 def _backfill_approval_to_requirements(
     run_response: Any,
     old_requirements: Optional[List[Any]] = None,
 ) -> None:
-    """Restore approval metadata and member provenance on requirements after a continue payload merge.
+    """Bind the continue payload's requirements to the stored originals.
 
-    During continue_run the client's requirements replace the session originals,
-    but approval_type/approval_id are typically absent from the client payload.
-    This function copies those fields back from two sources (checked in priority order):
+    Requirements arrive from the wire (to_dict() strips None values, raw
+    dicts are accepted), so every field on them is unverified client input.
+    When the pre-overwrite stored requirements are available, each payload
+    entry must bind one-to-one to a stored requirement — matched by
+    requirement id (cross-checked against the tool_call_id), falling back to
+    tool_call_id only when exactly one stored requirement carries it — and
+    the STORED requirement becomes the object routing sees, with only the
+    client's decision state merged onto it (_merge_requirement_decision).
+    Trusting the wire copy instead mis-executes: a swapped or duplicated id
+    binds one member's approved arguments to another member's tool.
 
-    1. run_response.tools — covers team-level approval tools whose metadata was
-       already preserved by _merge_tools_preserving_approval.
-    2. old_requirements (the pre-overwrite session requirements) — covers member-level
-       approval tools where run_response.tools only contains delegate_task_to_member
-       entries that have no approval_type. The original session requirements carry it.
+    Raises RunNotContinuableError — with the run left paused — for a payload
+    entry that is ambiguous (several stored requirements share its
+    tool_call_id and no id matches), matches no stored requirement, or maps
+    a stored requirement that another entry already claimed.
 
-    Member provenance (member_agent_id, member_agent_name, member_run_id) is
-    taken from the stored requirement as the authority: requirements arrive
-    from the wire (to_dict() strips None values, raw dicts are accepted), so
-    absent fields are ordinary and present fields are unverified client
-    input — routing on either mis-dispatches or skips the confirmed tool.
-    The stored requirement is matched by requirement id first, then by
-    tool_call_id when exactly one stored requirement carries it: two member
-    runs paused in one turn can share a tool_call_id (from_dict mints a
-    fresh id for a payload without one, so such a payload is ambiguous), and
-    guessing would silently drop one confirmed run.
-
-    Raises RunNotContinuableError for an ambiguous payload — the run stays
-    paused and can be continued again with the requirement ids included.
+    Without stored requirements (a caller-supplied bare run object), the
+    payload is kept as-is and only approval metadata is backfilled from
+    run_response.tools, whose approval fields _merge_tools_preserving_approval
+    already preserved.
     """
     reqs = getattr(run_response, "requirements", None)
     if not reqs:
@@ -5371,25 +5405,84 @@ def _backfill_approval_to_requirements(
             for attr in ("approval_type", "approval_id"):
                 if getattr(te, attr, None) is None and getattr(src, attr, None) is not None:
                     setattr(te, attr, getattr(src, attr))
+
+    if not old_requirements:
+        return
+
+    run_id = getattr(run_response, "run_id", None)
+    matched: Set[int] = set()
+    canonical: List[Any] = []
+    for req in reqs:
+        te = getattr(req, "tool_execution", None)
+        tool_call_id = te.tool_call_id if te is not None else None
         old_req = old_by_req_id.get(getattr(req, "id", None) or "")
-        if old_req is not None and te is not None and te.tool_call_id:
+        if old_req is not None and tool_call_id:
             old_te = getattr(old_req, "tool_execution", None)
-            if old_te is not None and old_te.tool_call_id and old_te.tool_call_id != te.tool_call_id:
+            if old_te is not None and old_te.tool_call_id and old_te.tool_call_id != tool_call_id:
                 old_req = None
-        if old_req is None and te is not None and te.tool_call_id:
-            candidates = old_by_tool_call_id.get(te.tool_call_id, [])
+        if old_req is None and tool_call_id:
+            candidates = old_by_tool_call_id.get(tool_call_id, [])
             if len(candidates) == 1:
                 old_req = candidates[0]
             elif len(candidates) > 1:
                 raise RunNotContinuableError(
-                    f"Cannot continue run {getattr(run_response, 'run_id', None)}: the requirement for "
-                    f"tool call '{te.tool_call_id}' matches {len(candidates)} stored requirements and "
-                    f"carries no matching requirement id. Resend the requirements with their original "
-                    f"'id' values. The run remains paused."
+                    f"Cannot continue run {run_id}: the requirement for tool call '{tool_call_id}' "
+                    f"matches {len(candidates)} stored requirements and carries no matching "
+                    f"requirement id. Resend the requirements with their original 'id' values. "
+                    f"The run remains paused."
                 )
-        if old_req is not None:
-            for attr in ("member_agent_id", "member_agent_name", "member_run_id"):
-                setattr(req, attr, getattr(old_req, attr, None))
+        if old_req is None:
+            raise RunNotContinuableError(
+                f"Cannot continue run {run_id}: the requirement with id '{getattr(req, 'id', None)}' "
+                f"and tool call '{tool_call_id}' matches no stored requirement of this run. "
+                f"The run remains paused."
+            )
+        if id(old_req) in matched:
+            raise RunNotContinuableError(
+                f"Cannot continue run {run_id}: two payload requirements both resolve to the stored "
+                f"requirement '{getattr(old_req, 'id', None)}'. The run remains paused."
+            )
+        matched.add(id(old_req))
+        _merge_requirement_decision(old_req, req)
+        canonical.append(old_req)
+    run_response.requirements = canonical
+
+
+def _apply_requirements_payload(
+    run_response: TeamRunOutput,
+    requirements: List[Any],
+) -> Tuple[Optional[List["RunRequirement"]], Optional[List[Any]]]:
+    """Apply a continue payload to the run object, keeping it intact on refusal.
+
+    Normalizes the payload, binds it to the stored requirements
+    (_backfill_approval_to_requirements), and merges the bound tool
+    executions into run_response.tools. On a binding refusal the run object
+    gets its requirements and tools back before the raise: the refusal asks
+    the client to resend the stored ids, which a caller-supplied live run
+    object only still has if nothing was overwritten.
+
+    Returns (old_requirements, old_tools) so the caller can restore them if
+    a later step of its payload apply raises.
+    """
+    old_requirements = run_response.requirements
+    old_tools = run_response.tools
+    run_response.requirements = _normalize_requirements_payload(requirements)
+    try:
+        _backfill_approval_to_requirements(run_response, old_requirements=old_requirements)
+    except Exception:
+        run_response.requirements = old_requirements
+        run_response.tools = old_tools
+        raise
+    # Merge the bound tool executions into the run's tools, preserving
+    # approval fields the FE omits. After binding these are the stored
+    # requirements' own tool executions carrying the client's decisions.
+    updated_tools = [req.tool_execution for req in run_response.requirements or [] if req.tool_execution is not None]
+    if updated_tools and run_response.tools:
+        updated_tools_map = {tool.tool_call_id: tool for tool in updated_tools if tool.tool_call_id}
+        run_response.tools = _merge_tools_preserving_approval(run_response.tools, updated_tools_map)
+    elif updated_tools:
+        run_response.tools = updated_tools
+    return old_requirements, old_tools
 
 
 def _reclaim_own_requirements(team: "Team", requirements: List[Any], continuing_run_id: Optional[str]) -> None:
@@ -5604,20 +5697,25 @@ def _group_requirements_for_continue(
             )
         _, member = route_result
         target = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
-        if isinstance(target, TeamRunOutput) and target.team_id is not None and target.team_id != get_member_id(member):
-            owners = [m for m in get_resolved_members(team, run_context) or [] if get_member_id(m) == target.team_id]
+        owner_id: Optional[str] = None
+        if isinstance(target, TeamRunOutput):
+            owner_id = target.team_id
+        elif isinstance(target, RunOutput):
+            owner_id = target.agent_id
+        if owner_id is not None:
+            owners = [m for m in get_resolved_members(team, run_context) or [] if get_member_id(m) == owner_id]
             if len(owners) == 1:
                 member = owners[0]
             elif not owners:
                 raise RunNotContinuableError(
                     f"Cannot continue run {run_response.run_id}: the paused run for requirement "
-                    f"'{member_id}' belongs to member '{target.team_id}', which is not a member of "
+                    f"'{member_id}' belongs to member '{owner_id}', which is not a member of "
                     f"team '{team.name or team.id}'. The run remains paused."
                 )
             else:
                 raise RunNotContinuableError(
                     f"Cannot continue run {run_response.run_id}: the paused run for requirement "
-                    f"'{member_id}' belongs to member id '{target.team_id}', which matches "
+                    f"'{member_id}' belongs to member id '{owner_id}', which matches "
                     f"{len(owners)} members of team '{team.name or team.id}'. The run remains paused."
                 )
         merged = False
@@ -6732,21 +6830,9 @@ def continue_run_dispatch(
             )
     # --- End snapshot dispatch ----------------------------------------------
 
-    # Save old requirements before overwriting — needed to preserve approval fields for member-level tools
-    old_requirements = run_response.requirements
-
     # Normalize and apply requirements
     if requirements:
-        requirements = _normalize_requirements_payload(requirements)
-        run_response.requirements = requirements
-        # Update tools from requirements, preserving approval fields the FE omits
-        updated_tools = [req.tool_execution for req in requirements if req.tool_execution is not None]
-        if updated_tools and run_response.tools:
-            updated_tools_map = {tool.tool_call_id: tool for tool in updated_tools}
-            run_response.tools = _merge_tools_preserving_approval(run_response.tools, updated_tools_map)
-        elif updated_tools:
-            run_response.tools = updated_tools
-        _backfill_approval_to_requirements(run_response, old_requirements=old_requirements)
+        old_requirements, old_tools = _apply_requirements_payload(run_response, requirements)
 
         # Also apply any resolved approval
         if run_response.tools:
@@ -6755,6 +6841,8 @@ def continue_run_dispatch(
             try:
                 check_and_apply_approval_resolution(team.db, run_id_resolved, run_response)
             except RuntimeError:
+                run_response.requirements = old_requirements
+                run_response.tools = old_tools
                 raise ValueError(
                     "To continue a run from a given run_id, the requirements parameter must be provided "
                     "(or resolve an admin approval first)."
@@ -8132,9 +8220,6 @@ async def _acontinue_run(
                     _maybe_append_input_message_team(run_response, input, team)
                 # --- End snapshot dispatch ---
 
-                # Save old requirements before overwriting — needed for member-level approval fields
-                old_requirements = run_response.requirements
-
                 # A freshly-forked run has no PAUSED requirements contract;
                 # skip the HITL machinery entirely. The fork is a fresh
                 # attempt seeded from the snapshot — no tools/approvals to
@@ -8147,15 +8232,7 @@ async def _acontinue_run(
                     run_response.content = None
                 # Normalize and apply requirements
                 elif requirements:
-                    requirements = _normalize_requirements_payload(requirements)
-                    run_response.requirements = requirements
-                    updated_tools = [req.tool_execution for req in requirements if req.tool_execution is not None]
-                    if updated_tools and run_response.tools:
-                        updated_tools_map = {tool.tool_call_id: tool for tool in updated_tools}
-                        run_response.tools = _merge_tools_preserving_approval(run_response.tools, updated_tools_map)
-                    elif updated_tools:
-                        run_response.tools = updated_tools
-                    _backfill_approval_to_requirements(run_response, old_requirements=old_requirements)
+                    old_requirements, old_tools = _apply_requirements_payload(run_response, requirements)
 
                     # Also apply any resolved approval
                     if run_response.tools:
@@ -8166,6 +8243,8 @@ async def _acontinue_run(
                                 team.db, run_response.run_id or run_id or "", run_response
                             )
                         except RuntimeError:
+                            run_response.requirements = old_requirements
+                            run_response.tools = old_tools
                             raise ValueError(
                                 "To continue a run from a given run_id, the requirements parameter must be provided "
                                 "(or resolve an admin approval first)."
@@ -8576,9 +8655,6 @@ async def _acontinue_run_stream(
                     _maybe_append_input_message_team(run_response, input, team)
                 # --- End snapshot dispatch ---
 
-                # Save old requirements before overwriting — needed for member-level approval fields
-                old_requirements = run_response.requirements
-
                 # A freshly-forked run has no PAUSED requirements contract;
                 # skip the HITL machinery entirely. The fork is a fresh
                 # attempt seeded from the snapshot — no tools/approvals to
@@ -8591,15 +8667,7 @@ async def _acontinue_run_stream(
                     run_response.content = None
                 # Normalize and apply requirements
                 elif requirements:
-                    requirements = _normalize_requirements_payload(requirements)
-                    run_response.requirements = requirements
-                    updated_tools = [req.tool_execution for req in requirements if req.tool_execution is not None]
-                    if updated_tools and run_response.tools:
-                        updated_tools_map = {tool.tool_call_id: tool for tool in updated_tools}
-                        run_response.tools = _merge_tools_preserving_approval(run_response.tools, updated_tools_map)
-                    elif updated_tools:
-                        run_response.tools = updated_tools
-                    _backfill_approval_to_requirements(run_response, old_requirements=old_requirements)
+                    old_requirements, old_tools = _apply_requirements_payload(run_response, requirements)
 
                     # Also apply any resolved approval
                     if run_response.tools:
@@ -8610,6 +8678,8 @@ async def _acontinue_run_stream(
                                 team.db, run_response.run_id or run_id or "", run_response
                             )
                         except RuntimeError:
+                            run_response.requirements = old_requirements
+                            run_response.tools = old_tools
                             raise ValueError(
                                 "To continue a run from a given run_id, the requirements parameter must be provided "
                                 "(or resolve an admin approval first)."

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5328,13 +5328,18 @@ def _backfill_approval_to_requirements(
        entries that have no approval_type. The original session requirements carry it.
 
     Member provenance (member_agent_id, member_agent_name, member_run_id) is
-    restored from old_requirements the same way: to_dict() strips None values,
-    so a wire payload may omit any of them, and routing then cannot find the
-    paused member run — nor tell a member's requirement from the team's own
-    lifted one when the two share an id (see _reclaim_own_requirements). Old
-    requirements are matched by requirement id first, then tool_call_id: two
-    member runs paused in one turn can carry the same tool_call_id, and a
-    tool_call_id-only match would hand both the same member_run_id.
+    taken from the stored requirement as the authority: requirements arrive
+    from the wire (to_dict() strips None values, raw dicts are accepted), so
+    absent fields are ordinary and present fields are unverified client
+    input — routing on either mis-dispatches or skips the confirmed tool.
+    The stored requirement is matched by requirement id first, then by
+    tool_call_id when exactly one stored requirement carries it: two member
+    runs paused in one turn can share a tool_call_id (from_dict mints a
+    fresh id for a payload without one, so such a payload is ambiguous), and
+    guessing would silently drop one confirmed run.
+
+    Raises RunNotContinuableError for an ambiguous payload — the run stays
+    paused and can be continued again with the requirement ids included.
     """
     reqs = getattr(run_response, "requirements", None)
     if not reqs:
@@ -5343,7 +5348,7 @@ def _backfill_approval_to_requirements(
     # Build lookups from both sources
     by_id: Dict[str, Any] = {}
     old_by_req_id: Dict[str, Any] = {}
-    old_by_tool_call_id: Dict[str, Any] = {}
+    old_by_tool_call_id: Dict[str, List[Any]] = {}
     # Old requirements first (lower priority)
     if old_requirements:
         for old_req in old_requirements:
@@ -5353,7 +5358,7 @@ def _backfill_approval_to_requirements(
             old_te = getattr(old_req, "tool_execution", None)
             if old_te and old_te.tool_call_id:
                 by_id[old_te.tool_call_id] = old_te
-                old_by_tool_call_id[old_te.tool_call_id] = old_req
+                old_by_tool_call_id.setdefault(old_te.tool_call_id, []).append(old_req)
     # run_response.tools second (higher priority, overwrites)
     for t in getattr(run_response, "tools", None) or []:
         if t.tool_call_id and getattr(t, "approval_type", None) is not None:
@@ -5367,12 +5372,24 @@ def _backfill_approval_to_requirements(
                 if getattr(te, attr, None) is None and getattr(src, attr, None) is not None:
                     setattr(te, attr, getattr(src, attr))
         old_req = old_by_req_id.get(getattr(req, "id", None) or "")
+        if old_req is not None and te is not None and te.tool_call_id:
+            old_te = getattr(old_req, "tool_execution", None)
+            if old_te is not None and old_te.tool_call_id and old_te.tool_call_id != te.tool_call_id:
+                old_req = None
         if old_req is None and te is not None and te.tool_call_id:
-            old_req = old_by_tool_call_id.get(te.tool_call_id)
+            candidates = old_by_tool_call_id.get(te.tool_call_id, [])
+            if len(candidates) == 1:
+                old_req = candidates[0]
+            elif len(candidates) > 1:
+                raise RunNotContinuableError(
+                    f"Cannot continue run {getattr(run_response, 'run_id', None)}: the requirement for "
+                    f"tool call '{te.tool_call_id}' matches {len(candidates)} stored requirements and "
+                    f"carries no matching requirement id. Resend the requirements with their original "
+                    f"'id' values. The run remains paused."
+                )
         if old_req is not None:
             for attr in ("member_agent_id", "member_agent_name", "member_run_id"):
-                if getattr(req, attr, None) is None and getattr(old_req, attr, None) is not None:
-                    setattr(req, attr, getattr(old_req, attr))
+                setattr(req, attr, getattr(old_req, attr, None))
 
 
 def _reclaim_own_requirements(team: "Team", requirements: List[Any], continuing_run_id: Optional[str]) -> None:
@@ -5559,11 +5576,15 @@ def _group_requirements_for_continue(
     the first match in member order while the paused run lives under another
     sibling. The resolved run's owner is authoritative for where the continue
     dispatches — following the leaf-id pick would hand one sibling's paused
-    run to the other and execute the wrong tool implementation.
+    run to the other and execute the wrong tool implementation. When the
+    owner cannot be resolved to exactly one direct member (it was removed
+    from the team, or several direct members share its id), the continue is
+    refused and the run stays paused.
 
     Returns entries of (routed_member, resolved_target_run_or_None, requirements).
     """
     from agno.team._tools import _find_member_route_by_id
+    from agno.utils.callables import get_resolved_members
     from agno.utils.team import get_member_id
 
     member_reqs: Dict[Tuple[str, Optional[str]], List["RunRequirement"]] = {}
@@ -5584,9 +5605,21 @@ def _group_requirements_for_continue(
         _, member = route_result
         target = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
         if isinstance(target, TeamRunOutput) and target.team_id is not None and target.team_id != get_member_id(member):
-            owner_route = _find_member_route_by_id(team, target.team_id, run_context=run_context)
-            if owner_route is not None and get_member_id(owner_route[1]) == target.team_id:
-                member = owner_route[1]
+            owners = [m for m in get_resolved_members(team, run_context) or [] if get_member_id(m) == target.team_id]
+            if len(owners) == 1:
+                member = owners[0]
+            elif not owners:
+                raise RunNotContinuableError(
+                    f"Cannot continue run {run_response.run_id}: the paused run for requirement "
+                    f"'{member_id}' belongs to member '{target.team_id}', which is not a member of "
+                    f"team '{team.name or team.id}'. The run remains paused."
+                )
+            else:
+                raise RunNotContinuableError(
+                    f"Cannot continue run {run_response.run_id}: the paused run for requirement "
+                    f"'{member_id}' belongs to member id '{target.team_id}', which matches "
+                    f"{len(owners)} members of team '{team.name or team.id}'. The run remains paused."
+                )
         merged = False
         if target is not None:
             for existing_member, existing_target, existing_reqs in entries:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -8004,6 +8004,8 @@ def _continue_run_stream(
                 log_error(f"Validation failed: {str(e)} | Check: {e.check_trigger}")
                 _cleanup_and_store(team, run_response=run_response, session=session)
                 yield run_error
+                if yield_run_output:
+                    yield run_response
                 break
 
             except KeyboardInterrupt:
@@ -8047,6 +8049,8 @@ def _continue_run_stream(
                 log_error(f"Error in Team continue_run stream: {str(e)}")
                 _cleanup_and_store(team, run_response=run_response, session=session)
                 yield run_error
+                if yield_run_output:
+                    yield run_response
     finally:
         _disconnect_connectable_tools(team)
         cleanup_run(run_response.run_id)  # type: ignore
@@ -8103,7 +8107,7 @@ async def _acontinue_run_background_stream(
     4. Yields SSE-formatted strings via an asyncio.Queue
     """
     from agno.team._session import asave_session
-    from agno.team._storage import _aread_or_create_session, _update_metadata
+    from agno.team._storage import _aread_or_create_session, _aread_session, _update_metadata
 
     _run_id = run_id or (run_response.run_id if run_response else None)
     if not _run_id:
@@ -8121,18 +8125,20 @@ async def _acontinue_run_background_stream(
     prior_object_status = _as_run_status(getattr(run_response, "status", None)) if run_response is not None else None
 
     if run_response is not None:
-        # A caller object that still reads paused over a stored run that reads
-        # COMPLETED or CANCELLED is stale: writing it back republishes the run
-        # as a pending approval, and its gated tool can then be approved a
-        # second time. Other statuses are not checked here.
+        # Continuability is decided from the STORED run, never from the caller's
+        # object: a stale paused object over a finished run would republish it
+        # as a pending approval, and a gated tool could then be approved a
+        # second time. fork and regenerate branch off a finished run and stay
+        # allowed. The run_id-only shape resolves the stored run downstream and
+        # has its own cancelled refusal.
         if (
             isinstance(status_before_takeover, RunStatus)
             and status_before_takeover in (RunStatus.completed, RunStatus.cancelled)
-            and getattr(run_response, "is_paused", False)
+            and not (fork or regenerate)
         ):
             raise RunNotContinuableError(
-                f"Cannot continue run {_run_id}: the stored run has status {status_before_takeover.value}, "
-                "but the run_response passed in still reads as paused. Re-read the run before continuing it. "
+                f"Cannot continue run {_run_id}: the stored run has status {status_before_takeover.value} "
+                "and cannot be continued in place. Pass fork=True to branch off a finished run. "
                 "The stored run is unchanged."
             )
         run_response.status = RunStatus.running
@@ -8219,20 +8225,39 @@ async def _acontinue_run_background_stream(
                         status_before_takeover if status_before_takeover is not None else prior_object_status
                     )
                     if run_response is not None and restore_status is not None:
-                        # A legacy string status is restored as-is; to_dict
-                        # serializes both shapes.
-                        run_response.status = cast(RunStatus, restore_status)
-                        # Persist into a fresh session read so runs persisted by
-                        # others since step 1 survive this write, and only while
-                        # the stored run still carries step 1's RUNNING marker;
-                        # any other value means another request owns the run now.
-                        fresh_session = await _aread_or_create_session(team, session_id=session_id, user_id=user_id)
-                        fresh_run = next(
-                            (r for r in fresh_session.runs or [] if getattr(r, "run_id", None) == _run_id), None
+                        # Persist into a fresh, uncached session read so runs
+                        # persisted by others since step 1 survive this write,
+                        # and only while the stored run still carries step 1's
+                        # RUNNING marker; any other value means another request
+                        # owns the run now. The read comes FIRST: with
+                        # cache_session the session's entry for this run IS
+                        # run_response, so mutating it before the read would
+                        # erase the marker being tested.
+                        fresh_session = cast(
+                            Optional[TeamSession],
+                            await _aread_session(team, session_id=session_id, user_id=user_id),
                         )
-                        if fresh_run is not None and fresh_run.status == RunStatus.running:
-                            fresh_session.upsert_run(run_response=run_response)
-                            await asave_session(team, session=fresh_session)
+                        if fresh_session is None:
+                            # The read failed. Restoring into the step-1 session
+                            # trades a rare clobber of a concurrent write for a
+                            # guaranteed restore; a run left RUNNING can never
+                            # be resumed.
+                            run_response.status = cast(RunStatus, restore_status)
+                            team_session.upsert_run(run_response=run_response)
+                            await asave_session(team, session=team_session)
+                        else:
+                            fresh_run = next(
+                                (r for r in fresh_session.runs or [] if getattr(r, "run_id", None) == _run_id),
+                                None,
+                            )
+                            if fresh_run is not None and _as_run_status(fresh_run.status) == RunStatus.running:
+                                # A legacy string status is restored as-is;
+                                # to_dict serializes both shapes.
+                                run_response.status = cast(RunStatus, restore_status)
+                                fresh_session.upsert_run(run_response=run_response)
+                                await asave_session(team, session=fresh_session)
+                                if team.cache_session:
+                                    team._cached_session = fresh_session
                 except Exception:
                     log_error(
                         f"Failed to restore the pre-continue state for background continue-run stream {_run_id}",
@@ -8245,14 +8270,26 @@ async def _acontinue_run_background_stream(
                 # marker, so a state another request persisted meanwhile stays.
                 try:
                     if run_response is not None:
-                        run_response.status = RunStatus.error
-                        fresh_session = await _aread_or_create_session(team, session_id=session_id, user_id=user_id)
-                        fresh_run = next(
-                            (r for r in fresh_session.runs or [] if getattr(r, "run_id", None) == _run_id), None
+                        # Same rules as the restore above, including read
+                        # before mutation.
+                        fresh_session = cast(
+                            Optional[TeamSession],
+                            await _aread_session(team, session_id=session_id, user_id=user_id),
                         )
-                        if fresh_run is not None and fresh_run.status == RunStatus.running:
-                            fresh_session.upsert_run(run_response=run_response)
-                            await asave_session(team, session=fresh_session)
+                        run_response.status = RunStatus.error
+                        if fresh_session is None:
+                            team_session.upsert_run(run_response=run_response)
+                            await asave_session(team, session=team_session)
+                        else:
+                            fresh_run = next(
+                                (r for r in fresh_session.runs or [] if getattr(r, "run_id", None) == _run_id),
+                                None,
+                            )
+                            if fresh_run is not None and _as_run_status(fresh_run.status) == RunStatus.running:
+                                fresh_session.upsert_run(run_response=run_response)
+                                await asave_session(team, session=fresh_session)
+                                if team.cache_session:
+                                    team._cached_session = fresh_session
                 except Exception:
                     log_error(
                         f"Failed to persist error state for background continue-run stream {_run_id}",
@@ -8303,8 +8340,14 @@ async def _acontinue_run_background_stream(
                 else:
                     # The run that actually executed. final_output covers the
                     # run_id-only path, where run_response stays None; a re-pause
-                    # or cancellation must not be advertised as completed.
-                    produced_status = final_output.status if final_output is not None else None
+                    # or cancellation must not be advertised as completed. A
+                    # fork or regenerate produces a run with a DIFFERENT id;
+                    # its status must not land under this run's key.
+                    produced_status = (
+                        final_output.status
+                        if final_output is not None and getattr(final_output, "run_id", None) == _run_id
+                        else None
+                    )
                     if produced_status is None and run_response is not None:
                         produced_status = run_response.status
                     if isinstance(produced_status, RunStatus) and produced_status in (
@@ -9600,6 +9643,8 @@ async def _acontinue_run_stream(
                 if team_session is not None:
                     await _acleanup_and_store(team, run_response=run_response, session=team_session)
                 yield run_error
+                if yield_run_output:
+                    yield run_response
                 break
 
             except (KeyboardInterrupt, asyncio.CancelledError, GeneratorExit) as cancel_exc:
@@ -9663,6 +9708,8 @@ async def _acontinue_run_stream(
                 if team_session is not None:
                     await _acleanup_and_store(team, run_response=run_response, session=team_session)
                 yield run_error
+                if yield_run_output:
+                    yield run_response
 
     finally:
         _disconnect_connectable_tools(team)

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5435,17 +5435,21 @@ def _backfill_approval_to_requirements(
     dicts are accepted), so every field on them is unverified client input.
     When the pre-overwrite stored requirements are available, each payload
     entry must bind one-to-one to a stored requirement — matched by
-    requirement id (cross-checked against the tool_call_id), falling back to
-    tool_call_id only when exactly one stored requirement carries it — and
+    requirement id, falling back to tool_call_id only when the supplied id
+    matches no stored requirement (ids are client-optional and regenerate on
+    deserialization, so an unknown id is indistinguishable from an absent
+    one) and exactly one stored requirement carries that tool call — and
     the STORED requirement becomes the object routing sees, with only the
     client's decision state merged onto it (_merge_requirement_decision).
     Trusting the wire copy instead mis-executes: a swapped or duplicated id
     binds one member's approved arguments to another member's tool.
 
     Raises RunNotContinuableError — with the run left paused — for a payload
-    entry that is ambiguous (several stored requirements share its
-    tool_call_id and no id matches), matches no stored requirement, or maps
-    a stored requirement that another entry already claimed.
+    entry whose matched id names a different tool call than the entry carries
+    (a conflicting identity must not fall back to the tool call), that is
+    ambiguous (several stored requirements share its tool_call_id and no id
+    matches), matches no stored requirement, or maps a stored requirement
+    that another entry already claimed.
 
     Without stored requirements (a caller-supplied bare run object), the
     payload is kept as-is and only approval metadata is backfilled from
@@ -5496,7 +5500,16 @@ def _backfill_approval_to_requirements(
         if old_req is not None and tool_call_id:
             old_te = getattr(old_req, "tool_execution", None)
             if old_te is not None and old_te.tool_call_id and old_te.tool_call_id != tool_call_id:
-                old_req = None
+                # A matched id whose tool call disagrees is a conflicting
+                # identity, not a fallback case: dropping the id match here
+                # would bind the client's decision to whichever requirement
+                # owns the payload's tool call — another member's tool.
+                raise RunNotContinuableError(
+                    f"Cannot continue run {run_id}: the requirement with id '{getattr(req, 'id', None)}' "
+                    f"names tool call '{tool_call_id}', but the stored requirement with that id belongs "
+                    f"to tool call '{old_te.tool_call_id}'. Resend the requirements exactly as issued. "
+                    f"The run remains paused."
+                )
         if old_req is None and tool_call_id:
             candidates = old_by_tool_call_id.get(tool_call_id, [])
             if len(candidates) == 1:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -4456,7 +4456,7 @@ def _cleanup_and_store(
     # Add scrubbed RunOutput to Team Session
     session.upsert_run(run_response=storage_copy)
 
-    # Calculate session metrics (each run counted once, when it is final)
+    # Calculate session metrics
     update_session_metrics(team, session=session, run_response=run_response)
 
     # Update session state before saving the session
@@ -4505,7 +4505,7 @@ async def _acleanup_and_store(
     # Add scrubbed RunOutput to Team Session
     session.upsert_run(run_response=storage_copy)
 
-    # Calculate session metrics (each run counted once, when it is final)
+    # Calculate session metrics
     update_session_metrics(team, session=session, run_response=run_response)
 
     # Update session state before saving the session

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5367,11 +5367,13 @@ def _merge_requirement_decision(stored: Any, wire: Any) -> None:
     model fixed at pause time. Answers therefore land by stored field name, and
     only in fields the model left open.
 
-    ``answered`` is inferred from the stored schema exactly as
-    ``RunRequirement.from_dict`` infers it — only when this merge fills the last
-    open field — and never copied off the wire, which would otherwise run the
-    gated tool with its fields still empty. A requirement carrying no schema at
-    all has no other way to be answered, so there the wire flag stands.
+    ``answered`` is inferred from the stored schema — when this merge fills
+    the last open field — and never copied off the wire while a field is
+    still open, which would otherwise run the gated tool with its fields
+    still empty. Once nothing is open (the schema was answered here, was
+    fully prefilled by the model at pause time, or never existed) the wire's
+    explicit flag stands: a prefilled pause has no open field to fill, so
+    the flag is its only accept gesture.
     """
     stored_te = getattr(stored, "tool_execution", None)
     wire_te = getattr(wire, "tool_execution", None)
@@ -5403,17 +5405,19 @@ def _merge_requirement_decision(stored: Any, wire: Any) -> None:
         _fill_user_feedback_answers(stored_feedback_schema, wire_te.user_feedback_schema)
         _fill_user_feedback_answers(stored_feedback_schema, getattr(wire, "user_feedback_schema", None))
         if stored_te.answered is None:
-            if input_was_open and all(field.value is not None for field in stored_input_schema or []):
+            input_open_now = any(field.value is None for field in stored_input_schema or [])
+            feedback_open_now = any(question.selected_options is None for question in stored_feedback_schema or [])
+            if input_was_open and not input_open_now:
                 stored_te.answered = True
-            elif feedback_was_open and all(
-                question.selected_options is not None for question in stored_feedback_schema or []
-            ):
+            elif feedback_was_open and not feedback_open_now:
                 stored_te.answered = True
-            elif (
-                getattr(wire_te, "answered", None) is not None
-                and not stored_input_schema
-                and not stored_feedback_schema
-            ):
+            elif getattr(wire_te, "answered", None) is not None and not input_open_now and not feedback_open_now:
+                # A schema the model prefilled completely was never open, so
+                # the fill-based inference above can never fire for it. The
+                # client's explicit flag is the accept gesture for such a
+                # pause; without honoring it the run could never resume. A
+                # still-open field keeps the flag ignored — answering is the
+                # schema's job, not the flag's.
                 stored_te.answered = wire_te.answered
         if getattr(stored_te, "external_execution_required", None) and getattr(wire_te, "result", None) is not None:
             stored_te.result = wire_te.result

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5353,6 +5353,28 @@ def _backfill_approval_to_requirements(
                     setattr(te, attr, getattr(src, attr))
 
 
+def _reclaim_own_requirements(team: "Team", requirements: List[Any]) -> None:
+    """Clear the member stamp from requirements that belong to this team itself.
+
+    When a sub-team's OWN tool pauses, _propagate_member_pause stamps the
+    sub-team's member id on the lifted requirement so the parent can route it
+    back down. Once the requirement arrives at the team it names, the stamp's
+    job is done: the requirement is this team's own, team-level requirement.
+    Without reclaiming it, member routing looks the team's own id up among
+    its members, finds nothing, and refuses the continue."""
+    from agno.utils.team import get_member_id
+
+    if not any(getattr(req, "member_agent_id", None) is not None for req in requirements):
+        return
+    own_id = get_member_id(team)
+    if not own_id:
+        return
+    for req in requirements:
+        if getattr(req, "member_agent_id", None) == own_id:
+            req.member_agent_id = None
+            req.member_agent_name = None
+
+
 def _has_member_requirements(requirements: List[Any]) -> bool:
     """Check if any requirements are for member agents (have member_agent_id set)."""
     return any(getattr(req, "member_agent_id", None) is not None for req in requirements)
@@ -6684,6 +6706,7 @@ def continue_run_dispatch(
         _did_snapshot_dispatch = True
 
     # Determine what kind of pause we're continuing from
+    _reclaim_own_requirements(team, run_response.requirements or [])
     has_member = _has_member_requirements(run_response.requirements or [])
     has_team_level = _has_team_level_requirements(run_response.requirements or [])
 
@@ -6711,12 +6734,18 @@ def continue_run_dispatch(
             )
         else:
             member_event_stream = None
-            member_results = _route_requirements_to_members(
-                team,
-                run_response=run_response,
-                session=team_session,
-                run_context=run_context,
-            )
+            try:
+                member_results = _route_requirements_to_members(
+                    team,
+                    run_response=run_response,
+                    session=team_session,
+                    run_context=run_context,
+                )
+            except Exception:
+                # Routing failed mid-flight; put the team-level requirements
+                # back so the caller's run object stays complete for a retry.
+                run_response.requirements = team_level_reqs + (run_response.requirements or [])
+                raise
 
         # For non-streaming, member routing is done eagerly above.
         # For streaming, we must consume member events lazily inside a returned generator.
@@ -6979,6 +7008,11 @@ def _continue_run_dispatch_stream_with_member_events(
         if opts.yield_run_output:
             yield run_response
         return
+    except Exception:
+        # Routing failed mid-flight; put the team-level requirements back so
+        # the caller's run object stays complete for a retry.
+        run_response.requirements = team_level_reqs + (run_response.requirements or [])
+        raise
 
     # Phase 2: After member routing completes, check for chained pauses
     newly_propagated = [r for r in (run_response.requirements or []) if id(r) not in original_member_req_ids]
@@ -8094,6 +8128,7 @@ async def _acontinue_run(
                     store_events=team.store_events,
                 )
 
+                _reclaim_own_requirements(team, run_response.requirements or [])
                 has_member = _has_member_requirements(run_response.requirements or [])
                 has_team_level = _has_team_level_requirements(run_response.requirements or [])
 
@@ -8108,12 +8143,18 @@ async def _acontinue_run(
                     ]
                     original_member_req_ids = {id(r) for r in member_reqs}
                     run_response.requirements = member_reqs
-                    member_results = await _aroute_requirements_to_members(
-                        team,
-                        run_response=run_response,
-                        session=team_session,
-                        run_context=run_context,
-                    )
+                    try:
+                        member_results = await _aroute_requirements_to_members(
+                            team,
+                            run_response=run_response,
+                            session=team_session,
+                            run_context=run_context,
+                        )
+                    except Exception:
+                        # Routing failed mid-flight; put the team-level requirements
+                        # back so the caller's run object stays complete for a retry.
+                        run_response.requirements = team_level_reqs + (run_response.requirements or [])
+                        raise
                     # Merge: keep team-level reqs + any newly propagated member reqs (chained HITL)
                     newly_propagated = [
                         r for r in (run_response.requirements or []) if id(r) not in original_member_req_ids
@@ -8521,6 +8562,7 @@ async def _acontinue_run_stream(
 
                 await aregister_run(run_response.run_id)  # type: ignore
 
+                _reclaim_own_requirements(team, run_response.requirements or [])
                 has_member = _has_member_requirements(run_response.requirements or [])
                 has_team_level = _has_team_level_requirements(run_response.requirements or [])
 
@@ -8535,16 +8577,22 @@ async def _acontinue_run_stream(
                     ]
                     original_member_req_ids = {id(r) for r in member_reqs}
                     run_response.requirements = member_reqs
-                    # Streaming: use the async generator variant that yields member events
-                    async for event in _aroute_requirements_to_members_stream(
-                        team,
-                        run_response=run_response,
-                        session=team_session,
-                        member_results=member_results,
-                        run_context=run_context,
-                        stream_events=stream_events,
-                    ):
-                        yield event
+                    try:
+                        # Streaming: use the async generator variant that yields member events
+                        async for event in _aroute_requirements_to_members_stream(
+                            team,
+                            run_response=run_response,
+                            session=team_session,
+                            member_results=member_results,
+                            run_context=run_context,
+                            stream_events=stream_events,
+                        ):
+                            yield event
+                    except Exception:
+                        # Routing failed mid-flight; put the team-level requirements
+                        # back so the caller's run object stays complete for a retry.
+                        run_response.requirements = team_level_reqs + (run_response.requirements or [])
+                        raise
                     # Merge: keep team-level reqs + any newly propagated member reqs (chained HITL)
                     newly_propagated = [
                         r for r in (run_response.requirements or []) if id(r) not in original_member_req_ids

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5830,6 +5830,7 @@ def _group_requirements_for_continue(
     run_response: TeamRunOutput,
     session: TeamSession,
     run_context: Optional[RunContext],
+    _depth: int = 0,
 ) -> List[Tuple[Union["Agent", "Team"], Optional[Union[RunOutput, TeamRunOutput]], List["RunRequirement"]]]:
     """Group HITL requirements by the paused run that will continue them.
 
@@ -5913,7 +5914,47 @@ def _group_requirements_for_continue(
                     break
         if not merged:
             entries.append((member, target, list(reqs)))
+
+    if _depth < _MAX_CONTINUE_PREFLIGHT_DEPTH:
+        _preflight_subteam_routes(entries, session, _depth)
     return entries
+
+
+_MAX_CONTINUE_PREFLIGHT_DEPTH = 12
+
+
+def _preflight_subteam_routes(
+    entries: List[Tuple[Union["Agent", "Team"], Optional[Union[RunOutput, TeamRunOutput]], List["RunRequirement"]]],
+    session: TeamSession,
+    depth: int,
+) -> None:
+    """Raise now if any sub-team in these entries could not route its own share.
+
+    Refusals at this level are all-or-nothing: nothing has run when they fire.
+    A sub-team's refusal is not, because the sub-team only reaches its own
+    grouping once its continue_run is already under way — by then the members
+    scheduled alongside it have executed their approved tools. The caller is
+    then told the run is still paused, which is false for those members, and
+    the retry it invites runs them again.
+
+    Descending here moves that refusal back to where it is still free. The
+    sub-team's grouping is a pure resolution pass over stored state — it
+    executes nothing — so running it early costs a lookup and buys the
+    all-or-nothing guarantee the refusal message claims.
+
+    This closes resolution drift, which is what a reload can introduce: a
+    member renamed or removed while the run sat paused. It cannot close a
+    failure that strikes mid-execution, so routing stays best-effort past this
+    point.
+    """
+    from agno.team.team import Team
+
+    for member, target, _reqs in entries:
+        if not isinstance(member, Team) or not isinstance(target, TeamRunOutput):
+            continue
+        if not _has_member_requirements(target.requirements or []):
+            continue
+        _group_requirements_for_continue(member, target, session, None, _depth=depth + 1)
 
 
 def _route_requirements_to_members(

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -4456,8 +4456,11 @@ def _cleanup_and_store(
     # Add scrubbed RunOutput to Team Session
     session.upsert_run(run_response=storage_copy)
 
-    # Calculate session metrics
-    update_session_metrics(team, session=session, run_response=run_response)
+    # Calculate session metrics. A paused run is not terminal: its metrics
+    # accumulate once, on the save after it completes — accumulating here too
+    # would count the pre-pause tokens twice when the run is resumed.
+    if run_response.status != RunStatus.paused:
+        update_session_metrics(team, session=session, run_response=run_response)
 
     # Update session state before saving the session
     if run_context is not None and run_context.session_state is not None:
@@ -4505,8 +4508,11 @@ async def _acleanup_and_store(
     # Add scrubbed RunOutput to Team Session
     session.upsert_run(run_response=storage_copy)
 
-    # Calculate session metrics
-    update_session_metrics(team, session=session, run_response=run_response)
+    # Calculate session metrics. A paused run is not terminal: its metrics
+    # accumulate once, on the save after it completes — accumulating here too
+    # would count the pre-pause tokens twice when the run is resumed.
+    if run_response.status != RunStatus.paused:
+        update_session_metrics(team, session=session, run_response=run_response)
 
     # Update session state before saving the session
     if run_context is not None and run_context.session_state is not None:
@@ -5415,9 +5421,11 @@ def _resolve_member_run_output_for_continue(
     1. The ``_member_run_response`` reference stored by _propagate_member_pause
        (avoids a session/DB lookup, which fails without a database since
        initialize_team clears the cached session). The reference is validated
-       against the routed member: each propagation level points it at the run
-       that surfaced the pause AT that level, so one level down it references
-       the containing team run, not the deep member's run.
+       by IDENTITY against the routed member: each propagation level points it
+       at the run that surfaced the pause AT that level, so below the top level
+       it references an ancestor team run, not the routed member's run. An
+       invalid reference falls through to the lookups below, which resolve
+       level by level.
     2. Same-process resume: the paused member output still held on the live
        team run's member_responses.
     3. After process restart: the team session's sibling runs persisted in the
@@ -5427,6 +5435,7 @@ def _resolve_member_run_output_for_continue(
        there by save_session's paused-run exemption.
     """
     from agno.team.team import Team
+    from agno.utils.team import get_member_id
 
     member_run_output = getattr(reqs[0], "_member_run_response", None) if reqs else None
     member_run_id = reqs[0].member_run_id if reqs else None
@@ -5434,9 +5443,13 @@ def _resolve_member_run_output_for_continue(
 
     if member_run_output is not None and member_run_id is not None:
         if routed_to_team:
-            valid = isinstance(member_run_output, TeamRunOutput) and (
-                member_run_output.run_id == member_run_id
-                or _team_run_references_member_run(member_run_output, member_run_id)
+            valid = (
+                isinstance(member_run_output, TeamRunOutput)
+                and member_run_output.run_id != run_response.run_id
+                and (
+                    member_run_output.run_id == member_run_id
+                    or (member_run_output.team_id is not None and member_run_output.team_id == get_member_id(member))
+                )
             )
         else:
             valid = getattr(member_run_output, "run_id", None) == member_run_id
@@ -5468,6 +5481,45 @@ def _resolve_member_run_output_for_continue(
     return member_run_output
 
 
+def _group_requirements_by_routed_member(
+    team: "Team",
+    run_response: TeamRunOutput,
+    run_context: Optional[RunContext],
+) -> Tuple[List[Tuple[Union["Agent", "Team"], List["RunRequirement"]]], List[str]]:
+    """Group HITL requirements by the direct member that will continue them.
+
+    Requirements are keyed by the deep member's agent id, and several deep
+    members can live inside the same sub-team. That sub-team must receive ALL
+    of their requirements in one continue_run call — its own dispatch routes
+    them deeper. One call per requirement group would hand the second group an
+    already-completed sub-team run and drop its confirmations.
+
+    Returns (groups, unroutable_messages).
+    """
+    from agno.team._tools import _find_member_route_by_id
+
+    member_reqs: Dict[str, List["RunRequirement"]] = {}
+    for req in run_response.requirements or []:
+        mid = getattr(req, "member_agent_id", None)
+        if mid is not None:
+            member_reqs.setdefault(mid, []).append(req)
+
+    groups: Dict[int, Tuple[Union["Agent", "Team"], List["RunRequirement"]]] = {}
+    unroutable: List[str] = []
+    for member_id, reqs in member_reqs.items():
+        route_result = _find_member_route_by_id(team, member_id, run_context=run_context)
+        if route_result is None:
+            log_warning(f"Could not find member with ID {member_id} for continue_run routing")
+            unroutable.append(f"[{member_id}]: Could not route requirement — member not found")
+            continue
+        route_index, member = route_result
+        if route_index in groups:
+            groups[route_index][1].extend(reqs)
+        else:
+            groups[route_index] = (member, list(reqs))
+    return list(groups.values()), unroutable
+
+
 def _route_requirements_to_members(
     team: "Team",
     run_response: TeamRunOutput,
@@ -5482,25 +5534,13 @@ def _route_requirements_to_members(
     Returns:
         List of member result strings.
     """
-    from agno.team._tools import _find_member_route_by_id
+    from agno.utils.team import get_member_id
 
-    # Group requirements by member
-    member_reqs: Dict[str, List[RunRequirement]] = {}
-    for req in run_response.requirements or []:
-        mid = getattr(req, "member_agent_id", None)
-        if mid is not None:
-            member_reqs.setdefault(mid, []).append(req)
+    groups, unroutable = _group_requirements_by_routed_member(team, run_response, run_context)
+    member_results: List[str] = list(unroutable)
 
-    member_results: List[str] = []
-
-    for member_id, reqs in member_reqs.items():
-        route_result = _find_member_route_by_id(team, member_id, run_context=run_context)
-        if route_result is None:
-            log_warning(f"Could not find member with ID {member_id} for continue_run routing")
-            member_results.append(f"[{member_id}]: Could not route requirement — member not found")
-            continue
-
-        _, member = route_result
+    for member, reqs in groups:
+        member_id = get_member_id(member) or ""
 
         # Get the member's paused run output — see _resolve_member_run_output_for_continue.
         member_run_output = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
@@ -5580,23 +5620,13 @@ def _route_requirements_to_members_stream(
     Yields:
         Member streaming events (RunOutputEvent, TeamRunOutputEvent).
     """
-    from agno.team._tools import _find_member_route_by_id
+    from agno.utils.team import get_member_id
 
-    # Group requirements by member
-    member_reqs: Dict[str, List[RunRequirement]] = {}
-    for req in run_response.requirements or []:
-        mid = getattr(req, "member_agent_id", None)
-        if mid is not None:
-            member_reqs.setdefault(mid, []).append(req)
+    groups, unroutable = _group_requirements_by_routed_member(team, run_response, run_context)
+    member_results.extend(unroutable)
 
-    for member_id, reqs in member_reqs.items():
-        route_result = _find_member_route_by_id(team, member_id, run_context=run_context)
-        if route_result is None:
-            log_warning(f"Could not find member with ID {member_id} for continue_run routing")
-            member_results.append(f"[{member_id}]: Could not route requirement — member not found")
-            continue
-
-        _, member = route_result
+    for member, reqs in groups:
+        member_id = get_member_id(member) or ""
 
         member_run_output = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
         member_run_id = reqs[0].member_run_id if reqs else None
@@ -5689,25 +5719,15 @@ async def _aroute_requirements_to_members(
     Returns:
         List of member result strings.
     """
-    from agno.team._tools import _find_member_route_by_id
+    from agno.utils.team import get_member_id
 
-    # Group requirements by member
-    member_reqs: Dict[str, List[RunRequirement]] = {}
-    for req in run_response.requirements or []:
-        mid = getattr(req, "member_agent_id", None)
-        if mid is not None:
-            member_reqs.setdefault(mid, []).append(req)
+    groups, unroutable = _group_requirements_by_routed_member(team, run_response, run_context)
 
-    if not member_reqs:
-        return []
+    if not groups:
+        return unroutable
 
-    async def _continue_member(member_id: str, reqs: List[RunRequirement]) -> Optional[str]:
-        route_result = _find_member_route_by_id(team, member_id, run_context=run_context)
-        if route_result is None:
-            log_warning(f"Could not find member with ID {member_id} for continue_run routing")
-            return f"[{member_id}]: Could not route requirement — member not found"
-
-        _, member = route_result
+    async def _continue_member(member: Union["Agent", "Team"], reqs: List["RunRequirement"]) -> Optional[str]:
+        member_id = get_member_id(member) or ""
         member_run_output = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
         member_run_id = reqs[0].member_run_id if reqs else None
 
@@ -5758,10 +5778,10 @@ async def _aroute_requirements_to_members(
             content = getattr(member_response, "content", None) or "Task completed"
             return f"[{member.name or member_id}]: {content}"
 
-    tasks = [_continue_member(mid, reqs) for mid, reqs in member_reqs.items()]
+    tasks = [_continue_member(member, reqs) for member, reqs in groups]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
-    member_results: List[str] = []
+    member_results: List[str] = list(unroutable)
     for r in results:
         if isinstance(r, BaseException):
             log_warning(f"Member continue_run failed: {r}")
@@ -5795,23 +5815,13 @@ async def _aroute_requirements_to_members_stream(
     Yields:
         Member streaming events (RunOutputEvent, TeamRunOutputEvent).
     """
-    from agno.team._tools import _find_member_route_by_id
+    from agno.utils.team import get_member_id
 
-    # Group requirements by member
-    member_reqs: Dict[str, List[RunRequirement]] = {}
-    for req in run_response.requirements or []:
-        mid = getattr(req, "member_agent_id", None)
-        if mid is not None:
-            member_reqs.setdefault(mid, []).append(req)
+    groups, unroutable = _group_requirements_by_routed_member(team, run_response, run_context)
+    member_results.extend(unroutable)
 
-    for member_id, reqs in member_reqs.items():
-        route_result = _find_member_route_by_id(team, member_id, run_context=run_context)
-        if route_result is None:
-            log_warning(f"Could not find member with ID {member_id} for continue_run routing")
-            member_results.append(f"[{member_id}]: Could not route requirement — member not found")
-            continue
-
-        _, member = route_result
+    for member, reqs in groups:
+        member_id = get_member_id(member) or ""
 
         member_run_output = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
         member_run_id = reqs[0].member_run_id if reqs else None

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5523,7 +5523,7 @@ def _backfill_approval_to_requirements(
                     f"Cannot continue run {run_id}: the requirement with id '{getattr(req, 'id', None)}' "
                     f"names tool call '{tool_call_id}', but the stored requirement with that id belongs "
                     f"to tool call '{old_te.tool_call_id}'. Resend the requirements exactly as issued. "
-                    f"The run remains paused."
+                    "The run remains paused."
                 )
         if old_req is None and tool_call_id:
             candidates = old_by_tool_call_id.get(tool_call_id, [])
@@ -5533,14 +5533,14 @@ def _backfill_approval_to_requirements(
                 raise RunNotContinuableError(
                     f"Cannot continue run {run_id}: the requirement for tool call '{tool_call_id}' "
                     f"matches {len(candidates)} stored requirements and carries no matching "
-                    f"requirement id. Resend the requirements with their original 'id' values. "
-                    f"The run remains paused."
+                    "requirement id. Resend the requirements with their original 'id' values. "
+                    "The run remains paused."
                 )
         if old_req is None:
             raise RunNotContinuableError(
                 f"Cannot continue run {run_id}: the requirement with id '{getattr(req, 'id', None)}' "
                 f"and tool call '{tool_call_id}' matches no stored requirement of this run. "
-                f"The run remains paused."
+                "The run remains paused."
             )
         if id(old_req) in matched:
             raise RunNotContinuableError(
@@ -5876,7 +5876,7 @@ def _group_requirements_for_continue(
             raise RunNotContinuableError(
                 f"Cannot continue run {run_response.run_id}: requirement routes to member "
                 f"'{member_id}', which is not a member of team '{team.name or team.id}'. "
-                f"The run remains paused."
+                "The run remains paused."
             )
         _, member = route_result
         target = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
@@ -7404,7 +7404,14 @@ def _continue_run_dispatch_stream_with_member_events(
 
     # Phase 1: Yield member streaming events
     try:
-        yield from member_event_stream
+        try:
+            yield from member_event_stream
+        except BaseException:
+            # Phase 1 runs with the team-level requirements stripped off the
+            # run object; every non-normal exit puts them back before anything
+            # persists or returns it.
+            run_response.requirements = team_level_reqs + (run_response.requirements or [])
+            raise
     except RunCancelledException as e:
         run_response = _handle_team_run_cancellation(run_response, e, session=team_session)
         cancelled_event, completed_event = _build_team_cancel_terminal_events(
@@ -7433,11 +7440,6 @@ def _continue_run_dispatch_stream_with_member_events(
         if opts.yield_run_output:
             yield run_response
         return
-    except Exception:
-        # Routing failed mid-flight; put the team-level requirements back so
-        # the caller's run object stays complete for a retry.
-        run_response.requirements = team_level_reqs + (run_response.requirements or [])
-        raise
 
     # Phase 2: After member routing completes, check for chained pauses
     newly_propagated = [r for r in (run_response.requirements or []) if id(r) not in original_member_req_ids]
@@ -8050,6 +8052,17 @@ def _continue_run_stream(
         cleanup_run(run_response.run_id)  # type: ignore
 
 
+def _as_run_status(value: Union[RunStatus, str, None]) -> Union[RunStatus, str, None]:
+    """Coerce a stored status to RunStatus. A run loaded from the DB carries its
+    status as a plain string; an unrecognized value is returned unchanged."""
+    if value is None or isinstance(value, RunStatus):
+        return value
+    try:
+        return RunStatus(value)
+    except ValueError:
+        return value
+
+
 async def _acontinue_run_background_stream(
     team: Team,
     run_context: RunContext,
@@ -8101,19 +8114,26 @@ async def _acontinue_run_background_stream(
     _update_metadata(team, session=team_session)
 
     stored_run = next((r for r in team_session.runs or [] if getattr(r, "run_id", None) == _run_id), None)
-    status_before_takeover = getattr(stored_run, "status", None)
+    status_before_takeover = _as_run_status(getattr(stored_run, "status", None))
+    # The status the caller's object carries at entry; the write below replaces
+    # it with RUNNING. When the session has no stored entry for this run, this
+    # is the only record of the pre-continue state.
+    prior_object_status = _as_run_status(getattr(run_response, "status", None)) if run_response is not None else None
 
     if run_response is not None:
-        # A caller-held run object outlives the run it describes. If it still
-        # reads as paused while the stored run has finished, someone else
-        # continued this run in between and the object is stale: writing it back
-        # would republish a finished run as a pending approval, and its gated
-        # tool could then be approved a second time. Nothing downstream can undo
-        # that, so refuse before the run is touched.
-        if status_before_takeover == RunStatus.completed and getattr(run_response, "is_paused", False):
+        # A caller object that still reads paused over a stored run that reads
+        # COMPLETED or CANCELLED is stale: writing it back republishes the run
+        # as a pending approval, and its gated tool can then be approved a
+        # second time. Other statuses are not checked here.
+        if (
+            isinstance(status_before_takeover, RunStatus)
+            and status_before_takeover in (RunStatus.completed, RunStatus.cancelled)
+            and getattr(run_response, "is_paused", False)
+        ):
             raise RunNotContinuableError(
-                f"Cannot continue run {_run_id}: it has already completed, but the run_response passed in "
-                f"still reads as paused. Re-read the run before continuing it. The stored run is unchanged."
+                f"Cannot continue run {_run_id}: the stored run has status {status_before_takeover.value}, "
+                "but the run_response passed in still reads as paused. Re-read the run before continuing it. "
+                "The stored run is unchanged."
             )
         run_response.status = RunStatus.running
         team_session.upsert_run(run_response=run_response)
@@ -8130,6 +8150,10 @@ async def _acontinue_run_background_stream(
         from agno.os.utils import format_sse_event_with_index
 
         producer_error: Optional[BaseException] = None
+        # The run object the continue actually produced. The caller-supplied
+        # run_response is not updated on the run_id-only path, so the terminal
+        # buffer status below reads this instead.
+        final_output: Optional[TeamRunOutput] = None
 
         async def _dispatch_sse(event: Any) -> None:
             """Buffer an event, hand it to the original client, and fan it out."""
@@ -8168,12 +8192,15 @@ async def _acontinue_run_background_stream(
                 session_id=session_id,
                 response_format=response_format,
                 stream_events=stream_events,
-                yield_run_output=yield_run_output or False,
+                # Always request the final run object; it is captured below and
+                # never forwarded to the client.
+                yield_run_output=True,
                 debug_mode=debug_mode,
                 background_tasks=background_tasks,
                 **kwargs,
             ):
                 if isinstance(event, TeamRunOutput):
+                    final_output = event
                     continue
 
                 await _dispatch_sse(event)
@@ -8182,25 +8209,30 @@ async def _acontinue_run_background_stream(
             producer_error = e
             refused = isinstance(e, RunNotContinuableError)
             if refused:
-                # A refusal is an answer, not a crash. The continue was rejected
-                # precisely so the run would stay paused and resumable, so its
-                # status has to survive: persisting ERROR here would strand the
-                # pause the refusal just protected.
-                #
-                # Step 1 above persisted RUNNING before the producer started, so
-                # putting the pause back is what leaves the run resumable —
-                # otherwise it stays advertised as in-flight for good and no
-                # later continue can pick it up.
+                # A refusal is an answer, not a crash: the run keeps the status
+                # it had before step 1 wrote RUNNING. status_before_takeover is
+                # the stored run's pre-continue status; with no stored entry,
+                # the caller object's own pre-write status is the only record.
                 log_info(f"Background continue-run stream {_run_id} refused the continue: {e}")
                 try:
-                    # Put back exactly what step 1 overwrote. Restoring a blanket
-                    # PAUSED instead would hand a resumable pause to any run that
-                    # had not been paused to begin with, and a pause is an
-                    # invitation to approve its gated tool.
-                    if run_response is not None and status_before_takeover is not None:
-                        run_response.status = status_before_takeover
-                        team_session.upsert_run(run_response=run_response)
-                        await asave_session(team, session=team_session)
+                    restore_status = (
+                        status_before_takeover if status_before_takeover is not None else prior_object_status
+                    )
+                    if run_response is not None and restore_status is not None:
+                        # A legacy string status is restored as-is; to_dict
+                        # serializes both shapes.
+                        run_response.status = cast(RunStatus, restore_status)
+                        # Persist into a fresh session read so runs persisted by
+                        # others since step 1 survive this write, and only while
+                        # the stored run still carries step 1's RUNNING marker;
+                        # any other value means another request owns the run now.
+                        fresh_session = await _aread_or_create_session(team, session_id=session_id, user_id=user_id)
+                        fresh_run = next(
+                            (r for r in fresh_session.runs or [] if getattr(r, "run_id", None) == _run_id), None
+                        )
+                        if fresh_run is not None and fresh_run.status == RunStatus.running:
+                            fresh_session.upsert_run(run_response=run_response)
+                            await asave_session(team, session=fresh_session)
                 except Exception:
                     log_error(
                         f"Failed to restore the pre-continue state for background continue-run stream {_run_id}",
@@ -8208,12 +8240,19 @@ async def _acontinue_run_background_stream(
                     )
             else:
                 log_error(f"Background continue-run stream {_run_id} failed", exc_info=True)
-                # Persist ERROR status
+                # Persist ERROR status. Same rules as the restore above: write
+                # into a fresh session read, and only over step 1's RUNNING
+                # marker, so a state another request persisted meanwhile stays.
                 try:
                     if run_response is not None:
                         run_response.status = RunStatus.error
-                        team_session.upsert_run(run_response=run_response)
-                        await asave_session(team, session=team_session)
+                        fresh_session = await _aread_or_create_session(team, session_id=session_id, user_id=user_id)
+                        fresh_run = next(
+                            (r for r in fresh_session.runs or [] if getattr(r, "run_id", None) == _run_id), None
+                        )
+                        if fresh_run is not None and fresh_run.status == RunStatus.running:
+                            fresh_session.upsert_run(run_response=run_response)
+                            await asave_session(team, session=fresh_session)
                 except Exception:
                     log_error(
                         f"Failed to persist error state for background continue-run stream {_run_id}",
@@ -8243,19 +8282,39 @@ async def _acontinue_run_background_stream(
             except Exception:
                 log_warning(f"Failed to signal primary queue for continue-run {_run_id} completion")
 
-            # Mark the run's terminal state in the event buffer. A producer that
-            # raised never reached one, so its status is whatever the failure
-            # left behind — not completed.
+            # Mark the run's terminal state in the event buffer. The value must
+            # be a RunStatus and must not be RUNNING: /resume formats it with
+            # .value, and treats RUNNING as an in-flight run to keep waiting on.
             try:
                 if isinstance(producer_error, RunNotContinuableError):
-                    # A refusal leaves the run as it was, whatever that was.
-                    # Advertising a blanket PAUSED would tell every reconnecting
-                    # client that a cancelled run is awaiting an approval.
-                    final_status = status_before_takeover or RunStatus.paused
+                    # A refused run keeps the status it had before the takeover.
+                    refused_status = (
+                        status_before_takeover if status_before_takeover is not None else prior_object_status
+                    )
+                    if isinstance(refused_status, RunStatus) and refused_status not in (
+                        RunStatus.running,
+                        RunStatus.pending,
+                    ):
+                        final_status = refused_status
+                    else:
+                        final_status = RunStatus.paused
                 elif producer_error is not None:
                     final_status = RunStatus.error
                 else:
-                    final_status = (run_response.status if run_response else None) or RunStatus.completed
+                    # The run that actually executed. final_output covers the
+                    # run_id-only path, where run_response stays None; a re-pause
+                    # or cancellation must not be advertised as completed.
+                    produced_status = final_output.status if final_output is not None else None
+                    if produced_status is None and run_response is not None:
+                        produced_status = run_response.status
+                    if isinstance(produced_status, RunStatus) and produced_status in (
+                        RunStatus.paused,
+                        RunStatus.cancelled,
+                        RunStatus.error,
+                    ):
+                        final_status = produced_status
+                    else:
+                        final_status = RunStatus.completed
                 event_buffer.set_run_completed(_run_id, final_status)
             except Exception:
                 log_warning(f"Failed to mark continue-run {_run_id} as completed in event buffer")
@@ -8881,8 +8940,9 @@ async def _acontinue_run(
                     raise
                 return run_response
 
-            except ValueError:
-                # Validation errors (e.g. cancelled run, missing args) propagate to the caller
+            except (ValueError, RunNotFoundError):
+                # Validation errors (e.g. cancelled run, unknown run id, missing
+                # args) propagate to the caller
                 raise
             except Exception as e:
                 run_response = cast(TeamRunOutput, run_response)

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5315,7 +5315,7 @@ def _backfill_approval_to_requirements(
     run_response: Any,
     old_requirements: Optional[List[Any]] = None,
 ) -> None:
-    """Restore approval metadata on requirements' tool_execution objects after a continue payload merge.
+    """Restore approval metadata and member provenance on requirements after a continue payload merge.
 
     During continue_run the client's requirements replace the session originals,
     but approval_type/approval_id are typically absent from the client payload.
@@ -5326,19 +5326,34 @@ def _backfill_approval_to_requirements(
     2. old_requirements (the pre-overwrite session requirements) — covers member-level
        approval tools where run_response.tools only contains delegate_task_to_member
        entries that have no approval_type. The original session requirements carry it.
+
+    Member provenance (member_agent_id, member_agent_name, member_run_id) is
+    restored from old_requirements the same way: to_dict() strips None values,
+    so a wire payload may omit any of them, and routing then cannot find the
+    paused member run — nor tell a member's requirement from the team's own
+    lifted one when the two share an id (see _reclaim_own_requirements). Old
+    requirements are matched by requirement id first, then tool_call_id: two
+    member runs paused in one turn can carry the same tool_call_id, and a
+    tool_call_id-only match would hand both the same member_run_id.
     """
     reqs = getattr(run_response, "requirements", None)
     if not reqs:
         return
 
-    # Build lookup from both sources
+    # Build lookups from both sources
     by_id: Dict[str, Any] = {}
+    old_by_req_id: Dict[str, Any] = {}
+    old_by_tool_call_id: Dict[str, Any] = {}
     # Old requirements first (lower priority)
     if old_requirements:
         for old_req in old_requirements:
+            old_req_id = getattr(old_req, "id", None)
+            if old_req_id:
+                old_by_req_id[old_req_id] = old_req
             old_te = getattr(old_req, "tool_execution", None)
             if old_te and old_te.tool_call_id:
                 by_id[old_te.tool_call_id] = old_te
+                old_by_tool_call_id[old_te.tool_call_id] = old_req
     # run_response.tools second (higher priority, overwrites)
     for t in getattr(run_response, "tools", None) or []:
         if t.tool_call_id and getattr(t, "approval_type", None) is not None:
@@ -5351,6 +5366,13 @@ def _backfill_approval_to_requirements(
             for attr in ("approval_type", "approval_id"):
                 if getattr(te, attr, None) is None and getattr(src, attr, None) is not None:
                     setattr(te, attr, getattr(src, attr))
+        old_req = old_by_req_id.get(getattr(req, "id", None) or "")
+        if old_req is None and te is not None and te.tool_call_id:
+            old_req = old_by_tool_call_id.get(te.tool_call_id)
+        if old_req is not None:
+            for attr in ("member_agent_id", "member_agent_name", "member_run_id"):
+                if getattr(req, attr, None) is None and getattr(old_req, attr, None) is not None:
+                    setattr(req, attr, getattr(old_req, attr))
 
 
 def _reclaim_own_requirements(team: "Team", requirements: List[Any], continuing_run_id: Optional[str]) -> None:
@@ -5368,7 +5390,11 @@ def _reclaim_own_requirements(team: "Team", requirements: List[Any], continuing_
     The requirement is the team's own only if it also points at the run being
     continued at this dispatch level — _propagate_member_pause stamps
     member_run_id alongside member_agent_id, and for a member's requirement
-    that is the member's run id, never this team's."""
+    that is the member's run id, never this team's. A requirement without
+    member_run_id is never reclaimed: to_dict() strips None values, so a wire
+    payload may omit the field, and _backfill_approval_to_requirements
+    restores it from the stored session requirements before dispatch reaches
+    this function."""
     from agno.utils.team import get_member_id
 
     if not any(getattr(req, "member_agent_id", None) is not None for req in requirements):
@@ -5380,7 +5406,7 @@ def _reclaim_own_requirements(team: "Team", requirements: List[Any], continuing_
         if getattr(req, "member_agent_id", None) != own_id:
             continue
         member_run_id = getattr(req, "member_run_id", None)
-        if member_run_id is not None and member_run_id != continuing_run_id:
+        if member_run_id is None or member_run_id != continuing_run_id:
             continue
         req.member_agent_id = None
         req.member_agent_name = None
@@ -5528,9 +5554,17 @@ def _group_requirements_for_continue(
     that is not in the team: the run stays paused and resumable instead of
     completing with the approved tool silently skipped.
 
+    The leaf-id route and run ownership can disagree: sibling sub-teams may
+    contain members with the same leaf id, and _find_member_route_by_id picks
+    the first match in member order while the paused run lives under another
+    sibling. The resolved run's owner is authoritative for where the continue
+    dispatches — following the leaf-id pick would hand one sibling's paused
+    run to the other and execute the wrong tool implementation.
+
     Returns entries of (routed_member, resolved_target_run_or_None, requirements).
     """
     from agno.team._tools import _find_member_route_by_id
+    from agno.utils.team import get_member_id
 
     member_reqs: Dict[Tuple[str, Optional[str]], List["RunRequirement"]] = {}
     for req in run_response.requirements or []:
@@ -5549,6 +5583,10 @@ def _group_requirements_for_continue(
             )
         _, member = route_result
         target = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
+        if isinstance(target, TeamRunOutput) and target.team_id is not None and target.team_id != get_member_id(member):
+            owner_route = _find_member_route_by_id(team, target.team_id, run_context=run_context)
+            if owner_route is not None and get_member_id(owner_route[1]) == target.team_id:
+                member = owner_route[1]
         merged = False
         if target is not None:
             for existing_member, existing_target, existing_reqs in entries:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5601,10 +5601,12 @@ def _apply_requirements_payload(
 
     Normalizes the payload, binds it to the stored requirements
     (_backfill_approval_to_requirements), and merges the bound tool
-    executions into run_response.tools. On a binding refusal the run object
-    gets its requirements and tools back before the raise: the refusal asks
-    the client to resend the stored ids, which a caller-supplied live run
-    object only still has if nothing was overwritten.
+    executions into run_response.tools. On a refusal the run object gets its
+    requirements, tools, and decision fields back before the raise: the
+    refusal asks the client to resend the stored ids, which a caller-supplied
+    live run object only still has if nothing was overwritten — and a merge
+    that raised mid-payload has already banked the earlier entries' decisions
+    onto the stored requirements.
 
     Returns (old_requirements, old_tools, decisions) so the caller can restore
     all three if a later step of its payload apply raises.
@@ -5618,6 +5620,10 @@ def _apply_requirements_payload(
     except Exception:
         run_response.requirements = old_requirements
         run_response.tools = old_tools
+        # The merge loop can raise on a malformed entry after earlier entries
+        # already wrote their decisions onto the stored requirements; the list
+        # references alone leave those banked.
+        _restore_requirement_decisions(decisions)
         raise
     # Merge the bound tool executions into the run's tools, preserving
     # approval fields the FE omits. After binding these are the stored

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5373,6 +5373,18 @@ def _merge_requirement_decision(stored: Any, wire: Any) -> None:
     gated tool with its fields still empty. A requirement carrying no schema at
     all has no other way to be answered, so there the wire flag stands.
     """
+    stored_te = getattr(stored, "tool_execution", None)
+    wire_te = getattr(wire, "tool_execution", None)
+
+    # Whether the model left anything open, read before any answer lands. The
+    # requirement-level schema and tool_execution's are often the same list
+    # object, so "did this call fill something" cannot carry the signal — the
+    # first fill would consume it and the run would never read as answered.
+    stored_input_schema = getattr(stored_te, "user_input_schema", None) if stored_te is not None else None
+    stored_feedback_schema = getattr(stored_te, "user_feedback_schema", None) if stored_te is not None else None
+    input_was_open = any(field.value is None for field in stored_input_schema or [])
+    feedback_was_open = any(question.selected_options is None for question in stored_feedback_schema or [])
+
     for attr in ("confirmation", "confirmation_note"):
         if getattr(wire, attr, None) is not None:
             setattr(stored, attr, getattr(wire, attr))
@@ -5380,31 +5392,27 @@ def _merge_requirement_decision(stored: Any, wire: Any) -> None:
     _fill_user_feedback_answers(
         getattr(stored, "user_feedback_schema", None), getattr(wire, "user_feedback_schema", None)
     )
-    stored_te = getattr(stored, "tool_execution", None)
-    wire_te = getattr(wire, "tool_execution", None)
     if stored_te is not None and wire_te is not None:
         for attr in ("confirmed", "confirmation_note"):
             if getattr(wire_te, attr, None) is not None:
                 setattr(stored_te, attr, getattr(wire_te, attr))
         # Dispatch reads only tool_execution's schema, so answers sent at either
         # level have to reach it.
-        input_filled = _fill_user_input_answers(stored_te.user_input_schema, wire_te.user_input_schema)
-        input_filled |= _fill_user_input_answers(stored_te.user_input_schema, getattr(wire, "user_input_schema", None))
-        feedback_filled = _fill_user_feedback_answers(stored_te.user_feedback_schema, wire_te.user_feedback_schema)
-        feedback_filled |= _fill_user_feedback_answers(
-            stored_te.user_feedback_schema, getattr(wire, "user_feedback_schema", None)
-        )
+        _fill_user_input_answers(stored_input_schema, wire_te.user_input_schema)
+        _fill_user_input_answers(stored_input_schema, getattr(wire, "user_input_schema", None))
+        _fill_user_feedback_answers(stored_feedback_schema, wire_te.user_feedback_schema)
+        _fill_user_feedback_answers(stored_feedback_schema, getattr(wire, "user_feedback_schema", None))
         if stored_te.answered is None:
-            if input_filled and all(field.value is not None for field in stored_te.user_input_schema or []):
+            if input_was_open and all(field.value is not None for field in stored_input_schema or []):
                 stored_te.answered = True
-            elif feedback_filled and all(
-                question.selected_options is not None for question in stored_te.user_feedback_schema or []
+            elif feedback_was_open and all(
+                question.selected_options is not None for question in stored_feedback_schema or []
             ):
                 stored_te.answered = True
             elif (
                 getattr(wire_te, "answered", None) is not None
-                and not stored_te.user_input_schema
-                and not stored_te.user_feedback_schema
+                and not stored_input_schema
+                and not stored_feedback_schema
             ):
                 stored_te.answered = wire_te.answered
         if getattr(stored_te, "external_execution_required", None) and getattr(wire_te, "result", None) is not None:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -7135,7 +7135,6 @@ def continue_run_dispatch(
                 team, run_response=run_response, session=team_session, run_context=run_context
             )
 
-
     # Route member requirements to member agents
     member_results: List[str] = []
     if has_member:
@@ -8134,9 +8133,7 @@ async def _acontinue_run_background_stream(
                 log_warning(f"Failed to push SSE data to queue for continue-run {_run_id}")
 
             try:
-                await sse_subscriber_manager.publish(
-                    _run_id, event_index if event_index is not None else -1, sse_data
-                )
+                await sse_subscriber_manager.publish(_run_id, event_index if event_index is not None else -1, sse_data)
             except Exception:
                 log_warning(f"Failed to publish SSE data to subscribers for continue-run {_run_id}")
 
@@ -8632,7 +8629,6 @@ async def _acontinue_run(
                         team, run_response=run_response, session=team_session, run_context=run_context
                     )
 
-
                 # Route member requirements
                 member_results: List[str] = list(routed_member_results)
                 if has_member:
@@ -9095,7 +9091,6 @@ async def _acontinue_run_stream(
                     if yield_run_output:
                         yield run_response
                     return
-
 
                 # Route member requirements. The routing generator appends into
                 # this list in place, so seeding it with the banked results

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -8332,6 +8332,11 @@ async def _acontinue_run(
     # re-binding the same payload against what is left refuses a run the retry
     # was meant to rescue.
     requirements_applied = False
+    # Member results survive retries for the same reason: routing consumed the
+    # member requirements, so a retry after a transient leader failure re-enters
+    # with nothing to route. Without the banked results every dispatch branch is
+    # skipped and the run would complete without the leader ever being called.
+    routed_member_results: List[str] = []
 
     try:
         num_attempts = team.retries + 1
@@ -8477,7 +8482,7 @@ async def _acontinue_run(
                 has_team_level = _has_team_level_requirements(run_response.requirements or [])
 
                 # Route member requirements
-                member_results: List[str] = []
+                member_results: List[str] = list(routed_member_results)
                 if has_member:
                     member_reqs = [
                         r for r in (run_response.requirements or []) if getattr(r, "member_agent_id", None) is not None
@@ -8504,6 +8509,11 @@ async def _acontinue_run(
                         r for r in (run_response.requirements or []) if id(r) not in original_member_req_ids
                     ]
                     run_response.requirements = team_level_reqs + newly_propagated
+                    # This attempt's routing succeeded; bank its results so a
+                    # transient leader failure below retries the leader with
+                    # them instead of completing a leaderless run.
+                    member_results = routed_member_results + member_results
+                    routed_member_results = member_results
 
                     # Check if still paused
                     if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
@@ -8772,8 +8782,12 @@ async def _acontinue_run_stream(
     log_debug(f"Team Continue Run Stream: {run_response.run_id if run_response else run_id}", center=True)
 
     team_session: Optional[TeamSession] = None
-    # See _acontinue_run: the payload binds once, not once per retry.
+    # See _acontinue_run: the payload binds once, not once per retry, and
+    # member results from a routing pass that succeeded are banked so a
+    # transient leader failure retries the leader instead of completing a
+    # run that skipped it.
     requirements_applied = False
+    routed_member_results: List[str] = []
 
     try:
         num_attempts = team.retries + 1
@@ -8908,8 +8922,10 @@ async def _acontinue_run_stream(
                 has_member = _has_member_requirements(run_response.requirements or [])
                 has_team_level = _has_team_level_requirements(run_response.requirements or [])
 
-                # Route member requirements
-                member_results: List[str] = []
+                # Route member requirements. The routing generator appends into
+                # this list in place, so seeding it with the banked results
+                # keeps earlier attempts' routing and this attempt's together.
+                member_results: List[str] = list(routed_member_results)
                 if has_member:
                     member_reqs = [
                         r for r in (run_response.requirements or []) if getattr(r, "member_agent_id", None) is not None
@@ -8940,6 +8956,8 @@ async def _acontinue_run_stream(
                         r for r in (run_response.requirements or []) if id(r) not in original_member_req_ids
                     ]
                     run_response.requirements = team_level_reqs + newly_propagated
+                    # Routing succeeded; bank the accumulated results for a retry.
+                    routed_member_results = member_results
 
                     if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
                         from agno.team import _hooks

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5353,7 +5353,7 @@ def _backfill_approval_to_requirements(
                     setattr(te, attr, getattr(src, attr))
 
 
-def _reclaim_own_requirements(team: "Team", requirements: List[Any]) -> None:
+def _reclaim_own_requirements(team: "Team", requirements: List[Any], continuing_run_id: Optional[str]) -> None:
     """Clear the member stamp from requirements that belong to this team itself.
 
     When a sub-team's OWN tool pauses, _propagate_member_pause stamps the
@@ -5361,7 +5361,14 @@ def _reclaim_own_requirements(team: "Team", requirements: List[Any]) -> None:
     back down. Once the requirement arrives at the team it names, the stamp's
     job is done: the requirement is this team's own, team-level requirement.
     Without reclaiming it, member routing looks the team's own id up among
-    its members, finds nothing, and refuses the continue."""
+    its members, finds nothing, and refuses the continue.
+
+    A matching id alone does not prove ownership: a member may share the
+    team's id, or its url-safe name (get_member_id falls back to the name).
+    The requirement is the team's own only if it also points at the run being
+    continued at this dispatch level — _propagate_member_pause stamps
+    member_run_id alongside member_agent_id, and for a member's requirement
+    that is the member's run id, never this team's."""
     from agno.utils.team import get_member_id
 
     if not any(getattr(req, "member_agent_id", None) is not None for req in requirements):
@@ -5370,9 +5377,13 @@ def _reclaim_own_requirements(team: "Team", requirements: List[Any]) -> None:
     if not own_id:
         return
     for req in requirements:
-        if getattr(req, "member_agent_id", None) == own_id:
-            req.member_agent_id = None
-            req.member_agent_name = None
+        if getattr(req, "member_agent_id", None) != own_id:
+            continue
+        member_run_id = getattr(req, "member_run_id", None)
+        if member_run_id is not None and member_run_id != continuing_run_id:
+            continue
+        req.member_agent_id = None
+        req.member_agent_name = None
 
 
 def _has_member_requirements(requirements: List[Any]) -> bool:
@@ -6706,7 +6717,7 @@ def continue_run_dispatch(
         _did_snapshot_dispatch = True
 
     # Determine what kind of pause we're continuing from
-    _reclaim_own_requirements(team, run_response.requirements or [])
+    _reclaim_own_requirements(team, run_response.requirements or [], run_response.run_id)
     has_member = _has_member_requirements(run_response.requirements or [])
     has_team_level = _has_team_level_requirements(run_response.requirements or [])
 
@@ -8128,7 +8139,7 @@ async def _acontinue_run(
                     store_events=team.store_events,
                 )
 
-                _reclaim_own_requirements(team, run_response.requirements or [])
+                _reclaim_own_requirements(team, run_response.requirements or [], run_response.run_id)
                 has_member = _has_member_requirements(run_response.requirements or [])
                 has_team_level = _has_team_level_requirements(run_response.requirements or [])
 
@@ -8562,7 +8573,7 @@ async def _acontinue_run_stream(
 
                 await aregister_run(run_response.run_id)  # type: ignore
 
-                _reclaim_own_requirements(team, run_response.requirements or [])
+                _reclaim_own_requirements(team, run_response.requirements or [], run_response.run_id)
                 has_member = _has_member_requirements(run_response.requirements or [])
                 has_team_level = _has_team_level_requirements(run_response.requirements or [])
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5312,6 +5312,45 @@ def _merge_tools_preserving_approval(
     return merged
 
 
+def _fill_user_input_answers(stored_schema: Optional[List[Any]], wire_schema: Optional[List[Any]]) -> bool:
+    """Fill the stored schema's open fields from the wire copy, keyed by field name.
+
+    Returns True if a field the model had left open was filled.
+    """
+    if not stored_schema or not wire_schema:
+        return False
+    answers = {field.name: field.value for field in wire_schema if getattr(field, "value", None) is not None}
+    filled = False
+    for field in stored_schema:
+        if field.value is None and field.name in answers:
+            field.value = answers[field.name]
+            filled = True
+    return filled
+
+
+def _fill_user_feedback_answers(stored_schema: Optional[List[Any]], wire_schema: Optional[List[Any]]) -> bool:
+    """Fill the stored schema's unanswered questions from the wire copy, keyed by question.
+
+    Returns True if a question the model had left open was answered.
+    """
+    if not stored_schema or not wire_schema:
+        return False
+    selections = {
+        question.question: question.selected_options
+        for question in wire_schema
+        if getattr(question, "selected_options", None) is not None
+    }
+    filled = False
+    for question in stored_schema:
+        if question.selected_options is None and question.question in selections:
+            question.selected_options = selections[question.question]
+            if question.options:
+                for option in question.options:
+                    option.selected = option.label in question.selected_options
+            filled = True
+    return filled
+
+
 def _merge_requirement_decision(stored: Any, wire: Any) -> None:
     """Copy the client's decision state onto the canonical stored requirement.
 
@@ -5320,24 +5359,54 @@ def _merge_requirement_decision(stored: Any, wire: Any) -> None:
     and routing (tool_execution, tool_args, member provenance) stay the
     stored requirement's own; a result on a non-external tool is dropped
     because honoring it would suppress the confirmed tool's execution.
+
+    The schemas are filled field by field, never rebound. The wire copy is a
+    client document: rebinding it would put client-chosen field NAMES into the
+    schema that ``handle_user_input_update`` writes into ``tool_args``
+    immediately before the call, so a renamed field overwrites an argument the
+    model fixed at pause time. Answers therefore land by stored field name, and
+    only in fields the model left open.
+
+    ``answered`` is inferred from the stored schema exactly as
+    ``RunRequirement.from_dict`` infers it — only when this merge fills the last
+    open field — and never copied off the wire, which would otherwise run the
+    gated tool with its fields still empty. A requirement carrying no schema at
+    all has no other way to be answered, so there the wire flag stands.
     """
     for attr in ("confirmation", "confirmation_note"):
         if getattr(wire, attr, None) is not None:
             setattr(stored, attr, getattr(wire, attr))
-    if getattr(wire, "user_input_schema", None) is not None:
-        stored.user_input_schema = wire.user_input_schema
-    if getattr(wire, "user_feedback_schema", None) is not None:
-        stored.user_feedback_schema = wire.user_feedback_schema
+    _fill_user_input_answers(getattr(stored, "user_input_schema", None), getattr(wire, "user_input_schema", None))
+    _fill_user_feedback_answers(
+        getattr(stored, "user_feedback_schema", None), getattr(wire, "user_feedback_schema", None)
+    )
     stored_te = getattr(stored, "tool_execution", None)
     wire_te = getattr(wire, "tool_execution", None)
     if stored_te is not None and wire_te is not None:
-        for attr in ("confirmed", "confirmation_note", "answered"):
+        for attr in ("confirmed", "confirmation_note"):
             if getattr(wire_te, attr, None) is not None:
                 setattr(stored_te, attr, getattr(wire_te, attr))
-        if getattr(wire_te, "user_input_schema", None) is not None:
-            stored_te.user_input_schema = wire_te.user_input_schema
-        if getattr(wire_te, "user_feedback_schema", None) is not None:
-            stored_te.user_feedback_schema = wire_te.user_feedback_schema
+        # Dispatch reads only tool_execution's schema, so answers sent at either
+        # level have to reach it.
+        input_filled = _fill_user_input_answers(stored_te.user_input_schema, wire_te.user_input_schema)
+        input_filled |= _fill_user_input_answers(stored_te.user_input_schema, getattr(wire, "user_input_schema", None))
+        feedback_filled = _fill_user_feedback_answers(stored_te.user_feedback_schema, wire_te.user_feedback_schema)
+        feedback_filled |= _fill_user_feedback_answers(
+            stored_te.user_feedback_schema, getattr(wire, "user_feedback_schema", None)
+        )
+        if stored_te.answered is None:
+            if input_filled and all(field.value is not None for field in stored_te.user_input_schema or []):
+                stored_te.answered = True
+            elif feedback_filled and all(
+                question.selected_options is not None for question in stored_te.user_feedback_schema or []
+            ):
+                stored_te.answered = True
+            elif (
+                getattr(wire_te, "answered", None) is not None
+                and not stored_te.user_input_schema
+                and not stored_te.user_feedback_schema
+            ):
+                stored_te.answered = wire_te.answered
         if getattr(stored_te, "external_execution_required", None) and getattr(wire_te, "result", None) is not None:
             stored_te.result = wire_te.result
     if (
@@ -5411,7 +5480,7 @@ def _backfill_approval_to_requirements(
 
     run_id = getattr(run_response, "run_id", None)
     matched: Set[int] = set()
-    canonical: List[Any] = []
+    bindings: List[Tuple[Any, Any]] = []
     for req in reqs:
         te = getattr(req, "tool_execution", None)
         tool_call_id = te.tool_call_id if te is not None else None
@@ -5443,15 +5512,66 @@ def _backfill_approval_to_requirements(
                 f"requirement '{getattr(old_req, 'id', None)}'. The run remains paused."
             )
         matched.add(id(old_req))
+        bindings.append((old_req, req))
+
+    # Nothing is written until the whole payload has bound. Merging inside the
+    # loop above would leave the entries before a refusal holding the client's
+    # decision, and the refusal restores list references, not field values — so
+    # a bare retry of a rejected request would execute the tools that bound
+    # before the bad entry.
+    for old_req, req in bindings:
         _merge_requirement_decision(old_req, req)
-        canonical.append(old_req)
-    run_response.requirements = canonical
+    run_response.requirements = [old_req for old_req, _ in bindings]
+
+
+_REQUIREMENT_DECISION_FIELDS = ("confirmation", "confirmation_note", "external_execution_result")
+_TOOL_EXECUTION_DECISION_FIELDS = ("confirmed", "confirmation_note", "answered", "result")
+
+
+def _requirement_decision_slots(requirements: Optional[List[Any]]) -> Iterator[Tuple[Any, str]]:
+    """Yield every (object, attribute) pair _merge_requirement_decision writes.
+
+    The merge fills schemas in place and never rebinds a list, so the objects
+    reached here before the merge are the same ones it writes to.
+    """
+    for req in requirements or []:
+        for attr in _REQUIREMENT_DECISION_FIELDS:
+            yield req, attr
+        for holder in (req, getattr(req, "tool_execution", None)):
+            if holder is None:
+                continue
+            if holder is not req:
+                for attr in _TOOL_EXECUTION_DECISION_FIELDS:
+                    yield holder, attr
+            for field in getattr(holder, "user_input_schema", None) or []:
+                yield field, "value"
+            for question in getattr(holder, "user_feedback_schema", None) or []:
+                yield question, "selected_options"
+                for option in getattr(question, "options", None) or []:
+                    yield option, "selected"
+
+
+def _snapshot_requirement_decisions(requirements: Optional[List[Any]]) -> List[Tuple[Any, str, Any]]:
+    """Record the stored requirements' decision state before a payload is merged."""
+    return [(obj, attr, getattr(obj, attr, None)) for obj, attr in _requirement_decision_slots(requirements)]
+
+
+def _restore_requirement_decisions(snapshot: List[Tuple[Any, str, Any]]) -> None:
+    """Put the decision state recorded by _snapshot_requirement_decisions back.
+
+    Restoring the requirements list alone is not enough for a gate that refuses
+    a continue after the payload has bound: the entries on that list are the
+    stored requirements the merge wrote into, so the client's decision would
+    survive a refusal the caller was told left the run untouched.
+    """
+    for obj, attr, value in snapshot:
+        setattr(obj, attr, value)
 
 
 def _apply_requirements_payload(
     run_response: TeamRunOutput,
     requirements: List[Any],
-) -> Tuple[Optional[List["RunRequirement"]], Optional[List[Any]]]:
+) -> Tuple[Optional[List["RunRequirement"]], Optional[List[Any]], List[Tuple[Any, str, Any]]]:
     """Apply a continue payload to the run object, keeping it intact on refusal.
 
     Normalizes the payload, binds it to the stored requirements
@@ -5461,11 +5581,12 @@ def _apply_requirements_payload(
     the client to resend the stored ids, which a caller-supplied live run
     object only still has if nothing was overwritten.
 
-    Returns (old_requirements, old_tools) so the caller can restore them if
-    a later step of its payload apply raises.
+    Returns (old_requirements, old_tools, decisions) so the caller can restore
+    all three if a later step of its payload apply raises.
     """
     old_requirements = run_response.requirements
     old_tools = run_response.tools
+    decisions = _snapshot_requirement_decisions(old_requirements)
     run_response.requirements = _normalize_requirements_payload(requirements)
     try:
         _backfill_approval_to_requirements(run_response, old_requirements=old_requirements)
@@ -5482,10 +5603,12 @@ def _apply_requirements_payload(
         run_response.tools = _merge_tools_preserving_approval(run_response.tools, updated_tools_map)
     elif updated_tools:
         run_response.tools = updated_tools
-    return old_requirements, old_tools
+    return old_requirements, old_tools, decisions
 
 
-def _reclaim_own_requirements(team: "Team", requirements: List[Any], continuing_run_id: Optional[str]) -> None:
+def _reclaim_own_requirements(
+    team: "Team", requirements: Optional[List[Any]], continuing_run_id: Optional[str]
+) -> Optional[List[Any]]:
     """Clear the member stamp from requirements that belong to this team itself.
 
     When a sub-team's OWN tool pauses, _propagate_member_pause stamps the
@@ -5504,22 +5627,39 @@ def _reclaim_own_requirements(team: "Team", requirements: List[Any], continuing_
     member_run_id is never reclaimed: to_dict() strips None values, so a wire
     payload may omit the field, and _backfill_approval_to_requirements
     restores it from the stored session requirements before dispatch reaches
-    this function."""
+    this function.
+
+    Returns the list to route with. A reclaimed requirement is de-stamped on a
+    COPY: when a parent team routes a sub-team's lifted requirement down, the
+    objects on the sub-team's run are the parent's own, and the parent still
+    lists them. De-stamping in place would leave the parent holding what looks
+    like a team-level requirement of its own, so if anything below this
+    dispatch refuses, the caller's run object comes back mis-routed — the very
+    retry the refusal promises would then skip the approved tool."""
+    from copy import copy
+
     from agno.utils.team import get_member_id
 
+    if not requirements:
+        return requirements
     if not any(getattr(req, "member_agent_id", None) is not None for req in requirements):
-        return
+        return requirements
     own_id = get_member_id(team)
     if not own_id:
-        return
+        return requirements
+    reclaimed: List[Any] = []
     for req in requirements:
-        if getattr(req, "member_agent_id", None) != own_id:
-            continue
         member_run_id = getattr(req, "member_run_id", None)
-        if member_run_id is None or member_run_id != continuing_run_id:
-            continue
-        req.member_agent_id = None
-        req.member_agent_name = None
+        if (
+            getattr(req, "member_agent_id", None) == own_id
+            and member_run_id is not None
+            and member_run_id == continuing_run_id
+        ):
+            req = copy(req)
+            req.member_agent_id = None
+            req.member_agent_name = None
+        reclaimed.append(req)
+    return reclaimed
 
 
 def _has_member_requirements(requirements: List[Any]) -> bool:
@@ -6832,7 +6972,7 @@ def continue_run_dispatch(
 
     # Normalize and apply requirements
     if requirements:
-        old_requirements, old_tools = _apply_requirements_payload(run_response, requirements)
+        old_requirements, old_tools, decisions = _apply_requirements_payload(run_response, requirements)
 
         # Also apply any resolved approval
         if run_response.tools:
@@ -6843,6 +6983,7 @@ def continue_run_dispatch(
             except RuntimeError:
                 run_response.requirements = old_requirements
                 run_response.tools = old_tools
+                _restore_requirement_decisions(decisions)
                 raise ValueError(
                     "To continue a run from a given run_id, the requirements parameter must be provided "
                     "(or resolve an admin approval first)."
@@ -6876,7 +7017,7 @@ def continue_run_dispatch(
         _did_snapshot_dispatch = True
 
     # Determine what kind of pause we're continuing from
-    _reclaim_own_requirements(team, run_response.requirements or [], run_response.run_id)
+    run_response.requirements = _reclaim_own_requirements(team, run_response.requirements, run_response.run_id)
     has_member = _has_member_requirements(run_response.requirements or [])
     has_team_level = _has_team_level_requirements(run_response.requirements or [])
 
@@ -8154,6 +8295,12 @@ async def _acontinue_run(
     log_debug(f"Team Continue Run: {run_response.run_id if run_response else run_id}", center=True)
 
     team_session: Optional[TeamSession] = None
+    # The payload binds to the stored requirements exactly once. A retry after a
+    # transient failure re-enters the loop with the run already carrying the
+    # bound requirements, and the member-level ones consumed by the dispatch —
+    # re-binding the same payload against what is left refuses a run the retry
+    # was meant to rescue.
+    requirements_applied = False
 
     try:
         num_attempts = team.retries + 1
@@ -8232,23 +8379,26 @@ async def _acontinue_run(
                     run_response.content = None
                 # Normalize and apply requirements
                 elif requirements:
-                    old_requirements, old_tools = _apply_requirements_payload(run_response, requirements)
+                    if not requirements_applied:
+                        old_requirements, old_tools, decisions = _apply_requirements_payload(run_response, requirements)
+                        requirements_applied = True
 
-                    # Also apply any resolved approval
-                    if run_response.tools:
-                        from agno.run.approval import acheck_and_apply_approval_resolution
+                        # Also apply any resolved approval
+                        if run_response.tools:
+                            from agno.run.approval import acheck_and_apply_approval_resolution
 
-                        try:
-                            await acheck_and_apply_approval_resolution(
-                                team.db, run_response.run_id or run_id or "", run_response
-                            )
-                        except RuntimeError:
-                            run_response.requirements = old_requirements
-                            run_response.tools = old_tools
-                            raise ValueError(
-                                "To continue a run from a given run_id, the requirements parameter must be provided "
-                                "(or resolve an admin approval first)."
-                            )
+                            try:
+                                await acheck_and_apply_approval_resolution(
+                                    team.db, run_response.run_id or run_id or "", run_response
+                                )
+                            except RuntimeError:
+                                run_response.requirements = old_requirements
+                                run_response.tools = old_tools
+                                _restore_requirement_decisions(decisions)
+                                raise ValueError(
+                                    "To continue a run from a given run_id, the requirements parameter must be "
+                                    "provided (or resolve an admin approval first)."
+                                )
                 elif run_response.tools:
                     from agno.run.approval import acheck_and_apply_approval_resolution
 
@@ -8289,7 +8439,9 @@ async def _acontinue_run(
                     store_events=team.store_events,
                 )
 
-                _reclaim_own_requirements(team, run_response.requirements or [], run_response.run_id)
+                run_response.requirements = _reclaim_own_requirements(
+                    team, run_response.requirements, run_response.run_id
+                )
                 has_member = _has_member_requirements(run_response.requirements or [])
                 has_team_level = _has_team_level_requirements(run_response.requirements or [])
 
@@ -8589,6 +8741,8 @@ async def _acontinue_run_stream(
     log_debug(f"Team Continue Run Stream: {run_response.run_id if run_response else run_id}", center=True)
 
     team_session: Optional[TeamSession] = None
+    # See _acontinue_run: the payload binds once, not once per retry.
+    requirements_applied = False
 
     try:
         num_attempts = team.retries + 1
@@ -8667,23 +8821,26 @@ async def _acontinue_run_stream(
                     run_response.content = None
                 # Normalize and apply requirements
                 elif requirements:
-                    old_requirements, old_tools = _apply_requirements_payload(run_response, requirements)
+                    if not requirements_applied:
+                        old_requirements, old_tools, decisions = _apply_requirements_payload(run_response, requirements)
+                        requirements_applied = True
 
-                    # Also apply any resolved approval
-                    if run_response.tools:
-                        from agno.run.approval import acheck_and_apply_approval_resolution
+                        # Also apply any resolved approval
+                        if run_response.tools:
+                            from agno.run.approval import acheck_and_apply_approval_resolution
 
-                        try:
-                            await acheck_and_apply_approval_resolution(
-                                team.db, run_response.run_id or run_id or "", run_response
-                            )
-                        except RuntimeError:
-                            run_response.requirements = old_requirements
-                            run_response.tools = old_tools
-                            raise ValueError(
-                                "To continue a run from a given run_id, the requirements parameter must be provided "
-                                "(or resolve an admin approval first)."
-                            )
+                            try:
+                                await acheck_and_apply_approval_resolution(
+                                    team.db, run_response.run_id or run_id or "", run_response
+                                )
+                            except RuntimeError:
+                                run_response.requirements = old_requirements
+                                run_response.tools = old_tools
+                                _restore_requirement_decisions(decisions)
+                                raise ValueError(
+                                    "To continue a run from a given run_id, the requirements parameter must be "
+                                    "provided (or resolve an admin approval first)."
+                                )
                 elif run_response.tools:
                     from agno.run.approval import acheck_and_apply_approval_resolution
 
@@ -8714,7 +8871,9 @@ async def _acontinue_run_stream(
 
                 await aregister_run(run_response.run_id)  # type: ignore
 
-                _reclaim_own_requirements(team, run_response.requirements or [], run_response.run_id)
+                run_response.requirements = _reclaim_own_requirements(
+                    team, run_response.requirements, run_response.run_id
+                )
                 has_member = _has_member_requirements(run_response.requirements or [])
                 has_team_level = _has_team_level_requirements(run_response.requirements or [])
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -134,6 +134,8 @@ _MEMBER_CANCEL_BYPASS_EVENT_TYPES = (
 )
 
 if TYPE_CHECKING:
+    from agno.agent import Agent
+    from agno.run.requirement import RunRequirement
     from agno.team._run_options import ResolvedRunOptions
     from agno.team.team import Team
 
@@ -5383,6 +5385,89 @@ def _member_continue_kwargs_from_run_context(run_context: Optional[RunContext]) 
     return kwargs
 
 
+def _team_run_references_member_run(team_run: TeamRunOutput, member_run_id: str) -> bool:
+    """True if the team run owns member_run_id — as a run in its
+    member-response subtree or as a requirement it carries."""
+    stack: List[Union[TeamRunOutput, RunOutput]] = list(team_run.member_responses or [])
+    while stack:
+        candidate = stack.pop()
+        if getattr(candidate, "run_id", None) == member_run_id:
+            return True
+        stack.extend(getattr(candidate, "member_responses", None) or [])
+    for req in team_run.requirements or []:
+        if getattr(req, "member_run_id", None) == member_run_id:
+            return True
+    return False
+
+
+def _resolve_member_run_output_for_continue(
+    member: Union["Agent", "Team"],
+    reqs: List["RunRequirement"],
+    run_response: TeamRunOutput,
+    session: TeamSession,
+) -> Optional[Union[RunOutput, TeamRunOutput]]:
+    """Resolve the paused run output to hand to the routed member's continue_run.
+
+    For an agent member this is its paused RunOutput; for a sub-team member it
+    is the sub-team's paused TeamRunOutput (the sub-team's own continue_run
+    routes deeper from there). Sources, in order:
+
+    1. The ``_member_run_response`` reference stored by _propagate_member_pause
+       (avoids a session/DB lookup, which fails without a database since
+       initialize_team clears the cached session). The reference is validated
+       against the routed member: each propagation level points it at the run
+       that surfaced the pause AT that level, so one level down it references
+       the containing team run, not the deep member's run.
+    2. Same-process resume: the paused member output still held on the live
+       team run's member_responses.
+    3. After process restart: the team session's sibling runs persisted in the
+       DB (member_responses is only assembled at runtime).
+    4. Sub-team members only: the direct child team run that owns the
+       requirement — the deep member's paused run lives inside it, persisted
+       there by save_session's paused-run exemption.
+    """
+    from agno.team.team import Team
+
+    member_run_output = getattr(reqs[0], "_member_run_response", None) if reqs else None
+    member_run_id = reqs[0].member_run_id if reqs else None
+    routed_to_team = isinstance(member, Team)
+
+    if member_run_output is not None and member_run_id is not None:
+        if routed_to_team:
+            valid = isinstance(member_run_output, TeamRunOutput) and (
+                member_run_output.run_id == member_run_id
+                or _team_run_references_member_run(member_run_output, member_run_id)
+            )
+        else:
+            valid = getattr(member_run_output, "run_id", None) == member_run_id
+        if not valid:
+            member_run_output = None
+
+    if member_run_output is None and member_run_id:
+        if run_response.member_responses:
+            for sibling_response in run_response.member_responses:
+                if getattr(sibling_response, "run_id", None) == member_run_id:
+                    member_run_output = sibling_response
+                    break
+        if member_run_output is None and session is not None and session.runs:
+            for session_run in session.runs:
+                if getattr(session_run, "run_id", None) == member_run_id:
+                    member_run_output = session_run  # type: ignore[assignment]
+                    break
+        if member_run_output is None and routed_to_team:
+            candidates: List[Union[TeamRunOutput, RunOutput]] = list(run_response.member_responses or [])
+            if session is not None and session.runs:
+                candidates.extend(r for r in session.runs if getattr(r, "parent_run_id", None) == run_response.run_id)
+            for candidate in candidates:
+                if not isinstance(candidate, TeamRunOutput) or candidate.run_id == run_response.run_id:
+                    continue
+                if _team_run_references_member_run(candidate, member_run_id):
+                    member_run_output = candidate
+                    break
+
+    return member_run_output
+
+
 def _route_requirements_to_members(
     team: "Team",
     run_response: TeamRunOutput,
@@ -5397,7 +5482,6 @@ def _route_requirements_to_members(
     Returns:
         List of member result strings.
     """
-    from agno.run.requirement import RunRequirement
     from agno.team._tools import _find_member_route_by_id
 
     # Group requirements by member
@@ -5418,27 +5502,9 @@ def _route_requirements_to_members(
 
         _, member = route_result
 
-        # Get the member's paused RunOutput from the requirement.
-        # This is stored by _propagate_member_pause and avoids needing a
-        # session/DB lookup (which fails without a database since
-        # initialize_team clears the cached session).
-        member_run_output = getattr(reqs[0], "_member_run_response", None)
+        # Get the member's paused run output — see _resolve_member_run_output_for_continue.
+        member_run_output = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
         member_run_id = reqs[0].member_run_id if reqs else None
-
-        if member_run_output is None and member_run_id:
-            # Same-process resume: the paused member output is still held on the live team run.
-            if run_response.member_responses:
-                for sibling_response in run_response.member_responses:
-                    if getattr(sibling_response, "run_id", None) == member_run_id:
-                        member_run_output = sibling_response
-                        break
-            # After process restart: member_responses is empty (it's only assembled at runtime),
-            # so fall back to the team session's sibling runs persisted in the DB.
-            if member_run_output is None and session is not None and session.runs:
-                for session_run in session.runs:
-                    if getattr(session_run, "run_id", None) == member_run_id:
-                        member_run_output = session_run  # type: ignore[assignment]
-                        break
 
         member_run_id = getattr(member_run_output, "run_id", None) if member_run_output is not None else member_run_id
         if member_run_id and run_response.run_id is not None:
@@ -5514,7 +5580,6 @@ def _route_requirements_to_members_stream(
     Yields:
         Member streaming events (RunOutputEvent, TeamRunOutputEvent).
     """
-    from agno.run.requirement import RunRequirement
     from agno.team._tools import _find_member_route_by_id
 
     # Group requirements by member
@@ -5533,23 +5598,8 @@ def _route_requirements_to_members_stream(
 
         _, member = route_result
 
-        member_run_output = getattr(reqs[0], "_member_run_response", None)
+        member_run_output = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
         member_run_id = reqs[0].member_run_id if reqs else None
-
-        if member_run_output is None and member_run_id:
-            # Same-process resume: the paused member output is still held on the live team run.
-            if run_response.member_responses:
-                for sibling_response in run_response.member_responses:
-                    if getattr(sibling_response, "run_id", None) == member_run_id:
-                        member_run_output = sibling_response
-                        break
-            # After process restart: member_responses is empty (it's only assembled at runtime),
-            # so fall back to the team session's sibling runs persisted in the DB.
-            if member_run_output is None and session is not None and session.runs:
-                for session_run in session.runs:
-                    if getattr(session_run, "run_id", None) == member_run_id:
-                        member_run_output = session_run  # type: ignore[assignment]
-                        break
 
         member_run_id = getattr(member_run_output, "run_id", None) if member_run_output is not None else member_run_id
         if member_run_id and run_response.run_id is not None:
@@ -5639,7 +5689,6 @@ async def _aroute_requirements_to_members(
     Returns:
         List of member result strings.
     """
-    from agno.run.requirement import RunRequirement
     from agno.team._tools import _find_member_route_by_id
 
     # Group requirements by member
@@ -5659,23 +5708,8 @@ async def _aroute_requirements_to_members(
             return f"[{member_id}]: Could not route requirement — member not found"
 
         _, member = route_result
-        member_run_output = getattr(reqs[0], "_member_run_response", None)
+        member_run_output = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
         member_run_id = reqs[0].member_run_id if reqs else None
-
-        if member_run_output is None and member_run_id:
-            # Same-process resume: the paused member output is still held on the live team run.
-            if run_response.member_responses:
-                for sibling_response in run_response.member_responses:
-                    if getattr(sibling_response, "run_id", None) == member_run_id:
-                        member_run_output = sibling_response
-                        break
-            # After process restart: member_responses is empty (it's only assembled at runtime),
-            # so fall back to the team session's sibling runs persisted in the DB.
-            if member_run_output is None and session is not None and session.runs:
-                for session_run in session.runs:
-                    if getattr(session_run, "run_id", None) == member_run_id:
-                        member_run_output = session_run  # type: ignore[assignment]
-                        break
 
         member_run_id = getattr(member_run_output, "run_id", None) if member_run_output is not None else member_run_id
         if member_run_id and run_response.run_id is not None:
@@ -5761,7 +5795,6 @@ async def _aroute_requirements_to_members_stream(
     Yields:
         Member streaming events (RunOutputEvent, TeamRunOutputEvent).
     """
-    from agno.run.requirement import RunRequirement
     from agno.team._tools import _find_member_route_by_id
 
     # Group requirements by member
@@ -5780,23 +5813,8 @@ async def _aroute_requirements_to_members_stream(
 
         _, member = route_result
 
-        member_run_output = getattr(reqs[0], "_member_run_response", None)
+        member_run_output = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
         member_run_id = reqs[0].member_run_id if reqs else None
-
-        if member_run_output is None and member_run_id:
-            # Same-process resume: the paused member output is still held on the live team run.
-            if run_response.member_responses:
-                for sibling_response in run_response.member_responses:
-                    if getattr(sibling_response, "run_id", None) == member_run_id:
-                        member_run_output = sibling_response
-                        break
-            # After process restart: member_responses is empty (it's only assembled at runtime),
-            # so fall back to the team session's sibling runs persisted in the DB.
-            if member_run_output is None and session is not None and session.runs:
-                for session_run in session.runs:
-                    if getattr(session_run, "run_id", None) == member_run_id:
-                        member_run_output = session_run  # type: ignore[assignment]
-                        break
 
         member_run_id = getattr(member_run_output, "run_id", None) if member_run_output is not None else member_run_id
         if member_run_id and run_response.run_id is not None:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -8341,26 +8341,38 @@ async def _acontinue_run_background_stream(
                 elif producer_error is not None:
                     final_status = RunStatus.error
                 else:
-                    # The run that actually executed. final_output covers the
-                    # run_id-only path, where run_response stays None; a re-pause
-                    # or cancellation must not be advertised as completed. A
-                    # fork or regenerate produces a run with a DIFFERENT id;
-                    # its status must not land under this run's key.
-                    produced_status = (
-                        final_output.status
-                        if final_output is not None and getattr(final_output, "run_id", None) == _run_id
-                        else None
-                    )
-                    if produced_status is None and run_response is not None:
-                        produced_status = run_response.status
-                    if isinstance(produced_status, RunStatus) and produced_status in (
-                        RunStatus.paused,
-                        RunStatus.cancelled,
-                        RunStatus.error,
-                    ):
-                        final_status = produced_status
+                    if fork or regenerate:
+                        # The executed run carries a DIFFERENT id; this key
+                        # keeps the original run's own stored status, never the
+                        # fork's status and never the caller object's.
+                        if isinstance(status_before_takeover, RunStatus) and status_before_takeover in (
+                            RunStatus.paused,
+                            RunStatus.cancelled,
+                            RunStatus.error,
+                        ):
+                            final_status = status_before_takeover
+                        else:
+                            final_status = RunStatus.completed
                     else:
-                        final_status = RunStatus.completed
+                        # The run that actually executed. final_output covers
+                        # the run_id-only path, where run_response stays None;
+                        # a re-pause or cancellation must not be advertised as
+                        # completed.
+                        produced_status = (
+                            final_output.status
+                            if final_output is not None and getattr(final_output, "run_id", None) == _run_id
+                            else None
+                        )
+                        if produced_status is None and run_response is not None:
+                            produced_status = run_response.status
+                        if isinstance(produced_status, RunStatus) and produced_status in (
+                            RunStatus.paused,
+                            RunStatus.cancelled,
+                            RunStatus.error,
+                        ):
+                            final_status = produced_status
+                        else:
+                            final_status = RunStatus.completed
                 event_buffer.set_run_completed(_run_id, final_status)
             except Exception:
                 log_warning(f"Failed to mark continue-run {_run_id} as completed in event buffer")

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -7063,14 +7063,13 @@ def continue_run_dispatch(
 
             try:
                 check_and_apply_approval_resolution(team.db, run_id_resolved, run_response)
-            except RuntimeError:
+            except RuntimeError as e:
                 run_response.requirements = old_requirements
                 run_response.tools = old_tools
                 _restore_requirement_decisions(decisions)
-                raise ValueError(
-                    "To continue a run from a given run_id, the requirements parameter must be provided "
-                    "(or resolve an admin approval first)."
-                )
+                # The payload was supplied; the approval gate is what refused.
+                # Surface its reason instead of asking for a payload again.
+                raise ValueError(str(e))
     elif run_response.tools:
         from agno.run.approval import check_and_apply_approval_resolution
 
@@ -8241,10 +8240,8 @@ async def _acontinue_run_background_stream(
                             await _aread_session(team, session_id=session_id, user_id=user_id),
                         )
                         if fresh_session is None:
-                            # The read failed. Restoring into the step-1 session
-                            # trades a rare clobber of a concurrent write for a
-                            # guaranteed restore; a run left RUNNING can never
-                            # be resumed.
+                            # The read failed. The restore lands in the step-1
+                            # session: a run left RUNNING can never be resumed.
                             run_response.status = cast(RunStatus, restore_status)
                             team_session.upsert_run(run_response=run_response)
                             await asave_session(team, session=team_session)
@@ -8695,14 +8692,13 @@ async def _acontinue_run(
                                 await acheck_and_apply_approval_resolution(
                                     team.db, run_response.run_id or run_id or "", run_response
                                 )
-                            except RuntimeError:
+                            except RuntimeError as e:
                                 run_response.requirements = old_requirements
                                 run_response.tools = old_tools
                                 _restore_requirement_decisions(decisions)
-                                raise ValueError(
-                                    "To continue a run from a given run_id, the requirements parameter must be "
-                                    "provided (or resolve an admin approval first)."
-                                )
+                                # The payload was supplied; the approval gate is
+                                # what refused. Surface its reason.
+                                raise ValueError(str(e))
                 elif run_response.tools:
                     from agno.run.approval import acheck_and_apply_approval_resolution
 
@@ -9165,14 +9161,13 @@ async def _acontinue_run_stream(
                                 await acheck_and_apply_approval_resolution(
                                     team.db, run_response.run_id or run_id or "", run_response
                                 )
-                            except RuntimeError:
+                            except RuntimeError as e:
                                 run_response.requirements = old_requirements
                                 run_response.tools = old_tools
                                 _restore_requirement_decisions(decisions)
-                                raise ValueError(
-                                    "To continue a run from a given run_id, the requirements parameter must be "
-                                    "provided (or resolve an admin approval first)."
-                                )
+                                # The payload was supplied; the approval gate is
+                                # what refused. Surface its reason.
+                                raise ValueError(str(e))
                 elif run_response.tools:
                     from agno.run.approval import acheck_and_apply_approval_resolution
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -8075,6 +8075,30 @@ async def _acontinue_run_background_stream(
         from agno.os.managers import event_buffer, sse_subscriber_manager
         from agno.os.utils import format_sse_event_with_index
 
+        producer_error: Optional[BaseException] = None
+
+        async def _dispatch_sse(event: Any) -> None:
+            """Buffer an event, hand it to the original client, and fan it out."""
+            event_index: Optional[int] = None
+            try:
+                event_index = event_buffer.add_event(_run_id, event)
+            except Exception:
+                log_warning(f"Failed to buffer event for continue-run {_run_id}")
+
+            sse_data = format_sse_event_with_index(event, event_index=event_index, run_id=_run_id)
+
+            try:
+                await sse_queue.put(sse_data)
+            except Exception:
+                log_warning(f"Failed to push SSE data to queue for continue-run {_run_id}")
+
+            try:
+                await sse_subscriber_manager.publish(
+                    _run_id, event_index if event_index is not None else -1, sse_data
+                )
+            except Exception:
+                log_warning(f"Failed to publish SSE data to subscribers for continue-run {_run_id}")
+
         try:
             async for event in _acontinue_run_stream(
                 team,
@@ -8100,43 +8124,61 @@ async def _acontinue_run_background_stream(
                 if isinstance(event, TeamRunOutput):
                     continue
 
-                # Buffer event for reconnection support
-                event_index: Optional[int] = None
+                await _dispatch_sse(event)
+
+        except Exception as e:
+            producer_error = e
+            refused = isinstance(e, RunNotContinuableError)
+            if refused:
+                # A refusal is an answer, not a crash. The continue was rejected
+                # precisely so the run would stay paused and resumable, so its
+                # status has to survive: persisting ERROR here would strand the
+                # pause the refusal just protected.
+                #
+                # Step 1 above persisted RUNNING before the producer started, so
+                # putting the pause back is what leaves the run resumable —
+                # otherwise it stays advertised as in-flight for good and no
+                # later continue can pick it up.
+                log_info(f"Background continue-run stream {_run_id} refused the continue: {e}")
                 try:
-                    event_index = event_buffer.add_event(_run_id, event)
+                    if run_response is not None:
+                        run_response.status = RunStatus.paused
+                        team_session.upsert_run(run_response=run_response)
+                        await asave_session(team, session=team_session)
                 except Exception:
-                    log_warning(f"Failed to buffer event for continue-run {_run_id}")
-
-                # Format as SSE
-                sse_data = format_sse_event_with_index(event, event_index=event_index, run_id=_run_id)
-
-                # Push to primary queue (original client)
-                try:
-                    await sse_queue.put(sse_data)
-                except Exception:
-                    log_warning(f"Failed to push SSE data to queue for continue-run {_run_id}")
-
-                # Publish to SSE subscribers (resumed clients)
-                try:
-                    await sse_subscriber_manager.publish(
-                        _run_id, event_index if event_index is not None else -1, sse_data
+                    log_error(
+                        f"Failed to restore paused state for background continue-run stream {_run_id}",
+                        exc_info=True,
                     )
+            else:
+                log_error(f"Background continue-run stream {_run_id} failed", exc_info=True)
+                # Persist ERROR status
+                try:
+                    if run_response is not None:
+                        run_response.status = RunStatus.error
+                        team_session.upsert_run(run_response=run_response)
+                        await asave_session(team, session=team_session)
                 except Exception:
-                    log_warning(f"Failed to publish SSE data to subscribers for continue-run {_run_id}")
+                    log_error(
+                        f"Failed to persist error state for background continue-run stream {_run_id}",
+                        exc_info=True,
+                    )
 
-        except Exception:
-            log_error(f"Background continue-run stream {_run_id} failed", exc_info=True)
-            # Persist ERROR status
+            # Tell the client. Without this the producer dies inside its detached
+            # task and the caller is left holding a 200 with an empty body — for a
+            # refusal, the single most misleading outcome available, since the
+            # request it refused looks like the one that worked.
             try:
-                if run_response is not None:
-                    run_response.status = RunStatus.error
-                    team_session.upsert_run(run_response=run_response)
-                    await asave_session(team, session=team_session)
-            except Exception:
-                log_error(
-                    f"Failed to persist error state for background continue-run stream {_run_id}",
-                    exc_info=True,
+                error_source = run_response
+                if error_source is None:
+                    error_source = TeamRunOutput(
+                        run_id=_run_id, session_id=session_id, team_id=team.id, team_name=team.name
+                    )
+                await _dispatch_sse(
+                    create_team_run_error_event(error_source, error=str(e), error_type=error_type_of(e))
                 )
+            except Exception:
+                log_warning(f"Failed to emit error event for continue-run {_run_id}")
 
         finally:
             # Signal primary queue FIRST — unblocks the original client
@@ -8145,9 +8187,16 @@ async def _acontinue_run_background_stream(
             except Exception:
                 log_warning(f"Failed to signal primary queue for continue-run {_run_id} completion")
 
-            # Mark run completed in event buffer
+            # Mark the run's terminal state in the event buffer. A producer that
+            # raised never reached one, so its status is whatever the failure
+            # left behind — not completed.
             try:
-                final_status = (run_response.status if run_response else None) or RunStatus.completed
+                if isinstance(producer_error, RunNotContinuableError):
+                    final_status = RunStatus.paused
+                elif producer_error is not None:
+                    final_status = RunStatus.error
+                else:
+                    final_status = (run_response.status if run_response else None) or RunStatus.completed
                 event_buffer.set_run_completed(_run_id, final_status)
             except Exception:
                 log_warning(f"Failed to mark continue-run {_run_id} as completed in event buffer")

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -8100,7 +8100,21 @@ async def _acontinue_run_background_stream(
     team_session = await _aread_or_create_session(team, session_id=session_id, user_id=user_id)
     _update_metadata(team, session=team_session)
 
+    stored_run = next((r for r in team_session.runs or [] if getattr(r, "run_id", None) == _run_id), None)
+    status_before_takeover = getattr(stored_run, "status", None)
+
     if run_response is not None:
+        # A caller-held run object outlives the run it describes. If it still
+        # reads as paused while the stored run has finished, someone else
+        # continued this run in between and the object is stale: writing it back
+        # would republish a finished run as a pending approval, and its gated
+        # tool could then be approved a second time. Nothing downstream can undo
+        # that, so refuse before the run is touched.
+        if status_before_takeover == RunStatus.completed and getattr(run_response, "is_paused", False):
+            raise RunNotContinuableError(
+                f"Cannot continue run {_run_id}: it has already completed, but the run_response passed in "
+                f"still reads as paused. Re-read the run before continuing it. The stored run is unchanged."
+            )
         run_response.status = RunStatus.running
         team_session.upsert_run(run_response=run_response)
     await asave_session(team, session=team_session)
@@ -8179,13 +8193,17 @@ async def _acontinue_run_background_stream(
                 # later continue can pick it up.
                 log_info(f"Background continue-run stream {_run_id} refused the continue: {e}")
                 try:
-                    if run_response is not None:
-                        run_response.status = RunStatus.paused
+                    # Put back exactly what step 1 overwrote. Restoring a blanket
+                    # PAUSED instead would hand a resumable pause to any run that
+                    # had not been paused to begin with, and a pause is an
+                    # invitation to approve its gated tool.
+                    if run_response is not None and status_before_takeover is not None:
+                        run_response.status = status_before_takeover
                         team_session.upsert_run(run_response=run_response)
                         await asave_session(team, session=team_session)
                 except Exception:
                     log_error(
-                        f"Failed to restore paused state for background continue-run stream {_run_id}",
+                        f"Failed to restore the pre-continue state for background continue-run stream {_run_id}",
                         exc_info=True,
                     )
             else:
@@ -8230,7 +8248,10 @@ async def _acontinue_run_background_stream(
             # left behind — not completed.
             try:
                 if isinstance(producer_error, RunNotContinuableError):
-                    final_status = RunStatus.paused
+                    # A refusal leaves the run as it was, whatever that was.
+                    # Advertising a blanket PAUSED would tell every reconnecting
+                    # client that a cancelled run is awaiting an approval.
+                    final_status = status_before_takeover or RunStatus.paused
                 elif producer_error is not None:
                     final_status = RunStatus.error
                 else:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -4456,11 +4456,8 @@ def _cleanup_and_store(
     # Add scrubbed RunOutput to Team Session
     session.upsert_run(run_response=storage_copy)
 
-    # Calculate session metrics. A paused run is not terminal: its metrics
-    # accumulate once, on the save after it completes — accumulating here too
-    # would count the pre-pause tokens twice when the run is resumed.
-    if run_response.status != RunStatus.paused:
-        update_session_metrics(team, session=session, run_response=run_response)
+    # Calculate session metrics (each run counted once, when it is final)
+    update_session_metrics(team, session=session, run_response=run_response)
 
     # Update session state before saving the session
     if run_context is not None and run_context.session_state is not None:
@@ -4508,11 +4505,8 @@ async def _acleanup_and_store(
     # Add scrubbed RunOutput to Team Session
     session.upsert_run(run_response=storage_copy)
 
-    # Calculate session metrics. A paused run is not terminal: its metrics
-    # accumulate once, on the save after it completes — accumulating here too
-    # would count the pre-pause tokens twice when the run is resumed.
-    if run_response.status != RunStatus.paused:
-        update_session_metrics(team, session=session, run_response=run_response)
+    # Calculate session metrics (each run counted once, when it is final)
+    update_session_metrics(team, session=session, run_response=run_response)
 
     # Update session state before saving the session
     if run_context is not None and run_context.session_state is not None:
@@ -5481,43 +5475,60 @@ def _resolve_member_run_output_for_continue(
     return member_run_output
 
 
-def _group_requirements_by_routed_member(
+def _group_requirements_for_continue(
     team: "Team",
     run_response: TeamRunOutput,
+    session: TeamSession,
     run_context: Optional[RunContext],
-) -> Tuple[List[Tuple[Union["Agent", "Team"], List["RunRequirement"]]], List[str]]:
-    """Group HITL requirements by the direct member that will continue them.
+) -> Tuple[
+    List[Tuple[Union["Agent", "Team"], Optional[Union[RunOutput, TeamRunOutput]], List["RunRequirement"]]], List[str]
+]:
+    """Group HITL requirements by the paused run that will continue them.
 
-    Requirements are keyed by the deep member's agent id, and several deep
-    members can live inside the same sub-team. That sub-team must receive ALL
-    of their requirements in one continue_run call — its own dispatch routes
-    them deeper. One call per requirement group would hand the second group an
-    already-completed sub-team run and drop its confirmations.
+    Requirements are keyed by (deep member agent id, deep member run id) and
+    resolved to their target run up front. Groups whose requirements resolve
+    to the SAME sub-team run are merged into one continue_run call — that
+    run's own dispatch routes them deeper; a second call on the same run
+    would hit an already-completed run and drop its confirmations. Groups
+    that resolve to DIFFERENT runs of the same sub-team (the leader delegated
+    to it more than once in one turn) stay separate — merging them would
+    strand every run but the first.
 
-    Returns (groups, unroutable_messages).
+    Returns (entries, unroutable_messages) where each entry is
+    (routed_member, resolved_target_run_or_None, requirements).
     """
     from agno.team._tools import _find_member_route_by_id
 
-    member_reqs: Dict[str, List["RunRequirement"]] = {}
+    member_reqs: Dict[Tuple[str, Optional[str]], List["RunRequirement"]] = {}
     for req in run_response.requirements or []:
         mid = getattr(req, "member_agent_id", None)
         if mid is not None:
-            member_reqs.setdefault(mid, []).append(req)
+            member_reqs.setdefault((mid, getattr(req, "member_run_id", None)), []).append(req)
 
-    groups: Dict[int, Tuple[Union["Agent", "Team"], List["RunRequirement"]]] = {}
+    entries: List[Tuple[Union["Agent", "Team"], Optional[Union[RunOutput, TeamRunOutput]], List["RunRequirement"]]] = []
     unroutable: List[str] = []
-    for member_id, reqs in member_reqs.items():
+    for (member_id, _), reqs in member_reqs.items():
         route_result = _find_member_route_by_id(team, member_id, run_context=run_context)
         if route_result is None:
             log_warning(f"Could not find member with ID {member_id} for continue_run routing")
             unroutable.append(f"[{member_id}]: Could not route requirement — member not found")
             continue
-        route_index, member = route_result
-        if route_index in groups:
-            groups[route_index][1].extend(reqs)
-        else:
-            groups[route_index] = (member, list(reqs))
-    return list(groups.values()), unroutable
+        _, member = route_result
+        target = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
+        merged = False
+        if target is not None:
+            for existing_member, existing_target, existing_reqs in entries:
+                if (
+                    existing_member is member
+                    and existing_target is not None
+                    and (existing_target is target or existing_target.run_id == target.run_id)
+                ):
+                    existing_reqs.extend(reqs)
+                    merged = True
+                    break
+        if not merged:
+            entries.append((member, target, list(reqs)))
+    return entries, unroutable
 
 
 def _route_requirements_to_members(
@@ -5536,14 +5547,11 @@ def _route_requirements_to_members(
     """
     from agno.utils.team import get_member_id
 
-    groups, unroutable = _group_requirements_by_routed_member(team, run_response, run_context)
+    groups, unroutable = _group_requirements_for_continue(team, run_response, session, run_context)
     member_results: List[str] = list(unroutable)
 
-    for member, reqs in groups:
+    for member, member_run_output, reqs in groups:
         member_id = get_member_id(member) or ""
-
-        # Get the member's paused run output — see _resolve_member_run_output_for_continue.
-        member_run_output = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
         member_run_id = reqs[0].member_run_id if reqs else None
 
         member_run_id = getattr(member_run_output, "run_id", None) if member_run_output is not None else member_run_id
@@ -5622,13 +5630,11 @@ def _route_requirements_to_members_stream(
     """
     from agno.utils.team import get_member_id
 
-    groups, unroutable = _group_requirements_by_routed_member(team, run_response, run_context)
+    groups, unroutable = _group_requirements_for_continue(team, run_response, session, run_context)
     member_results.extend(unroutable)
 
-    for member, reqs in groups:
+    for member, member_run_output, reqs in groups:
         member_id = get_member_id(member) or ""
-
-        member_run_output = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
         member_run_id = reqs[0].member_run_id if reqs else None
 
         member_run_id = getattr(member_run_output, "run_id", None) if member_run_output is not None else member_run_id
@@ -5721,14 +5727,17 @@ async def _aroute_requirements_to_members(
     """
     from agno.utils.team import get_member_id
 
-    groups, unroutable = _group_requirements_by_routed_member(team, run_response, run_context)
+    groups, unroutable = _group_requirements_for_continue(team, run_response, session, run_context)
 
     if not groups:
         return unroutable
 
-    async def _continue_member(member: Union["Agent", "Team"], reqs: List["RunRequirement"]) -> Optional[str]:
+    async def _continue_member(
+        member: Union["Agent", "Team"],
+        member_run_output: Optional[Union[RunOutput, TeamRunOutput]],
+        reqs: List["RunRequirement"],
+    ) -> Optional[str]:
         member_id = get_member_id(member) or ""
-        member_run_output = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
         member_run_id = reqs[0].member_run_id if reqs else None
 
         member_run_id = getattr(member_run_output, "run_id", None) if member_run_output is not None else member_run_id
@@ -5778,7 +5787,7 @@ async def _aroute_requirements_to_members(
             content = getattr(member_response, "content", None) or "Task completed"
             return f"[{member.name or member_id}]: {content}"
 
-    tasks = [_continue_member(member, reqs) for member, reqs in groups]
+    tasks = [_continue_member(member, member_run_output, reqs) for member, member_run_output, reqs in groups]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     member_results: List[str] = list(unroutable)
@@ -5817,13 +5826,11 @@ async def _aroute_requirements_to_members_stream(
     """
     from agno.utils.team import get_member_id
 
-    groups, unroutable = _group_requirements_by_routed_member(team, run_response, run_context)
+    groups, unroutable = _group_requirements_for_continue(team, run_response, session, run_context)
     member_results.extend(unroutable)
 
-    for member, reqs in groups:
+    for member, member_run_output, reqs in groups:
         member_id = get_member_id(member) or ""
-
-        member_run_output = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
         member_run_id = reqs[0].member_run_id if reqs else None
 
         member_run_id = getattr(member_run_output, "run_id", None) if member_run_output is not None else member_run_id

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -7063,6 +7063,38 @@ def continue_run_dispatch(
     has_member = _has_member_requirements(run_response.requirements or [])
     has_team_level = _has_team_level_requirements(run_response.requirements or [])
 
+    # Guard: a member requirement the client left unresolved has to re-pause,
+    # not dispatch. Routing hands it to the member's continue_run, which reads
+    # the pause as settled and runs the gated tool with whatever the schema
+    # holds -- for a requested field left untouched, with None. The team-level
+    # lane already re-pauses on its own unresolved requirements; a requirement
+    # addressed to a member is no less unresolved for being addressed to one.
+    unresolved_member = [
+        r
+        for r in (run_response.requirements or [])
+        if getattr(r, "member_agent_id", None) is not None and not r.is_resolved()
+    ]
+    if unresolved_member:
+        from agno.team import _hooks
+
+        if opts.stream:
+
+            def _member_paused_stream_with_final() -> Iterator[
+                Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]
+            ]:
+                yield from _hooks.handle_team_run_paused_stream(
+                    team, run_response=run_response, session=team_session, run_context=run_context
+                )
+                if opts.yield_run_output:
+                    yield run_response
+
+            return _member_paused_stream_with_final()
+        else:
+            return _hooks.handle_team_run_paused(
+                team, run_response=run_response, session=team_session, run_context=run_context
+            )
+
+
     # Route member requirements to member agents
     member_results: List[str] = []
     if has_member:
@@ -8492,6 +8524,25 @@ async def _acontinue_run(
                 has_member = _has_member_requirements(run_response.requirements or [])
                 has_team_level = _has_team_level_requirements(run_response.requirements or [])
 
+                # Guard: a member requirement the client left unresolved has to re-pause,
+                # not dispatch. Routing hands it to the member's continue_run, which reads
+                # the pause as settled and runs the gated tool with whatever the schema
+                # holds -- for a requested field left untouched, with None. The team-level
+                # lane already re-pauses on its own unresolved requirements; a requirement
+                # addressed to a member is no less unresolved for being addressed to one.
+                unresolved_member = [
+                    r
+                    for r in (run_response.requirements or [])
+                    if getattr(r, "member_agent_id", None) is not None and not r.is_resolved()
+                ]
+                if unresolved_member:
+                    from agno.team import _hooks
+
+                    return await _hooks.ahandle_team_run_paused(
+                        team, run_response=run_response, session=team_session, run_context=run_context
+                    )
+
+
                 # Route member requirements
                 member_results: List[str] = list(routed_member_results)
                 if has_member:
@@ -8932,6 +8983,29 @@ async def _acontinue_run_stream(
                 )
                 has_member = _has_member_requirements(run_response.requirements or [])
                 has_team_level = _has_team_level_requirements(run_response.requirements or [])
+
+                # Guard: a member requirement the client left unresolved has to re-pause,
+                # not dispatch. Routing hands it to the member's continue_run, which reads
+                # the pause as settled and runs the gated tool with whatever the schema
+                # holds -- for a requested field left untouched, with None. The team-level
+                # lane already re-pauses on its own unresolved requirements; a requirement
+                # addressed to a member is no less unresolved for being addressed to one.
+                unresolved_member = [
+                    r
+                    for r in (run_response.requirements or [])
+                    if getattr(r, "member_agent_id", None) is not None and not r.is_resolved()
+                ]
+                if unresolved_member:
+                    from agno.team import _hooks
+
+                    async for item in _hooks.ahandle_team_run_paused_stream(
+                        team, run_response=run_response, session=team_session, run_context=run_context
+                    ):
+                        yield item
+                    if yield_run_output:
+                        yield run_response
+                    return
+
 
                 # Route member requirements. The routing generator appends into
                 # this list in place, so seeding it with the banked results

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5412,9 +5412,8 @@ def _resolve_member_run_output_for_continue(
     is the sub-team's paused TeamRunOutput (the sub-team's own continue_run
     routes deeper from there). Sources, in order:
 
-    1. The ``_member_run_response`` reference stored by _propagate_member_pause
-       (avoids a session/DB lookup, which fails without a database since
-       initialize_team clears the cached session). The reference is validated
+    1. The ``_member_run_response`` reference stored by _propagate_member_pause,
+       which resolves without a session or DB lookup. The reference is validated
        by IDENTITY against the routed member: each propagation level points it
        at the run that surfaced the pause AT that level, so below the top level
        it references an ancestor team run, not the routed member's run. An

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5479,9 +5479,7 @@ def _group_requirements_for_continue(
     run_response: TeamRunOutput,
     session: TeamSession,
     run_context: Optional[RunContext],
-) -> Tuple[
-    List[Tuple[Union["Agent", "Team"], Optional[Union[RunOutput, TeamRunOutput]], List["RunRequirement"]]], List[str]
-]:
+) -> List[Tuple[Union["Agent", "Team"], Optional[Union[RunOutput, TeamRunOutput]], List["RunRequirement"]]]:
     """Group HITL requirements by the paused run that will continue them.
 
     Requirements are keyed by (deep member agent id, deep member run id) and
@@ -5493,8 +5491,11 @@ def _group_requirements_for_continue(
     to it more than once in one turn) stay separate — merging them would
     strand every run but the first.
 
-    Returns (entries, unroutable_messages) where each entry is
-    (routed_member, resolved_target_run_or_None, requirements).
+    Raises RunNotContinuableError if a requirement routes to a member id
+    that is not in the team: the run stays paused and resumable instead of
+    completing with the approved tool silently skipped.
+
+    Returns entries of (routed_member, resolved_target_run_or_None, requirements).
     """
     from agno.team._tools import _find_member_route_by_id
 
@@ -5505,13 +5506,14 @@ def _group_requirements_for_continue(
             member_reqs.setdefault((mid, getattr(req, "member_run_id", None)), []).append(req)
 
     entries: List[Tuple[Union["Agent", "Team"], Optional[Union[RunOutput, TeamRunOutput]], List["RunRequirement"]]] = []
-    unroutable: List[str] = []
     for (member_id, _), reqs in member_reqs.items():
         route_result = _find_member_route_by_id(team, member_id, run_context=run_context)
         if route_result is None:
-            log_warning(f"Could not find member with ID {member_id} for continue_run routing")
-            unroutable.append(f"[{member_id}]: Could not route requirement — member not found")
-            continue
+            raise RunNotContinuableError(
+                f"Cannot continue run {run_response.run_id}: requirement routes to member "
+                f"'{member_id}', which is not a member of team '{team.name or team.id}'. "
+                f"The run remains paused."
+            )
         _, member = route_result
         target = _resolve_member_run_output_for_continue(member, reqs, run_response, session)
         merged = False
@@ -5527,7 +5529,7 @@ def _group_requirements_for_continue(
                     break
         if not merged:
             entries.append((member, target, list(reqs)))
-    return entries, unroutable
+    return entries
 
 
 def _route_requirements_to_members(
@@ -5546,8 +5548,8 @@ def _route_requirements_to_members(
     """
     from agno.utils.team import get_member_id
 
-    groups, unroutable = _group_requirements_for_continue(team, run_response, session, run_context)
-    member_results: List[str] = list(unroutable)
+    groups = _group_requirements_for_continue(team, run_response, session, run_context)
+    member_results: List[str] = []
 
     for member, member_run_output, reqs in groups:
         member_id = get_member_id(member) or ""
@@ -5629,8 +5631,7 @@ def _route_requirements_to_members_stream(
     """
     from agno.utils.team import get_member_id
 
-    groups, unroutable = _group_requirements_for_continue(team, run_response, session, run_context)
-    member_results.extend(unroutable)
+    groups = _group_requirements_for_continue(team, run_response, session, run_context)
 
     for member, member_run_output, reqs in groups:
         member_id = get_member_id(member) or ""
@@ -5726,10 +5727,10 @@ async def _aroute_requirements_to_members(
     """
     from agno.utils.team import get_member_id
 
-    groups, unroutable = _group_requirements_for_continue(team, run_response, session, run_context)
+    groups = _group_requirements_for_continue(team, run_response, session, run_context)
 
     if not groups:
-        return unroutable
+        return []
 
     async def _continue_member(
         member: Union["Agent", "Team"],
@@ -5789,8 +5790,13 @@ async def _aroute_requirements_to_members(
     tasks = [_continue_member(member, member_run_output, reqs) for member, member_run_output, reqs in groups]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
-    member_results: List[str] = list(unroutable)
+    member_results: List[str] = []
     for r in results:
+        if isinstance(r, RunNotContinuableError):
+            # A member (e.g. a sub-team) refused the continue outright; the
+            # paused state is intact, so surface it instead of completing
+            # the team run without the approved tool.
+            raise r
         if isinstance(r, BaseException):
             log_warning(f"Member continue_run failed: {r}")
         elif isinstance(r, str):
@@ -5825,8 +5831,7 @@ async def _aroute_requirements_to_members_stream(
     """
     from agno.utils.team import get_member_id
 
-    groups, unroutable = _group_requirements_for_continue(team, run_response, session, run_context)
-    member_results.extend(unroutable)
+    groups = _group_requirements_for_continue(team, run_response, session, run_context)
 
     for member, member_run_output, reqs in groups:
         member_id = get_member_id(member) or ""
@@ -6763,9 +6768,15 @@ def continue_run_dispatch(
             from agno.team import _hooks
 
             if opts.stream:
-                return _hooks.handle_team_run_paused_stream(
-                    team, run_response=run_response, session=team_session, run_context=run_context
-                )  # type: ignore
+
+                def _paused_stream_with_final() -> Iterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]:
+                    yield from _hooks.handle_team_run_paused_stream(
+                        team, run_response=run_response, session=team_session, run_context=run_context
+                    )
+                    if opts.yield_run_output:
+                        yield run_response
+
+                return _paused_stream_with_final()
             else:
                 return _hooks.handle_team_run_paused(
                     team, run_response=run_response, session=team_session, run_context=run_context
@@ -6979,6 +6990,8 @@ def _continue_run_dispatch_stream_with_member_events(
         yield from _hooks.handle_team_run_paused_stream(
             team, run_response=run_response, session=team_session, run_context=run_context
         )
+        if opts.yield_run_output:
+            yield run_response
         return
 
     # Phase 3: Continue the team run with member results
@@ -6994,6 +7007,8 @@ def _continue_run_dispatch_stream_with_member_events(
             yield from _hooks.handle_team_run_paused_stream(
                 team, run_response=run_response, session=team_session, run_context=run_context
             )
+            if opts.yield_run_output:
+                yield run_response
             return
 
         response_format = get_response_format(team, run_context=run_context) if team.parser_model is None else None

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5411,16 +5411,27 @@ def _merge_requirement_decision(stored: Any, wire: Any) -> None:
                 stored_te.answered = True
             elif feedback_was_open and not feedback_open_now:
                 stored_te.answered = True
-            elif getattr(wire_te, "answered", None) is not None and not input_open_now and not feedback_open_now:
+            elif getattr(wire_te, "answered", None) is True and not input_open_now and not feedback_open_now:
                 # A schema the model prefilled completely was never open, so
                 # the fill-based inference above can never fire for it. The
                 # client's explicit flag is the accept gesture for such a
                 # pause; without honoring it the run could never resume. A
                 # still-open field keeps the flag ignored — answering is the
                 # schema's job, not the flag's.
+                #
+                # Only True is a gesture. Writing a wire False would close the
+                # `answered is None` guard above for good, and nothing ever
+                # re-opens it: the pause would stay unresumable for the rest of
+                # the session, with no way for the client to recover.
                 stored_te.answered = wire_te.answered
-        if getattr(stored_te, "external_execution_required", None) and getattr(wire_te, "result", None) is not None:
-            stored_te.result = wire_te.result
+        if getattr(stored_te, "external_execution_required", None):
+            if getattr(wire_te, "result", None) is not None:
+                stored_te.result = wire_te.result
+            # The result and the flag that says it is a failure travel together:
+            # binding the result alone rebinds a frontend's reported error as a
+            # success, and the tool message renders it as one.
+            if getattr(wire_te, "tool_call_error", None) is not None:
+                stored_te.tool_call_error = wire_te.tool_call_error
     if (
         stored_te is not None
         and getattr(stored_te, "external_execution_required", None)
@@ -5550,7 +5561,7 @@ def _backfill_approval_to_requirements(
 
 
 _REQUIREMENT_DECISION_FIELDS = ("confirmation", "confirmation_note", "external_execution_result")
-_TOOL_EXECUTION_DECISION_FIELDS = ("confirmed", "confirmation_note", "answered", "result")
+_TOOL_EXECUTION_DECISION_FIELDS = ("confirmed", "confirmation_note", "answered", "result", "tool_call_error")
 
 
 def _requirement_decision_slots(requirements: Optional[List[Any]]) -> Iterator[Tuple[Any, str]]:

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -8,10 +8,12 @@ from typing import (
     Dict,
     List,
     Optional,
+    Union,
     cast,
 )
 
 if TYPE_CHECKING:
+    from agno.run.agent import RunOutput
     from agno.team.team import Team
 
 from agno.db.base import SessionType
@@ -173,6 +175,18 @@ async def aget_session(
     return None
 
 
+def _scrub_member_responses_keeping_paused(run: Union[TeamRunOutput, "RunOutput"]) -> None:
+    """Remove member responses at every nesting level, sparing paused ones: a
+    paused member run is the resume state for continue_run after a session
+    reload, and the save after it completes scrubs it. Completed responses
+    inside a spared paused sub-team run are removed too."""
+    spared = [m for m in (getattr(run, "member_responses", None) or []) if getattr(m, "is_paused", False)]
+    run.member_responses = spared  # type: ignore[union-attr]
+    for member_response in spared:
+        if hasattr(member_response, "member_responses"):
+            _scrub_member_responses_keeping_paused(member_response)
+
+
 def save_session(team: "Team", session: TeamSession) -> None:
     """
     Save the TeamSession to storage
@@ -198,12 +212,7 @@ def save_session(team: "Team", session: TeamSession) -> None:
             for run in session.runs:
                 if hasattr(run, "member_responses"):
                     if not team.store_member_responses:
-                        # Remove member responses, sparing paused ones: a paused
-                        # member run is the resume state for continue_run after a
-                        # session reload, and the save after it completes scrubs it.
-                        run.member_responses = [
-                            m for m in (run.member_responses or []) if getattr(m, "is_paused", False)
-                        ]
+                        _scrub_member_responses_keeping_paused(run)
                     else:
                         # Scrub individual member responses based on their storage flags
                         _scrub_member_responses(team, run.member_responses)
@@ -233,12 +242,7 @@ async def asave_session(team: "Team", session: TeamSession) -> None:
             for run in session.runs:
                 if hasattr(run, "member_responses"):
                     if not team.store_member_responses:
-                        # Remove member responses, sparing paused ones: a paused
-                        # member run is the resume state for continue_run after a
-                        # session reload, and the save after it completes scrubs it.
-                        run.member_responses = [
-                            m for m in (run.member_responses or []) if getattr(m, "is_paused", False)
-                        ]
+                        _scrub_member_responses_keeping_paused(run)
                     else:
                         # Scrub individual member responses based on their storage flags
                         _scrub_member_responses(team, run.member_responses)

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -189,12 +189,12 @@ def _scrub_tool_results_keeping_unresolved(run: Union[TeamRunOutput, "RunOutput"
 
     if not run.messages:
         return
-    resolved = {message.tool_call_id for message in run.messages if message.role == "tool" and message.tool_call_id}
-    if not resolved:
+    if not any(message.role == "tool" for message in run.messages):
         return
+    resolved = {message.tool_call_id for message in run.messages if message.role == "tool" and message.tool_call_id}
     kept = []
     for message in run.messages:
-        if message.role == "tool" and message.tool_call_id in resolved:
+        if message.role == "tool":
             continue
         if message.role == "assistant" and message.tool_calls:
             remaining = [call for call in message.tool_calls if call.get("id") not in resolved]
@@ -273,7 +273,15 @@ def _storage_view_of_spared_run(
     if member is None:
         member = _resolve_spared_member(team, member_response)
     if member is None:
-        return member_response
+        # The owning member cannot be resolved (e.g. callable Team.members).
+        # Store the strictest view: every storage flag treated as off, with the
+        # paused-aware tool scrub so the pending call stays resumable.
+        view = copy(member_response)
+        isolate_media_scrub_targets(view)
+        scrub_media_from_run_output(view)
+        _scrub_tool_results_keeping_unresolved(view)
+        scrub_history_messages_from_run_output(view)
+        return view
     if member.store_media and member.store_tool_messages and member.store_history_messages:
         return member_response
 

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
+    from agno.agent import Agent
     from agno.run.agent import RunOutput
     from agno.team.team import Team
 
@@ -206,8 +207,49 @@ def _scrub_tool_results_keeping_unresolved(run: Union[TeamRunOutput, "RunOutput"
     run.messages = kept
 
 
-def _storage_view_of_spared_run(
+def _resolve_spared_member(
     team: "Team", member_response: Union[TeamRunOutput, "RunOutput"]
+) -> Optional[Union["Agent", "Team"]]:
+    """Resolve the member that produced a spared response, by owning path.
+
+    A run's member_responses belong to that team's DIRECT members, so the
+    owner of a spared response is resolved among the direct members of the
+    team level that carries it — never by a global search: sibling sub-teams
+    may hold leaves with the same member id, and a tree-wide first match
+    would apply the other leaf's storage flags. Among direct members an
+    agent response resolves to an Agent and a team response to a Team.
+    Only a response whose id matches no direct member at all (a
+    caller-assembled tree that skips levels) falls back to the global
+    search, which is then no worse than resolving it globally from the
+    root."""
+    from agno.run.agent import RunOutput
+    from agno.team._tools import _find_member_by_id
+    from agno.team.team import Team
+    from agno.utils.team import get_member_id
+
+    member_id = member_response.agent_id if isinstance(member_response, RunOutput) else member_response.team_id
+    if not member_id:
+        return None
+    response_is_team = not isinstance(member_response, RunOutput)
+    # Callable member lists resolve at run time; here (a storage scrub, no run
+    # context) only a plain list can be searched — matching get_resolved_members.
+    members = getattr(team, "members", None)
+    if not isinstance(members, list):
+        members = []
+    direct_matches = [member for member in members if get_member_id(member) == member_id]
+    for member in direct_matches:
+        if isinstance(member, Team) == response_is_team:
+            return member
+    if direct_matches:
+        return direct_matches[0]
+    member_result = _find_member_by_id(team, member_id)
+    return member_result[1] if member_result is not None else None
+
+
+def _storage_view_of_spared_run(
+    team: "Team",
+    member_response: Union[TeamRunOutput, "RunOutput"],
+    member: Optional[Union["Agent", "Team"]] = None,
 ) -> Union[TeamRunOutput, "RunOutput"]:
     """Apply a spared member's own storage flags to a copy of its paused run.
 
@@ -215,24 +257,23 @@ def _storage_view_of_spared_run(
     continue_run can resume it after a reload. That exemption must not also
     carry the member's data past its own store_media / store_tool_messages /
     store_history_messages settings: the delegation path applies them to every
-    member run it persists, and a run spared here is persisted the same way."""
+    member run it persists, and a run spared here is persisted the same way.
+
+    ``member`` is the already-resolved owner when the caller knows it;
+    otherwise it is resolved from ``team``'s direct members
+    (_resolve_spared_member)."""
     from copy import copy
 
-    from agno.run.agent import RunOutput
-    from agno.team._tools import _find_member_by_id
     from agno.utils.agent import (
         isolate_media_scrub_targets,
         scrub_history_messages_from_run_output,
         scrub_media_from_run_output,
     )
 
-    member_id = member_response.agent_id if isinstance(member_response, RunOutput) else member_response.team_id
-    if not member_id:
+    if member is None:
+        member = _resolve_spared_member(team, member_response)
+    if member is None:
         return member_response
-    member_result = _find_member_by_id(team, member_id)
-    if member_result is None:
-        return member_response
-    _, member = member_result
     if member.store_media and member.store_tool_messages and member.store_history_messages:
         return member_response
 
@@ -264,13 +305,21 @@ def _scrub_member_responses_keeping_paused(
     tree the caller holds keeps its member responses and its full messages."""
     from copy import copy
 
+    from agno.team.team import Team
+
     spared = []
     for member_response in getattr(run, "member_responses", None) or []:
         if not getattr(member_response, "is_paused", False):
             continue
-        member_response = _storage_view_of_spared_run(team, member_response)
+        # Resolve the owner at THIS level before recursing: the response tree
+        # mirrors the team tree, and carrying the owning sub-team down keeps a
+        # nested leaf resolving against its own branch — not a sibling's leaf
+        # that shares its id.
+        member = _resolve_spared_member(team, member_response)
+        member_response = _storage_view_of_spared_run(team, member_response, member=member)
         if getattr(member_response, "member_responses", None):
-            member_response = _scrub_member_responses_keeping_paused(team, member_response)
+            owning_team = member if isinstance(member, Team) else team
+            member_response = _scrub_member_responses_keeping_paused(owning_team, member_response)
         spared.append(member_response)
     run = copy(run)
     run.member_responses = spared  # type: ignore[union-attr]

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -530,9 +530,6 @@ async def aget_session_metrics(team: "Team", session_id: Optional[str] = None) -
     return await aget_session_metrics_util(cast(Any, team), session_id=session_id)
 
 
-_FINAL_RUN_STATUSES = frozenset({RunStatus.completed, RunStatus.error, RunStatus.cancelled})
-
-
 def update_session_metrics(team: "Team", session: TeamSession, run_response: TeamRunOutput) -> None:
     """Calculate session metrics and write them to session_data.
 
@@ -540,42 +537,35 @@ def update_session_metrics(team: "Team", session: TeamSession, run_response: Tea
     session-level SessionMetrics (details: List[ModelMetrics]) using
     SessionMetrics.accumulate_from_run().
 
-    Walks the team leader's run and all member responses (recursively for
-    nested teams). Each run is accumulated exactly once, at the first save
-    where it is in a final state; the accumulated run ids persist with the
-    session, so a run saved several times across a pause and its resume
-    contributes its full metrics once. A run that never reaches a final
-    state — an abandoned pause — is not counted.
+    Accumulates metrics from the team leader's own model calls as well as
+    all member agent/team responses (recursively for nested teams).
     """
     from agno.team._storage import get_session_metrics_internal
 
     session_metrics = get_session_metrics_internal(team, session=session)
     if session_metrics is None:
         return
+    if run_response.metrics is not None:
+        session_metrics.accumulate_from_run(run_response.metrics)
 
-    stored_run_ids = (
-        session.session_data.get("session_metrics_run_ids") if isinstance(session.session_data, dict) else None
-    )
-    accumulated_run_ids = set(stored_run_ids) if isinstance(stored_run_ids, list) else set()
-
-    def _accumulate(node: Any) -> None:
-        run_id = getattr(node, "run_id", None)
-        if (
-            getattr(node, "status", None) in _FINAL_RUN_STATUSES
-            and run_id is not None
-            and run_id not in accumulated_run_ids
-        ):
-            accumulated_run_ids.add(run_id)
-            if node.metrics is not None:
-                session_metrics.accumulate_from_run(node.metrics)
-        for member_response in getattr(node, "member_responses", None) or []:
-            _accumulate(member_response)
-
-    _accumulate(run_response)
+    # Accumulate metrics from member responses (agent and nested team runs)
+    _accumulate_member_metrics(session_metrics, run_response.member_responses)
 
     if session.session_data is not None:
         session.session_data["session_metrics"] = session_metrics.to_dict()
-        session.session_data["session_metrics_run_ids"] = sorted(accumulated_run_ids)
+
+
+def _accumulate_member_metrics(
+    session_metrics: SessionMetrics,
+    member_responses: "List",
+) -> None:
+    """Recursively accumulate metrics from member responses into session metrics."""
+    for member_response in member_responses:
+        if member_response.metrics is not None:
+            session_metrics.accumulate_from_run(member_response.metrics)
+        # Recurse into nested team member responses
+        if isinstance(member_response, TeamRunOutput) and member_response.member_responses:
+            _accumulate_member_metrics(session_metrics, member_response.member_responses)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -333,6 +333,8 @@ def save_session(team: "Team", session: TeamSession) -> None:
     Args:
         session: The TeamSession to save.
     """
+    from copy import copy
+
     from agno.team._init import _has_async_db
     from agno.team._run import _scrub_member_responses
     from agno.team._storage import _upsert_session
@@ -347,15 +349,21 @@ def save_session(team: "Team", session: TeamSession) -> None:
             session.session_data["session_state"].pop("current_run_id", None)
 
         # scrub the member responses based on storage settings
-        live_runs = session.runs
+        storage_session = session
         if session.runs is not None:
             if not team.store_member_responses:
-                # Hand the DB a scrubbed view and give the session its live runs
-                # back. Keeping the view would freeze the stored copy of a
-                # paused member run at PAUSED — the resume continues the live
-                # run, so a cached session would advertise a pending approval on
-                # a finished run for good.
-                session.runs = [
+                # Hand the DB a scrubbed view on a session of its own. Storing
+                # the view on the caller's session instead — even briefly —
+                # publishes it to everyone holding that session: with
+                # cache_session the object is shared, so a concurrent
+                # upsert_run would land in the throwaway list and a concurrent
+                # save would capture it as the state to restore. The view is
+                # also only ever a view: keeping it would freeze the stored
+                # copy of a paused member run at PAUSED, and the resume
+                # continues the live run, so a cached session would advertise
+                # a pending approval on a finished run for good.
+                storage_session = copy(session)
+                storage_session.runs = [
                     _scrub_member_responses_keeping_paused(team, run) if hasattr(run, "member_responses") else run
                     for run in session.runs
                 ]
@@ -364,10 +372,7 @@ def save_session(team: "Team", session: TeamSession) -> None:
                     if hasattr(run, "member_responses"):
                         # Scrub individual member responses based on their storage flags
                         _scrub_member_responses(team, run.member_responses)
-        try:
-            _upsert_session(team, session=session)
-        finally:
-            session.runs = live_runs
+        _upsert_session(team, session=storage_session)
         log_debug(f"Created or updated TeamSession record: {session.session_id}")
 
 
@@ -378,6 +383,8 @@ async def asave_session(team: "Team", session: TeamSession) -> None:
     Args:
         session: The TeamSession to save.
     """
+    from copy import copy
+
     from agno.team._init import _has_async_db
     from agno.team._run import _scrub_member_responses
     from agno.team._storage import _aupsert_session, _upsert_session
@@ -389,11 +396,16 @@ async def asave_session(team: "Team", session: TeamSession) -> None:
             session.session_data["session_state"].pop("current_run_id", None)
 
         # scrub the member responses based on storage settings
-        live_runs = session.runs
+        storage_session = session
         if session.runs is not None:
             if not team.store_member_responses:
-                # See save_session: the scrubbed view is for the DB write only.
-                session.runs = [
+                # See save_session: the scrubbed view is for the DB write only,
+                # and it goes on a session of its own. Here the await makes the
+                # window a real one — two overlapping saves on a shared session
+                # would restore each other's snapshots out of order and leave
+                # the scrubbed list live.
+                storage_session = copy(session)
+                storage_session.runs = [
                     _scrub_member_responses_keeping_paused(team, run) if hasattr(run, "member_responses") else run
                     for run in session.runs
                 ]
@@ -403,13 +415,10 @@ async def asave_session(team: "Team", session: TeamSession) -> None:
                         # Scrub individual member responses based on their storage flags
                         _scrub_member_responses(team, run.member_responses)
 
-        try:
-            if _has_async_db(team):
-                await _aupsert_session(team, session=session)
-            else:
-                _upsert_session(team, session=session)
-        finally:
-            session.runs = live_runs
+        if _has_async_db(team):
+            await _aupsert_session(team, session=storage_session)
+        else:
+            _upsert_session(team, session=storage_session)
         log_debug(f"Created or updated TeamSession record: {session.session_id}")
 
 

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -175,16 +175,30 @@ async def aget_session(
     return None
 
 
-def _scrub_member_responses_keeping_paused(run: Union[TeamRunOutput, "RunOutput"]) -> None:
-    """Remove member responses at every nesting level, sparing paused ones: a
-    paused member run is the resume state for continue_run after a session
-    reload, and the save after it completes scrubs it. Completed responses
-    inside a spared paused sub-team run are removed too."""
-    spared = [m for m in (getattr(run, "member_responses", None) or []) if getattr(m, "is_paused", False)]
+def _scrub_member_responses_keeping_paused(
+    run: Union[TeamRunOutput, "RunOutput"],
+) -> Union[TeamRunOutput, "RunOutput"]:
+    """Return a storage view of the run with member responses removed at every
+    nesting level, sparing paused ones: a paused member run is the resume
+    state for continue_run after a session reload, and the save after it
+    completes scrubs it. Completed responses inside a spared paused sub-team
+    run are removed too.
+
+    Copy-on-write: levels that need filtering are shallow-copied so the live
+    run tree the caller holds keeps its member responses; the spared paused
+    leaf runs are shared, never copied, so resume state stays live."""
+    from copy import copy
+
+    spared = []
+    for member_response in getattr(run, "member_responses", None) or []:
+        if not getattr(member_response, "is_paused", False):
+            continue
+        if getattr(member_response, "member_responses", None):
+            member_response = _scrub_member_responses_keeping_paused(member_response)
+        spared.append(member_response)
+    run = copy(run)
     run.member_responses = spared  # type: ignore[union-attr]
-    for member_response in spared:
-        if hasattr(member_response, "member_responses"):
-            _scrub_member_responses_keeping_paused(member_response)
+    return run
 
 
 def save_session(team: "Team", session: TeamSession) -> None:
@@ -209,10 +223,12 @@ def save_session(team: "Team", session: TeamSession) -> None:
 
         # scrub the member responses based on storage settings
         if session.runs is not None:
-            for run in session.runs:
+            for i, run in enumerate(session.runs):
                 if hasattr(run, "member_responses"):
                     if not team.store_member_responses:
-                        _scrub_member_responses_keeping_paused(run)
+                        # Store the scrubbed copy; the live run tree keeps its
+                        # member responses.
+                        session.runs[i] = _scrub_member_responses_keeping_paused(run)
                     else:
                         # Scrub individual member responses based on their storage flags
                         _scrub_member_responses(team, run.member_responses)
@@ -239,10 +255,12 @@ async def asave_session(team: "Team", session: TeamSession) -> None:
 
         # scrub the member responses based on storage settings
         if session.runs is not None:
-            for run in session.runs:
+            for i, run in enumerate(session.runs):
                 if hasattr(run, "member_responses"):
                     if not team.store_member_responses:
-                        _scrub_member_responses_keeping_paused(run)
+                        # Store the scrubbed copy; the live run tree keeps its
+                        # member responses.
+                        session.runs[i] = _scrub_member_responses_keeping_paused(run)
                     else:
                         # Scrub individual member responses based on their storage flags
                         _scrub_member_responses(team, run.member_responses)
@@ -512,6 +530,9 @@ async def aget_session_metrics(team: "Team", session_id: Optional[str] = None) -
     return await aget_session_metrics_util(cast(Any, team), session_id=session_id)
 
 
+_FINAL_RUN_STATUSES = frozenset({RunStatus.completed, RunStatus.error, RunStatus.cancelled})
+
+
 def update_session_metrics(team: "Team", session: TeamSession, run_response: TeamRunOutput) -> None:
     """Calculate session metrics and write them to session_data.
 
@@ -519,35 +540,42 @@ def update_session_metrics(team: "Team", session: TeamSession, run_response: Tea
     session-level SessionMetrics (details: List[ModelMetrics]) using
     SessionMetrics.accumulate_from_run().
 
-    Accumulates metrics from the team leader's own model calls as well as
-    all member agent/team responses (recursively for nested teams).
+    Walks the team leader's run and all member responses (recursively for
+    nested teams). Each run is accumulated exactly once, at the first save
+    where it is in a final state; the accumulated run ids persist with the
+    session, so a run saved several times across a pause and its resume
+    contributes its full metrics once. A run that never reaches a final
+    state — an abandoned pause — is not counted.
     """
     from agno.team._storage import get_session_metrics_internal
 
     session_metrics = get_session_metrics_internal(team, session=session)
     if session_metrics is None:
         return
-    if run_response.metrics is not None:
-        session_metrics.accumulate_from_run(run_response.metrics)
 
-    # Accumulate metrics from member responses (agent and nested team runs)
-    _accumulate_member_metrics(session_metrics, run_response.member_responses)
+    stored_run_ids = (
+        session.session_data.get("session_metrics_run_ids") if isinstance(session.session_data, dict) else None
+    )
+    accumulated_run_ids = set(stored_run_ids) if isinstance(stored_run_ids, list) else set()
+
+    def _accumulate(node: Any) -> None:
+        run_id = getattr(node, "run_id", None)
+        if (
+            getattr(node, "status", None) in _FINAL_RUN_STATUSES
+            and run_id is not None
+            and run_id not in accumulated_run_ids
+        ):
+            accumulated_run_ids.add(run_id)
+            if node.metrics is not None:
+                session_metrics.accumulate_from_run(node.metrics)
+        for member_response in getattr(node, "member_responses", None) or []:
+            _accumulate(member_response)
+
+    _accumulate(run_response)
 
     if session.session_data is not None:
         session.session_data["session_metrics"] = session_metrics.to_dict()
-
-
-def _accumulate_member_metrics(
-    session_metrics: SessionMetrics,
-    member_responses: "List",
-) -> None:
-    """Recursively accumulate metrics from member responses into session metrics."""
-    for member_response in member_responses:
-        if member_response.metrics is not None:
-            session_metrics.accumulate_from_run(member_response.metrics)
-        # Recurse into nested team member responses
-        if isinstance(member_response, TeamRunOutput) and member_response.member_responses:
-            _accumulate_member_metrics(session_metrics, member_response.member_responses)
+        session.session_data["session_metrics_run_ids"] = sorted(accumulated_run_ids)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -177,14 +177,14 @@ async def aget_session(
 
 
 def _scrub_tool_results_keeping_unresolved(run: Union[TeamRunOutput, "RunOutput"]) -> None:
-    """Drop stored tool calls and their results, keeping any call still awaiting one.
+    """Drop every stored tool-result message, keeping any call still awaiting one.
 
     ``scrub_tool_results_from_run_output`` drops every assistant message that
     made a call it removed. On a paused run that takes the message carrying the
     *pending* call with it whenever one assistant turn mixes a finished call
     with the gated one, leaving the resumed model nothing to answer. Here a
-    resolved call is stripped out of the message it was made in instead, so the
-    pending call survives and no removed call is left dangling."""
+    resolved call is stripped out of the message it was made in instead, and
+    the pending call survives."""
     from copy import copy
 
     if not run.messages:

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -175,26 +175,102 @@ async def aget_session(
     return None
 
 
+def _scrub_tool_results_keeping_unresolved(run: Union[TeamRunOutput, "RunOutput"]) -> None:
+    """Drop stored tool calls and their results, keeping any call still awaiting one.
+
+    ``scrub_tool_results_from_run_output`` drops every assistant message that
+    made a call it removed. On a paused run that takes the message carrying the
+    *pending* call with it whenever one assistant turn mixes a finished call
+    with the gated one, leaving the resumed model nothing to answer. Here a
+    resolved call is stripped out of the message it was made in instead, so the
+    pending call survives and no removed call is left dangling."""
+    from copy import copy
+
+    if not run.messages:
+        return
+    resolved = {message.tool_call_id for message in run.messages if message.role == "tool" and message.tool_call_id}
+    if not resolved:
+        return
+    kept = []
+    for message in run.messages:
+        if message.role == "tool" and message.tool_call_id in resolved:
+            continue
+        if message.role == "assistant" and message.tool_calls:
+            remaining = [call for call in message.tool_calls if call.get("id") not in resolved]
+            if not remaining:
+                continue
+            if len(remaining) != len(message.tool_calls):
+                message = copy(message)
+                message.tool_calls = remaining
+        kept.append(message)
+    run.messages = kept
+
+
+def _storage_view_of_spared_run(
+    team: "Team", member_response: Union[TeamRunOutput, "RunOutput"]
+) -> Union[TeamRunOutput, "RunOutput"]:
+    """Apply a spared member's own storage flags to a copy of its paused run.
+
+    A paused member run is kept out of the member-response scrub so
+    continue_run can resume it after a reload. That exemption must not also
+    carry the member's data past its own store_media / store_tool_messages /
+    store_history_messages settings: the delegation path applies them to every
+    member run it persists, and a run spared here is persisted the same way."""
+    from copy import copy
+
+    from agno.run.agent import RunOutput
+    from agno.team._tools import _find_member_by_id
+    from agno.utils.agent import (
+        isolate_media_scrub_targets,
+        scrub_history_messages_from_run_output,
+        scrub_media_from_run_output,
+    )
+
+    member_id = member_response.agent_id if isinstance(member_response, RunOutput) else member_response.team_id
+    if not member_id:
+        return member_response
+    member_result = _find_member_by_id(team, member_id)
+    if member_result is None:
+        return member_response
+    _, member = member_result
+    if member.store_media and member.store_tool_messages and member.store_history_messages:
+        return member_response
+
+    view = copy(member_response)
+    # The spared run is shared with the live tree, and the media scrub rewrites
+    # Message objects in place.
+    isolate_media_scrub_targets(view)
+    if not member.store_media:
+        scrub_media_from_run_output(view)
+    if not member.store_tool_messages:
+        _scrub_tool_results_keeping_unresolved(view)
+    if not member.store_history_messages:
+        scrub_history_messages_from_run_output(view)
+    return view
+
+
 def _scrub_member_responses_keeping_paused(
+    team: "Team",
     run: Union[TeamRunOutput, "RunOutput"],
 ) -> Union[TeamRunOutput, "RunOutput"]:
     """Return a storage view of the run with member responses removed at every
     nesting level, sparing paused ones: a paused member run is the resume
     state for continue_run after a session reload, and the save after it
     completes scrubs it. Completed responses inside a spared paused sub-team
-    run are removed too.
+    run are removed too, and a spared run still passes through its own member's
+    storage flags.
 
-    Copy-on-write: levels that need filtering are shallow-copied so the live
-    run tree the caller holds keeps its member responses; the spared paused
-    leaf runs are shared, never copied, so resume state stays live."""
+    Copy-on-write: every level this rebuilds is shallow-copied, so the live run
+    tree the caller holds keeps its member responses and its full messages."""
     from copy import copy
 
     spared = []
     for member_response in getattr(run, "member_responses", None) or []:
         if not getattr(member_response, "is_paused", False):
             continue
+        member_response = _storage_view_of_spared_run(team, member_response)
         if getattr(member_response, "member_responses", None):
-            member_response = _scrub_member_responses_keeping_paused(member_response)
+            member_response = _scrub_member_responses_keeping_paused(team, member_response)
         spared.append(member_response)
     run = copy(run)
     run.member_responses = spared  # type: ignore[union-attr]
@@ -222,17 +298,27 @@ def save_session(team: "Team", session: TeamSession) -> None:
             session.session_data["session_state"].pop("current_run_id", None)
 
         # scrub the member responses based on storage settings
+        live_runs = session.runs
         if session.runs is not None:
-            for i, run in enumerate(session.runs):
-                if hasattr(run, "member_responses"):
-                    if not team.store_member_responses:
-                        # Store the scrubbed copy; the live run tree keeps its
-                        # member responses.
-                        session.runs[i] = _scrub_member_responses_keeping_paused(run)
-                    else:
+            if not team.store_member_responses:
+                # Hand the DB a scrubbed view and give the session its live runs
+                # back. Keeping the view would freeze the stored copy of a
+                # paused member run at PAUSED — the resume continues the live
+                # run, so a cached session would advertise a pending approval on
+                # a finished run for good.
+                session.runs = [
+                    _scrub_member_responses_keeping_paused(team, run) if hasattr(run, "member_responses") else run
+                    for run in session.runs
+                ]
+            else:
+                for run in session.runs:
+                    if hasattr(run, "member_responses"):
                         # Scrub individual member responses based on their storage flags
                         _scrub_member_responses(team, run.member_responses)
-        _upsert_session(team, session=session)
+        try:
+            _upsert_session(team, session=session)
+        finally:
+            session.runs = live_runs
         log_debug(f"Created or updated TeamSession record: {session.session_id}")
 
 
@@ -254,21 +340,27 @@ async def asave_session(team: "Team", session: TeamSession) -> None:
             session.session_data["session_state"].pop("current_run_id", None)
 
         # scrub the member responses based on storage settings
+        live_runs = session.runs
         if session.runs is not None:
-            for i, run in enumerate(session.runs):
-                if hasattr(run, "member_responses"):
-                    if not team.store_member_responses:
-                        # Store the scrubbed copy; the live run tree keeps its
-                        # member responses.
-                        session.runs[i] = _scrub_member_responses_keeping_paused(run)
-                    else:
+            if not team.store_member_responses:
+                # See save_session: the scrubbed view is for the DB write only.
+                session.runs = [
+                    _scrub_member_responses_keeping_paused(team, run) if hasattr(run, "member_responses") else run
+                    for run in session.runs
+                ]
+            else:
+                for run in session.runs:
+                    if hasattr(run, "member_responses"):
                         # Scrub individual member responses based on their storage flags
                         _scrub_member_responses(team, run.member_responses)
 
-        if _has_async_db(team):
-            await _aupsert_session(team, session=session)
-        else:
-            _upsert_session(team, session=session)
+        try:
+            if _has_async_db(team):
+                await _aupsert_session(team, session=session)
+            else:
+                _upsert_session(team, session=session)
+        finally:
+            session.runs = live_runs
         log_debug(f"Created or updated TeamSession record: {session.session_id}")
 
 

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -198,8 +198,12 @@ def save_session(team: "Team", session: TeamSession) -> None:
             for run in session.runs:
                 if hasattr(run, "member_responses"):
                     if not team.store_member_responses:
-                        # Remove all member responses
-                        run.member_responses = []
+                        # Remove member responses, sparing paused ones: a paused
+                        # member run is the resume state for continue_run after a
+                        # session reload, and the save after it completes scrubs it.
+                        run.member_responses = [
+                            m for m in (run.member_responses or []) if getattr(m, "is_paused", False)
+                        ]
                     else:
                         # Scrub individual member responses based on their storage flags
                         _scrub_member_responses(team, run.member_responses)
@@ -229,8 +233,12 @@ async def asave_session(team: "Team", session: TeamSession) -> None:
             for run in session.runs:
                 if hasattr(run, "member_responses"):
                     if not team.store_member_responses:
-                        # Remove all member responses
-                        run.member_responses = []
+                        # Remove member responses, sparing paused ones: a paused
+                        # member run is the resume state for continue_run after a
+                        # session reload, and the save after it completes scrubs it.
+                        run.member_responses = [
+                            m for m in (run.member_responses or []) if getattr(m, "is_paused", False)
+                        ]
                     else:
                         # Scrub individual member responses based on their storage flags
                         _scrub_member_responses(team, run.member_responses)

--- a/libs/agno/tests/unit/team/test_acontinue_run_background_stream.py
+++ b/libs/agno/tests/unit/team/test_acontinue_run_background_stream.py
@@ -153,7 +153,11 @@ class TestAcontinueRunBackgroundStream:
             raise RuntimeError("boom")
             yield  # pragma: no cover  (make it an async generator)
 
+        stored_run = MagicMock()
+        stored_run.run_id = "r-1"
+        stored_run.status = RunStatus.running
         team_session = MagicMock()
+        team_session.runs = [stored_run]
 
         with (
             patch("agno.team._run._acontinue_run_stream", side_effect=failing_stream),
@@ -183,7 +187,9 @@ class TestAcontinueRunBackgroundStream:
 
         # The error path must have set RunStatus.error on the run_response
         assert run_response.status == RunStatus.error, "background helper must persist RunStatus.error on failure"
-        # asave_session is called at least twice: once for RUNNING, once for ERROR
+        # asave_session is called at least twice: once for RUNNING, once for
+        # ERROR, which is only written over a stored run still carrying the
+        # RUNNING marker step 1 wrote
         assert mock_save.await_count >= 2
         # SSE subscribers must be signaled even on failure (call_count covers either
         # direct await or asyncio.shield-wrapped await)

--- a/libs/agno/tests/unit/team/test_acontinue_run_background_stream.py
+++ b/libs/agno/tests/unit/team/test_acontinue_run_background_stream.py
@@ -166,6 +166,11 @@ class TestAcontinueRunBackgroundStream:
                 new_callable=AsyncMock,
                 return_value=team_session,
             ),
+            patch(
+                "agno.team._storage._aread_session",
+                new_callable=AsyncMock,
+                return_value=team_session,
+            ),
             patch("agno.team._storage._update_metadata"),
             patch("agno.team._session.asave_session", new_callable=AsyncMock) as mock_save,
             patch("agno.os.managers.event_buffer") as mock_eb,

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -4492,10 +4492,8 @@ async def test_a_stale_run_response_cannot_resurrect_a_finished_run(tmp_path):
     assert status == RunStatus.completed, f"a finished run was resurrected to {status!r}"
 
     team4 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
-    try:
-        await team4.acontinue_run(run_id=run1.run_id, session_id=session_id, requirements=good)
-    except Exception:
-        pass
+    retry = await team4.acontinue_run(run_id=run1.run_id, session_id=session_id, requirements=good)
+    assert retry.status == RunStatus.completed
     assert _EXECUTED == ["a@example.com"], f"the gated tool ran a second time: {_EXECUTED}"
 
 
@@ -4903,10 +4901,27 @@ def run_export(target: str) -> str:
     raise AssertionError("externally executed tools never run in-process")
 
 
+_PINGS: List[Any] = []
+
+
+@tool(requires_user_input=True)
+@approval(type="required")
+def run_ping() -> str:
+    _PINGS.append("ping")
+    return "pong"
+
+
+_APPROVAL_TOOL_ARGS: Dict[str, Dict[str, Any]] = {
+    "send_note": {"body": "hi"},
+    "run_export": {"target": "reports"},
+    "run_ping": {},
+}
+
+
 def _approval_team(db: SqliteDb, resuming: bool, member_tool=None) -> Team:
     member_tool = member_tool if member_tool is not None else send_note
     tool_name = member_tool.name
-    tool_args = {"body": "hi"} if tool_name == "send_note" else {"target": "reports"}
+    tool_args = _APPROVAL_TOOL_ARGS[tool_name]
     agent = Agent(
         name="Noter",
         id="noter",
@@ -4936,7 +4951,7 @@ def _approval_team(db: SqliteDb, resuming: bool, member_tool=None) -> Team:
     )
 
 
-def _resolve_required_approval(db: SqliteDb, run1, resolution_data) -> None:
+def _resolve_required_approval(db: SqliteDb, run1, resolution_data, status: str = "approved") -> None:
     approvals, _ = db.get_approvals(run_id=run1.run_id, approval_type="required", limit=5)
     if not approvals:
         for r in run1.requirements or []:
@@ -4947,7 +4962,7 @@ def _resolve_required_approval(db: SqliteDb, run1, resolution_data) -> None:
                     approvals = [record]
                     break
     assert approvals, "no approval record was created for the paused run"
-    db.update_approval(approvals[0]["id"], status="approved", resolution_data=resolution_data)
+    db.update_approval(approvals[0]["id"], status=status, resolution_data=resolution_data)
 
 
 def test_an_admin_approved_member_user_input_run_completes(tmp_path):
@@ -5021,3 +5036,467 @@ def test_an_approval_without_values_keeps_the_run_paused(tmp_path):
     run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id)
     assert run2.status == RunStatus.paused, f"an unfilled approval let the run reach {run2.status}"
     assert _NOTES == [], f"the gated tool ran without its input values: {_NOTES}"
+
+
+def test_a_rejected_member_approval_skips_the_tool_and_completes(tmp_path):
+    """A rejected approval must settle the requirement: the tool is skipped and
+    the run finishes instead of re-pausing forever with nothing left to change."""
+    _NOTES.clear()
+    db_file = str(tmp_path / "admin_approval_rejected.db")
+    session_id = "s-admin-approval-rejected"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = _approval_team(db, resuming=False).run("Send a note", session_id=session_id)
+    assert run1.is_paused
+
+    _resolve_required_approval(db, run1, None, status="rejected")
+
+    team2 = _approval_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.completed, f"a rejected approval left the run {run2.status}"
+    assert _NOTES == [], f"the rejected tool executed: {_NOTES}"
+
+
+def test_an_approved_zero_field_user_input_tool_completes(tmp_path):
+    """An approved requirement with no input fields to fill is resolved; the
+    empty schema must not read as 'not fully filled'."""
+    _PINGS.clear()
+    db_file = str(tmp_path / "admin_approval_zero.db")
+    session_id = "s-admin-approval-zero"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = _approval_team(db, resuming=False, member_tool=run_ping).run("Ping it", session_id=session_id)
+    assert run1.is_paused
+
+    _resolve_required_approval(db, run1, None)
+
+    team2 = _approval_team(SqliteDb(db_file=db_file), resuming=True, member_tool=run_ping)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.completed, f"an approved zero-field tool left the run {run2.status}"
+    assert _PINGS == ["ping"], _PINGS
+
+
+_DEPLOYS: List[Any] = []
+
+
+@tool(requires_confirmation=True)
+@approval(type="required")
+def deploy(target: str) -> str:
+    _DEPLOYS.append(target)
+    return f"deployed {target}"
+
+
+def _team_level_approval_team(db: SqliteDb, resuming: bool) -> Team:
+    return Team(
+        name="Deploy Team",
+        id="deploy-team",
+        model=_ScriptedModel(
+            "m-deploy",
+            [("content", "Done.")]
+            if resuming
+            else [("tool", "deploy", {"target": "prod"}, "tc-dep"), ("content", "Done.")],
+        ),
+        tools=[deploy],
+        members=[_emailer_agent(db, resuming)],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_a_team_level_approval_resolves_after_a_session_reload(tmp_path):
+    """After a reload, run.tools and the requirement hold distinct copies of the
+    gated tool call; the approved resolution must land on both."""
+    _DEPLOYS.clear()
+    db_file = str(tmp_path / "team_level_approval.db")
+    session_id = "s-team-level-approval"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = _team_level_approval_team(db, resuming=False).run("Deploy prod", session_id=session_id)
+    assert run1.is_paused
+
+    _resolve_required_approval(db, run1, None)
+
+    team2 = _team_level_approval_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.completed, f"the approved team-level run came back {run2.status}"
+    assert _DEPLOYS == ["prod"], _DEPLOYS
+
+
+def test_sync_requirements_after_approval_mirrors_the_resolution():
+    """Unit contract of _sync_requirements_after_approval: every field the
+    requirement's needs_* properties read is mirrored from the applied tools."""
+    from agno.run.approval import _sync_requirements_after_approval
+    from agno.tools.function import UserInputField
+
+    # Approved confirmation tool: the requirement-side confirmation is set.
+    te = ToolExecution(
+        tool_call_id="tc-c", tool_name="deploy", requires_confirmation=True, confirmed=True, approval_type="required"
+    )
+    req = RunRequirement(tool_execution=te)
+    holder = MagicMock(requirements=[req])
+    _sync_requirements_after_approval(holder, "approved")
+    assert req.confirmation is True
+
+    # Approved user-input tool with a DISTINCT schema copy: values are copied
+    # onto the requirement's schema and the tool reads answered.
+    te2 = ToolExecution(
+        tool_call_id="tc-u",
+        tool_name="send_note",
+        requires_user_input=True,
+        approval_type="required",
+        user_input_schema=[UserInputField(name="to", field_type=str, value="bob@example.com")],
+    )
+    req2 = RunRequirement(tool_execution=te2)
+    req2.user_input_schema = [UserInputField(name="to", field_type=str, value=None)]
+    holder2 = MagicMock(requirements=[req2])
+    _sync_requirements_after_approval(holder2, "approved")
+    assert te2.answered is True
+    assert [f.value for f in req2.user_input_schema] == ["bob@example.com"]
+    assert req2.is_resolved()
+
+    # Rejected user-input tool: settled through the reject lane, never answered
+    # for execution.
+    te3 = ToolExecution(
+        tool_call_id="tc-r",
+        tool_name="send_note",
+        requires_user_input=True,
+        approval_type="required",
+        user_input_schema=[UserInputField(name="to", field_type=str, value=None)],
+    )
+    req3 = RunRequirement(tool_execution=te3)
+    holder3 = MagicMock(requirements=[req3])
+    _sync_requirements_after_approval(holder3, "rejected")
+    assert te3.requires_user_input is False
+    assert te3.requires_confirmation is True and te3.confirmed is False
+    assert req3.confirmation is False
+    assert req3.is_resolved()
+
+
+@pytest.mark.asyncio
+async def test_a_reread_cancelled_run_is_refused_too(tmp_path):
+    """A caller who re-reads a cancelled run and continues with the fresh
+    object gets the same refusal the run_id lane gives."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "reread_cancelled.db")
+    session_id = "s-reread-cancelled"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    db = SqliteDb(db_file=db_file)
+    session = db.get_session(session_id=session_id, session_type="team")
+    for r in session.runs or []:
+        if r.run_id == run1.run_id:
+            r.status = RunStatus.cancelled
+    db.upsert_session(session)
+
+    fresh = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0]
+    assert fresh.is_paused is False
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    with pytest.raises(RunNotContinuableError):
+        async for _ in team2.acontinue_run(
+            run_response=fresh,
+            session_id=session_id,
+            requirements=_wire_requirements(run1.requirements),
+            stream=True,
+            stream_events=True,
+            background=True,
+        ):
+            pass
+    await _drain_background_tasks()
+
+    status = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status
+    assert status == RunStatus.cancelled, f"a cancelled run came back as {status!r}"
+    assert _EXECUTED == [], f"the gated tool ran on a cancelled run: {_EXECUTED}"
+
+
+@pytest.mark.asyncio
+async def test_a_completed_run_object_cannot_be_continued_in_place(tmp_path):
+    """A second background continue with the (now completed) caller object must
+    refuse, not edit the finished run in place and fire its tool again."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "completed_in_place.db")
+    session_id = "s-completed-in-place"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+    good = _wire_requirements(run1.requirements)
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    async for _ in team2.acontinue_run(
+        run_response=run1,
+        session_id=session_id,
+        requirements=good,
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        pass
+    await _drain_background_tasks()
+    assert _EXECUTED == ["a@example.com"]
+
+    team3 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    with pytest.raises(RunNotContinuableError):
+        async for _ in team3.acontinue_run(
+            run_response=run1,
+            session_id=session_id,
+            requirements=_wire_requirements(run1.requirements),
+            stream=True,
+            stream_events=True,
+            background=True,
+        ):
+            pass
+    await _drain_background_tasks()
+    assert _EXECUTED == ["a@example.com"], f"the gated tool ran a second time: {_EXECUTED}"
+
+
+@pytest.mark.asyncio
+async def test_a_background_fork_does_not_restamp_the_original_runs_buffer(tmp_path):
+    """A fork produces a run with a different id; the forked run's status must
+    not land under the original run's event-buffer key."""
+    from agno.os.managers import event_buffer
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "fork_buffer.db")
+    session_id = "s-fork-buffer"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+    await _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status == RunStatus.completed
+
+    # A resuming=False team replays the delegation, so the fork pauses on its
+    # own approval.
+    async for _ in _build_flat_team(SqliteDb(db_file=db_file), resuming=False).acontinue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        fork=True,
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        pass
+    await _drain_background_tasks()
+
+    buffer_status = event_buffer.get_run_status(run1.run_id)
+    assert buffer_status == RunStatus.completed, (
+        f"the original completed run's buffer entry took the fork's status: {buffer_status!r}"
+    )
+
+
+class _BoomModel(_ScriptedModel):
+    def invoke(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("leader boom")
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("leader boom")
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("leader boom")
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("leader boom")
+        yield
+
+
+@pytest.mark.asyncio
+async def test_a_failed_background_continue_is_not_advertised_as_completed(tmp_path):
+    """A background continue whose team leader fails must record ERROR in the
+    event buffer, matching the DB and the error event the client received."""
+    from agno.os.managers import event_buffer
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "leader_error.db")
+    session_id = "s-leader-error"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    team2.model = _BoomModel("m-leader", [("content", "All done.")])
+
+    chunks = []
+    async for chunk in team2.acontinue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(run1.requirements),
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        chunks.append(chunk)
+    await _drain_background_tasks()
+
+    assert [c for c in chunks if "TeamRunError" in c], "the failure must reach the client"
+    db_status = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status
+    assert db_status == RunStatus.error, db_status
+    buffer_status = event_buffer.get_run_status(run1.run_id)
+    assert buffer_status == RunStatus.error, (
+        f"the DB says {db_status!r} but reconnecting clients are told {buffer_status!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_cached_team_refusal_still_restores_the_stored_status(tmp_path):
+    """With cache_session the handler's session read can hand back the very
+    object step 1 wrote; the restore must still land in the DB."""
+    from agno.os.managers import event_buffer
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "cached_refusal.db")
+    session_id = "s-cached-refusal"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True, cache_session=True)
+    async for _ in team2.acontinue_run(
+        run_response=run1,
+        session_id=session_id,
+        requirements=_unbindable_payload(run1.requirements),
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        pass
+    await _drain_background_tasks()
+
+    stored = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0]
+    assert stored.status == RunStatus.paused, (
+        f"the cached-team refusal left the stored run {stored.status!r}; it can no longer be resumed"
+    )
+    buffer_status = event_buffer.get_run_status(run1.run_id)
+    assert isinstance(buffer_status, RunStatus) and buffer_status == RunStatus.paused
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_does_not_overwrite_a_run_another_request_finished(tmp_path):
+    """The restore writes only over step 1's RUNNING marker: a run another
+    request completed during the window must stay completed."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "cas_window.db")
+    session_id = "s-cas-window"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    async def _finish_then_refuse(*args: Any, **kwargs: Any):
+        db2 = SqliteDb(db_file=db_file)
+        session = db2.get_session(session_id=session_id, session_type="team")
+        for r in session.runs or []:
+            if r.run_id == run1.run_id:
+                r.status = RunStatus.completed
+        db2.upsert_session(session)
+        raise RunNotContinuableError("another request finished this run")
+        yield
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    with patch("agno.team._run._acontinue_run_stream", new=_finish_then_refuse):
+        async for _ in team2.acontinue_run(
+            run_response=run1,
+            session_id=session_id,
+            requirements=_unbindable_payload(run1.requirements),
+            stream=True,
+            stream_events=True,
+            background=True,
+        ):
+            pass
+    await _drain_background_tasks()
+
+    status = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status
+    assert status == RunStatus.completed, (
+        f"the refusal stamped {status!r} over a run another request finished; its approval is live again"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_read_failure_during_refusal_still_restores_the_run(tmp_path):
+    """When the handler's session read fails, the restore falls back to the
+    step-1 session instead of leaving the run advertised as RUNNING."""
+    from agno.os.managers import event_buffer
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "read_failure.db")
+    session_id = "s-read-failure"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    with patch("agno.team._storage._aread_session", new_callable=AsyncMock, return_value=None):
+        async for _ in team2.acontinue_run(
+            run_response=run1,
+            session_id=session_id,
+            requirements=_unbindable_payload(run1.requirements),
+            stream=True,
+            stream_events=True,
+            background=True,
+        ):
+            pass
+    await _drain_background_tasks()
+
+    stored = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0]
+    assert stored.status == RunStatus.paused, f"a failed session read left the run advertised as {stored.status!r}"
+    assert event_buffer.get_run_status(run1.run_id) == RunStatus.paused
+
+
+def test_paused_buffer_entries_are_reclaimed_after_the_cleanup_interval():
+    """A pause can wait on an approval forever; its buffer entry must not pin
+    memory for the process lifetime. A reclaimed entry is rebuilt by add_event
+    when the run is continued."""
+    from agno.os.managers import EventsBuffer
+
+    buf = EventsBuffer(cleanup_interval=-1)
+    buf.add_event("r-paused-reclaim", MagicMock())
+    buf.set_run_completed("r-paused-reclaim", RunStatus.paused)
+    buf.cleanup_runs()
+    assert buf.get_run_status("r-paused-reclaim") is None, "the paused buffer entry was never reclaimed"
+    assert "r-paused-reclaim" not in buf.run_metadata
+
+
+def test_a_routing_failure_restores_the_callers_team_level_requirements(tmp_path):
+    """A plain exception during member routing must leave the caller's run
+    object carrying each team-level requirement exactly once."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "routing_failure_reqs.db")
+    session_id = "s-routing-failure-reqs"
+
+    team1 = _build_own_tool_flat_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Publish the release and email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    def _boom_stream(*args: Any, **kwargs: Any):
+        raise RuntimeError("router boom")
+        yield
+
+    team2 = _build_own_tool_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    with patch("agno.team._run._route_requirements_to_members_stream", new=_boom_stream):
+        with pytest.raises(RuntimeError, match="router boom"):
+            for _ in team2.continue_run(
+                run_response=run1,
+                session_id=session_id,
+                requirements=_wire_requirements(run1.requirements),
+                stream=True,
+                stream_events=True,
+            ):
+                pass
+
+    names = [r.tool_execution.tool_name for r in (run1.requirements or [])]
+    assert names.count("publish") == 1, f"the caller's run object carries: {names}"

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -2674,3 +2674,448 @@ def test_team_level_pause_streaming_continue_yields_final_output(tmp_path):
     assert len(finals) == 1, "exactly one final TeamRunOutput must be yielded on a team-level re-pause"
     assert finals[0].is_paused
     assert _EXECUTED == []
+
+
+# ---------------------------------------------------------------------------
+# A continue payload is bound to the stored requirements as one unit. A refusal
+# on any entry must leave every stored requirement exactly as the session holds
+# it: the refusal tells the client the run is untouched and still resumable, so
+# a bare retry of a rejected request must not execute the part that bound.
+# ---------------------------------------------------------------------------
+
+
+def _build_two_gated_members(db: SqliteDb, resuming: bool) -> Team:
+    smser = Agent(
+        name="Smser",
+        id="smser",
+        model=_ScriptedModel(
+            "m-smser",
+            [("content", "SMS sent.")]
+            if resuming
+            else [("tool", "send_sms", {"to": "b@x.com"}, "tc-sms"), ("content", "SMS sent.")],
+        ),
+        tools=[send_sms],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-leader",
+            [("content", "All done.")]
+            if resuming
+            else [
+                (
+                    "tools",
+                    [
+                        ("delegate_task_to_member", {"member_id": "emailer", "task": "email"}, "tc-deleg-e"),
+                        ("delegate_task_to_member", {"member_id": "smser", "task": "sms"}, "tc-deleg-s"),
+                    ],
+                ),
+                ("content", "All done."),
+            ],
+        ),
+        members=[_emailer_agent(db, resuming), smser],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_refused_payload_does_not_bank_the_entries_that_bound(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "atomic.db")
+    session_id = "s-atomic"
+
+    team1 = _build_two_gated_members(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email and sms", session_id=session_id)
+    assert run1.is_paused
+    assert len(run1.requirements or []) == 2
+
+    # First entry binds cleanly, second matches no stored requirement.
+    payload = _wire_requirements(run1.requirements)
+    payload[1].id = "bogus-requirement-id"
+    payload[1].tool_execution.tool_call_id = "bogus-tool-call-id"
+
+    with pytest.raises(RunNotContinuableError):
+        team1.continue_run(run_response=run1, requirements=payload)
+
+    assert _EXECUTED == []
+    # The stored requirements carry no part of the rejected payload's decision.
+    assert [r.confirmation for r in run1.requirements or []] == [None, None]
+    assert [r.tool_execution.confirmed for r in run1.requirements or []] == [None, None]
+    assert not any(r.is_resolved() for r in run1.requirements or [])
+
+    # A bare retry therefore executes nothing, exactly as it would have before
+    # the refused call.
+    team1.continue_run(run_response=run1)
+    assert _EXECUTED == []
+
+
+def test_binding_refuses_a_stored_id_paired_with_another_tool_call(tmp_path):
+    """A valid requirement id carrying a different tool call must not bind: the
+    id match alone would confirm one member's tool with the other's arguments."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "crosscheck.db")
+    session_id = "s-crosscheck"
+
+    team1 = _build_two_gated_members(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email and sms", session_id=session_id)
+    assert run1.is_paused
+
+    payload = _wire_requirements(run1.requirements)
+    # Entry 0 keeps its own (valid) requirement id but carries entry 1's tool call.
+    payload[0].tool_execution.tool_call_id = payload[1].tool_execution.tool_call_id
+    payload[0].tool_execution.tool_name = payload[1].tool_execution.tool_name
+
+    with pytest.raises(RunNotContinuableError):
+        team1.continue_run(run_response=run1, requirements=payload)
+    assert _EXECUTED == []
+
+
+# ---------------------------------------------------------------------------
+# The stored schema is the tool's contract. A continue payload supplies answers
+# for the fields the model left open — it does not get to rename them, refill
+# the ones the model fixed, or declare itself answered.
+# ---------------------------------------------------------------------------
+
+
+_TRANSFERRED: List[Dict[str, Any]] = []
+
+
+@tool(requires_user_input=True, user_input_fields=["note"])
+def transfer_funds(account_id: str, note: str) -> str:
+    _TRANSFERRED.append({"account_id": account_id, "note": note})
+    return "Transfer done."
+
+
+def _build_user_input_team(db: SqliteDb, resuming: bool) -> Team:
+    banker = Agent(
+        name="Banker",
+        id="banker",
+        model=_ScriptedModel(
+            "m-banker",
+            [("content", "Transfer done.")]
+            if resuming
+            else [("tool", "transfer_funds", {"account_id": "victim"}, "tc-xfer"), ("content", "Transfer done.")],
+        ),
+        tools=[transfer_funds],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Bank Team",
+        id="bank-team",
+        model=_ScriptedModel(
+            "m-leader",
+            [("content", "All done.")]
+            if resuming
+            else [
+                ("tool", "delegate_task_to_member", {"member_id": "banker", "task": "move it"}, "tc-deleg"),
+                ("content", "All done."),
+            ],
+        ),
+        members=[banker],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _answered_payload(requirements, values: Dict[str, Any]) -> List[RunRequirement]:
+    """Wire round-trip that fills the open input fields, as a frontend would."""
+    payload = []
+    for data in [r.to_dict() for r in requirements or []]:
+        req = RunRequirement.from_dict(data)
+        req.provide_user_input(values)
+        payload.append(req)
+    return payload
+
+
+def test_user_input_answers_reach_the_member_tool(tmp_path):
+    _TRANSFERRED.clear()
+    db_file = str(tmp_path / "user_input.db")
+    session_id = "s-user-input"
+
+    team1 = _build_user_input_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Move the money", session_id=session_id)
+    assert run1.is_paused
+
+    team2 = _build_user_input_team(SqliteDb(db_file=db_file), resuming=True)
+    team2.continue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_answered_payload(run1.requirements, {"note": "monthly rent"}),
+    )
+    assert _TRANSFERRED == [{"account_id": "victim", "note": "monthly rent"}]
+
+
+def test_wire_schema_cannot_rewrite_an_argument_the_model_fixed(tmp_path):
+    """Renaming an open field to a fixed argument's name must not reach tool_args."""
+    _TRANSFERRED.clear()
+    db_file = str(tmp_path / "schema_tamper.db")
+    session_id = "s-schema-tamper"
+
+    team1 = _build_user_input_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Move the money", session_id=session_id)
+    assert run1.is_paused
+
+    payload = _answered_payload(run1.requirements, {"note": "ok"})
+    for req in payload:
+        for schema in (req.user_input_schema, req.tool_execution.user_input_schema):
+            for field in schema or []:
+                if field.name == "note":
+                    field.name = "account_id"
+                    field.value = "attacker"
+
+    team2 = _build_user_input_team(SqliteDb(db_file=db_file), resuming=True)
+    team2.continue_run(run_id=run1.run_id, session_id=session_id, requirements=payload)
+
+    # The renamed field answers nothing the stored schema asked for, so it never
+    # reaches tool_args: the argument the model fixed at pause time stands.
+    assert [t["account_id"] for t in _TRANSFERRED] == [] or all(t["account_id"] == "victim" for t in _TRANSFERRED)
+    assert "attacker" not in [t["account_id"] for t in _TRANSFERRED]
+
+
+def test_wire_answered_flag_alone_does_not_resolve_an_open_field(tmp_path):
+    """answered=True with no values must not run a gated tool with the field empty."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "answered_flip.db")
+    session_id = "s-answered-flip"
+
+    @tool(requires_user_input=True, user_input_fields=["note"])
+    def file_report(subject: str, note: str) -> str:
+        _EXECUTED.append(f"{subject}:{note}")
+        return "Filed."
+
+    def build(resuming: bool) -> Team:
+        return Team(
+            name="Desk Team",
+            id="desk-team",
+            model=_ScriptedModel(
+                "m-leader",
+                [("content", "All done.")]
+                if resuming
+                else [("tool", "file_report", {"subject": "q3"}, "tc-file"), ("content", "All done.")],
+            ),
+            tools=[file_report],
+            members=[_emailer_agent(SqliteDb(db_file=db_file), resuming)],
+            db=SqliteDb(db_file=db_file),
+            telemetry=False,
+        )
+
+    run1 = build(resuming=False).run("File it", session_id=session_id)
+    assert run1.is_paused
+
+    payload = []
+    for data in [r.to_dict() for r in run1.requirements or []]:
+        req = RunRequirement.from_dict(data)
+        req.tool_execution.answered = True
+        payload.append(req)
+
+    run2 = build(resuming=True).continue_run(run_id=run1.run_id, session_id=session_id, requirements=payload)
+    assert run2.is_paused, "an unanswered field must keep the run paused"
+    assert _EXECUTED == []
+
+
+def test_external_execution_result_reaches_the_tool_execution(tmp_path):
+    """The result is the answer for an external-execution requirement, so it is
+    the one payload value that crosses onto the stored tool execution."""
+    db_file = str(tmp_path / "external.db")
+    session_id = "s-external"
+
+    @tool(external_execution=True)
+    def fetch_ledger(quarter: str) -> str:
+        raise AssertionError("an external-execution tool must never run in-process")
+
+    def build(resuming: bool) -> Team:
+        return Team(
+            name="Ledger Team",
+            id="ledger-team",
+            model=_ScriptedModel(
+                "m-leader",
+                [("content", "All done.")]
+                if resuming
+                else [("tool", "fetch_ledger", {"quarter": "q3"}, "tc-ledger"), ("content", "All done.")],
+            ),
+            tools=[fetch_ledger],
+            members=[_emailer_agent(SqliteDb(db_file=db_file), resuming)],
+            db=SqliteDb(db_file=db_file),
+            telemetry=False,
+        )
+
+    run1 = build(resuming=False).run("Fetch it", session_id=session_id)
+    assert run1.is_paused
+
+    payload = []
+    for data in [r.to_dict() for r in run1.requirements or []]:
+        req = RunRequirement.from_dict(data)
+        req.external_execution_result = "ledger-rows"
+        req.tool_execution.result = "ledger-rows"
+        payload.append(req)
+
+    run2 = build(resuming=True).continue_run(run_id=run1.run_id, session_id=session_id, requirements=payload)
+    assert run2.status == RunStatus.completed
+    stored = [r for r in _reload_runs(db_file, session_id) if getattr(r, "team_id", None) == "ledger-team"]
+    results = [t.result for t in (stored[0].tools or []) if t.tool_name == "fetch_ledger"]
+    assert results == ["ledger-rows"]
+
+
+# ---------------------------------------------------------------------------
+# A refusal raised below the top level must not damage the caller's run object.
+# The requirement objects a parent routes into a sub-team are the parent's own,
+# so the sub-team's reclaim has to work on a copy: de-stamping in place leaves
+# the parent holding what looks like a team-level requirement of its own, and
+# the retry the refusal invites then completes with the approved tool skipped.
+# ---------------------------------------------------------------------------
+
+
+def test_nested_refusal_keeps_the_subteam_requirement_routable(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "nested_refusal.db")
+    session_id = "s-nested-refusal"
+
+    outer1 = _build_subteam_own_tool(SqliteDb(db_file=db_file), resuming=False, mixed=True)
+    run1 = outer1.run("Publish the release", session_id=session_id)
+    assert run1.is_paused
+    stamps_at_pause = {
+        r.tool_execution.tool_name: r.member_agent_id for r in run1.requirements or [] if r.tool_execution
+    }
+    assert stamps_at_pause["publish"] == "comms-team"
+
+    for req in run1.requirements or []:
+        req.confirm()
+
+    # The deep member's continue fails once, the way a transient model outage
+    # would, so the sub-team's dispatch raises after the reclaim has run.
+    outer2 = _build_subteam_own_tool(SqliteDb(db_file=db_file), resuming=True, mixed=True)
+    inner = outer2.members[0]
+    emailer = inner.members[0]
+    original_continue = emailer.continue_run
+
+    def failing_continue(*args, **kwargs):
+        raise RuntimeError("transient model outage")
+
+    emailer.continue_run = failing_continue  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError):
+        outer2.continue_run(run_response=run1)
+    emailer.continue_run = original_continue  # type: ignore[method-assign]
+
+    assert _EXECUTED == []
+    stamps_after = {r.tool_execution.tool_name: r.member_agent_id for r in run1.requirements or [] if r.tool_execution}
+    assert stamps_after == stamps_at_pause, "a refusal below must not restamp the caller's requirements"
+
+    # The retry the refusal invites executes every approved tool.
+    outer3 = _build_subteam_own_tool(SqliteDb(db_file=db_file), resuming=True, mixed=True)
+    run3 = outer3.continue_run(run_response=run1)
+    assert run3.status == RunStatus.completed
+    assert sorted(_EXECUTED) == ["a@example.com", "pub:release"]
+
+
+# ---------------------------------------------------------------------------
+# The scrub builds a storage view; it does not replace the session's live runs.
+# Rebinding them would freeze the stored copy of a paused member run at PAUSED
+# while the resume continues the live one, so a finished run would advertise a
+# pending approval for good.
+# ---------------------------------------------------------------------------
+
+
+def test_completed_run_stores_no_stale_paused_member(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "stale.db")
+    session_id = "s-stale"
+
+    outer = _build_nested_team(SqliteDb(db_file=db_file), resuming=False)
+    outer.cache_session = True
+    run1 = outer.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    # Same process, same team object: the cached session is the one that would
+    # keep a frozen copy.
+    outer.members[0]._model = None
+    outer2 = _build_nested_team(SqliteDb(db_file=db_file), resuming=True)
+    outer2.cache_session = True
+    run2 = outer2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+    for run in _reload_runs(db_file, session_id):
+        assert not run.is_paused
+        for member_response in getattr(run, "member_responses", None) or []:
+            assert not member_response.is_paused, "a finished run must not keep a paused member snapshot"
+
+
+# ---------------------------------------------------------------------------
+# Sparing a paused member run so it can be resumed must not carry its data past
+# that member's own storage flags — the delegation path applies them to every
+# member run it persists.
+# ---------------------------------------------------------------------------
+
+
+def test_spared_paused_member_run_honours_store_tool_messages(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "flags.db")
+    session_id = "s-flags"
+
+    def build(phase: str) -> Team:
+        team = _build_nested_chained_team(SqliteDb(db_file=db_file), phase=phase)
+        team.members[0].members[0].store_tool_messages = False
+        return team
+
+    run1 = build("pause").run("Email then sms", session_id=session_id)
+    assert run1.is_paused
+
+    # Confirm send_email; the member runs it and chains a gated send_sms.
+    run2 = build("chain").continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.is_paused
+    assert _EXECUTED == ["a@example.com"]
+
+    def leaf_runs(runs):
+        for run in runs:
+            for member_response in getattr(run, "member_responses", None) or []:
+                if getattr(member_response, "agent_id", None) == "emailer":
+                    yield member_response
+                yield from leaf_runs([member_response])
+
+    stored_leaves = list(leaf_runs(_reload_runs(db_file, session_id)))
+    assert stored_leaves, "the paused member run must still be persisted for the resume"
+    for leaf in stored_leaves:
+        roles = [m.role for m in leaf.messages or []]
+        assert "tool" not in roles, "store_tool_messages=False must reach a spared paused member run"
+        pending = [call["id"] for m in leaf.messages or [] if m.role == "assistant" for call in m.tool_calls or []]
+        assert "tc-sms-chain" in pending, "the unresolved call must survive the scrub for the resume"
+
+    # And the resume still works from a fresh process.
+    unresolved = [r for r in run2.requirements or [] if not r.is_resolved()]
+    run3 = build("finish").continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(unresolved)
+    )
+    assert run3.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com", "sms:c@x.com"]
+
+
+def test_live_run_tree_keeps_its_tool_messages_after_a_save(tmp_path):
+    """The storage scrub is copy-on-write: the caller's in-flight run keeps
+    everything the member's flags strip from the stored copy."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "cow.db")
+    session_id = "s-cow"
+
+    team = _build_nested_chained_team(SqliteDb(db_file=db_file), phase="pause")
+    team.members[0].members[0].store_tool_messages = False
+    run1 = team.run("Email then sms", session_id=session_id)
+    assert run1.is_paused
+
+    def leaves(run):
+        for member_response in getattr(run, "member_responses", None) or []:
+            if getattr(member_response, "agent_id", None) == "emailer":
+                yield member_response
+            yield from leaves(member_response)
+
+    live = list(leaves(run1))
+    assert live, "the live run tree must still hold the member response"
+    for leaf in live:
+        assert leaf.messages, "the live member run must keep its messages"

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -1827,6 +1827,316 @@ def test_member_sharing_team_name_resumes_fresh_process(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# to_dict() strips None values, so a wire payload may omit member provenance
+# (member_run_id and friends). The dispatch backfill restores it from the
+# stored session requirements; routing and the own-requirement reclaim must
+# then behave exactly as with a complete payload.
+# ---------------------------------------------------------------------------
+
+
+def _wire_requirements_stripped(requirements, *fields: str) -> List[RunRequirement]:
+    """Wire round-trip like _wire_requirements, but with the given payload keys
+    deleted, the way a client that only echoes HITL-relevant fields sends them."""
+    confirmed = []
+    for data in [r.to_dict() for r in requirements or []]:
+        for field in fields:
+            data.pop(field, None)
+        req = RunRequirement.from_dict(data)
+        req.confirm()
+        confirmed.append(req)
+    return confirmed
+
+
+def test_stripped_member_run_id_collision_still_routes(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "stripped_collision.db")
+    session_id = "s-stripped-collision"
+
+    team1 = _build_id_collision_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    team2 = _build_id_collision_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements_stripped(run1.requirements, "member_run_id"),
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+def test_stripped_member_run_id_ordinary_team_routes(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "stripped_flat.db")
+    session_id = "s-stripped-flat"
+
+    team1 = _build_flat_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements_stripped(run1.requirements, "member_run_id"),
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+def test_stripped_member_run_id_subteam_own_tool_still_reclaims(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "stripped_own_tool.db")
+    session_id = "s-stripped-own-tool"
+
+    outer1 = _build_subteam_own_tool(SqliteDb(db_file=db_file), resuming=False, mixed=False)
+    run1 = outer1.run("Publish the release", session_id=session_id)
+    assert run1.is_paused
+
+    outer2 = _build_subteam_own_tool(SqliteDb(db_file=db_file), resuming=True, mixed=False)
+    run2 = outer2.continue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements_stripped(run1.requirements, "member_run_id"),
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["pub:release"]
+
+
+def test_unrecoverable_provenance_collision_fails_loudly(tmp_path):
+    """A collision payload whose provenance cannot be restored (no matching
+    stored requirement) must raise, never complete with the tool skipped."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "unrecoverable.db")
+    session_id = "s-unrecoverable"
+
+    team1 = _build_id_collision_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    mangled = []
+    for data in [r.to_dict() for r in run1.requirements or []]:
+        data.pop("member_run_id", None)
+        data["id"] = "req-unknown"
+        data["tool_execution"]["tool_call_id"] = "tc-unknown"
+        req = RunRequirement.from_dict(data)
+        req.confirm()
+        mangled.append(req)
+
+    team2 = _build_id_collision_team(SqliteDb(db_file=db_file), resuming=True)
+    with pytest.raises(ValueError):
+        team2.continue_run(run_id=run1.run_id, session_id=session_id, requirements=mangled)
+    assert _EXECUTED == []
+
+
+def _build_same_member_twice_same_tool_call_id(db: SqliteDb, resuming: bool) -> Team:
+    _SHARED_CURSORS.pop("m-emailer-shared-tcid", None)
+    emailer = Agent(
+        name="Emailer",
+        id="emailer",
+        model=_SharedCursorModel(
+            "m-emailer-shared-tcid",
+            [("content", "Email sent."), ("content", "Email sent.")]
+            if resuming
+            else [
+                ("tool", "send_email", {"to": "a@x.com"}, "tc-shared"),
+                ("tool", "send_email", {"to": "b@x.com"}, "tc-shared"),
+            ],
+        ),
+        tools=[send_email],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-leader-shared-tcid",
+            [("content", "All done.")]
+            if resuming
+            else [
+                (
+                    "tools",
+                    [
+                        ("delegate_task_to_member", {"member_id": "emailer", "task": "task A"}, "tc-da"),
+                        ("delegate_task_to_member", {"member_id": "emailer", "task": "task B"}, "tc-db"),
+                    ],
+                ),
+                ("content", "All done."),
+            ],
+        ),
+        members=[emailer],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_stripped_payload_same_tool_call_id_both_runs_execute(tmp_path):
+    """Two paused runs of one member can share a tool_call_id, so provenance
+    restore must match by requirement id — a tool_call_id match hands both
+    requirements the same member_run_id and strands one of the runs."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "stripped_same_tcid.db")
+    session_id = "s-stripped-same-tcid"
+
+    team1 = _build_same_member_twice_same_tool_call_id(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email both", session_id=session_id)
+    assert run1.is_paused
+    assert len(run1.requirements or []) == 2
+    assert len({r.member_run_id for r in run1.requirements}) == 2
+
+    team2 = _build_same_member_twice_same_tool_call_id(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements_stripped(run1.requirements, "member_run_id"),
+    )
+    assert run2.status == RunStatus.completed
+    assert sorted(_EXECUTED) == ["a@x.com", "b@x.com"]
+
+
+# ---------------------------------------------------------------------------
+# Sibling sub-teams may contain members with the same leaf id. The leaf-id
+# route picks the first sibling in member order; the continue must dispatch
+# to the sibling that owns the paused run, and each sibling's own tool
+# implementation must execute with its own arguments.
+# ---------------------------------------------------------------------------
+
+_LEFT_EXECUTED: List[str] = []
+_RIGHT_EXECUTED: List[str] = []
+
+
+@tool(name="send_email", requires_confirmation=True)
+def left_send_email(to: str) -> str:
+    _LEFT_EXECUTED.append(to)
+    return f"LEFT sent to {to}"
+
+
+@tool(name="send_email", requires_confirmation=True)
+def right_send_email(to: str) -> str:
+    _RIGHT_EXECUTED.append(to)
+    return f"RIGHT sent to {to}"
+
+
+def _build_sibling_dup_leaf_teams(db: SqliteDb, resuming: bool, delegate_to_both: bool) -> Team:
+    def make_subteam(side: str, send_tool, to: str) -> Team:
+        agent_script = (
+            [("content", "Email sent.")]
+            if resuming
+            else [("tool", "send_email", {"to": to}, f"tc-send-{side}"), ("content", "Email sent.")]
+        )
+        sub_script = (
+            [("content", f"{side} done.")]
+            if resuming
+            else [
+                ("tool", "delegate_task_to_member", {"member_id": "dup", "task": "send it"}, f"tc-deleg-{side}"),
+                ("content", f"{side} done."),
+            ]
+        )
+        member = Agent(
+            name="Dup",
+            id="dup",
+            model=_ScriptedModel(f"m-agent-{side}", agent_script),
+            tools=[send_tool],
+            db=db,
+            telemetry=False,
+        )
+        return Team(
+            name=f"{side} Team",
+            id=f"{side}-team",
+            model=_ScriptedModel(f"m-{side}", sub_script),
+            members=[member],
+            db=db,
+            telemetry=False,
+        )
+
+    if delegate_to_both:
+        leader_turn = (
+            "tools",
+            [
+                ("delegate_task_to_member", {"member_id": "left-team", "task": "send left"}, "tc-outer-left"),
+                ("delegate_task_to_member", {"member_id": "right-team", "task": "send right"}, "tc-outer-right"),
+            ],
+        )
+    else:
+        leader_turn = ("tool", "delegate_task_to_member", {"member_id": "right-team", "task": "send right"}, "tc-outer")
+    return Team(
+        name="Org Team",
+        id="org-team",
+        model=_ScriptedModel(
+            "m-outer", [("content", "All done.")] if resuming else [leader_turn, ("content", "All done.")]
+        ),
+        members=[
+            make_subteam("left", left_send_email, "left@example.com"),
+            make_subteam("right", right_send_email, "right@example.com"),
+        ],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_duplicate_leaf_id_across_siblings_routes_to_owning_subteam(tmp_path):
+    _LEFT_EXECUTED.clear()
+    _RIGHT_EXECUTED.clear()
+    db_file = str(tmp_path / "sibling_dup.db")
+    session_id = "s-sibling-dup"
+
+    outer1 = _build_sibling_dup_leaf_teams(SqliteDb(db_file=db_file), resuming=False, delegate_to_both=False)
+    run1 = outer1.run("Email right", session_id=session_id)
+    assert run1.is_paused
+    assert _LEFT_EXECUTED == [] and _RIGHT_EXECUTED == []
+
+    outer2 = _build_sibling_dup_leaf_teams(SqliteDb(db_file=db_file), resuming=True, delegate_to_both=False)
+    run2 = outer2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _RIGHT_EXECUTED == ["right@example.com"]
+    assert _LEFT_EXECUTED == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_leaf_id_across_siblings_routes_to_owning_subteam_async(tmp_path):
+    _LEFT_EXECUTED.clear()
+    _RIGHT_EXECUTED.clear()
+    db_file = str(tmp_path / "sibling_dup_async.db")
+    session_id = "s-sibling-dup-async"
+
+    outer1 = _build_sibling_dup_leaf_teams(SqliteDb(db_file=db_file), resuming=False, delegate_to_both=False)
+    run1 = await outer1.arun("Email right", session_id=session_id)
+    assert run1.is_paused
+
+    outer2 = _build_sibling_dup_leaf_teams(SqliteDb(db_file=db_file), resuming=True, delegate_to_both=False)
+    run2 = await outer2.acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _RIGHT_EXECUTED == ["right@example.com"]
+    assert _LEFT_EXECUTED == []
+
+
+def test_duplicate_leaf_id_both_siblings_paused_each_executes_own(tmp_path):
+    _LEFT_EXECUTED.clear()
+    _RIGHT_EXECUTED.clear()
+    db_file = str(tmp_path / "sibling_dup_both.db")
+    session_id = "s-sibling-dup-both"
+
+    outer1 = _build_sibling_dup_leaf_teams(SqliteDb(db_file=db_file), resuming=False, delegate_to_both=True)
+    run1 = outer1.run("Email both sides", session_id=session_id)
+    assert run1.is_paused
+    assert len(run1.requirements or []) == 2
+
+    outer2 = _build_sibling_dup_leaf_teams(SqliteDb(db_file=db_file), resuming=True, delegate_to_both=True)
+    run2 = outer2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _LEFT_EXECUTED == ["left@example.com"]
+    assert _RIGHT_EXECUTED == ["right@example.com"]
+
+
+# ---------------------------------------------------------------------------
 # When routing raises, the caller's in-memory run object must keep ALL its
 # requirements (the dispatch temporarily strips team-level ones for routing),
 # so a retry after fixing the team does not lose an approved tool.

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -3166,3 +3166,59 @@ def test_live_run_tree_keeps_its_tool_messages_after_a_save(tmp_path):
     assert live, "the live run tree must still hold the member response"
     for leaf in live:
         assert leaf.messages, "the live member run must keep its messages"
+
+
+# ---------------------------------------------------------------------------
+# The user-feedback lane of the decision merge. No tool decorator declares
+# feedback, so it is pinned directly on the merge.
+# ---------------------------------------------------------------------------
+
+
+def _feedback_requirement() -> RunRequirement:
+    from agno.tools.function import UserFeedbackOption, UserFeedbackQuestion
+
+    schema = [
+        UserFeedbackQuestion(
+            question="Which channel?",
+            options=[UserFeedbackOption(label="email"), UserFeedbackOption(label="sms")],
+        )
+    ]
+    req = _make_requirement(tool_name="notify", tool_call_id="tc-fb", user_feedback_schema=schema)
+    req.user_feedback_schema = schema
+    return req
+
+
+def test_user_feedback_selections_reach_the_stored_tool_execution():
+    from agno.team._run import _merge_requirement_decision
+
+    stored = _feedback_requirement()
+    wire = RunRequirement.from_dict(stored.to_dict())
+    wire.provide_user_feedback({"Which channel?": ["sms"]})
+
+    _merge_requirement_decision(stored, wire)
+
+    stored_question = stored.tool_execution.user_feedback_schema[0]
+    assert stored_question.selected_options == ["sms"]
+    assert [(o.label, o.selected) for o in stored_question.options] == [("email", False), ("sms", True)]
+    assert stored.tool_execution.answered is True
+    assert stored.is_resolved()
+
+
+def test_user_feedback_answer_for_an_unknown_question_is_ignored():
+    from agno.tools.function import UserFeedbackQuestion
+
+    from agno.team._run import _merge_requirement_decision
+
+    stored = _feedback_requirement()
+    wire = RunRequirement.from_dict(stored.to_dict())
+    for question in wire.tool_execution.user_feedback_schema or []:
+        question.question = "Which account?"
+        question.selected_options = ["drain-it"]
+    wire.user_feedback_schema = [UserFeedbackQuestion(question="Which account?", selected_options=["drain-it"])]
+
+    _merge_requirement_decision(stored, wire)
+
+    stored_question = stored.tool_execution.user_feedback_schema[0]
+    assert stored_question.question == "Which channel?"
+    assert stored_question.selected_options is None
+    assert stored.tool_execution.answered is None, "an unanswered question must leave the run unresolved"

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -8,6 +8,7 @@ persisted to session.runs so subsequent continue_run calls can find it after
 session reload.
 """
 
+import asyncio
 import json
 from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -3927,3 +3928,182 @@ def test_spared_leaf_keeps_tool_messages_when_owning_member_stores_them():
     )
     kept_calls = [call["id"] for m in leaf.messages or [] if m.role == "assistant" for call in m.tool_calls or []]
     assert kept_calls == ["tc-done", "tc-pending"], "both tool calls must survive when the owning member stores them"
+
+
+# ---------------------------------------------------------------------------
+# Round 11: the payload binding must carry a failure, and must not latch
+# ---------------------------------------------------------------------------
+
+
+@tool(external_execution=True)
+def fetch_ledger(quarter: str) -> str:
+    raise AssertionError("an external-execution tool must never run in-process")
+
+
+def _build_external_execution_team(db_file: str, resuming: bool) -> Team:
+    return Team(
+        name="Ledger Team",
+        id="ledger-team",
+        model=_ScriptedModel(
+            "m-leader",
+            [("content", "All done.")]
+            if resuming
+            else [("tool", "fetch_ledger", {"quarter": "q3"}, "tc-ledger"), ("content", "All done.")],
+        ),
+        tools=[fetch_ledger],
+        members=[_emailer_agent(SqliteDb(db_file=db_file), resuming)],
+        db=SqliteDb(db_file=db_file),
+        telemetry=False,
+    )
+
+
+def test_external_execution_error_flag_survives_the_binding(tmp_path):
+    """A frontend tool that reported a failure must not be rebound as a success.
+
+    agno's own AG-UI interface sets tool_call_error before handing the
+    requirements to continue_run, so dropping the flag while copying the result
+    turns every reported failure into a success in the transcript and in
+    storage.
+    """
+    db_file = str(tmp_path / "extern_err.db")
+    session_id = "s-extern-err"
+
+    run1 = _build_external_execution_team(db_file, resuming=False).run("Fetch it", session_id=session_id)
+    assert run1.is_paused
+
+    # Exactly what os/interfaces/agui/resume.py does for a failed frontend tool.
+    payload: List[RunRequirement] = []
+    for data in [r.to_dict() for r in run1.requirements or []]:
+        req = RunRequirement.from_dict(data)
+        req.tool_execution.tool_call_error = True
+        req.set_external_execution_result("Ledger service returned 503")
+        payload.append(req)
+
+    run2 = _build_external_execution_team(db_file, resuming=True).continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=payload
+    )
+
+    msgs = [m for m in (run2.messages or []) if getattr(m, "tool_call_id", None) == "tc-ledger"]
+    assert msgs, "the external execution result must reach the conversation"
+    assert msgs[0].content == "Ledger service returned 503"
+    assert msgs[0].tool_call_error is True, "a failed frontend tool must be recorded as an error"
+
+    stored = [r for r in _reload_runs(db_file, session_id) if getattr(r, "team_id", None) == "ledger-team"]
+    tools = [t for t in (stored[0].tools or []) if t.tool_name == "fetch_ledger"]
+    assert [t.tool_call_error for t in tools] == [True], "the error flag must survive the storage round trip"
+
+
+def test_rolling_back_a_refused_merge_restores_the_error_flag():
+    """tool_call_error is a decision field, so the refusal snapshot has to cover
+    it — otherwise a refused payload leaves its error flag written behind."""
+    from agno.team._run import _requirement_decision_slots
+
+    req = RunRequirement(
+        tool_execution=ToolExecution(
+            tool_name="fetch_ledger",
+            tool_args={"quarter": "q3"},
+            tool_call_id="tc-ledger",
+            external_execution_required=True,
+        )
+    )
+    slots = {attr for obj, attr in _requirement_decision_slots([req]) if obj is req.tool_execution}
+    assert "tool_call_error" in slots, "the rollback must restore tool_call_error along with the result it describes"
+
+
+def test_wire_answered_false_does_not_latch_a_prefilled_pause():
+    """Only True is an accept gesture.
+
+    The branch that honours an explicit wire flag sits under `answered is None`,
+    so writing a wire False closes that guard for good: nothing in the codebase
+    ever re-nulls the flag, and the pause becomes unresumable for the rest of
+    the session with no client-side recovery.
+    """
+    from agno.team._run import _merge_requirement_decision
+
+    stored = _prefilled_input_requirement()
+
+    not_yet = RunRequirement.from_dict(stored.to_dict())
+    not_yet.tool_execution.answered = False
+    _merge_requirement_decision(stored, not_yet)
+    assert not stored.is_resolved(), "answered=False must leave the pause unresolved"
+    assert stored.tool_execution.answered is not False, "a wire False must not be written onto the stored requirement"
+
+    accepted = RunRequirement.from_dict(stored.to_dict())
+    accepted.tool_execution.answered = True
+    _merge_requirement_decision(stored, accepted)
+
+    assert stored.tool_execution.answered is True, "a later answered=True must still take effect"
+    assert stored.is_resolved()
+
+
+# ---------------------------------------------------------------------------
+# Round 11: the storage view must never be the session's public state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_async_saves_keep_the_live_member_responses(monkeypatch):
+    """Two overlapping saves on one session must not leave the scrubbed view live.
+
+    cache_session hands every caller the same TeamSession, so rebinding
+    session.runs for the length of an awaited write publishes the throwaway view:
+    the second save captures it as the state to restore and puts it back for good.
+    """
+    from agno.session import TeamSession
+    from agno.team import _storage as team_storage
+    from agno.team._session import asave_session
+
+    worker = Agent(name="Worker", id="worker", telemetry=False)
+    team = Team(name="Root", id="root", members=[worker], telemetry=False)
+    team.db = object()  # only truthiness is read; the upsert is stubbed below
+
+    completed = RunOutput(run_id="m1", agent_id="worker", status=RunStatus.completed)
+    team_run = TeamRunOutput(run_id="t1", team_id="root", member_responses=[completed])
+    session = TeamSession(session_id="s1", team_id="root", runs=[team_run])
+
+    async def _slow_upsert(team, session):
+        await asyncio.sleep(0.01)
+
+    monkeypatch.setattr(team_storage, "_aupsert_session", _slow_upsert)
+    monkeypatch.setattr("agno.team._init._has_async_db", lambda t: True)
+
+    await asyncio.gather(asave_session(team, session), asave_session(team, session))
+
+    assert session.runs[0].member_responses == [completed], (
+        "the live session lost its member responses to the storage view"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_run_finishing_during_an_async_save_is_not_discarded(monkeypatch):
+    """A concurrent upsert_run must not land in the throwaway view and vanish."""
+    from agno.session import TeamSession
+    from agno.team import _storage as team_storage
+    from agno.team._session import asave_session
+
+    worker = Agent(name="Worker", id="worker", telemetry=False)
+    team = Team(name="Root", id="root", members=[worker], telemetry=False)
+    team.db = object()
+
+    run_a = TeamRunOutput(run_id="run-a", team_id="root", session_id="s")
+    run_a.member_responses = []
+    session = TeamSession(session_id="s", team_id="root", runs=[run_a])
+
+    async def _slow_upsert(team, session):
+        await asyncio.sleep(0.05)
+
+    monkeypatch.setattr(team_storage, "_aupsert_session", _slow_upsert)
+    monkeypatch.setattr("agno.team._init._has_async_db", lambda t: True)
+
+    save = asyncio.create_task(asave_session(team, session))
+    await asyncio.sleep(0.01)  # land inside the DB-write window
+
+    run_b = TeamRunOutput(run_id="run-b", team_id="root", session_id="s")
+    run_b.member_responses = []
+    session.upsert_run(run_b)
+
+    await save
+
+    ids = [r.run_id for r in session.runs or []]
+    assert "run-b" in ids, f"the concurrently added run was dropped by the restore; runs={ids}"
+

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -16,8 +16,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from agno.agent import Agent
+from agno.approval.decorator import approval
 from agno.db.sqlite import SqliteDb
-from agno.exceptions import RunNotContinuableError
+from agno.exceptions import RunNotContinuableError, RunNotFoundError
 from agno.models.base import Model
 from agno.models.message import Message
 from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution
@@ -4405,8 +4406,12 @@ async def test_background_continue_reports_a_refusal_to_the_client(tmp_path):
 
     assert _EXECUTED == [], "a refused continue must not execute the gated tool"
     assert [c for c in chunks if "RunError" in c], f"the refusal reached the client as an empty stream: {chunks!r}"
-    assert event_buffer.get_run_status(run1.run_id) != RunStatus.completed, (
-        "a refused continue must not be recorded as a completed run"
+    buffer_status = event_buffer.get_run_status(run1.run_id)
+    assert isinstance(buffer_status, RunStatus), (
+        f"the buffer must hold a RunStatus, got {type(buffer_status)}: /resume formats it with .value"
+    )
+    assert buffer_status == RunStatus.paused, (
+        f"a refused continue of a paused run must be recorded as paused, got {buffer_status!r}"
     )
     db_status = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status
     assert db_status == RunStatus.paused
@@ -4467,13 +4472,15 @@ async def test_a_stale_run_response_cannot_resurrect_a_finished_run(tmp_path):
     assert done.status == RunStatus.completed
     assert _EXECUTED == ["a@example.com"]
 
-    # The caller still holds the stale paused object from before that completion.
+    # The caller still holds the stale paused object from before that
+    # completion, and sends a payload that would bind: only the guard stands
+    # between this approve and a second execution.
     team3 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
     with pytest.raises(RunNotContinuableError):
         async for _ in team3.acontinue_run(
             run_response=run1,
             session_id=session_id,
-            requirements=_unbindable_payload(run1.requirements),
+            requirements=_wire_requirements(run1.requirements),
             stream=True,
             stream_events=True,
             background=True,
@@ -4493,15 +4500,15 @@ async def test_a_stale_run_response_cannot_resurrect_a_finished_run(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_a_refused_continue_restores_the_status_it_replaced(tmp_path):
-    """The refusal must put back whatever it took over, not a blanket pause.
+async def test_a_stale_run_response_cannot_resurrect_a_cancelled_run(tmp_path):
+    """A stale paused object over a cancelled stored run is refused up front.
 
-    A cancelled run handed a refused continue has to come out cancelled. Coming
-    out paused would turn every terminal state into a resumable approval.
+    Without the guard, step 1 writes RUNNING over the cancellation and the
+    continue then executes the gated tool on a run an operator cancelled.
     """
     _EXECUTED.clear()
-    db_file = str(tmp_path / "restore_status.db")
-    session_id = "s-restore-status"
+    db_file = str(tmp_path / "stale_cancelled.db")
+    session_id = "s-stale-cancelled"
 
     run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
         "Email a@example.com", session_id=session_id
@@ -4515,7 +4522,52 @@ async def test_a_refused_continue_restores_the_status_it_replaced(tmp_path):
             r.status = RunStatus.cancelled
     db.upsert_session(session)
 
-    # The caller still holds the paused object from before the cancellation.
+    # The caller still holds the paused object from before the cancellation and
+    # sends a payload that would bind.
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    with pytest.raises(RunNotContinuableError):
+        async for _ in team2.acontinue_run(
+            run_response=run1,
+            session_id=session_id,
+            requirements=_wire_requirements(run1.requirements),
+            stream=True,
+            stream_events=True,
+            background=True,
+        ):
+            pass
+    await _drain_background_tasks()
+
+    status = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status
+    assert status == RunStatus.cancelled, f"a cancelled run came back as {status!r}"
+    assert _EXECUTED == [], f"the gated tool ran on a cancelled run: {_EXECUTED}"
+
+
+@pytest.mark.asyncio
+async def test_a_refused_continue_restores_the_status_it_replaced(tmp_path):
+    """The refusal must put back whatever it took over, not a blanket pause.
+
+    An errored run handed a refused continue has to come out errored. Coming
+    out paused would turn a terminal state into a resumable approval.
+    """
+    from agno.os.managers import event_buffer
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "restore_status.db")
+    session_id = "s-restore-status"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    db = SqliteDb(db_file=db_file)
+    session = db.get_session(session_id=session_id, session_type="team")
+    for r in session.runs or []:
+        if r.run_id == run1.run_id:
+            r.status = RunStatus.error
+    db.upsert_session(session)
+
+    # The caller still holds the paused object from before the failure.
     team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
     async for _ in team2.acontinue_run(
         run_response=run1,
@@ -4529,7 +4581,11 @@ async def test_a_refused_continue_restores_the_status_it_replaced(tmp_path):
     await _drain_background_tasks()
 
     status = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status
-    assert status == RunStatus.cancelled, f"a cancelled run came back as {status!r} after a refused continue"
+    assert status == RunStatus.error, f"an errored run came back as {status!r} after a refused continue"
+    buffer_status = event_buffer.get_run_status(run1.run_id)
+    assert isinstance(buffer_status, RunStatus) and buffer_status == RunStatus.error, (
+        f"the buffer must report the restored status, got {buffer_status!r}"
+    )
     assert _EXECUTED == []
 
 
@@ -4570,7 +4626,398 @@ async def test_the_event_buffer_does_not_advertise_a_cancelled_run_as_paused(tmp
         pass
     await _drain_background_tasks()
 
-    assert event_buffer.get_run_status(run1.run_id) != RunStatus.paused, (
-        "the buffer advertises a cancelled run as paused, so every reconnecting client reads it as resumable"
+    buffer_status = event_buffer.get_run_status(run1.run_id)
+    assert isinstance(buffer_status, RunStatus), (
+        f"the buffer must hold a RunStatus, got {type(buffer_status)}: /resume formats it with .value"
+    )
+    assert buffer_status == RunStatus.cancelled, (
+        f"the buffer must report the cancelled run as cancelled, got {buffer_status!r}; advertising it as "
+        "paused tells every reconnecting client it is resumable"
     )
     assert [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status == RunStatus.cancelled
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_over_a_running_run_never_advertises_running(tmp_path):
+    """A refusal while another continue holds the run must not record RUNNING
+    as the buffer's final status: /resume treats RUNNING as in-flight and waits
+    forever on a producer that already exited."""
+    from agno.os.managers import event_buffer
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "running_refusal.db")
+    session_id = "s-running-refusal"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    db = SqliteDb(db_file=db_file)
+    session = db.get_session(session_id=session_id, session_type="team")
+    for r in session.runs or []:
+        if r.run_id == run1.run_id:
+            r.status = RunStatus.running
+    db.upsert_session(session)
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    async for _ in team2.acontinue_run(
+        run_response=run1,
+        session_id=session_id,
+        requirements=_unbindable_payload(run1.requirements),
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        pass
+    await _drain_background_tasks()
+
+    buffer_status = event_buffer.get_run_status(run1.run_id)
+    assert isinstance(buffer_status, RunStatus) and buffer_status == RunStatus.paused, (
+        f"the buffer's final status is {buffer_status!r}; RUNNING makes every reconnecting client hang"
+    )
+    assert _EXECUTED == []
+
+
+@pytest.mark.asyncio
+async def test_a_refused_continue_of_a_run_missing_from_the_session_stays_resumable(tmp_path):
+    """When the stored session has no entry for the run, the caller's object is
+    the only record of the pre-continue state; a refusal must restore it, not
+    leave the RUNNING marker step 1 wrote."""
+    from agno.os.managers import event_buffer
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "missing_run.db")
+    session_id = "s-missing-run"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    db = SqliteDb(db_file=db_file)
+    session = db.get_session(session_id=session_id, session_type="team")
+    session.runs = [r for r in session.runs or [] if r.run_id != run1.run_id]
+    db.upsert_session(session)
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    async for _ in team2.acontinue_run(
+        run_response=run1,
+        session_id=session_id,
+        requirements=_unbindable_payload(run1.requirements),
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        pass
+    await _drain_background_tasks()
+
+    stored = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0]
+    assert stored.status == RunStatus.paused, (
+        f"the refusal left the run advertised as {stored.status!r}; a RUNNING orphan can never be resumed"
+    )
+    buffer_status = event_buffer.get_run_status(run1.run_id)
+    assert isinstance(buffer_status, RunStatus) and buffer_status == RunStatus.paused, (
+        f"the buffer says {buffer_status!r} while the DB says paused; reconnecting clients read the buffer"
+    )
+
+    team3 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    done = await team3.acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert done.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_does_not_erase_a_concurrently_persisted_run(tmp_path):
+    """The refusal write-back must not save the step-1 session snapshot: a run
+    another request persisted between step 1 and the refusal has to survive."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "concurrent_refusal.db")
+    session_id = "s-concurrent-refusal"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    team3 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+
+    async def refused_continue():
+        async for _ in team2.acontinue_run(
+            run_response=run1,
+            session_id=session_id,
+            requirements=_unbindable_payload(run1.requirements),
+            stream=True,
+            stream_events=True,
+            background=True,
+        ):
+            pass
+
+    async def second_ask():
+        return await team3.arun("second ask", session_id=session_id)
+
+    _, second = await asyncio.gather(refused_continue(), second_ask())
+    await _drain_background_tasks()
+
+    runs = _reload_runs(db_file, session_id)
+    ids = [r.run_id for r in runs]
+    assert second.run_id in ids, f"the refusal write-back erased the concurrently persisted run; DB holds {ids}"
+    assert [r for r in runs if r.run_id == run1.run_id][0].status == RunStatus.paused
+
+
+@pytest.mark.asyncio
+async def test_a_background_repause_is_not_advertised_as_completed(tmp_path):
+    """A background continue that re-pauses must record PAUSED in the event
+    buffer. This is the run_id-only shape AgentOS uses, where the producer has
+    no caller-supplied run object to read the status from."""
+    from agno.os.managers import event_buffer
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "repause_buffer.db")
+    session_id = "s-repause-buffer"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    # Bindable payload without a confirmation: the continue binds, the
+    # requirement stays unresolved, and the run re-pauses.
+    unconfirmed = [RunRequirement.from_dict(r.to_dict()) for r in run1.requirements or []]
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    async for _ in team2.acontinue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=unconfirmed,
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        pass
+    await _drain_background_tasks()
+
+    assert _EXECUTED == []
+    db_status = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status
+    assert db_status == RunStatus.paused
+    buffer_status = event_buffer.get_run_status(run1.run_id)
+    assert isinstance(buffer_status, RunStatus) and buffer_status == RunStatus.paused, (
+        f"the DB says paused but the buffer says {buffer_status!r}; a reconnecting client would stop "
+        "waiting for the approval"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_run_id_raises_run_not_found_in_the_async_non_stream_lane(tmp_path):
+    """All four continue lanes must surface an unknown run id as
+    RunNotFoundError; the async non-stream lane used to crash with
+    AttributeError instead."""
+    db_file = str(tmp_path / "unknown_run.db")
+    team = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    with pytest.raises(RunNotFoundError):
+        await team.acontinue_run(run_id="no-such-run", session_id="s-unknown-run")
+
+
+def _build_own_tool_flat_team(db: SqliteDb, resuming: bool) -> Team:
+    """Top-level team with its own gated tool plus a gated member tool, so a
+    pause carries one team-level and one member-level requirement."""
+    script = (
+        [("content", "All done.")]
+        if resuming
+        else [
+            (
+                "tools",
+                [
+                    ("delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-deleg"),
+                    ("publish", {"item": "release"}, "tc-pub"),
+                ],
+            ),
+            ("content", "All done."),
+        ]
+    )
+    return Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel("m-leader", script),
+        tools=[publish],
+        members=[_emailer_agent(db, resuming)],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_a_sync_stream_cancel_keeps_team_level_requirements(tmp_path):
+    """A cancel that lands during member routing must persist the run with its
+    team-level requirements still attached, the same set the async stream
+    persists."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "sync_cancel_reqs.db")
+    session_id = "s-sync-cancel-reqs"
+
+    team1 = _build_own_tool_flat_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Publish the release and email a@example.com", session_id=session_id)
+    assert run1.is_paused
+    names = sorted(r.tool_execution.tool_name for r in run1.requirements or [])
+    assert names == ["publish", "send_email"], names
+
+    team2 = _build_own_tool_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    stream = team2.continue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(run1.requirements),
+        stream=True,
+        stream_events=True,
+        yield_run_output=True,
+    )
+    # Cancel before iterating: the cancel lands inside member routing.
+    Team.cancel_run(run1.run_id)
+
+    final = None
+    for ev in stream:
+        if isinstance(ev, TeamRunOutput):
+            final = ev
+
+    assert final is not None and final.status == RunStatus.cancelled
+    final_names = sorted(r.tool_execution.tool_name for r in (final.requirements or []))
+    assert "publish" in final_names, f"the caller's run object lost the team-level requirement: {final_names}"
+    stored = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0]
+    stored_names = sorted(r.tool_execution.tool_name for r in (stored.requirements or []))
+    assert "publish" in stored_names, f"the stored run lost the team-level requirement: {stored_names}"
+
+
+_NOTES: List[Any] = []
+
+
+@tool(requires_user_input=True, user_input_fields=["to"])
+@approval(type="required")
+def send_note(to: str, body: str) -> str:
+    _NOTES.append((to, body))
+    return f"note to {to}: {body}"
+
+
+@tool(external_execution=True)
+@approval(type="required")
+def run_export(target: str) -> str:
+    raise AssertionError("externally executed tools never run in-process")
+
+
+def _approval_team(db: SqliteDb, resuming: bool, member_tool=None) -> Team:
+    member_tool = member_tool if member_tool is not None else send_note
+    tool_name = member_tool.name
+    tool_args = {"body": "hi"} if tool_name == "send_note" else {"target": "reports"}
+    agent = Agent(
+        name="Noter",
+        id="noter",
+        model=_ScriptedModel(
+            "m-noter",
+            [("content", "Sent.")] if resuming else [("tool", tool_name, tool_args, "tc-note"), ("content", "Sent.")],
+        ),
+        tools=[member_tool],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Notes Team",
+        id="notes-team",
+        model=_ScriptedModel(
+            "m-lead",
+            [("content", "All done.")]
+            if resuming
+            else [
+                ("tool", "delegate_task_to_member", {"member_id": "noter", "task": "note it"}, "tc-deleg"),
+                ("content", "All done."),
+            ],
+        ),
+        members=[agent],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _resolve_required_approval(db: SqliteDb, run1, resolution_data) -> None:
+    approvals, _ = db.get_approvals(run_id=run1.run_id, approval_type="required", limit=5)
+    if not approvals:
+        for r in run1.requirements or []:
+            aid = getattr(r.tool_execution, "approval_id", None)
+            if aid:
+                record = db.get_approval(aid)
+                if record:
+                    approvals = [record]
+                    break
+    assert approvals, "no approval record was created for the paused run"
+    db.update_approval(approvals[0]["id"], status="approved", resolution_data=resolution_data)
+
+
+def test_an_admin_approved_member_user_input_run_completes(tmp_path):
+    """An approval resolved out of band with the missing input values must let a
+    continue with no requirements payload finish the run."""
+    _NOTES.clear()
+    db_file = str(tmp_path / "admin_approval.db")
+    session_id = "s-admin-approval"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = _approval_team(db, resuming=False).run("Send a note", session_id=session_id)
+    assert run1.is_paused
+
+    _resolve_required_approval(db, run1, {"values": {"to": "bob@example.com"}})
+
+    team2 = _approval_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.completed, f"admin-approved run did not complete: {run2.status}"
+    assert _NOTES == [("bob@example.com", "hi")], _NOTES
+
+
+@pytest.mark.asyncio
+async def test_an_admin_approved_member_user_input_run_completes_async(tmp_path):
+    _NOTES.clear()
+    db_file = str(tmp_path / "admin_approval_async.db")
+    session_id = "s-admin-approval-async"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = await _approval_team(db, resuming=False).arun("Send a note", session_id=session_id)
+    assert run1.is_paused
+
+    _resolve_required_approval(db, run1, {"values": {"to": "bob@example.com"}})
+
+    team2 = _approval_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = await team2.acontinue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.completed, f"admin-approved run did not complete: {run2.status}"
+    assert _NOTES == [("bob@example.com", "hi")], _NOTES
+
+
+def test_an_admin_approved_external_execution_member_run_completes(tmp_path):
+    """An approval resolved with the external tool's result must let the
+    continue finish instead of re-pausing on needs_external_execution."""
+    db_file = str(tmp_path / "admin_approval_ext.db")
+    session_id = "s-admin-approval-ext"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = _approval_team(db, resuming=False, member_tool=run_export).run("Export it", session_id=session_id)
+    assert run1.is_paused
+
+    _resolve_required_approval(db, run1, {"result": "EXPORT_OK"})
+
+    team2 = _approval_team(SqliteDb(db_file=db_file), resuming=True, member_tool=run_export)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.completed, f"admin-approved run did not complete: {run2.status}"
+
+
+def test_an_approval_without_values_keeps_the_run_paused(tmp_path):
+    """An approval that supplies none of the required input values must not let
+    the gated tool run with None arguments; the run asks again."""
+    _NOTES.clear()
+    db_file = str(tmp_path / "admin_approval_empty.db")
+    session_id = "s-admin-approval-empty"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = _approval_team(db, resuming=False).run("Send a note", session_id=session_id)
+    assert run1.is_paused
+
+    _resolve_required_approval(db, run1, None)
+
+    team2 = _approval_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.paused, f"an unfilled approval let the run reach {run2.status}"
+    assert _NOTES == [], f"the gated tool ran without its input values: {_NOTES}"

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -5293,6 +5293,43 @@ async def test_a_background_fork_does_not_restamp_the_original_runs_buffer(tmp_p
     )
 
 
+@pytest.mark.asyncio
+async def test_a_run_id_auto_fork_does_not_restamp_the_original_runs_buffer(tmp_path):
+    """A background continue of a completed run by run_id auto-forks; the
+    auto-fork's status must not land under the original run's buffer key."""
+    from agno.os.managers import event_buffer
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "auto_fork_buffer.db")
+    session_id = "s-auto-fork-buffer"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+    await _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status == RunStatus.completed
+
+    # No fork flag: the dispatcher auto-forks the completed run, and the
+    # resuming=False team replays the delegation so the fork pauses.
+    async for _ in _build_flat_team(SqliteDb(db_file=db_file), resuming=False).acontinue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        pass
+    await _drain_background_tasks()
+
+    buffer_status = event_buffer.get_run_status(run1.run_id)
+    assert buffer_status == RunStatus.completed, (
+        f"the original completed run's buffer entry took the auto-fork's status: {buffer_status!r}"
+    )
+
+
 class _BoomModel(_ScriptedModel):
     def invoke(self, *args: Any, **kwargs: Any) -> Any:
         raise RuntimeError("leader boom")
@@ -5617,6 +5654,173 @@ async def test_one_approval_does_not_resolve_a_sibling_with_colliding_tool_call_
     run2 = await team2.acontinue_run(run_id=run1.run_id, session_id=session_id)
     assert run2.status == RunStatus.paused, f"a pending sibling approval let the run reach {run2.status}"
     assert _FIRED == [], f"a tool executed while its own approval was pending: {_FIRED}"
+
+
+def test_a_deleted_sibling_approval_blocks_the_continue(tmp_path):
+    """A tool whose own approval record is gone stays unresolved. Falling back
+    to a sibling's record would let that sibling's approval execute it."""
+    _FIRED.clear()
+    db_file = str(tmp_path / "deleted_approval.db")
+    session_id = "s-deleted-approval"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = _two_member_approval_team(db, resuming=False).run("Do both", session_id=session_id)
+    assert run1.is_paused
+
+    db.update_approval(_approval_record_for_tool(db, "alpha_action")["id"], status="approved", resolution_data=None)
+    assert db.delete_approval(_approval_record_for_tool(db, "beta_action")["id"])
+
+    team2 = _two_member_approval_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.paused, f"a deleted sibling record let the run reach {run2.status}"
+    assert _FIRED == [], f"a tool executed with its own approval record deleted: {_FIRED}"
+
+
+_MIXED: List[str] = []
+
+
+@tool(requires_confirmation=True)
+@approval(type="required")
+def announce(item: str) -> str:
+    _MIXED.append(f"announce:{item}")
+    return f"announced {item}"
+
+
+@tool(requires_confirmation=True)
+@approval(type="required")
+def notify(to: str) -> str:
+    _MIXED.append(f"notify:{to}")
+    return f"notified {to}"
+
+
+def _mixed_approval_team(db: SqliteDb, resuming: bool) -> Team:
+    """A team-level gated tool plus a delegated member gated tool, each backed
+    by its own approval record."""
+    noter = Agent(
+        name="Noter",
+        id="noter",
+        model=_ScriptedModel(
+            "m-noter",
+            [("content", "Notified.")]
+            if resuming
+            else [("tool", "notify", {"to": "ops@example.com"}, "tc-notify"), ("content", "Notified.")],
+        ),
+        tools=[notify],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Mixed Team",
+        id="mixed-team",
+        model=_ScriptedModel(
+            "m-lead",
+            [("content", "All done.")]
+            if resuming
+            else [
+                (
+                    "tools",
+                    [
+                        ("delegate_task_to_member", {"member_id": "noter", "task": "notify ops"}, "tc-deleg"),
+                        ("announce", {"item": "release"}, "tc-announce"),
+                    ],
+                ),
+                ("content", "All done."),
+            ],
+        ),
+        tools=[announce],
+        members=[noter],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_a_team_approval_does_not_decide_a_member_tools_record(tmp_path):
+    """The team pause's record must not overwrite the approval id a member
+    tool already owns; approving only the team record leaves the member's
+    record pending and nothing executes."""
+    _MIXED.clear()
+    db_file = str(tmp_path / "mixed_team_member.db")
+    session_id = "s-mixed-team-member"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = _mixed_approval_team(db, resuming=False).run("Announce and notify", session_id=session_id)
+    assert run1.is_paused
+    records, _ = db.get_approvals(approval_type="required", limit=50)
+    assert len(records) == 2, f"expected a team record and a member record, got {len(records)}"
+
+    db.update_approval(_approval_record_for_tool(db, "announce")["id"], status="approved", resolution_data=None)
+
+    team2 = _mixed_approval_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.paused, f"the member's pending record was ignored: {run2.status}"
+    assert _MIXED == [], f"a tool executed on the team record alone: {_MIXED}"
+
+    db2 = SqliteDb(db_file=db_file)
+    db2.update_approval(_approval_record_for_tool(db2, "notify")["id"], status="approved", resolution_data=None)
+    team3 = _mixed_approval_team(SqliteDb(db_file=db_file), resuming=True)
+    run3 = team3.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run3.status == RunStatus.completed, run3.status
+    assert sorted(_MIXED) == ["announce:release", "notify:ops@example.com"], _MIXED
+
+
+def test_a_reclaimed_paused_buffer_keeps_its_event_index():
+    """Reclaiming a paused entry must not reset the monotonic event index: a
+    later continuation would recycle indices a client's cursor already covers,
+    and its events would be silently deduplicated away."""
+    from agno.os.managers import EventsBuffer
+
+    buf = EventsBuffer(cleanup_interval=3600)
+    assert buf.add_event("r-reclaim-idx", MagicMock()) == 0
+    assert buf.add_event("r-reclaim-idx", MagicMock()) == 1
+    buf.set_run_completed("r-reclaim-idx", RunStatus.paused)
+    buf.cleanup_interval = -1
+    buf.cleanup_runs()
+    assert buf.get_run_status("r-reclaim-idx") is None
+
+    # The continuation after the reclaim keeps ascending.
+    buf.cleanup_interval = 3600
+    assert buf.add_event("r-reclaim-idx", MagicMock()) == 2, "the reclaimed run's event index restarted"
+    assert buf.get_run_status("r-reclaim-idx") == RunStatus.running
+
+
+@pytest.mark.asyncio
+async def test_a_background_fork_from_a_stale_object_keeps_the_originals_buffer_status(tmp_path):
+    """A fork's bookkeeping under the original run's key reflects the original
+    run's stored status, not the stale caller object's."""
+    from agno.os.managers import event_buffer
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "stale_fork_buffer.db")
+    session_id = "s-stale-fork-buffer"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+    done = await _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert done.status == RunStatus.completed
+
+    # The caller still holds the stale paused object and forks off it.
+    team3 = _build_flat_team(SqliteDb(db_file=db_file), resuming=False)
+    async for _ in team3.acontinue_run(
+        run_response=run1,
+        session_id=session_id,
+        fork=True,
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        pass
+    await _drain_background_tasks()
+
+    assert [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status == RunStatus.completed
+    buffer_status = event_buffer.get_run_status(run1.run_id)
+    assert buffer_status == RunStatus.completed, (
+        f"the completed original is advertised as {buffer_status!r} because the stale object leaked into "
+        "the fork's bookkeeping"
+    )
 
 
 def test_a_paused_buffer_entry_reused_by_a_continue_is_not_reclaimed():

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -9,7 +9,7 @@ session reload.
 """
 
 import json
-from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,6 +18,7 @@ from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.exceptions import RunNotContinuableError
 from agno.models.base import Model
+from agno.models.message import Message
 from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution
 from agno.run.agent import RunOutput
 from agno.run.base import RunStatus
@@ -3205,9 +3206,8 @@ def test_user_feedback_selections_reach_the_stored_tool_execution():
 
 
 def test_user_feedback_answer_for_an_unknown_question_is_ignored():
-    from agno.tools.function import UserFeedbackQuestion
-
     from agno.team._run import _merge_requirement_decision
+    from agno.tools.function import UserFeedbackQuestion
 
     stored = _feedback_requirement()
     wire = RunRequirement.from_dict(stored.to_dict())
@@ -3284,3 +3284,646 @@ def test_restoring_decisions_undoes_the_whole_merge():
 
     assert [r.to_dict() for r in stored] == before, "the snapshot must cover every field the merge writes"
     assert not any(r.is_resolved() for r in stored)
+
+
+# ---------------------------------------------------------------------------
+# Round 10: conflicting identities, prefilled input, merge rollback, retry
+# member phase, storage owning path
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Round 10.1: continue-payload binding when a payload requirement's identity
+# conflicts with the stored requirements.
+#
+# Defect: in _backfill_approval_to_requirements, a payload entry whose
+# requirement id matches stored requirement A but whose tool_call_id belongs
+# to a DIFFERENT stored requirement B silently drops the id match
+# ("cross-check failed") and falls through to the tool_call_id fallback,
+# binding the entry to B. The client's confirmation then executes B's tool
+# even though the entry named A. A conflicting identity must refuse the
+# continue instead; the tool_call_id fallback exists only for entries whose id
+# matches no stored requirement at all (RunRequirement auto-generates ids, so
+# unknown ids are a normal wire condition).
+# ---------------------------------------------------------------------------
+
+
+def _stored_confirmation_requirements() -> List[RunRequirement]:
+    req_a = RunRequirement(
+        tool_execution=_make_tool_execution(tool_name="send_email", tool_call_id="tc-a", requires_confirmation=True),
+        id="req-a",
+    )
+    req_b = RunRequirement(
+        tool_execution=_make_tool_execution(
+            tool_name="delete_records", tool_call_id="tc-b", requires_confirmation=True
+        ),
+        id="req-b",
+    )
+    return [req_a, req_b]
+
+
+def _run_with(stored: List[RunRequirement]) -> TeamRunOutput:
+    return TeamRunOutput(
+        run_id="run-1",
+        session_id="session-1",
+        requirements=stored,
+        tools=[r.tool_execution for r in stored],
+    )
+
+
+def test_conflicting_requirement_identity_refuses_the_continue():
+    """Pins the fix for the cross-check fallthrough: a payload entry carrying
+    stored requirement A's id but stored requirement B's tool_call_id must
+    raise RunNotContinuableError and leave the run paused and unchanged. At
+    the defective head the id match is silently discarded and the tool_call_id
+    fallback binds the entry to B, so B's tool executes with a confirmation
+    the client gave under A's identity."""
+    from agno.team._run import _apply_requirements_payload
+
+    stored = _stored_confirmation_requirements()
+    run_response = _run_with(stored)
+
+    conflicting = RunRequirement(
+        tool_execution=_make_tool_execution(
+            tool_name="delete_records", tool_call_id="tc-b", requires_confirmation=True
+        ),
+        id="req-a",  # stored A's identity over stored B's tool call
+    )
+    conflicting.confirm()
+
+    with pytest.raises(RunNotContinuableError):
+        _apply_requirements_payload(run_response, [conflicting])
+
+    # The refusal left the run paused and untouched: B never received the
+    # confirmation that was addressed to A, and the stored requirements are
+    # still the ones routing sees.
+    assert stored[1].confirmation is None
+    assert stored[1].tool_execution.confirmed is None
+    assert run_response.requirements == stored
+
+
+def test_unknown_requirement_id_still_binds_by_unique_tool_call_id():
+    """Pins behavior that must SURVIVE the conflicting-identity fix: an entry
+    whose id matches no stored requirement (RunRequirement auto-generates a
+    fresh id for every wire object, so unknown ids are normal) binds via the
+    tool_call_id fallback when exactly one stored requirement carries that
+    tool_call_id. This test passes at the defective head too; it guards the
+    fix against over-tightening the fallback."""
+    from agno.team._run import _apply_requirements_payload
+
+    stored = _stored_confirmation_requirements()
+    run_response = _run_with(stored)
+
+    wire = RunRequirement(  # auto-generated id, unknown to the stored run
+        tool_execution=_make_tool_execution(
+            tool_name="delete_records", tool_call_id="tc-b", requires_confirmation=True
+        ),
+    )
+    assert wire.id not in {r.id for r in stored}
+    wire.confirm()
+
+    _apply_requirements_payload(run_response, [wire])
+
+    # The fallback bound the entry to the STORED requirement object and merged
+    # only the decision onto it.
+    assert run_response.requirements is not None
+    assert run_response.requirements[0] is stored[1]
+    assert stored[1].confirmation is True
+    assert stored[1].tool_execution.confirmed is True
+
+
+# ---------------------------------------------------------------------------
+# Round 10.2: prefilled user-input pauses that could never resume.
+#
+# A requires_user_input tool can pause with EVERY canonical field already
+# populated by model-supplied arguments — the pause exists so the user can
+# review and accept them. _merge_requirement_decision computed
+# input_was_open/feedback_was_open from the stored schema before merging, so a
+# fully prefilled schema left both False, and the wire answered flag was
+# copied only when the stored requirement carried NO input schema and NO
+# feedback schema at all. The client's explicit answered=True was therefore
+# dropped, stored answered stayed None, and continuation left the run paused
+# forever.
+#
+# The correct behavior pinned here: when the stored canonical schema is
+# complete (no field open), an explicit wire answered flag is accepted — while
+# schemas are still never rebound and a wire answered=True with an OPEN stored
+# field is still ignored.
+# ---------------------------------------------------------------------------
+
+
+def _prefilled_input_requirement() -> RunRequirement:
+    """A user-input pause whose every field the model prefilled at pause time."""
+    from agno.tools.function import UserInputField
+
+    tool_execution = ToolExecution(
+        tool_name="transfer",
+        tool_args={"account_id": "victim", "note": "monthly rent"},
+        tool_call_id="tc-prefilled",
+        requires_user_input=True,
+        user_input_schema=[
+            UserInputField(name="account_id", field_type=str, value="victim"),
+            UserInputField(name="note", field_type=str, value="monthly rent"),
+        ],
+    )
+    return RunRequirement(tool_execution=tool_execution)
+
+
+def test_wire_answered_flag_resolves_a_fully_prefilled_input_schema():
+    """A fully prefilled schema has no open field for the merge to fill, so the
+    client's explicit answered=True is the only signal that the user accepted
+    the values. The merge dropped it (the wire flag was honored only when the
+    stored requirement had no schema at all), leaving answered=None and the
+    run paused forever."""
+    from agno.team._run import _merge_requirement_decision
+
+    stored = _prefilled_input_requirement()
+    stored_schema = stored.tool_execution.user_input_schema
+    assert stored.tool_execution.answered is None
+
+    wire = RunRequirement.from_dict(stored.to_dict())
+    # The user reviews the prefilled values and accepts them unchanged: every
+    # field already has a value, so the client marks the requirement answered.
+    wire.provide_user_input({})
+    assert wire.tool_execution.answered is True
+
+    _merge_requirement_decision(stored, wire)
+
+    assert stored.tool_execution.answered is True, "an accepted prefilled pause must read as answered"
+    assert stored.is_resolved()
+    # The schema is never rebound and the model-fixed values stand.
+    assert stored.tool_execution.user_input_schema is stored_schema
+    assert [(f.name, f.value) for f in stored_schema] == [("account_id", "victim"), ("note", "monthly rent")]
+
+
+def test_prefilled_input_pause_resolves_through_apply_requirements_payload():
+    """The end-to-end consequence of the dropped flag: a continuation payload
+    (raw dicts, as the wire delivers them) must leave the stored requirement
+    resolved rather than permanently paused."""
+    from agno.team._run import _apply_requirements_payload
+
+    stored = _prefilled_input_requirement()
+    run_response = TeamRunOutput(
+        run_id="run-prefilled",
+        session_id="session-prefilled",
+        requirements=[stored],
+        tools=[stored.tool_execution],
+    )
+
+    wire = RunRequirement.from_dict(stored.to_dict())
+    wire.provide_user_input({})
+    assert wire.tool_execution.answered is True
+    payload = [wire.to_dict()]
+
+    _apply_requirements_payload(run_response, payload)
+
+    assert run_response.requirements is not None
+    assert run_response.requirements[0] is stored, "binding must keep the stored requirement as the routed object"
+    assert stored.tool_execution.answered is True, "the accepted prefilled pause must resolve on continue"
+    assert stored.is_resolved()
+
+
+def test_wire_answered_flag_still_ignored_while_a_field_is_open():
+    """The safeguard the fix must not weaken: answered=True from the wire with
+    a stored field still open would run the gated tool with that field empty,
+    so it must continue to be ignored."""
+    from agno.team._run import _merge_requirement_decision
+    from agno.tools.function import UserInputField
+
+    stored = RunRequirement(
+        tool_execution=ToolExecution(
+            tool_name="transfer",
+            tool_args={"account_id": "victim"},
+            tool_call_id="tc-open",
+            requires_user_input=True,
+            user_input_schema=[
+                UserInputField(name="account_id", field_type=str, value="victim"),
+                UserInputField(name="note", field_type=str),
+            ],
+        )
+    )
+
+    wire = RunRequirement.from_dict(stored.to_dict())
+    wire.tool_execution.answered = True
+
+    _merge_requirement_decision(stored, wire)
+
+    assert stored.tool_execution.answered is None, "an open field must keep the requirement unanswered"
+    assert not stored.is_resolved()
+
+
+# ---------------------------------------------------------------------------
+# Round 10.3: a merge exception inside _apply_requirements_payload must not
+# bank earlier payload entries' decisions.
+#
+# _apply_requirements_payload snapshots the stored requirements' decision
+# state (_snapshot_requirement_decisions) before binding the payload, but its
+# except clause restores only the run object's requirements and tools list
+# references. _merge_requirement_decision can raise on malformed wire data
+# AFTER an earlier payload entry already merged - e.g. a user_feedback answer
+# whose selected_options is not iterable raises TypeError in the option
+# membership check. Without _restore_requirement_decisions in that except, the
+# earlier entry's banked confirmation and the partially written feedback state
+# survive the refusal, so a bare retry of the rejected request would execute
+# tools the caller was told stayed untouched.
+# ---------------------------------------------------------------------------
+
+
+def _stored_confirm_and_feedback_requirements() -> List[RunRequirement]:
+    from agno.tools.function import UserFeedbackOption, UserFeedbackQuestion
+
+    confirm_req = _make_requirement(
+        tool_name="send_email", tool_call_id="tc-confirm", requires_confirmation=True, approval_type="required"
+    )
+    feedback_req = _make_requirement(
+        tool_name="notify",
+        tool_call_id="tc-feedback",
+        user_feedback_schema=[
+            UserFeedbackQuestion(
+                question="Which channel?",
+                options=[UserFeedbackOption(label="email"), UserFeedbackOption(label="sms")],
+            )
+        ],
+    )
+    feedback_req.user_feedback_schema = feedback_req.tool_execution.user_feedback_schema
+    return [confirm_req, feedback_req]
+
+
+def _apply_two_entry_payload_that_raises_mid_merge(stored: List[RunRequirement]) -> TeamRunOutput:
+    """Run the production payload apply with a valid first entry and a second
+    entry whose feedback answer raises inside the merge, and return the run.
+
+    The second entry's selected_options is an int: UserFeedbackQuestion's
+    deserialization keeps it as-is, so the TypeError fires only inside
+    _fill_user_feedback_answers ("option.label in question.selected_options"),
+    after the first entry's confirmation already merged onto its stored
+    requirement.
+    """
+    from agno.team._run import _apply_requirements_payload
+
+    run_response = TeamRunOutput(
+        run_id="run-1",
+        session_id="session-1",
+        requirements=stored,
+        tools=[r.tool_execution for r in stored],
+    )
+    payload = [
+        {"id": stored[0].id, "tool_execution": {"tool_call_id": "tc-confirm"}, "confirmation": True},
+        {
+            "id": stored[1].id,
+            "tool_execution": {
+                "tool_call_id": "tc-feedback",
+                "user_feedback_schema": [{"question": "Which channel?", "selected_options": 5}],
+            },
+        },
+    ]
+
+    with pytest.raises(Exception):
+        _apply_requirements_payload(run_response, payload)
+    return run_response
+
+
+def test_merge_exception_does_not_bank_an_earlier_entrys_confirmation():
+    """Pins: the except in _apply_requirements_payload restores only list
+    references, so the confirmation merged from the first payload entry
+    survives when a later entry's merge raises.
+    """
+    stored = _stored_confirm_and_feedback_requirements()
+
+    _apply_two_entry_payload_that_raises_mid_merge(stored)
+
+    assert stored[0].confirmation is None, (
+        "a refused continue must not bank the first entry's confirmation on the stored requirement"
+    )
+    assert stored[0].tool_execution.confirmed is None, (
+        "a refused continue must not leave the stored tool execution confirmed"
+    )
+    assert not any(r.is_resolved() for r in stored)
+
+
+def test_merge_exception_does_not_leave_partial_feedback_state():
+    """Pins: _fill_user_feedback_answers writes selected_options before the
+    option loop raises on the malformed value, and the except never restores
+    decision fields - the corrupted answer survives the refusal.
+    """
+    stored = _stored_confirm_and_feedback_requirements()
+
+    _apply_two_entry_payload_that_raises_mid_merge(stored)
+
+    question = stored[1].tool_execution.user_feedback_schema[0]
+    assert question.selected_options is None, (
+        "a refused continue must not leave the malformed answer on the stored feedback question"
+    )
+    assert [option.selected for option in question.options] == [False, False]
+
+
+# ---------------------------------------------------------------------------
+# Round 10.4: async continue retries must not falsely complete member-only
+# continuations.
+#
+# Defect: in _acontinue_run and _acontinue_run_stream the whole continue
+# dispatch sits inside the retry loop. On attempt 1 the requirements payload
+# binds (requirements_applied=True), member routing succeeds and consumes the
+# member requirements, and then the leader model call raises a transient
+# (non-ValueError) exception. On attempt 2 member_results is re-initialized to
+# [], the requirements_applied guard skips re-binding, no requirements are
+# left, and every branch is skipped — the run falls through to
+# RunStatus.completed with content=None. The leader is never retried and the
+# member results are lost. The sync _continue_run does not have this defect
+# because its retry loop wraps only the model call.
+#
+# Correct behavior pinned here: after a transient leader-model failure that
+# follows successful member routing, the retry re-runs the leader with the
+# preserved member results and the run completes WITH the leader's content.
+# ---------------------------------------------------------------------------
+
+
+class _FlakyScriptedModel(Model):
+    """Emits scripted turns offline: ('tool', name, args, id), ('content', text),
+    or ('raise', message) which raises RuntimeError — a transient provider
+    failure that the team retry loop is meant to absorb (it is deliberately
+    not a ValueError, InputCheckError or RunCancelledException)."""
+
+    def __init__(self, model_id: str, script: List[tuple]):
+        super().__init__(id=model_id, name=model_id, provider="test")
+        self._script = list(script)
+        self._i = 0
+
+    def _next(self) -> ModelResponse:
+        from agno.metrics import MessageMetrics
+
+        turn = self._script[min(self._i, len(self._script) - 1)]
+        self._i += 1
+        if turn[0] == "raise":
+            raise RuntimeError(turn[1])
+        if turn[0] == "tool":
+            _, name, args, tcid = turn
+            r = ModelResponse(role="assistant")
+            r.tool_calls = [{"id": tcid, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}]
+        else:
+            r = ModelResponse(content=turn[1], role="assistant")
+            r.event = ModelResponseEvent.assistant_response.value
+        r.response_usage = MessageMetrics(input_tokens=10, output_tokens=5, total_tokens=15)
+        return r
+
+    def invoke(self, *a, **k):
+        return self._next()
+
+    async def ainvoke(self, *a, **k):
+        return self._next()
+
+    def invoke_stream(self, *a, **k) -> Iterator[ModelResponse]:
+        yield self._next()
+
+    async def ainvoke_stream(self, *a, **k) -> AsyncIterator[ModelResponse]:
+        yield self._next()
+
+    def parse_provider_response(self, response: Any, **k) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response(self, response: Any, **k) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+
+def _flaky_emailer_agent(db: SqliteDb, resuming: bool) -> Agent:
+    script = (
+        [("content", "Email sent.")]
+        if resuming
+        else [("tool", "send_email", {"to": "a@example.com"}, "tc-send"), ("content", "Email sent.")]
+    )
+    return Agent(
+        name="Emailer",
+        id="emailer",
+        model=_FlakyScriptedModel("m-emailer", script),
+        tools=[send_email],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _build_pausing_team(db: SqliteDb) -> Team:
+    """Phase 1: leader delegates, the member's gated tool pauses the run."""
+    return Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_FlakyScriptedModel(
+            "m-leader",
+            [
+                ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-deleg"),
+                ("content", "All done."),
+            ],
+        ),
+        members=[_flaky_emailer_agent(db, resuming=False)],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _build_flaky_resuming_team(db: SqliteDb) -> Team:
+    """Phase 2: the leader's FIRST call after member routing raises a
+    transient RuntimeError; the retry's call returns the final content."""
+    return Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_FlakyScriptedModel(
+            "m-leader-flaky",
+            [("raise", "transient provider failure"), ("content", "final answer")],
+        ),
+        members=[_flaky_emailer_agent(db, resuming=True)],
+        db=db,
+        telemetry=False,
+        retries=1,
+        delay_between_retries=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_continue_retry_reruns_leader_with_member_results_after_transient_failure(tmp_path):
+    """Pins the defect where _acontinue_run's retry attempt resets
+    member_results and skips re-binding after member routing consumed the
+    requirements, falling through to a false COMPLETED with content=None
+    instead of re-running the leader with the preserved member results."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "retry_member_phase.db")
+    session_id = "s-retry-member-phase"
+
+    team1 = _build_pausing_team(SqliteDb(db_file=db_file))
+    run1 = await team1.arun("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+    assert _EXECUTED == []
+
+    team2 = _build_flaky_resuming_team(SqliteDb(db_file=db_file))
+    run2 = await team2.acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+
+    # The confirmed member tool executed during routing on the first attempt.
+    assert _EXECUTED == ["a@example.com"]
+    # The retry must re-run the leader over the preserved member results and
+    # complete with the leader's content — not an empty COMPLETED.
+    assert run2.status == RunStatus.completed
+    assert run2.content == "final answer", (
+        "transient leader failure after member routing must retry the leader, "
+        f"not complete with content={run2.content!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_continue_retry_reruns_leader_with_member_results_after_transient_failure(tmp_path):
+    """Pins the same defect in _acontinue_run_stream: the retry attempt after
+    a transient leader-model failure skips every branch and yields a falsely
+    COMPLETED run with content=None instead of re-running the leader."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "retry_member_phase_stream.db")
+    session_id = "s-retry-member-phase-stream"
+
+    team1 = _build_pausing_team(SqliteDb(db_file=db_file))
+    run1 = await team1.arun("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+    assert _EXECUTED == []
+
+    team2 = _build_flaky_resuming_team(SqliteDb(db_file=db_file))
+    final = None
+    async for event in team2.acontinue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(run1.requirements),
+        stream=True,
+        yield_run_output=True,
+    ):
+        if isinstance(event, TeamRunOutput):
+            final = event
+
+    assert final is not None
+    assert _EXECUTED == ["a@example.com"]
+    assert final.status == RunStatus.completed
+    assert final.content == "final answer", (
+        "transient leader failure after member routing must retry the leader, "
+        f"not complete with content={final.content!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round 10.5: the storage view of a spared paused member run must resolve
+# storage flags through the paused response's OWNING PATH in the team tree,
+# not through a global first-match id search from the root team.
+#
+# Defect: duplicate leaf member ids across sibling subteams are supported, but
+# _storage_view_of_spared_run resolves flags via _find_member_by_id(team,
+# member_id) from the ROOT team, and _scrub_member_responses_keeping_paused
+# recurses into nested spared runs passing the ROOT team unchanged. A paused
+# run owned by the right subteam's leaf therefore picks up the LEFT subteam's
+# same-id leaf and applies the wrong store_tool_messages setting.
+# ---------------------------------------------------------------------------
+
+
+def _build_root_with_duplicate_leaf_ids(
+    left_store_tool_messages: bool, right_store_tool_messages: bool
+) -> Tuple[Team, Team]:
+    """Root -> [left subteam, right subteam]; each subteam holds a leaf agent
+    with the SAME name, so both leaves derive the same url-safe member id."""
+    from agno.utils.team import get_member_id
+
+    left_worker = Agent(name="Worker", store_tool_messages=left_store_tool_messages, telemetry=False)
+    right_worker = Agent(name="Worker", store_tool_messages=right_store_tool_messages, telemetry=False)
+    left_team = Team(name="Left Team", members=[left_worker], telemetry=False)
+    right_team = Team(name="Right Team", members=[right_worker], telemetry=False)
+    root = Team(name="Root Team", members=[left_team, right_team], telemetry=False)
+
+    assert get_member_id(left_worker) == get_member_id(right_worker), (
+        "the setup requires duplicate leaf member ids across sibling subteams"
+    )
+    return root, right_team
+
+
+def _paused_root_run_owned_by_right_leaf(root: Team, right_team: Team) -> TeamRunOutput:
+    """Root run whose only member response is a paused right-subteam run that
+    holds the paused leaf run: one completed tool call with its tool result
+    message, plus an unresolved pending call on the same assistant turn."""
+    from agno.utils.team import get_member_id
+
+    leaf_run = RunOutput(
+        run_id="member-run-right-worker",
+        agent_id=get_member_id(right_team.members[0]),
+        status=RunStatus.paused,
+        messages=[
+            Message(
+                role="assistant",
+                tool_calls=[
+                    {"id": "tc-done", "type": "function", "function": {"name": "send_email", "arguments": "{}"}},
+                    {"id": "tc-pending", "type": "function", "function": {"name": "send_sms", "arguments": "{}"}},
+                ],
+            ),
+            Message(role="tool", tool_call_id="tc-done", content="Email sent"),
+        ],
+    )
+    right_team_run = TeamRunOutput(
+        run_id="team-run-right",
+        team_id=get_member_id(right_team),
+        status=RunStatus.paused,
+        member_responses=[leaf_run],
+    )
+    return TeamRunOutput(
+        run_id="team-run-root",
+        team_id=get_member_id(root),
+        status=RunStatus.paused,
+        member_responses=[right_team_run],
+    )
+
+
+def _stored_leaf(view: TeamRunOutput) -> RunOutput:
+    stored_right = view.member_responses[0]
+    assert getattr(stored_right, "member_responses", None), "the paused leaf run must be spared for the resume"
+    return stored_right.member_responses[0]
+
+
+def test_spared_leaf_storage_flags_resolve_through_owning_subteam():
+    """Pins the defect where _storage_view_of_spared_run resolves a duplicate
+    leaf id from the ROOT team: the left sibling's store_tool_messages=True
+    wins over the owning right worker's False, so completed tool messages are
+    persisted against the actual member's setting."""
+    from agno.team._session import _scrub_member_responses_keeping_paused
+
+    root, right_team = _build_root_with_duplicate_leaf_ids(
+        left_store_tool_messages=True, right_store_tool_messages=False
+    )
+    root_run = _paused_root_run_owned_by_right_leaf(root, right_team)
+
+    view = _scrub_member_responses_keeping_paused(root, root_run)
+
+    leaf = _stored_leaf(view)
+    roles = [m.role for m in leaf.messages or []]
+    assert "tool" not in roles, (
+        "the owning right worker's store_tool_messages=False must scrub completed tool "
+        "messages, even though a left sibling shares the leaf member id"
+    )
+    kept_calls = [call["id"] for m in leaf.messages or [] if m.role == "assistant" for call in m.tool_calls or []]
+    assert kept_calls == ["tc-pending"], "the unresolved call must survive the scrub for the resume"
+
+
+def test_spared_leaf_keeps_tool_messages_when_owning_member_stores_them():
+    """Pins the same wrong-duplicate resolution from the other side: the left
+    sibling's store_tool_messages=False must not scrub a paused run owned by
+    the right worker whose own setting is True."""
+    from agno.team._session import _scrub_member_responses_keeping_paused
+
+    root, right_team = _build_root_with_duplicate_leaf_ids(
+        left_store_tool_messages=False, right_store_tool_messages=True
+    )
+    root_run = _paused_root_run_owned_by_right_leaf(root, right_team)
+
+    view = _scrub_member_responses_keeping_paused(root, root_run)
+
+    leaf = _stored_leaf(view)
+    roles = [m.role for m in leaf.messages or []]
+    assert "tool" in roles, (
+        "the owning right worker's store_tool_messages=True must keep its completed tool "
+        "messages, even though a left sibling with the same member id has it disabled"
+    )
+    kept_calls = [call["id"] for m in leaf.messages or [] if m.role == "assistant" for call in m.tool_calls or []]
+    assert kept_calls == ["tc-done", "tc-pending"], "both tool calls must survive when the owning member stores them"

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -2876,6 +2876,56 @@ def test_wire_schema_cannot_rewrite_an_argument_the_model_fixed(tmp_path):
     assert "attacker" not in [t["account_id"] for t in _TRANSFERRED]
 
 
+def test_user_input_answer_sent_only_on_the_tool_execution_reaches_the_tool(tmp_path):
+    """to_dict ships the schema at both levels, but a client may answer on
+    either one alone. Both lanes have to reach the stored tool execution."""
+    _TRANSFERRED.clear()
+    db_file = str(tmp_path / "te_only.db")
+    session_id = "s-te-only"
+
+    team1 = _build_user_input_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Move the money", session_id=session_id)
+    assert run1.is_paused
+
+    payload = []
+    for data in [r.to_dict() for r in run1.requirements or []]:
+        req = RunRequirement.from_dict(data)
+        for field in req.tool_execution.user_input_schema or []:
+            if field.name == "note":
+                field.value = "wire-only"
+        req.user_input_schema = None
+        payload.append(req)
+
+    team2 = _build_user_input_team(SqliteDb(db_file=db_file), resuming=True)
+    team2.continue_run(run_id=run1.run_id, session_id=session_id, requirements=payload)
+    assert _TRANSFERRED == [{"account_id": "victim", "note": "wire-only"}]
+
+
+def test_tampered_tool_execution_schema_does_not_change_the_executed_arguments(tmp_path):
+    """The dispatch reads the tool execution's schema, so that copy is the one
+    an attacker would rename. The stored schema still decides what runs: the
+    honest answer sent alongside it lands, and the renamed field does not."""
+    _TRANSFERRED.clear()
+    db_file = str(tmp_path / "te_tamper.db")
+    session_id = "s-te-tamper"
+
+    team1 = _build_user_input_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Move the money", session_id=session_id)
+    assert run1.is_paused
+
+    payload = _answered_payload(run1.requirements, {"note": "monthly rent"})
+    for req in payload:
+        for field in req.tool_execution.user_input_schema or []:
+            if field.name == "note":
+                field.name = "account_id"
+                field.value = "attacker"
+
+    team2 = _build_user_input_team(SqliteDb(db_file=db_file), resuming=True)
+    team2.continue_run(run_id=run1.run_id, session_id=session_id, requirements=payload)
+
+    assert _TRANSFERRED == [{"account_id": "victim", "note": "monthly rent"}]
+
+
 def test_wire_answered_flag_alone_does_not_resolve_an_open_field(tmp_path):
     """answered=True with no values must not run a gated tool with the field empty."""
     _EXECUTED.clear()
@@ -3024,17 +3074,14 @@ def test_completed_run_stores_no_stale_paused_member(tmp_path):
     db_file = str(tmp_path / "stale.db")
     session_id = "s-stale"
 
+    # One team object across both calls, with the session cached: the cached
+    # session is what would hold a frozen copy of the paused member run.
     outer = _build_nested_team(SqliteDb(db_file=db_file), resuming=False)
     outer.cache_session = True
     run1 = outer.run("Email a@example.com", session_id=session_id)
     assert run1.is_paused
 
-    # Same process, same team object: the cached session is the one that would
-    # keep a frozen copy.
-    outer.members[0]._model = None
-    outer2 = _build_nested_team(SqliteDb(db_file=db_file), resuming=True)
-    outer2.cache_session = True
-    run2 = outer2.continue_run(
+    run2 = outer.continue_run(
         run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
     )
     assert run2.status == RunStatus.completed

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -2331,6 +2331,246 @@ def test_ambiguous_owner_id_refuses(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# The payload's requirements bind one-to-one to the stored requirements, and
+# the STORED requirement is what routing sees afterwards — only the client's
+# decision state crosses over. Trusting the wire copy lets a swapped or
+# duplicated requirement id execute one member's approved arguments through
+# another member's tool, and a forged entry skip the stored approval.
+# ---------------------------------------------------------------------------
+
+
+def _build_two_agents_shared_tool_call_id(db: SqliteDb, resuming: bool) -> Team:
+    def make_agent(side: str, send_tool, to: str) -> Agent:
+        script = (
+            [("content", "Email sent.")]
+            if resuming
+            else [("tool", "send_email", {"to": to}, "tc-shared"), ("content", "Email sent.")]
+        )
+        return Agent(
+            name=f"{side} Agent",
+            id=f"{side}-agent",
+            model=_ScriptedModel(f"m-shared-{side}", script),
+            tools=[send_tool],
+            db=db,
+            telemetry=False,
+        )
+
+    return Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-shared-leader",
+            [("content", "All done.")]
+            if resuming
+            else [
+                (
+                    "tools",
+                    [
+                        ("delegate_task_to_member", {"member_id": "left-agent", "task": "send left"}, "tc-dl"),
+                        ("delegate_task_to_member", {"member_id": "right-agent", "task": "send right"}, "tc-dr"),
+                    ],
+                ),
+                ("content", "All done."),
+            ],
+        ),
+        members=[
+            make_agent("left", left_send_email, "left@example.com"),
+            make_agent("right", right_send_email, "right@example.com"),
+        ],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_swapped_requirement_ids_execute_each_members_own_arguments(tmp_path):
+    _LEFT_EXECUTED.clear()
+    _RIGHT_EXECUTED.clear()
+    db_file = str(tmp_path / "swapped_ids.db")
+    session_id = "s-swapped-ids"
+
+    team1 = _build_two_agents_shared_tool_call_id(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email both", session_id=session_id)
+    assert run1.is_paused
+    assert len(run1.requirements or []) == 2
+    assert {r.tool_execution.tool_call_id for r in run1.requirements} == {"tc-shared"}
+
+    payload_dicts = [r.to_dict() for r in run1.requirements]
+    payload_dicts[0]["id"], payload_dicts[1]["id"] = payload_dicts[1]["id"], payload_dicts[0]["id"]
+    swapped = []
+    for data in payload_dicts:
+        req = RunRequirement.from_dict(data)
+        req.confirm()
+        swapped.append(req)
+
+    team2 = _build_two_agents_shared_tool_call_id(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id, requirements=swapped)
+    assert run2.status == RunStatus.completed
+    assert _LEFT_EXECUTED == ["left@example.com"]
+    assert _RIGHT_EXECUTED == ["right@example.com"]
+
+
+def test_duplicate_requirement_id_payload_refuses(tmp_path):
+    _LEFT_EXECUTED.clear()
+    _RIGHT_EXECUTED.clear()
+    db_file = str(tmp_path / "dup_req_id.db")
+    session_id = "s-dup-req-id"
+
+    team1 = _build_two_agents_shared_tool_call_id(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email both", session_id=session_id)
+    assert run1.is_paused
+
+    payload_dicts = [r.to_dict() for r in run1.requirements]
+    payload_dicts[1]["id"] = payload_dicts[0]["id"]
+    duplicated = []
+    for data in payload_dicts:
+        req = RunRequirement.from_dict(data)
+        req.confirm()
+        duplicated.append(req)
+
+    team2 = _build_two_agents_shared_tool_call_id(SqliteDb(db_file=db_file), resuming=True)
+    with pytest.raises(RunNotContinuableError):
+        team2.continue_run(run_id=run1.run_id, session_id=session_id, requirements=duplicated)
+    assert _LEFT_EXECUTED == [] and _RIGHT_EXECUTED == []
+    stored = [r for r in _reload_runs(db_file, session_id) if getattr(r, "run_id", None) == run1.run_id]
+    assert stored and stored[0].status == RunStatus.paused
+
+
+def test_forged_unmatched_requirement_refuses(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "forged_req.db")
+    session_id = "s-forged-req"
+
+    team1 = _build_flat_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    forged_data = run1.requirements[0].to_dict()
+    forged_data["id"] = "req-forged"
+    forged_data["tool_execution"]["tool_call_id"] = "tc-forged"
+    forged_data["tool_execution"]["tool_args"] = {"to": "attacker@evil.com"}
+    forged = RunRequirement.from_dict(forged_data)
+    forged.confirm()
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    with pytest.raises(RunNotContinuableError):
+        team2.continue_run(run_id=run1.run_id, session_id=session_id, requirements=[forged])
+    assert _EXECUTED == []
+    stored = [r for r in _reload_runs(db_file, session_id) if getattr(r, "run_id", None) == run1.run_id]
+    assert stored and stored[0].status == RunStatus.paused
+
+
+def test_forged_result_does_not_suppress_confirmed_execution(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "forged_result.db")
+    session_id = "s-forged-result"
+
+    team1 = _build_flat_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    data = run1.requirements[0].to_dict()
+    data["tool_execution"]["result"] = "forged: already sent"
+    req = RunRequirement.from_dict(data)
+    req.confirm()
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id, requirements=[req])
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+def test_refusal_leaves_live_run_object_retryable(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "live_retry.db")
+    session_id = "s-live-retry"
+
+    team1 = _build_same_member_twice_same_tool_call_id(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email both", session_id=session_id)
+    assert run1.is_paused
+    original_req_ids = sorted(r.id for r in run1.requirements or [])
+
+    team2 = _build_same_member_twice_same_tool_call_id(SqliteDb(db_file=db_file), resuming=True)
+    with pytest.raises(RunNotContinuableError):
+        team2.continue_run(
+            run_response=run1,
+            session_id=session_id,
+            requirements=_wire_requirements_stripped(run1.requirements, "id", "member_run_id"),
+        )
+    assert _EXECUTED == []
+    # The live object still carries the stored requirements the refusal asks for.
+    assert sorted(r.id for r in run1.requirements or []) == original_req_ids
+    assert all(r.member_run_id is not None for r in run1.requirements)
+
+    run3 = team2.continue_run(
+        run_response=run1,
+        session_id=session_id,
+        requirements=_wire_requirements(run1.requirements),
+    )
+    assert run3.status == RunStatus.completed
+    assert sorted(_EXECUTED) == ["a@x.com", "b@x.com"]
+
+
+def test_duplicate_direct_agent_ids_refuse_continue(tmp_path):
+    _LEFT_EXECUTED.clear()
+    _RIGHT_EXECUTED.clear()
+    db_file = str(tmp_path / "dup_agent_ids.db")
+    session_id = "s-dup-agent-ids"
+
+    def build(resuming: bool) -> Team:
+        db = SqliteDb(db_file=db_file)
+        left = Agent(
+            name="left Agent",
+            id="dup",
+            model=_ScriptedModel(
+                "m-dupa-left",
+                [("content", "Email sent.")]
+                if resuming
+                else [("tool", "send_email", {"to": "left@example.com"}, "tc-send-l"), ("content", "Email sent.")],
+            ),
+            tools=[left_send_email],
+            db=db,
+            telemetry=False,
+        )
+        right = Agent(
+            name="right Agent",
+            id="dup",
+            model=_ScriptedModel("m-dupa-right", [("content", "Never runs.")]),
+            tools=[right_send_email],
+            db=db,
+            telemetry=False,
+        )
+        return Team(
+            name="Comms Team",
+            id="comms-team",
+            model=_ScriptedModel(
+                "m-dupa-leader",
+                [("content", "All done.")]
+                if resuming
+                else [
+                    ("tool", "delegate_task_to_member", {"member_id": "dup", "task": "send it"}, "tc-deleg"),
+                    ("content", "All done."),
+                ],
+            ),
+            members=[left, right],
+            db=db,
+            telemetry=False,
+        )
+
+    team1 = build(resuming=False)
+    run1 = team1.run("Email left", session_id=session_id)
+    assert run1.is_paused
+
+    team2 = build(resuming=True)
+    with pytest.raises(RunNotContinuableError):
+        team2.continue_run(
+            run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+        )
+    assert _LEFT_EXECUTED == [] and _RIGHT_EXECUTED == []
+    stored = [r for r in _reload_runs(db_file, session_id) if getattr(r, "run_id", None) == run1.run_id]
+    assert stored and stored[0].status == RunStatus.paused
+
+
+# ---------------------------------------------------------------------------
 # When routing raises, the caller's in-memory run object must keep ALL its
 # requirements (the dispatch temporarily strips team-level ones for routing),
 # so a retry after fixing the team does not lose an approved tool.

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -1632,6 +1632,201 @@ async def test_subteam_own_gated_tool_executes_on_continue_async(tmp_path, mixed
 
 
 # ---------------------------------------------------------------------------
+# A member may share the team's id — or its url-safe name, which get_member_id
+# falls back to. The member stamp on a requirement is then ambiguous, and
+# continue dispatch must still route the member's requirement to the member:
+# reclaiming it as team-level silently drops the confirmed tool.
+# ---------------------------------------------------------------------------
+
+
+def _build_id_collision_team(db: SqliteDb, resuming: bool) -> Team:
+    return Team(
+        name="Emailer Team",
+        id="emailer",
+        model=_ScriptedModel(
+            "m-leader",
+            [("content", "All done.")]
+            if resuming
+            else [
+                ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-deleg"),
+                ("content", "All done."),
+            ],
+        ),
+        members=[_emailer_agent(db, resuming)],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _build_deep_id_collision_team(db: SqliteDb, resuming: bool) -> Team:
+    inner = Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-inner",
+            [("content", "Inner done.")]
+            if resuming
+            else [
+                ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-inner-deleg"),
+                ("content", "Inner done."),
+            ],
+        ),
+        members=[_emailer_agent(db, resuming)],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Org Team",
+        id="emailer",
+        model=_ScriptedModel(
+            "m-outer",
+            [("content", "All done.")]
+            if resuming
+            else [
+                (
+                    "tool",
+                    "delegate_task_to_member",
+                    {"member_id": "comms-team", "task": "handle email"},
+                    "tc-outer-deleg",
+                ),
+                ("content", "All done."),
+            ],
+        ),
+        members=[inner],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _build_name_collision_team(db: SqliteDb, resuming: bool) -> Team:
+    member = Agent(
+        name="Emailer",
+        model=_ScriptedModel(
+            "m-emailer",
+            [("content", "Email sent.")]
+            if resuming
+            else [("tool", "send_email", {"to": "a@example.com"}, "tc-send"), ("content", "Email sent.")],
+        ),
+        tools=[send_email],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Emailer",
+        model=_ScriptedModel(
+            "m-leader",
+            [("content", "All done.")]
+            if resuming
+            else [
+                ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-deleg"),
+                ("content", "All done."),
+            ],
+        ),
+        members=[member],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_member_sharing_team_id_resumes_fresh_process(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "id_collision.db")
+    session_id = "s-id-collision"
+
+    team1 = _build_id_collision_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+    assert _EXECUTED == []
+
+    team2 = _build_id_collision_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_member_sharing_team_id_resumes_fresh_process_async(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "id_collision_async.db")
+    session_id = "s-id-collision-async"
+
+    team1 = _build_id_collision_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = await team1.arun("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+    assert _EXECUTED == []
+
+    team2 = _build_id_collision_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = await team2.acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+def test_member_sharing_team_id_resumes_fresh_process_streaming(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "id_collision_stream.db")
+    session_id = "s-id-collision-stream"
+
+    team1 = _build_id_collision_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    team2 = _build_id_collision_team(SqliteDb(db_file=db_file), resuming=True)
+    final = None
+    for event in team2.continue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(run1.requirements),
+        stream=True,
+        yield_run_output=True,
+    ):
+        if isinstance(event, TeamRunOutput):
+            final = event
+    assert final is not None
+    assert final.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+def test_deep_member_sharing_top_team_id_resumes_fresh_process(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "deep_id_collision.db")
+    session_id = "s-deep-id-collision"
+
+    outer1 = _build_deep_id_collision_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = outer1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+    assert _EXECUTED == []
+
+    outer2 = _build_deep_id_collision_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = outer2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+def test_member_sharing_team_name_resumes_fresh_process(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "name_collision.db")
+    session_id = "s-name-collision"
+
+    team1 = _build_name_collision_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+    assert _EXECUTED == []
+
+    team2 = _build_name_collision_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+# ---------------------------------------------------------------------------
 # When routing raises, the caller's in-memory run object must keep ALL its
 # requirements (the dispatch temporarily strips team-level ones for routing),
 # so a retry after fixing the team does not lose an approved tool.

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -364,8 +364,7 @@ class _ScriptedModel(Model):
         else:
             r = ModelResponse(content=turn[1], role="assistant")
             r.event = ModelResponseEvent.assistant_response.value
-        # Every model turn reports the same usage so tests can assert
-        # session-metrics totals as (number of model calls) * 15.
+        # Every model turn reports usage so runs carry realistic metrics.
         r.response_usage = MessageMetrics(input_tokens=10, output_tokens=5, total_tokens=15)
         return r
 
@@ -825,11 +824,6 @@ def test_three_level_nested_pause_survives_fresh_process_continue(tmp_path):
     assert run2.status == RunStatus.completed
     assert _EXECUTED == ["a@example.com"]
 
-    # Eight model turns at 15 tokens each across pause and resume, counted once.
-    session = SqliteDb(db_file=db_file).get_session(session_id=session_id, session_type="team")
-    metrics = (session.session_data or {}).get("session_metrics") or {}
-    assert metrics.get("total_tokens") == 120, f"expected 120 total tokens, got {metrics.get('total_tokens')}"
-
 
 @pytest.mark.asyncio
 async def test_three_level_nested_pause_resumes_same_process_async(tmp_path):
@@ -1017,32 +1011,8 @@ def test_completed_members_scrubbed_inside_spared_paused_subteam(tmp_path):
             assert getattr(m, "is_paused", False), f"completed member response persisted: {m.run_id}"
 
 
-def test_session_metrics_not_double_counted_on_fresh_process_resume(tmp_path):
-    """Every model turn reports 15 total tokens. Four turns happen across the
-    pause and the resume (leader delegate, member tool call, member resume,
-    leader continuation), so the session must report exactly 60 — not more."""
-    _EXECUTED.clear()
-    db_file = str(tmp_path / "metrics.db")
-    session_id = "s-metrics"
-
-    team1 = _build_flat_team(SqliteDb(db_file=db_file), resuming=False)
-    run1 = team1.run("Email a@example.com", session_id=session_id)
-    assert run1.is_paused
-
-    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
-    run2 = team2.continue_run(
-        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
-    )
-    assert run2.status == RunStatus.completed
-
-    session = SqliteDb(db_file=db_file).get_session(session_id=session_id, session_type="team")
-    metrics = (session.session_data or {}).get("session_metrics") or {}
-    assert metrics.get("total_tokens") == 60, f"expected 60 total tokens, got {metrics.get('total_tokens')}"
-
-
 # ---------------------------------------------------------------------------
-# Same sub-team paused twice in one turn, live-tree integrity, and
-# exactly-once session metrics.
+# Same sub-team paused twice in one turn, and live-tree integrity.
 # ---------------------------------------------------------------------------
 
 
@@ -1153,62 +1123,6 @@ async def test_same_subteam_paused_twice_both_confirmations_execute_async(tmp_pa
     )
     assert run2.status == RunStatus.completed
     assert sorted(_EXECUTED) == ["a@x.com", "sms:b@x.com"]
-
-
-def _build_completed_sibling_team(db: SqliteDb, resuming: bool) -> Team:
-    """Flat team where 'reporter' completes and then 'emailer' pauses."""
-    reporter = Agent(
-        name="Reporter",
-        id="reporter",
-        model=_ScriptedModel("m-reporter", [("content", "Report ready.")]),
-        db=db,
-        telemetry=False,
-    )
-    return Team(
-        name="Comms Team",
-        id="comms-team",
-        model=_ScriptedModel(
-            "m-leader",
-            [("content", "All done.")]
-            if resuming
-            else [
-                ("tool", "delegate_task_to_member", {"member_id": "reporter", "task": "report"}, "tc-rep"),
-                ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-mail"),
-                ("content", "All done."),
-            ],
-        ),
-        members=[reporter, _emailer_agent(db, resuming)],
-        db=db,
-        telemetry=False,
-    )
-
-
-def test_metrics_exact_with_completed_sibling_before_pause(tmp_path):
-    """Reporter completes before the pause; with the default flag its
-    response is scrubbed from storage, but its tokens count exactly once.
-    Six model turns at 15 tokens each = 90."""
-    _EXECUTED.clear()
-    db_file = str(tmp_path / "metrics_sibling.db")
-    session_id = "s-metrics-sibling"
-
-    team1 = _build_completed_sibling_team(SqliteDb(db_file=db_file), resuming=False)
-    run1 = team1.run("Report then email", session_id=session_id)
-    assert run1.is_paused
-
-    # The pause-time save counts only runs that reached a final state.
-    session = SqliteDb(db_file=db_file).get_session(session_id=session_id, session_type="team")
-    metrics = (session.session_data or {}).get("session_metrics") or {}
-    assert metrics.get("total_tokens") == 15, "only the completed reporter run is counted while paused"
-
-    team2 = _build_completed_sibling_team(SqliteDb(db_file=db_file), resuming=True)
-    run2 = team2.continue_run(
-        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
-    )
-    assert run2.status == RunStatus.completed
-
-    session = SqliteDb(db_file=db_file).get_session(session_id=session_id, session_type="team")
-    metrics = (session.session_data or {}).get("session_metrics") or {}
-    assert metrics.get("total_tokens") == 90, f"expected 90 total tokens, got {metrics.get('total_tokens')}"
 
 
 def test_live_run_tree_not_mutated_by_save(tmp_path):

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -5471,6 +5471,253 @@ def test_paused_buffer_entries_are_reclaimed_after_the_cleanup_interval():
     assert "r-paused-reclaim" not in buf.run_metadata
 
 
+_FIRED: List[str] = []
+
+
+@tool(requires_confirmation=True)
+@approval(type="required")
+def alpha_action(target: str) -> str:
+    _FIRED.append(f"alpha:{target}")
+    return "alpha done"
+
+
+@tool(requires_confirmation=True)
+@approval(type="required")
+def beta_action(target: str) -> str:
+    _FIRED.append(f"beta:{target}")
+    return "beta done"
+
+
+def _two_member_approval_team(db: SqliteDb, resuming: bool, collide: bool = False) -> Team:
+    """Two members, each pausing on its own approval-gated tool. With collide,
+    both provider tool calls share one provider-local tool_call_id."""
+    alpha_tcid = "call_1"
+    beta_tcid = "call_1" if collide else "call_2"
+    alpha = Agent(
+        name="Alpha",
+        id="alpha",
+        model=_ScriptedModel(
+            "m-alpha",
+            [("content", "Alpha done.")]
+            if resuming
+            else [("tool", "alpha_action", {"target": "A"}, alpha_tcid), ("content", "Alpha done.")],
+        ),
+        tools=[alpha_action],
+        db=db,
+        telemetry=False,
+    )
+    beta = Agent(
+        name="Beta",
+        id="beta",
+        model=_ScriptedModel(
+            "m-beta",
+            [("content", "Beta done.")]
+            if resuming
+            else [("tool", "beta_action", {"target": "B"}, beta_tcid), ("content", "Beta done.")],
+        ),
+        tools=[beta_action],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Ops Team",
+        id="ops-team",
+        model=_ScriptedModel(
+            "m-lead",
+            [("content", "All done.")]
+            if resuming
+            else [
+                (
+                    "tools",
+                    [
+                        ("delegate_task_to_member", {"member_id": "alpha", "task": "do alpha"}, "tc-d1"),
+                        ("delegate_task_to_member", {"member_id": "beta", "task": "do beta"}, "tc-d2"),
+                    ],
+                ),
+                ("content", "All done."),
+            ],
+        ),
+        members=[alpha, beta],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _approval_record_for_tool(db: SqliteDb, tool_name: str):
+    records, _ = db.get_approvals(approval_type="required", limit=50)
+    matches = [a for a in records if a["tool_name"] == tool_name]
+    assert matches, f"no approval record for {tool_name}; records: {[a['tool_name'] for a in records]}"
+    return matches[0]
+
+
+def test_one_approval_does_not_resolve_a_sibling_members_tool(tmp_path):
+    """Each member's gated tool is decided by ITS OWN approval record. With one
+    record approved and the other pending, nothing may execute."""
+    _FIRED.clear()
+    db_file = str(tmp_path / "sibling_approvals.db")
+    session_id = "s-sibling-approvals"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = _two_member_approval_team(db, resuming=False).run("Do both", session_id=session_id)
+    assert run1.is_paused
+    records, _ = db.get_approvals(approval_type="required", limit=50)
+    assert len(records) == 2, f"expected one approval record per paused member, got {len(records)}"
+
+    db.update_approval(_approval_record_for_tool(db, "alpha_action")["id"], status="approved", resolution_data=None)
+
+    team2 = _two_member_approval_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.paused, f"a pending sibling approval let the run reach {run2.status}"
+    assert _FIRED == [], f"a tool executed while its own approval was pending: {_FIRED}"
+
+    # Resolving the second record completes the run and fires both tools.
+    db2 = SqliteDb(db_file=db_file)
+    db2.update_approval(_approval_record_for_tool(db2, "beta_action")["id"], status="approved", resolution_data=None)
+    team3 = _two_member_approval_team(SqliteDb(db_file=db_file), resuming=True)
+    run3 = team3.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run3.status == RunStatus.completed, run3.status
+    assert sorted(_FIRED) == ["alpha:A", "beta:B"], _FIRED
+
+
+def test_a_rejected_sibling_does_not_block_or_get_run_by_anothers_approval(tmp_path):
+    """Approve one member, reject the other: the approved tool runs, the
+    rejected one is skipped, and the run completes."""
+    _FIRED.clear()
+    db_file = str(tmp_path / "mixed_approvals.db")
+    session_id = "s-mixed-approvals"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = _two_member_approval_team(db, resuming=False).run("Do both", session_id=session_id)
+    assert run1.is_paused
+
+    db.update_approval(_approval_record_for_tool(db, "alpha_action")["id"], status="approved", resolution_data=None)
+    db.update_approval(_approval_record_for_tool(db, "beta_action")["id"], status="rejected", resolution_data=None)
+
+    team2 = _two_member_approval_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.completed, run2.status
+    assert _FIRED == ["alpha:A"], f"the rejected member's tool must not run: {_FIRED}"
+
+
+@pytest.mark.asyncio
+async def test_one_approval_does_not_resolve_a_sibling_with_colliding_tool_call_ids(tmp_path):
+    """Provider-local tool_call_ids can collide across members; the collision
+    must not let one member's approval decide for the other."""
+    _FIRED.clear()
+    db_file = str(tmp_path / "colliding_approvals.db")
+    session_id = "s-colliding-approvals"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = await _two_member_approval_team(db, resuming=False, collide=True).arun("Do both", session_id=session_id)
+    assert run1.is_paused
+
+    db.update_approval(_approval_record_for_tool(db, "alpha_action")["id"], status="approved", resolution_data=None)
+
+    team2 = _two_member_approval_team(SqliteDb(db_file=db_file), resuming=True, collide=True)
+    run2 = await team2.acontinue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.paused, f"a pending sibling approval let the run reach {run2.status}"
+    assert _FIRED == [], f"a tool executed while its own approval was pending: {_FIRED}"
+
+
+def test_a_paused_buffer_entry_reused_by_a_continue_is_not_reclaimed():
+    """A continue reuses the paused run's buffer entry; its stale paused
+    metadata must not let a later cleanup pass delete the live continuation."""
+    from agno.os.managers import EventsBuffer
+
+    buf = EventsBuffer(cleanup_interval=3600)
+    buf.add_event("r-reuse", MagicMock())
+    buf.set_run_completed("r-reuse", RunStatus.paused)
+    assert buf.get_run_status("r-reuse") == RunStatus.paused
+
+    # The continuation's first event takes the run over.
+    buf.add_event("r-reuse", MagicMock())
+    assert buf.get_run_status("r-reuse") == RunStatus.running
+    assert "completed_at" not in buf.run_metadata["r-reuse"]
+
+    buf.cleanup_interval = -1
+    buf.cleanup_runs()
+    assert buf.get_run_status("r-reuse") == RunStatus.running, "cleanup reclaimed a live continuation"
+    assert buf.get_event_count("r-reuse") == 2
+
+
+@pytest.mark.asyncio
+async def test_a_background_fork_from_a_run_object_does_not_orphan_the_original(tmp_path):
+    """A fork executes under a new run id; the original run must keep the
+    status it has instead of being stranded at RUNNING."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "fork_orphan.db")
+    session_id = "s-fork-orphan"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    async for _ in team2.acontinue_run(
+        run_response=run1,
+        session_id=session_id,
+        requirements=_wire_requirements(run1.requirements),
+        fork=True,
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        pass
+    await _drain_background_tasks()
+
+    stored = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0]
+    assert stored.status == RunStatus.paused, (
+        f"the original run was left {stored.status!r} after a fork branched off it"
+    )
+
+
+def test_idless_tool_results_are_scrubbed_too():
+    """store_tool_messages=False stores NO tool-result message; ids only decide
+    which assistant calls lost their answer. The pending call survives."""
+    from agno.team._session import _scrub_tool_results_keeping_unresolved
+
+    run = RunOutput(run_id="r-idless")
+    run.messages = [
+        Message(role="user", content="do it"),
+        Message(role="assistant", tool_calls=[{"id": "t1", "type": "function", "function": {"name": "a"}}]),
+        Message(role="tool", tool_call_id="t1", content="resolved result"),
+        Message(role="tool", tool_call_id=None, content="LEGACY IDLESS RESULT"),
+        Message(role="assistant", tool_calls=[{"id": "p1", "type": "function", "function": {"name": "gated"}}]),
+    ]
+    _scrub_tool_results_keeping_unresolved(run)
+
+    assert not any(m.role == "tool" for m in run.messages), (
+        f"a tool-result message survived the scrub: {[m.content for m in run.messages if m.role == 'tool']}"
+    )
+    pending = [c["id"] for m in run.messages if m.role == "assistant" for c in (m.tool_calls or [])]
+    assert pending == ["p1"], f"the pending gated call must survive: {pending}"
+
+
+def test_an_unresolvable_member_response_is_stored_fail_closed():
+    """When the owning member cannot be found at storage time, the stored view
+    scrubs as if every storage flag were off; the pending call survives."""
+    from agno.team._session import _storage_view_of_spared_run
+
+    member_run = RunOutput(run_id="r-member", agent_id="ghost")
+    member_run.status = RunStatus.paused
+    member_run.messages = [
+        Message(role="user", content="do it"),
+        Message(role="assistant", tool_calls=[{"id": "t9", "type": "function", "function": {"name": "a"}}]),
+        Message(role="tool", tool_call_id="t9", content="SECRET TOOL RESULT"),
+        Message(role="assistant", tool_calls=[{"id": "p9", "type": "function", "function": {"name": "gated"}}]),
+    ]
+    team = _build_flat_team(SqliteDb(db_file=":memory:"), resuming=True)
+
+    view = _storage_view_of_spared_run(team, member_run)
+
+    assert not any(m.role == "tool" for m in view.messages or []), "an unresolved member's tool result was stored"
+    pending = [c["id"] for m in view.messages or [] if m.role == "assistant" for c in (m.tool_calls or [])]
+    assert "p9" in pending, f"the pending gated call must survive fail-closed storage: {pending}"
+    # The live object the caller holds is untouched.
+    assert any(m.role == "tool" for m in member_run.messages)
+
+
 def test_a_routing_failure_restores_the_callers_team_level_requirements(tmp_path):
     """A plain exception during member routing must leave the caller's run
     object carrying each team-level requirement exactly once."""

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -4107,3 +4107,340 @@ async def test_a_run_finishing_during_an_async_save_is_not_discarded(monkeypatch
     ids = [r.run_id for r in session.runs or []]
     assert "run-b" in ids, f"the concurrently added run was dropped by the restore; runs={ids}"
 
+
+
+# ---------------------------------------------------------------------------
+# Round 11: a refusal must arrive before any member has executed
+# ---------------------------------------------------------------------------
+
+
+def _build_dup_leaf_org(db: SqliteDb, resuming: bool, break_right_leaf: bool = False) -> Team:
+    """Two sub-teams, each delegating to a leaf named 'dup'.
+
+    With break_right_leaf the right sub-team's leaf has been renamed, which is
+    what a deploy landing while a run sits paused looks like: the stored run
+    still names 'dup', so the right sub-team can no longer route its share.
+    Without a preflight that refusal surfaces only once the right sub-team's
+    own continue is under way — after the left sub-team has sent its email.
+    """
+
+    def make_subteam(side: str, send_tool, to: str, leaf_id: str) -> Team:
+        agent_script = (
+            [("content", "Email sent.")]
+            if resuming
+            else [("tool", "send_email", {"to": to}, f"tc-send-{side}"), ("content", "Email sent.")]
+        )
+        sub_script = (
+            [("content", f"{side} done.")]
+            if resuming
+            else [
+                ("tool", "delegate_task_to_member", {"member_id": "dup", "task": "send it"}, f"tc-deleg-{side}"),
+                ("content", f"{side} done."),
+            ]
+        )
+        return Team(
+            name=f"{side} Team",
+            id=f"{side}-team",
+            model=_ScriptedModel(f"m-{side}", sub_script),
+            members=[
+                Agent(
+                    name="Dup",
+                    id=leaf_id,
+                    model=_ScriptedModel(f"m-agent-{side}", agent_script),
+                    tools=[send_tool],
+                    db=db,
+                    telemetry=False,
+                )
+            ],
+            db=db,
+            telemetry=False,
+        )
+
+    leader_turn = (
+        "tools",
+        [
+            ("delegate_task_to_member", {"member_id": "left-team", "task": "send left"}, "tc-outer-left"),
+            ("delegate_task_to_member", {"member_id": "right-team", "task": "send right"}, "tc-outer-right"),
+        ],
+    )
+    return Team(
+        name="Org Team",
+        id="org-team",
+        model=_ScriptedModel(
+            "m-outer", [("content", "All done.")] if resuming else [leader_turn, ("content", "All done.")]
+        ),
+        members=[
+            make_subteam("left", left_send_email, "left@example.com", "dup"),
+            make_subteam("right", right_send_email, "right@example.com", "renamed" if break_right_leaf else "dup"),
+        ],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_a_subteam_that_cannot_route_refuses_before_a_sibling_executes(tmp_path):
+    """The refusal says the run remains paused, so nothing may have run."""
+    _LEFT_EXECUTED.clear()
+    _RIGHT_EXECUTED.clear()
+    db_file = str(tmp_path / "preflight_sync.db")
+    session_id = "s-preflight-sync"
+
+    run1 = _build_dup_leaf_org(SqliteDb(db_file=db_file), resuming=False).run(
+        "Email both sides", session_id=session_id
+    )
+    assert run1.is_paused
+    assert len(run1.requirements or []) == 2
+
+    broken = _build_dup_leaf_org(SqliteDb(db_file=db_file), resuming=True, break_right_leaf=True)
+    with pytest.raises(RunNotContinuableError):
+        broken.continue_run(
+            run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+        )
+
+    assert _LEFT_EXECUTED == [], f"the refusal claims the run is untouched, but a sibling fired: {_LEFT_EXECUTED}"
+    assert _RIGHT_EXECUTED == []
+
+
+@pytest.mark.asyncio
+async def test_a_subteam_that_cannot_route_refuses_before_a_sibling_executes_async(tmp_path):
+    """Async twin: members are gathered, so without a preflight the refusal
+    lands only after every sibling coroutine has already finished."""
+    _LEFT_EXECUTED.clear()
+    _RIGHT_EXECUTED.clear()
+    db_file = str(tmp_path / "preflight_async.db")
+    session_id = "s-preflight-async"
+
+    run1 = await _build_dup_leaf_org(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email both sides", session_id=session_id
+    )
+    assert run1.is_paused
+
+    broken = _build_dup_leaf_org(SqliteDb(db_file=db_file), resuming=True, break_right_leaf=True)
+    with pytest.raises(RunNotContinuableError):
+        await broken.acontinue_run(
+            run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+        )
+
+    assert _LEFT_EXECUTED == [], f"the refusal claims the run is untouched, but a sibling fired: {_LEFT_EXECUTED}"
+    assert _RIGHT_EXECUTED == []
+
+
+@pytest.mark.asyncio
+async def test_a_refused_continue_still_resumes_once_the_member_is_back(tmp_path):
+    """The refusal must leave the run resumable, and the resume must run each
+    approved tool exactly once."""
+    _LEFT_EXECUTED.clear()
+    _RIGHT_EXECUTED.clear()
+    db_file = str(tmp_path / "preflight_retry.db")
+    session_id = "s-preflight-retry"
+
+    run1 = await _build_dup_leaf_org(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email both sides", session_id=session_id
+    )
+    assert run1.is_paused
+
+    broken = _build_dup_leaf_org(SqliteDb(db_file=db_file), resuming=True, break_right_leaf=True)
+    with pytest.raises(RunNotContinuableError):
+        await broken.acontinue_run(
+            run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+        )
+
+    fixed = _build_dup_leaf_org(SqliteDb(db_file=db_file), resuming=True)
+    run2 = await fixed.acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+
+    assert run2.status == RunStatus.completed
+    assert _LEFT_EXECUTED == ["left@example.com"], f"the approved tool did not run exactly once: {_LEFT_EXECUTED}"
+    assert _RIGHT_EXECUTED == ["right@example.com"]
+
+
+def test_preflight_does_not_disturb_a_healthy_nested_continue(tmp_path):
+    """The extra resolution pass must stay invisible when everything resolves."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "preflight_healthy.db")
+    session_id = "s-preflight-healthy"
+
+    run1 = _build_nested_team(SqliteDb(db_file=db_file), resuming=False).run("Send it", session_id=session_id)
+    assert run1.is_paused
+
+    run2 = _build_nested_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+
+    assert not run2.is_paused
+    assert _EXECUTED == ["a@example.com"], f"the healthy nested continue must still run its tool once: {_EXECUTED}"
+
+
+# ---------------------------------------------------------------------------
+# Round 11: an unresolved member requirement re-pauses; a refused background
+# continue is reported
+# ---------------------------------------------------------------------------
+
+
+@tool(name="file_expense", requires_user_input=True, user_input_fields=["approver"])
+def file_expense(amount: str, approver: str) -> str:
+    _EXECUTED.append(f"{amount}:{approver}")
+    return f"filed {amount} with {approver}"
+
+
+def _build_user_input_member_team(db: SqliteDb, resuming: bool) -> Team:
+    """A member whose gated tool needs a field the model did not fill."""
+    agent_script = (
+        [("content", "Filed.")]
+        if resuming
+        else [("tool", "file_expense", {"amount": "900"}, "tc-expense"), ("content", "Filed.")]
+    )
+    leader_script = (
+        [("content", "All done.")]
+        if resuming
+        else [
+            ("tool", "delegate_task_to_member", {"member_id": "filer", "task": "file it"}, "tc-deleg"),
+            ("content", "All done."),
+        ]
+    )
+    return Team(
+        name="Finance Team",
+        id="finance-team",
+        model=_ScriptedModel("m-leader", leader_script),
+        members=[
+            Agent(
+                name="Filer",
+                id="filer",
+                model=_ScriptedModel("m-filer", agent_script),
+                tools=[file_expense],
+                db=db,
+                telemetry=False,
+            )
+        ],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_an_unresolved_member_requirement_repauses_instead_of_executing(tmp_path):
+    """The team-level lane re-pauses its own unresolved requirements; the member
+    lane must too, rather than run the gated tool on input nobody supplied."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "unresolved_member.db")
+    session_id = "s-unresolved-member"
+
+    run1 = _build_user_input_member_team(SqliteDb(db_file=db_file), resuming=False).run(
+        "File the expense", session_id=session_id
+    )
+    assert run1.is_paused
+    assert not run1.requirements[0].is_resolved(), "the requested field is unfilled, so the pause is unresolved"
+
+    # The client sends the payload straight back without filling the field.
+    untouched = [RunRequirement.from_dict(r.to_dict()) for r in run1.requirements or []]
+    run2 = _build_user_input_member_team(SqliteDb(db_file=db_file), resuming=True).continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=untouched
+    )
+
+    assert _EXECUTED == [], f"a gated tool ran on input nobody supplied: {_EXECUTED}"
+    assert run2.is_paused, "an unresolved member requirement must leave the run paused"
+
+
+@pytest.mark.asyncio
+async def test_an_unresolved_member_requirement_repauses_instead_of_executing_async(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "unresolved_member_async.db")
+    session_id = "s-unresolved-member-async"
+
+    run1 = await _build_user_input_member_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "File the expense", session_id=session_id
+    )
+    assert run1.is_paused
+
+    untouched = [RunRequirement.from_dict(r.to_dict()) for r in run1.requirements or []]
+    run2 = await _build_user_input_member_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=untouched
+    )
+
+    assert _EXECUTED == [], f"a gated tool ran on input nobody supplied: {_EXECUTED}"
+    assert run2.is_paused, "an unresolved member requirement must leave the run paused"
+
+
+async def _drain_background_tasks() -> None:
+    """The SSE generator returns when the producer pushes its sentinel, which
+    happens before set_run_completed; wait for the detached task itself."""
+    from agno.team._run import _background_tasks
+
+    for _ in range(300):
+        if not [t for t in list(_background_tasks) if not t.done()]:
+            return
+        await asyncio.sleep(0.01)
+
+
+def _unbindable_payload(requirements):
+    payload = _wire_requirements(requirements)
+    payload[0].id = "not-a-stored-requirement-id"
+    payload[0].tool_execution.tool_call_id = "tc-bogus"
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_background_continue_reports_a_refusal_to_the_client(tmp_path):
+    """A refused continue must not reach the caller as an empty, successful stream."""
+    from agno.os.managers import event_buffer
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "bg_refusal.db")
+    session_id = "s-bg-refusal"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    chunks = []
+    async for chunk in team2.acontinue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_unbindable_payload(run1.requirements),
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        chunks.append(chunk)
+    await _drain_background_tasks()
+
+    assert _EXECUTED == [], "a refused continue must not execute the gated tool"
+    assert [c for c in chunks if "RunError" in c], f"the refusal reached the client as an empty stream: {chunks!r}"
+    assert event_buffer.get_run_status(run1.run_id) != RunStatus.completed, (
+        "a refused continue must not be recorded as a completed run"
+    )
+    db_status = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status
+    assert db_status == RunStatus.paused
+
+
+@pytest.mark.asyncio
+async def test_background_continue_refusal_keeps_the_run_resumable(tmp_path):
+    """The run_response shape persisted ERROR over the pause the refusal was
+    protecting, leaving nothing to resume."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "bg_refusal_obj.db")
+    session_id = "s-bg-refusal-obj"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    async for _ in team2.acontinue_run(
+        run_response=run1,
+        session_id=session_id,
+        requirements=_unbindable_payload(run1.requirements),
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        pass
+    await _drain_background_tasks()
+
+    db_status = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status
+    assert db_status == RunStatus.paused, (
+        f"the refusal clobbered the paused run to {db_status!r}; it can no longer be resumed"
+    )

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -347,15 +347,26 @@ class _ScriptedModel(Model):
         self._i = 0
 
     def _next(self) -> ModelResponse:
+        from agno.metrics import MessageMetrics
+
         turn = self._script[min(self._i, len(self._script) - 1)]
         self._i += 1
-        if turn[0] == "tool":
+        if turn[0] == "tools":
+            r = ModelResponse(role="assistant")
+            r.tool_calls = [
+                {"id": tcid, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}
+                for name, args, tcid in turn[1]
+            ]
+        elif turn[0] == "tool":
             _, name, args, tcid = turn
             r = ModelResponse(role="assistant")
             r.tool_calls = [{"id": tcid, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}]
-            return r
-        r = ModelResponse(content=turn[1], role="assistant")
-        r.event = ModelResponseEvent.assistant_response.value
+        else:
+            r = ModelResponse(content=turn[1], role="assistant")
+            r.event = ModelResponseEvent.assistant_response.value
+        # Every model turn reports the same usage so tests can assert
+        # session-metrics totals as (number of model calls) * 15.
+        r.response_usage = MessageMetrics(input_tokens=10, output_tokens=5, total_tokens=15)
         return r
 
     def invoke(self, *a, **k):
@@ -640,3 +651,390 @@ def test_store_member_responses_true_keeps_paused_and_completed(tmp_path):
     # With the flag on, completed member responses are kept.
     team_runs = [r for r in _reload_runs(db_file, session_id) if isinstance(r, TeamRunOutput)]
     assert len(team_runs[0].member_responses) == 1
+
+
+# ---------------------------------------------------------------------------
+# Deeper topologies: 3-level nesting, multiple paused members per sub-team,
+# streaming resume, deep scrub, and session-metrics accuracy.
+# ---------------------------------------------------------------------------
+
+
+@tool(requires_confirmation=True)
+def send_sms(to: str) -> str:
+    _EXECUTED.append(f"sms:{to}")
+    return f"SMS sent to {to}"
+
+
+def _build_three_level_team(db: SqliteDb, resuming: bool) -> Team:
+    inner = Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-inner",
+            [("content", "Inner done.")]
+            if resuming
+            else [
+                ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-inner-deleg"),
+                ("content", "Inner done."),
+            ],
+        ),
+        members=[_emailer_agent(db, resuming)],
+        db=db,
+        telemetry=False,
+    )
+    mid = Team(
+        name="Division Team",
+        id="div-team",
+        model=_ScriptedModel(
+            "m-mid",
+            [("content", "Division done.")]
+            if resuming
+            else [
+                (
+                    "tool",
+                    "delegate_task_to_member",
+                    {"member_id": "comms-team", "task": "handle email"},
+                    "tc-mid-deleg",
+                ),
+                ("content", "Division done."),
+            ],
+        ),
+        members=[inner],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Org Team",
+        id="org-team",
+        model=_ScriptedModel(
+            "m-outer",
+            [("content", "All done.")]
+            if resuming
+            else [
+                (
+                    "tool",
+                    "delegate_task_to_member",
+                    {"member_id": "div-team", "task": "handle comms"},
+                    "tc-outer-deleg",
+                ),
+                ("content", "All done."),
+            ],
+        ),
+        members=[mid],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _build_two_member_subteam(db: SqliteDb, resuming: bool) -> Team:
+    smser = Agent(
+        name="Smser",
+        id="smser",
+        model=_ScriptedModel(
+            "m-smser",
+            [("content", "SMS sent.")]
+            if resuming
+            else [("tool", "send_sms", {"to": "b@x.com"}, "tc-sms"), ("content", "SMS sent.")],
+        ),
+        tools=[send_sms],
+        db=db,
+        telemetry=False,
+    )
+    emailer = Agent(
+        name="Emailer",
+        id="emailer",
+        model=_ScriptedModel(
+            "m-emailer",
+            [("content", "Email sent.")]
+            if resuming
+            else [("tool", "send_email", {"to": "a@x.com"}, "tc-send"), ("content", "Email sent.")],
+        ),
+        tools=[send_email],
+        db=db,
+        telemetry=False,
+    )
+    inner = Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-inner",
+            [("content", "Inner done.")]
+            if resuming
+            else [
+                (
+                    "tools",
+                    [
+                        ("delegate_task_to_member", {"member_id": "emailer", "task": "email it"}, "tc-d1"),
+                        ("delegate_task_to_member", {"member_id": "smser", "task": "sms it"}, "tc-d2"),
+                    ],
+                ),
+                ("content", "Inner done."),
+            ],
+        ),
+        members=[emailer, smser],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Org Team",
+        id="org-team",
+        model=_ScriptedModel(
+            "m-outer",
+            [("content", "Outer done.")]
+            if resuming
+            else [
+                ("tool", "delegate_task_to_member", {"member_id": "comms-team", "task": "notify"}, "tc-outer"),
+                ("content", "Outer done."),
+            ],
+        ),
+        members=[inner],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_three_level_nested_pause_resumes_same_process(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "three_same.db")
+    session_id = "s-three-same"
+
+    outer = _build_three_level_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = outer.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    for req in run1.requirements or []:
+        req.confirm()
+    run2 = outer.continue_run(run1)
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"], "the confirmed tool must actually execute"
+
+
+def test_three_level_nested_pause_survives_fresh_process_continue(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "three_fresh.db")
+    session_id = "s-three-fresh"
+
+    outer1 = _build_three_level_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = outer1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    outer2 = _build_three_level_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = outer2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+    # Eight model turns at 15 tokens each across pause and resume, counted once.
+    session = SqliteDb(db_file=db_file).get_session(session_id=session_id, session_type="team")
+    metrics = (session.session_data or {}).get("session_metrics") or {}
+    assert metrics.get("total_tokens") == 120, f"expected 120 total tokens, got {metrics.get('total_tokens')}"
+
+
+@pytest.mark.asyncio
+async def test_three_level_nested_pause_resumes_same_process_async(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "three_same_async.db")
+    session_id = "s-three-same-async"
+
+    outer = _build_three_level_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = await outer.arun("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    for req in run1.requirements or []:
+        req.confirm()
+    run2 = await outer.acontinue_run(run1)
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"], "a swallowed member error must not report success"
+
+
+def test_two_paused_members_in_one_subteam_both_execute(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "two_members.db")
+    session_id = "s-two-members"
+
+    outer1 = _build_two_member_subteam(SqliteDb(db_file=db_file), resuming=False)
+    run1 = outer1.run("Notify everyone", session_id=session_id)
+    assert run1.is_paused
+    assert len(run1.requirements or []) == 2
+
+    outer2 = _build_two_member_subteam(SqliteDb(db_file=db_file), resuming=True)
+    run2 = outer2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert sorted(_EXECUTED) == ["a@x.com", "sms:b@x.com"], "both confirmed tools must execute"
+
+
+@pytest.mark.asyncio
+async def test_two_paused_members_in_one_subteam_both_execute_async(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "two_members_async.db")
+    session_id = "s-two-members-async"
+
+    outer1 = _build_two_member_subteam(SqliteDb(db_file=db_file), resuming=False)
+    run1 = await outer1.arun("Notify everyone", session_id=session_id)
+    assert run1.is_paused
+
+    outer2 = _build_two_member_subteam(SqliteDb(db_file=db_file), resuming=True)
+    run2 = await outer2.acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert sorted(_EXECUTED) == ["a@x.com", "sms:b@x.com"]
+
+
+def test_nested_member_pause_fresh_process_continue_streaming(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "nested_stream.db")
+    session_id = "s-nested-stream"
+
+    outer1 = _build_nested_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = outer1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    outer2 = _build_nested_team(SqliteDb(db_file=db_file), resuming=True)
+    final = None
+    for event in outer2.continue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(run1.requirements),
+        stream=True,
+        yield_run_output=True,
+    ):
+        if isinstance(event, TeamRunOutput):
+            final = event
+    assert final is not None
+    assert final.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_nested_member_pause_fresh_process_continue_streaming_async(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "nested_stream_async.db")
+    session_id = "s-nested-stream-async"
+
+    outer1 = _build_nested_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = await outer1.arun("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    outer2 = _build_nested_team(SqliteDb(db_file=db_file), resuming=True)
+    final = None
+    async for event in outer2.acontinue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(run1.requirements),
+        stream=True,
+        yield_run_output=True,
+    ):
+        if isinstance(event, TeamRunOutput):
+            final = event
+    assert final is not None
+    assert final.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+def test_completed_members_scrubbed_inside_spared_paused_subteam(tmp_path):
+    """A paused sub-team run is spared, but the COMPLETED member responses
+    inside it are still scrubbed with the default flag, at every level. The
+    sub-team sits two levels down so its run is NOT a top-level session row —
+    only the recursive scrub reaches the completed response inside it."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "deep_scrub.db")
+    session_id = "s-deep-scrub"
+
+    db = SqliteDb(db_file=db_file)
+    reporter = Agent(
+        name="Reporter",
+        id="reporter",
+        model=_ScriptedModel("m-reporter", [("content", "SENSITIVE_COMPLETED_RESULT")]),
+        db=db,
+        telemetry=False,
+    )
+    inner = Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-inner",
+            [
+                ("tool", "delegate_task_to_member", {"member_id": "reporter", "task": "report"}, "tc-rep"),
+                ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-mail"),
+                ("content", "Inner done."),
+            ],
+        ),
+        members=[reporter, _emailer_agent(db, resuming=False)],
+        db=db,
+        telemetry=False,
+    )
+    mid = Team(
+        name="Division Team",
+        id="div-team",
+        model=_ScriptedModel(
+            "m-mid",
+            [
+                ("tool", "delegate_task_to_member", {"member_id": "comms-team", "task": "notify"}, "tc-mid"),
+                ("content", "Division done."),
+            ],
+        ),
+        members=[inner],
+        db=db,
+        telemetry=False,
+    )
+    outer = Team(
+        name="Org Team",
+        id="org-team",
+        model=_ScriptedModel(
+            "m-outer",
+            [
+                ("tool", "delegate_task_to_member", {"member_id": "div-team", "task": "handle comms"}, "tc-outer"),
+                ("content", "Outer done."),
+            ],
+        ),
+        members=[mid],
+        db=db,
+        telemetry=False,
+    )
+
+    run1 = outer.run("Report then email", session_id=session_id)
+    assert run1.is_paused
+
+    def walk(runs):
+        stack = list(runs)
+        while stack:
+            r = stack.pop()
+            yield r
+            stack.extend(getattr(r, "member_responses", None) or [])
+
+    persisted = _reload_runs(db_file, session_id)
+    all_runs = list(walk(persisted))
+    # The paused chain survives: the sub-team run and the paused emailer inside it.
+    assert any(getattr(r, "team_id", None) == "comms-team" and r.is_paused for r in all_runs)
+    assert any(getattr(r, "agent_id", None) == "emailer" and r.is_paused for r in all_runs)
+    # Completed member responses are scrubbed at every level.
+    for r in persisted:
+        for m in walk(getattr(r, "member_responses", None) or []):
+            assert getattr(m, "is_paused", False), f"completed member response persisted: {m.run_id}"
+
+
+def test_session_metrics_not_double_counted_on_fresh_process_resume(tmp_path):
+    """Every model turn reports 15 total tokens. Four turns happen across the
+    pause and the resume (leader delegate, member tool call, member resume,
+    leader continuation), so the session must report exactly 60 — not more."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "metrics.db")
+    session_id = "s-metrics"
+
+    team1 = _build_flat_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+
+    session = SqliteDb(db_file=db_file).get_session(session_id=session_id, session_type="team")
+    metrics = (session.session_data or {}).get("session_metrics") or {}
+    assert metrics.get("total_tokens") == 60, f"expected 60 total tokens, got {metrics.get('total_tokens')}"

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -1535,3 +1535,203 @@ async def test_unroutable_requirement_raises_and_run_stays_paused_async(tmp_path
     team_runs = [r for r in _reload_runs(db_file, session_id) if isinstance(r, TeamRunOutput)]
     assert team_runs[0].is_paused, "the stored run must stay paused and resumable"
     assert any(not r.is_resolved() for r in (team_runs[0].requirements or []))
+
+
+# ---------------------------------------------------------------------------
+# A sub-team's OWN gated tool: _propagate_member_pause stamps the sub-team's
+# id on the lifted requirement so the parent can route it down; the sub-team
+# must reclaim it as its own team-level requirement, both alone and mixed
+# with a deep member requirement in the same turn.
+# ---------------------------------------------------------------------------
+
+
+@tool(requires_confirmation=True)
+def publish(item: str) -> str:
+    _EXECUTED.append(f"pub:{item}")
+    return f"Published {item}"
+
+
+def _build_subteam_own_tool(db: SqliteDb, resuming: bool, mixed: bool) -> Team:
+    inner_pause_turn = (
+        (
+            "tools",
+            [
+                ("delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-inner-deleg"),
+                ("publish", {"item": "release"}, "tc-pub"),
+            ],
+        )
+        if mixed
+        else ("tool", "publish", {"item": "release"}, "tc-pub")
+    )
+    inner = Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-inner", [("content", "Inner done.")] if resuming else [inner_pause_turn, ("content", "Inner done.")]
+        ),
+        tools=[publish],
+        members=[_emailer_agent(db, resuming)],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Org Team",
+        id="org-team",
+        model=_ScriptedModel(
+            "m-outer",
+            [("content", "All done.")]
+            if resuming
+            else [
+                ("tool", "delegate_task_to_member", {"member_id": "comms-team", "task": "handle comms"}, "tc-outer"),
+                ("content", "All done."),
+            ],
+        ),
+        members=[inner],
+        db=db,
+        telemetry=False,
+    )
+
+
+@pytest.mark.parametrize("mixed", [False, True], ids=["alone", "with_member_requirement"])
+def test_subteam_own_gated_tool_executes_on_continue(tmp_path, mixed):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "own_tool.db")
+    session_id = "s-own-tool"
+
+    outer1 = _build_subteam_own_tool(SqliteDb(db_file=db_file), resuming=False, mixed=mixed)
+    run1 = outer1.run("Publish the release", session_id=session_id)
+    assert run1.is_paused
+    expected = ["publish", "send_email"] if mixed else ["publish"]
+    assert sorted(r.tool_execution.tool_name for r in run1.requirements or []) == sorted(expected)
+
+    outer2 = _build_subteam_own_tool(SqliteDb(db_file=db_file), resuming=True, mixed=mixed)
+    run2 = outer2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert sorted(_EXECUTED) == (["a@example.com", "pub:release"] if mixed else ["pub:release"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mixed", [False, True], ids=["alone", "with_member_requirement"])
+async def test_subteam_own_gated_tool_executes_on_continue_async(tmp_path, mixed):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "own_tool_async.db")
+    session_id = "s-own-tool-async"
+
+    outer1 = _build_subteam_own_tool(SqliteDb(db_file=db_file), resuming=False, mixed=mixed)
+    run1 = await outer1.arun("Publish the release", session_id=session_id)
+    assert run1.is_paused
+
+    outer2 = _build_subteam_own_tool(SqliteDb(db_file=db_file), resuming=True, mixed=mixed)
+    run2 = await outer2.acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert sorted(_EXECUTED) == (["a@example.com", "pub:release"] if mixed else ["pub:release"])
+
+
+# ---------------------------------------------------------------------------
+# When routing raises, the caller's in-memory run object must keep ALL its
+# requirements (the dispatch temporarily strips team-level ones for routing),
+# so a retry after fixing the team does not lose an approved tool.
+# ---------------------------------------------------------------------------
+
+
+def _build_leader_tool_and_member(db: SqliteDb, member_id: str) -> Team:
+    member = Agent(
+        name="Emailer",
+        id=member_id,
+        model=_ScriptedModel("m-emailer", [("tool", "send_email", {"to": "a@x.com"}, "tc-send"), ("content", "Sent.")]),
+        tools=[send_email],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-leader",
+            [
+                (
+                    "tools",
+                    [
+                        ("delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-deleg"),
+                        ("publish", {"item": "release"}, "tc-pub"),
+                    ],
+                ),
+                ("content", "All done."),
+            ],
+        ),
+        tools=[publish],
+        members=[member],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_unroutable_raise_preserves_caller_requirements(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "preserve.db")
+    session_id = "s-preserve"
+
+    team1 = _build_leader_tool_and_member(SqliteDb(db_file=db_file), member_id="emailer")
+    run1 = team1.run("Email and publish", session_id=session_id)
+    assert run1.is_paused
+    assert sorted(r.tool_execution.tool_name for r in run1.requirements or []) == ["publish", "send_email"]
+
+    for req in run1.requirements or []:
+        req.confirm()
+
+    # The member id changed underneath the caller's live run object.
+    team2 = _build_leader_tool_and_member(SqliteDb(db_file=db_file), member_id="emailer2")
+    with pytest.raises(RunNotContinuableError, match="emailer"):
+        team2.continue_run(run_response=run1, session_id=session_id)
+
+    names = sorted(r.tool_execution.tool_name for r in run1.requirements or [])
+    assert names == ["publish", "send_email"], "the raise must not strip the caller's requirements"
+
+
+# ---------------------------------------------------------------------------
+# An unresolved team-level requirement on a streaming continue must yield the
+# final paused TeamRunOutput (the dispatch-entry pause exit), exactly once.
+# ---------------------------------------------------------------------------
+
+
+def test_team_level_pause_streaming_continue_yields_final_output(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "team_level_stream.db")
+    session_id = "s-team-level-stream"
+
+    db = SqliteDb(db_file=db_file)
+    team1 = Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel("m-leader", [("tool", "publish", {"item": "release"}, "tc-pub"), ("content", "Done.")]),
+        tools=[publish],
+        members=[_emailer_agent(db, resuming=False)],
+        db=db,
+        telemetry=False,
+    )
+    run1 = team1.run("Publish the release", session_id=session_id)
+    assert run1.is_paused
+
+    # Continue WITHOUT resolving the requirement: the run must re-pause and
+    # the stream must yield exactly one final TeamRunOutput.
+    team2 = Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel("m-leader2", [("content", "Done.")]),
+        tools=[publish],
+        members=[_emailer_agent(SqliteDb(db_file=db_file), resuming=True)],
+        db=SqliteDb(db_file=db_file),
+        telemetry=False,
+    )
+    finals = [
+        event
+        for event in team2.continue_run(run_id=run1.run_id, session_id=session_id, stream=True, yield_run_output=True)
+        if isinstance(event, TeamRunOutput)
+    ]
+    assert len(finals) == 1, "exactly one final TeamRunOutput must be yielded on a team-level re-pause"
+    assert finals[0].is_paused
+    assert _EXECUTED == []

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -8,14 +8,22 @@ persisted to session.runs so subsequent continue_run calls can find it after
 session reload.
 """
 
+import json
+from typing import Any, AsyncIterator, Iterator, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from agno.models.response import ToolExecution
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution
 from agno.run.agent import RunOutput
 from agno.run.base import RunStatus
 from agno.run.requirement import RunRequirement
+from agno.run.team import TeamRunOutput
+from agno.team import Team
+from agno.tools import tool
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -315,3 +323,320 @@ async def test_async_streaming_routing_persists_completed_member_run():
             pass
 
     session.upsert_run.assert_called_once_with(completed_response)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end persistence across a session reload (scripted model, no network)
+#
+# A member pause must survive the default store_member_responses=False scrub
+# and a full process restart: pause -> save -> reload with fresh Team/Agent
+# objects -> continue_run with wire-serialized requirements -> the gated tool
+# executes and the run completes. The nested-team variant is the regression
+# target: the paused sub-member run lives only inside the sub-team's
+# TeamRunOutput.member_responses (sub-teams skip save_session), so scrubbing
+# it leaves nothing to resume.
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedModel(Model):
+    """Emits scripted turns offline: ('tool', name, args, id) or ('content', text)."""
+
+    def __init__(self, model_id: str, script: List[tuple]):
+        super().__init__(id=model_id, name=model_id, provider="test")
+        self._script = list(script)
+        self._i = 0
+
+    def _next(self) -> ModelResponse:
+        turn = self._script[min(self._i, len(self._script) - 1)]
+        self._i += 1
+        if turn[0] == "tool":
+            _, name, args, tcid = turn
+            r = ModelResponse(role="assistant")
+            r.tool_calls = [{"id": tcid, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}]
+            return r
+        r = ModelResponse(content=turn[1], role="assistant")
+        r.event = ModelResponseEvent.assistant_response.value
+        return r
+
+    def invoke(self, *a, **k):
+        return self._next()
+
+    async def ainvoke(self, *a, **k):
+        return self._next()
+
+    def invoke_stream(self, *a, **k) -> Iterator[ModelResponse]:
+        yield self._next()
+
+    async def ainvoke_stream(self, *a, **k) -> AsyncIterator[ModelResponse]:
+        yield self._next()
+
+    def parse_provider_response(self, response: Any, **k) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response(self, response: Any, **k) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+
+_EXECUTED: List[str] = []
+
+
+@tool(requires_confirmation=True)
+def send_email(to: str) -> str:
+    _EXECUTED.append(to)
+    return f"Email sent to {to}"
+
+
+def _wire_requirements(requirements) -> List[RunRequirement]:
+    """Round-trip requirements through their wire format and confirm them,
+    the way a frontend or a fresh process would send them back."""
+    confirmed = []
+    for data in [r.to_dict() for r in requirements or []]:
+        req = RunRequirement.from_dict(data)
+        req.confirm()
+        confirmed.append(req)
+    return confirmed
+
+
+def _emailer_agent(db: SqliteDb, resuming: bool) -> Agent:
+    script = (
+        [("content", "Email sent.")]
+        if resuming
+        else [("tool", "send_email", {"to": "a@example.com"}, "tc-send"), ("content", "Email sent.")]
+    )
+    return Agent(
+        name="Emailer",
+        id="emailer",
+        model=_ScriptedModel("m-emailer", script),
+        tools=[send_email],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _build_flat_team(db: SqliteDb, resuming: bool, **team_kwargs) -> Team:
+    script = (
+        [("content", "All done.")]
+        if resuming
+        else [
+            ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-deleg"),
+            ("content", "All done."),
+        ]
+    )
+    return Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel("m-leader", script),
+        members=[_emailer_agent(db, resuming)],
+        db=db,
+        telemetry=False,
+        **team_kwargs,
+    )
+
+
+def _build_nested_team(db: SqliteDb, resuming: bool) -> Team:
+    inner_script = (
+        [("content", "Inner done.")]
+        if resuming
+        else [
+            ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-inner-deleg"),
+            ("content", "Inner done."),
+        ]
+    )
+    outer_script = (
+        [("content", "All done.")]
+        if resuming
+        else [
+            ("tool", "delegate_task_to_member", {"member_id": "comms-team", "task": "handle email"}, "tc-outer-deleg"),
+            ("content", "All done."),
+        ]
+    )
+    inner = Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel("m-inner", inner_script),
+        members=[_emailer_agent(db, resuming)],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Org Team",
+        id="org-team",
+        model=_ScriptedModel("m-outer", outer_script),
+        members=[inner],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _reload_runs(db_file: str, session_id: str):
+    session = SqliteDb(db_file=db_file).get_session(session_id=session_id, session_type="team")
+    assert session is not None
+    return session.runs or []
+
+
+def test_flat_member_pause_survives_fresh_process_continue(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "flat.db")
+    session_id = "s-flat"
+
+    team1 = _build_flat_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+    assert _EXECUTED == []
+
+    # The paused member run survives the save with the default flag: the team
+    # run row keeps it in member_responses with everything resume needs.
+    team_runs = [r for r in _reload_runs(db_file, session_id) if isinstance(r, TeamRunOutput)]
+    assert len(team_runs) == 1
+    spared = [m for m in team_runs[0].member_responses if getattr(m, "is_paused", False)]
+    assert len(spared) == 1
+    assert spared[0].run_id is not None
+    assert spared[0].messages, "resume continues the model conversation from these messages"
+    assert spared[0].tools and spared[0].tools[0].requires_confirmation
+    assert spared[0].requirements and not spared[0].requirements[0].is_resolved()
+
+    # Fresh process: new objects, wire-serialized requirements.
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+    # The member run completed, so the next save scrubbed it again.
+    team_runs = [r for r in _reload_runs(db_file, session_id) if isinstance(r, TeamRunOutput)]
+    assert all(r.member_responses == [] for r in team_runs)
+
+
+def test_nested_member_pause_survives_fresh_process_continue(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "nested.db")
+    session_id = "s-nested"
+
+    outer1 = _build_nested_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = outer1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+    assert _EXECUTED == []
+
+    # The paused sub-member run is only reachable through the sub-team's
+    # TeamRunOutput (sub-teams skip save_session), so it must survive there.
+    inner_runs = [r for r in _reload_runs(db_file, session_id) if getattr(r, "team_id", None) == "comms-team"]
+    assert len(inner_runs) == 1
+    spared = [m for m in inner_runs[0].member_responses if getattr(m, "is_paused", False)]
+    assert len(spared) == 1
+    assert spared[0].messages
+    assert spared[0].tools and spared[0].tools[0].requires_confirmation
+    assert spared[0].requirements and not spared[0].requirements[0].is_resolved()
+
+    outer2 = _build_nested_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = outer2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+    team_runs = [r for r in _reload_runs(db_file, session_id) if isinstance(r, TeamRunOutput)]
+    assert all(r.member_responses == [] for r in team_runs)
+
+
+@pytest.mark.asyncio
+async def test_nested_member_pause_survives_fresh_process_continue_async(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "nested_async.db")
+    session_id = "s-nested-async"
+
+    outer1 = _build_nested_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = await outer1.arun("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    inner_runs = [r for r in _reload_runs(db_file, session_id) if getattr(r, "team_id", None) == "comms-team"]
+    assert len(inner_runs) == 1
+    assert any(getattr(m, "is_paused", False) for m in inner_runs[0].member_responses)
+
+    outer2 = _build_nested_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = await outer2.acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+def test_nested_member_pause_resumes_same_process(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "nested_same.db")
+    session_id = "s-nested-same"
+
+    outer = _build_nested_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = outer.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    for req in run1.requirements or []:
+        req.confirm()
+    run2 = outer.continue_run(run1)
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"], "the confirmed tool must actually execute"
+
+
+def test_completed_member_responses_still_scrubbed_with_default_flag(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "completed.db")
+    session_id = "s-completed"
+
+    emailer = Agent(
+        name="Emailer",
+        id="emailer",
+        model=_ScriptedModel("m-emailer", [("content", "No email needed.")]),
+        db=SqliteDb(db_file=db_file),
+        telemetry=False,
+    )
+    team = Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-leader",
+            [
+                ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "check"}, "tc-deleg"),
+                ("content", "All done."),
+            ],
+        ),
+        members=[emailer],
+        db=SqliteDb(db_file=db_file),
+        telemetry=False,
+    )
+    run = team.run("Anything to send?", session_id=session_id)
+    assert run.status == RunStatus.completed
+
+    team_runs = [r for r in _reload_runs(db_file, session_id) if isinstance(r, TeamRunOutput)]
+    assert len(team_runs) == 1
+    assert team_runs[0].member_responses == []
+
+
+def test_store_member_responses_true_keeps_paused_and_completed(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "flag_true.db")
+    session_id = "s-flag-true"
+
+    team1 = _build_flat_team(SqliteDb(db_file=db_file), resuming=False, store_member_responses=True)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    team_runs = [r for r in _reload_runs(db_file, session_id) if isinstance(r, TeamRunOutput)]
+    assert len(team_runs) == 1
+    assert len(team_runs[0].member_responses) == 1
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True, store_member_responses=True)
+    run2 = team2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+    # With the flag on, completed member responses are kept.
+    team_runs = [r for r in _reload_runs(db_file, session_id) if isinstance(r, TeamRunOutput)]
+    assert len(team_runs[0].member_responses) == 1

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -3222,3 +3222,65 @@ def test_user_feedback_answer_for_an_unknown_question_is_ignored():
     assert stored_question.question == "Which channel?"
     assert stored_question.selected_options is None
     assert stored.tool_execution.answered is None, "an unanswered question must leave the run unresolved"
+
+
+# ---------------------------------------------------------------------------
+# The approval gate can refuse a continue AFTER the payload has bound, so the
+# merge has to be undoable. Restoring the requirements list is not enough: its
+# entries are the stored requirements the merge wrote into.
+# ---------------------------------------------------------------------------
+
+
+def _mixed_requirements() -> List[RunRequirement]:
+    from agno.tools.function import UserFeedbackOption, UserFeedbackQuestion, UserInputField
+
+    confirm_req = _make_requirement(
+        tool_name="send_email", tool_call_id="tc-c", requires_confirmation=True, approval_type="required"
+    )
+    input_req = _make_requirement(
+        tool_name="transfer",
+        tool_call_id="tc-i",
+        requires_user_input=True,
+        user_input_schema=[UserInputField(name="note", field_type=str)],
+    )
+    input_req.user_input_schema = input_req.tool_execution.user_input_schema
+    feedback_req = _make_requirement(
+        tool_name="notify",
+        tool_call_id="tc-f",
+        user_feedback_schema=[
+            UserFeedbackQuestion(question="Which channel?", options=[UserFeedbackOption(label="sms")])
+        ],
+    )
+    feedback_req.user_feedback_schema = feedback_req.tool_execution.user_feedback_schema
+    return [confirm_req, input_req, feedback_req]
+
+
+def test_restoring_decisions_undoes_the_whole_merge():
+    from agno.team._run import _apply_requirements_payload, _restore_requirement_decisions
+
+    stored = _mixed_requirements()
+    run_response = TeamRunOutput(
+        run_id="run-1",
+        session_id="session-1",
+        requirements=stored,
+        tools=[r.tool_execution for r in stored],
+    )
+    before = [r.to_dict() for r in stored]
+
+    payload = [RunRequirement.from_dict(d) for d in before]
+    payload[0].confirm()
+    payload[1].provide_user_input({"note": "typed"})
+    payload[2].provide_user_feedback({"Which channel?": ["sms"]})
+
+    _, _, decisions = _apply_requirements_payload(run_response, payload)
+
+    # The merge landed on every lane.
+    assert stored[0].tool_execution.confirmed is True
+    assert stored[1].tool_execution.user_input_schema[0].value == "typed"
+    assert stored[2].tool_execution.user_feedback_schema[0].selected_options == ["sms"]
+    assert stored[2].tool_execution.user_feedback_schema[0].options[0].selected is True
+
+    _restore_requirement_decisions(decisions)
+
+    assert [r.to_dict() for r in stored] == before, "the snapshot must cover every field the merge writes"
+    assert not any(r.is_resolved() for r in stored)

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -4441,3 +4441,136 @@ async def test_background_continue_refusal_keeps_the_run_resumable(tmp_path):
     assert db_status == RunStatus.paused, (
         f"the refusal clobbered the paused run to {db_status!r}; it can no longer be resumed"
     )
+
+
+@pytest.mark.asyncio
+async def test_a_stale_run_response_cannot_resurrect_a_finished_run(tmp_path):
+    """A caller-held run object outlives the run it describes.
+
+    If it still reads as paused after someone else finished the run, writing it
+    back would republish the finished run as a pending approval — and its gated
+    tool could then be approved a second time.
+    """
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "stale_takeover.db")
+    session_id = "s-stale-takeover"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+    good = _wire_requirements(run1.requirements)
+
+    done = await _build_flat_team(SqliteDb(db_file=db_file), resuming=True).acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert done.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+    # The caller still holds the stale paused object from before that completion.
+    team3 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    with pytest.raises(RunNotContinuableError):
+        async for _ in team3.acontinue_run(
+            run_response=run1,
+            session_id=session_id,
+            requirements=_unbindable_payload(run1.requirements),
+            stream=True,
+            stream_events=True,
+            background=True,
+        ):
+            pass
+    await _drain_background_tasks()
+
+    status = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status
+    assert status == RunStatus.completed, f"a finished run was resurrected to {status!r}"
+
+    team4 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    try:
+        await team4.acontinue_run(run_id=run1.run_id, session_id=session_id, requirements=good)
+    except Exception:
+        pass
+    assert _EXECUTED == ["a@example.com"], f"the gated tool ran a second time: {_EXECUTED}"
+
+
+@pytest.mark.asyncio
+async def test_a_refused_continue_restores_the_status_it_replaced(tmp_path):
+    """The refusal must put back whatever it took over, not a blanket pause.
+
+    A cancelled run handed a refused continue has to come out cancelled. Coming
+    out paused would turn every terminal state into a resumable approval.
+    """
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "restore_status.db")
+    session_id = "s-restore-status"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    db = SqliteDb(db_file=db_file)
+    session = db.get_session(session_id=session_id, session_type="team")
+    for r in session.runs or []:
+        if r.run_id == run1.run_id:
+            r.status = RunStatus.cancelled
+    db.upsert_session(session)
+
+    # The caller still holds the paused object from before the cancellation.
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    async for _ in team2.acontinue_run(
+        run_response=run1,
+        session_id=session_id,
+        requirements=_unbindable_payload(run1.requirements),
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        pass
+    await _drain_background_tasks()
+
+    status = [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status
+    assert status == RunStatus.cancelled, f"a cancelled run came back as {status!r} after a refused continue"
+    assert _EXECUTED == []
+
+
+@pytest.mark.asyncio
+async def test_the_event_buffer_does_not_advertise_a_cancelled_run_as_paused(tmp_path):
+    """Reconnecting clients read the buffer, not the DB.
+
+    Recording a blanket PAUSED for any refusal tells every one of them that a
+    cancelled run is waiting on an approval.
+    """
+    from agno.os.managers import event_buffer
+
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "buffer_status.db")
+    session_id = "s-buffer-status"
+
+    run1 = await _build_flat_team(SqliteDb(db_file=db_file), resuming=False).arun(
+        "Email a@example.com", session_id=session_id
+    )
+    assert run1.is_paused
+
+    db = SqliteDb(db_file=db_file)
+    session = db.get_session(session_id=session_id, session_type="team")
+    for r in session.runs or []:
+        if r.run_id == run1.run_id:
+            r.status = RunStatus.cancelled
+    db.upsert_session(session)
+
+    team2 = _build_flat_team(SqliteDb(db_file=db_file), resuming=True)
+    async for _ in team2.acontinue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_unbindable_payload(run1.requirements),
+        stream=True,
+        stream_events=True,
+        background=True,
+    ):
+        pass
+    await _drain_background_tasks()
+
+    assert event_buffer.get_run_status(run1.run_id) != RunStatus.paused, (
+        "the buffer advertises a cancelled run as paused, so every reconnecting client reads it as resumable"
+    )
+    assert [r for r in _reload_runs(db_file, session_id) if r.run_id == run1.run_id][0].status == RunStatus.cancelled

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -9,13 +9,14 @@ session reload.
 """
 
 import json
-from typing import Any, AsyncIterator, Iterator, List
+from typing import Any, AsyncIterator, Dict, Iterator, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
+from agno.exceptions import RunNotContinuableError
 from agno.models.base import Model
 from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution
 from agno.run.agent import RunOutput
@@ -654,7 +655,7 @@ def test_store_member_responses_true_keeps_paused_and_completed(tmp_path):
 
 # ---------------------------------------------------------------------------
 # Deeper topologies: 3-level nesting, multiple paused members per sub-team,
-# streaming resume, deep scrub, and session-metrics accuracy.
+# streaming resume, and the deep scrub.
 # ---------------------------------------------------------------------------
 
 
@@ -1206,3 +1207,331 @@ def test_live_run_tree_not_mutated_by_save(tmp_path):
     for r in _reload_runs(db_file, session_id):
         for m in walk(getattr(r, "member_responses", None) or []):
             assert getattr(m, "is_paused", False), f"completed member response persisted: {m.run_id}"
+
+
+# ---------------------------------------------------------------------------
+# Chained pause on the streaming continue path: after the first confirmation
+# is delivered, the member pauses on a second gated tool. The streaming
+# continue must yield the final paused TeamRunOutput and persist the
+# re-paused state, exactly like the other three routing variants.
+# ---------------------------------------------------------------------------
+
+
+def _build_nested_chained_team(db: SqliteDb, phase: str) -> Team:
+    """phase: 'pause' -> emailer calls send_email; 'chain' -> emailer chains
+    send_sms after the confirmed send_email runs; 'finish' -> emailer answers."""
+    emailer_script = {
+        "pause": [("tool", "send_email", {"to": "a@example.com"}, "tc-send")],
+        "chain": [("tool", "send_sms", {"to": "c@x.com"}, "tc-sms-chain"), ("content", "Both sent.")],
+        "finish": [("content", "Both sent.")],
+    }[phase]
+    emailer = Agent(
+        name="Emailer",
+        id="emailer",
+        model=_ScriptedModel("m-emailer", emailer_script),
+        tools=[send_email, send_sms],
+        db=db,
+        telemetry=False,
+    )
+    inner = Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-inner",
+            [("content", "Inner done.")]
+            if phase != "pause"
+            else [
+                ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-inner-deleg"),
+                ("content", "Inner done."),
+            ],
+        ),
+        members=[emailer],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Org Team",
+        id="org-team",
+        model=_ScriptedModel(
+            "m-outer",
+            [("content", "All done.")]
+            if phase != "pause"
+            else [
+                (
+                    "tool",
+                    "delegate_task_to_member",
+                    {"member_id": "comms-team", "task": "handle email"},
+                    "tc-outer-deleg",
+                ),
+                ("content", "All done."),
+            ],
+        ),
+        members=[inner],
+        db=db,
+        telemetry=False,
+    )
+
+
+def _assert_chained_pause_surfaced(final, db_file: str, session_id: str) -> None:
+    assert final is not None, "streaming continue must yield the final TeamRunOutput on a chained pause"
+    assert final.is_paused
+    unresolved = [r for r in (final.requirements or []) if not r.is_resolved()]
+    assert [r.tool_execution.tool_name for r in unresolved if r.tool_execution] == ["send_sms"]
+    assert _EXECUTED == ["a@example.com"], "the chained send_sms must not run before its confirmation"
+
+    # The re-paused state is persisted: a fresh reader sees the outer run
+    # paused with the unresolved chained requirement.
+    team_runs = [r for r in _reload_runs(db_file, session_id) if getattr(r, "team_id", None) == "org-team"]
+    assert team_runs[0].is_paused
+    stored_unresolved = [r for r in (team_runs[0].requirements or []) if not r.is_resolved()]
+    assert [r.tool_execution.tool_name for r in stored_unresolved if r.tool_execution] == ["send_sms"]
+
+
+def test_nested_chained_pause_streaming_repauses_and_resumes(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "chained_stream.db")
+    session_id = "s-chained-stream"
+
+    outer1 = _build_nested_chained_team(SqliteDb(db_file=db_file), phase="pause")
+    run1 = outer1.run("Email then sms", session_id=session_id)
+    assert run1.is_paused
+
+    outer2 = _build_nested_chained_team(SqliteDb(db_file=db_file), phase="chain")
+    final = None
+    for event in outer2.continue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(run1.requirements),
+        stream=True,
+        yield_run_output=True,
+    ):
+        if isinstance(event, TeamRunOutput):
+            final = event
+    _assert_chained_pause_surfaced(final, db_file, session_id)
+
+    outer3 = _build_nested_chained_team(SqliteDb(db_file=db_file), phase="finish")
+    run3 = None
+    for event in outer3.continue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements([r for r in final.requirements or [] if not r.is_resolved()]),
+        stream=True,
+        yield_run_output=True,
+    ):
+        if isinstance(event, TeamRunOutput):
+            run3 = event
+    assert run3 is not None
+    assert run3.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com", "sms:c@x.com"]
+
+
+@pytest.mark.asyncio
+async def test_nested_chained_pause_streaming_repauses_and_resumes_async(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "chained_stream_async.db")
+    session_id = "s-chained-stream-async"
+
+    outer1 = _build_nested_chained_team(SqliteDb(db_file=db_file), phase="pause")
+    run1 = await outer1.arun("Email then sms", session_id=session_id)
+    assert run1.is_paused
+
+    outer2 = _build_nested_chained_team(SqliteDb(db_file=db_file), phase="chain")
+    final = None
+    async for event in outer2.acontinue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements(run1.requirements),
+        stream=True,
+        yield_run_output=True,
+    ):
+        if isinstance(event, TeamRunOutput):
+            final = event
+    _assert_chained_pause_surfaced(final, db_file, session_id)
+
+    outer3 = _build_nested_chained_team(SqliteDb(db_file=db_file), phase="finish")
+    run3 = None
+    async for event in outer3.acontinue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements([r for r in final.requirements or [] if not r.is_resolved()]),
+        stream=True,
+        yield_run_output=True,
+    ):
+        if isinstance(event, TeamRunOutput):
+            run3 = event
+    assert run3 is not None
+    assert run3.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com", "sms:c@x.com"]
+
+
+# ---------------------------------------------------------------------------
+# One member paused in TWO delegations of the same turn: the requirements
+# share member_agent_id but belong to distinct member runs, so grouping by
+# (member id, member run id) must keep them separate — one continue per
+# paused run, both confirmations execute.
+# ---------------------------------------------------------------------------
+
+_SHARED_CURSORS: Dict[str, int] = {}
+
+
+class _SharedCursorModel(_ScriptedModel):
+    """Script cursor kept in module scope by model id, so the copies a leader
+    makes when it delegates to the same member twice in one turn consume
+    consecutive script turns instead of each starting at turn one."""
+
+    def _next(self):
+        self._i = _SHARED_CURSORS.get(self.id, 0)
+        response = super()._next()
+        _SHARED_CURSORS[self.id] = self._i
+        return response
+
+
+def _build_same_member_twice(db: SqliteDb, resuming: bool) -> Team:
+    _SHARED_CURSORS.pop("m-emailer-twice", None)
+    emailer = Agent(
+        name="Emailer",
+        id="emailer",
+        model=_SharedCursorModel(
+            "m-emailer-twice",
+            [("content", "Email sent."), ("content", "Email sent.")]
+            if resuming
+            else [
+                ("tool", "send_email", {"to": "a@x.com"}, "tc-e1"),
+                ("tool", "send_email", {"to": "b@x.com"}, "tc-e2"),
+            ],
+        ),
+        tools=[send_email],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-leader-twice",
+            [("content", "All done.")]
+            if resuming
+            else [
+                (
+                    "tools",
+                    [
+                        ("delegate_task_to_member", {"member_id": "emailer", "task": "task A"}, "tc-da"),
+                        ("delegate_task_to_member", {"member_id": "emailer", "task": "task B"}, "tc-db"),
+                    ],
+                ),
+                ("content", "All done."),
+            ],
+        ),
+        members=[emailer],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_same_member_paused_twice_in_one_turn_both_execute(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "same_member_twice.db")
+    session_id = "s-same-member-twice"
+
+    team1 = _build_same_member_twice(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Do task A and task B", session_id=session_id)
+    assert run1.is_paused
+    assert len(run1.requirements or []) == 2
+    assert {r.member_agent_id for r in run1.requirements or []} == {"emailer"}
+    assert len({r.member_run_id for r in run1.requirements or []}) == 2, "two distinct paused member runs"
+
+    team2 = _build_same_member_twice(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert sorted(_EXECUTED) == ["a@x.com", "b@x.com"], "both confirmed tools must execute"
+
+
+@pytest.mark.asyncio
+async def test_same_member_paused_twice_in_one_turn_both_execute_async(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "same_member_twice_async.db")
+    session_id = "s-same-member-twice-async"
+
+    team1 = _build_same_member_twice(SqliteDb(db_file=db_file), resuming=False)
+    run1 = await team1.arun("Do task A and task B", session_id=session_id)
+    assert run1.is_paused
+    assert len({r.member_run_id for r in run1.requirements or []}) == 2
+
+    team2 = _build_same_member_twice(SqliteDb(db_file=db_file), resuming=True)
+    run2 = await team2.acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert sorted(_EXECUTED) == ["a@x.com", "b@x.com"]
+
+
+# ---------------------------------------------------------------------------
+# A requirement that cannot be routed to any current member fails loudly.
+# The run stays paused and resumable; the approved tool is not silently
+# skipped and the run does not report completed.
+# ---------------------------------------------------------------------------
+
+
+def _build_renamed_member_team(db: SqliteDb) -> Team:
+    renamed = Agent(
+        name="Emailer",
+        id="emailer2",
+        model=_ScriptedModel("m-emailer2", [("content", "Email sent.")]),
+        tools=[send_email],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel("m-leader-renamed", [("content", "All done.")]),
+        members=[renamed],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_unroutable_requirement_raises_and_run_stays_paused(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "unroutable.db")
+    session_id = "s-unroutable"
+
+    team1 = _build_flat_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    # The member id changed between pause and continue (e.g. a redeploy).
+    team2 = _build_renamed_member_team(SqliteDb(db_file=db_file))
+    with pytest.raises(RunNotContinuableError, match="emailer"):
+        team2.continue_run(
+            run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+        )
+
+    assert _EXECUTED == [], "no confirmed tool may execute when routing fails"
+    team_runs = [r for r in _reload_runs(db_file, session_id) if isinstance(r, TeamRunOutput)]
+    assert team_runs[0].is_paused, "the stored run must stay paused and resumable"
+    assert any(not r.is_resolved() for r in (team_runs[0].requirements or []))
+
+
+@pytest.mark.asyncio
+async def test_unroutable_requirement_raises_and_run_stays_paused_async(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "unroutable_async.db")
+    session_id = "s-unroutable-async"
+
+    team1 = _build_flat_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = await team1.arun("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    team2 = _build_renamed_member_team(SqliteDb(db_file=db_file))
+    with pytest.raises(RunNotContinuableError, match="emailer"):
+        await team2.acontinue_run(
+            run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+        )
+
+    assert _EXECUTED == [], "no confirmed tool may execute when routing fails"
+    team_runs = [r for r in _reload_runs(db_file, session_id) if isinstance(r, TeamRunOutput)]
+    assert team_runs[0].is_paused, "the stored run must stay paused and resumable"
+    assert any(not r.is_resolved() for r in (team_runs[0].requirements or []))

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -5676,6 +5676,131 @@ def test_a_deleted_sibling_approval_blocks_the_continue(tmp_path):
     assert _FIRED == [], f"a tool executed with its own approval record deleted: {_FIRED}"
 
 
+_SHIPPED: List[str] = []
+
+
+@tool(requires_confirmation=True)
+@approval(type="required")
+def ship(target: str) -> str:
+    _SHIPPED.append(f"ship:{target}")
+    return f"shipped {target}"
+
+
+def _same_tool_two_member_team(db: SqliteDb, resuming: bool) -> Team:
+    """Two members calling the SAME gated tool with colliding provider-local
+    tool_call_ids: neither name nor id can tell their requirements apart."""
+
+    def member(name: str, mid: str, target: str) -> Agent:
+        return Agent(
+            name=name,
+            id=mid,
+            model=_ScriptedModel(
+                f"m-{mid}",
+                [("content", "Done.")]
+                if resuming
+                else [("tool", "ship", {"target": target}, "call_1"), ("content", "Done.")],
+            ),
+            tools=[ship],
+            db=db,
+            telemetry=False,
+        )
+
+    return Team(
+        name="Ship Team",
+        id="ship-team",
+        model=_ScriptedModel(
+            "m-lead",
+            [("content", "All done.")]
+            if resuming
+            else [
+                (
+                    "tools",
+                    [
+                        ("delegate_task_to_member", {"member_id": "alpha", "task": "ship A"}, "tc-d1"),
+                        ("delegate_task_to_member", {"member_id": "beta", "task": "ship B"}, "tc-d2"),
+                    ],
+                ),
+                ("content", "All done."),
+            ],
+        ),
+        members=[member("Alpha", "alpha", "A"), member("Beta", "beta", "B")],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_an_ambiguous_tool_owner_blocks_instead_of_borrowing_a_sibling_record(tmp_path):
+    """Two members calling the same tool with colliding tool_call_ids: a member
+    whose own record is gone must block, not resolve through the requirement
+    that happens to match first."""
+    _SHIPPED.clear()
+    db_file = str(tmp_path / "ambiguous_owner.db")
+    session_id = "s-ambiguous-owner"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = _same_tool_two_member_team(db, resuming=False).run("Ship both", session_id=session_id)
+    assert run1.is_paused
+    records, _ = db.get_approvals(approval_type="required", limit=50)
+    assert len(records) == 2
+
+    approved_record, deleted_record = records
+    db.update_approval(approved_record["id"], status="approved", resolution_data=None)
+    assert db.delete_approval(deleted_record["id"])
+
+    team2 = _same_tool_two_member_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.paused, f"an ambiguous owner match let the run reach {run2.status}"
+    assert _SHIPPED == [], f"a tool with no record of its own executed on a sibling's approval: {_SHIPPED}"
+
+
+def test_an_ambiguous_value_match_resolves_no_owner():
+    """Unit contract of _member_run_id_for_tool: identity wins outright; a
+    value match fitting requirements of more than one member is ambiguous."""
+    from agno.run.approval import _AMBIGUOUS_OWNER, _member_run_id_for_tool
+
+    te_a = ToolExecution(tool_call_id="call_1", tool_name="ship", approval_type="required")
+    te_b = ToolExecution(tool_call_id="call_1", tool_name="ship", approval_type="required")
+    req_a = RunRequirement(tool_execution=te_a)
+    req_a.member_run_id = "run-alpha"
+    req_b = RunRequirement(tool_execution=te_b)
+    req_b.member_run_id = "run-beta"
+    holder = MagicMock(requirements=[req_a, req_b])
+
+    assert _member_run_id_for_tool(holder, te_b) == "run-beta"
+    reloaded_copy = ToolExecution(tool_call_id="call_1", tool_name="ship", approval_type="required")
+    assert _member_run_id_for_tool(holder, reloaded_copy) == _AMBIGUOUS_OWNER
+
+
+def test_a_reissued_team_approval_record_still_resolves(tmp_path):
+    """A team-level tool whose stamped record was deleted and re-created under
+    the same run resolves against the re-issued record; the stale id must not
+    block the run forever."""
+    _DEPLOYS.clear()
+    db_file = str(tmp_path / "reissued_record.db")
+    session_id = "s-reissued-record"
+
+    db = SqliteDb(db_file=db_file)
+    run1 = _team_level_approval_team(db, resuming=False).run("Deploy prod", session_id=session_id)
+    assert run1.is_paused
+    records, _ = db.get_approvals(approval_type="required", limit=50)
+    assert len(records) == 1
+    original = records[0]
+
+    assert db.delete_approval(original["id"])
+    reissued = dict(original)
+    reissued["id"] = "reissued-record-id"
+    reissued["status"] = "pending"
+    db.create_approval(reissued)
+    db.update_approval("reissued-record-id", status="approved", resolution_data=None)
+
+    team2 = _team_level_approval_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id)
+    assert run2.status == RunStatus.completed, (
+        f"the re-issued approved record was not found; the run is stuck at {run2.status}"
+    )
+    assert _DEPLOYS == ["prod"], _DEPLOYS
+
+
 _MIXED: List[str] = []
 
 

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -1038,3 +1038,257 @@ def test_session_metrics_not_double_counted_on_fresh_process_resume(tmp_path):
     session = SqliteDb(db_file=db_file).get_session(session_id=session_id, session_type="team")
     metrics = (session.session_data or {}).get("session_metrics") or {}
     assert metrics.get("total_tokens") == 60, f"expected 60 total tokens, got {metrics.get('total_tokens')}"
+
+
+# ---------------------------------------------------------------------------
+# Same sub-team paused twice in one turn, live-tree integrity, and
+# exactly-once session metrics.
+# ---------------------------------------------------------------------------
+
+
+def _build_same_subteam_twice(db: SqliteDb, resuming: bool) -> Team:
+    """The leader delegates TWICE to the same sub-team in one turn; a
+    different member pauses in each delegation, so the session holds two
+    distinct paused runs of the same sub-team."""
+    smser = Agent(
+        name="Smser",
+        id="smser",
+        model=_ScriptedModel(
+            "m-smser",
+            [("content", "SMS sent.")]
+            if resuming
+            else [("tool", "send_sms", {"to": "b@x.com"}, "tc-sms"), ("content", "SMS sent.")],
+        ),
+        tools=[send_sms],
+        db=db,
+        telemetry=False,
+    )
+    emailer = Agent(
+        name="Emailer",
+        id="emailer",
+        model=_ScriptedModel(
+            "m-emailer",
+            [("content", "Email sent.")]
+            if resuming
+            else [("tool", "send_email", {"to": "a@x.com"}, "tc-send"), ("content", "Email sent.")],
+        ),
+        tools=[send_email],
+        db=db,
+        telemetry=False,
+    )
+    inner = Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-inner",
+            # Run 1 consumes the first turn (pauses on emailer), run 2 the
+            # second (pauses on smser); on resume the clamped last turn answers.
+            [("content", "Inner done.")]
+            if resuming
+            else [
+                ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "email it"}, "tc-d1"),
+                ("tool", "delegate_task_to_member", {"member_id": "smser", "task": "sms it"}, "tc-d2"),
+            ],
+        ),
+        members=[emailer, smser],
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Org Team",
+        id="org-team",
+        model=_ScriptedModel(
+            "m-outer",
+            [("content", "Outer done.")]
+            if resuming
+            else [
+                (
+                    "tools",
+                    [
+                        ("delegate_task_to_member", {"member_id": "comms-team", "task": "task A"}, "tc-oa"),
+                        ("delegate_task_to_member", {"member_id": "comms-team", "task": "task B"}, "tc-ob"),
+                    ],
+                ),
+                ("content", "Outer done."),
+            ],
+        ),
+        members=[inner],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_same_subteam_paused_twice_both_confirmations_execute(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "twice.db")
+    session_id = "s-twice"
+
+    outer1 = _build_same_subteam_twice(SqliteDb(db_file=db_file), resuming=False)
+    run1 = outer1.run("Do task A and task B", session_id=session_id)
+    assert run1.is_paused
+    assert len(run1.requirements or []) == 2
+    assert len({r.member_run_id for r in run1.requirements or []}) == 2, "two distinct paused member runs"
+
+    outer2 = _build_same_subteam_twice(SqliteDb(db_file=db_file), resuming=True)
+    run2 = outer2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert sorted(_EXECUTED) == ["a@x.com", "sms:b@x.com"], "both confirmed tools must execute"
+
+
+@pytest.mark.asyncio
+async def test_same_subteam_paused_twice_both_confirmations_execute_async(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "twice_async.db")
+    session_id = "s-twice-async"
+
+    outer1 = _build_same_subteam_twice(SqliteDb(db_file=db_file), resuming=False)
+    run1 = await outer1.arun("Do task A and task B", session_id=session_id)
+    assert run1.is_paused
+
+    outer2 = _build_same_subteam_twice(SqliteDb(db_file=db_file), resuming=True)
+    run2 = await outer2.acontinue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+    assert sorted(_EXECUTED) == ["a@x.com", "sms:b@x.com"]
+
+
+def _build_completed_sibling_team(db: SqliteDb, resuming: bool) -> Team:
+    """Flat team where 'reporter' completes and then 'emailer' pauses."""
+    reporter = Agent(
+        name="Reporter",
+        id="reporter",
+        model=_ScriptedModel("m-reporter", [("content", "Report ready.")]),
+        db=db,
+        telemetry=False,
+    )
+    return Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-leader",
+            [("content", "All done.")]
+            if resuming
+            else [
+                ("tool", "delegate_task_to_member", {"member_id": "reporter", "task": "report"}, "tc-rep"),
+                ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-mail"),
+                ("content", "All done."),
+            ],
+        ),
+        members=[reporter, _emailer_agent(db, resuming)],
+        db=db,
+        telemetry=False,
+    )
+
+
+def test_metrics_exact_with_completed_sibling_before_pause(tmp_path):
+    """Reporter completes before the pause; with the default flag its
+    response is scrubbed from storage, but its tokens count exactly once.
+    Six model turns at 15 tokens each = 90."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "metrics_sibling.db")
+    session_id = "s-metrics-sibling"
+
+    team1 = _build_completed_sibling_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Report then email", session_id=session_id)
+    assert run1.is_paused
+
+    # The pause-time save counts only runs that reached a final state.
+    session = SqliteDb(db_file=db_file).get_session(session_id=session_id, session_type="team")
+    metrics = (session.session_data or {}).get("session_metrics") or {}
+    assert metrics.get("total_tokens") == 15, "only the completed reporter run is counted while paused"
+
+    team2 = _build_completed_sibling_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run2.status == RunStatus.completed
+
+    session = SqliteDb(db_file=db_file).get_session(session_id=session_id, session_type="team")
+    metrics = (session.session_data or {}).get("session_metrics") or {}
+    assert metrics.get("total_tokens") == 90, f"expected 90 total tokens, got {metrics.get('total_tokens')}"
+
+
+def test_live_run_tree_not_mutated_by_save(tmp_path):
+    """The default-flag scrub writes filtered copies to storage; the run tree
+    the caller holds keeps every member response, at every level. The
+    completed reporter sits three levels down, where the recursive scrub
+    reaches it — on the storage copy only."""
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "live_tree.db")
+    session_id = "s-live-tree"
+
+    db = SqliteDb(db_file=db_file)
+    reporter = Agent(
+        name="Reporter",
+        id="reporter",
+        model=_ScriptedModel("m-reporter", [("content", "Report ready.")]),
+        db=db,
+        telemetry=False,
+    )
+    inner = Team(
+        name="Comms Team",
+        id="comms-team",
+        model=_ScriptedModel(
+            "m-inner",
+            [
+                ("tool", "delegate_task_to_member", {"member_id": "reporter", "task": "report"}, "tc-rep"),
+                ("tool", "delegate_task_to_member", {"member_id": "emailer", "task": "send it"}, "tc-mail"),
+                ("content", "Inner done."),
+            ],
+        ),
+        members=[reporter, _emailer_agent(db, resuming=False)],
+        db=db,
+        telemetry=False,
+    )
+    mid = Team(
+        name="Division Team",
+        id="div-team",
+        model=_ScriptedModel(
+            "m-mid",
+            [
+                ("tool", "delegate_task_to_member", {"member_id": "comms-team", "task": "notify"}, "tc-mid"),
+                ("content", "Division done."),
+            ],
+        ),
+        members=[inner],
+        db=db,
+        telemetry=False,
+    )
+    outer = Team(
+        name="Org Team",
+        id="org-team",
+        model=_ScriptedModel(
+            "m-outer",
+            [
+                ("tool", "delegate_task_to_member", {"member_id": "div-team", "task": "handle comms"}, "tc-outer"),
+                ("content", "Outer done."),
+            ],
+        ),
+        members=[mid],
+        db=db,
+        telemetry=False,
+    )
+
+    run1 = outer.run("Report then email", session_id=session_id)
+    assert run1.is_paused
+
+    # Live tree intact at depth 3: both the completed reporter and the paused emailer.
+    div_run = run1.member_responses[0]
+    comms_run = div_run.member_responses[0]
+    agent_ids = {getattr(m, "agent_id", None) for m in comms_run.member_responses}
+    assert agent_ids == {"reporter", "emailer"}
+
+    # Storage scrubbed at every level: no completed member response anywhere.
+    def walk(runs):
+        stack = list(runs)
+        while stack:
+            r = stack.pop()
+            yield r
+            stack.extend(getattr(r, "member_responses", None) or [])
+
+    for r in _reload_runs(db_file, session_id):
+        for m in walk(getattr(r, "member_responses", None) or []):
+            assert getattr(m, "is_paused", False), f"completed member response persisted: {m.run_id}"

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -9,7 +9,7 @@ session reload.
 """
 
 import json
-from typing import Any, AsyncIterator, Dict, Iterator, List
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -2019,8 +2019,14 @@ def right_send_email(to: str) -> str:
     return f"RIGHT sent to {to}"
 
 
-def _build_sibling_dup_leaf_teams(db: SqliteDb, resuming: bool, delegate_to_both: bool) -> Team:
-    def make_subteam(side: str, send_tool, to: str) -> Team:
+def _build_sibling_dup_leaf_teams(
+    db: SqliteDb,
+    resuming: bool,
+    delegate_to_both: bool,
+    omit_right: bool = False,
+    duplicate_right: bool = False,
+) -> Team:
+    def make_subteam(side: str, send_tool, to: str, team_id: Optional[str] = None) -> Team:
         agent_script = (
             [("content", "Email sent.")]
             if resuming
@@ -2044,7 +2050,7 @@ def _build_sibling_dup_leaf_teams(db: SqliteDb, resuming: bool, delegate_to_both
         )
         return Team(
             name=f"{side} Team",
-            id=f"{side}-team",
+            id=team_id or f"{side}-team",
             model=_ScriptedModel(f"m-{side}", sub_script),
             members=[member],
             db=db,
@@ -2061,16 +2067,18 @@ def _build_sibling_dup_leaf_teams(db: SqliteDb, resuming: bool, delegate_to_both
         )
     else:
         leader_turn = ("tool", "delegate_task_to_member", {"member_id": "right-team", "task": "send right"}, "tc-outer")
+    members = [make_subteam("left", left_send_email, "left@example.com")]
+    if not omit_right:
+        members.append(make_subteam("right", right_send_email, "right@example.com"))
+    if duplicate_right:
+        members.append(make_subteam("right2", right_send_email, "right2@example.com", team_id="right-team"))
     return Team(
         name="Org Team",
         id="org-team",
         model=_ScriptedModel(
             "m-outer", [("content", "All done.")] if resuming else [leader_turn, ("content", "All done.")]
         ),
-        members=[
-            make_subteam("left", left_send_email, "left@example.com"),
-            make_subteam("right", right_send_email, "right@example.com"),
-        ],
+        members=members,
         db=db,
         telemetry=False,
     )
@@ -2134,6 +2142,192 @@ def test_duplicate_leaf_id_both_siblings_paused_each_executes_own(tmp_path):
     assert run2.status == RunStatus.completed
     assert _LEFT_EXECUTED == ["left@example.com"]
     assert _RIGHT_EXECUTED == ["right@example.com"]
+
+
+# ---------------------------------------------------------------------------
+# Requirements arrive from the wire, so their routing fields are unverified
+# client input. The stored session requirement is the authority: on a unique
+# match its provenance overwrites the payload's; an ambiguous payload (two
+# stored requirements share a tool_call_id, no requirement ids to tell them
+# apart) is refused with the run left paused, never guessed.
+# ---------------------------------------------------------------------------
+
+
+def test_ambiguous_stripped_payload_refuses_then_recovers(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "ambiguous_payload.db")
+    session_id = "s-ambiguous-payload"
+
+    team1 = _build_same_member_twice_same_tool_call_id(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email both", session_id=session_id)
+    assert run1.is_paused
+
+    team2 = _build_same_member_twice_same_tool_call_id(SqliteDb(db_file=db_file), resuming=True)
+    with pytest.raises(RunNotContinuableError):
+        team2.continue_run(
+            run_id=run1.run_id,
+            session_id=session_id,
+            requirements=_wire_requirements_stripped(run1.requirements, "id", "member_run_id"),
+        )
+    assert _EXECUTED == []
+    stored = [r for r in _reload_runs(db_file, session_id) if getattr(r, "run_id", None) == run1.run_id]
+    assert stored and stored[0].status == RunStatus.paused
+
+    # With the requirement ids included the same minimal payload resumes.
+    team3 = _build_same_member_twice_same_tool_call_id(SqliteDb(db_file=db_file), resuming=True)
+    run3 = team3.continue_run(
+        run_id=run1.run_id,
+        session_id=session_id,
+        requirements=_wire_requirements_stripped(run1.requirements, "member_run_id"),
+    )
+    assert run3.status == RunStatus.completed
+    assert sorted(_EXECUTED) == ["a@x.com", "b@x.com"]
+
+
+def test_lied_member_run_id_is_overwritten_by_stored(tmp_path):
+    _EXECUTED.clear()
+    db_file = str(tmp_path / "lied_run_id.db")
+    session_id = "s-lied-run-id"
+
+    team1 = _build_id_collision_team(SqliteDb(db_file=db_file), resuming=False)
+    run1 = team1.run("Email a@example.com", session_id=session_id)
+    assert run1.is_paused
+
+    lied = []
+    for data in [r.to_dict() for r in run1.requirements or []]:
+        data["member_run_id"] = run1.run_id
+        req = RunRequirement.from_dict(data)
+        req.confirm()
+        lied.append(req)
+
+    team2 = _build_id_collision_team(SqliteDb(db_file=db_file), resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id, requirements=lied)
+    assert run2.status == RunStatus.completed
+    assert _EXECUTED == ["a@example.com"]
+
+
+def test_lied_member_agent_id_is_overwritten_by_stored(tmp_path):
+    _LEFT_EXECUTED.clear()
+    _RIGHT_EXECUTED.clear()
+    db_file = str(tmp_path / "lied_agent_id.db")
+    session_id = "s-lied-agent-id"
+
+    def build(resuming: bool) -> Team:
+        def make_agent(side: str, send_tool, to: str) -> Agent:
+            script = (
+                [("content", "Email sent.")]
+                if resuming
+                else [("tool", "send_email", {"to": to}, f"tc-send-{side}"), ("content", "Email sent.")]
+            )
+            return Agent(
+                name=f"{side} Agent",
+                id=f"agent-{side}",
+                model=_ScriptedModel(f"m-lied-{side}", script),
+                tools=[send_tool],
+                db=db,
+                telemetry=False,
+            )
+
+        db = SqliteDb(db_file=db_file)
+        return Team(
+            name="Comms Team",
+            id="comms-team",
+            model=_ScriptedModel(
+                "m-lied-leader",
+                [("content", "All done.")]
+                if resuming
+                else [
+                    ("tool", "delegate_task_to_member", {"member_id": "agent-right", "task": "send it"}, "tc-deleg"),
+                    ("content", "All done."),
+                ],
+            ),
+            members=[
+                make_agent("left", left_send_email, "left@example.com"),
+                make_agent("right", right_send_email, "right@example.com"),
+            ],
+            db=db,
+            telemetry=False,
+        )
+
+    team1 = build(resuming=False)
+    run1 = team1.run("Email right", session_id=session_id)
+    assert run1.is_paused
+
+    lied = []
+    for data in [r.to_dict() for r in run1.requirements or []]:
+        data["member_agent_id"] = "agent-left"
+        data["member_agent_name"] = "left Agent"
+        req = RunRequirement.from_dict(data)
+        req.confirm()
+        lied.append(req)
+
+    team2 = build(resuming=True)
+    run2 = team2.continue_run(run_id=run1.run_id, session_id=session_id, requirements=lied)
+    assert run2.status == RunStatus.completed
+    assert _RIGHT_EXECUTED == ["right@example.com"]
+    assert _LEFT_EXECUTED == []
+
+
+# ---------------------------------------------------------------------------
+# The owner of the resolved paused run must resolve to exactly one direct
+# member of the continuing team. A removed owner or several direct members
+# sharing the owner's id refuse the continue and leave the run paused.
+# ---------------------------------------------------------------------------
+
+
+def test_removed_owner_refuses_and_recovers(tmp_path):
+    _LEFT_EXECUTED.clear()
+    _RIGHT_EXECUTED.clear()
+    db_file = str(tmp_path / "removed_owner.db")
+    session_id = "s-removed-owner"
+
+    outer1 = _build_sibling_dup_leaf_teams(SqliteDb(db_file=db_file), resuming=False, delegate_to_both=False)
+    run1 = outer1.run("Email right", session_id=session_id)
+    assert run1.is_paused
+
+    without_owner = _build_sibling_dup_leaf_teams(
+        SqliteDb(db_file=db_file), resuming=True, delegate_to_both=False, omit_right=True
+    )
+    with pytest.raises(RunNotContinuableError):
+        without_owner.continue_run(
+            run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+        )
+    assert _LEFT_EXECUTED == [] and _RIGHT_EXECUTED == []
+    stored = [r for r in _reload_runs(db_file, session_id) if getattr(r, "run_id", None) == run1.run_id]
+    assert stored and stored[0].status == RunStatus.paused
+
+    # With the owner back in the team the same continue succeeds.
+    restored = _build_sibling_dup_leaf_teams(SqliteDb(db_file=db_file), resuming=True, delegate_to_both=False)
+    run3 = restored.continue_run(
+        run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+    )
+    assert run3.status == RunStatus.completed
+    assert _RIGHT_EXECUTED == ["right@example.com"]
+    assert _LEFT_EXECUTED == []
+
+
+def test_ambiguous_owner_id_refuses(tmp_path):
+    _LEFT_EXECUTED.clear()
+    _RIGHT_EXECUTED.clear()
+    db_file = str(tmp_path / "ambiguous_owner.db")
+    session_id = "s-ambiguous-owner"
+
+    outer1 = _build_sibling_dup_leaf_teams(
+        SqliteDb(db_file=db_file), resuming=False, delegate_to_both=False, duplicate_right=True
+    )
+    run1 = outer1.run("Email right", session_id=session_id)
+    assert run1.is_paused
+
+    outer2 = _build_sibling_dup_leaf_teams(
+        SqliteDb(db_file=db_file), resuming=True, delegate_to_both=False, duplicate_right=True
+    )
+    with pytest.raises(RunNotContinuableError):
+        outer2.continue_run(
+            run_id=run1.run_id, session_id=session_id, requirements=_wire_requirements(run1.requirements)
+        )
+    assert _LEFT_EXECUTED == [] and _RIGHT_EXECUTED == []
+    stored = [r for r in _reload_runs(db_file, session_id) if getattr(r, "run_id", None) == run1.run_id]
+    assert stored and stored[0].status == RunStatus.paused
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/tests/unit/team/test_paused_member_persistence.py
+++ b/libs/agno/tests/unit/team/test_paused_member_persistence.py
@@ -4108,7 +4108,6 @@ async def test_a_run_finishing_during_an_async_save_is_not_discarded(monkeypatch
     assert "run-b" in ids, f"the concurrently added run was dropped by the restore; runs={ids}"
 
 
-
 # ---------------------------------------------------------------------------
 # Round 11: a refusal must arrive before any member has executed
 # ---------------------------------------------------------------------------
@@ -4185,9 +4184,7 @@ def test_a_subteam_that_cannot_route_refuses_before_a_sibling_executes(tmp_path)
     db_file = str(tmp_path / "preflight_sync.db")
     session_id = "s-preflight-sync"
 
-    run1 = _build_dup_leaf_org(SqliteDb(db_file=db_file), resuming=False).run(
-        "Email both sides", session_id=session_id
-    )
+    run1 = _build_dup_leaf_org(SqliteDb(db_file=db_file), resuming=False).run("Email both sides", session_id=session_id)
     assert run1.is_paused
     assert len(run1.requirements or []) == 2
 


### PR DESCRIPTION
## Summary

Fix for the 2.9 release: a paused member HITL run now survives the session save with the default `store_member_responses=False`, and `continue_run` can resolve it after a session reload — including for nested teams, where the resume was a hard dead end.

Fixes #7959.

### The failure mode

When a member agent pauses on a HITL tool (`requires_confirmation_tools` etc.), the pause propagates up and the team run is saved PAUSED. On every save, the default scrub removed all member responses from every team run row:

```python
if not team.store_member_responses:
    run.member_responses = []
```

Re-verifying on `main` (v2.8.7) before fixing, the blast radius is narrower than "all member pauses" but worse where it hits:

- **Flat team, fresh process: worked.** `_process_delegate_task_to_member` already upserts the paused member run as a session sibling at initial pause time, and the routing lookup finds siblings by `member_run_id`. Verified empirically in sync, async, and streaming modes.
- **Nested team (member is a `Team`), fresh process: dead end.** The sub-team skips `save_session` (`parent_team_id` is set), so its in-memory session object — the only place the paused sub-member run was upserted as a sibling — is discarded. The only persisted copy of the paused sub-member run lives inside the sub-team's `TeamRunOutput.member_responses`, and the scrub erased exactly that. A fresh request (AgentOS reloads the session per request, Slack button, MCP `continue_run`) then finds nothing:

  ```
  agno.exceptions.RunNotFoundError: No runs found for run ID <sub-member run id>
  ```

  The approval arrives and there is nothing to resume.
- **Nested team, same process: silent approval loss.** `_propagate_member_pause` points `req._member_run_response` at the run that surfaced the pause *at each level*, so one level down the reference is the containing team run, not the member's run. The member agent's `continue_run` then received a `TeamRunOutput`, and the run completed **without executing the confirmed tool**.

The asymmetry that proves the persistence gap: the chained-pause path already does `session.upsert_run(member_response)` with the comment "Persist paused member run so continue_run can find it after session reload". The nested initial pause had no persisted equivalent.

### Why the flag was the wrong switch

`store_member_responses` is a storage-size / observability flag (default `False`). Whether a pending human approval can be resumed is correctness, not observability — resume state must never depend on a flag whose documented purpose is controlling session weight.

### The fix (commit 1)

Two parts, both required for the end-to-end nested resume:

1. **The scrub spares paused member runs** (`save_session` + `asave_session`). A paused member run survives every save and is scrubbed by the first save after it resumes and completes. Flag semantics are otherwise unchanged: completed member responses are still scrubbed when the flag is `False` (asserted in tests), and `store_member_responses=True` behavior is untouched. Live-object semantics are preserved: the scrub rebinds the attribute on the storage copy, matching the existing protection — spared runs are shared, not mutated.

2. **Routing resolves a sub-team's paused run.** The four routing variants (sync/async × non-streaming/streaming) shared a three-step lookup (requirement reference → live `member_responses` → session siblings) that could only match the deep member's `run_id` at the top level. The lookup is now one shared resolver, `_resolve_member_run_output_for_continue`, which validates the requirement reference and, for sub-team members, falls back to the direct child team run that owns the requirement. The sub-team's own `continue_run` then routes deeper, level by level.

I tried the scrub-spare change alone first, per the preferred shape: it persists the state but the nested resume still dead-ends, because no lookup could connect the deep `member_run_id` to the sub-team's `TeamRunOutput`. The resolver closes that half. The fallback shape (upserting the deep member run as a top-level sibling at initial pause) was rejected: the outer routing would then hand a member agent's `RunOutput` to a sub-team's `continue_run`, which expects the sub-team's own run.

### Hardening from adversarial review (commits 2 and 3)

A 25-agent adversarial review (5 finders, 2 executing verifiers per finding) was run against commit 1, and a second 3-agent verification pass against commit 2. Every confirmed finding is fixed, each with a test that fails on the commit before it:

1. **Depth ≥ 3 reference clobbering** (commit 2). The first resolver validated a Team-routed reference by subtree containment, which accepts an *ancestor* run — at three nesting levels a mid-team handed its own run to the inner sub-team (sync: `RunNotFoundError`; async: error swallowed by `asyncio.gather`, run reported COMPLETED, tool never executed). Validation is now by identity, and invalid references fall through to level-by-level lookups.
2. **Grouping by the wrong key** (commits 2 + 3). Grouping requirements by the *deep* member id sent two `continue_run` calls to the same sub-team run when two of its members paused — the second call hit an already-completed run and silently dropped its confirmation. Grouping by the routed *direct* member (commit 2) fixed that but collapsed two *distinct* paused runs of the same sub-team (the leader delegated to it twice in one turn) into one call, stranding the second run. The correct key is the **paused run being continued**: `_group_requirements_for_continue` resolves each requirement group's target run up front and merges only groups that resolve to the same run (commit 3).
3. **Deep storage leak** (commit 2) **without mutating live objects** (commit 3). The scrub-spare only filtered top-level session rows, so from depth 3 a COMPLETED member response inside a spared paused sub-team run was persisted verbatim despite the flag. The scrub now recurses — and does it copy-on-write: `save_session` stores filtered shallow copies while the run tree the caller holds keeps every member response; spared paused leaf runs stay shared so resume state remains live.
4. **Session metrics: deliberately left as on `main`** (commit 4 reverts the attempts in commits 2 + 3). The review rounds established with executed A/B scripts that `update_session_metrics` is an accumulator that re-adds overlapping cumulative snapshots on every save, and that it is already inexact on `main` (flag-True HITL resumes and mid-run checkpoints double-count; ERROR-run retries over-count). Two in-PR redesigns each traded one accounting error for another: skipping paused saves zeroed abandoned-pause windows; exactly-once-by-final-state made ERROR-run retries permanently uncounted, read zero during pause windows (which the daily metrics rollup can make permanent), and grew an unbounded run-id list. Making the accumulator exact needs per-run delta bookkeeping — a metrics redesign, not something to smuggle into a HITL fix. This PR restores `main`'s accumulation verbatim. Known interaction, stated plainly: with the default flag, a resumed member's tokens now also accumulate at the final save (the spared member is present in `member_responses` on reload), which extends `main`'s existing over-count pattern on resume to flag-False sessions — the same shape flag-True sessions already have on `main` today.

### Test evidence

New end-to-end tests in `libs/agno/tests/unit/team/test_paused_member_persistence.py` (scripted model, real `SqliteDb`, no network). "Fresh process" means: new `Team`/`Agent`/`SqliteDb` objects and requirements round-tripped through `to_dict`/`from_dict`, so no in-memory state survives.

| Test | Before | Now |
|---|---|---|
| `test_flat_member_pause_survives_fresh_process_continue` | FAIL on v2.8.7 (persistence contract) | PASS |
| `test_nested_member_pause_survives_fresh_process_continue` (+ async) | FAIL on v2.8.7 (`RunNotFoundError`) | PASS |
| `test_nested_member_pause_resumes_same_process` | FAIL on v2.8.7 (tool never executed) | PASS |
| `test_three_level_nested_pause_resumes_same_process` (+ async) | FAIL on commit 1 | PASS |
| `test_three_level_nested_pause_survives_fresh_process_continue` | PASS (guards level-by-level resolution + exact metrics) | PASS |
| `test_two_paused_members_in_one_subteam_both_execute` (+ async) | FAIL on commit 1 (second confirmation dropped) | PASS |
| `test_same_subteam_paused_twice_both_confirmations_execute` (+ async) | FAIL on commit 2 (second run stranded) | PASS |
| `test_nested_member_pause_fresh_process_continue_streaming` (+ async) | guards the streaming variants | PASS |
| `test_completed_members_scrubbed_inside_spared_paused_subteam` | FAIL on commit 1 (depth-3 leak) | PASS |
| `test_live_run_tree_not_mutated_by_save` | FAIL on commit 2 (live deep tree lost members) | PASS |
| `test_completed_member_responses_still_scrubbed_with_default_flag` | contract pinned | PASS |
| `test_store_member_responses_true_keeps_paused_and_completed` | contract pinned | PASS |

Every "FAIL on commit N" row was verified by stashing the later source changes and re-running — 25 tests in the file, all green on the final head.

The tests assert the spared paused run round-trips with everything resume needs: message history (member `continue_run` continues the model conversation), tool executions with `requires_confirmation` state, and unresolved requirements.

The final verification round also swept the routing fix itself: the (deep member id, deep member run id) grouping plus same-run merge held across 48 executed routing cases (two-paused-in-one-subteam / mixed direct+subteam / same-subteam-delegated-twice × both flag values × sync/async × streaming/non-streaming × fresh/same process) and across 2, 3, and 4 nesting levels; the copy-on-write scrub leaked nothing to storage and mutated nothing live in the same sweep.

Suite results (final head):

- `tests/unit/team/` + `tests/unit/os/interfaces/` + `tests/unit/app/` + `tests/unit/agent/`: **1275 passed, 2 skipped**
- Full `tests/unit/`: 8518+ passed; the failures and collection errors are missing optional provider SDKs in the dev venv, byte-identical on clean `main` (verified by stash-and-rerun)
- `tests/integration/teams/human_in_the_loop/` + `test_storage_and_memory.py` (real OpenAI): **37 passed**
- `./scripts/format.sh` and `./scripts/validate.sh`: clean (ruff, mypy)

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

Two open PRs touch the same underlying problem, neither fixes it:

- **#8057** persists the member's own `AgentSession` row on HITL pause. It targets the same nested cross-process failure (#7959) but changes the storage model — member agents intentionally skip `save_session` under a team, and per-member session rows duplicate what the team session already owns. This PR instead persists the resume state inside the team session, which is where the routing lookups actually search, and it also fixes the same-process nested resume (silently skipped tool), which #8057 does not touch.
- **#7979** only logs a warning when the scrub wipes member responses on a paused run. After this PR the wipe no longer happens, so there is nothing to warn about.

---

## Additional Notes

- **Follow-up once released:** `agentos-railway` can drop `store_member_responses=True` from Chief (`agents/chief.py`) and shed the session weight — after this fix the flag is purely an observability choice and is no longer load-bearing for HITL resume.
- **Follow-up candidate — session-metrics accuracy:** `update_session_metrics` re-adds overlapping cumulative run snapshots on every save. Executed evidence gathered during review: flag-True HITL resume reports 90 tokens for 60 truly spent; ERROR-run retry reports 60 for 45; mid-run checkpoints inflate similarly; the agent-side session metrics share the shape. An exact design needs per-run accumulated-so-far snapshots (delta accumulation, pruned at completion). Kept out of this PR deliberately after two attempted in-PR fixes each produced a different accounting error.
- Session rows written by pre-2.9 versions (paused before upgrade) are unchanged by this fix: flat pauses resume as before; nested pauses from old rows remain unresumable because the data was already scrubbed at save time.

---

## Review round 4 — independent adversarial review of the opened PR

A 30-agent adversarial review (5 finder lenses, 2 executing verifiers per finding, plus verification of externally reported findings and of the fix commits themselves) produced two more commits.

**Commit 5 (`3aeb18640`)**

- **Sync-streaming continue lost a chained pause.** The three pause exits on the sync continue path never yielded the final `TeamRunOutput` (the async counterparts do), so the parent's routing loop saw no terminal, reported the delegation complete, and skipped `_propagate_member_pause` and the session upsert. The outer run persisted COMPLETED beside a PAUSED member with the second confirmation unreachable, and replaying the stale stored sub-team row re-executed the already-confirmed tool. The exits now yield the run output under `yield_run_output`, matching the async side and the cancellation exits in the same function. Verified over a 16-cell matrix (flat/nested x four variants x same/fresh process) plus an explicit replay probe.
- **Unroutable requirements fail loudly.** A requirement that routes to a member id not in the team raises `RunNotContinuableError` (409 at the OS layer) instead of log-warning + completing with the approved tool silently skipped. The stored run stays paused and resumable.
- **The `(member id, member run id)` grouping key gained its missing regression test:** one member paused in two delegations of one turn. Reverting the key to member-id-only grouping passed all 1082 team+agent tests before this; the scenario silently dropped the second confirmation (also broken on `main`).

**Commit 6 (`8878a1f14`)** — closes #9403

- **A sub-team's own gated tool now resumes.** The refusal above initially fired on a shape the framework itself produces: `_propagate_member_pause` stamps the sub-team's own id on the sub-team's OWN gated-tool requirement so the parent can route it down, and the sub-team then could not route it among its members. Continue dispatch now reclaims requirements stamped with the team's own id as team-level requirements. A sub-team's own gated tool executes on continue, alone and mixed with a deep member requirement in the same turn, sync and async. On `main` this shape silently dropped the approval (alone) or crashed (`ValueError`/`RunNotFoundError`, mixed).
- **Routing failures no longer strip the caller's requirements.** A raise inside member routing previously exited between the dispatch's requirement strip and its restore, losing approved team-level requirements from the caller's run object so a retry silently skipped them. All four routing sites restore the full list before re-raising.

Final head: 37 tests in the file — every behavior change is mutation-tested (reverting each fix line fails its test); team/agent/run/os/app unit suites green; `./scripts/format.sh` and `./scripts/validate.sh` clean; the review round's own 16-cell chained-pause matrix and sub-team-own-tool probes re-executed green on the final head.

**Follow-up issues filed from confirmed pre-existing findings:** #9399 (`CustomJSONEncoder` has no fallback, session save silently lost at WARNING), #9400 (`fork_session` does not re-id nested runs: cross-session rows + stranded paused orphan), #9401 (partial requirement delivery silently orphans undelivered pauses; requirement re-delivery is not idempotent), #9402 (paused subtree persisted once per ancestor level, ~4x row growth at depth 4).

**Known and accepted (quantified during review, extends the disclosure above):** with the default flag, a fresh-process HITL resume over-counts `session_metrics` by the resumed member's pre-pause tokens (60 true -> 90 reported on the flat scripted topology). `main` is exact only in that quadrant and already over-counts in the other three (same-process resumes, flag-True); the accumulator redesign stays a follow-up.

---

## Review round 5 — external review, adversarially re-verified

An external review of head `8878a1f14` raised four findings. Each was verified by executing repros on the head, on `cfbd91382` (before commits 5-6), and on `main`. One was real and is fixed; the verification evidence for the rest is recorded here.

**Commit 7 (`f0107f942`) — id/name collision no longer drops a confirmed member tool.** Confirmed, introduced by commit 6. `_reclaim_own_requirements` treated id equality as proof of ownership, so a Team and a member sharing an id — or merely a NAME, since `get_member_id` falls back to `url_safe_string(name)` — had the member's confirmed requirement reclaimed as team-level: `continue_run` returned COMPLETED with the approved tool silently skipped, on all four continue variants and at depth. The reclaim is now gated on run identity: the requirement is the team's own only if its `member_run_id` is the run being continued at that dispatch level (`_propagate_member_pause` stamps both fields together, so a member's requirement always carries the member's run id, never the containing team's). Five regression tests cover flat sync/async/streaming, the deep variant, and the accidental name-only collision. Mutation-tested in both directions: reverting to id-only reclaim fails all five; removing the reclaim entirely fails the four sub-team-own-tool tests.

**Refuted — "paused members bypass storage opt-outs."** Executed A/B on head, base, and `main` (raw sqlite rows, member with `store_media=False` / `store_history_messages=False`, 8-cell matrix): media never leaks in any quadrant, because the delegate path (`_default_tools.py:582-590`) applies the member's own scrub in place before the run is embedded or upserted — identically on `main`. The history content the review observed does persist, but via `RunInput.input_content`, which no scrub path touches on `main` either (the flat sibling row and the flag-True embedded copy carry the same bytes on every released version). That is a pre-existing gap in `store_history_messages` coverage, PR-independent, now filed as #9419. What this PR changes at the default flag is duplication of an already-scrubbed object, not a new data class in storage.

**Pre-existing — non-JSON values silently lose the session save.** Confirmed exactly as described, and byte-identical on `main` and on `cfbd91382`, including with a plain single Agent and a completed run — the PR changes which runs sit in the row, not whether the row serializes. This is #9399 (filed from round 4); the new pass added the precise swallow sites (`team/_storage.py:205-207`/`:221-223`, `agent/_storage.py:178-182`/`:199-203` — the sqlite adapter itself re-raises), the absent-vs-stale failure shapes, the loud sibling route (`utils/tools.py:96` plain `json.dumps` on confirmed tool args), and an executed str-fallback probe (works end to end, zero deltas across 1234 unit tests) — all appended to the issue. Fixing it here would smuggle a storage-layer redesign decision (lossy fallback vs loud failure) into a HITL routing PR.

**Already disclosed — fresh-process flag-False resume over-counts session metrics.** The review's numbers match the disclosure above (60 true -> 90 reported); no new information. The accumulator redesign remains the filed follow-up.

Final head after commit 7: 42 tests in the file, all green; team + agent + run + os/interfaces + app unit suites: 1396 passed, 2 skipped; ruff format, ruff check, and mypy clean on the changed files.

---

## Review round 6 — second external review, adversarially re-verified

The external reviewer withdrew the two findings refuted in round 5 and raised two new P1s on `f0107f942`. Both were verified by executing repros on the head, on `8878a1f14`, on `cfbd91382`, and on pre-PR `main` — both are real, with one correction to the reviewer's attribution — and both are fixed in commit 8 (`cda14ea56`).

**Omitted `member_run_id` regressed to id-only reclaim.** Confirmed. `to_dict()` strips `None` values and `_normalize_requirements_payload` accepts raw dicts, so a wire payload legitimately omits the field; the run-identity gate then fell through to id-only reclaim, and a collision payload completed silently where `cfbd91382` raised a `ValueError`. The codebase already compensates for exactly this payload pattern for approval metadata (`_backfill_approval_to_requirements`, which runs before the reclaim at all three dispatch sites), so the fix extends that backfill to restore member provenance (`member_agent_id`, `member_agent_name`, `member_run_id`) from the stored session requirements, and the reclaim now requires positive run-id identity — `None` never reclaims. Provenance is matched by requirement id first, then `tool_call_id`: two runs paused in one turn can share a `tool_call_id`, and a `tool_call_id`-only match hands both requirements the same `member_run_id` and strands one run — the verification round caught that in the first fix draft, and `test_stripped_payload_same_tool_call_id_both_runs_execute` pins it. Side effect: an ordinary (non-collision) team's stripped payload, which failed loudly on every prior version, now resumes. When provenance is unrecoverable (no matching stored requirement), the continue raises instead of completing with the tool skipped (`test_unrecoverable_provenance_collision_fails_loudly`).

**Duplicate leaf ids across sibling sub-teams executed the wrong sibling's tool.** Confirmed, with a corrected A/B: the reviewer attributed it to the routing commits and reported the base "executed nothing or failed" — in fact it reproduces identically back to this PR's FIRST commit (the mis-route itself exists on `main`, where the continue then dies loudly with `RunNotFoundError`; this PR's ownership-based target resolution turned that loud failure into a silent wrong execution returning COMPLETED). With `Team -> [left(members=[Agent(id="dup")]), right(members=[Agent(id="dup")])]` and only right paused, the left implementation of the same-named tool executed with the approved arguments; with both siblings paused, the left tool ran twice and the right never. `_find_member_route_by_id` picks the first DFS match on the leaf id while `_resolve_member_run_output_for_continue` resolves the target run by ownership — the two keys diverge exactly on duplicate leaf ids. Grouping now re-binds the routed member to the resolved run's owner when they disagree, before the merge step. Executed green across sync/async x same/fresh process x both streaming variants, the both-siblings shape (each sibling's own tool exactly once), and a 3-level nesting; the re-route branch fires zero times across the rest of the suite.

Both fixes are mutation-tested: the `None` fall-through, the provenance restore, the requirement-id keying, and the owner re-bind each have a test that fails when that piece alone is reverted.

**Filed from this round's verification, pre-existing:** #9421 — `_aroute_requirements_to_members` downgrades any member `continue_run` failure except `RunNotContinuableError` to a `log_warning` (`asyncio.gather(..., return_exceptions=True)`), so on the async path a routing failure completes the team run silently where sync raises. Reproduced at `cfbd91382` on an ordinary team; independent of this PR's changes.

Final head after commit 8: 50 tests in the file; team + agent + run + os/interfaces + app unit suites: 1404 passed, 2 skipped; ruff format, ruff check, and mypy clean on the changed files.

---

## Review round 7 — third external review, adversarially re-verified

The external review raised two P1s on `cda14ea56`, both about fail-open routing on adversarial or drifted continue input. Four sub-claims were verified by executing repros on the head and on `cfbd91382`; all four are real (three pre-existing, one a regression from commit 8), and commit 9 (`f0ff59bb8` after rebasing on the main merge) fixes them.

**Stored requirements are now the routing authority.** Three payload shapes broke the provenance restore:

- *Ambiguous minimal payload (regression from commit 8).* A client that echoes only HITL fields omits the requirement `id`; `from_dict` mints a fresh uuid, so the id lookup misses and the `tool_call_id` fallback guessed — and that dict was last-writer-wins. With two paused runs sharing a `tool_call_id`, one confirmed run executed and the other was silently dropped, COMPLETED, in all four dispatch modes; `cfbd91382` refused this loudly. The fallback now applies only when exactly one stored requirement carries the `tool_call_id`; an ambiguous payload raises `RunNotContinuableError`, the run stays paused, and resending with the original ids resumes it (executed end to end).
- *Lied `member_agent_id` / lied `member_run_id` (both pre-existing — the base misroutes identically).* Fill-only-when-None trusted any present client value: a swapped member id dispatched the confirmed tool through the wrong member's implementation; a `member_run_id` pointing at the outer run made the reclaim treat a member requirement as the team's own and skip it. On a unique stored match, member provenance is now overwritten from the stored requirement, not filled — both lies now execute the right tool (executed sync and async; the raise also survives the async gather because grouping runs before it, verified by execution).

**The owner re-bind requires exactly one direct member.** Commit 8's re-bind fixed the owner-present case and silently kept the wrong leaf-id pick when the owner lookup failed. With the owning sub-team removed between pause and continue — ordinary config drift, full correct payload — the remaining sibling executed the removed owner's approved arguments and the stored paused run was overwritten to COMPLETED, destroying the resume state (pre-existing: the base does the same; commits 5-8 narrowed but didn't close it). The owner of the resolved run must now match exactly one direct member: zero (removed) or several (duplicate ids) raise `RunNotContinuableError`, the stored run stays paused with its requirement intact, and re-adding the owner then continuing succeeds with the right implementation (executed across sync/async/streaming, same- and fresh-process).

All four guard arms are mutation-tested: guessing on ambiguity, reverting overwrite to fill-when-None, letting a missing owner fall through, and first-picking among duplicate owners each fail exactly their intended test.

**Known residual, filed as #9422 (pre-existing, not fixable at continue time):** duplicate direct-member ids are accepted silently (including by name collision — "Right Team"/"right_team" both url-safe to `right-team`), and `delegate_to_all_members=True` lets a shadowed same-id sibling hold a paused run. When the DFS pick's id equals the target run's `team_id`, no mismatch is observable at continue time, so the wrong sibling can still execute under broadcast-plus-same-leaf-id or id-drift shapes. An always-on ambiguity refusal was probed and rejected: it refuses three configurations that work correctly today. The right fix is construction-time validation of duplicate ids — that's #9422.

Final head after commit 9: 55 tests in the file; team + agent + run + os/interfaces + app unit suites: 1409 passed, 2 skipped; ruff format, ruff check, and mypy clean on the changed files.

---

## Review round 8 — fourth external review, adversarially re-verified

The external review conceded the round-7 repros and raised two P1s plus one P2 on the generalized identity handling. Three executing verifiers confirmed all three (four sub-claims; one attribution split), and commit 10 (`2e170ef6d`) fixes them.

**The stored requirement is now canonical after binding — commit 9's overwrite was half a fix.** Round 7 made stored *provenance* authoritative but left the wire `tool_execution` as the object routing consumes. Two regressions followed (both new in commit 9, executed A/B against `cda14ea56`): a payload with two valid requirement ids *swapped* — the two stored requirements sharing a natural `tool_call_id`, so the round-7 id↔tcid cross-check passes — executed each member's approved arguments through the other member's tool in all four dispatch modes; a payload carrying the *same* valid id twice completed the parent while stranding the second paused run. And pre-existing on every version: a payload entry matching no stored requirement kept its unverified client routing fields and completed with the stored approval skipped. Binding is now one-to-one — requirement id first (tcid cross-checked), unique-tcid fallback, and the stored requirement object replaces the wire entry with only the client's decision state merged onto it: confirmation, user-input and feedback answers, and `result` gated on the stored tool's `external_execution_required` (the gate closes a further live hole where a forged `result` on a confirmation tool suppressed its execution entirely — pinned by `test_forged_result_does_not_suppress_confirmed_execution`). `tool_args` never crosses from the wire: carrying it reopens the swap verbatim (executed), and agno has no arg-edit-on-confirm feature — human-driven input flows through `user_input_schema`, which the merge preserves. Unknown entries and duplicate mappings refuse with the run left paused.

**Owner resolution is always-on and covers agent runs.** The round-7 uniqueness check only fired when the DFS pick's id *differed* from the target's owner id, so duplicate direct ids bypassed it entirely — same-id sibling sub-teams under broadcast, same-id direct agents, and a no-broadcast member-order-drift shape all executed the first sibling's implementation with the other sibling's approved arguments (executed; pre-existing on every version, the round-7 fix narrowed but could not see these). The resolved run's owner (`team_id` for team runs, `agent_id` for agent runs, isinstance-guarded) must now match exactly one direct member; zero or several refuse loudly with the run left paused. Accepted behavior change, stated plainly: configurations with duplicate direct-member ids that silently worked by list position now refuse with a "matches N members" error until the ids are made unique — they were already broken-by-construction for delegation, and #9422 tracks rejecting them at construction time. Name-derived collisions with unique agent identities are unaffected (executed).

**A refusal no longer corrupts the caller's run object.** The payload overwrite preceded validation, so the new refusals destroyed the stored requirement ids their own error message asks the client to resend — a caller-supplied live run object became permanently unresumable (executed: the retry fails even with a maximally generous payload). The three duplicated dispatch blocks now share one helper that binds under restore-on-raise, and the approval-resolution raise one statement later restores the same state. `test_refusal_leaves_live_run_object_retryable` executes the refuse-then-retry cycle on one live object.

All seven new guard arms are mutation-tested (six targeted mutations, each failing exactly its intended tests — the wire-canonical revert fails both the swap and forged-result tests). File now 61 tests; team + agent + run + os/interfaces + app unit suites: 1435 passed, 2 skipped; ruff and mypy clean.

**Residual, disclosed:** a payload that simply *omits* one of two stored requirements still completes the parent with the omitted member left paused — that is #9401 (partial requirement delivery, pre-existing, identical on every version), deliberately out of scope here.

---

## Review round 9 — fifth external review plus a 30-agent sweep, adversarially re-verified

Two reviews ran against `e078e1b6a`: an external one raising two P1s and a P2, and a 30-agent internal sweep (6 lenses, 2 executing verifiers per finding). Every claim below was reproduced by execution before it was fixed, and commits 11 and 12 close them.

**A refused payload no longer banks the entries that bound.** `_backfill_approval_to_requirements` merged each entry's decision inside its validation loop, so a refusal on a later entry left the earlier stored requirements confirmed — and the rollback restores list *references*, which does nothing for field values already written. Executed: a two-requirement payload whose second entry names no stored requirement raises, then a **bare** retry completes and runs the first tool (`['email:a@x.com']` against a control of `[]`). It leaks on the live-run-object path and, via the cached session, on the `run_id` path. Binding now resolves and validates every entry first and merges only once the whole payload has bound; the approval-resolution gate, which can still refuse *after* binding, restores the same decision state through a matched snapshot/restore pair.

**A continue payload can no longer rewrite arguments the model fixed.** The merge rebound the wire `user_input_schema` / `user_feedback_schema` wholesale onto the stored requirement, and `handle_user_input_update` writes every schema field into `tool_args` immediately before the call. Executed: renaming the permitted `note` field to `account_id` changed the executed `tool_args['account_id']` from `victim` to `attacker`; tampering the `tool_execution` copy alone was sufficient, and an unknown field name reached `tool_args` too. Answers now land by **stored** field name, only into fields the model left open, and the schema list is never rebound. Separately, the wire could set `answered=True` with no values at all, which converted a correct re-pause into executing the gated tool with the field empty — `answered` is now inferred the way `RunRequirement.from_dict` infers it (only when this merge fills the last open field), with the wire flag honoured only for a requirement carrying no schema. Verified after the fix: honest answers still land (`{'account_id': 'victim', 'note': 'monthly rent'}`), every tampered variant keeps `victim`, and the bare `answered` flip re-pauses with nothing executed.

**A refusal below the top level no longer mis-routes the caller's run.** `_reclaim_own_requirements` de-stamped `member_agent_id` in place, but the requirement objects a parent routes into a sub-team are the parent's own. If anything below then raised — a duplicate-id refusal, or just a transient model outage — the parent was left holding what looked like a team-level requirement of its own, so the retry the refusal invites completed with the approved tool silently skipped (executed: `['a@example.com']`, `pub:release` never ran, no error). The reclaim now works on a copy; after the fix both scenarios retry to `['a@example.com', 'pub:release']`.

**A finished run no longer advertises a pending approval.** `save_session` rebound `session.runs` to the scrubbed storage view. With `cache_session=True` and a sub-team member, the cached session then held a copy frozen at PAUSED while the resume continued the live run, so the completed parent's row permanently carried a paused member response with an unresolved requirement — and re-spared it on every later save. The scrub is now a view handed to the DB write, with the session's live runs restored afterwards, so every save re-derives from live state.

**Sparing a paused run no longer bypasses the member's storage flags.** The delegation path applies each member's `store_media` / `store_tool_messages` / `store_history_messages` to every member run it persists; the continue path did not, so a chained pause persisted a completed step's tool result in the spared leaf's messages. Spared runs now pass through those flags on a copy-on-write storage view, using a paused-aware tool scrub: a resolved call is stripped out of the assistant message it was made in rather than taking the whole message, so the message carrying the *pending* call survives and no removed call is left dangling. Verified that the resume still completes from a fresh process and that the live in-flight run keeps everything the stored copy loses.

**The async continue binds the payload once, not once per retry.** Both async variants applied the payload inside the `for attempt in range(num_attempts)` loop, so a second attempt re-bound a payload the first had already consumed — turning a transient failure into a permanent binding refusal. Sync already applied once.

Nine targeted mutations, one per fix arm, each fail exactly their intended test. File now 73 tests; team + agent + run unit suites: 1254 passed, 2 skipped; ruff format, ruff check and mypy clean on the changed files.

**Filed from this round, all pre-existing and out of scope here:** #9426 (`store_tool_messages=False` never scrubs `ToolExecution.result`, standalone agents included), #9427 (a member-level `requires_user_input` tool executes with its fields unanswered), #9428 (a pause under a recursively-delegated member cannot be continued — this PR turns the old silent mis-dispatch into a loud refusal), #9429 (teams with a callable `members` factory cannot continue a member pause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round 10 (head `a6ac577c0`)

Five P1 findings from the round-9 review, each reproduced with a failing-first regression before its fix, one commit per fix so each is independently revertible:

| Finding | Fix commit | Regression tests |
|---|---|---|
| Conflicting requirement identities fell back to the tool-call id and executed the other requirement's tool | `dee8408eb` — refuse with `RunNotContinuableError`; fallback only for ids matching no stored requirement | `test_conflicting_requirement_identity_refuses_the_continue` (+ fallback contract pinned) |
| Fully prefilled `requires_user_input` pauses could never resume (`answered` stayed `None`) | `89275430d` — honor the explicit wire `answered` flag once no schema field is open | `test_wire_answered_flag_resolves_a_fully_prefilled_input_schema` (+ open-field safeguard pinned) |
| A mid-merge raise banked earlier entries' decisions despite the refusal | `83ead22d8` — the production catch now restores the decision snapshot | `test_merge_exception_does_not_bank_an_earlier_entrys_confirmation` (+ partial-feedback state) |
| Async retries after member routing completed the run with `content=None`, leader never retried | `fab155432` — bank routed member results across attempts in both async variants (sync unaffected: its retry loop wraps only the model call) | `test_async_continue_retry_reruns_leader...` (+ streaming variant) |
| Storage flags resolved against the wrong duplicate leaf across sibling subteams | `854ef0bbf` — resolve the member through the response's owning path, recursing with the owning sub-team; global search only as fallback | `test_spared_leaf_storage_flags_resolve_through_owning_subteam` (+ inverse direction) |

**Verification at `a6ac577c0`:** focused file **87 passed** (76 + 11 new); `tests/unit/team` + `agent` + `run`: **1268 passed, 2 skipped**; `os/interfaces` + `app`: **193 passed**; `format.sh`, `validate.sh`, `git diff --check` clean. Mutation check: each fix commit reverted in isolation makes exactly its own regression tests fail (5/5 killed, no collateral failures).


---

## Rounds 11-12 (heads `b959af0db`, `f43f3ca1a`)

Round 11 fixed the six findings two independent reviews converged on: an external `tool_call_error` now binds with its result; a wire `answered` flag is honored only when it is `True` (a `False` latched the pause shut); the scrubbed storage view is built on a copy of the session so no shared state is mutated across an await; an unresolved MEMBER requirement re-pauses in all three dispatchers instead of completing with the tool skipped; the background stream reports a refusal as an SSE error and keeps the run resumable; and `_preflight_subteam_routes` refuses an unroutable payload before anything is scheduled. Thirteen failing-first regression tests, nine mutations killed.

Round 12 stopped a stale caller-held run object from republishing a COMPLETED run as a pending approval (the gated tool could then be approved a second time), and made the refusal path restore the status it actually replaced instead of a blanket PAUSED.

## Round 13 (head `0ec9469e6`)

A 28-agent adversarial review of the round-12 head (7 finder lenses, merge, one executing verifier per finding — every verdict backed by a repro run through public entry points), then an attack pass on the fixes themselves before pushing.

**Fixed in this round:**

| Finding | Fix |
|---|---|
| The round-12 guard covered COMPLETED only: a stale paused object over a CANCELLED stored run executed the gated tool and erased the cancellation (reachable: pause, `acancel_run`, stale approve) | Guard refuses CANCELLED too; statuses it does not cover are named in the comment |
| The refusal write-back saved the step-1 session snapshot, deleting every run persisted concurrently; the error write-back had the same shape | Both re-read the session and write only while the stored run still carries step 1's RUNNING marker |
| A refusal skipped the restore when the session had no entry for the run, leaving a permanent RUNNING orphan while the buffer said PAUSED (round-12 regression, bisected) | Restore falls back to the status the caller's object carried at entry |
| The buffer received a raw DB string; `/resume` crashed on `.value` and returned 200 with an empty body (round-12 regression) | Statuses are coerced to `RunStatus` at the read site |
| A RUNNING pre-takeover status was recorded as the final buffer status; `/resume` hung forever (round-12 regression) | The buffer never receives RUNNING or PENDING; those fall back to PAUSED |
| A background continue that re-paused was recorded COMPLETED in the buffer on the run_id-only shape AgentOS uses | The producer captures the run the continue produced and advertises its real status |
| Admin-approved member `requires_user_input` / `external_execution` runs re-paused forever: the approval applier wrote ToolExecution fields, the requirement's `needs_*` properties read the requirement side (round-11 regression) | `_sync_requirements_after_approval` mirrors the resolution onto the requirements; `answered` is set only when every field has a value, so an approval without values still re-pauses |
| A cancel during member routing dropped team-level requirements from the persisted run (sync stream only; the async twin restored them) | The wrapper restores them on every non-normal exit of member routing |
| An unknown run id crashed `acontinue_run` with `AttributeError`; the other three lanes raise `RunNotFoundError` | `RunNotFoundError` propagates, so the AgentOS 404 handler works |
| The three round-12 tests could not fail for their stated reasons (unbindable payload made the double-execution asserts vacuous; `!=` buffer asserts passed when nothing was recorded) | Bindable payloads and exact `==` + `isinstance` assertions |

Verification at `0ec9469e6`: focused file **114 passed**; team + run + approval suites **794 passed, 1 skipped**; ruff, mypy clean on changed files. Ten targeted mutations — one per fix arm — each fail exactly their named test when the arm is reverted.

**Verified pre-existing at the merge base and filed as follow-ups, out of scope here:** #9447 (foreground continues trust a caller-supplied `run_response` over the stored run, all four dispatchers), #9448 (two concurrent continues both execute the gated tool), #9449 (background continue of a completed run edits it in place instead of forking; background fork orphans the original at RUNNING), #9450 (whole-session saves are last-writer-wins and can drop a concurrently persisted run — round 13 closes the two producer write-backs; the success path needs per-run persistence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Round 14 (head `8cb820b0a`)

Before calling round 13 clean, a five-agent attack pass ran against its uncommitted fixes (compare-and-set, guard matrix, stream visibility A/B, approval sync, test honesty — every attack executed, 60 recorded non-findings). It confirmed the round-13 fixes hold on their stated cases and found these, all fixed in this round:

| Finding | Fix |
|---|---|
| With `cache_session=True` the handler's session read returned the cached object — the very run the restore had already mutated — so the compare-and-set never fired and a refused continue left the run RUNNING forever (round-13 regression, bisected against round 12) | The handler reads an uncached session copy BEFORE any mutation and updates the cache after a successful write; a failed read falls back to the step-1 session, since a run left RUNNING can never be resumed |
| The stale-object guard keyed on the caller object reading paused, so a caller who followed the refusal message and re-read a CANCELLED run held an object that walked past the guard and fired the gated tool; a completed run continued through its own fresh object was edited in place and double-fired | The guard decides purely from the stored status: COMPLETED or CANCELLED refuses any in-place background continue; `fork`/`regenerate` still branch off |
| A background fork's paused status was stamped under the ORIGINAL run's buffer key, telling reconnecting clients a finished run was awaiting approval (round-13 regression) | `final_output` is trusted only when it carries the same run id |
| A failed background continue on the run_id-only shape was advertised COMPLETED — the stream's error branches never yielded the run object | All four error branches (sync/async, guardrail/generic) yield it; the buffer records ERROR |
| Round 13 made refusal buffer entries correctly PAUSED — which `cleanup_runs` never reclaims, so every abandoned approval pinned its buffer for the process lifetime | Paused entries are reclaimed after the cleanup interval; a later continue rebuilds the entry via `add_event` |
| A REJECTED admin approval on a member user-input/external tool re-paused forever (main completes it), and an approved tool with an empty input schema read as unfilled | A rejection settles the requirement through the reject lane (tool skipped, run completes); an empty schema resolves |
| After a session reload the team-level approval lane was unresolvable: `run.tools` and the requirement hold distinct copies of the tool call and the dedupe kept only one | Approval tools are deduped by object identity so the resolution lands on both copies |

Verification at `8cb820b0a`: focused file **133 passed**; team + run + os + approval suites **2517 passed, 1 skipped**; ruff, mypy clean on changed files. **Twenty targeted mutations** across rounds 13-14, each killed by a named test — including the vacuous-test class (a buffer-reclaim test that passed for the wrong reason was itself caught and fixed by the harness).

Additional follow-up filed: #9451 (a rejected user-input tool still executes when a requirements payload answers it — `agent/_tools.py` Case 4 never checks `confirmed`; pre-existing on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Round 15 (head `3dc45a9d2`) — the external review's six findings, executed and resolved

Each of the six findings was verified by an executing agent that reproduced it through public entry points and A/B'd it against the parent commit (`8cb820b0a`'s parent) and the merge base. Verdicts:

| # | Finding | Verdict | Action |
|---|---|---|---|
| 1 | One approval record resolves sibling members' tools | Real, and DEEPER than reported: on main today, with ordinary distinct tool ids, approving one member executes both — including a member whose record was explicitly REJECTED. Round 14's identity dedupe only flipped the colliding-id sub-case from fail-closed to fail-open. | **Fixed.** Each gated tool pairs with its own record (stamped approval_id → owning member run → run-level fallback). Any pending or missing record blocks the whole continue. Three regression tests incl. the approve-one/reject-one split. |
| 2 | The refusal write-back is not an atomic CAS | Real, pre-existing class, strictly narrowed by this PR. Unreachable with a sync db in a single process (the read and save share one event-loop tick); needs async db or multi-worker plus a one-round-trip window. A post-save verify read cannot detect a writer that landed inside the window; a per-session lock does nothing across workers and leaves the 2-3x wider `_acleanup_and_store` save unguarded. | **Deferred to #9450** (per-run conditional persistence). No pseudo-CAS added. |
| 3 | Callable members bypass storage flags | Mechanism real, consequence unreachable today: the delegation path scrubs the member run before storage ever sees it, and callable-members teams refuse continue (#9429). The reviewer retracted; our verifier agreed on unreachability. | **Fixed anyway (fail-closed):** an unresolvable owner is now stored with every storage flag treated as off, using the paused-aware scrub so the pending call stays resumable. |
| 4 | Id-less tool messages evade scrubbing | Real but latent — every supported provider backfills a uuid on id-less tool calls; reachable via legacy/checkpointed transcripts. Two leak sites, not one. | **Fixed:** no tool-result message is stored when the flag is off; ids only decide which assistant calls lost their answer. The id-less PENDING call keeps its spare (dropping it would strand runs that are unresumable for other reasons). |
| 5 | Cleanup can delete an active continuation's buffer | Confirmed round-14 regression. Worse than reported: the reused entry's event indices restart at 0, so an already-subscribed client silently drops the recycled range. | **Fixed:** an event arriving on a paused entry marks it RUNNING and drops `completed_at`. Terminal entries are untouched. Also incidentally fixes a pre-existing `/resume` mis-route during live continuations. |
| 6 | Completed-run auto-fork parity | The lane never auto-forked: at the parent AND the merge base it edited the finished run in place and double-fired the gated tool (executed probes). The refusal is fail-closed over corruption, unreachable from AgentOS (routers use the run_id lane, which forks correctly). | **Guard kept.** Two adjacent fixes shipped: fork/regenerate no longer write RUNNING under the original run id (a merge-base orphan bug the round-14 message steered users into), and the message now points at `acontinue_run(run_id=..., fork=True)`. |

Verification at `3dc45a9d2`: focused file **134 passed**; team + run + os + agent + approval suites **3058 passed, 1 skipped**; ruff, mypy clean. **25 targeted mutations killed** across rounds 13-15. One deliberate survivor documented: removing the pending-approval raise changes nothing observable, because the unresolved-requirement re-pause guards behind it fail closed on their own — it stays as defense in depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Round 16 (head `b073ec7e1`) — the four follow-up findings, all fixed

All four verified by execution before fixing; each fix arm has a mutation check (29 killed total across rounds 13-16).

- **A scoped approval that is missing stays missing.** The run-level lookup serves only tools with no stamped `approval_id` and no owning member run; a tool whose own record was deleted now blocks the continue instead of borrowing a sibling's approval. Regression test: approve one member, delete the other's record — nothing executes.
- **A team pause's record no longer overwrites a member tool's approval id.** Mixed team-plus-member pauses create two records and each tool resolves against its own; approving only the team record leaves the run paused with nothing executed. (The mutation harness itself caught an incomplete first version of this check's test target — the requirements-side stamp is the load-bearing one.)
- **A reclaimed paused buffer keeps its monotonic event index**, so a continuation after reclaim cannot recycle indices a client's cursor already covers. Tested on the cleanup-then-rebuild path, alongside the round-15 reuse-before-cleanup test.
- **Fork/regenerate terminal bookkeeping derives from the original run's stored status**, never the stale caller object — a completed original is no longer advertised PAUSED after an object-lane fork, and the run_id auto-fork keeps its guard (its own new test).

Verification at `b073ec7e1`: focused file **139 passed**; team + run + os + agent + approval suites **3063 passed, 1 skipped**; ruff, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Round 17 (head `e98554f66`) — final-pass hardening

A final adversarial pass (round-16 attack, flakiness sweep, hygiene, broad-suite health) came back with two blocking approval fail-opens, both from round 16's per-record scoping, plus cosmetic items. Both fixed; the rest verified.

- **An ambiguous tool owner no longer borrows a sibling's record.** Two members calling the *same* tool with a colliding provider `tool_call_id` matched the first requirement by value, so a member whose own record was deleted executed on a sibling's approval — with the sibling's approved arguments injected. Owner resolution is now identity-first; a value match fitting more than one member is ambiguous and resolves no record, so the continue blocks. (Both-approved collisions still complete via identity; only the genuinely unresolvable mix blocks, fail-closed.)
- **A reissued team-level approval record resolves again.** A team tool whose stamped record was deleted and re-created under the same run was stuck paused forever, because the run-level fallback was skipped for any tool carrying an `approval_id`. Such a tool now falls back to its own run's record — a record reissued for this run counts, a sibling member's never does.
- **A refused continue that supplied a payload surfaces the gate's real reason** instead of "the requirements parameter must be provided" (which the caller already did). Applied to all three dispatchers.
- Three decision-narrating comments trimmed to the constraint; one stale docstring corrected.

**Verified clean by the pass (non-blocking, no action):** no flakiness (focused file 10×139, five timing-sensitive tests 30× each, reverse-order and standalone all green; every buffer test uses a unique run id); no merge conflict (branch fast-forwards onto origin/main); every PR-body test count re-verified against reality; all sync/async twins parity-checked; a new AsyncSqlite nested-HITL smoke (5 tests) passes at head. Left as filed follow-ups: the retained per-run event index is unbounded but ~120× smaller than the leak it replaced; the double-record dedupe scans only `tools`; the resolved-approval post-hook publishes the first record.

Verification at `e98554f66`: focused file **143 passed**; team + run + os + agent + approval suites **3066 passed, 1 skipped**; ruff, mypy clean. **33 targeted mutations killed** across rounds 13-17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
