### PR TITLE
[fix] Persist tool_hook session_state mutations (#9328)

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1119,14 +1119,14 @@ class FunctionCall(BaseModel):
                     cache_file = self.function._get_cache_file_path(cache_key)
                     self.function._save_to_cache(cache_file, self.result)
 
+                # Capture session_state from the shared RunContext so mutations made
+                # inside tool_hooks (which receive run_context even when the tool
+                # function itself does not declare a run_context parameter) are
+                # propagated and persisted. Mirrors the generator-path recapture in
+                # agno/models/base.py.
                 updated_session_state = None
-                if entrypoint_args.get("run_context") is not None:
-                    run_context = entrypoint_args.get("run_context")
-                    updated_session_state = (
-                        run_context.session_state
-                        if run_context is not None and run_context.session_state is not None
-                        else None
-                    )
+                if self.function._run_context is not None and self.function._run_context.session_state is not None:
+                    updated_session_state = self.function._run_context.session_state
 
                 execution_result = FunctionExecutionResult(
                     status="success", result=self.result, updated_session_state=updated_session_state
@@ -1345,14 +1345,14 @@ class FunctionCall(BaseModel):
             if isgenerator(self.result) or isasyncgen(self.result):
                 updated_session_state = None
             else:
+                # Capture session_state from the shared RunContext so mutations made
+                # inside tool_hooks (which receive run_context even when the tool
+                # function itself does not declare a run_context parameter) are
+                # propagated and persisted. Mirrors the generator-path recapture in
+                # agno/models/base.py.
                 updated_session_state = None
-                if entrypoint_args.get("run_context") is not None:
-                    run_context = entrypoint_args.get("run_context")
-                    updated_session_state = (
-                        run_context.session_state
-                        if run_context is not None and run_context.session_state is not None
-                        else None
-                    )
+                if self.function._run_context is not None and self.function._run_context.session_state is not None:
+                    updated_session_state = self.function._run_context.session_state
 
             execution_result = FunctionExecutionResult(
                 status="success", result=self.result, updated_session_state=updated_session_state

--- a/libs/agno/tests/unit/tools/test_tool_hook_session_state.py
+++ b/libs/agno/tests/unit/tools/test_tool_hook_session_state.py
@@ -1,0 +1,56 @@
+from typing import Any, Callable, Dict
+
+import pytest
+
+from agno.run.base import RunContext
+from agno.tools.decorator import tool
+from agno.tools.function import FunctionCall
+
+
+def test_tool_hook_session_state_mutation_is_captured():
+    """A tool_hook that mutates run_context.session_state must have its changes
+    captured in updated_session_state, even when the tool function itself does
+    not declare a run_context parameter (e.g. MCP tools). Regression for #9328."""
+
+    def tool_hook(function_name: str, function_call: Callable, arguments: Dict[str, Any], run_context: RunContext):
+        calls = run_context.session_state.get("tool_call", [])
+        calls.append({"tool_name": function_name, "args": arguments})
+        run_context.session_state["tool_call"] = calls
+        return function_call(**arguments)
+
+    @tool(tool_hooks=[tool_hook])
+    def test_func(param1: str) -> str:
+        return f"processed-{param1}"
+
+    test_func.process_entrypoint()
+    test_func._run_context = RunContext(run_id="r", session_id="s", session_state={"tool_call": []})
+
+    result = FunctionCall(function=test_func, arguments={"param1": "value1"}).execute()
+
+    assert result.status == "success"
+    assert result.updated_session_state == {"tool_call": [{"tool_name": "test_func", "args": {"param1": "value1"}}]}
+
+
+@pytest.mark.asyncio
+async def test_tool_hook_session_state_mutation_is_captured_async():
+    """Async counterpart of the #9328 regression."""
+
+    async def tool_hook(
+        function_name: str, function_call: Callable, arguments: Dict[str, Any], run_context: RunContext
+    ):
+        calls = run_context.session_state.get("tool_call", [])
+        calls.append({"tool_name": function_name, "args": arguments})
+        run_context.session_state["tool_call"] = calls
+        return await function_call(**arguments)
+
+    @tool(tool_hooks=[tool_hook])
+    async def test_func(param1: str) -> str:
+        return f"processed-{param1}"
+
+    test_func.process_entrypoint()
+    test_func._run_context = RunContext(run_id="r", session_id="s", session_state={"tool_call": []})
+
+    result = await FunctionCall(function=test_func, arguments={"param1": "value1"}).aexecute()
+
+    assert result.status == "success"
+    assert result.updated_session_state == {"tool_call": [{"tool_name": "test_func", "args": {"param1": "value1"}}]}


### PR DESCRIPTION
## Description

Fixes #9328.

When an Agent is a member of a Team, mutating `run_context.session_state` inside a **`tool_hook`** was silently lost — the `session_data` column stayed `null` after the run. Modifying `session_state` inside a regular tool *function* (one that declares a `run_context: RunContext` parameter) worked fine.

### Root cause

`FunctionCall.execute()` / `aexecute()` capture the state to propagate (`updated_session_state`) **only from `entrypoint_args["run_context"]`**, which is populated *only when the tool function itself declares a `run_context` parameter*:

```python
updated_session_state = None
if entrypoint_args.get("run_context") is not None:
    run_context = entrypoint_args.get("run_context")
    updated_session_state = run_context.session_state ...
```

A `tool_hook` always receives `run_context` (via `self.function._run_context`) regardless of the wrapped function's signature. So when a tool has no `run_context` parameter — e.g. **MCP tools, whose entrypoints are external processes and cannot take one** — `entrypoint_args["run_context"]` is `None`, `updated_session_state` stays `None`, and the hook's mutation is never propagated or persisted.

### Fix

Capture `session_state` from the shared `RunContext` (`self.function._run_context`) that the hook actually mutates, instead of from `entrypoint_args`. Since the hook and the entrypoint are handed the *same* `RunContext` object and `session_state` is a by-reference dict, this captures mutations from either source. This mirrors the existing generator-path recapture already present in `agno/models/base.py`:

```python
if function_execution_result.updated_session_state is None:
    if function_call.function._run_context is not None and function_call.function._run_context.session_state is not None:
        function_execution_result.updated_session_state = function_call.function._run_context.session_state
```

Two lines changed (sync + async capture sites).

## Tests

Added `libs/agno/tests/unit/tools/test_tool_hook_session_state.py` — a tool with a `tool_hook` (accepting `run_context`) mutating `session_state`, where the tool function does **not** declare `run_context`. Sync and async variants assert the mutation appears in `updated_session_state`. Both tests fail on `main` and pass with this change; the existing `tests/unit/tools/test_functions.py` and `tests/unit/models/test_generator_session_state.py` suites remain green.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
