### PR TITLE
feat: add per-agent knowledge templating

### DIFF
--- a/cookbook/05_agent_os/22_studio/README.md
+++ b/cookbook/05_agent_os/22_studio/README.md
@@ -1,15 +1,16 @@
 # Studio
 
 `StudioTools` lets an Agent compose persisted Agents, Teams, and Workflows from
-the live objects in an AgentOS `Registry`. This lesson separates four concerns:
-standalone composition, composition served by AgentOS, human-in-the-loop
-control, and the Registry/Components HTTP contracts.
+the live objects in an AgentOS `Registry`. This lesson covers standalone and
+AgentOS-served composition, per-Agent knowledge, human-in-the-loop control, and
+the Registry/Components HTTP contracts.
 
 ## Files
 
 | File | What it teaches |
 |---|---|
 | `standalone_studio_agent.py` | Create, edit, inspect, and publish a versioned Agent without starting AgentOS. |
+| `per_agent_knowledge.py` | Register one knowledge template and attach it to multiple Studio-created Agents with isolated corpora. |
 | `studio_tools_agent.py` | Serve a Studio Agent beside code-defined Agents and create a component over HTTP. |
 | `studio_hitl_agent.py` | Resolve structured feedback, free-text input, and confirmation pauses in a console process. |
 | `studio_hitl_agent_os.py` | Resolve the same pauses through AgentOS run and continuation endpoints. |
