### PR TITLE
fix(agui): forward add_history_to_context from forwarded_props

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -83,6 +83,15 @@ async def run_entity(
         run_kwargs: dict = {}
         if ui_deps:
             run_kwargs["add_dependencies_to_context"] = True
+        # Prefer forwarded_props (documented AGUI extension point); also accept a
+        # top-level extra field because RunAgentInput allows extras.
+        add_history = None
+        if run_input.forwarded_props and isinstance(run_input.forwarded_props, dict):
+            add_history = run_input.forwarded_props.get("add_history_to_context")
+        if add_history is None:
+            add_history = getattr(run_input, "add_history_to_context", None)
+        if add_history is not None:
+            run_kwargs["add_history_to_context"] = bool(add_history)
 
         # 4. Determine if this is a resume (trailing ToolMessages) or fresh run
         if tool_messages:

--- a/libs/agno/tests/unit/os/interfaces/test_agui_router.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_router.py
@@ -150,3 +150,28 @@ async def test_run_entity_fresh_run_calls_arun():
         pass
 
     assert fake_entity.arun_called is True
+
+
+@pytest.mark.asyncio
+async def test_run_entity_forwarded_props_passes_add_history_to_context():
+    """forwarded_props.add_history_to_context is forwarded into entity.arun."""
+    fake_entity = CaptureKwargsEntity()
+    run_input = FakeRunInput()
+    run_input.forwarded_props = {"add_history_to_context": True}
+
+    async for _ in run_entity(fake_entity, run_input):
+        pass
+
+    assert fake_entity.captured_kwargs.get("add_history_to_context") is True
+
+
+@pytest.mark.asyncio
+async def test_run_entity_omits_add_history_when_not_provided():
+    fake_entity = CaptureKwargsEntity()
+    run_input = FakeRunInput()
+    run_input.forwarded_props = {}
+
+    async for _ in run_entity(fake_entity, run_input):
+        pass
+
+    assert "add_history_to_context" not in fake_entity.captured_kwargs


### PR DESCRIPTION
## Summary
`/agui` could not pass `add_history_to_context` even though Agent/Team.run support it.

## Changes
- Read from `forwarded_props` / top-level extras into `run_kwargs`
- Unit tests

Fixes #9384