### PR TITLE
fix(tools): persist toolkit_complete so instructions survive toolkit growth

### DIFF
--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -557,6 +557,7 @@ def to_dict(agent: Agent) -> Dict[str, Any]:
     # Registry.rehydrate_function). Mirrors the parse_tools walk: tools are
     # processed in declaration order and the first one to claim a name wins.
     _owning_toolkit: Dict[str, str] = {}
+    _toolkit_complete_names: Set[str] = set()
     if agent.model is not None and agent.tools and isinstance(agent.tools, list):
         _tools = parse_tools(
             agent,
@@ -574,11 +575,14 @@ def to_dict(agent: Agent) -> Dict[str, Any]:
                     _claimed_names.add(_func.name)
                     if isinstance(_tool.name, str) and _tool.name:
                         _owning_toolkit[_func.name] = _tool.name
+                        _toolkit_complete_names.add(_func.name)
             elif isinstance(_tool, Function):
                 if _tool.name not in _claimed_names:
                     _claimed_names.add(_tool.name)
                     if _tool.owning_toolkit:
                         _owning_toolkit[_tool.name] = _tool.owning_toolkit
+                    if getattr(_tool, "toolkit_complete", None):
+                        _toolkit_complete_names.add(_tool.name)
             elif callable(_tool) and getattr(_tool, "__name__", None) is not None:
                 _claimed_names.add(_tool.__name__)
     if _tools:
@@ -590,6 +594,8 @@ def to_dict(agent: Agent) -> Dict[str, Any]:
                     _toolkit_name = _owning_toolkit.get(tool.name)
                     if _toolkit_name is not None:
                         tool_dict["toolkit"] = _toolkit_name
+                    if tool.name in _toolkit_complete_names or getattr(tool, "toolkit_complete", None):
+                        tool_dict["toolkit_complete"] = True
                     serialized_tools.append(tool_dict)
                 else:
                     serialized_tools.append(tool)

--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -360,7 +360,7 @@ def parse_tools(
     _function_names: List[str] = []
     _functions: List[Union[Function, dict]] = []
     _toolkit_instruction_keys: Set[ToolkitKey] = set()
-    _source_toolkit_last_index, _source_toolkit_members, _toolkit_keys = _group_source_toolkits(tools)
+    _source_toolkit_last_index, _source_toolkit_members, _toolkit_keys, _toolkit_complete_keys = _group_source_toolkits(tools)
     agent._tool_instructions = []
 
     def toolkit_key(toolkit: Toolkit) -> ToolkitKey:
@@ -389,6 +389,7 @@ def parse_tools(
             last_index=_source_toolkit_last_index,
             members=_source_toolkit_members,
             async_mode=async_mode,
+            complete_keys=_toolkit_complete_keys,
         )
 
     # Get output_schema from run_context

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -223,6 +223,8 @@ class Registry:
             # re-stamps the "toolkit" key even though the loaded component holds
             # bare Functions instead of Toolkits.
             func.owning_toolkit = toolkit_name
+        if func_dict.get("toolkit_complete") is True:
+            func.toolkit_complete = True
 
         owner_maps = rebuild_state.get("owners")
         if owner_maps is None:

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -554,6 +554,8 @@ def to_dict(team: "Team") -> Dict[str, Any]:
                     # attribution they carry so it survives the round trip.
                     if tool.owning_toolkit:
                         func_dict["toolkit"] = tool.owning_toolkit
+                    if getattr(tool, "toolkit_complete", None):
+                        func_dict["toolkit_complete"] = True
                     serialized_tools.append(func_dict)
                 elif isinstance(tool, Toolkit):
                     # get_functions() is the exposed subset -- the only functions
@@ -565,6 +567,7 @@ def to_dict(team: "Team") -> Dict[str, Any]:
                         # Registry.rehydrate_function).
                         if isinstance(tool.name, str) and tool.name:
                             func_dict["toolkit"] = tool.name
+                        func_dict["toolkit_complete"] = True
                         serialized_tools.append(func_dict)
                 elif callable(tool):
                     func = Function.from_callable(tool)

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -361,6 +361,7 @@ def _determine_tools_for_model(
             last_index=_source_toolkit_last_index,
             members=_source_toolkit_members,
             async_mode=async_mode,
+            complete_keys=_toolkit_complete_keys,
         )
 
     # Get output_schema from run_context

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -264,6 +264,11 @@ class Function(BaseModel):
     # to_dict: it is persisted via the storage layer's "toolkit" key and never
     # sent to models.
     owning_toolkit: Optional[str] = None
+    # True when this function was persisted as part of a whole Toolkit (not a
+    # hand-picked subset). Used to keep toolkit instructions stable if the live
+    # toolkit later gains/loses members. Excluded from to_dict; storage uses the
+    # "toolkit_complete" key.
+    toolkit_complete: Optional[bool] = None
     # Live Toolkit this function was flattened from during registry
     # rehydration. It restores toolkit-level behavior without persisting the
     # Toolkit or its instructions in component configs.

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -38,19 +38,18 @@ def _toolkit_key(toolkit: "Toolkit") -> ToolkitKey:
 
 def _group_source_toolkits(
     tools: Sequence[Any],
-) -> Tuple[Dict[ToolkitKey, int], Dict[ToolkitKey, Set[str]], Dict[int, ToolkitKey]]:
+) -> Tuple[Dict[ToolkitKey, int], Dict[ToolkitKey, Set[str]], Dict[int, ToolkitKey], Set[ToolkitKey]]:
     """Index the bare Functions that a live Toolkit was flattened into.
 
     Returns the last index each toolkit's members occupy in ``tools`` and the
     member names present, both keyed by :func:`_toolkit_key`, plus the key
-    itself memoized per live Toolkit object. The key folds the toolkit's whole
-    function surface, so rebuilding it per member Function would make one
-    collection pass quadratic in the toolkit's size; every later key read must
-    come from the memo.
+    itself memoized per live Toolkit object, and the set of keys that were
+    persisted as a complete toolkit (``toolkit_complete``).
     """
     last_index: Dict[ToolkitKey, int] = {}
     members: Dict[ToolkitKey, Set[str]] = {}
     keys_by_id: Dict[int, ToolkitKey] = {}
+    complete_keys: Set[ToolkitKey] = set()
     for index, tool in enumerate(tools):
         if not isinstance(tool, Function):
             continue
@@ -62,7 +61,9 @@ def _group_source_toolkits(
             key = keys_by_id[id(source_toolkit)] = _toolkit_key(source_toolkit)
         last_index[key] = index
         members.setdefault(key, set()).add(tool.name)
-    return last_index, members, keys_by_id
+        if getattr(tool, "toolkit_complete", None):
+            complete_keys.add(key)
+    return last_index, members, keys_by_id, complete_keys
 
 
 def _emits_toolkit_instructions(
@@ -72,6 +73,7 @@ def _emits_toolkit_instructions(
     last_index: Dict[ToolkitKey, int],
     members: Dict[ToolkitKey, Set[str]],
     async_mode: bool = False,
+    complete_keys: Set[ToolkitKey] | None = None,
 ) -> bool:
     """Whether the bare Function at ``index`` should emit its toolkit's guidance.
 
@@ -92,6 +94,10 @@ def _emits_toolkit_instructions(
     """
     if last_index.get(key) != index:
         return False
+    # Persisted whole-toolkit components keep their guidance even if the live
+    # toolkit later gains or loses members (#9405).
+    if complete_keys is not None and key in complete_keys:
+        return True
     # Measured against the set this run would actually deliver: in async mode a
     # live Toolkit contributes its async variants too, and the registry cannot
     # rehydrate those, so an async-only member always leaves a gap here.

--- a/libs/agno/tests/unit/tools/test_toolkit_complete_instructions.py
+++ b/libs/agno/tests/unit/tools/test_toolkit_complete_instructions.py
@@ -4,6 +4,7 @@ from agno.agent import Agent
 from agno.agent._tools import parse_tools
 from agno.models.openai import OpenAIChat
 from agno.registry import Registry
+from agno.tools.function import Function
 from agno.tools.toolkit import Toolkit
 
 
@@ -45,3 +46,41 @@ def test_saved_toolkit_instructions_survive_toolkit_growth():
 
     files.register(delete_file)
     assert "Always read a file before you write it." in load_and_collect()
+
+
+def test_toolkit_complete_round_trips_through_agent_storage():
+    """Serialize stamps toolkit_complete; hydrate restores it on regenerated tools."""
+
+    def read_file(path: str) -> str:
+        """Read a file."""
+        return path
+
+    def write_file(path: str, body: str) -> str:
+        """Write a file."""
+        return path
+
+    files = Toolkit(
+        name="files",
+        tools=[read_file, write_file],
+        instructions="Always read a file before you write it.",
+        add_instructions=True,
+    )
+    model = OpenAIChat(id="gpt-4o-mini")
+    registry = Registry(tools=[files], models=[model])
+    agent = Agent(id="toolkit-complete-agent", model=model, tools=[files])
+
+    config = agent.to_dict()
+    tools_by_name = {t["name"]: t for t in config["tools"]}
+    assert tools_by_name["read_file"]["toolkit_complete"] is True
+    assert tools_by_name["write_file"]["toolkit_complete"] is True
+
+    loaded = Agent.from_dict(config, registry=registry)
+    assert loaded.tools is not None
+    for tool in loaded.tools:
+        assert isinstance(tool, Function)
+        assert tool.toolkit_complete is True
+
+    # Load -> save must re-stamp the key so a later session still sees it.
+    resaved = loaded.to_dict()
+    for tool_dict in resaved["tools"]:
+        assert tool_dict.get("toolkit_complete") is True

--- a/libs/agno/tests/unit/tools/test_toolkit_complete_instructions.py
+++ b/libs/agno/tests/unit/tools/test_toolkit_complete_instructions.py
@@ -1,0 +1,47 @@
+"""Toolkit instructions must survive the live toolkit gaining functions (#9405)."""
+
+from agno.agent import Agent
+from agno.agent._tools import parse_tools
+from agno.models.openai import OpenAIChat
+from agno.registry import Registry
+from agno.tools.toolkit import Toolkit
+
+
+def test_saved_toolkit_instructions_survive_toolkit_growth():
+    def read_file(path: str) -> str:
+        """Read a file."""
+        return path
+
+    def write_file(path: str, body: str) -> str:
+        """Write a file."""
+        return path
+
+    files = Toolkit(
+        name="files",
+        tools=[read_file, write_file],
+        instructions="Always read a file before you write it.",
+        add_instructions=True,
+    )
+    model = OpenAIChat(id="gpt-4o-mini")
+    registry = Registry(tools=[files], models=[model])
+
+    stored = []
+    for _name, function in files.get_functions().items():
+        tool_dict = function.to_dict()
+        tool_dict["toolkit"] = files.name
+        tool_dict["toolkit_complete"] = True
+        stored.append(tool_dict)
+
+    def load_and_collect() -> list:
+        agent = Agent(name="a", model=model, tools=registry.rehydrate_functions([dict(d) for d in stored]))
+        parse_tools(agent=agent, tools=agent.tools, model=model)
+        return agent._tool_instructions or []
+
+    assert "Always read a file before you write it." in load_and_collect()
+
+    def delete_file(path: str) -> str:
+        """Delete a file."""
+        return path
+
+    files.register(delete_file)
+    assert "Always read a file before you write it." in load_and_collect()


### PR DESCRIPTION
## Summary
Saved agents lost toolkit-level instructions when the live Toolkit later gained a function.

## Changes
- Persist/restore `toolkit_complete`
- Prefer the marker in `_emits_toolkit_instructions`
- Regression test

Fixes #9405