@@ -25,7 +26,8 @@ export OPENAI_API_KEY=...
 export ANTHROPIC_API_KEY=...
 ```
 
-All examples use synchronous `SqliteDb` databases under `22_studio/tmp/`.
+Most examples use synchronous `SqliteDb` databases under `22_studio/tmp/`.
+`per_agent_knowledge.py` uses PostgreSQL for both content metadata and vectors.
 StudioTools persistence and the `/components` router require a synchronous
 `BaseDb`. If AgentOS receives an async database, it exposes a disabled
 `/components` surface instead. `GET /registry` is independent of component
@@ -43,6 +45,39 @@ out a full published-v1 to draft-v2 to published-v2 lifecycle:
 `versions=True` is opt-in. With it, `edit_agent`, `edit_team`, and
 `edit_workflow` write a draft that `publish_component` must promote. Without
 versioning, edits publish a new current version immediately.
+
+## Give Studio-created Agents isolated knowledge
+
+Start the cookbook PostgreSQL service, then build two persisted Agents from one
+registered knowledge toolkit:
+
+```bash
+./cookbook/scripts/run_pgvector.sh
+.venvs/demo/bin/python cookbook/05_agent_os/22_studio/per_agent_knowledge.py
+```
+
+The Registry declares `agent_knowledge` once. Both calls to
+`StudioTools.create_agent()` attach it through
+`tool_names=["agent_knowledge"]`; tool calls resolve
+`corpora/{agent_id}` separately for each created Agent. The vector table and
+content table stay shared, while the resolved namespace scopes each Agent's
+writes and searches.
+
+The setup command only creates component records. It does not embed or search
+text. Set `OPENAI_API_KEY` before running a created Agent so
+`OpenAIEmbedder()` can use the same provider key as the platform. Set
+`DATABASE_URL` to override the default local cookbook PostgreSQL URL.
+
+Use a printed id to add or search text through the reloaded Studio component:
+
+```bash
+export OPENAI_API_KEY=...
+.venvs/demo/bin/python cookbook/05_agent_os/22_studio/per_agent_knowledge.py \
+  --agent-id <printed-id> \
+  --message "Remember this text: the launch codename is Lark."
+```
+
+Run a search prompt against each printed id to observe the namespace boundary.
 
 ## Run the AgentOS Studio Agent
 

--- a/cookbook/05_agent_os/22_studio/TEST_LOG.md
+++ b/cookbook/05_agent_os/22_studio/TEST_LOG.md
@@ -3,6 +3,11 @@
 Tested live on 2026-07-24 against Agno source commit
 `45bfff9f2aa6ec11b7386c3cd3bf6d1141d005dc`.
 
+The five live entries below belong to that run. The newer
+`per_agent_knowledge.py` entry records source-only validation against
+uncommitted feature work based on `03d2bf051bfdd3d4a04becce6977712070b30c4d`;
+it does not claim a live PostgreSQL, embedding, or model run.
+
 Every process loaded Agno from this worktree through
 `PYTHONPATH=/Users/ab/code/worktrees/agno-agent-os-rewrite/libs/agno`.
 Provider credentials were loaded with `direnv exec .`; no credential values
@@ -93,10 +98,38 @@ with HTTP 404.
 
 ---
 
+### per_agent_knowledge.py
+
+**Status:** PASS
+
+**Test mode:** CONSTRUCTION_SMOKE
+
+**Description:** Ran targeted Ruff formatting and checks plus worktree-pinned
+Python compilation for the new per-Agent knowledge example. A no-service smoke
+loaded the module from this worktree with `PgVector.exists()` and `create()`
+stubbed, then checked the registry entry, namespace template, exposed functions,
+and `StudioTools` resolution of `agent_knowledge`.
+
+**Result:** The file formatted cleanly, Ruff reported no findings, and
+`py_compile` and the construction smoke succeeded. The development environment
+lacks the optional `pgvector` package, so the smoke used `.venvs/demo`, where
+that cookbook dependency is installed. No PostgreSQL service, OpenAI embedding
+request, model run, content write, or isolation search was executed, so this
+entry makes no live isolation claim.
+
+---
+
 ## Validation
 
-- All five Python targets passed worktree-pinned compilation and targeted Ruff
-  format/check.
+### 2026-08-06 static validation
+
+- `per_agent_knowledge.py` passed targeted Ruff format/check, Python
+  compilation, and a no-service construction smoke on 2026-08-06.
+
+### 2026-07-24 live validation
+
+- The original five Python targets passed worktree-pinned compilation and
+  targeted Ruff format/check.
 - Recursive inventory and pattern validation checked exactly five Python files
   with zero violations.
 - The focused StudioTools, Registry-router, and Components-router unit suites

--- a/cookbook/05_agent_os/22_studio/per_agent_knowledge.py
+++ b/cookbook/05_agent_os/22_studio/per_agent_knowledge.py
@@ -1,0 +1,130 @@
+"""
+Give Studio-created Agents isolated knowledge
+==============================================
+
+Register one templated KnowledgeTools toolkit, then attach that toolkit to two
+Studio-created Agents by its registry name. At tool-call time, each Agent uses
+its own ``corpora/{agent_id}`` namespace over the shared PostgreSQL tables.
+
+Prerequisites: ./cookbook/scripts/run_pgvector.sh
+Run: .venvs/demo/bin/python cookbook/05_agent_os/22_studio/per_agent_knowledge.py
+Try: rerun with --agent-id <printed-id> --message "Remember this text: ..."
+"""
+
+import argparse
+import json
+import os
+from typing import Any, Dict
+from uuid import uuid4
+
+from agno.db.postgres import PostgresDb
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
+from agno.registry import Registry
+from agno.tools.knowledge import KnowledgeTools
+from agno.tools.studio import StudioTools
+from agno.vectordb.pgvector import PgVector
+
+# ---------------------------------------------------------------------------
+# Register one per-Agent knowledge building block
+# ---------------------------------------------------------------------------
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql+psycopg://ai:ai@localhost:5532/ai",
+)
+db = PostgresDb(
+    id="studio-per-agent-knowledge-db",
+    db_url=DATABASE_URL,
+    knowledge_table="studio_agent_knowledge_contents",
+    components_table="studio_agent_knowledge_components",
+    component_configs_table="studio_agent_knowledge_component_configs",
+)
+
+agent_knowledge = KnowledgeTools(
+    name="agent_knowledge",
+    knowledge=Knowledge(
+        vector_db=PgVector(
+            table_name="studio_agent_knowledge_vectors",
+            db_url=DATABASE_URL,
+            embedder=OpenAIEmbedder(),
+        ),
+        contents_db=db,
+    ),
+    namespace="corpora/{agent_id}",
+    enable_add=True,
+    enable_think=False,
+    enable_analyze=False,
+    instructions=(
+        "Use search_knowledge to search this Agent's private corpus. "
+        "Use add_text_to_knowledge only when the user asks to remember or index text."
+    ),
+)
+
+registry = Registry(
+    name="Per-Agent Knowledge Registry",
+    tools=[agent_knowledge],
+    models=[OpenAIResponses(id="gpt-5.5")],
+    dbs=[db],
+)
+
+studio_tools = StudioTools(
+    registry=registry,
+    db=db,
+    default_model_id="gpt-5.5",
+)
+
+
+# ---------------------------------------------------------------------------
+# Build two Agents from the same registry primitive
+# ---------------------------------------------------------------------------
+
+
+def create_knowledge_agent(name: str) -> Dict[str, Any]:
+    """Persist one Studio Agent wired to the templated knowledge toolkit."""
+    result = json.loads(
+        studio_tools.create_agent(
+            name=name,
+            instructions=(
+                "Use add_text_to_knowledge to remember text only when asked. "
+                "Use search_knowledge before answering questions about saved text."
+            ),
+            tool_names=["agent_knowledge"],
+        )
+    )
+    if "error" in result:
+        raise RuntimeError(result["error"])
+    return result
+
+
+def build_agents() -> None:
+    """Create two persisted Agents that share configuration, not corpus data."""
+    suffix = uuid4().hex[:8]
+    agents = [
+        create_knowledge_agent(f"Research Notes {suffix}"),
+        create_knowledge_agent(f"Customer Notes {suffix}"),
+    ]
+
+    for agent in agents:
+        print(f"Created: {agent['id']} with tools {agent['tools']}")
+        print(f"Namespace configured for tool calls: corpora/{agent['id']}")
+
+    print("No text was embedded by this setup run.")
+    print(
+        "Set OPENAI_API_KEY, then run either id with StudioTools.run_agent to add or search text."
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-id", help="Run a previously created Studio Agent.")
+    parser.add_argument("--message", help="Message for --agent-id.")
+    args = parser.parse_args()
+
+    if args.agent_id:
+        if not args.message:
+            parser.error("--message is required with --agent-id")
+        print(studio_tools.run_agent(args.agent_id, args.message))
+    else:
+        build_agents()

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -3,7 +3,7 @@ import hashlib
 import io
 import json
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from io import BytesIO
 from os.path import basename
@@ -55,6 +55,11 @@ class Knowledge(RemoteKnowledge):
     # Requires re-indexing existing data to add linked_to metadata.
     # Default is False for backwards compatibility with existing data.
     isolate_vector_search: bool = False
+    # Internal opt-in for strict content-id and contents-row isolation. This is
+    # enabled on the ephemeral views created by context-bound KnowledgeTools.
+    # Keeping it out of __init__ preserves the IDs and management semantics of
+    # existing static Knowledge(isolate_vector_search=True) instances.
+    _enforce_content_isolation: bool = field(default=False, init=False, repr=False, compare=False)
 
     def __post_init__(self):
         from agno.vectordb import VectorDb
@@ -64,6 +69,50 @@ class Knowledge(RemoteKnowledge):
             self.vector_db.create()
 
         self.construct_readers()
+
+    def _get_isolation_namespace(self) -> Optional[str]:
+        """Return the namespace that must own isolated content, if enabled."""
+        if self._enforce_content_isolation and self.isolate_vector_search and self.name:
+            return self.name
+        return None
+
+    def _is_content_row_accessible(self, content_row: KnowledgeRow) -> bool:
+        """Return whether a contents row belongs to this isolated Knowledge view."""
+        namespace = self._get_isolation_namespace()
+        return namespace is None or content_row.linked_to == namespace
+
+    def _remove_isolation_metadata_override(self, metadata: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Remove caller-controlled isolation metadata from an isolated view."""
+        if not metadata or self._get_isolation_namespace() is None or "linked_to" not in metadata:
+            return metadata
+        return {key: value for key, value in metadata.items() if key != "linked_to"}
+
+    def _prepare_vector_db_filters(self, metadata: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Apply the framework-owned namespace after caller-provided vector filters."""
+        namespace = self._get_isolation_namespace()
+        if namespace is None:
+            return metadata
+        return {**(metadata or {}), "linked_to": namespace}
+
+    def _get_content_size(self, content: Content) -> Optional[int]:
+        """Return source size, using exact UTF-8 bytes for strict views."""
+        if not self._enforce_content_isolation:
+            if content.size:
+                return content.size
+            if content.file_data and content.file_data.content:
+                return len(content.file_data.content)
+            return None
+        if content.size is not None:
+            return content.size
+        if content.file_data is None:
+            return None
+        if content.file_data.size is not None:
+            return content.file_data.size
+        if isinstance(content.file_data.content, str):
+            return len(content.file_data.content.encode("utf-8"))
+        if isinstance(content.file_data.content, bytes):
+            return len(content.file_data.content)
+        return None
 
     # ==========================================
     # PUBLIC API - INSERT METHODS
@@ -132,12 +181,14 @@ class Knowledge(RemoteKnowledge):
             return
 
         # Strip reserved _agno key from user-provided metadata
-        safe_metadata = strip_agno_metadata(metadata)
+        safe_metadata = self._remove_isolation_metadata_override(strip_agno_metadata(metadata))
 
         content = None
         file_data = None
         if text_content:
             file_data = FileData(content=text_content, type="Text")
+            if self._enforce_content_isolation:
+                file_data.size = len(text_content.encode("utf-8"))
 
         content = Content(
             name=name,
@@ -200,12 +251,14 @@ class Knowledge(RemoteKnowledge):
             return
 
         # Strip reserved _agno key from user-provided metadata
-        safe_metadata = strip_agno_metadata(metadata)
+        safe_metadata = self._remove_isolation_metadata_override(strip_agno_metadata(metadata))
 
         content = None
         file_data = None
         if text_content:
             file_data = FileData(content=text_content, type="Text")
+            if self._enforce_content_isolation:
+                file_data.size = len(text_content.encode("utf-8"))
 
         content = Content(
             name=name,
@@ -645,7 +698,7 @@ class Knowledge(RemoteKnowledge):
             )
 
         content_row = self.contents_db.get_knowledge_content(content_id)
-        if content_row is None:
+        if content_row is None or not self._is_content_row_accessible(content_row):
             return None
         return self._content_row_to_content(content_row)
 
@@ -658,7 +711,7 @@ class Knowledge(RemoteKnowledge):
         else:
             content_row = self.contents_db.get_knowledge_content(content_id)
 
-        if content_row is None:
+        if content_row is None or not self._is_content_row_accessible(content_row):
             return None
         return self._content_row_to_content(content_row)
 
@@ -672,7 +725,7 @@ class Knowledge(RemoteKnowledge):
             )
 
         content_row = self.contents_db.get_knowledge_content(content_id)
-        if content_row is None:
+        if content_row is None or not self._is_content_row_accessible(content_row):
             return None, "Content not found"
 
         return self._parse_content_status(content_row.status), content_row.status_message
@@ -686,7 +739,7 @@ class Knowledge(RemoteKnowledge):
         else:
             content_row = self.contents_db.get_knowledge_content(content_id)
 
-        if content_row is None:
+        if content_row is None or not self._is_content_row_accessible(content_row):
             return None, "Content not found"
 
         return self._parse_content_status(content_row.status), content_row.status_message
@@ -700,11 +753,28 @@ class Knowledge(RemoteKnowledge):
     def remove_content_by_id(self, content_id: str):
         from agno.vectordb import VectorDb
 
+        owned_content: Optional[Content] = None
+        if self._get_isolation_namespace() is not None:
+            if self.contents_db is None:
+                log_warning("Cannot verify content ownership without a contents db")
+                return
+            if isinstance(self.contents_db, AsyncBaseDb):
+                raise ValueError(
+                    "remove_content_by_id() is not supported for async databases. "
+                    "Please use aremove_content_by_id() instead."
+                )
+
+            content_row = self.contents_db.get_knowledge_content(content_id)
+            if content_row is None or not self._is_content_row_accessible(content_row):
+                log_warning(f"Content row not found for id: {content_id}, cannot remove content")
+                return
+            owned_content = self._content_row_to_content(content_row)
+
         self.vector_db = cast(VectorDb, self.vector_db)
         if self.vector_db is not None:
             if self.vector_db.__class__.__name__ == "LightRag":
                 # For LightRAG, get the content first to find the external_id
-                content = self.get_content_by_id(content_id)
+                content = owned_content or self.get_content_by_id(content_id)
                 if content and content.external_id:
                     self.vector_db.delete_by_external_id(content.external_id)  # type: ignore
                 else:
@@ -716,10 +786,25 @@ class Knowledge(RemoteKnowledge):
             self.contents_db.delete_knowledge_content(content_id)
 
     async def aremove_content_by_id(self, content_id: str):
+        owned_content: Optional[Content] = None
+        if self._get_isolation_namespace() is not None:
+            if self.contents_db is None:
+                log_warning("Cannot verify content ownership without a contents db")
+                return
+
+            if isinstance(self.contents_db, AsyncBaseDb):
+                content_row = await self.contents_db.get_knowledge_content(content_id)
+            else:
+                content_row = self.contents_db.get_knowledge_content(content_id)
+            if content_row is None or not self._is_content_row_accessible(content_row):
+                log_warning(f"Content row not found for id: {content_id}, cannot remove content")
+                return
+            owned_content = self._content_row_to_content(content_row)
+
         if self.vector_db is not None:
             if self.vector_db.__class__.__name__ == "LightRag":
                 # For LightRAG, get the content first to find the external_id
-                content = await self.aget_content_by_id(content_id)
+                content = owned_content or await self.aget_content_by_id(content_id)
                 if content and content.external_id:
                     self.vector_db.delete_by_external_id(content.external_id)  # type: ignore
                 else:
@@ -1639,13 +1724,19 @@ class Knowledge(RemoteKnowledge):
                 # Insert with per-document hash
                 if self.vector_db.upsert_available() and upsert:
                     try:
-                        await self.vector_db.async_upsert(doc_hash, source_docs, content.metadata)
+                        await self.vector_db.async_upsert(
+                            doc_hash, source_docs, self._prepare_vector_db_filters(content.metadata)
+                        )
                     except Exception as e:
                         log_error(f"Error upserting document from {source_url}: {str(e)}")
                         continue
                 else:
                     try:
-                        await self.vector_db.async_insert(doc_hash, documents=source_docs, filters=content.metadata)
+                        await self.vector_db.async_insert(
+                            doc_hash,
+                            documents=source_docs,
+                            filters=self._prepare_vector_db_filters(content.metadata),
+                        )
                     except Exception as e:
                         log_error(f"Error inserting document from {source_url}: {str(e)}")
                         continue
@@ -1794,13 +1885,17 @@ class Knowledge(RemoteKnowledge):
                 # Insert with per-document hash
                 if self.vector_db.upsert_available() and upsert:
                     try:
-                        self.vector_db.upsert(doc_hash, source_docs, content.metadata)
+                        self.vector_db.upsert(doc_hash, source_docs, self._prepare_vector_db_filters(content.metadata))
                     except Exception as e:
                         log_error(f"Error upserting document from {source_url}: {str(e)}")
                         continue
                 else:
                     try:
-                        self.vector_db.insert(doc_hash, documents=source_docs, filters=content.metadata)
+                        self.vector_db.insert(
+                            doc_hash,
+                            documents=source_docs,
+                            filters=self._prepare_vector_db_filters(content.metadata),
+                        )
                     except Exception as e:
                         log_error(f"Error inserting document from {source_url}: {str(e)}")
                         continue
@@ -2227,6 +2322,9 @@ class Knowledge(RemoteKnowledge):
           metadata to coexist instead of collapsing onto each other).
         """
         hash_parts = []
+        isolation_namespace = self._get_isolation_namespace()
+        if isolation_namespace is not None:
+            hash_parts.append(f"linked_to={isolation_namespace}")
         if content.name:
             hash_parts.append(content.name)
         if content.description:
@@ -2295,6 +2393,9 @@ class Knowledge(RemoteKnowledge):
             A unique hash string for this specific document
         """
         hash_parts = []
+        isolation_namespace = self._get_isolation_namespace()
+        if isolation_namespace is not None:
+            hash_parts.append(f"linked_to={isolation_namespace}")
 
         if content.name:
             hash_parts.append(content.name)
@@ -2391,13 +2492,9 @@ class Knowledge(RemoteKnowledge):
             id=content.id,
             name=self._ensure_string_field(content.name, "content.name", default=""),
             description=self._ensure_string_field(content.description, "content.description", default=""),
-            metadata=content.metadata,
+            metadata=self._remove_isolation_metadata_override(content.metadata),
             type=file_type,
-            size=content.size
-            if content.size
-            else len(content.file_data.content)
-            if content.file_data and content.file_data.content
-            else None,
+            size=self._get_content_size(content),
             linked_to=self.name if self.name else "",
             access_count=0,
             status=content.status if content.status else ContentStatus.PROCESSING,
@@ -2453,9 +2550,10 @@ class Knowledge(RemoteKnowledge):
             await self._aupdate_content(content)
             return
 
+        vector_db_filters = self._prepare_vector_db_filters(content.metadata)
         if self.vector_db.upsert_available() and upsert:
             try:
-                await self.vector_db.async_upsert(content.content_hash, read_documents, content.metadata)  # type: ignore[arg-type]
+                await self.vector_db.async_upsert(content.content_hash, read_documents, vector_db_filters)  # type: ignore[arg-type]
             except Exception as e:
                 log_error(f"Error upserting document: {str(e)}")
                 content.status = ContentStatus.FAILED
@@ -2467,7 +2565,7 @@ class Knowledge(RemoteKnowledge):
                 await self.vector_db.async_insert(
                     content.content_hash,  # type: ignore[arg-type]
                     documents=read_documents,
-                    filters=content.metadata,  # type: ignore[arg-type]
+                    filters=vector_db_filters,
                 )
             except Exception as e:
                 log_error(f"Error inserting document: {str(e)}")
@@ -2492,9 +2590,10 @@ class Knowledge(RemoteKnowledge):
             self._update_content(content)
             return
 
+        vector_db_filters = self._prepare_vector_db_filters(content.metadata)
         if self.vector_db.upsert_available() and upsert:
             try:
-                self.vector_db.upsert(content.content_hash, read_documents, content.metadata)  # type: ignore[arg-type]
+                self.vector_db.upsert(content.content_hash, read_documents, vector_db_filters)  # type: ignore[arg-type]
             except Exception as e:
                 log_error(f"Error upserting document: {str(e)}")
                 content.status = ContentStatus.FAILED
@@ -2506,7 +2605,7 @@ class Knowledge(RemoteKnowledge):
                 self.vector_db.insert(
                     content.content_hash,  # type: ignore[arg-type]
                     documents=read_documents,
-                    filters=content.metadata,  # type: ignore[arg-type]
+                    filters=vector_db_filters,
                 )
             except Exception as e:
                 log_error(f"Error inserting document: {str(e)}")
@@ -2536,9 +2635,11 @@ class Knowledge(RemoteKnowledge):
 
             # TODO: we shouldn't check for content here, we should trust the upsert method to handle conflicts
             content_row = self.contents_db.get_knowledge_content(content.id)
-            if content_row is None:
+            if content_row is None or not self._is_content_row_accessible(content_row):
                 log_warning(f"Content row not found for id: {content.id}, cannot update status")
                 return None
+
+            safe_metadata = self._remove_isolation_metadata_override(content.metadata)
 
             # Apply safe string handling for updates as well
             if content.name is not None:
@@ -2547,8 +2648,8 @@ class Knowledge(RemoteKnowledge):
                 content_row.description = self._ensure_string_field(
                     content.description, "content.description", default=""
                 )
-            if content.metadata is not None:
-                content_row.metadata = merge_user_metadata(content_row.metadata, content.metadata)
+            if safe_metadata is not None:
+                content_row.metadata = merge_user_metadata(content_row.metadata, safe_metadata)
             if content.status is not None:
                 content_row.status = content.status
             if content.status_message is not None:
@@ -2564,8 +2665,11 @@ class Knowledge(RemoteKnowledge):
 
             if self.vector_db:
                 # Strip _agno from metadata sent to vector_db — only user fields should be searchable
-                user_metadata = strip_agno_metadata(content.metadata) or {}
-                self.vector_db.update_metadata(content_id=content.id, metadata=user_metadata)
+                user_metadata = strip_agno_metadata(safe_metadata) or {}
+                self.vector_db.update_metadata(
+                    content_id=content.id,
+                    metadata=self._prepare_vector_db_filters(user_metadata) or {},
+                )
 
             return content_row.to_dict()
 
@@ -2583,9 +2687,11 @@ class Knowledge(RemoteKnowledge):
                 content_row = await self.contents_db.get_knowledge_content(content.id)
             else:
                 content_row = self.contents_db.get_knowledge_content(content.id)
-            if content_row is None:
+            if content_row is None or not self._is_content_row_accessible(content_row):
                 log_warning(f"Content row not found for id: {content.id}, cannot update status")
                 return None
+
+            safe_metadata = self._remove_isolation_metadata_override(content.metadata)
 
             # Apply safe string handling for updates
             if content.name is not None:
@@ -2594,8 +2700,8 @@ class Knowledge(RemoteKnowledge):
                 content_row.description = self._ensure_string_field(
                     content.description, "content.description", default=""
                 )
-            if content.metadata is not None:
-                content_row.metadata = merge_user_metadata(content_row.metadata, content.metadata)
+            if safe_metadata is not None:
+                content_row.metadata = merge_user_metadata(content_row.metadata, safe_metadata)
             if content.status is not None:
                 content_row.status = content.status
             if content.status_message is not None:
@@ -2615,8 +2721,11 @@ class Knowledge(RemoteKnowledge):
 
             if self.vector_db:
                 # Strip _agno from metadata sent to vector_db — only user fields should be searchable
-                user_metadata = strip_agno_metadata(content.metadata) or {}
-                self.vector_db.update_metadata(content_id=content.id, metadata=user_metadata)
+                user_metadata = strip_agno_metadata(safe_metadata) or {}
+                self.vector_db.update_metadata(
+                    content_id=content.id,
+                    metadata=self._prepare_vector_db_filters(user_metadata) or {},
+                )
 
             return content_row.to_dict()
 

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -79,6 +79,7 @@ from agno.os.utils import (
 from agno.registry import Registry
 from agno.remote.base import RemoteDb, RemoteKnowledge
 from agno.team import RemoteTeam, Team, TeamFactory
+from agno.tools.toolkit import Toolkit
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id, generate_id_from_name
 from agno.workflow import RemoteWorkflow, Workflow, WorkflowFactory
@@ -1561,7 +1562,7 @@ class AgentOS:
         }
 
     def _auto_discover_databases(self) -> None:
-        """Auto-discover and initialize the databases used by all contextual agents, teams and workflows."""
+        """Auto-discover databases used by contextual resources and registered toolkits."""
 
         dbs: Dict[str, List[Union[BaseDb, AsyncBaseDb, RemoteDb]]] = {}
         knowledge_dbs: Dict[
@@ -1606,6 +1607,27 @@ class AgentOS:
         for knowledge_base in self.knowledge or []:
             if knowledge_base.contents_db:
                 self._register_db_with_validation(knowledge_dbs, knowledge_base.contents_db)
+
+        # A registry-owned context-bound knowledge toolkit is the Studio
+        # building block. Its shared contents DB must be provisioned even when
+        # no code-defined agent directly owns the Knowledge instance. Do not add
+        # that Knowledge to ``knowledge_instances``: global knowledge routes do
+        # not have the runtime context required to resolve its namespace.
+        if self.registry is not None:
+            for tool in self.registry.tools:
+                if not isinstance(tool, Toolkit):
+                    continue
+                if getattr(tool, "namespace", None) is None:
+                    continue
+                try:
+                    toolkit_knowledge = getattr(tool, "knowledge", None)
+                    toolkit_contents_db = (
+                        getattr(toolkit_knowledge, "contents_db", None) if toolkit_knowledge is not None else None
+                    )
+                    if toolkit_contents_db:
+                        self._register_db_with_validation(knowledge_dbs, toolkit_contents_db)
+                except Exception as e:
+                    log_debug(f"Database auto-discovery: skipped toolkit knowledge due to error: {e}")
 
         for interface in self.interfaces or []:
             if interface.agent and interface.agent.db:

--- a/libs/agno/agno/os/routers/registry/registry.py
+++ b/libs/agno/agno/os/routers/registry/registry.py
@@ -213,10 +213,35 @@ def attach_routes(router: APIRouter, registry: Registry) -> APIRouter:
                             )
                         )
 
+                    namespace_template = _safe_str(getattr(tool, "namespace", None))
+                    raw_placeholders = getattr(tool, "template_placeholders", None)
+                    template_placeholders: Optional[List[str]] = None
+                    if isinstance(raw_placeholders, (list, tuple)):
+                        template_placeholders = []
+                        for placeholder in raw_placeholders:
+                            placeholder_name = _safe_str(placeholder)
+                            if placeholder_name is not None:
+                                template_placeholders.append(placeholder_name)
+
+                    has_namespace_metadata = namespace_template is not None or bool(template_placeholders)
+                    knowledge = getattr(tool, "knowledge", None) if has_namespace_metadata else None
+                    vector_db = getattr(knowledge, "vector_db", None) if knowledge is not None else None
+                    contents_db = getattr(knowledge, "contents_db", None) if knowledge is not None else None
+
                     toolkit_metadata = ToolMetadata(
                         class_path=_class_path(tool),
                         is_toolkit=True,
                         functions=function_details,
+                        namespace_template=namespace_template if has_namespace_metadata else None,
+                        template_placeholders=template_placeholders if has_namespace_metadata else None,
+                        is_templated=bool(template_placeholders) if has_namespace_metadata else None,
+                        knowledge_class=_class_path(knowledge) if knowledge is not None else None,
+                        vector_db_class=_class_path(vector_db) if vector_db is not None else None,
+                        contents_db_class=_class_path(contents_db) if contents_db is not None else None,
+                        max_content_bytes=getattr(tool, "max_content_bytes", None) if has_namespace_metadata else None,
+                        max_namespace_bytes=getattr(tool, "max_namespace_bytes", None)
+                        if has_namespace_metadata
+                        else None,
                     )
                     resources.append(
                         RegistryContentResponse(

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -910,6 +910,18 @@ class ToolMetadata(BaseModel):
     functions: Optional[List[CallableMetadata]] = Field(
         None, description="Functions in the toolkit (if is_toolkit=True)"
     )
+    namespace_template: Optional[str] = Field(
+        None, description="Namespace template resolved by a context-aware toolkit"
+    )
+    template_placeholders: Optional[List[str]] = Field(
+        None, description="Framework context placeholders required by the namespace template"
+    )
+    is_templated: Optional[bool] = Field(None, description="Whether the toolkit namespace requires context resolution")
+    knowledge_class: Optional[str] = Field(None, description="Class of the knowledge instance owned by the toolkit")
+    vector_db_class: Optional[str] = Field(None, description="Class of the toolkit knowledge vector database")
+    contents_db_class: Optional[str] = Field(None, description="Class of the toolkit knowledge contents database")
+    max_content_bytes: Optional[int] = Field(None, description="Maximum bytes accepted for one knowledge item")
+    max_namespace_bytes: Optional[int] = Field(None, description="Maximum source bytes accepted for one namespace")
 
     # Fields for non-toolkit tools (Function or raw callable)
     module: Optional[str] = Field(None, description="Module where the callable is defined")

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -1702,13 +1702,15 @@ def collect_components_from_os(
     workflows: Optional[List[Any]],
     registry: Registry,
 ) -> None:
-    """Walk all agents, teams and workflows of an AgentOS and add their components to ``registry``.
+    """Walk all AgentOS resources and add their backing components to ``registry``.
 
     The registry owns deduplication (see ``Registry.add_*``), so components are
     added directly during the walk. Each top-level node is walked inside its own
     guard, so a single malformed agent/team/workflow degrades to "not collected"
-    rather than failing the whole walk. Remote and factory components are skipped
-    because they expose no locally-walkable instances.
+    rather than failing the whole walk. Registered toolkits are inspected after
+    the walk so toolkit-owned knowledge contributes its backing databases without
+    registering that knowledge as a global resource. Remote and factory components
+    are skipped because they expose no locally-walkable instances.
     """
     visited: Set[int] = set()
 
@@ -1735,6 +1737,21 @@ def collect_components_from_os(
             collect_components_from_workflow(workflow, registry, visited)
         except Exception as e:
             log_debug(f"Registry auto-population: skipped workflow due to error: {e}")
+
+    # Registry tools include both user-declared building blocks and toolkits
+    # discovered while walking agents, teams and workflows. A context-bound
+    # knowledge toolkit owns a shared backing Knowledge object, but that object
+    # is deliberately not a global knowledge resource: global knowledge routes
+    # have no agent/team/run context with which to resolve its namespace.
+    for tool in registry.tools:
+        if not isinstance(tool, Toolkit):
+            continue
+        if getattr(tool, "namespace", None) is None:
+            continue
+        try:
+            _collect_components_from_knowledge(getattr(tool, "knowledge", None), registry)
+        except Exception as e:
+            log_debug(f"Registry auto-population: skipped toolkit knowledge due to error: {e}")
 
 
 def _get_python_type_from_json_schema(field_schema: Dict[str, Any], field_name: str = "NestedModel") -> Type:

--- a/libs/agno/agno/tools/knowledge.py
+++ b/libs/agno/agno/tools/knowledge.py
@@ -1,12 +1,30 @@
+import asyncio
 import json
+import unicodedata
+from _thread import LockType
+from contextlib import asynccontextmanager
+from copy import copy
+from io import BytesIO
 from textwrap import dedent
-from typing import Any, List, Optional
+from threading import Lock
+from typing import Any, AsyncIterator, List, Optional, Tuple
+from weakref import WeakValueDictionary
 
+from agno.agent.agent import Agent
+from agno.fs._paths import normalize_namespace, normalize_template_value, parse_namespace_template
+from agno.fs.errors import InvalidPathError
+from agno.knowledge.content import Content, ContentStatus, FileData
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
 from agno.run import RunContext
+from agno.team.team import Team
 from agno.tools import Toolkit
 from agno.utils.log import log_debug, log_error
+from agno.utils.string import generate_id
+
+DEFAULT_MAX_CONTENT_BYTES = 1_000_000
+DEFAULT_MAX_NAMESPACE_BYTES = 20_000_000
+MAX_NAME_BYTES = 255
 
 
 class KnowledgeTools(Toolkit):
@@ -21,10 +39,42 @@ class KnowledgeTools(Toolkit):
         add_few_shot: bool = False,
         few_shot_examples: Optional[str] = None,
         all: bool = False,
+        *,
+        namespace: Optional[str] = None,
+        enable_add: bool = False,
+        max_content_bytes: int = DEFAULT_MAX_CONTENT_BYTES,
+        max_namespace_bytes: int = DEFAULT_MAX_NAMESPACE_BYTES,
         **kwargs,
     ):
         if knowledge is None:
             raise ValueError("knowledge must be provided when using KnowledgeTools")
+        if max_content_bytes <= 0:
+            raise ValueError("max_content_bytes must be greater than zero")
+        if max_namespace_bytes <= 0:
+            raise ValueError("max_namespace_bytes must be greater than zero")
+        if max_content_bytes > max_namespace_bytes:
+            raise ValueError("max_content_bytes cannot exceed max_namespace_bytes")
+        if enable_add and knowledge.contents_db is None:
+            raise ValueError("knowledge.contents_db must be provided when enable_add=True")
+
+        self.namespace = normalize_namespace(namespace) if namespace is not None else None
+        self.template_placeholders: Tuple[str, ...] = (
+            parse_namespace_template(self.namespace) if self.namespace is not None else ()
+        )
+        if enable_add and self.namespace is None:
+            raise ValueError("enable_add=True requires an agent namespace")
+        if self.namespace is not None and self.template_placeholders != ("agent_id",):
+            raise ValueError("namespace must contain exactly one {agent_id} placeholder")
+        if self.namespace is not None and not getattr(knowledge.vector_db, "supports_namespaced_knowledge", False):
+            raise ValueError(
+                "namespace requires a vector database that supports namespaced knowledge; "
+                "PgVector is currently supported"
+            )
+        self.max_content_bytes = max_content_bytes
+        self.max_namespace_bytes = max_namespace_bytes
+        self.enable_add = enable_add
+        self._write_locks: WeakValueDictionary[str, LockType] = WeakValueDictionary()
+        self._write_locks_guard = Lock()
 
         # Add instructions for using this toolkit
         if instructions is None:
@@ -34,6 +84,8 @@ class KnowledgeTools(Toolkit):
                     self.instructions += "\n" + few_shot_examples
                 else:
                     self.instructions += "\n" + self.FEW_SHOT_EXAMPLES
+            if enable_add:
+                self.instructions += "\n" + self.ADD_INSTRUCTIONS
         else:
             self.instructions = instructions
 
@@ -47,14 +99,189 @@ class KnowledgeTools(Toolkit):
             tools.append(self.search_knowledge)
         if enable_analyze or all:
             tools.append(self.analyze)
+        if enable_add:
+            tools.append(self.add_text_to_knowledge)
+
+        async_tools: List[tuple[Any, str]] = list(kwargs.pop("async_tools", None) or [])
+        # Preserve the existing static KnowledgeTools execution path when the
+        # namespace feature is not enabled.
+        if self.namespace is not None and (enable_search or all):
+            async_tools.append((self.asearch_knowledge, "search_knowledge"))
+        if enable_add:
+            async_tools.append((self.aadd_text_to_knowledge, "add_text_to_knowledge"))
 
         super().__init__(
-            name="knowledge_tools",
+            name=kwargs.pop("name", "knowledge_tools"),
             tools=tools,
+            async_tools=async_tools,
             instructions=self.instructions,
             add_instructions=add_instructions,
             **kwargs,
         )
+
+    def _resolve_namespace(
+        self,
+        run_context: Optional[RunContext],
+        agent: Optional[Agent],
+        team: Optional[Team],
+    ) -> Optional[str]:
+        """Resolve the configured namespace from framework-injected context."""
+        if self.namespace is None:
+            return None
+
+        values = {
+            "user_id": getattr(run_context, "user_id", None) if run_context is not None else None,
+            "agent_id": getattr(agent, "id", None) if agent is not None else None,
+            "team_id": getattr(team, "id", None) if team is not None else None,
+        }
+        resolved = self.namespace
+        for placeholder in set(self.template_placeholders):
+            value = values.get(placeholder)
+            if value is None:
+                raise InvalidPathError(
+                    f"this agent's knowledge requires {placeholder} for this run and none was provided."
+                )
+            resolved = resolved.replace(
+                "{" + placeholder + "}",
+                normalize_template_value(placeholder, value),
+            )
+        return normalize_namespace(resolved)
+
+    def _resolved(
+        self,
+        run_context: Optional[RunContext],
+        agent: Optional[Agent],
+        team: Optional[Team],
+    ) -> Knowledge:
+        """Return an isolated per-call Knowledge view without mutating the template."""
+        namespace = self._resolve_namespace(run_context, agent, team)
+        if namespace is None:
+            return self.knowledge
+        knowledge = copy(self.knowledge)
+        knowledge.name = namespace
+        knowledge.isolate_vector_search = True
+        knowledge._enforce_content_isolation = True
+        return knowledge
+
+    def _get_write_lock(self, namespace: str) -> LockType:
+        with self._write_locks_guard:
+            lock = self._write_locks.get(namespace)
+            if lock is None:
+                lock = Lock()
+                self._write_locks[namespace] = lock
+            return lock
+
+    @asynccontextmanager
+    async def _acquire_async_write_lock(self, namespace: str) -> AsyncIterator[None]:
+        """Acquire the same namespace lock used by synchronous writers."""
+        lock = self._get_write_lock(namespace)
+        while not lock.acquire(blocking=False):
+            await asyncio.sleep(0.01)
+        try:
+            yield
+        finally:
+            lock.release()
+
+    @staticmethod
+    def _text_content_hash(knowledge: Knowledge, name: str, text_content: str, size_bytes: int) -> str:
+        content = Content(
+            name=name,
+            file_data=FileData(content=text_content, type="Text", size=size_bytes),
+        )
+        return knowledge._build_content_hash(content)
+
+    @staticmethod
+    def _text_content_id(knowledge: Knowledge, name: str, text_content: str, size_bytes: int) -> str:
+        return generate_id(KnowledgeTools._text_content_hash(knowledge, name, text_content, size_bytes))
+
+    def _check_content_size(self, text_content: str) -> int:
+        size_bytes = len(text_content.encode("utf-8"))
+        if size_bytes > self.max_content_bytes:
+            raise ValueError(
+                f"content is {size_bytes} bytes (limit {self.max_content_bytes} bytes per item). "
+                "Split it into smaller items and retry."
+            )
+        return size_bytes
+
+    @staticmethod
+    def _check_name(name: str) -> None:
+        if not name.strip():
+            raise ValueError("name must not be empty")
+        if any(unicodedata.category(character) == "Cc" for character in name):
+            raise ValueError("name must not contain control characters")
+        size_bytes = len(name.encode("utf-8"))
+        if size_bytes > MAX_NAME_BYTES:
+            raise ValueError(f"name is {size_bytes} bytes (limit {MAX_NAME_BYTES} bytes)")
+
+    @staticmethod
+    def _expected_text_documents(knowledge: Knowledge, name: str, text_content: str) -> int:
+        reader = knowledge._select_reader("Text")
+        documents = reader.read(BytesIO(text_content.encode("utf-8")), name=name)
+        if not documents:
+            raise RuntimeError("knowledge text could not be read")
+        return len(documents)
+
+    def _check_namespace_quota(
+        self,
+        contents: List[Content],
+        existing: Optional[Content],
+        size_bytes: int,
+    ) -> int:
+        # Failed rows count conservatively: if vector cleanup could not be
+        # confirmed, excluding them could leave searchable but unmetered data.
+        # A retry with the same stable name still uses delta accounting.
+        used_bytes = sum(content.size or 0 for content in contents)
+        existing_bytes = (existing.size or 0) if existing is not None else 0
+        projected_bytes = used_bytes - existing_bytes + size_bytes
+        if projected_bytes > self.max_namespace_bytes:
+            raise ValueError(
+                f"knowledge is full ({projected_bytes} bytes after this write; limit {self.max_namespace_bytes} bytes)."
+            )
+        return projected_bytes
+
+    @staticmethod
+    def _require_completed_insert(status: Optional[ContentStatus], status_message: Optional[str]) -> None:
+        if status == ContentStatus.COMPLETED:
+            return
+        detail = status_message or (f"content status is {status.value}" if status is not None else "content not found")
+        raise RuntimeError(f"knowledge indexing did not complete: {detail}")
+
+    @staticmethod
+    def _mark_insert_failed(knowledge: Knowledge, content_id: str, message: str) -> None:
+        content = knowledge.get_content_by_id(content_id)
+        if content is not None:
+            content.status = ContentStatus.FAILED
+            content.status_message = message
+            knowledge.patch_content(content)
+
+    @staticmethod
+    async def _amark_insert_failed(knowledge: Knowledge, content_id: str, message: str) -> None:
+        content = await knowledge.aget_content_by_id(content_id)
+        if content is not None:
+            content.status = ContentStatus.FAILED
+            content.status_message = message
+            await knowledge.apatch_content(content)
+
+    @staticmethod
+    def _cleanup_failed_vectors(knowledge: Knowledge, content_id: str) -> None:
+        if knowledge.vector_db is None:
+            return
+        try:
+            if not knowledge.vector_db.delete_by_content_id(content_id):
+                log_error(f"Could not confirm vector cleanup for failed knowledge content {content_id}")
+        except Exception as error:
+            log_error(f"Could not clean up vectors for failed knowledge content {content_id}: {error}")
+
+    @staticmethod
+    async def _acleanup_failed_vectors(knowledge: Knowledge, content_id: str) -> None:
+        if knowledge.vector_db is None:
+            return
+        try:
+            deleted = await asyncio.to_thread(knowledge.vector_db.delete_by_content_id, content_id)
+            if not deleted:
+                log_error(f"Could not confirm vector cleanup for failed knowledge content {content_id}")
+        except Exception as error:
+            log_error(f"Could not clean up vectors for failed knowledge content {content_id}: {error}")
 
     def think(self, run_context: RunContext, thought: str) -> str:
         """Use this tool as a scratchpad to reason about the question, refine your approach, brainstorm search terms, or revise your plan.
@@ -92,7 +319,14 @@ class KnowledgeTools(Toolkit):
             log_error(f"Error recording thought: {str(e)}")
             return f"Error recording thought: {e}"
 
-    def search_knowledge(self, run_context: RunContext, query: str) -> str:
+    def search_knowledge(
+        self,
+        run_context: RunContext,
+        query: str,
+        *,
+        agent: Optional[Agent] = None,
+        team: Optional[Team] = None,
+    ) -> str:
         """Use this tool to search the knowledge base for relevant information.
         After thinking through the question, use this tool as many times as needed to search for relevant information.
 
@@ -106,13 +340,145 @@ class KnowledgeTools(Toolkit):
             log_debug(f"Searching knowledge base: {query}")
 
             # Get the relevant documents from the knowledge base
-            relevant_docs: List[Document] = self.knowledge.search(query=query)
+            knowledge = self._resolved(run_context, agent, team)
+            relevant_docs: List[Document] = knowledge.search(query=query)
             if len(relevant_docs) == 0:
                 return "No documents found"
             return json.dumps([doc.to_dict() for doc in relevant_docs])
         except Exception as e:
             log_error(f"Error searching knowledge base: {str(e)}")
             return f"Error searching knowledge base: {e}"
+
+    async def asearch_knowledge(
+        self,
+        run_context: RunContext,
+        query: str,
+        *,
+        agent: Optional[Agent] = None,
+        team: Optional[Team] = None,
+    ) -> str:
+        """Async variant of search_knowledge."""
+        try:
+            log_debug(f"Searching knowledge base: {query}")
+            knowledge = self._resolved(run_context, agent, team)
+            relevant_docs: List[Document] = await knowledge.asearch(query=query)
+            if len(relevant_docs) == 0:
+                return "No documents found"
+            return json.dumps([doc.to_dict() for doc in relevant_docs])
+        except Exception as e:
+            log_error(f"Error searching knowledge base: {str(e)}")
+            return f"Error searching knowledge base: {e}"
+
+    def add_text_to_knowledge(
+        self,
+        run_context: RunContext,
+        name: str,
+        text_content: str,
+        *,
+        agent: Optional[Agent] = None,
+        team: Optional[Team] = None,
+    ) -> str:
+        """Add one bounded text item to this agent's knowledge.
+
+        Args:
+            name: A short, stable name for the content.
+            text_content: The UTF-8 text to add.
+
+        Returns:
+            str: A success message or an error starting with "Error".
+        """
+        try:
+            self._check_name(name)
+            if not text_content:
+                raise ValueError("text_content must not be empty")
+            size_bytes = self._check_content_size(text_content)
+            knowledge = self._resolved(run_context, agent, team)
+            namespace = knowledge.name or "knowledge"
+            content_hash = self._text_content_hash(knowledge, name, text_content, size_bytes)
+            content_id = generate_id(content_hash)
+            expected_documents = self._expected_text_documents(knowledge, name, text_content)
+
+            with self._get_write_lock(namespace):
+                contents, _ = knowledge.get_content()
+                existing = knowledge.get_content_by_id(content_id)
+                projected_bytes = self._check_namespace_quota(contents, existing, size_bytes)
+                knowledge.insert(name=name, text_content=text_content)
+                status, status_message = knowledge.get_content_status(content_id)
+                try:
+                    self._require_completed_insert(status, status_message)
+                except RuntimeError:
+                    self._cleanup_failed_vectors(knowledge, content_id)
+                    raise
+                if knowledge.vector_db is None or not knowledge.vector_db.content_hash_is_indexed(
+                    content_hash, expected_documents
+                ):
+                    message = "knowledge indexing did not produce a searchable vector"
+                    self._cleanup_failed_vectors(knowledge, content_id)
+                    self._mark_insert_failed(knowledge, content_id, message)
+                    raise RuntimeError(message)
+
+            return (
+                f"Added {size_bytes} bytes to knowledge as {name!r} "
+                f"({projected_bytes} of {self.max_namespace_bytes} bytes used)."
+            )
+        except Exception as e:
+            log_error(f"Error adding text to knowledge: {str(e)}")
+            return f"Error adding text to knowledge: {e}"
+
+    async def aadd_text_to_knowledge(
+        self,
+        run_context: RunContext,
+        name: str,
+        text_content: str,
+        *,
+        agent: Optional[Agent] = None,
+        team: Optional[Team] = None,
+    ) -> str:
+        """Async variant of add_text_to_knowledge."""
+        try:
+            self._check_name(name)
+            if not text_content:
+                raise ValueError("text_content must not be empty")
+            size_bytes = self._check_content_size(text_content)
+            knowledge = self._resolved(run_context, agent, team)
+            namespace = knowledge.name or "knowledge"
+            content_hash = self._text_content_hash(knowledge, name, text_content, size_bytes)
+            content_id = generate_id(content_hash)
+            expected_documents = self._expected_text_documents(knowledge, name, text_content)
+
+            async with self._acquire_async_write_lock(namespace):
+                contents, _ = await knowledge.aget_content()
+                existing = await knowledge.aget_content_by_id(content_id)
+                projected_bytes = self._check_namespace_quota(contents, existing, size_bytes)
+                await knowledge.ainsert(name=name, text_content=text_content)
+                status, status_message = await knowledge.aget_content_status(content_id)
+                try:
+                    self._require_completed_insert(status, status_message)
+                except RuntimeError:
+                    await self._acleanup_failed_vectors(knowledge, content_id)
+                    raise
+                indexed = (
+                    await asyncio.to_thread(
+                        knowledge.vector_db.content_hash_is_indexed,
+                        content_hash,
+                        expected_documents,
+                    )
+                    if knowledge.vector_db is not None
+                    else False
+                )
+                if not indexed:
+                    message = "knowledge indexing did not produce a searchable vector"
+                    await self._acleanup_failed_vectors(knowledge, content_id)
+                    await self._amark_insert_failed(knowledge, content_id, message)
+                    raise RuntimeError(message)
+
+            return (
+                f"Added {size_bytes} bytes to knowledge as {name!r} "
+                f"({projected_bytes} of {self.max_namespace_bytes} bytes used)."
+            )
+        except Exception as e:
+            log_error(f"Error adding text to knowledge: {str(e)}")
+            return f"Error adding text to knowledge: {e}"
 
     def analyze(self, run_context: RunContext, analysis: str) -> str:
         """Use this tool to evaluate whether the returned documents are correct and sufficient.
@@ -178,6 +544,13 @@ class KnowledgeTools(Toolkit):
         - When you do provide a final answer to the user, be clear, concise, and accurate.
         - If search results are sparse or contradictory, acknowledge limitations in your response.
         - Synthesize information from multiple sources rather than relying on a single document.\
+    """)
+
+    ADD_INSTRUCTIONS = dedent("""\
+        ## Adding knowledge
+        - Use `add_text_to_knowledge` only when the user asks you to remember or index text.
+        - Give each item a short, stable name and keep it within the tool's byte limit.
+        - Added text is scoped to the current Agent's persistent knowledge namespace.\
     """)
 
     FEW_SHOT_EXAMPLES = dedent("""\

--- a/libs/agno/agno/vectordb/base.py
+++ b/libs/agno/agno/vectordb/base.py
@@ -9,6 +9,11 @@ from agno.utils.string import generate_id
 class VectorDb(ABC):
     """Base class for Vector Databases"""
 
+    # Context-bound KnowledgeTools requires exact metadata filtering on insert,
+    # search, update, and delete. Backends must opt in only after proving that
+    # contract; PgVector is the first supported backend.
+    supports_namespaced_knowledge: bool = False
+
     def __init__(
         self,
         *,
@@ -60,6 +65,14 @@ class VectorDb(ABC):
     @abstractmethod
     def content_hash_exists(self, content_hash: str) -> bool:
         raise NotImplementedError
+
+    def content_hash_is_indexed(self, content_hash: str, expected_count: int = 1) -> bool:
+        """Return whether a content hash has the expected usable index records.
+
+        Backends opting into namespaced knowledge must override this with an
+        exact count. The fallback preserves existing backend behavior.
+        """
+        return expected_count > 0 and self.content_hash_exists(content_hash)
 
     @abstractmethod
     def insert(self, content_hash: str, documents: List[Document], filters: Optional[Dict[str, Any]] = None) -> None:

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -45,6 +45,8 @@ class PgVector(VectorDb):
     vector data in a PostgreSQL database using the pgvector extension.
     """
 
+    supports_namespaced_knowledge: bool = True
+
     def __init__(
         self,
         table_name: str,
@@ -298,6 +300,19 @@ class PgVector(VectorDb):
         """
         return self._record_exists(self.table.c.content_hash, content_hash)
 
+    def content_hash_is_indexed(self, content_hash: str, expected_count: int = 1) -> bool:
+        """Check that a content hash has exactly the expected non-NULL vectors."""
+        try:
+            stmt = select(func.count()).where(
+                self.table.c.content_hash == content_hash,
+                self.table.c.embedding.is_not(None),
+            )
+            with self.Session() as sess:
+                return sess.execute(stmt).scalar_one() == expected_count
+        except Exception as e:
+            log_error(f"Error checking indexed content hash: {str(e)}")
+            return False
+
     def _clean_content(self, content: str) -> str:
         """
         Clean the content by replacing null characters.
@@ -436,7 +451,8 @@ class PgVector(VectorDb):
         """
         try:
             if self.content_hash_exists(content_hash):
-                self._delete_by_content_hash(content_hash)
+                if not self._delete_by_content_hash(content_hash):
+                    raise RuntimeError(f"Could not replace existing content hash: {content_hash}")
             self._upsert(content_hash, documents, filters, batch_size)
         except Exception as e:
             log_error(f"Error upserting documents by content hash: {str(e)}")
@@ -627,7 +643,8 @@ class PgVector(VectorDb):
         """Upsert documents asynchronously by running in a thread."""
         try:
             if self.content_hash_exists(content_hash):
-                self._delete_by_content_hash(content_hash)
+                if not self._delete_by_content_hash(content_hash):
+                    raise RuntimeError(f"Could not replace existing content hash: {content_hash}")
             await self._async_upsert(content_hash, documents, filters, batch_size)
         except Exception as e:
             log_error(f"Error upserting documents by content hash: {str(e)}")

--- a/libs/agno/tests/integration/vector_dbs/test_pgvector_namespaced_knowledge.py
+++ b/libs/agno/tests/integration/vector_dbs/test_pgvector_namespaced_knowledge.py
@@ -1,0 +1,122 @@
+"""Production-backend proof for per-Agent knowledge isolation.
+
+Requires the cookbook PgVector service on localhost:5532. The deterministic
+embedder keeps this test independent of provider credentials.
+"""
+
+import json
+from typing import Dict, List, Optional, Tuple
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+
+pytest.importorskip("pgvector")
+
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.knowledge.embedder.base import Embedder
+from agno.knowledge.knowledge import Knowledge
+from agno.run import RunContext
+from agno.tools.knowledge import KnowledgeTools
+from agno.vectordb.pgvector import PgVector
+
+PG_URL = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+
+def _postgres_reachable() -> bool:
+    engine = create_engine(PG_URL, connect_args={"connect_timeout": 1})
+    try:
+        with engine.connect() as connection:
+            connection.execute(text("SELECT 1"))
+        return True
+    except Exception:
+        return False
+    finally:
+        engine.dispose()
+
+
+pytestmark = pytest.mark.skipif(not _postgres_reachable(), reason="PgVector is not reachable on localhost:5532")
+
+
+class DeterministicEmbedder(Embedder):
+    """Small deterministic embedding for database isolation tests."""
+
+    dimensions: int = 3
+
+    def get_embedding(self, text: str) -> List[float]:
+        return [1.0, 0.0, 0.0]
+
+    def get_embedding_and_usage(self, text: str) -> Tuple[List[float], Optional[Dict]]:
+        return self.get_embedding(text), None
+
+    async def async_get_embedding(self, text: str) -> List[float]:
+        return self.get_embedding(text)
+
+    async def async_get_embedding_and_usage(self, text: str) -> Tuple[List[float], Optional[Dict]]:
+        return self.get_embedding(text), None
+
+
+@pytest.fixture
+def namespaced_knowledge():
+    schema = f"agent_knowledge_test_{uuid4().hex[:12]}"
+    engine = create_engine(PG_URL)
+    vector_db = PgVector(
+        table_name="vectors",
+        schema=schema,
+        db_engine=engine,
+        embedder=DeterministicEmbedder(dimensions=3),
+    )
+    contents_db = PostgresDb(
+        id=f"contents-{schema}",
+        db_engine=engine,
+        db_schema=schema,
+        knowledge_table="contents",
+    )
+    toolkit = KnowledgeTools(
+        name="agent_knowledge",
+        knowledge=Knowledge(vector_db=vector_db, contents_db=contents_db),
+        namespace="corpora/{agent_id}",
+        enable_think=False,
+        enable_analyze=False,
+        enable_add=True,
+    )
+
+    try:
+        yield toolkit
+    finally:
+        vector_db.Session.remove()
+        with engine.begin() as connection:
+            connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        engine.dispose()
+
+
+def test_pgvector_isolates_two_agent_corpora_in_shared_tables(namespaced_knowledge: KnowledgeTools):
+    alpha = Agent(id="alpha", telemetry=False)
+    beta = Agent(id="beta", telemetry=False)
+    run_context = RunContext(run_id="run-1", session_id="session-1")
+
+    for agent, private_text in ((alpha, "alpha secret"), (beta, "beta secret")):
+        assert namespaced_knowledge.add_text_to_knowledge(run_context, "private", private_text, agent=agent).startswith(
+            "Added"
+        )
+        assert namespaced_knowledge.add_text_to_knowledge(
+            run_context, "same", "identical text", agent=agent
+        ).startswith("Added")
+
+    alpha_results = json.loads(namespaced_knowledge.search_knowledge(run_context, "secret", agent=alpha))
+    beta_results = json.loads(namespaced_knowledge.search_knowledge(run_context, "secret", agent=beta))
+    alpha_contents = namespaced_knowledge._resolved(run_context, alpha, None).get_content()[0]
+    beta_contents = namespaced_knowledge._resolved(run_context, beta, None).get_content()[0]
+
+    assert {document["content"] for document in alpha_results} == {"alpha secret", "identical text"}
+    assert {document["content"] for document in beta_results} == {"beta secret", "identical text"}
+    assert {content.id for content in alpha_contents}.isdisjoint({content.id for content in beta_contents})
+    assert {content.name for content in alpha_contents} == {"private", "same"}
+    assert {content.name for content in beta_contents} == {"private", "same"}
+
+    assert namespaced_knowledge.add_text_to_knowledge(run_context, "private", "alpha updated", agent=alpha).startswith(
+        "Added"
+    )
+    alpha_updated = json.loads(namespaced_knowledge.search_knowledge(run_context, "updated", agent=alpha))
+    assert {document["content"] for document in alpha_updated} == {"alpha updated", "identical text"}

--- a/libs/agno/tests/unit/knowledge/test_knowledge_isolation.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_isolation.py
@@ -3,10 +3,13 @@
 Tests that knowledge instances with isolate_vector_search=True filter by linked_to.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import pytest
 
+from agno.db.in_memory import InMemoryDb
+from agno.db.schemas.knowledge import KnowledgeRow
+from agno.knowledge.content import Content, ContentStatus, FileData
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
 from agno.vectordb.base import VectorDb
@@ -18,6 +21,9 @@ class MockVectorDb(VectorDb):
     def __init__(self):
         self.search_calls: List[Dict[str, Any]] = []
         self.inserted_documents: List[Document] = []
+        self.upsert_calls: List[Dict[str, Any]] = []
+        self.updated_metadata: List[Dict[str, Any]] = []
+        self.deleted_content_ids: List[str] = []
 
     def create(self) -> None:
         pass
@@ -44,10 +50,10 @@ class MockVectorDb(VectorDb):
         self.inserted_documents.extend(documents)
 
     def upsert(self, content_hash: str, documents: List[Document], filters=None) -> None:
-        pass
+        self.upsert_calls.append({"content_hash": content_hash, "documents": documents, "filters": filters})
 
     async def async_upsert(self, content_hash: str, documents: List[Document], filters=None) -> None:
-        pass
+        self.upsert_calls.append({"content_hash": content_hash, "documents": documents, "filters": filters})
 
     def upsert_available(self) -> bool:
         return True
@@ -85,13 +91,49 @@ class MockVectorDb(VectorDb):
         return True
 
     def update_metadata(self, content_id: str, metadata: Dict[str, Any]) -> None:
-        pass
+        self.updated_metadata.append({"content_id": content_id, "metadata": metadata})
 
     def delete_by_content_id(self, content_id: str) -> bool:
+        self.deleted_content_ids.append(content_id)
         return True
 
     def get_supported_search_types(self) -> List[str]:
         return ["vector"]
+
+
+def _upsert_content_row(
+    contents_db: InMemoryDb,
+    content_id: str,
+    linked_to: Optional[str],
+    *,
+    name: Optional[str] = None,
+) -> None:
+    contents_db.upsert_knowledge_content(
+        KnowledgeRow(
+            id=content_id,
+            name=name or content_id,
+            description="",
+            metadata={"seed": content_id},
+            linked_to=linked_to,
+            status=ContentStatus.COMPLETED,
+        )
+    )
+
+
+def _build_isolated_knowledge() -> tuple[Knowledge, InMemoryDb, MockVectorDb]:
+    contents_db = InMemoryDb()
+    vector_db = MockVectorDb()
+    _upsert_content_row(contents_db, "owned", "scope-a")
+    _upsert_content_row(contents_db, "foreign", "scope-b")
+    _upsert_content_row(contents_db, "legacy", None)
+    knowledge = Knowledge(
+        name="scope-a",
+        contents_db=contents_db,
+        vector_db=vector_db,
+        isolate_vector_search=True,
+    )
+    knowledge._enforce_content_isolation = True
+    return knowledge, contents_db, vector_db
 
 
 class TestKnowledgeIsolation:
@@ -289,3 +331,194 @@ class TestLinkedToMetadata:
 
         # The knowledge's name should override since we set it after metadata merge
         assert result[0].meta_data["linked_to"] == "New KB"
+
+
+class TestSharedTableIsolationHardening:
+    def test_isolated_namespaces_have_distinct_content_and_document_hashes(self):
+        vector_db = MockVectorDb()
+        scope_a = Knowledge(name="scope-a", vector_db=vector_db, isolate_vector_search=True)
+        scope_b = Knowledge(name="scope-b", vector_db=vector_db, isolate_vector_search=True)
+        scope_a._enforce_content_isolation = True
+        scope_b._enforce_content_isolation = True
+        unisolated_a = Knowledge(name="scope-a", vector_db=vector_db)
+        unisolated_b = Knowledge(name="scope-b", vector_db=vector_db)
+        content = Content(url="https://example.com/docs")
+        document = Document(content="same text", meta_data={"url": "https://example.com/docs/page"})
+
+        assert scope_a._build_content_hash(content) != scope_b._build_content_hash(content)
+        assert scope_a._build_document_content_hash(document, content) != scope_b._build_document_content_hash(
+            document, content
+        )
+        assert unisolated_a._build_content_hash(content) == unisolated_b._build_content_hash(content)
+        assert unisolated_a._build_document_content_hash(
+            document, content
+        ) == unisolated_b._build_document_content_hash(document, content)
+
+    def test_isolated_vector_metadata_reserves_linked_to(self):
+        vector_db = MockVectorDb()
+        knowledge = Knowledge(name="scope-a", vector_db=vector_db, isolate_vector_search=True)
+        knowledge._enforce_content_isolation = True
+        content = Content(
+            id="content-id",
+            content_hash="content-hash",
+            metadata={"category": "docs", "linked_to": "scope-b"},
+        )
+        documents = [Document(content="content", meta_data={"linked_to": "scope-b"})]
+
+        knowledge._prepare_documents_for_insert(documents, "content-id", metadata=content.metadata)
+        knowledge._handle_vector_db_insert(content, documents, upsert=True)
+
+        assert documents[0].meta_data["linked_to"] == "scope-a"
+        assert vector_db.upsert_calls[0]["filters"] == {"category": "docs", "linked_to": "scope-a"}
+
+    def test_unisolated_vector_metadata_is_unchanged(self):
+        vector_db = MockVectorDb()
+        knowledge = Knowledge(name="scope-a", vector_db=vector_db)
+        content = Content(
+            id="content-id",
+            content_hash="content-hash",
+            metadata={"category": "docs", "linked_to": "scope-b"},
+        )
+
+        knowledge._handle_vector_db_insert(content, [Document(content="content")], upsert=True)
+
+        assert vector_db.upsert_calls[0]["filters"] == {"category": "docs", "linked_to": "scope-b"}
+
+    def test_text_content_size_uses_utf8_bytes(self, monkeypatch):
+        knowledge = Knowledge(vector_db=MockVectorDb())
+        knowledge._enforce_content_isolation = True
+        captured: Dict[str, Content] = {}
+
+        def capture_content(content: Content, *args, **kwargs) -> None:
+            captured["content"] = content
+
+        monkeypatch.setattr(knowledge, "_load_content", capture_content)
+        knowledge.insert(text_content="café")
+
+        content = captured["content"]
+        assert content.file_data == FileData(content="café", type="Text", size=5)
+        assert knowledge._build_knowledge_row(content).size == 5
+
+    def test_static_knowledge_preserves_legacy_character_size(self, monkeypatch):
+        knowledge = Knowledge(vector_db=MockVectorDb())
+        captured: Dict[str, Content] = {}
+
+        def capture_content(content: Content, *args, **kwargs) -> None:
+            captured["content"] = content
+
+        monkeypatch.setattr(knowledge, "_load_content", capture_content)
+        knowledge.insert(text_content="café")
+
+        content = captured["content"]
+        assert content.file_data == FileData(content="café", type="Text")
+        assert knowledge._build_knowledge_row(content).size == 4
+
+    def test_sync_content_id_operations_fail_closed_outside_namespace(self):
+        knowledge, contents_db, vector_db = _build_isolated_knowledge()
+
+        assert knowledge.get_content_by_id("owned") is not None
+        assert knowledge.get_content_by_id("foreign") is None
+        assert knowledge.get_content_by_id("legacy") is None
+        assert knowledge.get_content_status("owned") == (ContentStatus.COMPLETED, None)
+        assert knowledge.get_content_status("foreign") == (None, "Content not found")
+        assert knowledge.get_content_status("legacy") == (None, "Content not found")
+
+        assert knowledge.patch_content(Content(id="foreign", name="changed")) is None
+        assert knowledge.patch_content(Content(id="legacy", name="changed")) is None
+        assert contents_db.get_knowledge_content("foreign").name == "foreign"  # type: ignore[union-attr]
+        assert contents_db.get_knowledge_content("legacy").name == "legacy"  # type: ignore[union-attr]
+        assert vector_db.updated_metadata == []
+
+        updated = knowledge.patch_content(Content(id="owned", metadata={"category": "updated", "linked_to": "scope-b"}))
+        assert updated is not None
+        owned_row = contents_db.get_knowledge_content("owned")
+        assert owned_row is not None
+        assert owned_row.linked_to == "scope-a"
+        assert owned_row.metadata == {"seed": "owned", "category": "updated"}
+        assert vector_db.updated_metadata == [
+            {
+                "content_id": "owned",
+                "metadata": {"category": "updated", "linked_to": "scope-a"},
+            }
+        ]
+
+        knowledge.remove_content_by_id("foreign")
+        knowledge.remove_content_by_id("legacy")
+        assert contents_db.get_knowledge_content("foreign") is not None
+        assert contents_db.get_knowledge_content("legacy") is not None
+        assert vector_db.deleted_content_ids == []
+
+        knowledge.remove_content_by_id("owned")
+        assert contents_db.get_knowledge_content("owned") is None
+        assert vector_db.deleted_content_ids == ["owned"]
+
+    @pytest.mark.asyncio
+    async def test_async_content_id_operations_fail_closed_outside_namespace(self):
+        knowledge, contents_db, vector_db = _build_isolated_knowledge()
+
+        assert await knowledge.aget_content_by_id("foreign") is None
+        assert await knowledge.aget_content_by_id("legacy") is None
+        assert await knowledge.aget_content_status("foreign") == (None, "Content not found")
+        assert await knowledge.aget_content_status("legacy") == (None, "Content not found")
+        assert await knowledge.apatch_content(Content(id="foreign", name="changed")) is None
+        assert await knowledge.apatch_content(Content(id="legacy", name="changed")) is None
+
+        updated = await knowledge.apatch_content(Content(id="owned", name="updated"))
+        assert updated is not None
+        assert contents_db.get_knowledge_content("owned").name == "updated"  # type: ignore[union-attr]
+
+        await knowledge.aremove_content_by_id("foreign")
+        await knowledge.aremove_content_by_id("legacy")
+        assert contents_db.get_knowledge_content("foreign") is not None
+        assert contents_db.get_knowledge_content("legacy") is not None
+        assert vector_db.deleted_content_ids == []
+
+        await knowledge.aremove_content_by_id("owned")
+        assert contents_db.get_knowledge_content("owned") is None
+        assert vector_db.deleted_content_ids == ["owned"]
+
+    @pytest.mark.asyncio
+    async def test_content_id_operations_preserve_unisolated_behavior(self):
+        contents_db = InMemoryDb()
+        vector_db = MockVectorDb()
+        _upsert_content_row(contents_db, "foreign", "scope-b")
+        _upsert_content_row(contents_db, "legacy", None)
+        knowledge = Knowledge(name="scope-a", contents_db=contents_db, vector_db=vector_db)
+
+        assert knowledge.get_content_by_id("foreign") is not None
+        assert await knowledge.aget_content_by_id("legacy") is not None
+        assert knowledge.get_content_status("legacy") == (ContentStatus.COMPLETED, None)
+        assert await knowledge.aget_content_status("foreign") == (ContentStatus.COMPLETED, None)
+        assert knowledge.patch_content(Content(id="foreign", name="sync-updated")) is not None
+        assert await knowledge.apatch_content(Content(id="legacy", name="async-updated")) is not None
+
+        knowledge.remove_content_by_id("foreign")
+        await knowledge.aremove_content_by_id("legacy")
+        assert contents_db.get_knowledge_content("foreign") is None
+        assert contents_db.get_knowledge_content("legacy") is None
+        assert vector_db.deleted_content_ids == ["foreign", "legacy"]
+
+    def test_isolated_delete_without_contents_db_fails_closed(self):
+        vector_db = MockVectorDb()
+        knowledge = Knowledge(name="scope-a", vector_db=vector_db, isolate_vector_search=True)
+        knowledge._enforce_content_isolation = True
+
+        knowledge.remove_content_by_id("unknown")
+
+        assert vector_db.deleted_content_ids == []
+
+    def test_existing_vector_isolation_keeps_legacy_content_ids_and_crud_semantics(self):
+        contents_db = InMemoryDb()
+        vector_db = MockVectorDb()
+        _upsert_content_row(contents_db, "foreign", "scope-b")
+        scope_a = Knowledge(
+            name="scope-a",
+            contents_db=contents_db,
+            vector_db=vector_db,
+            isolate_vector_search=True,
+        )
+        scope_b = Knowledge(name="scope-b", vector_db=vector_db, isolate_vector_search=True)
+        content = Content(url="https://example.com/docs")
+
+        assert scope_a._build_content_hash(content) == scope_b._build_content_hash(content)
+        assert scope_a.get_content_by_id("foreign") is not None

--- a/libs/agno/tests/unit/os/routers/test_registry_router.py
+++ b/libs/agno/tests/unit/os/routers/test_registry_router.py
@@ -56,6 +56,32 @@ def _create_mock_model_class():
     return type("MockModel", (Model,), abstract_methods)
 
 
+class _BackingContentsDb:
+    pass
+
+
+class _BackingVectorDb:
+    pass
+
+
+class _BackingKnowledge:
+    def __init__(self):
+        self.contents_db = _BackingContentsDb()
+        self.vector_db = _BackingVectorDb()
+
+
+class _TemplatedKnowledgeToolkit(Toolkit):
+    """KnowledgeTools-like shape proving registry metadata stays generic."""
+
+    def __init__(self):
+        super().__init__(name="agent_knowledge", tools=[])
+        self.namespace = "agent-knowledge/{agent_id}"
+        self.template_placeholders = ("agent_id",)
+        self.max_content_bytes = 1_000_000
+        self.max_namespace_bytes = 20_000_000
+        self.knowledge = _BackingKnowledge()
+
+
 @pytest.fixture
 def settings():
     """Create test settings with auth disabled (no security key = auth disabled)."""
@@ -211,6 +237,33 @@ class TestListRegistryWithTools:
         assert len(tools) >= 1
         tool_names = [t["name"] for t in tools]
         assert "simple_function" in tool_names
+
+    def test_templated_knowledge_toolkit_metadata(self, settings):
+        """Template/backing metadata is exposed without a global knowledge resource."""
+        toolkit = _TemplatedKnowledgeToolkit()
+        registry = Registry(tools=[toolkit])
+
+        app = FastAPI()
+        router = get_registry_router(registry=registry, settings=settings)
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.get("/registry")
+
+        assert response.status_code == 200
+        data = response.json()
+        tools = [resource for resource in data["data"] if resource["type"] == "tool"]
+        assert len(tools) == 1
+        metadata = tools[0]["metadata"]
+        assert metadata["namespace_template"] == "agent-knowledge/{agent_id}"
+        assert metadata["template_placeholders"] == ["agent_id"]
+        assert metadata["is_templated"] is True
+        assert metadata["knowledge_class"] == f"{_BackingKnowledge.__module__}.{_BackingKnowledge.__name__}"
+        assert metadata["contents_db_class"] == f"{_BackingContentsDb.__module__}.{_BackingContentsDb.__name__}"
+        assert metadata["vector_db_class"] == f"{_BackingVectorDb.__module__}.{_BackingVectorDb.__name__}"
+        assert metadata["max_content_bytes"] == 1_000_000
+        assert metadata["max_namespace_bytes"] == 20_000_000
+        assert not [resource for resource in data["data"] if resource["type"] == "knowledge"]
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/os/test_registry_population.py
+++ b/libs/agno/tests/unit/os/test_registry_population.py
@@ -53,6 +53,16 @@ def _model(model_id, provider="openai"):
     return model
 
 
+class _KnowledgeOwningToolkit(Toolkit):
+    """Generic toolkit shape used to prove discovery is attribute-based."""
+
+    def __init__(self, knowledge: Knowledge):
+        self.knowledge = knowledge
+        self.namespace = "agent-knowledge/{agent_id}"
+        self.template_placeholders = ("agent_id",)
+        super().__init__(name="context_bound_knowledge", tools=[])
+
+
 # =============================================================================
 # _populate_registry_managers()
 # =============================================================================
@@ -299,6 +309,66 @@ class TestPopulateRegistryComponentsAgents:
         os = AgentOS(agents=[agent], telemetry=False)
 
         assert vector_db in os.registry.vector_dbs
+
+
+class TestPopulateRegistryComponentsToolkitKnowledge:
+    """Registered toolkit knowledge contributes backings, not global routes."""
+
+    def test_backings_collected_without_registering_global_knowledge(self, tmp_path):
+        vector_db = _mock_vector_db_class()()
+        contents_db = SqliteDb(db_file=str(tmp_path / "toolkit-kb.db"), id="toolkit-kb")
+        knowledge = Knowledge(name="Unresolved template backing", contents_db=contents_db, vector_db=vector_db)
+        toolkit = _KnowledgeOwningToolkit(knowledge)
+        registry = Registry(tools=[toolkit])
+
+        os = AgentOS(
+            agents=[Agent(name="Studio host", id="studio-host", telemetry=False)], registry=registry, telemetry=False
+        )
+
+        assert contents_db in os.registry.dbs
+        assert vector_db in os.registry.vector_dbs
+        assert os.registry.knowledge == []
+        assert os.knowledge_instances == []
+
+        # Re-running global knowledge discovery must not surface toolkit-owned
+        # knowledge through /knowledge routes.
+        os._auto_discover_knowledge_instances()
+        assert os.registry.knowledge == []
+        assert os.knowledge_instances == []
+
+    def test_contents_db_is_discovered_and_initialized_at_boot(self, tmp_path, monkeypatch):
+        contents_db = SqliteDb(db_file=str(tmp_path / "toolkit-kb.db"), id="toolkit-kb")
+        create_tables = MagicMock()
+        monkeypatch.setattr(contents_db, "_create_all_tables", create_tables)
+        knowledge = Knowledge(name="Unresolved template backing", contents_db=contents_db, vector_db=MagicMock())
+        registry = Registry(tools=[_KnowledgeOwningToolkit(knowledge)])
+        os = AgentOS(
+            agents=[Agent(name="Studio host", id="studio-host", telemetry=False)], registry=registry, telemetry=False
+        )
+
+        os._auto_discover_databases()
+
+        assert os.knowledge_dbs[contents_db.id] == [contents_db]
+        os._initialize_sync_databases()
+        create_tables.assert_called_once_with()
+
+    def test_static_toolkit_knowledge_is_not_newly_auto_registered(self, tmp_path):
+        vector_db = _mock_vector_db_class()()
+        contents_db = SqliteDb(db_file=str(tmp_path / "static-toolkit-kb.db"), id="static-toolkit-kb")
+        toolkit = _KnowledgeOwningToolkit(
+            Knowledge(name="Static toolkit knowledge", contents_db=contents_db, vector_db=vector_db)
+        )
+        toolkit.namespace = None
+        registry = Registry(tools=[toolkit])
+
+        os = AgentOS(
+            agents=[Agent(name="Studio host", id="studio-host", telemetry=False)], registry=registry, telemetry=False
+        )
+        os._auto_discover_databases()
+
+        assert contents_db not in os.registry.dbs
+        assert vector_db not in os.registry.vector_dbs
+        assert contents_db.id not in os.knowledge_dbs
 
 
 class TestPopulateRegistryComponentsDedup:

--- a/libs/agno/tests/unit/tools/test_knowledge_tools.py
+++ b/libs/agno/tests/unit/tools/test_knowledge_tools.py
@@ -1,0 +1,774 @@
+"""Tests for per-call KnowledgeTools namespace isolation."""
+
+import asyncio
+import time
+from copy import deepcopy
+from threading import Lock
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from agno.agent import Agent
+from agno.agent._tools import determine_tools_for_model
+from agno.db.in_memory import InMemoryDb
+from agno.db.sqlite import SqliteDb
+from agno.fs.errors import InvalidPathError
+from agno.knowledge.content import ContentStatus
+from agno.knowledge.document import Document
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
+from agno.registry import Registry
+from agno.run import RunContext
+from agno.run.agent import RunOutput
+from agno.session import AgentSession
+from agno.tools.function import Function, FunctionCall
+from agno.tools.knowledge import KnowledgeTools
+from agno.tools.studio import StudioTools
+from agno.vectordb.base import VectorDb
+
+
+class MemoryVectorDb(VectorDb):
+    """Small shared vector store that enforces metadata filters."""
+
+    supports_namespaced_knowledge = True
+
+    def __init__(self):
+        super().__init__(name="memory-vector-db")
+        self.records: List[tuple[str, Document]] = []
+        self._lock = Lock()
+
+    def create(self) -> None:
+        pass
+
+    async def async_create(self) -> None:
+        pass
+
+    def name_exists(self, name: str) -> bool:
+        return any(document.name == name for _, document in self.records)
+
+    async def async_name_exists(self, name: str) -> bool:
+        return self.name_exists(name)
+
+    def id_exists(self, id: str) -> bool:
+        return any(document.id == id for _, document in self.records)
+
+    def content_hash_exists(self, content_hash: str) -> bool:
+        return any(stored_hash == content_hash for stored_hash, _ in self.records)
+
+    def content_hash_is_indexed(self, content_hash: str, expected_count: int = 1) -> bool:
+        return sum(stored_hash == content_hash for stored_hash, _ in self.records) == expected_count
+
+    def insert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        with self._lock:
+            for document in documents:
+                stored = deepcopy(document)
+                if filters:
+                    stored.meta_data.update(filters)
+                self.records.append((content_hash, stored))
+
+    async def async_insert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.insert(content_hash, documents, filters)
+
+    def upsert_available(self) -> bool:
+        return True
+
+    def upsert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        with self._lock:
+            self.records = [(h, d) for h, d in self.records if h != content_hash]
+        self.insert(content_hash, documents, filters)
+
+    async def async_upsert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.upsert(content_hash, documents, filters)
+
+    def search(self, query: str, limit: int = 5, filters: Optional[Any] = None) -> List[Document]:
+        matches: List[Document] = []
+        for _, document in self.records:
+            if query.lower() not in (document.content or "").lower():
+                continue
+            if isinstance(filters, dict) and any(
+                document.meta_data.get(key) != value for key, value in filters.items()
+            ):
+                continue
+            matches.append(deepcopy(document))
+        return matches[:limit]
+
+    async def async_search(self, query: str, limit: int = 5, filters: Optional[Any] = None) -> List[Document]:
+        return self.search(query, limit, filters)
+
+    def drop(self) -> None:
+        self.records = []
+
+    async def async_drop(self) -> None:
+        self.drop()
+
+    def exists(self) -> bool:
+        return True
+
+    async def async_exists(self) -> bool:
+        return True
+
+    def delete(self) -> bool:
+        self.drop()
+        return True
+
+    def delete_by_id(self, id: str) -> bool:
+        before = len(self.records)
+        self.records = [(h, d) for h, d in self.records if d.id != id]
+        return len(self.records) != before
+
+    def delete_by_name(self, name: str) -> bool:
+        before = len(self.records)
+        self.records = [(h, d) for h, d in self.records if d.name != name]
+        return len(self.records) != before
+
+    def delete_by_metadata(self, metadata: Dict[str, Any]) -> bool:
+        before = len(self.records)
+        self.records = [
+            (h, d) for h, d in self.records if not all(d.meta_data.get(key) == value for key, value in metadata.items())
+        ]
+        return len(self.records) != before
+
+    def update_metadata(self, content_id: str, metadata: Dict[str, Any]) -> None:
+        for _, document in self.records:
+            if document.content_id == content_id:
+                document.meta_data.update(metadata)
+
+    def delete_by_content_id(self, content_id: str) -> bool:
+        before = len(self.records)
+        self.records = [(h, d) for h, d in self.records if d.content_id != content_id]
+        return len(self.records) != before
+
+    def get_supported_search_types(self) -> List[str]:
+        return ["vector"]
+
+
+class SlowKnowledge(Knowledge):
+    """Expose quota races by pausing after each namespace snapshot."""
+
+    def get_content(self, *args, **kwargs):
+        result = super().get_content(*args, **kwargs)
+        time.sleep(0.05)
+        return result
+
+    async def aget_content(self, *args, **kwargs):
+        result = await super().aget_content(*args, **kwargs)
+        await asyncio.sleep(0.05)
+        return result
+
+
+class FailingVectorDb(MemoryVectorDb):
+    """Vector store that can expose swallowed indexing failures."""
+
+    def __init__(self):
+        super().__init__()
+        self.fail = True
+
+    def upsert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if self.fail:
+            raise RuntimeError("index unavailable")
+        super().upsert(content_hash, documents, filters)
+
+    async def async_upsert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if self.fail:
+            raise RuntimeError("index unavailable")
+        await super().async_upsert(content_hash, documents, filters)
+
+
+class SilentFailVectorDb(MemoryVectorDb):
+    """Vector store that swallows writes without creating an index record."""
+
+    def __init__(self):
+        super().__init__()
+        self.fail = True
+
+    def upsert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if not self.fail:
+            super().upsert(content_hash, documents, filters)
+
+    async def async_upsert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if not self.fail:
+            await super().async_upsert(content_hash, documents, filters)
+
+
+class PartialVectorDb(MemoryVectorDb):
+    """Vector store that silently indexes only the first text chunk."""
+
+    def upsert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().upsert(content_hash, documents[:1], filters)
+
+    async def async_upsert(
+        self,
+        content_hash: str,
+        documents: List[Document],
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.upsert(content_hash, documents, filters)
+
+
+class VerificationFailVectorDb(MemoryVectorDb):
+    """Vector store that commits a vector but cannot verify it afterward."""
+
+    def __init__(self):
+        super().__init__()
+        self.fail_verification = True
+        self.cleaned_content_ids: List[str] = []
+
+    def content_hash_is_indexed(self, content_hash: str, expected_count: int = 1) -> bool:
+        if self.fail_verification:
+            return False
+        return super().content_hash_is_indexed(content_hash, expected_count)
+
+    def delete_by_content_id(self, content_id: str) -> bool:
+        self.cleaned_content_ids.append(content_id)
+        super().delete_by_content_id(content_id)
+        return True
+
+
+@pytest.fixture
+def knowledge_stack():
+    vector_db = MemoryVectorDb()
+    vector_db.embedder = OpenAIEmbedder()
+    contents_db = InMemoryDb()
+    knowledge = Knowledge(name="Registry knowledge", vector_db=vector_db, contents_db=contents_db)
+    toolkit = KnowledgeTools(
+        name="agent_knowledge",
+        knowledge=knowledge,
+        namespace="corpora/{agent_id}",
+        enable_think=False,
+        enable_analyze=False,
+        enable_add=True,
+    )
+    return toolkit, knowledge, vector_db, contents_db
+
+
+def _context() -> RunContext:
+    return RunContext(run_id="run-1", session_id="session-1")
+
+
+class TestNamespaceResolution:
+    def test_resolves_fresh_view_without_mutating_template(self, knowledge_stack):
+        toolkit, knowledge, vector_db, contents_db = knowledge_stack
+        alpha = Agent(id="Alpha", name="Alpha", telemetry=False)
+
+        resolved = toolkit._resolved(_context(), alpha, None)
+
+        assert resolved is not knowledge
+        assert resolved.name == "corpora/alpha"
+        assert resolved.isolate_vector_search is True
+        assert resolved.vector_db is vector_db
+        assert resolved.contents_db is contents_db
+        assert resolved.vector_db.embedder is vector_db.embedder
+        assert resolved.vector_db.embedder.api_key is None
+        assert resolved._enforce_content_isolation is True
+        assert knowledge.name == "Registry knowledge"
+        assert knowledge.isolate_vector_search is False
+        assert knowledge._enforce_content_isolation is False
+
+    def test_missing_agent_context_fails_closed(self, knowledge_stack):
+        toolkit, _, _, _ = knowledge_stack
+
+        result = toolkit.search_knowledge(_context(), "anything")
+
+        assert (
+            result
+            == "Error searching knowledge base: this agent's knowledge requires agent_id for this run and none was provided."
+        )
+
+    @pytest.mark.parametrize("spoofed_agent", [{"id": "victim"}, "victim"])
+    def test_spoofed_json_identity_fails_closed_through_hook_path(self, knowledge_stack, spoofed_agent):
+        toolkit, _, _, _ = knowledge_stack
+        function = toolkit.functions["search_knowledge"]
+        function.process_entrypoint()
+        function._agent = Agent(id="real-agent", name="Real", telemetry=False)
+        function._run_context = _context()
+
+        def passthrough(function_name, function_call, arguments):
+            return function_call(**arguments)
+
+        function.tool_hooks = [passthrough]
+        call = FunctionCall(
+            function=function,
+            arguments={"query": "anything", "agent": spoofed_agent},
+        )
+
+        result = call.execute()
+
+        assert result.status == "success"
+        assert result.result == (
+            "Error searching knowledge base: this agent's knowledge requires agent_id for this run and none was provided."
+        )
+
+    def test_spoof_without_hooks_fails_before_entrypoint(self, knowledge_stack):
+        toolkit, _, _, _ = knowledge_stack
+        function = toolkit.functions["search_knowledge"]
+        function.process_entrypoint()
+        function._agent = Agent(id="real-agent", telemetry=False)
+        function._run_context = _context()
+
+        result = FunctionCall(
+            function=function,
+            arguments={"query": "anything", "agent": {"id": "victim"}},
+        ).execute()
+
+        assert result.status == "failure"
+        assert "multiple values for keyword argument 'agent'" in result.error
+
+    def test_write_identity_spoof_fails_closed_without_writing(self, knowledge_stack):
+        toolkit, _, _, contents_db = knowledge_stack
+        function = toolkit.functions["add_text_to_knowledge"]
+        function.process_entrypoint()
+        function._agent = Agent(id="real-agent", telemetry=False)
+        function._run_context = _context()
+
+        def passthrough(function_name, function_call, arguments):
+            return function_call(**arguments)
+
+        function.tool_hooks = [passthrough]
+        result = FunctionCall(
+            function=function,
+            arguments={
+                "name": "spoofed",
+                "text_content": "victim secret",
+                "agent": {"id": "victim"},
+            },
+        ).execute()
+
+        assert result.status == "success"
+        assert result.result == (
+            "Error adding text to knowledge: this agent's knowledge requires agent_id for this run and none was provided."
+        )
+        assert contents_db._knowledge == []
+
+    def test_invalid_template_is_rejected(self):
+        knowledge = Knowledge(name="K", vector_db=MemoryVectorDb(), contents_db=InMemoryDb())
+
+        with pytest.raises(InvalidPathError, match="unknown placeholder"):
+            KnowledgeTools(knowledge=knowledge, namespace="corpora/{tenant_id}")
+
+    @pytest.mark.parametrize("namespace", ["corpora/static", "corpora/{user_id}", "corpora/{team_id}"])
+    def test_v1_namespace_requires_exactly_agent_id(self, namespace):
+        knowledge = Knowledge(name="K", vector_db=MemoryVectorDb(), contents_db=InMemoryDb())
+
+        with pytest.raises(ValueError, match=r"exactly one \{agent_id\}"):
+            KnowledgeTools(knowledge=knowledge, namespace=namespace)
+
+    def test_namespaced_toolkit_rejects_unsupported_vector_database(self):
+        vector_db = MemoryVectorDb()
+        vector_db.supports_namespaced_knowledge = False
+        knowledge = Knowledge(name="K", vector_db=vector_db, contents_db=InMemoryDb())
+
+        with pytest.raises(ValueError, match="PgVector is currently supported"):
+            KnowledgeTools(knowledge=knowledge, namespace="corpora/{agent_id}")
+
+    def test_static_toolkit_keeps_existing_sync_search_registration(self):
+        toolkit = KnowledgeTools(
+            knowledge=Knowledge(name="K", vector_db=MemoryVectorDb()),
+            enable_think=False,
+            enable_analyze=False,
+        )
+
+        assert "search_knowledge" in toolkit.functions
+        assert "search_knowledge" not in toolkit.async_functions
+
+    def test_legacy_positional_constructor_order_is_preserved(self):
+        knowledge = Knowledge(name="K", vector_db=MemoryVectorDb())
+
+        toolkit = KnowledgeTools(knowledge, False, True, False, "legacy instructions", False, False, None, False)
+
+        assert toolkit.knowledge is knowledge
+        assert set(toolkit.functions) == {"search_knowledge"}
+        assert toolkit.instructions == "legacy instructions"
+        assert toolkit.namespace is None
+
+    def test_add_tool_requires_agent_namespace(self):
+        knowledge = Knowledge(name="K", vector_db=MemoryVectorDb(), contents_db=InMemoryDb())
+
+        with pytest.raises(ValueError, match="requires an agent namespace"):
+            KnowledgeTools(knowledge=knowledge, enable_add=True)
+
+    def test_runtime_parameters_are_hidden_from_tool_schemas(self, knowledge_stack):
+        toolkit, _, _, _ = knowledge_stack
+
+        for functions in (toolkit.functions, toolkit.async_functions):
+            for name in ("search_knowledge", "add_text_to_knowledge"):
+                function = functions[name]
+                function.process_entrypoint()
+                properties = function.parameters["properties"]
+                assert "agent" not in properties
+                assert "team" not in properties
+                assert "run_context" not in properties
+        assert set(toolkit.functions["search_knowledge"].parameters["properties"]) == {"query"}
+        assert set(toolkit.functions["add_text_to_knowledge"].parameters["properties"]) == {
+            "name",
+            "text_content",
+        }
+
+
+class TestIsolation:
+    def test_two_agents_share_one_store_without_sharing_corpora(self, knowledge_stack):
+        toolkit, knowledge, vector_db, contents_db = knowledge_stack
+        alpha = Agent(id="alpha", name="Alpha", telemetry=False)
+        beta = Agent(id="beta", name="Beta", telemetry=False)
+
+        assert toolkit.add_text_to_knowledge(_context(), "private", "alpha secret", agent=alpha).startswith("Added")
+        assert toolkit.add_text_to_knowledge(_context(), "private", "beta secret", agent=beta).startswith("Added")
+
+        assert "alpha secret" in toolkit.search_knowledge(_context(), "secret", agent=alpha)
+        assert "beta secret" not in toolkit.search_knowledge(_context(), "secret", agent=alpha)
+        assert "beta secret" in toolkit.search_knowledge(_context(), "secret", agent=beta)
+        assert "alpha secret" not in toolkit.search_knowledge(_context(), "secret", agent=beta)
+        assert knowledge.name == "Registry knowledge"
+        assert len(vector_db.records) == 2
+        assert {row["linked_to"] for row in contents_db._knowledge} == {"corpora/alpha", "corpora/beta"}
+
+    def test_identical_content_has_distinct_ids_per_agent(self, knowledge_stack):
+        toolkit, _, vector_db, contents_db = knowledge_stack
+        alpha = Agent(id="alpha", name="Alpha", telemetry=False)
+        beta = Agent(id="beta", name="Beta", telemetry=False)
+
+        toolkit.add_text_to_knowledge(_context(), "same", "identical text", agent=alpha)
+        toolkit.add_text_to_knowledge(_context(), "same", "identical text", agent=beta)
+
+        assert len(contents_db._knowledge) == 2
+        assert len({row["id"] for row in contents_db._knowledge}) == 2
+        assert len(vector_db.records) == 2
+        assert len({content_hash for content_hash, _ in vector_db.records}) == 2
+
+    @pytest.mark.asyncio
+    async def test_async_add_and_search_are_isolated(self, knowledge_stack):
+        toolkit, _, _, _ = knowledge_stack
+        alpha = Agent(id="alpha", name="Alpha", telemetry=False)
+        beta = Agent(id="beta", name="Beta", telemetry=False)
+
+        assert (await toolkit.aadd_text_to_knowledge(_context(), "async", "alpha async", agent=alpha)).startswith(
+            "Added"
+        )
+
+        assert "alpha async" in await toolkit.asearch_knowledge(_context(), "async", agent=alpha)
+        assert await toolkit.asearch_knowledge(_context(), "async", agent=beta) == "No documents found"
+
+
+class TestQuotas:
+    def test_invalid_utf8_fails_before_creating_content(self, knowledge_stack):
+        toolkit, _, _, contents_db = knowledge_stack
+        agent = Agent(id="alpha", telemetry=False)
+
+        result = toolkit.add_text_to_knowledge(_context(), "invalid", "\ud800", agent=agent)
+
+        assert result.startswith("Error adding text to knowledge:")
+        assert "surrogates not allowed" in result
+        assert contents_db._knowledge == []
+
+    @pytest.mark.parametrize(
+        ("name", "error"),
+        [
+            ("x" * 256, "limit 255 bytes"),
+            ("line\nbreak", "control characters"),
+        ],
+    )
+    def test_name_caps_fail_before_creating_content(self, knowledge_stack, name, error):
+        toolkit, _, _, contents_db = knowledge_stack
+        agent = Agent(id="alpha", telemetry=False)
+
+        result = toolkit.add_text_to_knowledge(_context(), name, "text", agent=agent)
+
+        assert error in result
+        assert contents_db._knowledge == []
+
+    @pytest.mark.parametrize("is_async", [False, True])
+    @pytest.mark.asyncio
+    async def test_partial_chunk_indexing_is_reported_and_cleaned(self, is_async):
+        vector_db = PartialVectorDb()
+        toolkit = KnowledgeTools(
+            knowledge=Knowledge(name="K", vector_db=vector_db, contents_db=InMemoryDb()),
+            namespace="corpora/{agent_id}",
+            enable_think=False,
+            enable_analyze=False,
+            enable_add=True,
+            max_content_bytes=6_000,
+            max_namespace_bytes=6_000,
+        )
+        agent = Agent(id="alpha", telemetry=False)
+        text_content = "x" * 6_000
+
+        if is_async:
+            result = await toolkit.aadd_text_to_knowledge(_context(), "partial", text_content, agent=agent)
+        else:
+            result = await asyncio.to_thread(
+                toolkit.add_text_to_knowledge,
+                _context(),
+                "partial",
+                text_content,
+                agent=agent,
+            )
+
+        assert result == "Error adding text to knowledge: knowledge indexing did not produce a searchable vector"
+        assert vector_db.records == []
+
+    def test_failed_post_check_cleans_committed_vectors_and_reserves_quota(self):
+        vector_db = VerificationFailVectorDb()
+        toolkit = KnowledgeTools(
+            knowledge=Knowledge(name="K", vector_db=vector_db, contents_db=InMemoryDb()),
+            namespace="corpora/{agent_id}",
+            enable_think=False,
+            enable_analyze=False,
+            enable_add=True,
+            max_content_bytes=1,
+            max_namespace_bytes=1,
+        )
+        agent = Agent(id="alpha", telemetry=False)
+
+        failed = toolkit.add_text_to_knowledge(_context(), "item", "x", agent=agent)
+        different_name = toolkit.add_text_to_knowledge(_context(), "other", "y", agent=agent)
+        vector_db.fail_verification = False
+        recovered = toolkit.add_text_to_knowledge(_context(), "item", "y", agent=agent)
+
+        assert failed == "Error adding text to knowledge: knowledge indexing did not produce a searchable vector"
+        assert vector_db.cleaned_content_ids
+        assert len(vector_db.records) == 1
+        assert "knowledge is full" in different_name
+        assert recovered.startswith("Added 1 bytes")
+
+    @pytest.mark.parametrize("is_async", [False, True])
+    @pytest.mark.asyncio
+    async def test_silent_indexing_failure_is_reported_and_allows_same_name_retry(self, is_async):
+        vector_db = SilentFailVectorDb()
+        toolkit = KnowledgeTools(
+            knowledge=Knowledge(name="K", vector_db=vector_db, contents_db=InMemoryDb()),
+            namespace="corpora/{agent_id}",
+            enable_think=False,
+            enable_analyze=False,
+            enable_add=True,
+            max_content_bytes=1,
+            max_namespace_bytes=1,
+        )
+        agent = Agent(id="alpha", telemetry=False)
+
+        if is_async:
+            failed = await toolkit.aadd_text_to_knowledge(_context(), "failed", "x", agent=agent)
+        else:
+            failed = await asyncio.to_thread(toolkit.add_text_to_knowledge, _context(), "failed", "x", agent=agent)
+        vector_db.fail = False
+        if is_async:
+            recovered = await toolkit.aadd_text_to_knowledge(_context(), "failed", "y", agent=agent)
+        else:
+            recovered = await asyncio.to_thread(toolkit.add_text_to_knowledge, _context(), "failed", "y", agent=agent)
+
+        assert failed == "Error adding text to knowledge: knowledge indexing did not produce a searchable vector"
+        assert recovered.startswith("Added 1 bytes")
+
+    def test_failed_indexing_is_reported_and_allows_same_name_retry(self):
+        vector_db = FailingVectorDb()
+        toolkit = KnowledgeTools(
+            knowledge=Knowledge(name="K", vector_db=vector_db, contents_db=InMemoryDb()),
+            namespace="corpora/{agent_id}",
+            enable_think=False,
+            enable_analyze=False,
+            enable_add=True,
+            max_content_bytes=1,
+            max_namespace_bytes=1,
+        )
+        agent = Agent(id="alpha", telemetry=False)
+
+        failed = toolkit.add_text_to_knowledge(_context(), "failed", "x", agent=agent)
+        failed_status = toolkit._resolved(_context(), agent, None).get_content_status(
+            toolkit._text_content_id(toolkit._resolved(_context(), agent, None), "failed", "x", 1)
+        )[0]
+        vector_db.fail = False
+        recovered = toolkit.add_text_to_knowledge(_context(), "failed", "y", agent=agent)
+
+        assert (
+            failed == "Error adding text to knowledge: knowledge indexing did not complete: Could not upsert embedding"
+        )
+        assert failed_status == ContentStatus.FAILED
+        assert recovered.startswith("Added 1 bytes")
+
+    @pytest.mark.asyncio
+    async def test_async_failed_indexing_is_reported_and_allows_same_name_retry(self):
+        vector_db = FailingVectorDb()
+        toolkit = KnowledgeTools(
+            knowledge=Knowledge(name="K", vector_db=vector_db, contents_db=InMemoryDb()),
+            namespace="corpora/{agent_id}",
+            enable_think=False,
+            enable_analyze=False,
+            enable_add=True,
+            max_content_bytes=1,
+            max_namespace_bytes=1,
+        )
+        agent = Agent(id="alpha", telemetry=False)
+
+        failed = await toolkit.aadd_text_to_knowledge(_context(), "failed", "x", agent=agent)
+        vector_db.fail = False
+        recovered = await toolkit.aadd_text_to_knowledge(_context(), "failed", "y", agent=agent)
+
+        assert (
+            failed == "Error adding text to knowledge: knowledge indexing did not complete: Could not upsert embedding"
+        )
+        assert recovered.startswith("Added 1 bytes")
+
+    def test_item_and_namespace_caps_use_utf8_bytes(self):
+        toolkit = KnowledgeTools(
+            knowledge=Knowledge(name="K", vector_db=MemoryVectorDb(), contents_db=InMemoryDb()),
+            namespace="corpora/{agent_id}",
+            enable_think=False,
+            enable_analyze=False,
+            enable_add=True,
+            max_content_bytes=4,
+            max_namespace_bytes=5,
+        )
+        agent = Agent(id="alpha", name="Alpha", telemetry=False)
+
+        assert toolkit.add_text_to_knowledge(_context(), "unicode", "éé", agent=agent).startswith("Added 4 bytes")
+        assert toolkit.add_text_to_knowledge(_context(), "last", "x", agent=agent).startswith("Added 1 bytes")
+        assert "knowledge is full" in toolkit.add_text_to_knowledge(_context(), "overflow", "y", agent=agent)
+        assert "limit 4 bytes per item" in toolkit.add_text_to_knowledge(_context(), "large", "abcde", agent=agent)
+
+    def test_same_name_retry_and_overwrite_use_delta_accounting(self):
+        toolkit = KnowledgeTools(
+            knowledge=Knowledge(name="K", vector_db=MemoryVectorDb(), contents_db=InMemoryDb()),
+            namespace="corpora/{agent_id}",
+            enable_think=False,
+            enable_analyze=False,
+            enable_add=True,
+            max_content_bytes=4,
+            max_namespace_bytes=5,
+        )
+        agent = Agent(id="alpha", telemetry=False)
+
+        first = toolkit.add_text_to_knowledge(_context(), "same", "éé", agent=agent)
+        retry = toolkit.add_text_to_knowledge(_context(), "same", "éé", agent=agent)
+        overwrite = toolkit.add_text_to_knowledge(_context(), "same", "abc", agent=agent)
+        final = toolkit.add_text_to_knowledge(_context(), "other", "xy", agent=agent)
+
+        assert first.startswith("Added 4 bytes")
+        assert retry.startswith("Added 4 bytes")
+        assert overwrite.startswith("Added 3 bytes")
+        assert final.startswith("Added 2 bytes")
+        contents = toolkit._resolved(_context(), agent, None).get_content()[0]
+        assert len(contents) == 2
+        assert sum(content.size or 0 for content in contents) == 5
+
+    @pytest.mark.asyncio
+    async def test_sync_and_async_writes_share_one_namespace_lock(self):
+        toolkit = KnowledgeTools(
+            knowledge=SlowKnowledge(name="K", vector_db=MemoryVectorDb(), contents_db=InMemoryDb()),
+            namespace="corpora/{agent_id}",
+            enable_think=False,
+            enable_analyze=False,
+            enable_add=True,
+            max_content_bytes=1,
+            max_namespace_bytes=1,
+        )
+        agent = Agent(id="alpha", telemetry=False)
+
+        sync_result, async_result = await asyncio.gather(
+            asyncio.to_thread(toolkit.add_text_to_knowledge, _context(), "sync", "x", agent=agent),
+            toolkit.aadd_text_to_knowledge(_context(), "async", "y", agent=agent),
+        )
+
+        assert sum(result.startswith("Added") for result in (sync_result, async_result)) == 1
+        assert sum("knowledge is full" in result for result in (sync_result, async_result)) == 1
+        contents, _ = toolkit._resolved(_context(), agent, None).get_content()
+        assert sum(content.size or 0 for content in contents) == 1
+
+
+class TestStudioPersistence:
+    def test_two_studio_agents_rehydrate_one_namespaced_toolkit(self, tmp_path, knowledge_stack):
+        toolkit, knowledge, _, _ = knowledge_stack
+        component_db = SqliteDb(id="studio-db", db_file=str(tmp_path / "studio.db"))
+        registry = Registry(
+            tools=[toolkit],
+            models=[OpenAIResponses(id="gpt-5.4")],
+            dbs=[component_db],
+        )
+        studio = StudioTools(registry=registry, db=component_db)
+
+        for name in ("Alpha", "Beta"):
+            result = studio.create_agent(
+                name=name,
+                instructions="Use your private knowledge.",
+                model_id="gpt-5.4",
+                tool_names=["agent_knowledge"],
+            )
+            assert '"status": "created"' in result
+
+        for agent_id, text in (("alpha", "alpha studio"), ("beta", "beta studio")):
+            config = component_db.get_config(agent_id)["config"]
+            assert {tool["toolkit"] for tool in config["tools"]} == {"agent_knowledge"}
+            agent = Agent.from_dict(config, registry=registry)
+            assert agent.id == agent_id
+            run_context = _context()
+            prepared_tools = determine_tools_for_model(
+                agent=agent,
+                model=agent.model,
+                processed_tools=agent.tools or [],
+                run_response=RunOutput(run_id=run_context.run_id, agent_id=agent.id),
+                run_context=run_context,
+                session=AgentSession(session_id=run_context.session_id or "session-1", agent_id=agent.id),
+            )
+            add_function = next(
+                tool for tool in prepared_tools if isinstance(tool, Function) and tool.name == "add_text_to_knowledge"
+            )
+            assert add_function._agent is agent
+            assert add_function._run_context is run_context
+            result = FunctionCall(
+                function=add_function,
+                arguments={"name": "studio", "text_content": text},
+            ).execute()
+            assert result.status == "success"
+            assert isinstance(result.result, str) and result.result.startswith("Added")
+
+        assert "alpha studio" in toolkit.search_knowledge(
+            _context(), "studio", agent=Agent(id="alpha", telemetry=False)
+        )
+        assert "beta studio" not in toolkit.search_knowledge(
+            _context(), "studio", agent=Agent(id="alpha", telemetry=False)
+        )
+        assert "beta studio" in toolkit.search_knowledge(_context(), "studio", agent=Agent(id="beta", telemetry=False))
+        assert knowledge.name == "Registry knowledge"

--- a/libs/agno/tests/unit/vectordb/test_pgvector.py
+++ b/libs/agno/tests/unit/vectordb/test_pgvector.py
@@ -15,6 +15,10 @@ TEST_TABLE = f"test_vectors_{uuid.uuid4().hex[:8]}"
 TEST_SCHEMA = "test_schema"
 
 
+def test_supports_namespaced_knowledge():
+    assert PgVector.supports_namespaced_knowledge is True
+
+
 @pytest.fixture
 def mock_engine():
     """Create a mock SQLAlchemy engine with inspect attribute."""
@@ -194,6 +198,22 @@ def test_id_exists(mock_pgvector):
         assert mock_pgvector.id_exists("test_id") is False
 
 
+def test_content_hash_is_indexed_requires_non_null_vector(mock_pgvector):
+    session = MagicMock()
+    mock_pgvector.Session.return_value.__enter__.return_value = session
+
+    with patch("agno.vectordb.pgvector.pgvector.select") as mock_select:
+        statement = MagicMock()
+        statement.where.return_value = statement
+        mock_select.return_value = statement
+
+        session.execute.return_value.scalar_one.return_value = 2
+        assert mock_pgvector.content_hash_is_indexed("content-hash", expected_count=2) is True
+
+        session.execute.return_value.scalar_one.return_value = 1
+        assert mock_pgvector.content_hash_is_indexed("content-hash", expected_count=2) is False
+
+
 def test_insert(mock_pgvector):
     """Test insert method with patched insert functionality."""
     docs = create_test_documents()
@@ -210,6 +230,18 @@ def test_upsert(mock_pgvector):
     # Bypass the SQLAlchemy-specific parts by patching the upsert method directly
     with patch.object(mock_pgvector, "upsert", wraps=lambda content_hash, documents, **kwargs: None):
         mock_pgvector.upsert(content_hash="test_hash", documents=docs)
+
+
+def test_upsert_stops_when_existing_content_cannot_be_deleted(mock_pgvector):
+    with (
+        patch.object(mock_pgvector, "content_hash_exists", return_value=True),
+        patch.object(mock_pgvector, "_delete_by_content_hash", return_value=False),
+        patch.object(mock_pgvector, "_upsert") as mock_upsert,
+    ):
+        with pytest.raises(RuntimeError, match="Could not replace existing content hash"):
+            mock_pgvector.upsert("content-hash", create_test_documents())
+
+        mock_upsert.assert_not_called()
 
 
 def test_insert_builds_records_and_uses_expected_ids(mock_pgvector, mock_embedder):
@@ -458,6 +490,19 @@ async def test_async_upsert(mock_pgvector):
 
                     # Verify the insert was attempted
                     mock_insert.assert_called_once_with(mock_pgvector.table)
+
+
+@pytest.mark.asyncio
+async def test_async_upsert_stops_when_existing_content_cannot_be_deleted(mock_pgvector):
+    with (
+        patch.object(mock_pgvector, "content_hash_exists", return_value=True),
+        patch.object(mock_pgvector, "_delete_by_content_hash", return_value=False),
+        patch.object(mock_pgvector, "_async_upsert") as mock_upsert,
+    ):
+        with pytest.raises(RuntimeError, match="Could not replace existing content hash"):
+            await mock_pgvector.async_upsert("content-hash", create_test_documents())
+
+        mock_upsert.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Pickup status — verified 2026-08-11

This PR is intentionally **draft** and is the durable handoff for the work. The original temporary worktree no longer exists; resume from the remote branch, not from session-local files.

- PR: #9397
- Head: `codex/per-agent-knowledge` at `ab5f2bd16ef07111c8e998d49212db58b8adaa04`
- Original base/merge base: `03d2bf051bfdd3d4a04becce6977712070b30c4d` (Agno 2.8.7)
- Current `main` when this handoff was written: `5cc8b1bc443b887f35502d98e460553fabb596d7`
- Divergence: feature is 1 commit ahead and 7 commits behind current `main`
- GitHub state: open, draft, review required, `CONFLICTING` / `DIRTY`
- Reviews/comments: none yet
- Historical GitHub checks: all 11 passed (PR lint, triage, four style jobs, five test shards). These ran on the original head and must be rerun after conflict resolution.
- Commit provenance: the current commit is attributed to `z <x@y>` / GitHub user `allanturner1234`, while the PR author is `ashpreetbedi`. Amend during the rebase if repository provenance policy requires the PR author's identity.

### Resume in a separate worktree

This sequence avoids depending on any prior local branch/worktree registration:

```bash
git fetch origin
git worktree add -b pickup/per-agent-knowledge \
  /tmp/agno-per-agent-knowledge \
  origin/codex/per-agent-knowledge
