### PR TITLE
[fix] Persist a session whose session_data is still None (#9390)

### DIFF
--- a/libs/agno/agno/agent/_session.py
+++ b/libs/agno/agno/agent/_session.py
@@ -222,12 +222,7 @@ def save_session(agent: Agent, session: Union[AgentSession, TeamSession, Workflo
     if _init.has_async_db(agent):
         raise ValueError("Cannot use sync save_session() with an async database. Use asave_session() instead.")
     # If the agent is a member of a team, do not save the session to the database
-    if (
-        agent.db is not None
-        and agent.team_id is None
-        and agent.workflow_id is None
-        and session.session_data is not None
-    ):
+    if agent.db is not None and agent.team_id is None and agent.workflow_id is None:
         if session.session_data is not None and isinstance(session.session_data.get("session_state"), dict):
             session.session_data["session_state"].pop("current_session_id", None)
             session.session_data["session_state"].pop("current_user_id", None)
@@ -244,12 +239,7 @@ async def asave_session(agent: Agent, session: Union[AgentSession, TeamSession, 
     from agno.agent import _init, _storage
 
     # If the agent is a member of a team, do not save the session to the database
-    if (
-        agent.db is not None
-        and agent.team_id is None
-        and agent.workflow_id is None
-        and session.session_data is not None
-    ):
+    if agent.db is not None and agent.team_id is None and agent.workflow_id is None:
         if session.session_data is not None and isinstance(session.session_data.get("session_state"), dict):
             session.session_data["session_state"].pop("current_session_id", None)
             session.session_data["session_state"].pop("current_user_id", None)

--- a/libs/agno/tests/unit/agent/test_session_persistence.py
+++ b/libs/agno/tests/unit/agent/test_session_persistence.py
@@ -1,0 +1,79 @@
+"""Saving an AgentSession must not depend on session_data being populated.
+
+Regression test for #9390: ``POST /sessions`` stores ``session_data=None`` when
+neither ``session_state`` nor ``session_name`` is supplied, so the first run
+against such a session was silently dropped instead of being persisted with
+``RUNNING`` status. ``Team``'s equivalent savers never had this condition.
+"""
+
+import os
+import tempfile
+import time
+
+import pytest
+
+from agno.agent import Agent
+from agno.agent._session import asave_session, save_session
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.session import AgentSession
+
+
+@pytest.fixture
+def sqlite_db():
+    from agno.db.sqlite.sqlite import SqliteDb
+
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = SqliteDb(db_file=path)
+    yield db
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _session_created_by_the_sessions_api(db) -> AgentSession:
+    """Mirror what POST /sessions writes with no session_state or name."""
+    db.upsert_session(
+        AgentSession(
+            session_id="s1",
+            agent_id="my-agent",
+            user_id="u",
+            created_at=int(time.time()),
+        )
+    )
+    session = db.get_session(session_id="s1")
+    assert session.session_data is None
+    return session
+
+
+def _running_run() -> RunOutput:
+    return RunOutput(
+        run_id="r1",
+        session_id="s1",
+        agent_id="my-agent",
+        status=RunStatus.running,
+    )
+
+
+def test_save_session_persists_run_when_session_data_is_none(sqlite_db):
+    agent = Agent(id="my-agent", db=sqlite_db)
+    session = _session_created_by_the_sessions_api(sqlite_db)
+    session.upsert_run(run=_running_run())
+
+    save_session(agent, session=session)
+
+    stored = sqlite_db.get_session(session_id="s1")
+    assert [run.status for run in stored.runs] == [RunStatus.running]
+
+
+async def test_asave_session_persists_run_when_session_data_is_none(sqlite_db):
+    agent = Agent(id="my-agent", db=sqlite_db)
+    session = _session_created_by_the_sessions_api(sqlite_db)
+    session.upsert_run(run=_running_run())
+
+    await asave_session(agent, session=session)
+
+    stored = sqlite_db.get_session(session_id="s1")
+    assert [run.status for run in stored.runs] == [RunStatus.running]


### PR DESCRIPTION
## Summary

Fixes #9390.

`POST /sessions` writes `session_data=None` whenever the request carries neither `session_state` nor `session_name` ([`os/routers/session/session.py`](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/os/routers/session/session.py) — `session_data=session_data if session_data else None`). The issue's example request sends only `session_id` / `agent_id` / `user_id`, so it lands in exactly that case.

`save_session()` / `asave_session()` then guarded on:

```python
if (
    agent.db is not None
    and agent.team_id is None
    and agent.workflow_id is None
    and session.session_data is not None     # <-- here
):
```

so every write against such a session was skipped silently. The first run never reached the database with `RUNNING` status, which is precisely the reported symptom; it only shows up later, once something else has populated `session_data`.

Passing a fresh UUID instead works because `aread_or_create_session()` builds the session with `session_data = {}` — not `None` — so the guard passes.

## Why this predicate

`Team.save_session()` / `Team.asave_session()` guard on `db` / `parent_team_id` / `workflow_id` only, with no `session_data` condition, and the comment above the agent guard (*"If the agent is a member of a team, do not save the session to the database"*) describes only those three. The `session_data` check is the outlier, so this drops it. The inner `session_state` scrub already tests `session.session_data is not None` on its own, so it is unaffected.

Scoped to the agent path that the issue reports — `workflow.py` has a similar-looking condition, but workflow sessions always initialize `session_data` with `session_state`, so it is a different shape and is left alone here.

## Verification

Against `main` (`pip install agno==2.8.7` is byte-identical to `libs/agno/agno/agent/_session.py` on `main`, so the installed tree is a faithful harness):

- **Repro**, seeding a session row the way `POST /sessions` does and saving a `RUNNING` run:

  | | `save_session` | `asave_session` |
  |---|---|---|
  | before | run **not** persisted (`runs=0`) | run **not** persisted (`runs=0`) |
  | after | `runs=1`, status `RUNNING` | `runs=1`, status `RUNNING` |

- **New regression test** `libs/agno/tests/unit/agent/test_session_persistence.py` — fails on both paths before the change, passes after.
- **No regressions**: 95 downloaded unit-test modules from `tests/unit/{agent,db,os,session}` give an identical `1459 passed / 18 failed` before and after; the 18 are pre-existing Windows / optional-dependency failures unrelated to this change.
- `ruff` (0.16.0, repo `line-length = 120`): both files clean; the source file reports the same pre-existing findings before and after.

*AI-assisted, human reviewed.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
