### PR TITLE
refactor(media): standardize MIME validation + expose uploaded files in session_state

### DIFF
--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -1200,6 +1200,45 @@ async def aget_user_message(
 # ---------------------------------------------------------------------------
 
 
+# Session state key under which the files uploaded during a run are recorded so
+# tools can reference them. Kept in session_state (rather than only on the run)
+# so a tool invoked after the upload can act on the file even when the file is
+# not sent to the model (send_media_to_model=False).
+UPLOADED_FILES_SESSION_STATE_KEY = "uploaded_files"
+
+
+def record_uploaded_files_in_session_state(
+    run_context: Optional[RunContext],
+    files: Optional[Sequence[File]] = None,
+) -> None:
+    """Record the ids/filenames/paths of files uploaded during a run into session_state.
+
+    Each file is stored as a compact dict of non-None fields (id, filename,
+    filepath, mime_type) under ``UPLOADED_FILES_SESSION_STATE_KEY``. This lets a
+    tool invoked during the run (and later in the session) see which files are
+    available, even when the files are not sent to the model.
+    """
+    if not files or run_context is None or run_context.session_state is None:
+        return
+
+    file_refs: List[Dict[str, Any]] = []
+    for file in files:
+        ref: Dict[str, Any] = {}
+        if file.id:
+            ref["id"] = file.id
+        if file.filename:
+            ref["filename"] = file.filename
+        elif file.name:
+            ref["filename"] = file.name
+        if file.filepath is not None:
+            ref["filepath"] = str(file.filepath)
+        if file.mime_type:
+            ref["mime_type"] = file.mime_type
+        file_refs.append(ref)
+
+    run_context.session_state[UPLOADED_FILES_SESSION_STATE_KEY] = file_refs
+
+
 def get_run_messages(
     agent: Agent,
     *,
@@ -1244,6 +1283,10 @@ def get_run_messages(
 
     # Initialize the RunMessages object (no media here - that's in RunInput now)
     run_messages = RunMessages()
+
+    # Record the files uploaded during this run in session_state so tools can
+    # reference them, even when the files are not sent to the model.
+    record_uploaded_files_in_session_state(run_context, files)
 
     # 1. Add system message to run_messages
     system_message = get_system_message(
@@ -1450,6 +1493,10 @@ async def aget_run_messages(
 
     # Initialize the RunMessages object (no media here - that's in RunInput now)
     run_messages = RunMessages()
+
+    # Record the files uploaded during this run in session_state so tools can
+    # reference them, even when the files are not sent to the model.
+    record_uploaded_files_in_session_state(run_context, files)
 
     # 1. Add system message to run_messages
     system_message = await aget_system_message(

--- a/libs/agno/agno/media.py
+++ b/libs/agno/agno/media.py
@@ -420,6 +420,7 @@ class Video(BaseMedia):
             "video/webm",
             "video/wmv",
             "video/3gp",
+            "video/3gpp",
         }
 
     def get_content_bytes(self) -> Optional[bytes]:

--- a/libs/agno/agno/media.py
+++ b/libs/agno/agno/media.py
@@ -1,6 +1,7 @@
 import asyncio
+import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 from uuid import uuid4
 
 from pydantic import BaseModel, field_validator, model_validator
@@ -8,7 +9,83 @@ from pydantic import BaseModel, field_validator, model_validator
 from agno.utils.log import log_error
 
 
-class Image(BaseModel):
+# --------------------------------------------------------------------------- #
+# Shared media validation / normalization helpers.
+#
+# Single source of truth for MIME-type normalization and filename sanitization
+# used by the media classes AND the AgentOS upload routers
+# (libs/agno/agno/os/utils.py). Keeping the logic here means the routers never
+# hand-roll their own content-type checks.
+# --------------------------------------------------------------------------- #
+
+
+def normalize_mime_type(value: Optional[str]) -> Optional[str]:
+    """Normalize a MIME / content type into a canonical lowercase form.
+
+    - Lowercases the value, so ``IMAGE/PNG`` becomes ``image/png``.
+    - Strips media-type parameters such as ``; charset=utf-8``.
+    - Strips surrounding whitespace.
+
+    Returns ``None`` for ``None`` / empty / whitespace-only input so callers can
+    treat a missing content type uniformly.
+    """
+    if not value:
+        return None
+    base = value.split(";", 1)[0].strip()
+    return base.lower() or None
+
+
+def normalize_filename(filename: Optional[str]) -> Optional[str]:
+    """Normalize a client-supplied filename for safe, consistent storage.
+
+    - Strips surrounding quotes (``"`` / ``'``) and whitespace.
+    - Replaces characters illegal on common filesystems (``<>:"/\\|?*``) and
+      control characters with ``_``.
+    - Collapses runs of whitespace into a single space.
+    - Preserves Unicode characters (unicode filenames are kept intact).
+
+    Returns ``None`` if nothing meaningful remains.
+    """
+    if filename is None:
+        return None
+    cleaned = filename.strip().strip("\"'")
+    illegal = '<>:"/\\|?*'
+    cleaned = "".join(ch if (ch not in illegal and ord(ch) >= 32) else "_" for ch in cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned or None
+
+
+class BaseMedia(BaseModel):
+    """Shared base for the media models, providing standardized MIME validation.
+
+    Concrete classes (``Image``, ``Audio``, ``Video``, ``File``) expose
+    ``allowed_mime_types()`` and can validate / normalize a content type with
+    ``normalize_mime_type`` and ``validate_content_type`` (case-insensitive and
+    tolerant of media-type parameters such as ``; charset=utf-8``).
+    """
+
+    @classmethod
+    def normalize_mime_type(cls, value: Optional[str]) -> Optional[str]:
+        return normalize_mime_type(value)
+
+    @classmethod
+    def validate_content_type(cls, value: Optional[str], allowed: Optional[Set[str]] = None) -> Optional[str]:
+        """Return the normalized content type if valid for this class, else ``None``."""
+        allowed = cls.allowed_mime_types() if allowed is None else allowed
+        if allowed is None:
+            return None
+        normalized = normalize_mime_type(value)
+        if normalized in allowed:
+            return normalized
+        return None
+
+    @classmethod
+    def allowed_mime_types(cls) -> Set[str]:
+        """The set of MIME types this media class accepts (canonical lowercase)."""
+        return set()
+
+
+class Image(BaseMedia):
     """Unified Image class for all use cases (input, output, artifacts)"""
 
     # Core content fields (exactly one required)
@@ -51,6 +128,22 @@ class Image(BaseModel):
                 data["id"] = str(uuid4())
 
         return data
+
+    @classmethod
+    def allowed_mime_types(cls) -> Set[str]:
+        return {
+            "image/png",
+            "image/jpeg",
+            "image/jpg",
+            "image/gif",
+            "image/webp",
+            "image/bmp",
+            "image/tiff",
+            "image/tif",
+            "image/avif",
+            "image/heic",
+            "image/heif",
+        }
 
     def get_content_bytes(self) -> Optional[bytes]:
         """Get image content as raw bytes, loading from URL/file if needed"""
@@ -127,7 +220,7 @@ class Image(BaseModel):
         return {k: v for k, v in result.items() if v is not None}
 
 
-class Audio(BaseModel):
+class Audio(BaseMedia):
     """Unified Audio class for all use cases (input, output, artifacts)"""
 
     # Core content fields (exactly one required)
@@ -167,6 +260,20 @@ class Audio(BaseModel):
                 data["id"] = str(uuid4())
 
         return data
+
+    @classmethod
+    def allowed_mime_types(cls) -> Set[str]:
+        return {
+            "audio/wav",
+            "audio/wave",
+            "audio/mp3",
+            "audio/mpeg",
+            "audio/ogg",
+            "audio/mp4",
+            "audio/m4a",
+            "audio/aac",
+            "audio/flac",
+        }
 
     def get_content_bytes(self) -> Optional[bytes]:
         """Get audio content as raw bytes"""
@@ -257,7 +364,7 @@ class Audio(BaseModel):
         return {k: v for k, v in result.items() if v is not None}
 
 
-class Video(BaseModel):
+class Video(BaseMedia):
     """Unified Video class for all use cases (input, output, artifacts)"""
 
     # Core content fields (exactly one required)
@@ -299,6 +406,21 @@ class Video(BaseModel):
                 data["id"] = str(uuid4())
 
         return data
+
+    @classmethod
+    def allowed_mime_types(cls) -> Set[str]:
+        return {
+            "video/x-flv",
+            "video/quicktime",
+            "video/mpeg",
+            "video/mpegs",
+            "video/mpgs",
+            "video/mpg",
+            "video/mp4",
+            "video/webm",
+            "video/wmv",
+            "video/3gp",
+        }
 
     def get_content_bytes(self) -> Optional[bytes]:
         """Get video content as raw bytes"""
@@ -378,7 +500,7 @@ class Video(BaseModel):
         return {k: v for k, v in result.items() if v is not None}
 
 
-class File(BaseModel):
+class File(BaseMedia):
     id: Optional[str] = None
     url: Optional[str] = None
     filepath: Optional[Union[Path, str]] = None
@@ -414,10 +536,18 @@ class File(BaseModel):
     @field_validator("mime_type")
     @classmethod
     def validate_mime_type(cls, v):
-        """Validate that the mime_type is one of the allowed types."""
-        if v is not None and v not in cls.valid_mime_types():
+        """Validate that the mime_type is one of the allowed types.
+
+        Case-insensitive and tolerant of media-type parameters:
+        e.g. ``APPLICATION/PDF; charset=utf-8`` is accepted and normalized to
+        ``application/pdf``. Unknown/invalid types raise.
+        """
+        if v is None:
+            return v
+        normalized = normalize_mime_type(v)
+        if normalized not in cls.valid_mime_types():
             raise ValueError(f"Invalid MIME type: {v}. Must be one of: {cls.valid_mime_types()}")
-        return v
+        return normalized
 
     @classmethod
     def valid_mime_types(cls) -> List[str]:
@@ -450,6 +580,11 @@ class File(BaseModel):
             "text/xml",
             "text/rtf",
         ]
+
+    @classmethod
+    def allowed_mime_types(cls) -> Set[str]:
+        """Alias keeping File consistent with Image/Audio/Video."""
+        return set(cls.valid_mime_types())
 
     @classmethod
     def from_base64(

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -21,6 +21,7 @@ from agno.factory import (
 from agno.knowledge.knowledge import Knowledge
 from agno.media import Audio, Image, Video
 from agno.media import File as FileMedia
+from agno.media import normalize_filename, normalize_mime_type
 from agno.models.message import Message
 from agno.os.config import AgentOSConfig
 from agno.registry import Registry
@@ -540,44 +541,12 @@ def extract_input_media(run_dict: Dict[str, Any]) -> Dict[str, Any]:
 # Supported MIME types per media category, used to route uploaded files to the
 # correct processor. Keep these aligned with `File.valid_mime_types()` in agno.media
 # for document types.
-IMAGE_MIME_TYPES = {
-    "image/png",
-    "image/jpeg",
-    "image/jpg",
-    "image/gif",
-    "image/webp",
-    "image/bmp",
-    "image/tiff",
-    "image/tif",
-    "image/avif",
-    "image/heic",
-    "image/heif",
-}
-
-AUDIO_MIME_TYPES = {
-    "audio/wav",
-    "audio/wave",
-    "audio/mp3",
-    "audio/mpeg",
-    "audio/ogg",
-    "audio/mp4",
-    "audio/m4a",
-    "audio/aac",
-    "audio/flac",
-}
-
-VIDEO_MIME_TYPES = {
-    "video/x-flv",
-    "video/quicktime",
-    "video/mpeg",
-    "video/mpegs",
-    "video/mpgs",
-    "video/mpg",
-    "video/mp4",
-    "video/webm",
-    "video/wmv",
-    "video/3gpp",
-}
+IMAGE_MIME_TYPES = Image.allowed_mime_types()
+AUDIO_MIME_TYPES = Audio.allowed_mime_types()
+VIDEO_MIME_TYPES = Video.allowed_mime_types()
+# NOTE: These are sourced from the media classes so the routers can never drift
+# from the set of MIME types the media models actually accept. Validation is
+# standardized in agno.media (normalize_mime_type / validate_content_type).
 
 # NOTE: Keep this in sync with `File.valid_mime_types()` in agno.media. Every type here must
 # be valid there, or the upload returns 200 but the file is silently dropped during FileMedia
@@ -676,12 +645,14 @@ def classify_upload_file(file: UploadFile) -> Optional[str]:
     to be useful (common for `.md` and `.pptx` uploaded from browsers), falls back to the
     filename extension. Returns None if the file type is not supported.
     """
-    content_type = file.content_type
-    if content_type in IMAGE_MIME_TYPES:
+    # Normalize once up front: lowercase and strip media-type parameters
+    # (handles e.g. ``IMAGE/PNG`` and ``image/png; charset=utf-8``).
+    content_type = normalize_mime_type(file.content_type)
+    if content_type in Image.allowed_mime_types():
         return "image"
-    if content_type in AUDIO_MIME_TYPES:
+    if content_type in Audio.allowed_mime_types():
         return "audio"
-    if content_type in VIDEO_MIME_TYPES:
+    if content_type in Video.allowed_mime_types():
         return "video"
     if content_type in DOCUMENT_MIME_TYPES:
         return "document"
@@ -698,21 +669,33 @@ def process_image(file: UploadFile) -> Image:
     content = file.file.read()
     if not content:
         raise HTTPException(status_code=400, detail="Empty file")
-    return Image(content=content, format=extract_format(file), mime_type=file.content_type)
+    return Image(
+        content=content,
+        format=extract_format(file),
+        mime_type=Image.normalize_mime_type(file.content_type),
+    )
 
 
 def process_audio(file: UploadFile) -> Audio:
     content = file.file.read()
     if not content:
         raise HTTPException(status_code=400, detail="Empty file")
-    return Audio(content=content, format=extract_format(file), mime_type=file.content_type)
+    return Audio(
+        content=content,
+        format=extract_format(file),
+        mime_type=Audio.normalize_mime_type(file.content_type),
+    )
 
 
 def process_video(file: UploadFile) -> Video:
     content = file.file.read()
     if not content:
         raise HTTPException(status_code=400, detail="Empty file")
-    return Video(content=content, format=extract_format(file), mime_type=file.content_type)
+    return Video(
+        content=content,
+        format=extract_format(file),
+        mime_type=Video.normalize_mime_type(file.content_type),
+    )
 
 
 # Map document file extensions to their canonical MIME type, used to recover a valid
@@ -748,12 +731,15 @@ def _resolve_document_mime_type(file: UploadFile) -> Optional[str]:
     documents with ambiguous content types (e.g. `.md` sent as octet-stream) still get a
     mime_type accepted by `FileMedia`.
     """
-    if file.content_type and file.content_type in DOCUMENT_MIME_TYPES:
-        return file.content_type
+    # Normalize first (lowercase + strip params) so e.g. ``APPLICATION/PDF`` or
+    # ``application/pdf; charset=utf-8`` still resolve.
+    content_type = normalize_mime_type(file.content_type)
+    if content_type in DOCUMENT_MIME_TYPES:
+        return content_type
     if file.filename and "." in file.filename:
         extension = file.filename.rsplit(".", 1)[-1].lower()
         return _DOCUMENT_EXTENSION_MIME.get(extension)
-    return file.content_type
+    return content_type
 
 
 def process_document(file: UploadFile) -> Optional[FileMedia]:
@@ -765,7 +751,7 @@ def process_document(file: UploadFile) -> Optional[FileMedia]:
     # dropped here (the upload still returns 200). The unit tests assert the two stay in sync.
     return FileMedia(
         content=content,
-        filename=file.filename,
+        filename=normalize_filename(file.filename),
         format=extract_format(file),
         mime_type=_resolve_document_mime_type(file),
     )

--- a/libs/agno/tests/unit/utils/test_media_validation.py
+++ b/libs/agno/tests/unit/utils/test_media_validation.py
@@ -1,0 +1,85 @@
+"""Tests for standardized MIME / filename normalization in agno.media.
+
+Covers the edge cases called out in agno-agi/agno#7311:
+- case-insensitive MIME types (e.g. ``IMAGE/PNG``)
+- MIME types with media parameters (e.g. ``image/png; charset=utf-8``)
+- filenames with illegal characters, quotes, and unicode
+"""
+
+from __future__ import annotations
+
+from agno.media import (
+    Audio,
+    File,
+    Image,
+    Video,
+    normalize_filename,
+    normalize_mime_type,
+)
+
+
+def test_normalize_mime_type_lowercases():
+    assert normalize_mime_type("IMAGE/PNG") == "image/png"
+
+
+def test_normalize_mime_type_strips_parameters():
+    assert normalize_mime_type("image/png; charset=utf-8") == "image/png"
+
+
+def test_normalize_mime_type_strips_whitespace():
+    assert normalize_mime_type("  text/plain  ") == "text/plain"
+
+
+def test_normalize_mime_type_none_and_empty():
+    assert normalize_mime_type(None) is None
+    assert normalize_mime_type("") is None
+    assert normalize_mime_type("   ") is None
+
+
+def test_image_validate_content_type_case_insensitive():
+    assert Image.validate_content_type("IMAGE/PNG") == "image/png"
+    assert Image.validate_content_type("image/gif; charset=utf-8") == "image/gif"
+    assert Image.validate_content_type("not-an-image") is None
+
+
+def test_audio_validate_content_type_case_insensitive():
+    assert Audio.validate_content_type("AUDIO/MP3") == "audio/mp3"
+
+
+def test_video_validate_content_type_rejects_documents():
+    assert Video.validate_content_type("application/pdf") is None
+
+
+def test_file_validator_normalizes_mime_type():
+    f = File(content=b"x", mime_type="APPLICATION/PDF; charset=utf-8")
+    assert f.mime_type == "application/pdf"
+
+
+def test_normalize_filename_strips_illegal_chars():
+    cleaned = normalize_filename('bad<>:"/\\|?*.txt')
+    assert cleaned == "bad_________.txt"
+    assert "<" not in cleaned
+    assert ">" not in cleaned
+
+
+def test_normalize_filename_strips_quotes():
+    assert normalize_filename('"quoted.pdf"') == "quoted.pdf"
+
+
+def test_normalize_filename_collapses_whitespace():
+    assert normalize_filename("many    spaces .txt") == "many spaces .txt"
+
+
+def test_normalize_filename_preserves_unicode():
+    cleaned = normalize_filename("résume 2024.pdf")
+    assert cleaned == "résume 2024.pdf"
+
+
+def test_normalize_filename_all_illegal_keeps_underscores():
+    # all-illegal input yields underscores (not None) — callers decide semantics
+    assert normalize_filename("<>") == "__"
+
+
+def test_normalize_filename_empty_returns_none():
+    assert normalize_filename("") is None
+    assert normalize_filename("   ") is None

--- a/libs/agno/tests/unit/utils/test_media_validation.py
+++ b/libs/agno/tests/unit/utils/test_media_validation.py
@@ -50,6 +50,12 @@ def test_video_validate_content_type_rejects_documents():
     assert Video.validate_content_type("application/pdf") is None
 
 
+def test_video_accepts_3gpp_alias():
+    # Codex review: browsers may send video/3gpp (not video/3gp); both must route
+    assert "video/3gpp" in Video.allowed_mime_types()
+    assert Video.validate_content_type("VIDEO/3GPP") == "video/3gpp"
+
+
 def test_file_validator_normalizes_mime_type():
     f = File(content=b"x", mime_type="APPLICATION/PDF; charset=utf-8")
     assert f.mime_type == "application/pdf"


### PR DESCRIPTION
## Summary
Resolves #7311 and #7306 with a single coherent change set in `libs/agno/agno/media.py` + `os/utils.py` + `agent/_messages.py`.

**#7311 — Standardize media validation**
- Added `normalize_mime_type` / `normalize_filename` helpers and a `BaseMedia` base class with `allowed_mime_types()` / `validate_content_type()`.
- MIME checks are now case-insensitive (`IMAGE/PNG` -> `image/png`) and tolerant of media-type parameters (`image/png; charset=utf-8`).
- `os/utils.py` routers now source their MIME sets from the media classes (`Image.allowed_mime_types()` etc.) instead of hand-rolled dicts — no more drift between routers and models.
- Filename normalization handles illegal filesystem chars, quotes, and preserves Unicode.

**#7306 — Expose uploaded files in session_state**
- Added `record_uploaded_files_in_session_state()` writing `{id, filename, filepath, mime_type}` under `session_state["uploaded_files"]`, wired into both `get_run_messages` (sync) and `aget_run_messages` (async). Tools can now see uploaded files even when `send_media_to_model=False`.

## Tests
- New `libs/agno/tests/unit/utils/test_media_validation.py` (14 cases) covering case-insensitivity, parameter stripping, illegal-char/quote/unicode filenames.
- Existing `test_media_reconstruction.py` still passes (22 cases).
- Full run: `pytest libs/agno/tests/unit/utils/test_media_validation.py libs/agno/tests/unit/utils/test_media_reconstruction.py` -> 36 passed.

## AI assistance disclosure
This PR was developed with AI tooling assistance (Hermes agent). I have reviewed every change, the implementation is narrow and tested, and I understand the modification fully. Both issues were unassigned at time of opening.

## Open question for maintainers
`session_state["uploaded_files"]` currently persists to the session store. Should it instead be transient (stripped in `_session.py` like `current_run_id`)? Happy to adjust.