cd /tmp/agno-per-agent-knowledge
git rebase origin/main
```

As of 2026-08-11, Git's merge analysis reports textual conflicts only in:

- `cookbook/05_agent_os/22_studio/README.md`
- `cookbook/05_agent_os/22_studio/TEST_LOG.md`

Resolve both by preserving current `main`'s newer `StudioRunnerTools` material **and** this PR's `per_agent_knowledge.py` entry, setup, usage, and construction-smoke record. These files auto-merge but require semantic review because current `main` changed adjacent Studio/rehydration behavior:

- `libs/agno/agno/os/app.py`
- `libs/agno/agno/os/utils.py`
- `libs/agno/tests/unit/os/test_registry_population.py`

After resolving and validating, update this PR's branch:

```bash
git push --force-with-lease origin HEAD:codex/per-agent-knowledge
```

Then update the base/head SHAs and validation counts in this description, confirm hosted CI, and only then mark the PR ready/request review. The original 2.8.8 sizing verdict was made against the old base; reassess the release target after the rebase.

## Summary

Adds opt-in per-Agent knowledge templating for Studio-built Agents.

- `KnowledgeTools(namespace=".../{agent_id}")` resolves a fresh isolated `Knowledge` view on every tool call from the framework-injected Agent identity.
- One registry toolkit can be attached to multiple Studio Agents through the existing `tool_names` surface.
- Adds an opt-in, text-only write tool with 1 MB item, 20 MB namespace, and 255-byte name limits.
- Uses shared PgVector and contents tables with protected `linked_to` scoping, namespace-qualified IDs, fail-closed ownership checks, and exact post-index verification.
- Registers toolkit-owned database/vector backings with AgentOS and exposes template metadata through `GET /registry`, without exposing the unresolved backing as global knowledge.
- Adds a Studio cookbook example and focused unit/integration coverage.

Static `Knowledge` and `KnowledgeTools` behavior is unchanged when `namespace` is omitted. No schema migration, dependency, Studio persistence-format, or `create_agent` API change is required.

## Intended outcome and acceptance

A registry declares one knowledge building block. Two Studio-built Agents attach it through the existing `tool_names` surface and get provably isolated corpora in shared tables.

Acceptance conditions implemented and tested on the original head:

1. Per-call `{agent_id}` resolution uses only the framework-injected Agent object.
2. Missing, invalid, or model-spoofed Agent context fails closed; there is no shared-corpus fallback.
3. Different Agents cannot search or mutate one another's content, including when names or text are identical.
4. Sync and async search/write paths preserve the same boundary.
5. AgentOS discovers the backing DB/vector resources and exposes template metadata through `GET /registry`, but does not expose unresolved per-Agent knowledge through global knowledge routes.
6. `OpenAIEmbedder()` is shared by shallow views and continues to use the platform process's normal `OPENAI_API_KEY`; no separate key plumbing is added.

## Public API and Studio usage

```python
agent_knowledge = KnowledgeTools(
    name="agent_knowledge",
    knowledge=Knowledge(
        vector_db=PgVector(
            table_name="studio_agent_knowledge_vectors",
            db_url=database_url,
            embedder=OpenAIEmbedder(),
        ),
        contents_db=db,
    ),
    namespace="corpora/{agent_id}",
    enable_add=True,
)

