### PR TITLE
fix(agent): keep unanswered member tools paused

### DIFF
--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -608,6 +608,13 @@ def handle_user_input_update(agent: Agent, tool: ToolExecution):
         tool.tool_args[field.name] = field.value
 
 
+def _is_user_input_complete(tool: ToolExecution) -> bool:
+    """Return whether a user-input tool has a complete, acknowledged answer."""
+    if tool.answered is not True:
+        return False
+    return not tool.user_input_schema or all(field.value is not None for field in tool.user_input_schema)
+
+
 def handle_get_user_input_tool_update(agent: Agent, run_messages: RunMessages, tool: ToolExecution):
     import json
 
@@ -941,7 +948,7 @@ def handle_tool_call_updates(
             _t.answered = True
 
         # Case 4: Handle user input required tools
-        elif _t.requires_user_input is not None and _t.requires_user_input is True:
+        elif _t.requires_user_input is True and _is_user_input_complete(_t):
             handle_user_input_update(agent, tool=_t)
             _t.requires_user_input = False
             _t.answered = True
@@ -994,7 +1001,7 @@ def handle_tool_call_updates_stream(
             _t.answered = True
 
         # Case 4: Handle user input required tools
-        elif _t.requires_user_input is not None and _t.requires_user_input is True:
+        elif _t.requires_user_input is True and _is_user_input_complete(_t):
             handle_user_input_update(agent, tool=_t)
             yield from run_tool(
                 agent, run_response, run_messages, _t, functions=_functions, stream_events=stream_events
@@ -1042,7 +1049,7 @@ async def ahandle_tool_call_updates(
             _t.requires_user_input = False
             _t.answered = True
         # Case 4: Handle user input required tools
-        elif _t.requires_user_input is not None and _t.requires_user_input is True:
+        elif _t.requires_user_input is True and _is_user_input_complete(_t):
             handle_user_input_update(agent, tool=_t)
             async for _ in arun_tool(agent, run_response, run_messages, _t, functions=_functions):
                 pass
@@ -1095,7 +1102,7 @@ async def ahandle_tool_call_updates_stream(
             _t.requires_user_input = False
             _t.answered = True
         # Case 4: Handle user input required tools
-        elif _t.requires_user_input is not None and _t.requires_user_input is True:
+        elif _t.requires_user_input is True and _is_user_input_complete(_t):
             handle_user_input_update(agent, tool=_t)
             async for event in arun_tool(
                 agent, run_response, run_messages, _t, functions=_functions, stream_events=stream_events

--- a/libs/agno/tests/unit/agent/test_member_user_input.py
+++ b/libs/agno/tests/unit/agent/test_member_user_input.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agno.agent import _tools
+from agno.models.response import ToolExecution
+from agno.run.agent import RunOutput
+from agno.run.messages import RunMessages
+from agno.tools.function import UserInputField
+
+
+def _paused_member_tool(*, answered: bool | None = None, value=None) -> ToolExecution:
+    return ToolExecution(
+        tool_name="collect_info",
+        requires_user_input=True,
+        answered=answered,
+        user_input_schema=[UserInputField(name="note", field_type=str, value=value)],
+        tool_args={},
+    )
+
+
+def _run_context(tool: ToolExecution):
+    return SimpleNamespace(model=None), RunOutput(tools=[tool]), RunMessages()
+
+
+def test_member_user_input_stays_paused_until_answered(monkeypatch):
+    tool = _paused_member_tool()
+    agent, run_response, run_messages = _run_context(tool)
+    monkeypatch.setattr(_tools, "run_tool", lambda *args, **kwargs: pytest.fail("unanswered tool was executed"))
+
+    _tools.handle_tool_call_updates(agent, run_response, run_messages, tools=[])
+
+    assert tool.requires_user_input is True
+    assert tool.answered is None
+    assert tool.tool_args == {}
+
+
+def test_member_user_input_stream_stays_paused_until_answered(monkeypatch):
+    tool = _paused_member_tool()
+    agent, run_response, run_messages = _run_context(tool)
+    monkeypatch.setattr(_tools, "run_tool", lambda *args, **kwargs: pytest.fail("unanswered tool was executed"))
+
+    assert list(_tools.handle_tool_call_updates_stream(agent, run_response, run_messages, tools=[])) == []
+    assert tool.requires_user_input is True
+
+
+@pytest.mark.asyncio
+async def test_async_member_user_input_stays_paused_until_answered(monkeypatch):
+    tool = _paused_member_tool()
+    agent, run_response, run_messages = _run_context(tool)
+    monkeypatch.setattr(_tools, "arun_tool", lambda *args, **kwargs: pytest.fail("unanswered tool was executed"))
+
+    await _tools.ahandle_tool_call_updates(agent, run_response, run_messages, tools=[])
+
+    assert tool.requires_user_input is True
+
+
+@pytest.mark.asyncio
+async def test_async_member_user_input_stream_stays_paused_until_answered(monkeypatch):
+    tool = _paused_member_tool()
+    agent, run_response, run_messages = _run_context(tool)
+    monkeypatch.setattr(_tools, "arun_tool", lambda *args, **kwargs: pytest.fail("unanswered tool was executed"))
+
+    events = []
+    async for event in _tools.ahandle_tool_call_updates_stream(agent, run_response, run_messages, tools=[]):
+        events.append(event)
+
+    assert events == []
+    assert tool.requires_user_input is True
+
+
+def test_member_user_input_executes_after_complete_answer(monkeypatch):
+    tool = _paused_member_tool(answered=True, value="provided")
+    agent, run_response, run_messages = _run_context(tool)
+    executed: list[bool] = []
+
+    def fake_run_tool(*args, **kwargs):
+        executed.append(True)
+        return iter(())
+
+    monkeypatch.setattr(_tools, "run_tool", fake_run_tool)
+
+    _tools.handle_tool_call_updates(agent, run_response, run_messages, tools=[])
+
+    assert executed == [True]
+    assert tool.requires_user_input is False
+    assert tool.tool_args == {"note": "provided"}


### PR DESCRIPTION
## Problem

A member-level tool marked `requires_user_input=True` can execute while its required fields are still unanswered. This passes `None` into the tool instead of keeping the member run paused for the user.

## Root Cause

The four member tool-dispatch paths in `agent/_tools.py` checked only `requires_user_input is True`. They did not require `answered=True` or verify that every `user_input_schema` field had a non-`None` value.

## Solution

Require a complete, acknowledged user-input response before executing a member tool. Incomplete responses leave the tool's paused state unchanged so the surrounding continuation flow can request the missing input again.

## Changes

- Added a shared completeness check for member user-input tools.
- Applied it to sync, sync-stream, async, and async-stream dispatch paths.
- Added regression coverage for all four paused paths and for execution after a complete answer.

## Testing

- Baseline before modification: `py -m pytest libs/agno/tests/unit/agent/test_unified_continue.py -q` — passed (76 tests).
- Focused regression: `py -m pytest libs/agno/tests/unit/agent/test_member_user_input.py -q` — passed (5 tests).
- Final focused combination: `py -m pytest libs/agno/tests/unit/agent/test_unified_continue.py libs/agno/tests/unit/agent/test_member_user_input.py -q` — passed (81 tests).
- `py -m ruff format --check agno/agent/_tools.py tests/unit/agent/test_member_user_input.py` — passed.
- `py -m ruff check agno/agent/_tools.py tests/unit/agent/test_member_user_input.py` — passed.
- `py -m py_compile agno/agent/_tools.py tests/unit/agent/test_member_user_input.py` — passed.
- Narrow typecheck: `py -m mypy --follow-imports=skip --ignore-missing-imports agno/agent/_tools.py tests/unit/agent/test_member_user_input.py` — passed.
- Full configured mypy — not verified: it exceeded the 120-second local timeout.
- Full package suite/integration — not run; this is a focused agent dispatch fix.

## Compatibility/Risk

Low. Tools without an active user-input requirement are unchanged. A member tool with a user-input schema now executes only after all fields are supplied and acknowledged; values such as `False`, `0`, and empty strings remain valid because only `None` is treated as unanswered.

## Notes for Reviewer

The linked issue is open and unassigned with no matching open PR at publication time. Related PR #9396 addresses member-run persistence but does not change this dispatch guard; this patch is limited to the unanswered-field execution path.

## Linked Issue

Closes #9427