registry = Registry(tools=[agent_knowledge])

studio_tools.create_agent(
    name="Research Notes",
    tool_names=["agent_knowledge"],
)
```

The builder surface is unchanged: Studio persists the toolkit name, and the toolkit resolves the Agent-specific namespace at execution time.

## Design decisions

### Templating lives on `KnowledgeTools`

Per-Agent identity is available at tool-call time, not while a global `Knowledge` object is registered. Putting the template on the toolkit preserves the existing meaning of `Knowledge.name`, registry identity, global REST behavior, static callers, and persisted Studio configuration.

V1 accepts exactly one `{agent_id}` placeholder. User/team placeholders, static namespace strings passed through this opt-in path, and multiple placeholders are rejected. Template/value parsing reuses FileSystem's segment validation and canonical namespace normalization. Every call shallow-copies the configured `Knowledge`, applies the resolved namespace to the copy, and never mutates or caches Agent state on the registry-owned toolkit or backing Knowledge.

### One shared table, scoped by namespace

V1 uses the existing `linked_to` mechanism instead of table-per-Agent DDL:

- vectors receive protected `linked_to=<resolved namespace>` metadata;
- searches inject the framework namespace filter after caller filters;
- content rows are filtered and ownership-checked by the same namespace;
- content and document hashes include the namespace so identical names/text in two Agents produce distinct IDs;
- cross-namespace content-ID get/status/update/delete operations fail closed.

PgVector is the only production backend opted into this contract. Other backends must not opt in until conformance tests prove insert/update filter preservation, vector/keyword/hybrid search isolation, content-ID CRUD isolation, exact chunk verification, sync/async parity, and spoof resistance.

### Bounded, text-only writes

`enable_add=False` remains the default. When enabled with an Agent namespace, the toolkit exposes `add_text_to_knowledge(name, text_content)` with these limits:

- 1,000,000 UTF-8 source bytes per item;
- 20,000,000 UTF-8 source bytes per resolved namespace;
- 255 UTF-8 bytes per name; control characters are rejected;
- one process-local namespace lock shared by sync and async writers.

Success requires both a `COMPLETED` content row and the exact expected number of non-null indexed chunks. Failed indexing triggers best-effort vector cleanup. Failed rows conservatively remain charged to quota; retrying the same stable name uses delta accounting and can recover the row.

URL ingestion is deliberately excluded: redirects, SSRF policy, bounded downloads, content type, and timeout behavior require a separate contract.

## Trust boundary and residual risks

- The Agent object is framework-injected and hidden from the model schema. A string/dict supplied by model arguments is not trusted as identity.
- Missing or unresolved context errors before any DB/vector operation; it never falls back to the shared backing corpus.
- Legacy `KnowledgeTools` positional arguments remain compatible; new namespace/write settings are keyword-only, and `all=True` does not silently enable writes.
- Isolation is application-level, not PostgreSQL RLS. Direct trusted use of the backing `Knowledge` object or tables is outside this boundary.
- Content-row and vector writes are not one database transaction. If indexing and cleanup both fail, partial vectors can remain searchable **inside the same Agent namespace**; a reconciliation/cleanup job would be the remedy.
- Quota locking is process-local. A quota used across multiple workers or for billing/security needs a DB transaction or advisory lock.
- PgVector's namespace filter uses currently unindexed JSONB metadata, and the contents table's existing `linked_to` column is unindexed.
- Global approximate HNSW candidate selection can reduce recall for a small namespace even though the predicate still prevents cross-Agent results.

Follow-up triggers:

- multi-worker hard quotas → transactional/advisory locking;
- large tenant counts, latency regressions, or weak small-namespace recall → benchmark with `EXPLAIN ANALYZE`, then consider dedicated scope columns/indexes, iterative scans, partitioning, or per-scope indexes;
- another vector backend → add and pass the isolation conformance suite before capability opt-in;
- URL ingestion, delete tools, or native Knowledge/REST templating → preserve hidden-context identity, namespace-owned CRUD, and the no-global-fallback rule.

## Implementation map

Core behavior:

- `libs/agno/agno/tools/knowledge.py` — namespace parsing/resolution, fresh isolated views, sync/async search, bounded text writes, quota locking, post-index verification, and cleanup.
- `libs/agno/agno/knowledge/knowledge.py` — toolkit-only strict isolation, protected `linked_to`, namespace-qualified hashes, UTF-8 sizes, and content-ID ownership checks.
- `libs/agno/agno/vectordb/base.py` — backend capability and indexed-content verification hooks.
- `libs/agno/agno/vectordb/pgvector/pgvector.py` — PgVector opt-in, exact non-null vector counts, and fail-closed replacement when stale-vector deletion fails.

AgentOS/registry:

- `libs/agno/agno/os/app.py` — provision toolkit-owned contents DBs.
- `libs/agno/agno/os/utils.py` — register backing DB/vector resources without registering unresolved global knowledge.
- `libs/agno/agno/os/schema.py` — namespace/template/backing/cap metadata.
- `libs/agno/agno/os/routers/registry/registry.py` — emit that metadata from `GET /registry`.

Example and proof:

- `cookbook/05_agent_os/22_studio/per_agent_knowledge.py` — one registry toolkit attached to two Studio Agents.
- `libs/agno/tests/unit/tools/test_knowledge_tools.py` — resolution, model spoofing, hidden schema fields, compatibility, isolation, quotas, failure cleanup, concurrency, embedder reuse, and Studio rehydration.
- `libs/agno/tests/unit/knowledge/test_knowledge_isolation.py` — hash, metadata, and content-ID CRUD isolation.
- `libs/agno/tests/unit/vectordb/test_pgvector.py` — backend capability, exact-count verification, and safe replacement.
- `libs/agno/tests/integration/vector_dbs/test_pgvector_namespaced_knowledge.py` — real shared-table isolation and overwrite proof.
- `libs/agno/tests/unit/os/routers/test_registry_router.py` and `libs/agno/tests/unit/os/test_registry_population.py` — AgentOS discovery and registry visibility.

## Validation on the original head

Historical results for `ab5f2bd16ef07111c8e998d49212db58b8adaa04`:

- 111 focused KnowledgeTools, Knowledge-isolation, Studio, and AgentOS registry tests passed.
- All 66 PgVector unit tests passed.
- A real PostgreSQL/PgVector integration test passed (`1 passed`, not skipped), proving two Agent namespaces remain isolated in shared tables, produce disjoint IDs for identical text, and replace same-name content without stale vectors.
- `./scripts/format.sh` passed.
- `./scripts/validate.sh` passed: Agno Ruff/mypy, agnoctl Ruff/mypy, and cookbook Ruff/pattern checks.
- Cookbook `py_compile` and `git diff --check` passed.
- Three independent reviews found no blockers.
- All 11 hosted checks passed.

The real database test uses a deterministic embedder and makes no OpenAI request. The cookbook record is a construction smoke, not a live model/embedding run. Unit coverage verifies that resolved views share the registry's `OpenAIEmbedder()` and leave its unset API key to the normal process environment.

### Exact focused commands to rerun after rebasing

Use the repository's `.venv` for core work and `.venvs/demo` for PgVector/cookbook dependencies. Run `./scripts/dev_setup.sh` and `./scripts/demo_setup.sh` first if those environments are absent.

```bash
source .venv/bin/activate

PYTHONPATH="$PWD/libs/agno" python -m pytest -q --tb=short \
  libs/agno/tests/unit/tools/test_knowledge_tools.py \
  libs/agno/tests/unit/knowledge/test_knowledge_isolation.py \
  libs/agno/tests/unit/os/routers/test_registry_router.py \
  libs/agno/tests/unit/os/test_registry_population.py
```

Expected on the original head: `111 passed`.

```bash
PYTHONPATH="$PWD/libs/agno" .venvs/demo/bin/python -m pytest -q --tb=short \
  libs/agno/tests/unit/vectordb/test_pgvector.py
```

Expected on the original head: `66 passed`.

Start an isolated temporary PostgreSQL/PgVector instance, then run the real backend proof:

```bash
docker run -d \
  -e POSTGRES_DB=ai \
  -e POSTGRES_USER=ai \
  -e POSTGRES_PASSWORD=ai \
  -e PGDATA=/var/lib/postgresql \
  -p 5532:5432 \
  --name per-agent-knowledge-pgvector \
  agnohq/pgvector:18

docker exec per-agent-knowledge-pgvector pg_isready -U ai -d ai

PYTHONPATH="$PWD/libs/agno" .venvs/demo/bin/python -m pytest -q --tb=short \
  libs/agno/tests/integration/vector_dbs/test_pgvector_namespaced_knowledge.py

docker rm -f per-agent-knowledge-pgvector
```

Confirm the integration says `1 passed`, not skipped.

Finally run the repository gates:

```bash
source .venv/bin/activate
./scripts/format.sh
./scripts/validate.sh

.venvs/demo/bin/python -m py_compile \
  cookbook/05_agent_os/22_studio/per_agent_knowledge.py

git diff --check origin/main...HEAD
```

After the rebase, specifically re-check model-spoof/fail-closed execution, two-Agent Studio create/reload behavior, toolkit-owned registry population, and the real PgVector overwrite case because current `main` changed tool injection and Studio/rehydration-adjacent code.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) on the original head
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated
- [x] Tested in clean environment on the original head
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Out of scope for this PR

- PgVector/content-table schema migrations or namespace indexes
- PostgreSQL RLS
- distributed quota transactions
- URL ingestion
- table-per-Agent factories or runtime DDL
- native `Knowledge.name` / REST templating
- user/team namespace placeholders
- Studio `create_agent` signature changes
- generic async-tool persistence changes
