### PR TITLE
feat: harden component and scheduler persistence

### DIFF
--- a/cookbook/05_agent_os/22_studio/registry_and_components.py
+++ b/cookbook/05_agent_os/22_studio/registry_and_components.py
@@ -3,8 +3,10 @@ Inspect Registry resources and manage persisted components
 ==========================================================
 
 The Registry endpoint lists code-defined primitives. The Components endpoints
-manage versioned Agent, Team, and Workflow configurations in the AgentOS
-database. Components require a synchronous BaseDb; this example uses SqliteDb.
+manage guarded, versioned Agent, Team, and Workflow configurations in the
+AgentOS database. Metadata edits append a draft, publishing moves the current
+pointer, and DELETE soft-archives the component with compare-and-set guards.
+Components require a synchronous BaseDb; this example uses SqliteDb.
 
 Prerequisites: none for the HTTP demo; provider keys are needed only to run the catalog Agent
 Run: .venvs/demo/bin/python cookbook/05_agent_os/22_studio/registry_and_components.py
@@ -13,15 +15,18 @@ Try: run this file with --demo in another terminal
 
 import argparse
 import os
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from uuid import uuid4
 
 import httpx
+import jwt
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.anthropic import Claude
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
+from agno.os.config import AuthorizationConfig
 from agno.registry import Registry
 from agno.tools.calculator import CalculatorTools
 
@@ -31,6 +36,29 @@ from agno.tools.calculator import CalculatorTools
 
 PORT = int(os.getenv("PORT", "7777"))
 BASE_URL = os.getenv("AGENT_OS_BASE_URL", f"http://127.0.0.1:{PORT}")
+OS_ID = "registry-components-os"
+ADMIN_USER_ID = "components-admin"
+JWT_SECRET = os.getenv(
+    "JWT_VERIFICATION_KEY",
+    "registry-components-development-secret-at-least-256-bits-long",
+)
+
+
+def make_admin_token() -> str:
+    """Mint a short-lived, audience-bound token for the local HTTP demo."""
+    now = datetime.now(UTC)
+    return jwt.encode(
+        {
+            "sub": ADMIN_USER_ID,
+            "aud": OS_ID,
+            "scopes": ["agent_os:admin"],
+            "iat": now,
+            "exp": now + timedelta(minutes=15),
+        },
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+
 
 DB_DIR = Path(__file__).parent / "tmp"
 DB_DIR.mkdir(exist_ok=True)
@@ -59,12 +87,18 @@ catalog_agent = Agent(
 )
 
 agent_os = AgentOS(
-    id="registry-components-os",
+    id=OS_ID,
     name="Registry and Components AgentOS",
-    description="Read-only Registry discovery plus persisted component CRUD.",
+    description="Read-only Registry discovery plus a guarded persisted-component lifecycle.",
     agents=[catalog_agent],
     registry=registry,
     db=db,
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+    ),
 )
 app = agent_os.get_app()
 
@@ -75,7 +109,7 @@ app = agent_os.get_app()
 
 
 def run_demo() -> None:
-    """List registry resources and complete one component CRUD lifecycle."""
+    """List registry resources, append and publish a draft, then soft-archive it."""
     component_id = f"registry-crud-agent-{uuid4().hex[:8]}"
     component_name = "Registry CRUD Agent"
     component_config = Agent(
@@ -85,7 +119,11 @@ def run_demo() -> None:
         instructions="Answer catalog questions in one sentence.",
     ).to_dict()
 
-    with httpx.Client(base_url=BASE_URL, timeout=60.0) as client:
+    with httpx.Client(
+        base_url=BASE_URL,
+        timeout=60.0,
+        headers={"Authorization": f"Bearer {make_admin_token()}"},
+    ) as client:
         registry_response = client.get("/registry", params={"limit": 100})
         registry_response.raise_for_status()
         registry_payload = registry_response.json()
@@ -134,32 +172,69 @@ def run_demo() -> None:
                 "name": "Updated Registry CRUD Agent",
                 "description": "Updated through PATCH /components/{component_id}.",
                 "metadata": {"owner": "cookbook", "reviewed": True},
+                "guard": {"latest_version": 1, "current_version": 1},
             },
         )
         update_response.raise_for_status()
-        updated = update_response.json()
-        if updated["name"] != "Updated Registry CRUD Agent":
-            raise RuntimeError(f"Component update did not persist: {updated}")
+        draft = update_response.json()
+        if (
+            draft["version"] != 2
+            or draft["stage"] != "draft"
+            or draft["config"]["name"] != "Updated Registry CRUD Agent"
+        ):
+            raise RuntimeError(f"PATCH did not append the expected draft: {draft}")
 
         config_response = client.get(f"/components/{component_id}/configs/current")
         config_response.raise_for_status()
-        current_config = config_response.json()
-        if current_config["version"] != 1 or current_config["stage"] != "published":
-            raise RuntimeError(f"Unexpected current config: {current_config}")
+        pre_publish_current = config_response.json()
+        if (
+            pre_publish_current["version"] != 1
+            or pre_publish_current["stage"] != "published"
+        ):
+            raise RuntimeError(
+                f"Draft edit moved the current pointer: {pre_publish_current}"
+            )
 
-        delete_response = client.delete(f"/components/{component_id}")
+        publish_response = client.patch(
+            f"/components/{component_id}/configs/2",
+            json={
+                "stage": "published",
+                "guard": {"latest_version": 2, "current_version": 1},
+            },
+        )
+        publish_response.raise_for_status()
+        published = publish_response.json()
+        if published["version"] != 2 or published["stage"] != "published":
+            raise RuntimeError(f"Draft publication failed: {published}")
+
+        current_response = client.get(f"/components/{component_id}")
+        current_response.raise_for_status()
+        current = current_response.json()
+        if (
+            current["current_version"] != 2
+            or current["name"] != "Updated Registry CRUD Agent"
+        ):
+            raise RuntimeError(
+                f"Published projection did not move atomically: {current}"
+            )
+
+        delete_response = client.request(
+            "DELETE",
+            f"/components/{component_id}",
+            json={"guard": {"latest_version": 2, "current_version": 2}},
+        )
         if delete_response.status_code != 204:
             raise RuntimeError(
-                f"Expected DELETE 204, got {delete_response.status_code}"
+                f"Expected archive 204, got {delete_response.status_code}"
             )
         if client.get(f"/components/{component_id}").status_code != 404:
-            raise RuntimeError("Deleted component remained visible")
+            raise RuntimeError("Archived component remained visible")
 
     print(f"Registry resources: {registry_payload['meta']['total_count']}")
     print(f"Created: {created['component_id']} v{created['current_version']}")
-    print(f"Updated name: {updated['name']}")
-    print(f"Current config: v{current_config['version']} ({current_config['stage']})")
-    print("Deleted component: HTTP 204; follow-up GET: HTTP 404")
+    print(f"Appended draft: v{draft['version']} ({draft['stage']})")
+    print(f"Published current: v{current['current_version']} as {current['name']}")
+    print("Soft-archived component: HTTP 204; follow-up GET: HTTP 404")
 
 
 if __name__ == "__main__":

--- a/libs/agno/agno/agent/_init.py
+++ b/libs/agno/agno/agent/_init.py
@@ -36,12 +36,12 @@ from agno.utils.log import (
     set_log_level_to_info,
 )
 from agno.utils.safe_formatter import SafeFormatter
-from agno.utils.string import generate_id_from_name
+from agno.utils.string import generate_component_id_from_name
 
 
 def set_id(agent: Agent) -> None:
     if agent.id is None:
-        agent.id = generate_id_from_name(agent.name)
+        agent.id = generate_component_id_from_name(agent.name)
 
 
 def set_debug(agent: Agent, debug_mode: Optional[bool] = None) -> None:

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from agno.agent.agent import Agent
 
 from agno.db.base import BaseDb, ComponentType, SessionType
-from agno.db.utils import resolve_db_from_config
+from agno.db.utils import resolve_db_from_config, save_component_config
 from agno.exceptions import ComponentRehydrationError
 from agno.metrics import RunMetrics, SessionMetrics
 from agno.models.base import Model
@@ -1299,18 +1299,13 @@ def save(
         agent.id = generate_id_from_name(agent.name)
 
     try:
-        # Create or update component
-        db_.upsert_component(
+        config = save_component_config(
+            db_,
             component_id=agent.id,
             component_type=ComponentType.AGENT,
             name=getattr(agent, "name", agent.id),
             description=getattr(agent, "description", None),
             metadata=getattr(agent, "metadata", None),
-        )
-
-        # Create or update config
-        config = db_.upsert_config(
-            component_id=agent.id,
             config=to_dict(agent),
             label=label,
             stage=stage,
@@ -1377,6 +1372,7 @@ def delete(
     *,
     db: Optional[BaseDb] = None,
     hard_delete: bool = False,
+    require_no_dependents: bool = True,
 ) -> bool:
     """
     Delete the agent component.
@@ -1385,9 +1381,18 @@ def delete(
         agent: The Agent instance.
         db: The database to delete the component from.
         hard_delete: Whether to hard delete the component.
+        require_no_dependents: Refuse deletion while another active component
+            references this agent. Setting this to False bypasses dependency
+            validation and can leave active components with dangling links;
+            use it only for a deliberate repair or migration. Catalog-v1
+            adapters retain their historical unguarded deletion behavior.
 
     Returns:
         True if the component was deleted, False otherwise.
+
+    Raises:
+        ComponentDependencyError: If a dependent component references this
+            agent and require_no_dependents is True.
     """
     db_ = db or agent.db
     if not db_:
@@ -1397,4 +1402,12 @@ def delete(
     if agent.id is None:
         raise ValueError("Cannot delete agent without an id")
 
-    return db_.delete_component(component_id=agent.id, hard_delete=hard_delete)
+    if getattr(db_, "component_catalog_api_version", 1) < 2:
+        # Preserve the exact pre-2.9 adapter call shape. Third-party catalog-v1
+        # implementations cannot accept the v2-only keyword-only policy.
+        return db_.delete_component(component_id=agent.id, hard_delete=hard_delete)
+    return db_.delete_component(
+        component_id=agent.id,
+        hard_delete=hard_delete,
+        require_no_dependents=require_no_dependents,
+    )

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -24,6 +24,7 @@ from agno.db.utils import (
     bind_component_version_guard_after_append,
     capture_component_version_guard,
     get_bound_component_version_guard,
+    resolve_component_id,
     resolve_db_from_config,
     save_component_config,
 )
@@ -45,7 +46,6 @@ from agno.utils.agent import (
 from agno.utils.db_fallback import require_db_fallback_matches
 from agno.utils.log import log_debug, log_error, log_warning
 from agno.utils.merge_dict import merge_dictionaries
-from agno.utils.string import generate_component_id_from_name
 
 # ---------------------------------------------------------------------------
 # Run output accessors
@@ -1305,7 +1305,7 @@ def save(
         raise ValueError("Async databases not yet supported for save(). Use a sync database.")
 
     if agent.id is None:
-        agent.id = generate_component_id_from_name(agent.name)
+        agent.id = resolve_component_id(db_, agent.name, ComponentType.AGENT)
 
     mutation_guard = guard or get_bound_component_version_guard(agent, db_)
 

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -19,8 +19,14 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
     from agno.agent.agent import Agent
 
-from agno.db.base import BaseDb, ComponentType, SessionType
-from agno.db.utils import resolve_db_from_config, save_component_config
+from agno.db.base import BaseDb, ComponentType, ComponentVersionGuard, ComponentVersionGuardRequiredError, SessionType
+from agno.db.utils import (
+    bind_component_version_guard_after_append,
+    capture_component_version_guard,
+    get_bound_component_version_guard,
+    resolve_db_from_config,
+    save_component_config,
+)
 from agno.exceptions import ComponentRehydrationError
 from agno.metrics import RunMetrics, SessionMetrics
 from agno.models.base import Model
@@ -39,7 +45,7 @@ from agno.utils.agent import (
 from agno.utils.db_fallback import require_db_fallback_matches
 from agno.utils.log import log_debug, log_error, log_warning
 from agno.utils.merge_dict import merge_dictionaries
-from agno.utils.string import generate_id_from_name
+from agno.utils.string import generate_component_id_from_name
 
 # ---------------------------------------------------------------------------
 # Run output accessors
@@ -1275,6 +1281,7 @@ def save(
     stage: str = "published",
     label: Optional[str] = None,
     notes: Optional[str] = None,
+    guard: Optional[ComponentVersionGuard] = None,
 ) -> Optional[int]:
     """
     Save the agent component and config.
@@ -1285,6 +1292,8 @@ def save(
         stage: The stage of the component. Defaults to "published".
         label: The label of the component.
         notes: The notes of the component.
+        guard: Explicit catalog-v2 compare-and-set state. Loaded and
+            previously saved objects reuse their captured guard automatically.
 
     Returns:
         Optional[int]: The version number of the saved config.
@@ -1296,7 +1305,9 @@ def save(
         raise ValueError("Async databases not yet supported for save(). Use a sync database.")
 
     if agent.id is None:
-        agent.id = generate_id_from_name(agent.name)
+        agent.id = generate_component_id_from_name(agent.name)
+
+    mutation_guard = guard or get_bound_component_version_guard(agent, db_)
 
     try:
         config = save_component_config(
@@ -1310,9 +1321,18 @@ def save(
             label=label,
             stage=stage,
             notes=notes,
+            guard=mutation_guard,
         )
-
-        return config.get("version")
+        version = config.get("version")
+        if isinstance(version, int) and getattr(db_, "component_catalog_api_version", 1) >= 2:
+            bind_component_version_guard_after_append(
+                agent,
+                db_,
+                previous=mutation_guard,
+                version=version,
+                stage=stage,
+            )
+        return version
 
     except Exception as e:
         log_error(f"Error saving Agent to database: {str(e)}")
@@ -1364,6 +1384,8 @@ def load(
             require_db_fallback_matches(config, db, "agent", id)
         agent.db = db
 
+    capture_component_version_guard(agent, db, id, expected_config_version=data.get("version"))
+
     return agent
 
 
@@ -1373,6 +1395,7 @@ def delete(
     db: Optional[BaseDb] = None,
     hard_delete: bool = False,
     require_no_dependents: bool = True,
+    guard: Optional[ComponentVersionGuard] = None,
 ) -> bool:
     """
     Delete the agent component.
@@ -1386,6 +1409,8 @@ def delete(
             validation and can leave active components with dangling links;
             use it only for a deliberate repair or migration. Catalog-v1
             adapters retain their historical unguarded deletion behavior.
+        guard: Explicit catalog-v2 compare-and-set state. Loaded and
+            previously saved objects reuse their captured guard automatically.
 
     Returns:
         True if the component was deleted, False otherwise.
@@ -1406,8 +1431,13 @@ def delete(
         # Preserve the exact pre-2.9 adapter call shape. Third-party catalog-v1
         # implementations cannot accept the v2-only keyword-only policy.
         return db_.delete_component(component_id=agent.id, hard_delete=hard_delete)
+    mutation_guard = guard or get_bound_component_version_guard(agent, db_)
+    if mutation_guard is None:
+        raise ComponentVersionGuardRequiredError(agent.id)
     return db_.delete_component(
         component_id=agent.id,
         hard_delete=hard_delete,
+        guard=mutation_guard,
         require_no_dependents=require_no_dependents,
+        expected_component_type=ComponentType.AGENT,
     )

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -965,8 +965,33 @@ class Agent:
         *,
         db: Optional["BaseDb"] = None,
         hard_delete: bool = False,
+        require_no_dependents: bool = True,
     ) -> bool:
-        return _storage.delete(self, db=db, hard_delete=hard_delete)
+        """Delete this agent's persisted component.
+
+        Args:
+            db: The database to delete the component from.
+            hard_delete: Permanently delete the component and its history.
+            require_no_dependents: Refuse deletion while another component
+                references this agent. Setting this to False bypasses
+                dependency validation and can leave active components with
+                dangling links; use it only for a deliberate repair or
+                migration. Catalog-v1 adapters retain their historical
+                unguarded deletion behavior.
+
+        Returns:
+            True if the component was deleted, False otherwise.
+
+        Raises:
+            ComponentDependencyError: If a dependent component references
+                this agent and require_no_dependents is True.
+        """
+        return _storage.delete(
+            self,
+            db=db,
+            hard_delete=hard_delete,
+            require_no_dependents=require_no_dependents,
+        )
 
     def get_run_output(
         self, run_id: str, session_id: Optional[str] = None, user_id: Optional[str] = None
@@ -1722,13 +1747,15 @@ def get_agent_by_id(
     label: Optional[str] = None,
     registry: Optional["Registry"] = None,
     strict: bool = False,
+    published_only: bool = False,
 ) -> Optional["Agent"]:
     """
     Get an Agent by id from the database (new entities/configs schema).
 
     Resolution order:
     - if label is provided: load that labeled version
-    - else: load component.current_version
+    - else: load the current published version, or the latest draft when the
+      component has never been published
 
     Args:
         db: Database handle.
@@ -1737,6 +1764,9 @@ def get_agent_by_id(
         registry: Optional Registry for reconstructing unserializable components.
         strict: If True, unresolvable registry references raise
             ComponentRehydrationError; None strictly means the agent was not found.
+        published_only: Resolve only the current published config when neither
+            an exact version nor label is supplied. Runtime dispatch uses this;
+            ordinary reads retain the draft-only fallback.
 
     Returns:
         Agent instance or None.
@@ -1748,7 +1778,11 @@ def get_agent_by_id(
     from agno.utils.log import log_error
 
     try:
-        row = db.get_config(component_id=id, label=label, version=version)
+        row = (
+            db.get_current_config(component_id=id)
+            if published_only and version is None and label is None
+            else db.get_config(component_id=id, label=label, version=version)
+        )
         if row is None:
             return None
 
@@ -1796,7 +1830,7 @@ def get_agents(
         )
         for component in components:
             try:
-                config = db.get_config(component_id=component["component_id"])
+                config = db.get_latest_config(component_id=component["component_id"])
                 if config is not None:
                     agent_config = config.get("config")
                     if agent_config is not None:
@@ -1807,7 +1841,7 @@ def get_agents(
                         # components so they stay visible and fixable.
                         agent = Agent.from_dict(agent_config, registry=registry, strict=False)
                         agent.id = component_id
-                        agent._version = component.get("current_version")
+                        agent._version = config.get("version")
                         agent._stage = config.get("stage")
                         agents.append(agent)
             except Exception as e:

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -34,8 +34,9 @@ from agno.agent import (
 )
 from agno.compression.manager import CompressionManager
 from agno.culture.manager import CultureManager
-from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, UserMemory
+from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, ComponentVersionGuard, UserMemory
 from agno.db.schemas.culture import CulturalKnowledge
+from agno.db.utils import bind_component_version_guard, capture_component_version_guard
 from agno.eval.base import BaseEval
 from agno.filters import FilterExpr
 from agno.guardrails import BaseGuardrail
@@ -944,8 +945,9 @@ class Agent:
         stage: str = "published",
         label: Optional[str] = None,
         notes: Optional[str] = None,
+        guard: Optional[ComponentVersionGuard] = None,
     ) -> Optional[int]:
-        return _storage.save(self, db=db, stage=stage, label=label, notes=notes)
+        return _storage.save(self, db=db, stage=stage, label=label, notes=notes, guard=guard)
 
     @classmethod
     def load(
@@ -966,6 +968,7 @@ class Agent:
         db: Optional["BaseDb"] = None,
         hard_delete: bool = False,
         require_no_dependents: bool = True,
+        guard: Optional[ComponentVersionGuard] = None,
     ) -> bool:
         """Delete this agent's persisted component.
 
@@ -991,6 +994,7 @@ class Agent:
             db=db,
             hard_delete=hard_delete,
             require_no_dependents=require_no_dependents,
+            guard=guard,
         )
 
     def get_run_output(
@@ -1801,6 +1805,8 @@ def get_agent_by_id(
                 require_db_fallback_matches(cfg, db, "agent", id)
             agent.db = db
 
+        capture_component_version_guard(agent, db, id, expected_config_version=row.get("version"))
+
         return agent
 
     except ComponentRehydrationError:
@@ -1843,6 +1849,12 @@ def get_agents(
                         agent.id = component_id
                         agent._version = config.get("version")
                         agent._stage = config.get("stage")
+                        bind_component_version_guard(
+                            agent,
+                            db,
+                            latest_version=config.get("version"),
+                            current_version=component.get("current_version"),
+                        )
                         agents.append(agent)
             except Exception as e:
                 component_id = component.get("component_id", "unknown")

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -55,10 +55,10 @@ class BaseExternalAgent:
     db: Optional[Union[BaseDb, AsyncBaseDb]] = None
 
     def __post_init__(self) -> None:
-        from agno.utils.string import generate_id_from_name
+        from agno.utils.string import generate_component_id_from_name
 
         if self.id is None:
-            self.id = generate_id_from_name(self.name)
+            self.id = generate_component_id_from_name(self.name)
 
     def get_id(self) -> str:
         """Return the agent ID, guaranteed non-None after __post_init__."""

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -2824,6 +2824,210 @@ class AsyncBaseDb(ABC):
         """
         raise NotImplementedError
 
+    # --- Components (Optional) ---
+    # These methods are optional. Override in subclasses to enable component persistence.
+    # Kept as plain def, mirroring the SQL async adapters' stubs: an async def default
+    # called without await returns an un-awaited coroutine and silently no-ops instead
+    # of raising at the sync call sites.
+
+    def get_component(
+        self,
+        component_id: str,
+        component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Get a component by ID."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def get_components(
+        self,
+        component_ids: Set[str],
+        component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Get a bounded set of components by ID."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def upsert_component(
+        self,
+        component_id: str,
+        component_type: Optional[ComponentType] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        current_version: Optional[int] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Create or update a component."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def delete_component(
+        self,
+        component_id: str,
+        hard_delete: bool = False,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        require_no_dependents: bool = True,
+        projection: Optional[ComponentProjection] = None,
+        expected_component_type: Optional[ComponentType] = None,
+    ) -> bool:
+        """Delete a component and all its configs/links."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def restore_component(
+        self,
+        component_id: str,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+    ) -> bool:
+        """Restore a soft-deleted component without replacing its identity or history."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def list_components(
+        self,
+        component_type: Optional[ComponentType] = None,
+        include_deleted: bool = False,
+        limit: int = 20,
+        offset: int = 0,
+        exclude_component_ids: Optional[Set[str]] = None,
+        name: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """List components with pagination."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def create_component_with_config(
+        self,
+        component_id: str,
+        component_type: ComponentType,
+        name: Optional[str],
+        config: Dict[str, Any],
+        description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        label: Optional[str] = None,
+        stage: str = "draft",
+        notes: Optional[str] = None,
+        links: Optional[List[Dict[str, Any]]] = None,
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """Create a component with its initial config atomically."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    # --- Component Configs (Optional) ---
+
+    def get_config(
+        self,
+        component_id: str,
+        version: Optional[int] = None,
+        label: Optional[str] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Get a config by component ID and version or label."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def get_current_config(self, component_id: str) -> Optional[Dict[str, Any]]:
+        """Get only the component's current published config."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def get_latest_config(
+        self,
+        component_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Get the latest visible config, regardless of publication stage."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def get_latest_configs(
+        self,
+        component_ids: Set[str],
+        *,
+        include_deleted: bool = False,
+    ) -> Dict[str, Optional[Dict[str, Any]]]:
+        """Get each requested component's latest visible config."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def upsert_config(
+        self,
+        component_id: str,
+        config: Optional[Dict[str, Any]] = None,
+        version: Optional[int] = None,
+        label: Optional[str] = None,
+        stage: Optional[str] = None,
+        notes: Optional[str] = None,
+        links: Optional[List[Dict[str, Any]]] = None,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+        restore_if_deleted: bool = False,
+        expected_component_type: Optional[ComponentType] = None,
+    ) -> Dict[str, Any]:
+        """Create or update a config version for a component."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def delete_config(
+        self,
+        component_id: str,
+        version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+    ) -> bool:
+        """Logically delete a specific config version."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def list_configs(
+        self,
+        component_id: str,
+        include_config: bool = False,
+        *,
+        include_deleted: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """List all config versions for a component."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def set_current_version(
+        self,
+        component_id: str,
+        version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+    ) -> bool:
+        """Set a specific published version as current."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    # --- Component Links (Optional) ---
+
+    def get_links(
+        self,
+        component_id: str,
+        version: int,
+        link_kind: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Get links for a config version."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def get_dependents(
+        self,
+        component_id: str,
+        version: Optional[int] = None,
+        *,
+        active_parents_only: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Find all components that reference this component."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
+    def load_component_graph(
+        self,
+        component_id: str,
+        version: Optional[int] = None,
+        label: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Load a component with its full resolved graph."""
+        raise NotImplementedError("Component methods not yet supported for async databases")
+
     # --- Schedules (Optional) ---
     # These methods are optional. Override in subclasses to enable scheduler persistence.
 

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -78,6 +78,24 @@ class ComponentVersionConflictError(ValueError):
         self.actual = actual
 
 
+class ComponentVersionGuardRequiredError(ValueError):
+    """Raised when a catalog-v2 mutation has no compare-and-set state."""
+
+    def __init__(self, component_id: str):
+        super().__init__(
+            f"Component {component_id} already exists; load it, reuse its saved object, or pass a ComponentVersionGuard"
+        )
+        self.component_id = component_id
+
+
+class ComponentArchivedError(ValueError):
+    """Raised when a normal mutation targets a reserved, archived ID."""
+
+    def __init__(self, component_id: str):
+        super().__init__(f"Component {component_id} is archived; restore it explicitly before saving")
+        self.component_id = component_id
+
+
 class ComponentDependencyError(ValueError):
     """Raised when a component or config is still referenced."""
 
@@ -985,6 +1003,7 @@ class BaseDb(ABC):
         guard: Optional[ComponentVersionGuard] = None,
         require_no_dependents: bool = True,
         projection: Optional[ComponentProjection] = None,
+        expected_component_type: Optional[ComponentType] = None,
     ) -> bool:
         """Delete a component and all its configs/links.
 
@@ -996,6 +1015,8 @@ class BaseDb(ABC):
                 default). Soft deletion considers active parents; hard deletion
                 considers every parent.
             projection: Component fields to update atomically with a soft deletion.
+            expected_component_type: Optional identity invariant validated in
+                the same transaction as deletion.
 
         Returns:
             True if deleted, False if not found or already deleted.
@@ -1092,6 +1113,8 @@ class BaseDb(ABC):
         component_id: str,
         version: Optional[int] = None,
         label: Optional[str] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Get a config by component ID and version or label.
 
@@ -1101,6 +1124,7 @@ class BaseDb(ABC):
                 omitted, returns the current published config or the latest
                 draft when the component has never been published.
             label: Config label to lookup. Ignored if version is provided.
+            include_deleted: Allow reading config history for an archived component.
 
         Returns:
             Config dictionary or None if not found.
@@ -1246,12 +1270,15 @@ class BaseDb(ABC):
         self,
         component_id: str,
         include_config: bool = False,
+        *,
+        include_deleted: bool = False,
     ) -> List[Dict[str, Any]]:
         """List all config versions for a component.
 
         Args:
             component_id: The component ID.
             include_config: If True, include full config blob. Otherwise just metadata.
+            include_deleted: Allow listing config history for an archived component.
 
         Returns:
             List of config dictionaries, newest first.

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import date, datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Set, Tuple, TypedDict, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -30,11 +31,133 @@ class ComponentType(str, Enum):
     WORKFLOW = "workflow"
 
 
+DELETED_CONFIG_STAGE = "_deleted"
+
+
+@dataclass(frozen=True)
+class ComponentVersionGuard:
+    """Compare-and-set state for a component mutation."""
+
+    latest_version: Optional[int]
+    current_version: Optional[int]
+
+
+class ComponentProjection(TypedDict, total=False):
+    """Denormalized component fields synchronized with a config mutation."""
+
+    name: str
+    description: Optional[str]
+    metadata: Optional[Dict[str, Any]]
+
+
+class ComponentAlreadyExistsError(ValueError):
+    """Raised when an atomic component create finds an occupied id."""
+
+    def __init__(self, component_id: str):
+        super().__init__(f"Component {component_id} already exists")
+        self.component_id = component_id
+
+
+class ComponentVersionConflictError(ValueError):
+    """Raised when component state no longer matches a compare-and-set guard."""
+
+    def __init__(
+        self,
+        component_id: str,
+        *,
+        expected: ComponentVersionGuard,
+        actual: ComponentVersionGuard,
+    ):
+        super().__init__(
+            f"Component {component_id} version conflict: expected "
+            f"latest={expected.latest_version}, current={expected.current_version}; "
+            f"found latest={actual.latest_version}, current={actual.current_version}"
+        )
+        self.component_id = component_id
+        self.expected = expected
+        self.actual = actual
+
+
+class ComponentDependencyError(ValueError):
+    """Raised when a component or config is still referenced."""
+
+    def __init__(self, component_id: str, dependents: List[Dict[str, Any]], version: Optional[int] = None):
+        target = f"{component_id} v{version}" if version is not None else component_id
+        super().__init__(f"Cannot delete {target}: it is referenced by {len(dependents)} component link(s)")
+        self.component_id = component_id
+        self.version = version
+        self.dependents = dependents
+
+
+class ComponentDependencyUnavailableError(ValueError):
+    """Raised when restoring a published component would expose a broken dependency graph."""
+
+    def __init__(self, component_id: str, dependencies: List[Dict[str, Any]]):
+        super().__init__(
+            f"Cannot restore {component_id}: {len(dependencies)} pinned dependency version(s) are unavailable"
+        )
+        self.component_id = component_id
+        self.dependencies = dependencies
+
+
+class ComponentCycleError(ValueError):
+    """Raised when a component-link mutation would create a dependency cycle."""
+
+    def __init__(self, component_id: str, cycle_path: List[str]):
+        rendered_path = " -> ".join(cycle_path)
+        super().__init__(f"Component dependency cycle detected: {rendered_path}")
+        self.component_id = component_id
+        self.cycle_path = cycle_path
+
+
+class ComponentDraftRequiredError(ValueError):
+    """Raised when an operation only valid for drafts targets a published config."""
+
+    def __init__(self, component_id: str, version: int):
+        super().__init__(f"Cannot delete published config {component_id} v{version}; only draft configs can be deleted")
+        self.component_id = component_id
+        self.version = version
+
+
+class ComponentLastConfigError(ValueError):
+    """Raised when deleting a config would leave an active component unusable."""
+
+    def __init__(self, component_id: str, version: int):
+        super().__init__(f"Cannot delete the last config for {component_id}; archive the component instead")
+        self.component_id = component_id
+        self.version = version
+
+
 class BaseDb(ABC):
     """Base abstract class for all our Database implementations."""
 
     # We assume the database to be up to date with the 2.0.0 release
     default_schema_version = "2.0.0"
+    # Component persistence is an optional database capability. Catalog
+    # consumers must fail at construction time when a backend does not opt in,
+    # rather than surfacing a late NotImplementedError during a mutation.
+    supports_component_persistence = False
+    # Version 1 is the pre-2.9 component adapter contract. Direct component
+    # saves retain a deliberate v1 path; the guarded 2.9 control plane requires
+    # an adapter that explicitly advertises version 2.
+    component_catalog_api_version = 1
+    # Version 1 is the legacy scheduler adapter contract. Scheduler surfaces
+    # that rely on scoped names and durable manual triggers require an adapter
+    # that explicitly advertises version 2.
+    scheduler_api_version = 1
+
+    @staticmethod
+    def _projection_from_config(config: Dict[str, Any]) -> ComponentProjection:
+        """Extract denormalized component fields from one stored config payload."""
+        projection: ComponentProjection = {}
+        name = config.get("name")
+        if isinstance(name, str):
+            projection["name"] = name
+        if "description" in config and (config["description"] is None or isinstance(config["description"], str)):
+            projection["description"] = config["description"]
+        if "metadata" in config and (config["metadata"] is None or isinstance(config["metadata"], dict)):
+            projection["metadata"] = config["metadata"]
+        return projection
 
     def __init__(
         self,
@@ -782,17 +905,47 @@ class BaseDb(ABC):
         self,
         component_id: str,
         component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Get a component by ID.
 
         Args:
             component_id: The component ID.
             component_type: Optional filter by type (agent|team|workflow).
+            include_deleted: Include a soft-deleted component in the lookup.
 
         Returns:
             Component dictionary or None if not found.
         """
         raise NotImplementedError
+
+    def get_components(
+        self,
+        component_ids: Set[str],
+        component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Get a bounded set of components by ID.
+
+        The compatibility implementation uses scalar reads. Catalog adapters
+        should override this with one bulk query.
+        """
+        rows: List[Dict[str, Any]] = []
+        for component_id in sorted(component_ids):
+            row = (
+                self.get_component(
+                    component_id,
+                    component_type=component_type,
+                    include_deleted=True,
+                )
+                if include_deleted
+                else self.get_component(component_id, component_type)
+            )
+            if row is not None:
+                rows.append(row)
+        return rows
 
     def upsert_component(
         self,
@@ -810,14 +963,17 @@ class BaseDb(ABC):
             component_type: Type (agent|team|workflow). Required for create, optional for update.
             name: Display name.
             description: Optional description.
-            current_version: Optional current version.
+            current_version: Reserved for compatibility. Direct current-pointer
+                mutation is rejected; use set_current_version with a guard and
+                synchronized projection.
             metadata: Optional metadata dict.
 
         Returns:
             Created/updated component dictionary.
 
         Raises:
-            ValueError: If creating and component_type is not provided.
+            ValueError: If creating and component_type is not provided, or if
+                current_version is supplied.
         """
         raise NotImplementedError
 
@@ -825,15 +981,48 @@ class BaseDb(ABC):
         self,
         component_id: str,
         hard_delete: bool = False,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        require_no_dependents: bool = True,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Delete a component and all its configs/links.
 
         Args:
             component_id: The component ID.
             hard_delete: If True, permanently delete. Otherwise soft-delete.
+            guard: Optional expected latest/current version state.
+            require_no_dependents: Refuse deletion while referenced (the safe
+                default). Soft deletion considers active parents; hard deletion
+                considers every parent.
+            projection: Component fields to update atomically with a soft deletion.
 
         Returns:
             True if deleted, False if not found or already deleted.
+        """
+        raise NotImplementedError
+
+    def restore_component(
+        self,
+        component_id: str,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+    ) -> bool:
+        """Restore a soft-deleted component without replacing its identity or history.
+
+        A component with a current published version is restored only when its
+        complete pinned dependency graph is active and published. Draft-only
+        components have no runtime graph and may be restored independently.
+
+        Args:
+            component_id: The archived component ID.
+            guard: Optional expected latest/current version state.
+            projection: Optional component fields to restore atomically with
+                the archived row.
+
+        Returns:
+            True if restored, False if the component was not archived.
         """
         raise NotImplementedError
 
@@ -908,13 +1097,66 @@ class BaseDb(ABC):
 
         Args:
             component_id: The component ID.
-            version: Specific version number. If None, uses current.
+            version: Specific version number. When both version and label are
+                omitted, returns the current published config or the latest
+                draft when the component has never been published.
             label: Config label to lookup. Ignored if version is provided.
 
         Returns:
             Config dictionary or None if not found.
         """
         raise NotImplementedError
+
+    def get_current_config(self, component_id: str) -> Optional[Dict[str, Any]]:
+        """Get only the component's current published config.
+
+        The default implementation uses v1-compatible calls so third-party
+        adapters can inherit it. Version-2 adapters should override it with a
+        single consistent read.
+        """
+        component = self.get_component(component_id)
+        if component is None:
+            return None
+        current_version = component.get("current_version")
+        if not isinstance(current_version, int):
+            return None
+        return self.get_config(component_id, version=current_version)
+
+    def get_latest_config(
+        self,
+        component_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Get the latest visible config, regardless of publication stage.
+
+        The default implementation retains compatibility with version-1
+        adapters. Version-2 adapters should override it with a direct query.
+        """
+        if include_deleted:
+            raise NotImplementedError("Catalog API v1 cannot read configs for archived components")
+        configs = self.list_configs(component_id, include_config=True)
+        return configs[0] if configs else None
+
+    def get_latest_configs(
+        self,
+        component_ids: Set[str],
+        *,
+        include_deleted: bool = False,
+    ) -> Dict[str, Optional[Dict[str, Any]]]:
+        """Get each requested component's latest visible config.
+
+        The compatibility implementation uses scalar reads. Catalog adapters
+        should override this with one bulk query.
+        """
+        rows: Dict[str, Optional[Dict[str, Any]]] = {}
+        for component_id in sorted(component_ids):
+            rows[component_id] = (
+                self.get_latest_config(component_id, include_deleted=True)
+                if include_deleted
+                else self.get_latest_config(component_id)
+            )
+        return rows
 
     def upsert_config(
         self,
@@ -925,22 +1167,40 @@ class BaseDb(ABC):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+        restore_if_deleted: bool = False,
+        expected_component_type: Optional[ComponentType] = None,
     ) -> Dict[str, Any]:
         """Create or update a config version for a component.
 
         Rules:
-            - Draft configs can be edited freely
+            - Stored config versions are immutable
+            - The latest draft may transition to published with a guard
             - Published configs are immutable
             - Publishing a config automatically sets it as current_version
 
         Args:
             component_id: The component ID.
-            config: The config data. Required for create, optional for update.
-            version: If None, creates new version. If provided, updates that version.
+            config: The config data. Required when appending a version.
+            version: If None, appends a version. If provided, publishes that draft.
             label: Optional human-readable label.
             stage: "draft" or "published". Defaults to "draft" for new configs.
             notes: Optional notes.
             links: Optional list of links. Each link must have child_version set.
+            guard: Optional expected latest/current version state. Required when
+                publishing an existing draft.
+            projection: Component fields to update atomically when publishing,
+                or while the component is draft-only. When omitted during a
+                pointer change, implementations derive it from the locked target
+                config. Once a published current version exists, a draft
+                projection is ignored.
+            restore_if_deleted: Restore an archived component in the same
+                transaction as the config mutation. Catalog API v2 adapters
+                must roll the restore back if the config mutation fails.
+            expected_component_type: Optional component identity invariant to
+                validate while holding the component write lock.
 
         Returns:
             Created/updated config dictionary.
@@ -955,21 +1215,30 @@ class BaseDb(ABC):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
-        """Delete a specific config version.
+        """Logically delete a specific config version.
 
         Only draft configs can be deleted. Published configs are immutable.
-        Cannot delete the current version.
+        Cannot delete the current version or the component's last visible
+        config. Implementations retain a hidden tombstone so version numbers
+        are never reused.
 
         Args:
             component_id: The component ID.
             version: The version to delete.
+            guard: Optional expected latest/current version state.
+            projection: Component fields to update atomically with deletion.
 
         Returns:
             True if deleted, False if not found.
 
         Raises:
-            ValueError: If attempting to delete a published or current config.
+            ComponentDraftRequiredError: If the config is published.
+            ComponentLastConfigError: If deleting the component's last visible config.
+            ValueError: If attempting to delete the current config.
         """
         raise NotImplementedError
 
@@ -994,6 +1263,9 @@ class BaseDb(ABC):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Set a specific published version as current.
 
@@ -1004,6 +1276,9 @@ class BaseDb(ABC):
         Args:
             component_id: The component ID.
             version: The version to set as current (must be published).
+            guard: Optional expected latest/current version state.
+            projection: Component fields to update atomically with the current pointer.
+                When omitted, implementations derive them from the target config.
 
         Returns:
             True if successful, False if component or version not found.
@@ -1036,12 +1311,15 @@ class BaseDb(ABC):
         self,
         component_id: str,
         version: Optional[int] = None,
+        *,
+        active_parents_only: bool = False,
     ) -> List[Dict[str, Any]]:
         """Find all components that reference this component.
 
         Args:
             component_id: The component ID to find dependents of.
             version: Optional specific version. If None, finds links to any version.
+            active_parents_only: Exclude links owned by soft-deleted parents.
 
         Returns:
             List of link dictionaries showing what depends on this component.
@@ -1343,8 +1621,15 @@ class BaseDb(ABC):
         """Get a schedule by ID."""
         raise NotImplementedError
 
-    def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
-        """Get a schedule by name."""
+    def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Get a schedule by name, optionally within one ownership namespace."""
         raise NotImplementedError
 
     def get_schedules(
@@ -1352,6 +1637,7 @@ class BaseDb(ABC):
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         """List schedules with optional filtering.
 
@@ -1372,12 +1658,43 @@ class BaseDb(ABC):
         """Delete a schedule and its associated runs."""
         raise NotImplementedError
 
+    def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue a manual trigger for a schedule."""
+        raise NotImplementedError
+
+    def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules in one managed target namespace."""
+        raise NotImplementedError
+
     def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
         """Atomically claim a due schedule for execution."""
         raise NotImplementedError
 
-    def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
-        """Release a claimed schedule and optionally update next_run_at."""
+    def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a fenced schedule claim and return its new lock timestamp."""
+        raise NotImplementedError
+
+    def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
+        """Release a claimed schedule, optionally fenced by its worker/timestamp lock pair."""
         raise NotImplementedError
 
     # --- Schedule Runs (Optional) ---
@@ -1605,6 +1922,10 @@ class BaseDb(ABC):
 
 class AsyncBaseDb(ABC):
     """Base abstract class for all our async database implementations."""
+
+    supports_component_persistence = False
+    component_catalog_api_version = 1
+    scheduler_api_version = 1
 
     def __init__(
         self,
@@ -2483,8 +2804,15 @@ class AsyncBaseDb(ABC):
         """Get a schedule by ID."""
         raise NotImplementedError
 
-    async def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
-        """Get a schedule by name."""
+    async def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Get a schedule by name, optionally within one ownership namespace."""
         raise NotImplementedError
 
     async def get_schedules(
@@ -2492,6 +2820,7 @@ class AsyncBaseDb(ABC):
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         """List schedules with optional filtering.
 
@@ -2512,12 +2841,43 @@ class AsyncBaseDb(ABC):
         """Delete a schedule and its associated runs."""
         raise NotImplementedError
 
+    async def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue a manual trigger for a schedule."""
+        raise NotImplementedError
+
+    async def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules in one managed target namespace."""
+        raise NotImplementedError
+
     async def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
         """Atomically claim a due schedule for execution."""
         raise NotImplementedError
 
-    async def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
-        """Release a claimed schedule and optionally update next_run_at."""
+    async def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a fenced schedule claim and return its new lock timestamp."""
+        raise NotImplementedError
+
+    async def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
+        """Release a claimed schedule, optionally fenced by its worker/timestamp lock pair."""
         raise NotImplementedError
 
     # --- Schedule Runs (Optional) ---

--- a/libs/agno/agno/db/clickhouse/clickhouse.py
+++ b/libs/agno/agno/db/clickhouse/clickhouse.py
@@ -788,6 +788,8 @@ class ClickhouseDb(BaseDb):
         self,
         component_id: str,
         component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         return None
 

--- a/libs/agno/agno/db/migrations/manager.py
+++ b/libs/agno/agno/db/migrations/manager.py
@@ -16,6 +16,7 @@ class MigrationManager:
         ("v2_3_0", packaging_version.parse("2.3.0")),
         ("v2_5_0", packaging_version.parse("2.5.0")),
         ("v2_5_6", packaging_version.parse("2.5.6")),
+        ("v2_9_0", packaging_version.parse("2.9.0")),
         ("v3_0_0", packaging_version.parse("3.0.0")),
     ]
 
@@ -52,6 +53,7 @@ class MigrationManager:
             "knowledge": "knowledge_table_name",
             "culture": "culture_table_name",
             "approvals": "approvals_table_name",
+            "schedules": "schedules_table_name",
         }
 
         # Select tables to migrate
@@ -129,8 +131,11 @@ class MigrationManager:
                 return await migration_module.async_up(self.db, table_type, table_name)
             else:
                 return migration_module.up(self.db, table_type, table_name)
-        except Exception as e:
-            log_error(f"Error running migration to version {version}: {str(e)}")
+        except Exception:
+            # Backend exception strings can contain connection URLs, credentials,
+            # or query parameters. The original exception is re-raised for the
+            # caller without duplicating those details into application logs.
+            log_error(f"Migration to version {version} failed")
             raise
 
     async def down(self, target_version: str, table_type: Optional[str] = None, force: bool = False):
@@ -151,6 +156,7 @@ class MigrationManager:
             "knowledge": "knowledge_table_name",
             "culture": "culture_table_name",
             "approvals": "approvals_table_name",
+            "schedules": "schedules_table_name",
         }
 
         # Select tables to migrate
@@ -212,6 +218,6 @@ class MigrationManager:
                 return await migration_module.async_down(self.db, table_type, table_name)
             else:
                 return migration_module.down(self.db, table_type, table_name)
-        except Exception as e:
-            log_error(f"Error running migration to version {version}: {str(e)}")
+        except Exception:
+            log_error(f"Migration rollback from version {version} failed")
             raise

--- a/libs/agno/agno/db/migrations/versions/v2_9_0.py
+++ b/libs/agno/agno/db/migrations/versions/v2_9_0.py
@@ -1,0 +1,1109 @@
+"""Migration v2.9.0: add Studio provenance and durable manual triggers.
+
+Generic schedule names stay globally unique within the generic surface. Studio
+names occupy a separate actor-scoped namespace, so a private Studio record is
+neither a name oracle nor a collision for an unrelated actor.
+"""
+
+import re
+from typing import Any
+
+from agno.db.base import AsyncBaseDb, BaseDb
+from agno.db.migrations.utils import quote_db_identifier
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY
+from agno.utils.log import log_info
+
+try:
+    from sqlalchemy import text
+except ImportError:
+    raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
+
+
+_PROVENANCE_COLUMNS = (
+    "managed_by",
+    "owner_actor_id",
+    "target_type",
+    "target_id",
+    "created_by_run_id",
+    "created_by_session_id",
+    "updated_by_run_id",
+    "updated_by_session_id",
+)
+_V2_9_COLUMNS = (*_PROVENANCE_COLUMNS, "pending_trigger_count", "manual_trigger_claimed")
+_LEGACY_SQLITE_COLUMNS = (
+    "id",
+    "name",
+    "description",
+    "method",
+    "endpoint",
+    "payload",
+    "cron_expr",
+    "timezone",
+    "timeout_seconds",
+    "max_retries",
+    "retry_delay_seconds",
+    "enabled",
+    "next_run_at",
+    "locked_by",
+    "locked_at",
+    "created_at",
+    "updated_at",
+)
+
+
+def _duplicate_error() -> ValueError:
+    return ValueError(
+        "Cannot enforce scoped unique schedule names because duplicates already exist; "
+        "remove or rename duplicate schedule rows, then retry the v2.9.0 migration."
+    )
+
+
+def _studio_data_error() -> ValueError:
+    return ValueError(
+        "Cannot remove Studio schedule provenance while Studio-managed schedules or their run history exist; "
+        "delete those schedules and runs, then retry the v2.9.0 downgrade."
+    )
+
+
+def _pending_trigger_error() -> ValueError:
+    return ValueError(
+        "Cannot remove durable schedule triggers while pending or claimed manual triggers exist; "
+        "allow the scheduler to consume them, then retry the v2.9.0 downgrade."
+    )
+
+
+def _sqlite_schema_error(schema_objects: list[str]) -> ValueError:
+    details = ", ".join(sorted(schema_objects))
+    return ValueError(
+        "Cannot safely rebuild the SQLite schedule table because it contains caller-owned or "
+        f"unrecognized schema: {details}. Remove or migrate that schema explicitly, then retry the v2.9.0 downgrade."
+    )
+
+
+def _studio_schedule_exists_query(db_type: str, table: str) -> Any:
+    managed_by = quote_db_identifier(db_type, "managed_by")
+    return text(f"SELECT 1 FROM {table} WHERE {managed_by} = :managed_by LIMIT 1")
+
+
+def _assert_no_studio_schedule_data(session: Any, db_type: str, table: str) -> None:
+    """Refuse to erase the only ownership boundary for Studio schedule data.
+
+    Schedule runs are owned through their parent schedule and are deleted with
+    it, so retaining a Studio schedule also retains every private run payload.
+    This check must run under the same write lock as the schema change.
+    """
+    studio_schedule = session.execute(
+        _studio_schedule_exists_query(db_type, table),
+        {"managed_by": STUDIO_SCHEDULE_MANAGED_BY},
+    ).scalar()
+    if studio_schedule is not None:
+        raise _studio_data_error()
+
+
+async def _assert_no_studio_schedule_data_async(session: Any, db_type: str, table: str) -> None:
+    studio_schedule = (
+        await session.execute(
+            _studio_schedule_exists_query(db_type, table),
+            {"managed_by": STUDIO_SCHEDULE_MANAGED_BY},
+        )
+    ).scalar()
+    if studio_schedule is not None:
+        raise _studio_data_error()
+
+
+def _assert_no_pending_triggers(
+    session: Any,
+    table: str,
+    *,
+    has_pending_count: bool,
+    has_claimed_marker: bool,
+) -> None:
+    predicates = []
+    if has_pending_count:
+        predicates.append("pending_trigger_count > 0")
+    if has_claimed_marker:
+        predicates.append("manual_trigger_claimed = TRUE")
+    if not predicates:
+        return
+    pending = session.execute(text(f"SELECT 1 FROM {table} WHERE {' OR '.join(predicates)} LIMIT 1")).scalar()
+    if pending is not None:
+        raise _pending_trigger_error()
+
+
+async def _assert_no_pending_triggers_async(
+    session: Any,
+    table: str,
+    *,
+    has_pending_count: bool,
+    has_claimed_marker: bool,
+) -> None:
+    predicates = []
+    if has_pending_count:
+        predicates.append("pending_trigger_count > 0")
+    if has_claimed_marker:
+        predicates.append("manual_trigger_claimed = TRUE")
+    if not predicates:
+        return
+    pending = (await session.execute(text(f"SELECT 1 FROM {table} WHERE {' OR '.join(predicates)} LIMIT 1"))).scalar()
+    if pending is not None:
+        raise _pending_trigger_error()
+
+
+def _is_sqlite(db: Any) -> bool:
+    from agno.db.sqlite.sqlite import SqliteDb
+
+    return isinstance(db, SqliteDb)
+
+
+def _is_postgres(db: Any) -> bool:
+    from agno.db.postgres.postgres import PostgresDb
+
+    return isinstance(db, PostgresDb)
+
+
+def _is_async_sqlite(db: Any) -> bool:
+    from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+
+    return isinstance(db, AsyncSqliteDb)
+
+
+def _is_async_postgres(db: Any) -> bool:
+    from agno.db.postgres.async_postgres import AsyncPostgresDb
+
+    return isinstance(db, AsyncPostgresDb)
+
+
+def up(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Apply the schedule migration for synchronous SQLite and PostgreSQL."""
+    if table_type != "schedules":
+        return False
+    db_type = type(db).__name__
+    if _is_sqlite(db):
+        return _migrate_sqlite(db, table_name)
+    if _is_postgres(db):
+        return _migrate_postgres(db, table_name)
+    log_info(f"{db_type} does not require the v2.9.0 schedule migration")
+    return False
+
+
+async def async_up(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Apply the schedule migration for asynchronous SQLite and PostgreSQL."""
+    if table_type != "schedules":
+        return False
+    db_type = type(db).__name__
+    if _is_async_sqlite(db):
+        return await _migrate_async_sqlite(db, table_name)
+    if _is_async_postgres(db):
+        return await _migrate_async_postgres(db, table_name)
+    log_info(f"{db_type} does not require the v2.9.0 schedule migration")
+    return False
+
+
+def down(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Remove schedule provenance only after Studio-managed data is gone."""
+    if table_type != "schedules":
+        return False
+    if _is_sqlite(db):
+        return _revert_sqlite(db, table_name)
+    if _is_postgres(db):
+        return _revert_postgres(db, table_name)
+    return False
+
+
+async def async_down(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Remove schedule provenance asynchronously only when no Studio data remains."""
+    if table_type != "schedules":
+        return False
+    if _is_async_sqlite(db):
+        return await _revert_async_sqlite(db, table_name)
+    if _is_async_postgres(db):
+        return await _revert_async_postgres(db, table_name)
+    return False
+
+
+def _index_names(db_type: str, table_name: str) -> dict[str, str]:
+    return {
+        "legacy": quote_db_identifier(db_type, f"{table_name}_uq_name"),
+        "generic": quote_db_identifier(db_type, f"{table_name}_uq_generic_name"),
+        "studio": quote_db_identifier(db_type, f"{table_name}_uq_studio_owner_name"),
+        "managed": quote_db_identifier(db_type, f"idx_{table_name}_managed_by"),
+        "owner": quote_db_identifier(db_type, f"idx_{table_name}_owner_actor_id"),
+    }
+
+
+def _sqlite_names(table_name: str) -> tuple[str, dict[str, str]]:
+    return quote_db_identifier("SqliteDb", table_name), _index_names("SqliteDb", table_name)
+
+
+def _sqlite_legacy_indexes(table_name: str) -> tuple[str, ...]:
+    return (
+        f"CREATE INDEX {quote_db_identifier('SqliteDb', f'idx_{table_name}_name')} "
+        f"ON {quote_db_identifier('SqliteDb', table_name)} (name)",
+        f"CREATE INDEX {quote_db_identifier('SqliteDb', f'idx_{table_name}_next_run_at')} "
+        f"ON {quote_db_identifier('SqliteDb', table_name)} (next_run_at)",
+        f"CREATE INDEX {quote_db_identifier('SqliteDb', f'idx_{table_name}_created_at')} "
+        f"ON {quote_db_identifier('SqliteDb', table_name)} (created_at)",
+        f"CREATE INDEX {quote_db_identifier('SqliteDb', f'idx_{table_name}_enabled_next_run_at')} "
+        f"ON {quote_db_identifier('SqliteDb', table_name)} (enabled, next_run_at)",
+    )
+
+
+def _sqlite_split_table_definitions(definitions: str) -> list[str]:
+    """Split a CREATE TABLE body without splitting nested expressions."""
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    quote: str | None = None
+    index = 0
+    while index < len(definitions):
+        char = definitions[index]
+        if quote is not None:
+            if quote == "[":
+                if char == "]":
+                    quote = None
+            elif char == quote:
+                if index + 1 < len(definitions) and definitions[index + 1] == quote:
+                    index += 1
+                else:
+                    quote = None
+        elif char in ("'", '"', "`", "["):
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        elif char == "," and depth == 0:
+            parts.append(definitions[start:index].strip())
+            start = index + 1
+        index += 1
+    parts.append(definitions[start:].strip())
+    return [part for part in parts if part]
+
+
+def _sqlite_definition_name(definition: str) -> str:
+    match = re.match(r'^\s*(?:"((?:""|[^"])*)"|`((?:``|[^`])*)`|\[([^]]+)\]|([^\s]+))', definition)
+    if match is None:
+        return ""
+    for value in match.groups():
+        if value is not None:
+            return value.replace('""', '"').replace("``", "`")
+    return ""
+
+
+def _sqlite_legacy_table_sql(source_sql: str, temporary_table_name: str) -> str:
+    """Remove only v2.9 columns while retaining the legacy table definition."""
+    open_paren = source_sql.find("(")
+    if open_paren < 0:
+        raise _sqlite_schema_error(["unreadable table definition"])
+
+    depth = 0
+    quote: str | None = None
+    close_paren = -1
+    index = open_paren
+    while index < len(source_sql):
+        char = source_sql[index]
+        if quote is not None:
+            if quote == "[":
+                if char == "]":
+                    quote = None
+            elif char == quote:
+                if index + 1 < len(source_sql) and source_sql[index + 1] == quote:
+                    index += 1
+                else:
+                    quote = None
+        elif char in ("'", '"', "`", "["):
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                close_paren = index
+                break
+        index += 1
+    if close_paren < 0:
+        raise _sqlite_schema_error(["unreadable table definition"])
+
+    definitions = _sqlite_split_table_definitions(source_sql[open_paren + 1 : close_paren])
+    legacy_definitions = [
+        definition for definition in definitions if _sqlite_definition_name(definition) not in _V2_9_COLUMNS
+    ]
+    if len(definitions) - len(legacy_definitions) != len(
+        {_sqlite_definition_name(definition) for definition in definitions}.intersection(_V2_9_COLUMNS)
+    ):
+        raise _sqlite_schema_error(["ambiguous v2.9 column definitions"])
+
+    temporary_table = quote_db_identifier("SqliteDb", temporary_table_name)
+    suffix = source_sql[close_paren + 1 :].strip()
+    suffix_sql = f" {suffix}" if suffix else ""
+    return f"CREATE TABLE {temporary_table} ({', '.join(legacy_definitions)}){suffix_sql}"
+
+
+def _sqlite_expected_index_specs(
+    table_name: str, indexes: dict[str, str]
+) -> dict[str, tuple[tuple[str, ...], bool, bool, str | None]]:
+    return {
+        f"idx_{table_name}_name": (("name",), False, False, None),
+        f"idx_{table_name}_next_run_at": (("next_run_at",), False, False, None),
+        f"idx_{table_name}_created_at": (("created_at",), False, False, None),
+        f"idx_{table_name}_enabled_next_run_at": (("enabled", "next_run_at"), False, False, None),
+        indexes["legacy"].strip('"'): (("name",), True, False, None),
+        indexes["managed"].strip('"'): (("managed_by",), False, False, None),
+        indexes["owner"].strip('"'): (("owner_actor_id",), False, False, None),
+        indexes["generic"].strip('"'): (
+            ("name",),
+            True,
+            True,
+            "managed_by is null or managed_by <> 'studio'",
+        ),
+        indexes["studio"].strip('"'): (
+            ("owner_actor_id", "name"),
+            True,
+            True,
+            "managed_by = 'studio'",
+        ),
+    }
+
+
+def _sqlite_normalize_predicate(index_sql: str | None) -> str | None:
+    if index_sql is None or re.search(r"\bwhere\b", index_sql, flags=re.IGNORECASE) is None:
+        return None
+    predicate = re.split(r"\bwhere\b", index_sql, maxsplit=1, flags=re.IGNORECASE)[1]
+    return " ".join(predicate.strip().lower().split())
+
+
+def _sqlite_schema_issues(
+    *,
+    table_name: str,
+    indexes: dict[str, str],
+    table_sql: str | None,
+    columns: list[Any],
+    index_rows: list[Any],
+    index_columns: dict[str, tuple[str, ...]],
+    index_sql: dict[str, str | None],
+    trigger_names: list[str],
+    foreign_keys: list[Any],
+    dependent_view_names: list[str],
+    temporary_object: str | None,
+) -> list[str]:
+    issues: list[str] = []
+    column_names = {row[1] for row in columns}
+    unknown_columns = column_names.difference((*_LEGACY_SQLITE_COLUMNS, *_V2_9_COLUMNS))
+    missing_columns = set(_LEGACY_SQLITE_COLUMNS).difference(column_names)
+    issues.extend(f"column {name!r}" for name in sorted(unknown_columns))
+    issues.extend(f"missing legacy column {name!r}" for name in sorted(missing_columns))
+    issues.extend(f"generated or hidden column {row[1]!r}" for row in columns if len(row) > 6 and row[6])
+
+    expected_indexes = _sqlite_expected_index_specs(table_name, indexes)
+    for row in index_rows:
+        name = row[1]
+        unique = bool(row[2])
+        origin = row[3] if len(row) > 3 else "c"
+        partial = bool(row[4]) if len(row) > 4 else False
+        columns_for_index = index_columns.get(name, ())
+        if origin == "pk" and columns_for_index == ("id",):
+            continue
+        expected = expected_indexes.get(name)
+        if expected is None:
+            issues.append(f"index {name!r}")
+            continue
+        expected_columns, expected_unique, expected_partial, expected_predicate = expected
+        if (
+            columns_for_index != expected_columns
+            or unique != expected_unique
+            or partial != expected_partial
+            or _sqlite_normalize_predicate(index_sql.get(name)) != expected_predicate
+        ):
+            issues.append(f"unrecognized definition for index {name!r}")
+
+    issues.extend(f"trigger {name!r}" for name in trigger_names)
+    if foreign_keys:
+        issues.append("outbound foreign key constraints")
+    issues.extend(f"dependent view {name!r}" for name in dependent_view_names)
+    if temporary_object is not None:
+        issues.append(f"existing downgrade temporary object {temporary_object!r}")
+
+    if table_sql is None:
+        issues.append("missing table definition")
+    else:
+        unsupported_features = re.findall(
+            r"\b(?:check|collate|generated|references|foreign\s+key|unique|without\s+rowid|strict|autoincrement)\b",
+            table_sql,
+            flags=re.IGNORECASE,
+        )
+        issues.extend(f"table feature {feature.lower()!r}" for feature in sorted(set(unsupported_features)))
+    return issues
+
+
+def _sqlite_rebuild_legacy_table(session: Any, table_name: str, table: str, source_sql: str) -> None:
+    temporary_table_name = f"{table_name}__v2_9_down"
+    temporary_table = quote_db_identifier("SqliteDb", temporary_table_name)
+    legacy_columns = ", ".join(quote_db_identifier("SqliteDb", column) for column in _LEGACY_SQLITE_COLUMNS)
+    session.execute(text(_sqlite_legacy_table_sql(source_sql, temporary_table_name)))
+    session.execute(text(f"INSERT INTO {temporary_table} ({legacy_columns}) SELECT {legacy_columns} FROM {table}"))
+    session.execute(text(f"DROP TABLE {table}"))
+    session.execute(text(f"ALTER TABLE {temporary_table} RENAME TO {quote_db_identifier('SqliteDb', table_name)}"))
+    for statement in _sqlite_legacy_indexes(table_name):
+        session.execute(text(statement))
+
+
+async def _sqlite_rebuild_legacy_table_async(session: Any, table_name: str, table: str, source_sql: str) -> None:
+    temporary_table_name = f"{table_name}__v2_9_down"
+    temporary_table = quote_db_identifier("AsyncSqliteDb", temporary_table_name)
+    legacy_columns = ", ".join(quote_db_identifier("AsyncSqliteDb", column) for column in _LEGACY_SQLITE_COLUMNS)
+    await session.execute(text(_sqlite_legacy_table_sql(source_sql, temporary_table_name)))
+    await session.execute(
+        text(f"INSERT INTO {temporary_table} ({legacy_columns}) SELECT {legacy_columns} FROM {table}")
+    )
+    await session.execute(text(f"DROP TABLE {table}"))
+    await session.execute(
+        text(f"ALTER TABLE {temporary_table} RENAME TO {quote_db_identifier('AsyncSqliteDb', table_name)}")
+    )
+    for statement in _sqlite_legacy_indexes(table_name):
+        await session.execute(text(statement))
+
+
+def _sqlite_table_exists(session: Any, table_name: str) -> bool:
+    return (
+        session.execute(
+            text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:table_name"),
+            {"table_name": table_name},
+        ).scalar()
+        is not None
+    )
+
+
+def _assert_sqlite_downgrade_schema_safe(session: Any, table_name: str, table: str, indexes: dict[str, str]) -> str:
+    table_sql = session.execute(
+        text("SELECT sql FROM sqlite_master WHERE type='table' AND name=:table_name"),
+        {"table_name": table_name},
+    ).scalar()
+    columns = list(session.execute(text(f"PRAGMA table_xinfo({table})")).fetchall())
+    index_rows = list(session.execute(text(f"PRAGMA index_list({table})")).fetchall())
+    index_columns: dict[str, tuple[str, ...]] = {}
+    index_sql: dict[str, str | None] = {}
+    for row in index_rows:
+        name = row[1]
+        quoted_name = quote_db_identifier("SqliteDb", name)
+        index_columns[name] = tuple(
+            index_row[2]
+            for index_row in session.execute(text(f"PRAGMA index_info({quoted_name})")).fetchall()
+            if index_row[2] is not None
+        )
+        index_sql[name] = session.execute(
+            text("SELECT sql FROM sqlite_master WHERE type='index' AND name=:name"), {"name": name}
+        ).scalar()
+    trigger_names = [
+        row[0]
+        for row in session.execute(
+            text("SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name=:table_name"),
+            {"table_name": table_name},
+        ).fetchall()
+    ]
+    foreign_keys = list(session.execute(text(f"PRAGMA foreign_key_list({table})")).fetchall())
+    dependent_view_names = [
+        row[0]
+        for row in session.execute(text("SELECT name, sql FROM sqlite_master WHERE type='view'")).fetchall()
+        if row[1] is not None and table_name.casefold() in row[1].casefold()
+    ]
+    temporary_table_name = f"{table_name}__v2_9_down"
+    temporary_object = session.execute(
+        text("SELECT type || ' ' || name FROM sqlite_master WHERE name=:name"),
+        {"name": temporary_table_name},
+    ).scalar()
+    issues = _sqlite_schema_issues(
+        table_name=table_name,
+        indexes=indexes,
+        table_sql=table_sql,
+        columns=columns,
+        index_rows=index_rows,
+        index_columns=index_columns,
+        index_sql=index_sql,
+        trigger_names=trigger_names,
+        foreign_keys=foreign_keys,
+        dependent_view_names=dependent_view_names,
+        temporary_object=temporary_object,
+    )
+    if issues:
+        raise _sqlite_schema_error(issues)
+    return table_sql
+
+
+async def _assert_sqlite_downgrade_schema_safe_async(
+    session: Any, table_name: str, table: str, indexes: dict[str, str]
+) -> str:
+    table_sql = (
+        await session.execute(
+            text("SELECT sql FROM sqlite_master WHERE type='table' AND name=:table_name"),
+            {"table_name": table_name},
+        )
+    ).scalar()
+    columns = list((await session.execute(text(f"PRAGMA table_xinfo({table})"))).fetchall())
+    index_rows = list((await session.execute(text(f"PRAGMA index_list({table})"))).fetchall())
+    index_columns: dict[str, tuple[str, ...]] = {}
+    index_sql: dict[str, str | None] = {}
+    for row in index_rows:
+        name = row[1]
+        quoted_name = quote_db_identifier("AsyncSqliteDb", name)
+        index_columns[name] = tuple(
+            index_row[2]
+            for index_row in (await session.execute(text(f"PRAGMA index_info({quoted_name})"))).fetchall()
+            if index_row[2] is not None
+        )
+        index_sql[name] = (
+            await session.execute(
+                text("SELECT sql FROM sqlite_master WHERE type='index' AND name=:name"), {"name": name}
+            )
+        ).scalar()
+    trigger_names = [
+        row[0]
+        for row in (
+            await session.execute(
+                text("SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name=:table_name"),
+                {"table_name": table_name},
+            )
+        ).fetchall()
+    ]
+    foreign_keys = list((await session.execute(text(f"PRAGMA foreign_key_list({table})"))).fetchall())
+    dependent_view_names = [
+        row[0]
+        for row in (await session.execute(text("SELECT name, sql FROM sqlite_master WHERE type='view'"))).fetchall()
+        if row[1] is not None and table_name.casefold() in row[1].casefold()
+    ]
+    temporary_table_name = f"{table_name}__v2_9_down"
+    temporary_object = (
+        await session.execute(
+            text("SELECT type || ' ' || name FROM sqlite_master WHERE name=:name"),
+            {"name": temporary_table_name},
+        )
+    ).scalar()
+    issues = _sqlite_schema_issues(
+        table_name=table_name,
+        indexes=indexes,
+        table_sql=table_sql,
+        columns=columns,
+        index_rows=index_rows,
+        index_columns=index_columns,
+        index_sql=index_sql,
+        trigger_names=trigger_names,
+        foreign_keys=foreign_keys,
+        dependent_view_names=dependent_view_names,
+        temporary_object=temporary_object,
+    )
+    if issues:
+        raise _sqlite_schema_error(issues)
+    return table_sql
+
+
+def _migrate_sqlite(db: BaseDb, table_name: str) -> bool:
+    table, indexes = _sqlite_names(table_name)
+    with db.Session() as session, session.begin():  # type: ignore[attr-defined]
+        session.connection().exec_driver_sql("BEGIN IMMEDIATE")
+        if not _sqlite_table_exists(session, table_name):
+            return False
+        columns = {row[1] for row in session.execute(text(f"PRAGMA table_info({table})")).fetchall()}
+        # SQLite may persist ALTER TABLE even when a surrounding ORM
+        # transaction later fails. Preflight legacy uniqueness before the
+        # first DDL statement so a rejected migration leaves no new columns.
+        if "managed_by" not in columns:
+            legacy_duplicate = session.execute(
+                text(f"SELECT 1 FROM {table} GROUP BY name HAVING COUNT(*) > 1 LIMIT 1")
+            ).scalar()
+            if legacy_duplicate is not None:
+                raise _duplicate_error()
+        else:
+            generic_duplicate = session.execute(
+                text(
+                    f"SELECT 1 FROM {table} WHERE managed_by IS NULL OR managed_by <> :studio "
+                    "GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"
+                ),
+                {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+            ).scalar()
+            studio_group = "owner_actor_id, name" if "owner_actor_id" in columns else "name"
+            studio_duplicate = session.execute(
+                text(
+                    f"SELECT 1 FROM {table} WHERE managed_by = :studio "
+                    f"GROUP BY {studio_group} HAVING COUNT(*) > 1 LIMIT 1"
+                ),
+                {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+            ).scalar()
+            if generic_duplicate is not None or studio_duplicate is not None:
+                raise _duplicate_error()
+        applied = False
+        for column in _PROVENANCE_COLUMNS:
+            if column not in columns:
+                quoted_column = quote_db_identifier("SqliteDb", column)
+                session.execute(text(f"ALTER TABLE {table} ADD COLUMN {quoted_column} TEXT"))
+                applied = True
+        if "pending_trigger_count" not in columns:
+            session.execute(text(f"ALTER TABLE {table} ADD COLUMN pending_trigger_count INTEGER NOT NULL DEFAULT 0"))
+            applied = True
+        if "manual_trigger_claimed" not in columns:
+            session.execute(text(f"ALTER TABLE {table} ADD COLUMN manual_trigger_claimed INTEGER NOT NULL DEFAULT 0"))
+            applied = True
+
+        generic_duplicate = session.execute(
+            text(
+                f"SELECT 1 FROM {table} WHERE managed_by IS NULL OR managed_by <> :studio "
+                "GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"
+            ),
+            {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+        ).scalar()
+        studio_duplicate = session.execute(
+            text(
+                f"SELECT 1 FROM {table} WHERE managed_by = :studio "
+                "GROUP BY owner_actor_id, name HAVING COUNT(*) > 1 LIMIT 1"
+            ),
+            {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+        ).scalar()
+        if generic_duplicate is not None or studio_duplicate is not None:
+            raise _duplicate_error()
+
+        index_names = {row[1] for row in session.execute(text(f"PRAGMA index_list({table})")).fetchall()}
+        if indexes["legacy"].strip('"') in index_names:
+            session.execute(text(f"DROP INDEX {indexes['legacy']}"))
+            applied = True
+        statements = {
+            "managed": f"CREATE INDEX {indexes['managed']} ON {table} (managed_by)",
+            "owner": f"CREATE INDEX {indexes['owner']} ON {table} (owner_actor_id)",
+            "generic": (
+                f"CREATE UNIQUE INDEX {indexes['generic']} ON {table} (name) "
+                "WHERE managed_by IS NULL OR managed_by <> 'studio'"
+            ),
+            "studio": (
+                f"CREATE UNIQUE INDEX {indexes['studio']} ON {table} (owner_actor_id, name) WHERE managed_by = 'studio'"
+            ),
+        }
+        for key, statement in statements.items():
+            if indexes[key].strip('"') not in index_names:
+                session.execute(text(statement))
+                applied = True
+        return applied
+
+
+async def _migrate_async_sqlite(db: AsyncBaseDb, table_name: str) -> bool:
+    table, indexes = _sqlite_names(table_name)
+    async with db.async_session_factory() as session, session.begin():  # type: ignore[attr-defined]
+        await session.execute(text("BEGIN IMMEDIATE"))
+        exists = (
+            await session.execute(
+                text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:table_name"),
+                {"table_name": table_name},
+            )
+        ).scalar()
+        if exists is None:
+            return False
+        columns = {row[1] for row in (await session.execute(text(f"PRAGMA table_info({table})"))).fetchall()}
+        if "managed_by" not in columns:
+            legacy_duplicate = (
+                await session.execute(text(f"SELECT 1 FROM {table} GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"))
+            ).scalar()
+            if legacy_duplicate is not None:
+                raise _duplicate_error()
+        else:
+            generic_duplicate = (
+                await session.execute(
+                    text(
+                        f"SELECT 1 FROM {table} WHERE managed_by IS NULL OR managed_by <> :studio "
+                        "GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"
+                    ),
+                    {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+                )
+            ).scalar()
+            studio_group = "owner_actor_id, name" if "owner_actor_id" in columns else "name"
+            studio_duplicate = (
+                await session.execute(
+                    text(
+                        f"SELECT 1 FROM {table} WHERE managed_by = :studio "
+                        f"GROUP BY {studio_group} HAVING COUNT(*) > 1 LIMIT 1"
+                    ),
+                    {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+                )
+            ).scalar()
+            if generic_duplicate is not None or studio_duplicate is not None:
+                raise _duplicate_error()
+        applied = False
+        for column in _PROVENANCE_COLUMNS:
+            if column not in columns:
+                quoted_column = quote_db_identifier("AsyncSqliteDb", column)
+                await session.execute(text(f"ALTER TABLE {table} ADD COLUMN {quoted_column} TEXT"))
+                applied = True
+        if "pending_trigger_count" not in columns:
+            await session.execute(
+                text(f"ALTER TABLE {table} ADD COLUMN pending_trigger_count INTEGER NOT NULL DEFAULT 0")
+            )
+            applied = True
+        if "manual_trigger_claimed" not in columns:
+            await session.execute(
+                text(f"ALTER TABLE {table} ADD COLUMN manual_trigger_claimed INTEGER NOT NULL DEFAULT 0")
+            )
+            applied = True
+
+        generic_duplicate = (
+            await session.execute(
+                text(
+                    f"SELECT 1 FROM {table} WHERE managed_by IS NULL OR managed_by <> :studio "
+                    "GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"
+                ),
+                {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+            )
+        ).scalar()
+        studio_duplicate = (
+            await session.execute(
+                text(
+                    f"SELECT 1 FROM {table} WHERE managed_by = :studio "
+                    "GROUP BY owner_actor_id, name HAVING COUNT(*) > 1 LIMIT 1"
+                ),
+                {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+            )
+        ).scalar()
+        if generic_duplicate is not None or studio_duplicate is not None:
+            raise _duplicate_error()
+
+        index_names = {row[1] for row in (await session.execute(text(f"PRAGMA index_list({table})"))).fetchall()}
+        if indexes["legacy"].strip('"') in index_names:
+            await session.execute(text(f"DROP INDEX {indexes['legacy']}"))
+            applied = True
+        statements = {
+            "managed": f"CREATE INDEX {indexes['managed']} ON {table} (managed_by)",
+            "owner": f"CREATE INDEX {indexes['owner']} ON {table} (owner_actor_id)",
+            "generic": (
+                f"CREATE UNIQUE INDEX {indexes['generic']} ON {table} (name) "
+                "WHERE managed_by IS NULL OR managed_by <> 'studio'"
+            ),
+            "studio": (
+                f"CREATE UNIQUE INDEX {indexes['studio']} ON {table} (owner_actor_id, name) WHERE managed_by = 'studio'"
+            ),
+        }
+        for key, statement in statements.items():
+            if indexes[key].strip('"') not in index_names:
+                await session.execute(text(statement))
+                applied = True
+        return applied
+
+
+def _postgres_names(db: Any, table_name: str) -> tuple[str, dict[str, str]]:
+    db_type = type(db).__name__
+    schema = quote_db_identifier(db_type, db.db_schema)
+    table = quote_db_identifier(db_type, table_name)
+    full_table = f"{schema}.{table}"
+    return full_table, _index_names(db_type, table_name)
+
+
+def _migrate_postgres(db: BaseDb, table_name: str) -> bool:
+    full_table, indexes = _postgres_names(db, table_name)
+    schema = full_table.rsplit(".", 1)[0]
+    with db.Session() as session, session.begin():  # type: ignore[attr-defined]
+        exists = session.execute(
+            text("SELECT 1 FROM information_schema.tables WHERE table_schema=:schema AND table_name=:table"),
+            {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+        ).scalar()
+        if exists is None:
+            return False
+        for column in _PROVENANCE_COLUMNS:
+            quoted_column = quote_db_identifier(type(db).__name__, column)
+            session.execute(text(f"ALTER TABLE {full_table} ADD COLUMN IF NOT EXISTS {quoted_column} VARCHAR"))
+        session.execute(
+            text(f"ALTER TABLE {full_table} ADD COLUMN IF NOT EXISTS pending_trigger_count BIGINT NOT NULL DEFAULT 0")
+        )
+        session.execute(
+            text(
+                f"ALTER TABLE {full_table} ADD COLUMN IF NOT EXISTS manual_trigger_claimed BOOLEAN NOT NULL DEFAULT FALSE"
+            )
+        )
+        generic_duplicate = session.execute(
+            text(
+                f"SELECT 1 FROM {full_table} WHERE managed_by IS DISTINCT FROM :studio "
+                "GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"
+            ),
+            {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+        ).scalar()
+        studio_duplicate = session.execute(
+            text(
+                f"SELECT 1 FROM {full_table} WHERE managed_by = :studio "
+                "GROUP BY owner_actor_id, name HAVING COUNT(*) > 1 LIMIT 1"
+            ),
+            {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+        ).scalar()
+        if generic_duplicate is not None or studio_duplicate is not None:
+            raise _duplicate_error()
+        session.execute(text(f"DROP INDEX IF EXISTS {schema}.{indexes['legacy']}"))
+        session.execute(text(f"CREATE INDEX IF NOT EXISTS {indexes['managed']} ON {full_table} (managed_by)"))
+        session.execute(text(f"CREATE INDEX IF NOT EXISTS {indexes['owner']} ON {full_table} (owner_actor_id)"))
+        session.execute(
+            text(
+                f"CREATE UNIQUE INDEX IF NOT EXISTS {indexes['generic']} ON {full_table} (name) "
+                "WHERE managed_by IS DISTINCT FROM 'studio'"
+            )
+        )
+        session.execute(
+            text(
+                f"CREATE UNIQUE INDEX IF NOT EXISTS {indexes['studio']} ON {full_table} (owner_actor_id, name) "
+                "WHERE managed_by = 'studio'"
+            )
+        )
+        return True
+
+
+async def _migrate_async_postgres(db: AsyncBaseDb, table_name: str) -> bool:
+    full_table, indexes = _postgres_names(db, table_name)
+    schema = full_table.rsplit(".", 1)[0]
+    async with db.async_session_factory() as session, session.begin():  # type: ignore[attr-defined]
+        exists = (
+            await session.execute(
+                text("SELECT 1 FROM information_schema.tables WHERE table_schema=:schema AND table_name=:table"),
+                {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+            )
+        ).scalar()
+        if exists is None:
+            return False
+        for column in _PROVENANCE_COLUMNS:
+            quoted_column = quote_db_identifier(type(db).__name__, column)
+            await session.execute(text(f"ALTER TABLE {full_table} ADD COLUMN IF NOT EXISTS {quoted_column} VARCHAR"))
+        await session.execute(
+            text(f"ALTER TABLE {full_table} ADD COLUMN IF NOT EXISTS pending_trigger_count BIGINT NOT NULL DEFAULT 0")
+        )
+        await session.execute(
+            text(
+                f"ALTER TABLE {full_table} ADD COLUMN IF NOT EXISTS manual_trigger_claimed BOOLEAN NOT NULL DEFAULT FALSE"
+            )
+        )
+        generic_duplicate = (
+            await session.execute(
+                text(
+                    f"SELECT 1 FROM {full_table} WHERE managed_by IS DISTINCT FROM :studio "
+                    "GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"
+                ),
+                {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+            )
+        ).scalar()
+        studio_duplicate = (
+            await session.execute(
+                text(
+                    f"SELECT 1 FROM {full_table} WHERE managed_by = :studio "
+                    "GROUP BY owner_actor_id, name HAVING COUNT(*) > 1 LIMIT 1"
+                ),
+                {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+            )
+        ).scalar()
+        if generic_duplicate is not None or studio_duplicate is not None:
+            raise _duplicate_error()
+        await session.execute(text(f"DROP INDEX IF EXISTS {schema}.{indexes['legacy']}"))
+        await session.execute(text(f"CREATE INDEX IF NOT EXISTS {indexes['managed']} ON {full_table} (managed_by)"))
+        await session.execute(text(f"CREATE INDEX IF NOT EXISTS {indexes['owner']} ON {full_table} (owner_actor_id)"))
+        await session.execute(
+            text(
+                f"CREATE UNIQUE INDEX IF NOT EXISTS {indexes['generic']} ON {full_table} (name) "
+                "WHERE managed_by IS DISTINCT FROM 'studio'"
+            )
+        )
+        await session.execute(
+            text(
+                f"CREATE UNIQUE INDEX IF NOT EXISTS {indexes['studio']} ON {full_table} (owner_actor_id, name) "
+                "WHERE managed_by = 'studio'"
+            )
+        )
+        return True
+
+
+def _revert_sqlite(db: BaseDb, table_name: str) -> bool:
+    table, indexes = _sqlite_names(table_name)
+    # SQLite's portable DROP COLUMN path is a table rebuild. Foreign keys must
+    # be disabled on this exact connection before the transaction begins so
+    # replacing the parent schedule table does not cascade-delete run history.
+    with db.db_engine.connect() as session:  # type: ignore[attr-defined]
+        foreign_keys_enabled = bool(session.exec_driver_sql("PRAGMA foreign_keys").scalar())
+        session.exec_driver_sql("PRAGMA foreign_keys=OFF")
+        session.commit()
+        try:
+            session.exec_driver_sql("BEGIN IMMEDIATE")
+            if not _sqlite_table_exists(session, table_name):
+                session.rollback()
+                return False
+            columns = {row[1] for row in session.execute(text(f"PRAGMA table_info({table})")).fetchall()}
+            v2_9_columns_present = set(_V2_9_COLUMNS).intersection(columns)
+            source_sql = None
+            if v2_9_columns_present:
+                source_sql = _assert_sqlite_downgrade_schema_safe(session, table_name, table, indexes)
+            if "managed_by" in columns:
+                _assert_no_studio_schedule_data(session, "SqliteDb", table)
+            if "pending_trigger_count" in columns or "manual_trigger_claimed" in columns:
+                _assert_no_pending_triggers(
+                    session,
+                    table,
+                    has_pending_count="pending_trigger_count" in columns,
+                    has_claimed_marker="manual_trigger_claimed" in columns,
+                )
+            index_names = {row[1] for row in session.execute(text(f"PRAGMA index_list({table})")).fetchall()}
+            applied = bool(v2_9_columns_present) or any(index.strip('"') in index_names for index in indexes.values())
+            if applied and v2_9_columns_present:
+                assert source_sql is not None
+                _sqlite_rebuild_legacy_table(session, table_name, table, source_sql)
+            else:
+                for index in indexes.values():
+                    if index.strip('"') in index_names:
+                        session.execute(text(f"DROP INDEX IF EXISTS {index}"))
+            session.commit()
+            return applied
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.exec_driver_sql(f"PRAGMA foreign_keys={1 if foreign_keys_enabled else 0}")
+            session.commit()
+
+
+async def _revert_async_sqlite(db: AsyncBaseDb, table_name: str) -> bool:
+    table, indexes = _sqlite_names(table_name)
+    async with db.db_engine.connect() as session:  # type: ignore[attr-defined]
+        foreign_keys_enabled = bool((await session.exec_driver_sql("PRAGMA foreign_keys")).scalar())
+        await session.exec_driver_sql("PRAGMA foreign_keys=OFF")
+        await session.commit()
+        try:
+            await session.exec_driver_sql("BEGIN IMMEDIATE")
+            exists = (
+                await session.execute(
+                    text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:table_name"),
+                    {"table_name": table_name},
+                )
+            ).scalar()
+            if exists is None:
+                await session.rollback()
+                return False
+            columns = {row[1] for row in (await session.execute(text(f"PRAGMA table_info({table})"))).fetchall()}
+            v2_9_columns_present = set(_V2_9_COLUMNS).intersection(columns)
+            source_sql = None
+            if v2_9_columns_present:
+                source_sql = await _assert_sqlite_downgrade_schema_safe_async(session, table_name, table, indexes)
+            if "managed_by" in columns:
+                await _assert_no_studio_schedule_data_async(session, "AsyncSqliteDb", table)
+            if "pending_trigger_count" in columns or "manual_trigger_claimed" in columns:
+                await _assert_no_pending_triggers_async(
+                    session,
+                    table,
+                    has_pending_count="pending_trigger_count" in columns,
+                    has_claimed_marker="manual_trigger_claimed" in columns,
+                )
+            index_names = {row[1] for row in (await session.execute(text(f"PRAGMA index_list({table})"))).fetchall()}
+            applied = bool(v2_9_columns_present) or any(index.strip('"') in index_names for index in indexes.values())
+            if applied and v2_9_columns_present:
+                assert source_sql is not None
+                await _sqlite_rebuild_legacy_table_async(session, table_name, table, source_sql)
+            else:
+                for index in indexes.values():
+                    if index.strip('"') in index_names:
+                        await session.execute(text(f"DROP INDEX IF EXISTS {index}"))
+            await session.commit()
+            return applied
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.exec_driver_sql(f"PRAGMA foreign_keys={1 if foreign_keys_enabled else 0}")
+            await session.commit()
+
+
+def _revert_postgres(db: BaseDb, table_name: str) -> bool:
+    full_table, indexes = _postgres_names(db, table_name)
+    schema = full_table.rsplit(".", 1)[0]
+    with db.Session() as session, session.begin():  # type: ignore[attr-defined]
+        exists = session.execute(
+            text("SELECT 1 FROM information_schema.tables WHERE table_schema=:schema AND table_name=:table"),
+            {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+        ).scalar()
+        if exists is None:
+            return False
+        session.execute(text(f"LOCK TABLE {full_table} IN ACCESS EXCLUSIVE MODE"))
+        managed_by_exists = session.execute(
+            text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema=:schema AND table_name=:table AND column_name='managed_by'"
+            ),
+            {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+        ).scalar()
+        if managed_by_exists is not None:
+            _assert_no_studio_schedule_data(session, type(db).__name__, full_table)
+        pending_trigger_exists = session.execute(
+            text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema=:schema AND table_name=:table AND column_name='pending_trigger_count'"
+            ),
+            {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+        ).scalar()
+        claimed_trigger_exists = session.execute(
+            text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema=:schema AND table_name=:table AND column_name='manual_trigger_claimed'"
+            ),
+            {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+        ).scalar()
+        if pending_trigger_exists is not None or claimed_trigger_exists is not None:
+            _assert_no_pending_triggers(
+                session,
+                full_table,
+                has_pending_count=pending_trigger_exists is not None,
+                has_claimed_marker=claimed_trigger_exists is not None,
+            )
+        for index in indexes.values():
+            session.execute(text(f"DROP INDEX IF EXISTS {schema}.{index}"))
+        for column in reversed(_V2_9_COLUMNS):
+            quoted_column = quote_db_identifier(type(db).__name__, column)
+            session.execute(text(f"ALTER TABLE {full_table} DROP COLUMN IF EXISTS {quoted_column}"))
+        return True
+
+
+async def _revert_async_postgres(db: AsyncBaseDb, table_name: str) -> bool:
+    full_table, indexes = _postgres_names(db, table_name)
+    schema = full_table.rsplit(".", 1)[0]
+    async with db.async_session_factory() as session, session.begin():  # type: ignore[attr-defined]
+        exists = (
+            await session.execute(
+                text("SELECT 1 FROM information_schema.tables WHERE table_schema=:schema AND table_name=:table"),
+                {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+            )
+        ).scalar()
+        if exists is None:
+            return False
+        await session.execute(text(f"LOCK TABLE {full_table} IN ACCESS EXCLUSIVE MODE"))
+        managed_by_exists = (
+            await session.execute(
+                text(
+                    "SELECT 1 FROM information_schema.columns "
+                    "WHERE table_schema=:schema AND table_name=:table AND column_name='managed_by'"
+                ),
+                {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+            )
+        ).scalar()
+        if managed_by_exists is not None:
+            await _assert_no_studio_schedule_data_async(session, type(db).__name__, full_table)
+        pending_trigger_exists = (
+            await session.execute(
+                text(
+                    "SELECT 1 FROM information_schema.columns "
+                    "WHERE table_schema=:schema AND table_name=:table AND column_name='pending_trigger_count'"
+                ),
+                {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+            )
+        ).scalar()
+        claimed_trigger_exists = (
+            await session.execute(
+                text(
+                    "SELECT 1 FROM information_schema.columns "
+                    "WHERE table_schema=:schema AND table_name=:table AND column_name='manual_trigger_claimed'"
+                ),
+                {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+            )
+        ).scalar()
+        if pending_trigger_exists is not None or claimed_trigger_exists is not None:
+            await _assert_no_pending_triggers_async(
+                session,
+                full_table,
+                has_pending_count=pending_trigger_exists is not None,
+                has_claimed_marker=claimed_trigger_exists is not None,
+            )
+        for index in indexes.values():
+            await session.execute(text(f"DROP INDEX IF EXISTS {schema}.{index}"))
+        for column in reversed(_V2_9_COLUMNS):
+            quoted_column = quote_db_identifier(type(db).__name__, column)
+            await session.execute(text(f"ALTER TABLE {full_table} DROP COLUMN IF EXISTS {quoted_column}"))
+        return True

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -116,6 +116,7 @@ def _is_schedule_name_conflict(error: DuplicateKeyError) -> bool:
     details = error.details
     return isinstance(details, dict) and details.get("keyPattern") in (
         {"name": 1},
+        {"name": 1, "managed_by": 1},
         {"owner_actor_id": 1, "name": 1},
     )
 
@@ -159,6 +160,8 @@ def _detect_client_type(client: Any) -> str:
 
 
 class AsyncMongoDb(AsyncBaseDb):
+    supports_component_persistence = False
+    component_catalog_api_version = 1
     scheduler_api_version = 2
 
     # Client type constants (class-level access to module constants)

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -28,7 +28,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
-from agno.db.schemas.scheduler import ScheduleNameConflictError
+from agno.db.schemas.scheduler import ScheduleNameConflictError, validate_schedule_update
 from agno.db.utils import (
     HISTORY_SKIP_STATUSES,
     build_single_run_row,
@@ -3358,6 +3358,7 @@ class AsyncMongoDb(AsyncBaseDb):
             raise
 
     async def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        validate_schedule_update(kwargs)
         try:
             collection = await self._get_collection(table_type="schedules")
             if collection is None:

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 from agno.db.base import AsyncBaseDb, SessionType
 from agno.db.mongo.utils import (
+    _is_schedule_name_conflict,
     apply_pagination,
     apply_sorting,
     bulk_upsert_metrics,
@@ -109,16 +110,6 @@ else:
 _CLIENT_TYPE_MOTOR = "motor"
 _CLIENT_TYPE_PYMONGO_ASYNC = "pymongo_async"
 _CLIENT_TYPE_UNKNOWN = "unknown"
-
-
-def _is_schedule_name_conflict(error: DuplicateKeyError) -> bool:
-    """Match only MongoDB's generic or actor-scoped name indexes."""
-    details = error.details
-    return isinstance(details, dict) and details.get("keyPattern") in (
-        {"name": 1},
-        {"name": 1, "managed_by": 1},
-        {"owner_actor_id": 1, "name": 1},
-    )
 
 
 def _detect_client_type(client: Any) -> str:

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -28,6 +28,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import ScheduleNameConflictError
 from agno.db.utils import (
     HISTORY_SKIP_STATUSES,
     build_single_run_row,
@@ -110,6 +111,15 @@ _CLIENT_TYPE_PYMONGO_ASYNC = "pymongo_async"
 _CLIENT_TYPE_UNKNOWN = "unknown"
 
 
+def _is_schedule_name_conflict(error: DuplicateKeyError) -> bool:
+    """Match only MongoDB's generic or actor-scoped name indexes."""
+    details = error.details
+    return isinstance(details, dict) and details.get("keyPattern") in (
+        {"name": 1},
+        {"owner_actor_id": 1, "name": 1},
+    )
+
+
 def _detect_client_type(client: Any) -> str:
     """Detect whether a client is Motor or PyMongo async."""
     if client is None:
@@ -149,6 +159,8 @@ def _detect_client_type(client: Any) -> str:
 
 
 class AsyncMongoDb(AsyncBaseDb):
+    scheduler_api_version = 2
+
     # Client type constants (class-level access to module constants)
     CLIENT_TYPE_MOTOR = _CLIENT_TYPE_MOTOR
     CLIENT_TYPE_PYMONGO_ASYNC = _CLIENT_TYPE_PYMONGO_ASYNC
@@ -3259,31 +3271,46 @@ class AsyncMongoDb(AsyncBaseDb):
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error getting schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule")
+            raise
 
-    async def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
+    async def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         try:
             collection = await self._get_collection(table_type="schedules")
             if collection is None:
                 return None
 
-            result = await collection.find_one({"name": name})
+            query: Dict[str, Any] = {"name": name}
+            if managed_by is not None:
+                query["managed_by"] = managed_by
+            if owner_actor_id is not None:
+                query["owner_actor_id"] = owner_actor_id
+            if exclude_managed_by is not None:
+                query["managed_by"] = {"$ne": exclude_managed_by}
+            result = await collection.find_one(query)
             if result is None:
                 return None
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error getting schedule by name: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule by name")
+            raise
 
     async def get_schedules(
         self,
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             collection = await self._get_collection(table_type="schedules")
@@ -3293,6 +3320,8 @@ class AsyncMongoDb(AsyncBaseDb):
             query: Dict[str, Any] = {}
             if enabled is not None:
                 query["enabled"] = enabled
+            if exclude_managed_by is not None:
+                query["managed_by"] = {"$ne": exclude_managed_by}
 
             total_count = await collection.count_documents(query)
             offset = (page - 1) * limit
@@ -3301,12 +3330,14 @@ class AsyncMongoDb(AsyncBaseDb):
             for schedule in schedules:
                 schedule.pop("_id", None)
             return schedules, total_count
-        except Exception as e:
-            log_debug(f"Error listing schedules: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error listing schedules")
+            raise
 
     async def create_schedule(self, schedule_data: Dict[str, Any]) -> Dict[str, Any]:
         try:
+            schedule_data.setdefault("pending_trigger_count", 0)
+            schedule_data.setdefault("manual_trigger_claimed", False)
             collection = await self._get_collection(table_type="schedules", create_collection_if_not_found=True)
             if collection is None:
                 raise RuntimeError("Failed to get or create schedules collection")
@@ -3314,9 +3345,14 @@ class AsyncMongoDb(AsyncBaseDb):
             await collection.insert_one(schedule_data)
             schedule_data.pop("_id", None)
             return schedule_data
-        except Exception as e:
-            log_error(f"Error creating schedule: {e}")
-            raise e
+        except DuplicateKeyError as error:
+            if _is_schedule_name_conflict(error):
+                raise ScheduleNameConflictError(schedule_data["name"]) from None
+            log_error("Error creating schedule")
+            raise
+        except Exception:
+            log_error("Error creating schedule")
+            raise
 
     async def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
         try:
@@ -3329,9 +3365,55 @@ class AsyncMongoDb(AsyncBaseDb):
             if result.matched_count == 0:
                 return None
             return await self.get_schedule(schedule_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule: {e}")
+        except DuplicateKeyError as error:
+            name = kwargs.get("name")
+            if isinstance(name, str) and _is_schedule_name_conflict(error):
+                raise ScheduleNameConflictError(name) from None
+            log_debug("Error updating schedule")
+            raise
+        except Exception:
+            log_debug("Error updating schedule")
+            raise
+
+    async def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue one manual execution for a schedule."""
+        collection = await self._get_collection(table_type="schedules")
+        if collection is None:
             return None
+        result = await collection.find_one_and_update(
+            {"id": schedule_id},
+            {
+                "$inc": {"pending_trigger_count": 1},
+                "$set": {"updated_at": int(time.time())},
+            },
+            return_document=ReturnDocument.AFTER,
+        )
+        if result is None:
+            return None
+        result.pop("_id", None)
+        return result
+
+    async def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules for one managed target."""
+        collection = await self._get_collection(table_type="schedules")
+        if collection is None:
+            return 0
+        result = await collection.update_many(
+            {
+                "managed_by": managed_by,
+                "target_type": target_type,
+                "target_id": target_id,
+                "enabled": True,
+            },
+            {"$set": {"enabled": False, "updated_at": int(time.time())}},
+        )
+        return int(result.modified_count)
 
     async def delete_schedule(self, schedule_id: str) -> bool:
         try:
@@ -3345,8 +3427,8 @@ class AsyncMongoDb(AsyncBaseDb):
 
             result = await schedules_collection.delete_one({"id": schedule_id})
             return result.deleted_count > 0
-        except Exception as e:
-            log_debug(f"Error deleting schedule: {e}")
+        except Exception:
+            log_debug("Error deleting schedule")
             return False
 
     async def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
@@ -3358,42 +3440,121 @@ class AsyncMongoDb(AsyncBaseDb):
             now = int(time.time())
             stale_lock_threshold = now - lock_grace_seconds
 
+            lock_query = {
+                "$or": [
+                    {"locked_by": None},
+                    {"locked_at": {"$lte": stale_lock_threshold}},
+                ]
+            }
             result = await collection.find_one_and_update(
                 {
                     "enabled": True,
-                    "next_run_at": {"$lte": now},
-                    "$or": [
-                        {"locked_by": None},
-                        {"locked_at": {"$lte": stale_lock_threshold}},
-                    ],
+                    "manual_trigger_claimed": True,
+                    **lock_query,
                 },
                 {"$set": {"locked_by": worker_id, "locked_at": now}},
-                sort=[("next_run_at", 1)],
+                sort=[("locked_at", 1)],
                 return_document=ReturnDocument.AFTER,
             )
+            if result is None:
+                result = await collection.find_one_and_update(
+                    {
+                        "enabled": True,
+                        "manual_trigger_claimed": {"$ne": True},
+                        "pending_trigger_count": {"$gt": 0},
+                        "$nor": [{"next_run_at": {"$lte": now}}],
+                        **lock_query,
+                    },
+                    {
+                        "$inc": {"pending_trigger_count": -1},
+                        "$set": {
+                            "locked_by": worker_id,
+                            "locked_at": now,
+                            "manual_trigger_claimed": True,
+                        },
+                    },
+                    sort=[("created_at", 1)],
+                    return_document=ReturnDocument.AFTER,
+                )
+            if result is None:
+                result = await collection.find_one_and_update(
+                    {
+                        "enabled": True,
+                        "manual_trigger_claimed": {"$ne": True},
+                        "next_run_at": {"$lte": now},
+                        **lock_query,
+                    },
+                    {
+                        "$set": {
+                            "locked_by": worker_id,
+                            "locked_at": now,
+                            "manual_trigger_claimed": False,
+                        }
+                    },
+                    sort=[("next_run_at", 1)],
+                    return_document=ReturnDocument.AFTER,
+                )
             if result is None:
                 return None
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error claiming schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error claiming schedule")
+            raise
 
-    async def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
+    async def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a claim only while its worker/timestamp fence still matches."""
+        collection = await self._get_collection(table_type="schedules")
+        if collection is None:
+            return None
+        renewed_at = max(int(time.time()), locked_at + 1)
+        result = await collection.find_one_and_update(
+            {"id": schedule_id, "locked_by": worker_id, "locked_at": locked_at},
+            {"$set": {"locked_at": renewed_at}},
+            return_document=ReturnDocument.AFTER,
+        )
+        return renewed_at if result is not None else None
+
+    async def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
         try:
+            if (worker_id is None) != (locked_at is None):
+                return False
             collection = await self._get_collection(table_type="schedules")
             if collection is None:
                 return False
 
-            updates: Dict[str, Any] = {"locked_by": None, "locked_at": None, "updated_at": int(time.time())}
+            updates: Dict[str, Any] = {
+                "locked_by": None,
+                "locked_at": None,
+                "manual_trigger_claimed": False,
+                "updated_at": int(time.time()),
+            }
             if next_run_at is not None:
                 updates["next_run_at"] = next_run_at
 
-            result = await collection.update_one({"id": schedule_id}, {"$set": updates})
+            query: Dict[str, Any] = {"id": schedule_id}
+            if worker_id is None:
+                query["manual_trigger_claimed"] = {"$ne": True}
+            else:
+                query.update(locked_by=worker_id, locked_at=locked_at)
+            result = await collection.update_one(query, {"$set": updates})
             return result.matched_count > 0
-        except Exception as e:
-            log_debug(f"Error releasing schedule: {e}")
+        except Exception:
+            log_debug("Error releasing schedule")
             return False
 
     async def create_schedule_run(self, run_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -3405,9 +3566,9 @@ class AsyncMongoDb(AsyncBaseDb):
             await collection.insert_one(run_data)
             run_data.pop("_id", None)
             return run_data
-        except Exception as e:
-            log_error(f"Error creating schedule run: {e}")
-            raise e
+        except Exception:
+            log_error("Error creating schedule run")
+            raise
 
     async def update_schedule_run(self, schedule_run_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
         try:
@@ -3419,8 +3580,8 @@ class AsyncMongoDb(AsyncBaseDb):
             if result.matched_count == 0:
                 return None
             return await self.get_schedule_run(schedule_run_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule run: {e}")
+        except Exception:
+            log_debug("Error updating schedule run")
             return None
 
     async def get_schedule_run(self, run_id: str) -> Optional[Dict[str, Any]]:
@@ -3435,9 +3596,9 @@ class AsyncMongoDb(AsyncBaseDb):
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error getting schedule run: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule run")
+            raise
 
     async def get_schedule_runs(
         self,
@@ -3458,9 +3619,9 @@ class AsyncMongoDb(AsyncBaseDb):
             for run in runs:
                 run.pop("_id", None)
             return runs, total_count
-        except Exception as e:
-            log_debug(f"Error getting schedule runs: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error getting schedule runs")
+            raise
 
     # -- Learning methods --
     async def get_learning(

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -3297,7 +3297,12 @@ class AsyncMongoDb(AsyncBaseDb):
             if owner_actor_id is not None:
                 query["owner_actor_id"] = owner_actor_id
             if exclude_managed_by is not None:
-                query["managed_by"] = {"$ne": exclude_managed_by}
+                if "managed_by" in query:
+                    # AND with the managed_by equality instead of overwriting
+                    # it, matching the SQL adapters' conjunctive scope.
+                    query = {"$and": [query, {"managed_by": {"$ne": exclude_managed_by}}]}
+                else:
+                    query["managed_by"] = {"$ne": exclude_managed_by}
             result = await collection.find_one(query)
             if result is None:
                 return None

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -3164,7 +3164,12 @@ class MongoDb(BaseDb):
             if owner_actor_id is not None:
                 query["owner_actor_id"] = owner_actor_id
             if exclude_managed_by is not None:
-                query["managed_by"] = {"$ne": exclude_managed_by}
+                if "managed_by" in query:
+                    # AND with the managed_by equality instead of overwriting
+                    # it, matching the SQL adapters' conjunctive scope.
+                    query = {"$and": [query, {"managed_by": {"$ne": exclude_managed_by}}]}
+                else:
+                    query["managed_by"] = {"$ne": exclude_managed_by}
             result = collection.find_one(query)
             if result is None:
                 return None

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -64,11 +64,17 @@ def _is_schedule_name_conflict(error: DuplicateKeyError) -> bool:
     details = error.details
     return isinstance(details, dict) and details.get("keyPattern") in (
         {"name": 1},
+        {"name": 1, "managed_by": 1},
         {"owner_actor_id": 1, "name": 1},
     )
 
 
 class MongoDb(BaseDb):
+    # Component catalog v2 is currently implemented only by the synchronous
+    # SQL adapters. Keep Mongo explicit so control planes fail capability
+    # detection instead of implying partial parity from scheduler support.
+    supports_component_persistence = False
+    component_catalog_api_version = 1
     scheduler_api_version = 2
 
     def __init__(

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -28,7 +28,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
-from agno.db.schemas.scheduler import ScheduleNameConflictError
+from agno.db.schemas.scheduler import ScheduleNameConflictError, validate_schedule_update
 from agno.db.utils import (
     HISTORY_SKIP_STATUSES,
     build_single_run_row,
@@ -3226,6 +3226,7 @@ class MongoDb(BaseDb):
             raise
 
     def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        validate_schedule_update(kwargs)
         try:
             collection = self._get_collection(table_type="schedules")
             if collection is None:

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -28,6 +28,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import ScheduleNameConflictError
 from agno.db.utils import (
     HISTORY_SKIP_STATUSES,
     build_single_run_row,
@@ -58,7 +59,18 @@ except ImportError:
 DRIVER_METADATA = DriverInfo(name="Agno", version=metadata.version("agno"))
 
 
+def _is_schedule_name_conflict(error: DuplicateKeyError) -> bool:
+    """Match only MongoDB's generic or actor-scoped name indexes."""
+    details = error.details
+    return isinstance(details, dict) and details.get("keyPattern") in (
+        {"name": 1},
+        {"owner_actor_id": 1, "name": 1},
+    )
+
+
 class MongoDb(BaseDb):
+    scheduler_api_version = 2
+
     def __init__(
         self,
         db_client: Optional[MongoClient] = None,
@@ -3123,31 +3135,46 @@ class MongoDb(BaseDb):
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error getting schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule")
+            raise
 
-    def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
+    def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         try:
             collection = self._get_collection(table_type="schedules")
             if collection is None:
                 return None
 
-            result = collection.find_one({"name": name})
+            query: Dict[str, Any] = {"name": name}
+            if managed_by is not None:
+                query["managed_by"] = managed_by
+            if owner_actor_id is not None:
+                query["owner_actor_id"] = owner_actor_id
+            if exclude_managed_by is not None:
+                query["managed_by"] = {"$ne": exclude_managed_by}
+            result = collection.find_one(query)
             if result is None:
                 return None
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error getting schedule by name: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule by name")
+            raise
 
     def get_schedules(
         self,
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             collection = self._get_collection(table_type="schedules")
@@ -3157,6 +3184,8 @@ class MongoDb(BaseDb):
             query: Dict[str, Any] = {}
             if enabled is not None:
                 query["enabled"] = enabled
+            if exclude_managed_by is not None:
+                query["managed_by"] = {"$ne": exclude_managed_by}
 
             total_count = collection.count_documents(query)
 
@@ -3166,12 +3195,14 @@ class MongoDb(BaseDb):
             for schedule in schedules:
                 schedule.pop("_id", None)
             return schedules, total_count
-        except Exception as e:
-            log_debug(f"Error listing schedules: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error listing schedules")
+            raise
 
     def create_schedule(self, schedule_data: Dict[str, Any]) -> Dict[str, Any]:
         try:
+            schedule_data.setdefault("pending_trigger_count", 0)
+            schedule_data.setdefault("manual_trigger_claimed", False)
             collection = self._get_collection(table_type="schedules", create_collection_if_not_found=True)
             if collection is None:
                 raise RuntimeError("Failed to get or create schedules collection")
@@ -3179,9 +3210,14 @@ class MongoDb(BaseDb):
             collection.insert_one(schedule_data)
             schedule_data.pop("_id", None)
             return schedule_data
-        except Exception as e:
-            log_error(f"Error creating schedule: {e}")
-            raise e
+        except DuplicateKeyError as error:
+            if _is_schedule_name_conflict(error):
+                raise ScheduleNameConflictError(schedule_data["name"]) from None
+            log_error("Error creating schedule")
+            raise
+        except Exception:
+            log_error("Error creating schedule")
+            raise
 
     def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
         try:
@@ -3194,9 +3230,55 @@ class MongoDb(BaseDb):
             if result.matched_count == 0:
                 return None
             return self.get_schedule(schedule_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule: {e}")
+        except DuplicateKeyError as error:
+            name = kwargs.get("name")
+            if isinstance(name, str) and _is_schedule_name_conflict(error):
+                raise ScheduleNameConflictError(name) from None
+            log_debug("Error updating schedule")
+            raise
+        except Exception:
+            log_debug("Error updating schedule")
+            raise
+
+    def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue one manual execution for a schedule."""
+        collection = self._get_collection(table_type="schedules")
+        if collection is None:
             return None
+        result = collection.find_one_and_update(
+            {"id": schedule_id},
+            {
+                "$inc": {"pending_trigger_count": 1},
+                "$set": {"updated_at": int(time.time())},
+            },
+            return_document=ReturnDocument.AFTER,
+        )
+        if result is None:
+            return None
+        result.pop("_id", None)
+        return result
+
+    def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules for one managed target."""
+        collection = self._get_collection(table_type="schedules")
+        if collection is None:
+            return 0
+        result = collection.update_many(
+            {
+                "managed_by": managed_by,
+                "target_type": target_type,
+                "target_id": target_id,
+                "enabled": True,
+            },
+            {"$set": {"enabled": False, "updated_at": int(time.time())}},
+        )
+        return int(result.modified_count)
 
     def delete_schedule(self, schedule_id: str) -> bool:
         try:
@@ -3210,8 +3292,8 @@ class MongoDb(BaseDb):
 
             result = schedules_collection.delete_one({"id": schedule_id})
             return result.deleted_count > 0
-        except Exception as e:
-            log_debug(f"Error deleting schedule: {e}")
+        except Exception:
+            log_debug("Error deleting schedule")
             return False
 
     def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
@@ -3223,42 +3305,126 @@ class MongoDb(BaseDb):
             now = int(time.time())
             stale_lock_threshold = now - lock_grace_seconds
 
+            lock_query = {
+                "$or": [
+                    {"locked_by": None},
+                    {"locked_at": {"$lte": stale_lock_threshold}},
+                ]
+            }
+            # Recover an already-claimed manual trigger first. The in-flight
+            # marker survives a dead worker, so stale-lock recovery must not
+            # consume another pending trigger.
             result = collection.find_one_and_update(
                 {
                     "enabled": True,
-                    "next_run_at": {"$lte": now},
-                    "$or": [
-                        {"locked_by": None},
-                        {"locked_at": {"$lte": stale_lock_threshold}},
-                    ],
+                    "manual_trigger_claimed": True,
+                    **lock_query,
                 },
                 {"$set": {"locked_by": worker_id, "locked_at": now}},
-                sort=[("next_run_at", 1)],
+                sort=[("locked_at", 1)],
                 return_document=ReturnDocument.AFTER,
             )
+            if result is None:
+                result = collection.find_one_and_update(
+                    {
+                        "enabled": True,
+                        "manual_trigger_claimed": {"$ne": True},
+                        "pending_trigger_count": {"$gt": 0},
+                        # A due cron occurrence is claimed first, leaving this
+                        # manual unit pending for the next claim.
+                        "$nor": [{"next_run_at": {"$lte": now}}],
+                        **lock_query,
+                    },
+                    {
+                        "$inc": {"pending_trigger_count": -1},
+                        "$set": {
+                            "locked_by": worker_id,
+                            "locked_at": now,
+                            "manual_trigger_claimed": True,
+                        },
+                    },
+                    sort=[("created_at", 1)],
+                    return_document=ReturnDocument.AFTER,
+                )
+            if result is None:
+                result = collection.find_one_and_update(
+                    {
+                        "enabled": True,
+                        "manual_trigger_claimed": {"$ne": True},
+                        "next_run_at": {"$lte": now},
+                        **lock_query,
+                    },
+                    {
+                        "$set": {
+                            "locked_by": worker_id,
+                            "locked_at": now,
+                            "manual_trigger_claimed": False,
+                        }
+                    },
+                    sort=[("next_run_at", 1)],
+                    return_document=ReturnDocument.AFTER,
+                )
             if result is None:
                 return None
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error claiming schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error claiming schedule")
+            raise
 
-    def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
+    def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a claim only while its worker/timestamp fence still matches."""
+        collection = self._get_collection(table_type="schedules")
+        if collection is None:
+            return None
+        renewed_at = max(int(time.time()), locked_at + 1)
+        result = collection.find_one_and_update(
+            {"id": schedule_id, "locked_by": worker_id, "locked_at": locked_at},
+            {"$set": {"locked_at": renewed_at}},
+            return_document=ReturnDocument.AFTER,
+        )
+        return renewed_at if result is not None else None
+
+    def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
         try:
+            if (worker_id is None) != (locked_at is None):
+                return False
             collection = self._get_collection(table_type="schedules")
             if collection is None:
                 return False
 
-            updates: Dict[str, Any] = {"locked_by": None, "locked_at": None, "updated_at": int(time.time())}
+            updates: Dict[str, Any] = {
+                "locked_by": None,
+                "locked_at": None,
+                "manual_trigger_claimed": False,
+                "updated_at": int(time.time()),
+            }
             if next_run_at is not None:
                 updates["next_run_at"] = next_run_at
 
-            result = collection.update_one({"id": schedule_id}, {"$set": updates})
+            query: Dict[str, Any] = {"id": schedule_id}
+            if worker_id is None:
+                query["manual_trigger_claimed"] = {"$ne": True}
+            else:
+                query.update(locked_by=worker_id, locked_at=locked_at)
+            result = collection.update_one(query, {"$set": updates})
             return result.matched_count > 0
-        except Exception as e:
-            log_debug(f"Error releasing schedule: {e}")
+        except Exception:
+            log_debug("Error releasing schedule")
             return False
 
     def create_schedule_run(self, run_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -3270,9 +3436,9 @@ class MongoDb(BaseDb):
             collection.insert_one(run_data)
             run_data.pop("_id", None)
             return run_data
-        except Exception as e:
-            log_error(f"Error creating schedule run: {e}")
-            raise e
+        except Exception:
+            log_error("Error creating schedule run")
+            raise
 
     def update_schedule_run(self, schedule_run_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
         try:
@@ -3284,8 +3450,8 @@ class MongoDb(BaseDb):
             if result.matched_count == 0:
                 return None
             return self.get_schedule_run(schedule_run_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule run: {e}")
+        except Exception:
+            log_debug("Error updating schedule run")
             return None
 
     def get_schedule_run(self, run_id: str) -> Optional[Dict[str, Any]]:
@@ -3299,9 +3465,9 @@ class MongoDb(BaseDb):
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error getting schedule run: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule run")
+            raise
 
     def get_schedule_runs(
         self,
@@ -3323,9 +3489,9 @@ class MongoDb(BaseDb):
             for run in runs:
                 run.pop("_id", None)
             return runs, total_count
-        except Exception as e:
-            log_debug(f"Error getting schedule runs: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error getting schedule runs")
+            raise
 
     # -- Learning methods (stubs) --
     def get_learning(

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 from agno.db.base import BaseDb, SessionType
 from agno.db.mongo.utils import (
+    _is_schedule_name_conflict,
     apply_pagination,
     apply_sorting,
     bulk_upsert_metrics,
@@ -57,16 +58,6 @@ except ImportError:
     raise ImportError("`pymongo` not installed. Please install it using `pip install pymongo`")
 
 DRIVER_METADATA = DriverInfo(name="Agno", version=metadata.version("agno"))
-
-
-def _is_schedule_name_conflict(error: DuplicateKeyError) -> bool:
-    """Match only MongoDB's generic or actor-scoped name indexes."""
-    details = error.details
-    return isinstance(details, dict) and details.get("keyPattern") in (
-        {"name": 1},
-        {"name": 1, "managed_by": 1},
-        {"owner_actor_id": 1, "name": 1},
-    )
 
 
 class MongoDb(BaseDb):

--- a/libs/agno/agno/db/mongo/schemas.py
+++ b/libs/agno/agno/db/mongo/schemas.py
@@ -133,9 +133,11 @@ SCHEDULES_COLLECTION_SCHEMA = [
     {"key": "id", "unique": True},
     {
         # Keep this key pattern distinct from the pre-2.9 global {name: 1}
-        # index. MongoDB cannot build the partial replacement alongside that
-        # legacy index when both use the same key pattern, which would make a
-        # fail-safe create-before-drop migration impossible.
+        # index: same-key-pattern coexistence needs MongoDB >= 5.0 and an
+        # exclusion filter ($or in partialFilterExpression) needs >= 6.0,
+        # while pymongo's server floor is 4.2 — so the fail-safe
+        # create-before-drop migration keeps a distinct compound key and an
+        # equality-only filter.
         "key": [("name", 1), ("managed_by", 1)],
         "name": "uq_generic_name",
         "unique": True,

--- a/libs/agno/agno/db/mongo/schemas.py
+++ b/libs/agno/agno/db/mongo/schemas.py
@@ -131,9 +131,28 @@ LEARNINGS_COLLECTION_SCHEMA = [
 
 SCHEDULES_COLLECTION_SCHEMA = [
     {"key": "id", "unique": True},
-    {"key": "name", "unique": True},
+    {
+        # Keep this key pattern distinct from the pre-2.9 global {name: 1}
+        # index. MongoDB cannot build the partial replacement alongside that
+        # legacy index when both use the same key pattern, which would make a
+        # fail-safe create-before-drop migration impossible.
+        "key": [("name", 1), ("managed_by", 1)],
+        "name": "uq_generic_name",
+        "unique": True,
+        "partialFilterExpression": {"managed_by": None},
+    },
+    {
+        "key": [("owner_actor_id", 1), ("name", 1)],
+        "name": "uq_studio_owner_name",
+        "unique": True,
+        "partialFilterExpression": {"managed_by": "studio"},
+    },
+    {"key": "managed_by"},
+    {"key": "owner_actor_id"},
     {"key": "enabled"},
     {"key": "next_run_at"},
+    {"key": "pending_trigger_count"},
+    {"key": "manual_trigger_claimed"},
     {"key": "locked_by"},
     {"key": "locked_at"},
     {"key": "created_at"},

--- a/libs/agno/agno/db/mongo/utils.py
+++ b/libs/agno/agno/db/mongo/utils.py
@@ -7,10 +7,11 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
+from pymongo.errors import DuplicateKeyError
+
 from agno.db.mongo.schemas import get_collection_indexes
 from agno.db.schemas.culture import CulturalKnowledge
 from agno.utils.log import log_error, log_warning
-from pymongo.errors import DuplicateKeyError
 
 try:
     from pymongo.collection import Collection

--- a/libs/agno/agno/db/mongo/utils.py
+++ b/libs/agno/agno/db/mongo/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for the MongoDB database class."""
 
+import inspect
 import json
 import time
 from datetime import date, datetime, timedelta, timezone
@@ -20,35 +21,74 @@ except ImportError:
 def create_collection_indexes(collection: Collection, collection_type: str) -> None:
     """Create all required indexes for a collection"""
     try:
+        legacy_schedule_indexes: List[str] = []
+        if collection_type == "schedules":
+            # v2.9 replaces the legacy global unique name index with separate
+            # generic and actor-scoped Studio namespaces. Keep the legacy
+            # authority until both replacements have been created.
+            for existing in collection.list_indexes():
+                if (
+                    existing.get("name") != "uq_generic_name"
+                    and existing.get("unique") is True
+                    and dict(existing.get("key", {})) == {"name": 1}
+                ):
+                    legacy_schedule_indexes.append(existing["name"])
         indexes = get_collection_indexes(collection_type)
         for index_spec in indexes:
             key = index_spec["key"]
-            unique = index_spec.get("unique", False)
+            options = {option: value for option, value in index_spec.items() if option != "key"}
 
             if isinstance(key, list):
-                collection.create_index(key, unique=unique)
+                collection.create_index(key, **options)
             else:
-                collection.create_index([(key, 1)], unique=unique)
+                collection.create_index([(key, 1)], **options)
+        for index_name in legacy_schedule_indexes:
+            collection.drop_index(index_name)
 
     except Exception as e:
         log_warning(f"Error creating indexes for {collection_type} collection: {str(e)}")
+        # Schedule adapters advertise actor-scoped name isolation only after
+        # these indexes exist.  Continuing without them would turn a failed
+        # migration into a silent cross-actor uniqueness regression.
+        if collection_type == "schedules":
+            raise
 
 
 async def create_collection_indexes_async(collection: Any, collection_type: str) -> None:
     """Create all required indexes for a collection (async version for Motor)"""
     try:
+        legacy_schedule_indexes: List[str] = []
+        if collection_type == "schedules":
+            cursor = collection.list_indexes()
+            if inspect.isawaitable(cursor):
+                cursor = await cursor
+            if hasattr(cursor, "to_list"):
+                existing_indexes = await cursor.to_list(length=None)
+            else:
+                existing_indexes = [existing async for existing in cursor]
+            for existing in existing_indexes:
+                if (
+                    existing.get("name") != "uq_generic_name"
+                    and existing.get("unique") is True
+                    and dict(existing.get("key", {})) == {"name": 1}
+                ):
+                    legacy_schedule_indexes.append(existing["name"])
         indexes = get_collection_indexes(collection_type)
         for index_spec in indexes:
             key = index_spec["key"]
-            unique = index_spec.get("unique", False)
+            options = {option: value for option, value in index_spec.items() if option != "key"}
 
             if isinstance(key, list):
-                await collection.create_index(key, unique=unique)
+                await collection.create_index(key, **options)
             else:
-                await collection.create_index([(key, 1)], unique=unique)
+                await collection.create_index([(key, 1)], **options)
+        for index_name in legacy_schedule_indexes:
+            await collection.drop_index(index_name)
 
     except Exception as e:
         log_warning(f"Error creating indexes for {collection_type} collection: {str(e)}")
+        if collection_type == "schedules":
+            raise
 
 
 def apply_sorting(

--- a/libs/agno/agno/db/mongo/utils.py
+++ b/libs/agno/agno/db/mongo/utils.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from agno.db.mongo.schemas import get_collection_indexes
 from agno.db.schemas.culture import CulturalKnowledge
 from agno.utils.log import log_error, log_warning
+from pymongo.errors import DuplicateKeyError
 
 try:
     from pymongo.collection import Collection
@@ -313,4 +314,14 @@ def deserialize_cultural_knowledge_from_db(db_row: Dict[str, Any]) -> CulturalKn
             "agent_id": db_row.get("agent_id"),
             "team_id": db_row.get("team_id"),
         }
+    )
+
+
+def _is_schedule_name_conflict(error: DuplicateKeyError) -> bool:
+    """Match only MongoDB's generic or actor-scoped name indexes."""
+    details = error.details
+    return isinstance(details, dict) and details.get("keyPattern") in (
+        {"name": 1},
+        {"name": 1, "managed_by": 1},
+        {"owner_actor_id": 1, "name": 1},
     )

--- a/libs/agno/agno/db/mongo/utils.py
+++ b/libs/agno/agno/db/mongo/utils.py
@@ -7,7 +7,10 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
-from pymongo.errors import DuplicateKeyError
+try:
+    from pymongo.errors import DuplicateKeyError
+except ImportError:
+    DuplicateKeyError = Exception  # type: ignore[assignment,misc]
 
 from agno.db.mongo.schemas import get_collection_indexes
 from agno.db.schemas.culture import CulturalKnowledge

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -11,6 +11,7 @@ from agno.db.base import AsyncBaseDb, ComponentProjection, ComponentType, Compon
 from agno.db.migrations.manager import MigrationManager
 from agno.db.postgres.schemas import get_table_schema_definition
 from agno.db.postgres.utils import (
+    _is_schedule_name_conflict,
     abulk_upsert_metrics,
     acreate_schema,
     ais_table_available,
@@ -92,29 +93,6 @@ def _db_epoch() -> Any:
     only shift scheduling/reporting by the skew, never ownership.
     """
     return sa_cast(func.floor(func.extract("epoch", func.now())), BigInteger)
-
-
-def _is_schedule_name_conflict(error: IntegrityError, table_name: str, schema_name: str) -> bool:
-    """Match only the generic or actor-scoped schedule-name indexes."""
-    original = error.orig
-    cause = getattr(original, "__cause__", None)
-    sqlstate = (
-        getattr(original, "sqlstate", None) or getattr(original, "pgcode", None) or getattr(cause, "sqlstate", None)
-    )
-    diagnostic = getattr(original, "diag", None)
-    constraint_name = getattr(diagnostic, "constraint_name", None) or getattr(cause, "constraint_name", None)
-    reported_table = getattr(diagnostic, "table_name", None) or getattr(cause, "table_name", None)
-    reported_schema = getattr(diagnostic, "schema_name", None) or getattr(cause, "schema_name", None)
-    return (
-        sqlstate == "23505"
-        and constraint_name
-        in {
-            f"{table_name}_uq_generic_name",
-            f"{table_name}_uq_studio_owner_name",
-        }
-        and reported_table == table_name
-        and reported_schema == schema_name
-    )
 
 
 class AsyncPostgresDb(AsyncBaseDb):

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -118,6 +118,8 @@ def _is_schedule_name_conflict(error: IntegrityError, table_name: str, schema_na
 
 
 class AsyncPostgresDb(AsyncBaseDb):
+    supports_component_persistence = False
+    component_catalog_api_version = 1
     scheduler_api_version = 2
 
     def __init__(
@@ -4204,6 +4206,7 @@ class AsyncPostgresDb(AsyncBaseDb):
         guard: Optional[ComponentVersionGuard] = None,
         require_no_dependents: bool = True,
         projection: Optional[ComponentProjection] = None,
+        expected_component_type: Optional[ComponentType] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4238,6 +4241,8 @@ class AsyncPostgresDb(AsyncBaseDb):
         component_id: str,
         version: Optional[int] = None,
         label: Optional[str] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4270,6 +4275,8 @@ class AsyncPostgresDb(AsyncBaseDb):
         self,
         component_id: str,
         include_config: bool = False,
+        *,
+        include_deleted: bool = False,
     ) -> List[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -26,7 +26,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
-from agno.db.schemas.scheduler import ScheduleNameConflictError
+from agno.db.schemas.scheduler import ScheduleNameConflictError, validate_schedule_update
 from agno.db.schemas.service_accounts import (
     resolve_service_account_sort_column,
     validate_service_account_update,
@@ -4414,6 +4414,7 @@ class AsyncPostgresDb(AsyncBaseDb):
             raise
 
     async def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        validate_schedule_update(kwargs)
         try:
             table = await self._get_table(table_type="schedules")
             if table is None:

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from agno.run.status_persist import RunPersistOutcome
     from agno.tracing.schemas import Span, Trace
 
-from agno.db.base import AsyncBaseDb, ComponentType, SessionType
+from agno.db.base import AsyncBaseDb, ComponentProjection, ComponentType, ComponentVersionGuard, SessionType
 from agno.db.migrations.manager import MigrationManager
 from agno.db.postgres.schemas import get_table_schema_definition
 from agno.db.postgres.utils import (
@@ -26,6 +26,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import ScheduleNameConflictError
 from agno.db.schemas.service_accounts import (
     resolve_service_account_sort_column,
     validate_service_account_update,
@@ -68,7 +69,7 @@ try:
     from sqlalchemy import cast as sa_cast
     from sqlalchemy.dialects import postgresql
     from sqlalchemy.dialects.postgresql import TIMESTAMP
-    from sqlalchemy.exc import ProgrammingError
+    from sqlalchemy.exc import IntegrityError, ProgrammingError
     from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
     from sqlalchemy.schema import Column, MetaData
     from sqlalchemy.sql.expression import select, text
@@ -93,7 +94,32 @@ def _db_epoch() -> Any:
     return sa_cast(func.floor(func.extract("epoch", func.now())), BigInteger)
 
 
+def _is_schedule_name_conflict(error: IntegrityError, table_name: str, schema_name: str) -> bool:
+    """Match only the generic or actor-scoped schedule-name indexes."""
+    original = error.orig
+    cause = getattr(original, "__cause__", None)
+    sqlstate = (
+        getattr(original, "sqlstate", None) or getattr(original, "pgcode", None) or getattr(cause, "sqlstate", None)
+    )
+    diagnostic = getattr(original, "diag", None)
+    constraint_name = getattr(diagnostic, "constraint_name", None) or getattr(cause, "constraint_name", None)
+    reported_table = getattr(diagnostic, "table_name", None) or getattr(cause, "table_name", None)
+    reported_schema = getattr(diagnostic, "schema_name", None) or getattr(cause, "schema_name", None)
+    return (
+        sqlstate == "23505"
+        and constraint_name
+        in {
+            f"{table_name}_uq_generic_name",
+            f"{table_name}_uq_studio_owner_name",
+        }
+        and reported_table == table_name
+        and reported_schema == schema_name
+    )
+
+
 class AsyncPostgresDb(AsyncBaseDb):
+    scheduler_api_version = 2
+
     def __init__(
         self,
         id: Optional[str] = None,
@@ -4154,6 +4180,8 @@ class AsyncPostgresDb(AsyncBaseDb):
         self,
         component_id: str,
         component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4163,6 +4191,7 @@ class AsyncPostgresDb(AsyncBaseDb):
         component_type: Optional[ComponentType] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
+        current_version: Optional[int] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         raise NotImplementedError("Component methods not yet supported for async databases")
@@ -4171,6 +4200,10 @@ class AsyncPostgresDb(AsyncBaseDb):
         self,
         component_id: str,
         hard_delete: bool = False,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        require_no_dependents: bool = True,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4217,6 +4250,9 @@ class AsyncPostgresDb(AsyncBaseDb):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> Dict[str, Any]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4224,6 +4260,9 @@ class AsyncPostgresDb(AsyncBaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4238,6 +4277,9 @@ class AsyncPostgresDb(AsyncBaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4253,6 +4295,8 @@ class AsyncPostgresDb(AsyncBaseDb):
         self,
         component_id: str,
         version: Optional[int] = None,
+        *,
+        active_parents_only: bool = False,
     ) -> List[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4274,28 +4318,43 @@ class AsyncPostgresDb(AsyncBaseDb):
                 result = await sess.execute(select(table).where(table.c.id == schedule_id))
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
-        except Exception as e:
-            log_debug(f"Error getting schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule")
+            raise
 
-    async def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
+    async def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         try:
             table = await self._get_table(table_type="schedules")
             if table is None:
                 return None
             async with self.async_session_factory() as sess:
-                result = await sess.execute(select(table).where(table.c.name == name))
+                query = select(table).where(table.c.name == name)
+                if managed_by is not None:
+                    query = query.where(table.c.managed_by == managed_by)
+                if owner_actor_id is not None:
+                    query = query.where(table.c.owner_actor_id == owner_actor_id)
+                if exclude_managed_by is not None:
+                    query = query.where(or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by))
+                result = await sess.execute(query)
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
-        except Exception as e:
-            log_debug(f"Error getting schedule by name: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule by name")
+            raise
 
     async def get_schedules(
         self,
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = await self._get_table(table_type="schedules")
@@ -4306,6 +4365,10 @@ class AsyncPostgresDb(AsyncBaseDb):
                 base_query = select(table)
                 if enabled is not None:
                     base_query = base_query.where(table.c.enabled == enabled)
+                if exclude_managed_by is not None:
+                    base_query = base_query.where(
+                        or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by)
+                    )
 
                 # Get total count
                 count_stmt = select(func.count()).select_from(base_query.alias())
@@ -4319,12 +4382,14 @@ class AsyncPostgresDb(AsyncBaseDb):
                 stmt = base_query.order_by(table.c.created_at.desc()).limit(limit).offset(offset)
                 result = await sess.execute(stmt)
                 return [dict(row._mapping) for row in result.fetchall()], total_count
-        except Exception as e:
-            log_debug(f"Error listing schedules: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error listing schedules")
+            raise
 
     async def create_schedule(self, schedule_data: Dict[str, Any]) -> Dict[str, Any]:
         try:
+            schedule_data.setdefault("pending_trigger_count", 0)
+            schedule_data.setdefault("manual_trigger_claimed", False)
             table = await self._get_table(table_type="schedules", create_table_if_not_found=True)
             if table is None:
                 raise RuntimeError("Failed to get or create schedules table")
@@ -4332,8 +4397,13 @@ class AsyncPostgresDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.insert().values(**schedule_data))
             return schedule_data
-        except Exception as e:
-            log_error(f"Error creating schedule: {str(e)}")
+        except IntegrityError as error:
+            if _is_schedule_name_conflict(error, self.schedules_table_name, self.db_schema):
+                raise ScheduleNameConflictError(schedule_data["name"]) from None
+            log_error("Error creating schedule")
+            raise
+        except Exception:
+            log_error("Error creating schedule")
             raise
 
     async def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -4346,9 +4416,59 @@ class AsyncPostgresDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.update().where(table.c.id == schedule_id).values(**kwargs))
             return await self.get_schedule(schedule_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule: {e}")
+        except IntegrityError as error:
+            name = kwargs.get("name")
+            if isinstance(name, str) and _is_schedule_name_conflict(error, self.schedules_table_name, self.db_schema):
+                raise ScheduleNameConflictError(name) from None
+            log_debug("Error updating schedule")
+            raise
+        except Exception:
+            log_debug("Error updating schedule")
+            raise
+
+    async def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue one manual execution for a schedule."""
+        table = await self._get_table(table_type="schedules")
+        if table is None:
             return None
+        async with self.async_session_factory() as sess:
+            async with sess.begin():
+                result = await sess.execute(
+                    update(table)
+                    .where(table.c.id == schedule_id)
+                    .values(
+                        pending_trigger_count=func.coalesce(table.c.pending_trigger_count, 0) + 1,
+                        updated_at=int(time.time()),
+                    )
+                    .returning(*table.c)
+                )
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+
+    async def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules for one managed target."""
+        table = await self._get_table(table_type="schedules")
+        if table is None:
+            return 0
+        async with self.async_session_factory() as sess:
+            async with sess.begin():
+                result = await sess.execute(
+                    table.update()
+                    .where(
+                        table.c.managed_by == managed_by,
+                        table.c.target_type == target_type,
+                        table.c.target_id == target_id,
+                        table.c.enabled == True,  # noqa: E712
+                    )
+                    .values(enabled=False, updated_at=int(time.time()))
+                )
+                return int(result.rowcount or 0)  # type: ignore[attr-defined]
 
     async def delete_schedule(self, schedule_id: str) -> bool:
         try:
@@ -4362,8 +4482,8 @@ class AsyncPostgresDb(AsyncBaseDb):
                         await sess.execute(runs_table.delete().where(runs_table.c.schedule_id == schedule_id))
                     result = await sess.execute(table.delete().where(table.c.id == schedule_id))
                     return result.rowcount > 0  # type: ignore[attr-defined]
-        except Exception as e:
-            log_debug(f"Error deleting schedule: {e}")
+        except Exception:
+            log_debug("Error deleting schedule")
             return False
 
     async def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
@@ -4380,13 +4500,30 @@ class AsyncPostgresDb(AsyncBaseDb):
                         select(table.c.id)
                         .where(
                             table.c.enabled == True,  # noqa: E712
-                            table.c.next_run_at <= now,
+                            or_(
+                                table.c.manual_trigger_claimed == True,  # noqa: E712
+                                table.c.pending_trigger_count > 0,
+                                table.c.next_run_at <= now,
+                            ),
                             or_(
                                 table.c.locked_by.is_(None),
                                 table.c.locked_at <= stale_lock_threshold,
                             ),
                         )
-                        .order_by(table.c.next_run_at.asc())
+                        .order_by(
+                            case(
+                                (table.c.manual_trigger_claimed == True, 0),  # noqa: E712
+                                (
+                                    and_(
+                                        table.c.pending_trigger_count > 0,
+                                        or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                    ),
+                                    1,
+                                ),
+                                else_=2,
+                            ),
+                            table.c.next_run_at.asc(),
+                        )
                         .limit(1)
                         .with_for_update(skip_locked=True)
                         .scalar_subquery()
@@ -4394,7 +4531,26 @@ class AsyncPostgresDb(AsyncBaseDb):
                     stmt = (
                         update(table)
                         .where(table.c.id == subq)
-                        .values(locked_by=worker_id, locked_at=now)
+                        .values(
+                            locked_by=worker_id,
+                            locked_at=now,
+                            pending_trigger_count=case(
+                                (
+                                    and_(
+                                        table.c.manual_trigger_claimed == False,  # noqa: E712
+                                        table.c.pending_trigger_count > 0,
+                                        or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                    ),
+                                    table.c.pending_trigger_count - 1,
+                                ),
+                                else_=table.c.pending_trigger_count,
+                            ),
+                            manual_trigger_claimed=case(
+                                (table.c.manual_trigger_claimed == True, True),  # noqa: E712
+                                (table.c.next_run_at <= now, False),
+                                else_=True,
+                            ),
+                        )
                         .returning(*table.c)
                     )
                     result = await sess.execute(stmt)
@@ -4402,24 +4558,68 @@ class AsyncPostgresDb(AsyncBaseDb):
                     if row is None:
                         return None
                     return dict(row._mapping)
-        except Exception as e:
-            log_debug(f"Error claiming schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error claiming schedule")
+            raise
 
-    async def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
+    async def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a claim only while its worker/timestamp fence still matches."""
+        table = await self._get_table(table_type="schedules")
+        if table is None:
+            return None
+        renewed_at = max(int(time.time()), locked_at + 1)
+        async with self.async_session_factory() as sess:
+            async with sess.begin():
+                result = await sess.execute(
+                    table.update()
+                    .where(
+                        table.c.id == schedule_id,
+                        table.c.locked_by == worker_id,
+                        table.c.locked_at == locked_at,
+                    )
+                    .values(locked_at=renewed_at)
+                )
+                return renewed_at if result.rowcount > 0 else None  # type: ignore[attr-defined]
+
+    async def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
         try:
+            if (worker_id is None) != (locked_at is None):
+                return False
             table = await self._get_table(table_type="schedules")
             if table is None:
                 return False
-            updates: Dict[str, Any] = {"locked_by": None, "locked_at": None, "updated_at": int(time.time())}
+            updates: Dict[str, Any] = {
+                "locked_by": None,
+                "locked_at": None,
+                "manual_trigger_claimed": False,
+                "updated_at": int(time.time()),
+            }
             if next_run_at is not None:
                 updates["next_run_at"] = next_run_at
             async with self.async_session_factory() as sess:
                 async with sess.begin():
-                    result = await sess.execute(table.update().where(table.c.id == schedule_id).values(**updates))
+                    stmt = table.update().where(table.c.id == schedule_id)
+                    if worker_id is None:
+                        stmt = stmt.where(table.c.manual_trigger_claimed == False)  # noqa: E712
+                    else:
+                        stmt = stmt.where(table.c.locked_by == worker_id, table.c.locked_at == locked_at)
+                    result = await sess.execute(stmt.values(**updates))
                     return result.rowcount > 0  # type: ignore[attr-defined]
-        except Exception as e:
-            log_debug(f"Error releasing schedule: {e}")
+        except Exception:
+            log_debug("Error releasing schedule")
             return False
 
     async def create_schedule_run(self, run_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -4431,8 +4631,8 @@ class AsyncPostgresDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.insert().values(**run_data))
             return run_data
-        except Exception as e:
-            log_error(f"Error creating schedule run: {str(e)}")
+        except Exception:
+            log_error("Error creating schedule run")
             raise
 
     async def update_schedule_run(self, schedule_run_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -4444,8 +4644,8 @@ class AsyncPostgresDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.update().where(table.c.id == schedule_run_id).values(**kwargs))
             return await self.get_schedule_run(schedule_run_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule run: {e}")
+        except Exception:
+            log_debug("Error updating schedule run")
             return None
 
     async def get_schedule_run(self, run_id: str) -> Optional[Dict[str, Any]]:
@@ -4457,9 +4657,9 @@ class AsyncPostgresDb(AsyncBaseDb):
                 result = await sess.execute(select(table).where(table.c.id == run_id))
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
-        except Exception as e:
-            log_debug(f"Error getting schedule run: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule run")
+            raise
 
     async def get_schedule_runs(
         self,
@@ -4490,9 +4690,9 @@ class AsyncPostgresDb(AsyncBaseDb):
                 )
                 result = await sess.execute(stmt)
                 return [dict(row._mapping) for row in result.fetchall()], total_count
-        except Exception as e:
-            log_debug(f"Error getting schedule runs: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error getting schedule runs")
+            raise
 
     # -- Job queue methods --
     #

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -27,6 +27,7 @@ from agno.db.base import (
 from agno.db.migrations.manager import MigrationManager
 from agno.db.postgres.schemas import get_table_schema_definition
 from agno.db.postgres.utils import (
+    _is_schedule_name_conflict,
     apply_sorting,
     bulk_upsert_metrics,
     calculate_date_metrics,
@@ -134,29 +135,6 @@ def _shared_table_init_lock(database_key: str) -> RLock:
     """Return one in-process lazy-DDL lock for every database schema."""
     with _TABLE_INIT_LOCKS_GUARD:
         return _TABLE_INIT_LOCKS.setdefault(database_key, RLock())
-
-
-def _is_schedule_name_conflict(error: IntegrityError, table_name: str, schema_name: str) -> bool:
-    """Match only the generic or actor-scoped schedule-name indexes."""
-    original = error.orig
-    cause = getattr(original, "__cause__", None)
-    sqlstate = (
-        getattr(original, "sqlstate", None) or getattr(original, "pgcode", None) or getattr(cause, "sqlstate", None)
-    )
-    diagnostic = getattr(original, "diag", None)
-    constraint_name = getattr(diagnostic, "constraint_name", None) or getattr(cause, "constraint_name", None)
-    reported_table = getattr(diagnostic, "table_name", None) or getattr(cause, "table_name", None)
-    reported_schema = getattr(diagnostic, "schema_name", None) or getattr(cause, "schema_name", None)
-    return (
-        sqlstate == "23505"
-        and constraint_name
-        in {
-            f"{table_name}_uq_generic_name",
-            f"{table_name}_uq_studio_owner_name",
-        }
-        and reported_table == table_name
-        and reported_schema == schema_name
-    )
 
 
 class PostgresDb(BaseDb):

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -4709,6 +4709,7 @@ class PostgresDb(BaseDb):
         guard: Optional[ComponentVersionGuard] = None,
         require_no_dependents: bool = True,
         projection: Optional[ComponentProjection] = None,
+        expected_component_type: Optional[ComponentType] = None,
     ) -> bool:
         """Delete a component and all its configs/links.
 
@@ -4718,6 +4719,7 @@ class PostgresDb(BaseDb):
             guard: Expected latest/current version state for compare-and-set.
             require_no_dependents: Refuse deletion while qualifying inbound links exist.
             projection: Component fields to update atomically with a soft archive.
+            expected_component_type: Optional identity invariant.
 
         Returns:
             True if deleted, False if not found or already deleted.
@@ -4759,6 +4761,16 @@ class PostgresDb(BaseDb):
                     log_error(f"Component {component_id} not found")
                     return False
                 self._check_component_guard(component_id, guard, actual)
+                if expected_component_type is not None:
+                    actual_type = sess.execute(
+                        select(components_table.c.component_type)
+                        .where(components_table.c.component_id == component_id)
+                        .with_for_update()
+                    ).scalar_one()
+                    if actual_type != expected_component_type.value:
+                        raise ValueError(
+                            f"Component {component_id} has type {actual_type}, not {expected_component_type.value}"
+                        )
 
                 if require_no_dependents and links_table is not None:
                     dependents = self._component_dependents(
@@ -5102,6 +5114,8 @@ class PostgresDb(BaseDb):
         component_id: str,
         version: Optional[int] = None,
         label: Optional[str] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Get a config by component ID and version or label.
 
@@ -5111,6 +5125,7 @@ class PostgresDb(BaseDb):
                 the current published version or the latest draft when the
                 component has never been published.
             label: Config label to lookup. Ignored if version is provided.
+            include_deleted: Allow reading config history for an archived component.
 
         Returns:
             Config dictionary or None if not found.
@@ -5123,17 +5138,13 @@ class PostgresDb(BaseDb):
                 return None
 
             with self.Session() as sess:
-                # Verify component exists and get current_version
-                component_row = (
-                    sess.execute(
-                        select(components_table.c.component_id, components_table.c.current_version).where(
-                            components_table.c.component_id == component_id,
-                            components_table.c.deleted_at.is_(None),
-                        )
-                    )
-                    .mappings()
-                    .one_or_none()
-                )
+                component_query = select(
+                    components_table.c.component_id,
+                    components_table.c.current_version,
+                ).where(components_table.c.component_id == component_id)
+                if not include_deleted:
+                    component_query = component_query.where(components_table.c.deleted_at.is_(None))
+                component_row = sess.execute(component_query).mappings().one_or_none()
 
                 if component_row is None:
                     return None
@@ -5727,12 +5738,15 @@ class PostgresDb(BaseDb):
         self,
         component_id: str,
         include_config: bool = False,
+        *,
+        include_deleted: bool = False,
     ) -> List[Dict[str, Any]]:
         """List all config versions for a component.
 
         Args:
             component_id: The component ID.
             include_config: If True, include full config blob. Otherwise just metadata.
+            include_deleted: Allow listing config history for an archived component.
 
         Returns:
             List of config dictionaries, newest first.
@@ -5746,13 +5760,12 @@ class PostgresDb(BaseDb):
                 return []
 
             with self.Session() as sess:
-                # Verify component exists and is not deleted
-                exists = sess.execute(
-                    select(components_table.c.component_id).where(
-                        components_table.c.component_id == component_id,
-                        components_table.c.deleted_at.is_(None),
-                    )
-                ).scalar_one_or_none()
+                component_query = select(components_table.c.component_id).where(
+                    components_table.c.component_id == component_id
+                )
+                if not include_deleted:
+                    component_query = component_query.where(components_table.c.deleted_at.is_(None))
+                exists = sess.execute(component_query).scalar_one_or_none()
 
                 if exists is None:
                     return []
@@ -6025,12 +6038,11 @@ class PostgresDb(BaseDb):
             if resolved_version is None:
                 return None
 
-            # Cycle detection
-            if _visited is None:
-                _visited = set()
-
+            # Track only the active recursion path. A global visited set
+            # incorrectly marks a shared child in a valid DAG as a cycle.
+            active_path = set(_visited or set())
             node_key = (component_id, resolved_version)
-            if node_key in _visited:
+            if node_key in active_path:
                 return {
                     "component": component,
                     "config": self.get_config(component_id, version=resolved_version),
@@ -6038,7 +6050,7 @@ class PostgresDb(BaseDb):
                     "resolved_versions": {component_id: resolved_version},
                     "cycle_detected": True,
                 }
-            _visited.add(node_key)
+            active_path.add(node_key)
 
             config = self.get_config(component_id, version=resolved_version)
             if config is None:
@@ -6069,7 +6081,7 @@ class PostgresDb(BaseDb):
                 child_graph = self.load_component_graph(
                     child_id,
                     version=resolved_child_ver,
-                    _visited=_visited,
+                    _visited=active_path,
                     _max_depth=_max_depth - 1,
                 )
 

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -1,5 +1,6 @@
 import time
 from datetime import date, datetime, timedelta, timezone
+from threading import RLock
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union, cast
 from uuid import uuid4
 
@@ -8,7 +9,21 @@ if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
 
 from agno.db import mcp_oauth_store
-from agno.db.base import BaseDb, ComponentType, SessionType
+from agno.db.base import (
+    DELETED_CONFIG_STAGE,
+    BaseDb,
+    ComponentAlreadyExistsError,
+    ComponentCycleError,
+    ComponentDependencyError,
+    ComponentDependencyUnavailableError,
+    ComponentDraftRequiredError,
+    ComponentLastConfigError,
+    ComponentProjection,
+    ComponentType,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+    SessionType,
+)
 from agno.db.migrations.manager import MigrationManager
 from agno.db.postgres.schemas import get_table_schema_definition
 from agno.db.postgres.utils import (
@@ -35,6 +50,7 @@ from agno.db.schemas.mcp_oauth import (
     MCP_OAUTH_TRANSACTIONS,
 )
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import ScheduleNameConflictError
 from agno.db.schemas.service_accounts import (
     resolve_service_account_sort_column,
     validate_service_account_update,
@@ -80,7 +96,7 @@ try:
     from sqlalchemy.dialects import postgresql
     from sqlalchemy.dialects.postgresql import TIMESTAMP
     from sqlalchemy.engine import Engine, create_engine
-    from sqlalchemy.exc import ProgrammingError
+    from sqlalchemy.exc import IntegrityError, ProgrammingError
     from sqlalchemy.orm import scoped_session, sessionmaker
     from sqlalchemy.schema import Column, MetaData, Table
     from sqlalchemy.sql.expression import text
@@ -105,7 +121,49 @@ def _db_epoch() -> Any:
     return sa_cast(func.floor(func.extract("epoch", func.now())), BigInteger)
 
 
+_TABLE_INIT_LOCKS_GUARD = RLock()
+_TABLE_INIT_LOCKS: Dict[str, RLock] = {}
+# Graph writes can lock a parent and one or more children. A transaction-scoped
+# advisory lock gives those low-volume control-plane mutations one global lock
+# order, including across processes, while unrelated component metadata writes
+# remain concurrent.
+_COMPONENT_GRAPH_WRITE_LOCK_KEY = 0x41676E6F436F6D70
+
+
+def _shared_table_init_lock(database_key: str) -> RLock:
+    """Return one in-process lazy-DDL lock for every database schema."""
+    with _TABLE_INIT_LOCKS_GUARD:
+        return _TABLE_INIT_LOCKS.setdefault(database_key, RLock())
+
+
+def _is_schedule_name_conflict(error: IntegrityError, table_name: str, schema_name: str) -> bool:
+    """Match only the generic or actor-scoped schedule-name indexes."""
+    original = error.orig
+    cause = getattr(original, "__cause__", None)
+    sqlstate = (
+        getattr(original, "sqlstate", None) or getattr(original, "pgcode", None) or getattr(cause, "sqlstate", None)
+    )
+    diagnostic = getattr(original, "diag", None)
+    constraint_name = getattr(diagnostic, "constraint_name", None) or getattr(cause, "constraint_name", None)
+    reported_table = getattr(diagnostic, "table_name", None) or getattr(cause, "table_name", None)
+    reported_schema = getattr(diagnostic, "schema_name", None) or getattr(cause, "schema_name", None)
+    return (
+        sqlstate == "23505"
+        and constraint_name
+        in {
+            f"{table_name}_uq_generic_name",
+            f"{table_name}_uq_studio_owner_name",
+        }
+        and reported_table == table_name
+        and reported_schema == schema_name
+    )
+
+
 class PostgresDb(BaseDb):
+    supports_component_persistence = True
+    component_catalog_api_version = 2
+    scheduler_api_version = 2
+
     def __init__(
         self,
         db_url: Optional[str] = None,
@@ -195,10 +253,11 @@ class PostgresDb(BaseDb):
         self.db_url: Optional[str] = db_url
         self.db_engine: Engine = _engine
 
+        database_identity = db_url if db_url is not None else str(_engine.url)
+
         if id is None:
-            base_seed = db_url or str(db_engine.url)  # type: ignore
             schema_suffix = db_schema if db_schema is not None else "ai"
-            seed = f"{base_seed}#{schema_suffix}"
+            seed = f"{database_identity}#{schema_suffix}"
             id = generate_id(seed)
 
         super().__init__(
@@ -232,6 +291,8 @@ class PostgresDb(BaseDb):
 
         self.db_schema: str = db_schema if db_schema is not None else "ai"
         self.metadata: MetaData = MetaData(schema=self.db_schema)
+        database_key = generate_id(f"{database_identity}#{self.db_schema}")
+        self._table_init_lock = _shared_table_init_lock(database_key)
         self.create_schema: bool = create_schema
 
         # Initialize database session
@@ -482,9 +543,22 @@ class PostgresDb(BaseDb):
             # Create table
             table_created = False
             if not self.table_exists(table_name):
-                table.create(self.db_engine, checkfirst=True)
-                log_debug(f"Successfully created table '{self.db_schema}.{table_name}'")
-                table_created = True
+                try:
+                    table.create(self.db_engine, checkfirst=True)
+                    log_debug(f"Successfully created table '{self.db_schema}.{table_name}'")
+                    table_created = True
+                except Exception:
+                    # A separate process can win after the existence check.
+                    # Accept only a valid table created by that concurrent
+                    # initializer; every other DDL error still propagates.
+                    if not self.table_exists(table_name) or not is_valid_table(
+                        db_engine=self.db_engine,
+                        table_name=table_name,
+                        table_type=table_type,
+                        db_schema=self.db_schema,
+                    ):
+                        raise
+                    log_debug(f"Table '{self.db_schema}.{table_name}' was created concurrently")
             else:
                 log_debug(f"Table {self.db_schema}.{table_name} already exists, skipping creation")
 
@@ -731,6 +805,17 @@ class PostgresDb(BaseDb):
         raise ValueError(f"Unknown table type: {table_type}")
 
     def _get_or_create_table(
+        self, table_name: str, table_type: str, create_table_if_not_found: Optional[bool] = False
+    ) -> Optional[Table]:
+        # SQLAlchemy MetaData rejects two concurrent definitions of the same
+        # table before the database-level checkfirst guard can run. A single
+        # PostgresDb is intentionally shared across Studio worker threads, so
+        # serialize its lazy table reflection/creation. RLock is required
+        # because table creation can resolve another table through _get_table.
+        with self._table_init_lock:
+            return self._get_or_create_table_unlocked(table_name, table_type, create_table_if_not_found)
+
+    def _get_or_create_table_unlocked(
         self, table_name: str, table_type: str, create_table_if_not_found: Optional[bool] = False
     ) -> Optional[Table]:
         """
@@ -4175,21 +4260,310 @@ class PostgresDb(BaseDb):
             return [], 0
 
     # --- Components ---
+    @staticmethod
+    def _lock_component_graph_writes(sess: Any) -> None:
+        sess.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_key)"),
+            {"lock_key": _COMPONENT_GRAPH_WRITE_LOCK_KEY},
+        )
+
+    @staticmethod
+    def _component_version_state(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        component_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[ComponentVersionGuard]:
+        """Lock a component row and return the state used by guarded writes."""
+        stmt = select(components_table.c.current_version).where(components_table.c.component_id == component_id)
+        if not include_deleted:
+            stmt = stmt.where(components_table.c.deleted_at.is_(None))
+        component = sess.execute(stmt.with_for_update()).mappings().one_or_none()
+        if component is None:
+            return None
+
+        latest_version = sess.execute(
+            select(func.max(configs_table.c.version)).where(
+                configs_table.c.component_id == component_id,
+                configs_table.c.stage != DELETED_CONFIG_STAGE,
+            )
+        ).scalar()
+        return ComponentVersionGuard(
+            latest_version=latest_version,
+            current_version=component["current_version"],
+        )
+
+    @staticmethod
+    def _check_component_guard(
+        component_id: str,
+        expected: Optional[ComponentVersionGuard],
+        actual: ComponentVersionGuard,
+    ) -> None:
+        if expected is not None and expected != actual:
+            raise ComponentVersionConflictError(component_id, expected=expected, actual=actual)
+
+    @staticmethod
+    def _projection_values(projection: Optional[ComponentProjection]) -> Dict[str, Any]:
+        if projection is None:
+            return {}
+        allowed = {"name", "description", "metadata"}
+        unknown = set(projection) - allowed
+        if unknown:
+            raise ValueError(f"Invalid component projection fields: {sorted(unknown)}")
+        return dict(projection)
+
+    @staticmethod
+    def _validate_component_links(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        links: Optional[List[Dict[str, Any]]],
+        *,
+        require_published: bool,
+    ) -> None:
+        """Validate and lock every exact child version referenced by a write."""
+        sorted_links = sorted(
+            links or [],
+            key=lambda link: (str(link.get("child_component_id")), int(link.get("child_version") or 0)),
+        )
+        for link in sorted_links:
+            child_id = link.get("child_component_id")
+            child_version = link.get("child_version")
+            if not child_id or child_version is None:
+                raise ValueError("Each component link requires child_component_id and child_version")
+
+            child = (
+                sess.execute(
+                    select(components_table.c.component_type, configs_table.c.stage)
+                    .select_from(
+                        components_table.join(
+                            configs_table,
+                            (configs_table.c.component_id == components_table.c.component_id)
+                            & (configs_table.c.version == child_version),
+                        )
+                    )
+                    .where(
+                        components_table.c.component_id == child_id,
+                        components_table.c.deleted_at.is_(None),
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    )
+                    .with_for_update(of=components_table)
+                )
+                .mappings()
+                .one_or_none()
+            )
+            if child is None:
+                raise ValueError(f"Linked component version not found: {child_id} v{child_version}")
+            if require_published and child["stage"] != "published":
+                raise ValueError(f"Linked component version is not published: {child_id} v{child_version}")
+
+            expected_type = None
+            link_kind = link.get("link_kind")
+            if link_kind == "step_agent":
+                expected_type = ComponentType.AGENT.value
+            elif link_kind == "step_team":
+                expected_type = ComponentType.TEAM.value
+            elif link_kind == "step_workflow":
+                expected_type = ComponentType.WORKFLOW.value
+            elif link_kind == "member" and isinstance(link.get("meta"), dict):
+                expected_type = link["meta"].get("type")
+            if isinstance(expected_type, ComponentType):
+                expected_type = expected_type.value
+            if expected_type is not None and child["component_type"] != expected_type:
+                raise ValueError(
+                    f"Linked component {child_id} has type {child['component_type']}, expected {expected_type}"
+                )
+
+    @staticmethod
+    def _validate_restore_dependencies(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        links_table: Any,
+        component_id: str,
+        version: int,
+    ) -> None:
+        """Require every version reachable from a restored published root to remain runnable."""
+        unavailable: List[Dict[str, Any]] = []
+        unavailable_keys: Set[Tuple[str, int, str, int, str]] = set()
+        seen: Set[Tuple[str, int]] = {(component_id, version)}
+        pending: List[Tuple[str, int]] = [(component_id, version)]
+
+        while pending:
+            parent_id, parent_version = pending.pop()
+            links = (
+                sess.execute(
+                    select(
+                        links_table.c.child_component_id,
+                        links_table.c.child_version,
+                    )
+                    .where(
+                        links_table.c.parent_component_id == parent_id,
+                        links_table.c.parent_version == parent_version,
+                    )
+                    .order_by(links_table.c.child_component_id, links_table.c.child_version)
+                )
+                .mappings()
+                .all()
+            )
+
+            for link in reversed(links):
+                child_id = link["child_component_id"]
+                child_version = link["child_version"]
+                child = (
+                    sess.execute(
+                        select(components_table.c.deleted_at)
+                        .where(components_table.c.component_id == child_id)
+                        .with_for_update(of=components_table)
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+
+                reason: Optional[str] = None
+                if child is None:
+                    reason = "component_missing"
+                elif child["deleted_at"] is not None:
+                    reason = "component_archived"
+                else:
+                    child_stage = sess.execute(
+                        select(configs_table.c.stage)
+                        .where(
+                            configs_table.c.component_id == child_id,
+                            configs_table.c.version == child_version,
+                        )
+                        .with_for_update()
+                    ).scalar_one_or_none()
+                    if child_stage is None or child_stage == DELETED_CONFIG_STAGE:
+                        reason = "version_missing"
+                    elif child_stage != "published":
+                        reason = "version_not_published"
+
+                if reason is not None:
+                    unavailable_key = (parent_id, parent_version, child_id, child_version, reason)
+                    if unavailable_key not in unavailable_keys:
+                        unavailable_keys.add(unavailable_key)
+                        unavailable.append(
+                            {
+                                "component_id": child_id,
+                                "version": child_version,
+                                "referenced_by": {
+                                    "component_id": parent_id,
+                                    "version": parent_version,
+                                },
+                                "reason": reason,
+                            }
+                        )
+                    continue
+
+                child_key = (child_id, child_version)
+                if child_key not in seen:
+                    seen.add(child_key)
+                    pending.append(child_key)
+
+        if unavailable:
+            raise ComponentDependencyUnavailableError(component_id, unavailable)
+
+    @staticmethod
+    def _validate_component_acyclic(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        links_table: Any,
+        component_id: str,
+        version: int,
+        links: List[Dict[str, Any]],
+    ) -> None:
+        """Reject cycles while the caller holds the graph advisory lock."""
+        rows = (
+            sess.execute(
+                select(
+                    links_table.c.parent_component_id,
+                    links_table.c.parent_version,
+                    links_table.c.child_component_id,
+                )
+                .select_from(
+                    links_table.join(
+                        configs_table,
+                        (configs_table.c.component_id == links_table.c.parent_component_id)
+                        & (configs_table.c.version == links_table.c.parent_version),
+                    ).join(
+                        components_table,
+                        components_table.c.component_id == links_table.c.parent_component_id,
+                    )
+                )
+                .where(
+                    configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    components_table.c.deleted_at.is_(None),
+                )
+            )
+            .mappings()
+            .all()
+        )
+
+        adjacency: Dict[str, Set[str]] = {}
+        for row in rows:
+            if row["parent_component_id"] == component_id and row["parent_version"] == version:
+                continue
+            adjacency.setdefault(row["parent_component_id"], set()).add(row["child_component_id"])
+        for link in links:
+            child_id = link.get("child_component_id")
+            if child_id:
+                adjacency.setdefault(component_id, set()).add(child_id)
+
+        seen = {component_id}
+        pending: List[Tuple[str, List[str]]] = [(component_id, [component_id])]
+        while pending:
+            node, path = pending.pop()
+            for child_id in reversed(sorted(adjacency.get(node, set()))):
+                if child_id == component_id:
+                    raise ComponentCycleError(component_id, [*path, child_id])
+                if child_id in seen:
+                    continue
+                seen.add(child_id)
+                pending.append((child_id, [*path, child_id]))
+
+    @staticmethod
+    def _component_dependents(
+        sess: Any,
+        components_table: Any,
+        links_table: Any,
+        component_id: str,
+        *,
+        version: Optional[int] = None,
+        active_parents_only: bool = False,
+    ) -> List[Dict[str, Any]]:
+        stmt = select(links_table).where(links_table.c.child_component_id == component_id)
+        if version is not None:
+            stmt = stmt.where(links_table.c.child_version == version)
+        if active_parents_only:
+            stmt = stmt.select_from(
+                links_table.join(
+                    components_table,
+                    components_table.c.component_id == links_table.c.parent_component_id,
+                )
+            ).where(components_table.c.deleted_at.is_(None))
+        return [dict(row) for row in sess.execute(stmt).mappings().all()]
+
     def get_component(
         self,
         component_id: str,
         component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
+        """Get a component, excluding archived rows unless explicitly requested."""
         try:
             table = self._get_table(table_type="components")
             if table is None:
                 return None
 
             with self.Session() as sess:
-                stmt = select(table).where(
-                    table.c.component_id == component_id,
-                    table.c.deleted_at.is_(None),
-                )
+                stmt = select(table).where(table.c.component_id == component_id)
+                if not include_deleted:
+                    stmt = stmt.where(table.c.deleted_at.is_(None))
 
                 if component_type is not None:
                     stmt = stmt.where(table.c.component_type == component_type.value)
@@ -4199,6 +4573,36 @@ class PostgresDb(BaseDb):
 
         except Exception as e:
             log_error(f"Error getting component: {str(e)}")
+            raise
+
+    def get_components(
+        self,
+        component_ids: Set[str],
+        component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Get a bounded set of component rows in one query."""
+        if not component_ids:
+            return []
+        try:
+            table = getattr(self, "component_table", None)
+            if table is None:
+                table = self._get_table(table_type="components")
+            if table is None:
+                return []
+
+            with self.Session() as sess:
+                stmt = select(table).where(table.c.component_id.in_(component_ids))
+                if not include_deleted:
+                    stmt = stmt.where(table.c.deleted_at.is_(None))
+                if component_type is not None:
+                    stmt = stmt.where(table.c.component_type == component_type.value)
+                stmt = stmt.order_by(table.c.component_id)
+                return [dict(row) for row in sess.execute(stmt).mappings().all()]
+
+        except Exception as e:
+            log_error(f"Error getting components: {str(e)}")
             raise
 
     def upsert_component(
@@ -4217,27 +4621,33 @@ class PostgresDb(BaseDb):
             component_type: Type (agent|team|workflow). Required for create, optional for update.
             name: Display name.
             description: Optional description.
-            current_version: Optional current version.
+            current_version: Reserved. Use set_current_version for guarded,
+                projection-synchronized current-pointer changes.
             metadata: Optional metadata dict.
 
         Returns:
             Created/updated component dictionary.
 
         Raises:
-            ValueError: If creating and component_type is not provided.
+            ValueError: If creating and component_type is not provided, or if
+                current_version is supplied.
         """
+        if current_version is not None:
+            raise ValueError("current_version can only be changed with set_current_version")
+
         try:
             table = self._get_table(table_type="components", create_table_if_not_found=True)
             if table is None:
                 raise ValueError("Components table not found")
 
             with self.Session() as sess, sess.begin():
-                existing = sess.execute(select(table).where(table.c.component_id == component_id)).fetchone()
+                existing = sess.execute(
+                    select(table).where(table.c.component_id == component_id).with_for_update()
+                ).fetchone()
                 if existing is None:
                     # Create new component
                     if component_type is None:
                         raise ValueError("component_type is required when creating a new component")
-
                     sess.execute(
                         table.insert().values(
                             component_id=component_id,
@@ -4252,45 +4662,39 @@ class PostgresDb(BaseDb):
                     log_debug(f"Created component {component_id}")
 
                 elif existing.deleted_at is not None:
-                    # Reactivate soft-deleted
-                    if component_type is None:
-                        raise ValueError("component_type is required when reactivating a deleted component")
-
-                    sess.execute(
-                        table.update()
-                        .where(table.c.component_id == component_id)
-                        .values(
-                            component_type=component_type.value,
-                            name=name or component_id,
-                            description=description,
-                            current_version=None,
-                            metadata=metadata,
-                            updated_at=int(time.time()),
-                            deleted_at=None,
-                        )
-                    )
-                    log_debug(f"Reactivated component {component_id}")
+                    raise ValueError(f"Component {component_id} is archived and remains reserved")
 
                 else:
                     # Update existing
+                    if component_type is not None and component_type.value != existing.component_type:
+                        raise ValueError(
+                            f"Component {component_id} has type {existing.component_type}, not {component_type.value}"
+                        )
                     updates: Dict[str, Any] = {"updated_at": int(time.time())}
-                    if component_type is not None:
-                        updates["component_type"] = component_type.value
                     if name is not None:
                         updates["name"] = name
                     if description is not None:
                         updates["description"] = description
-                    if current_version is not None:
-                        updates["current_version"] = current_version
                     if metadata is not None:
                         updates["metadata"] = metadata
 
                     sess.execute(table.update().where(table.c.component_id == component_id).values(**updates))
                     log_debug(f"Updated component {component_id}")
 
-            result = self.get_component(component_id)
-            if result is None:
-                raise ValueError(f"Failed to get component {component_id} after upsert")
+                result_row = (
+                    sess.execute(
+                        select(table).where(
+                            table.c.component_id == component_id,
+                            table.c.deleted_at.is_(None),
+                        )
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                if result_row is None:
+                    raise ValueError(f"Failed to get component {component_id} during upsert")
+                result = dict(result_row)
+
             return result
 
         except Exception as e:
@@ -4301,12 +4705,19 @@ class PostgresDb(BaseDb):
         self,
         component_id: str,
         hard_delete: bool = False,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        require_no_dependents: bool = True,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Delete a component and all its configs/links.
 
         Args:
             component_id: The component ID.
             hard_delete: If True, permanently delete. Otherwise soft-delete.
+            guard: Expected latest/current version state for compare-and-set.
+            require_no_dependents: Refuse deletion while qualifying inbound links exist.
+            projection: Component fields to update atomically with a soft archive.
 
         Returns:
             True if deleted, False if not found or already deleted.
@@ -4318,47 +4729,141 @@ class PostgresDb(BaseDb):
 
             if components_table is None:
                 return False
+            if hard_delete and projection is not None:
+                raise ValueError("projection is not supported for hard delete")
 
             with self.Session() as sess, sess.begin():
-                # Verify component exists (and not already soft-deleted for soft-delete)
-                if hard_delete:
-                    exists = sess.execute(
-                        select(components_table.c.component_id).where(components_table.c.component_id == component_id)
-                    ).scalar_one_or_none()
+                self._lock_component_graph_writes(sess)
+                if configs_table is not None:
+                    actual = self._component_version_state(
+                        sess,
+                        components_table,
+                        configs_table,
+                        component_id,
+                        include_deleted=hard_delete,
+                    )
                 else:
-                    exists = sess.execute(
-                        select(components_table.c.component_id).where(
-                            components_table.c.component_id == component_id,
-                            components_table.c.deleted_at.is_(None),
-                        )
-                    ).scalar_one_or_none()
+                    component_stmt = select(components_table.c.current_version).where(
+                        components_table.c.component_id == component_id
+                    )
+                    if not hard_delete:
+                        component_stmt = component_stmt.where(components_table.c.deleted_at.is_(None))
+                    component = sess.execute(component_stmt.with_for_update()).mappings().one_or_none()
+                    actual = (
+                        ComponentVersionGuard(latest_version=None, current_version=component["current_version"])
+                        if component is not None
+                        else None
+                    )
 
-                if exists is None:
+                if actual is None:
                     log_error(f"Component {component_id} not found")
                     return False
+                self._check_component_guard(component_id, guard, actual)
+
+                if require_no_dependents and links_table is not None:
+                    dependents = self._component_dependents(
+                        sess,
+                        components_table,
+                        links_table,
+                        component_id,
+                        active_parents_only=not hard_delete,
+                    )
+                    if dependents:
+                        raise ComponentDependencyError(component_id, dependents)
 
                 if hard_delete:
-                    # Delete links where this component is parent or child
                     if links_table is not None:
                         sess.execute(links_table.delete().where(links_table.c.parent_component_id == component_id))
                         sess.execute(links_table.delete().where(links_table.c.child_component_id == component_id))
-                    # Delete configs
                     if configs_table is not None:
                         sess.execute(configs_table.delete().where(configs_table.c.component_id == component_id))
-                    # Delete component
-                    sess.execute(components_table.delete().where(components_table.c.component_id == component_id))
+                    result = sess.execute(
+                        components_table.delete().where(components_table.c.component_id == component_id)
+                    )
                 else:
-                    # Soft delete (preserve current_version for potential reactivation)
-                    sess.execute(
+                    now = int(time.time())
+                    updates: Dict[str, Any] = {"deleted_at": now, "updated_at": now}
+                    updates.update(self._projection_values(projection))
+                    result = sess.execute(
                         components_table.update()
-                        .where(components_table.c.component_id == component_id)
-                        .values(deleted_at=int(time.time()))
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                        .values(**updates)
                     )
 
-            return True
+            return result.rowcount > 0
 
         except Exception as e:
             log_error(f"Error deleting component: {str(e)}")
+            raise
+
+    def restore_component(
+        self,
+        component_id: str,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+    ) -> bool:
+        """Restore one archived component with an optional CAS guard."""
+        try:
+            components_table = self._get_table(table_type="components")
+            configs_table = self._get_table(table_type="component_configs")
+            links_table = self._get_table(table_type="component_links")
+            if components_table is None or configs_table is None:
+                return False
+
+            with self.Session() as sess, sess.begin():
+                self._lock_component_graph_writes(sess)
+                actual = self._component_version_state(
+                    sess,
+                    components_table,
+                    configs_table,
+                    component_id,
+                    include_deleted=True,
+                )
+                if actual is None:
+                    return False
+                archived = (
+                    sess.execute(
+                        select(components_table.c.deleted_at)
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_not(None),
+                        )
+                        .with_for_update()
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                if archived is None:
+                    return False
+                self._check_component_guard(component_id, guard, actual)
+                if actual.current_version is not None and links_table is not None:
+                    self._validate_restore_dependencies(
+                        sess,
+                        components_table,
+                        configs_table,
+                        links_table,
+                        component_id,
+                        actual.current_version,
+                    )
+
+                updates: Dict[str, Any] = {"deleted_at": None, "updated_at": int(time.time())}
+                updates.update(self._projection_values(projection))
+                result = sess.execute(
+                    components_table.update()
+                    .where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_not(None),
+                    )
+                    .values(**updates)
+                )
+                return result.rowcount > 0
+
+        except Exception as e:
+            log_error(f"Error restoring component: {str(e)}")
             raise
 
     def list_components(
@@ -4459,12 +4964,6 @@ class PostgresDb(BaseDb):
         if stage not in {"draft", "published"}:
             raise ValueError(f"Invalid stage: {stage}")
 
-        # Validate links have child_version
-        if links:
-            for link in links:
-                if link.get("child_version") is None:
-                    raise ValueError(f"child_version is required for link to {link['child_component_id']}")
-
         try:
             components_table = self._get_table(table_type="components", create_table_if_not_found=True)
             configs_table = self._get_table(table_type="component_configs", create_table_if_not_found=True)
@@ -4476,13 +4975,14 @@ class PostgresDb(BaseDb):
                 raise ValueError("Component configs table not found")
 
             with self.Session() as sess, sess.begin():
+                self._lock_component_graph_writes(sess)
                 # Check if component already exists
                 existing = sess.execute(
                     select(components_table.c.component_id).where(components_table.c.component_id == component_id)
                 ).scalar_one_or_none()
 
                 if existing is not None:
-                    raise ValueError(f"Component {component_id} already exists")
+                    raise ComponentAlreadyExistsError(component_id)
 
                 # Check label uniqueness
                 if label is not None:
@@ -4498,18 +4998,39 @@ class PostgresDb(BaseDb):
                 now = int(time.time())
                 version = 1
 
-                # Create component
-                sess.execute(
-                    components_table.insert().values(
-                        component_id=component_id,
-                        component_type=component_type.value,
-                        name=name,
-                        description=description,
-                        metadata=metadata,
-                        current_version=version if stage == "published" else None,
-                        created_at=now,
+                if links is not None and links_table is not None:
+                    self._validate_component_acyclic(
+                        sess,
+                        components_table,
+                        configs_table,
+                        links_table,
+                        component_id,
+                        version,
+                        links,
                     )
+
+                self._validate_component_links(
+                    sess,
+                    components_table,
+                    configs_table,
+                    links,
+                    require_published=stage == "published",
                 )
+
+                try:
+                    sess.execute(
+                        components_table.insert().values(
+                            component_id=component_id,
+                            component_type=component_type.value,
+                            name=name,
+                            description=description,
+                            metadata=metadata,
+                            current_version=version if stage == "published" else None,
+                            created_at=now,
+                        )
+                    )
+                except IntegrityError as exc:
+                    raise ComponentAlreadyExistsError(component_id) from exc
 
                 # Create initial config
                 sess.execute(
@@ -4541,14 +5062,33 @@ class PostgresDb(BaseDb):
                             )
                         )
 
-            # Fetch and return both
-            component = self.get_component(component_id)
-            config_result = self.get_config(component_id, version=version)
-
-            if component is None:
-                raise ValueError(f"Failed to get component {component_id} after creation")
-            if config_result is None:
-                raise ValueError(f"Failed to get config for {component_id} after creation")
+                component_row = (
+                    sess.execute(
+                        select(components_table).where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                config_row = (
+                    sess.execute(
+                        select(configs_table).where(
+                            configs_table.c.component_id == component_id,
+                            configs_table.c.version == version,
+                            configs_table.c.stage != DELETED_CONFIG_STAGE,
+                        )
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                if component_row is None:
+                    raise ValueError(f"Failed to get component {component_id} during creation")
+                if config_row is None:
+                    raise ValueError(f"Failed to get config for {component_id} during creation")
+                component = dict(component_row)
+                config_result = dict(config_row)
 
             return component, config_result
 
@@ -4567,7 +5107,9 @@ class PostgresDb(BaseDb):
 
         Args:
             component_id: The component ID.
-            version: Specific version number. If None, uses current or latest draft.
+            version: Specific version number. If omitted with no label, uses
+                the current published version or the latest draft when the
+                component has never been published.
             label: Config label to lookup. Ignored if version is provided.
 
         Returns:
@@ -4615,7 +5157,6 @@ class PostgresDb(BaseDb):
                         configs_table.c.version == current_version,
                     )
                 else:
-                    # No current_version set (draft only) - get the latest version
                     stmt = (
                         select(configs_table)
                         .where(configs_table.c.component_id == component_id)
@@ -4623,11 +5164,145 @@ class PostgresDb(BaseDb):
                         .limit(1)
                     )
 
+                stmt = stmt.where(configs_table.c.stage != DELETED_CONFIG_STAGE)
                 row = sess.execute(stmt).mappings().one_or_none()
                 return dict(row) if row else None
 
         except Exception as e:
             log_error(f"Error getting config: {str(e)}")
+            raise
+
+    def get_current_config(self, component_id: str) -> Optional[Dict[str, Any]]:
+        """Get only the current published config for an active component."""
+        try:
+            configs_table = self._get_table(table_type="component_configs")
+            components_table = self._get_table(table_type="components")
+            if configs_table is None or components_table is None:
+                return None
+
+            with self.Session() as sess:
+                row = (
+                    sess.execute(
+                        select(configs_table)
+                        .select_from(
+                            components_table.join(
+                                configs_table,
+                                (configs_table.c.component_id == components_table.c.component_id)
+                                & (configs_table.c.version == components_table.c.current_version),
+                            )
+                        )
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                            configs_table.c.stage == "published",
+                        )
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                return dict(row) if row else None
+
+        except Exception as e:
+            log_error(f"Error getting current config: {str(e)}")
+            raise
+
+    def get_latest_config(
+        self,
+        component_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Get the latest visible config, optionally for an archived component."""
+        try:
+            configs_table = self._get_table(table_type="component_configs")
+            components_table = self._get_table(table_type="components")
+            if configs_table is None or components_table is None:
+                return None
+
+            with self.Session() as sess:
+                component_stmt = select(components_table.c.component_id).where(
+                    components_table.c.component_id == component_id
+                )
+                if not include_deleted:
+                    component_stmt = component_stmt.where(components_table.c.deleted_at.is_(None))
+                if sess.execute(component_stmt).scalar_one_or_none() is None:
+                    return None
+
+                row = (
+                    sess.execute(
+                        select(configs_table)
+                        .where(
+                            configs_table.c.component_id == component_id,
+                            configs_table.c.stage != DELETED_CONFIG_STAGE,
+                        )
+                        .order_by(configs_table.c.version.desc())
+                        .limit(1)
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                return dict(row) if row else None
+
+        except Exception as e:
+            log_error(f"Error getting latest config: {str(e)}")
+            raise
+
+    def get_latest_configs(
+        self,
+        component_ids: Set[str],
+        *,
+        include_deleted: bool = False,
+    ) -> Dict[str, Optional[Dict[str, Any]]]:
+        """Get one latest visible config per requested component in one query."""
+        if not component_ids:
+            return {}
+        try:
+            configs_table = getattr(self, "component_configs_table", None)
+            if configs_table is None:
+                configs_table = self._get_table(table_type="component_configs")
+            components_table = getattr(self, "component_table", None)
+            if components_table is None:
+                components_table = self._get_table(table_type="components")
+            if configs_table is None or components_table is None:
+                return {component_id: None for component_id in component_ids}
+
+            latest_versions = (
+                select(
+                    configs_table.c.component_id,
+                    func.max(configs_table.c.version).label("latest_version"),
+                )
+                .where(
+                    configs_table.c.component_id.in_(component_ids),
+                    configs_table.c.stage != DELETED_CONFIG_STAGE,
+                )
+                .group_by(configs_table.c.component_id)
+                .subquery()
+            )
+            with self.Session() as sess:
+                stmt = (
+                    select(configs_table)
+                    .select_from(
+                        configs_table.join(
+                            latest_versions,
+                            (configs_table.c.component_id == latest_versions.c.component_id)
+                            & (configs_table.c.version == latest_versions.c.latest_version),
+                        ).join(
+                            components_table,
+                            components_table.c.component_id == configs_table.c.component_id,
+                        )
+                    )
+                    .where(components_table.c.component_id.in_(component_ids))
+                )
+                if not include_deleted:
+                    stmt = stmt.where(components_table.c.deleted_at.is_(None))
+                result: Dict[str, Optional[Dict[str, Any]]] = {component_id: None for component_id in component_ids}
+                for row in sess.execute(stmt).mappings().all():
+                    config_row = dict(row)
+                    result[config_row["component_id"]] = config_row
+                return result
+
+        except Exception as e:
+            log_error(f"Error getting latest configs: {str(e)}")
             raise
 
     def upsert_config(
@@ -4639,22 +5314,35 @@ class PostgresDb(BaseDb):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+        restore_if_deleted: bool = False,
+        expected_component_type: Optional[ComponentType] = None,
     ) -> Dict[str, Any]:
         """Create or update a config version for a component.
 
         Rules:
-            - Draft configs can be edited freely
+            - Stored config versions are immutable
+            - The latest draft may transition to published with a guard
             - Published configs are immutable
             - Publishing a config automatically sets it as current_version
 
         Args:
             component_id: The component ID.
-            config: The config data. Required for create, optional for update.
-            version: If None, creates new version. If provided, updates that version.
+            config: The config data. Required when appending a version.
+            version: If None, appends a version. If provided, publishes that draft.
             label: Optional human-readable label.
             stage: "draft" or "published". Defaults to "draft" for new configs.
             notes: Optional notes.
             links: Optional list of links. Each link must have child_version set.
+            guard: Expected latest/current version state for compare-and-set.
+            projection: Component fields synchronized atomically when publishing.
+                When omitted, they are derived from the target config.
+            restore_if_deleted: Restore an archived component in the same
+                transaction as this config mutation.
+            expected_component_type: Optional component type to validate under
+                the component row lock.
 
         Returns:
             Created/updated config dictionary.
@@ -4677,22 +5365,39 @@ class PostgresDb(BaseDb):
                 raise ValueError("Component configs table not found")
 
             with self.Session() as sess, sess.begin():
-                # Verify component exists and is not deleted
-                component = sess.execute(
-                    select(components_table.c.component_id).where(
-                        components_table.c.component_id == component_id,
-                        components_table.c.deleted_at.is_(None),
-                    )
-                ).scalar_one_or_none()
-
-                if component is None:
+                self._lock_component_graph_writes(sess)
+                actual = self._component_version_state(
+                    sess,
+                    components_table,
+                    configs_table,
+                    component_id,
+                    include_deleted=restore_if_deleted,
+                )
+                if actual is None:
                     raise ValueError(f"Component {component_id} not found")
+                self._check_component_guard(component_id, guard, actual)
+                is_archived = False
+                if restore_if_deleted:
+                    is_archived = (
+                        sess.execute(
+                            select(components_table.c.deleted_at).where(components_table.c.component_id == component_id)
+                        ).scalar_one()
+                        is not None
+                    )
+                if expected_component_type is not None:
+                    actual_type = sess.execute(
+                        select(components_table.c.component_type).where(components_table.c.component_id == component_id)
+                    ).scalar_one()
+                    if actual_type != expected_component_type.value:
+                        raise ValueError(
+                            f"Component {component_id} has type {actual_type}, not {expected_component_type.value}"
+                        )
 
-                # Label uniqueness check
                 if label is not None:
                     label_query = select(configs_table.c.version).where(
                         configs_table.c.component_id == component_id,
                         configs_table.c.label == label,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
                     )
                     if version is not None:
                         label_query = label_query.where(configs_table.c.version != version)
@@ -4700,79 +5405,105 @@ class PostgresDb(BaseDb):
                     if sess.execute(label_query).first():
                         raise ValueError(f"Label '{label}' already exists for {component_id}")
 
-                # Validate links have child_version
-                if links:
-                    for link in links:
-                        if link.get("child_version") is None:
-                            raise ValueError(f"child_version is required for link to {link['child_component_id']}")
-
+                existing: Optional[Dict[str, Any]] = None
                 if version is None:
                     if config is None:
                         raise ValueError("config is required when creating a new version")
-
-                    # Default to draft for new configs
-                    if stage is None:
-                        stage = "draft"
-
-                    max_version = sess.execute(
-                        select(configs_table.c.version)
-                        .where(configs_table.c.component_id == component_id)
-                        .order_by(configs_table.c.version.desc())
-                        .limit(1)
+                    final_stage = stage or "draft"
+                    target_config = config
+                    high_water = sess.execute(
+                        select(func.max(configs_table.c.version)).where(configs_table.c.component_id == component_id)
                     ).scalar()
+                    final_version = (high_water or 0) + 1
+                else:
+                    existing_row = (
+                        sess.execute(
+                            select(configs_table.c.version, configs_table.c.stage, configs_table.c.config)
+                            .where(
+                                configs_table.c.component_id == component_id,
+                                configs_table.c.version == version,
+                            )
+                            .with_for_update()
+                        )
+                        .mappings()
+                        .one_or_none()
+                    )
+                    if existing_row is None:
+                        raise ValueError(f"Config {component_id} v{version} not found")
+                    existing = dict(existing_row)
 
-                    final_version = (max_version or 0) + 1
+                    if existing["stage"] == DELETED_CONFIG_STAGE:
+                        raise ValueError(f"Config {component_id} v{version} not found")
+                    if existing["stage"] == "published":
+                        raise ValueError(f"Cannot update published config {component_id} v{version}")
 
+                    if guard is None:
+                        raise ValueError("Publishing an existing draft requires a component version guard")
+                    if stage != "published":
+                        raise ValueError("An existing config version is immutable; only guarded publication is allowed")
+                    if any(value is not None for value in (config, label, notes)):
+                        raise ValueError("A guarded publish cannot mutate config, label, or notes")
+                    if version != actual.latest_version:
+                        raise ValueError(f"Only the latest draft can be published; latest is v{actual.latest_version}")
+                    target_config = existing["config"]
+                    if not isinstance(target_config, dict):
+                        raise ValueError(f"Config {component_id} v{version} payload must be an object")
+                    final_version = version
+                    final_stage = "published"
+
+                links_to_validate = links
+                if final_stage == "published" and links_to_validate is None and links_table is not None:
+                    links_to_validate = [
+                        dict(row)
+                        for row in sess.execute(
+                            select(links_table).where(
+                                links_table.c.parent_component_id == component_id,
+                                links_table.c.parent_version == final_version,
+                            )
+                        )
+                        .mappings()
+                        .all()
+                    ]
+                if links_to_validate is not None and links_table is not None:
+                    self._validate_component_acyclic(
+                        sess,
+                        components_table,
+                        configs_table,
+                        links_table,
+                        component_id,
+                        final_version,
+                        links_to_validate,
+                    )
+                self._validate_component_links(
+                    sess,
+                    components_table,
+                    configs_table,
+                    links_to_validate,
+                    require_published=final_stage == "published",
+                )
+                now = int(time.time())
+
+                if version is None:
                     sess.execute(
                         configs_table.insert().values(
                             component_id=component_id,
                             version=final_version,
                             label=label,
-                            stage=stage,
+                            stage=final_stage,
                             config=config,
                             notes=notes,
-                            created_at=int(time.time()),
+                            created_at=now,
                         )
                     )
                 else:
-                    existing = (
-                        sess.execute(
-                            select(configs_table.c.version, configs_table.c.stage).where(
-                                configs_table.c.component_id == component_id,
-                                configs_table.c.version == version,
-                            )
-                        )
-                        .mappings()
-                        .one_or_none()
-                    )
-
-                    if existing is None:
-                        raise ValueError(f"Config {component_id} v{version} not found")
-
-                    # Published configs are immutable
-                    if existing["stage"] == "published":
-                        raise ValueError(f"Cannot update published config {component_id} v{version}")
-
-                    # Build update dict with only provided fields
-                    updates: Dict[str, Any] = {"updated_at": int(time.time())}
-                    if label is not None:
-                        updates["label"] = label
-                    if stage is not None:
-                        updates["stage"] = stage
-                    if config is not None:
-                        updates["config"] = config
-                    if notes is not None:
-                        updates["notes"] = notes
-
                     sess.execute(
                         configs_table.update()
                         .where(
                             configs_table.c.component_id == component_id,
                             configs_table.c.version == version,
                         )
-                        .values(**updates)
+                        .values(stage="published", updated_at=now)
                     )
-                    final_version = version
 
                 if links is not None and links_table is not None:
                     sess.execute(
@@ -4792,23 +5523,79 @@ class PostgresDb(BaseDb):
                                 child_version=link["child_version"],
                                 position=link["position"],
                                 meta=link.get("meta"),
-                                created_at=int(time.time()),
+                                created_at=now,
                             )
                         )
 
-                # Determine final stage (could be from update or create)
-                final_stage = stage if stage is not None else (existing["stage"] if version is not None else "draft")
-
-                if final_stage == "published":
+                if restore_if_deleted and is_archived:
+                    restored_version = final_version if final_stage == "published" else actual.current_version
+                    if restored_version is not None and links_table is not None:
+                        self._validate_restore_dependencies(
+                            sess,
+                            components_table,
+                            configs_table,
+                            links_table,
+                            component_id,
+                            restored_version,
+                        )
+                    # Reactivation is part of this write transaction. Any
+                    # label, graph, projection, or config failure rolls it back
+                    # together with the attempted config append.
                     sess.execute(
                         components_table.update()
                         .where(components_table.c.component_id == component_id)
-                        .values(current_version=final_version, updated_at=int(time.time()))
+                        .values(deleted_at=None, updated_at=now)
                     )
 
-            result = self.get_config(component_id, version=final_version)
-            if result is None:
-                raise ValueError(f"Failed to get config {component_id} v{final_version} after upsert")
+                if final_stage == "published":
+                    effective_projection = projection
+                    if effective_projection is None:
+                        effective_projection = self._projection_from_config(target_config)
+                    component_updates: Dict[str, Any] = {
+                        "current_version": final_version,
+                        "updated_at": now,
+                    }
+                    component_updates.update(self._projection_values(effective_projection))
+                    sess.execute(
+                        components_table.update()
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                        .values(**component_updates)
+                    )
+                elif projection is not None:
+                    # Draft-only components project their latest draft. The
+                    # conditional update safely ignores this projection when a
+                    # current published version already exists (including one
+                    # committed by a concurrent publisher).
+                    component_updates = {"updated_at": now}
+                    component_updates.update(self._projection_values(projection))
+                    sess.execute(
+                        components_table.update()
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                            components_table.c.current_version.is_(None),
+                        )
+                        .values(**component_updates)
+                    )
+
+                result_row = (
+                    sess.execute(
+                        select(configs_table).where(
+                            configs_table.c.component_id == component_id,
+                            configs_table.c.version == final_version,
+                            configs_table.c.stage != DELETED_CONFIG_STAGE,
+                        )
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                if result_row is None:
+                    raise ValueError(f"Failed to get config {component_id} v{final_version} during upsert")
+                result = dict(result_row)
+
             return result
 
         except Exception as e:
@@ -4819,6 +5606,9 @@ class PostgresDb(BaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Delete a specific config version.
 
@@ -4828,12 +5618,15 @@ class PostgresDb(BaseDb):
         Args:
             component_id: The component ID.
             version: The version to delete.
+            guard: Expected latest/current version state for compare-and-set.
+            projection: Component fields to update atomically with deletion.
 
         Returns:
             True if deleted, False if not found.
 
         Raises:
-            ValueError: If attempting to delete a published or current config.
+            ComponentDraftRequiredError: If attempting to delete a published config.
+            ValueError: If attempting to delete the current config.
         """
         try:
             configs_table = self._get_table(table_type="component_configs")
@@ -4844,26 +5637,50 @@ class PostgresDb(BaseDb):
                 return False
 
             with self.Session() as sess, sess.begin():
-                # Get config stage and check if it's current
-                config_row = sess.execute(
+                self._lock_component_graph_writes(sess)
+                actual = self._component_version_state(sess, components_table, configs_table, component_id)
+                if actual is None:
+                    return False
+                self._check_component_guard(component_id, guard, actual)
+
+                config_stage = sess.execute(
                     select(configs_table.c.stage).where(
                         configs_table.c.component_id == component_id,
                         configs_table.c.version == version,
                     )
                 ).scalar_one_or_none()
 
-                if config_row is None:
+                if config_stage is None:
                     return False
-
-                # Check if it's current version
-                current = sess.execute(
-                    select(components_table.c.current_version).where(components_table.c.component_id == component_id)
-                ).scalar_one_or_none()
-
-                if current == version:
+                if config_stage == DELETED_CONFIG_STAGE:
+                    return False
+                if config_stage == "published":
+                    raise ComponentDraftRequiredError(component_id, version)
+                if actual.current_version == version:
                     raise ValueError(f"Cannot delete current config {component_id} v{version}")
 
-                # Delete associated links
+                if links_table is not None:
+                    dependents = self._component_dependents(
+                        sess,
+                        components_table,
+                        links_table,
+                        component_id,
+                        version=version,
+                    )
+                    if dependents:
+                        raise ComponentDependencyError(component_id, dependents, version=version)
+
+                visible_count = sess.execute(
+                    select(func.count())
+                    .select_from(configs_table)
+                    .where(
+                        configs_table.c.component_id == component_id,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    )
+                ).scalar_one()
+                if visible_count <= 1:
+                    raise ComponentLastConfigError(component_id, version)
+
                 if links_table is not None:
                     sess.execute(
                         links_table.delete().where(
@@ -4872,15 +5689,35 @@ class PostgresDb(BaseDb):
                         )
                     )
 
-                # Delete the config
-                sess.execute(
-                    configs_table.delete().where(
+                result = sess.execute(
+                    configs_table.update()
+                    .where(
                         configs_table.c.component_id == component_id,
                         configs_table.c.version == version,
                     )
+                    .values(
+                        label=None,
+                        stage=DELETED_CONFIG_STAGE,
+                        config={},
+                        notes=None,
+                        updated_at=int(time.time()),
+                        deleted_at=int(time.time()),
+                    )
                 )
 
-            return True
+                component_updates = self._projection_values(projection)
+                if component_updates:
+                    component_updates["updated_at"] = int(time.time())
+                    sess.execute(
+                        components_table.update()
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                        .values(**component_updates)
+                    )
+
+            return result.rowcount > 0
 
         except Exception as e:
             log_error(f"Error deleting config: {str(e)}")
@@ -4934,7 +5771,10 @@ class PostgresDb(BaseDb):
                         configs_table.c.updated_at,
                     )
 
-                stmt = stmt.where(configs_table.c.component_id == component_id).order_by(configs_table.c.version.desc())
+                stmt = stmt.where(
+                    configs_table.c.component_id == component_id,
+                    configs_table.c.stage != DELETED_CONFIG_STAGE,
+                ).order_by(configs_table.c.version.desc())
 
                 results = sess.execute(stmt).mappings().all()
                 return [dict(row) for row in results]
@@ -4947,6 +5787,9 @@ class PostgresDb(BaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Set a specific published version as current.
 
@@ -4957,6 +5800,9 @@ class PostgresDb(BaseDb):
         Args:
             component_id: The component ID.
             version: The version to set as current (must be published).
+            guard: Expected latest/current version state for compare-and-set.
+            projection: Component fields synchronized atomically with the pointer.
+                When omitted, they are derived from the target config.
 
         Returns:
             True if successful, False if component or version not found.
@@ -4972,40 +5818,53 @@ class PostgresDb(BaseDb):
                 return False
 
             with self.Session() as sess, sess.begin():
-                # Verify component exists and is not deleted
-                component_exists = sess.execute(
-                    select(components_table.c.component_id).where(
-                        components_table.c.component_id == component_id,
-                        components_table.c.deleted_at.is_(None),
-                    )
-                ).scalar_one_or_none()
-
-                if component_exists is None:
+                actual = self._component_version_state(sess, components_table, configs_table, component_id)
+                if actual is None:
                     return False
+                self._check_component_guard(component_id, guard, actual)
 
-                # Verify version exists and get stage
-                stage = sess.execute(
-                    select(configs_table.c.stage).where(
-                        configs_table.c.component_id == component_id,
-                        configs_table.c.version == version,
+                target = (
+                    sess.execute(
+                        select(configs_table.c.stage, configs_table.c.config)
+                        .where(
+                            configs_table.c.component_id == component_id,
+                            configs_table.c.version == version,
+                        )
+                        .with_for_update()
                     )
-                ).scalar_one_or_none()
+                    .mappings()
+                    .one_or_none()
+                )
 
-                if stage is None:
+                if target is None:
                     return False
 
                 # Only published configs can be set as current
-                if stage != "published":
+                if target["stage"] != "published":
                     raise ValueError(
                         f"Cannot set draft config {component_id} v{version} as current. "
                         "Only published configs can be current."
                     )
 
-                # Update pointer
+                effective_projection = projection
+                if effective_projection is None:
+                    target_config = target["config"]
+                    if not isinstance(target_config, dict):
+                        raise ValueError(f"Config {component_id} v{version} payload must be an object")
+                    effective_projection = self._projection_from_config(target_config)
+
+                updates: Dict[str, Any] = {
+                    "current_version": version,
+                    "updated_at": int(time.time()),
+                }
+                updates.update(self._projection_values(effective_projection))
                 result = sess.execute(
                     components_table.update()
-                    .where(components_table.c.component_id == component_id)
-                    .values(current_version=version, updated_at=int(time.time()))
+                    .where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_(None),
+                    )
+                    .values(**updates)
                 )
 
                 if result.rowcount == 0:
@@ -5063,28 +5922,36 @@ class PostgresDb(BaseDb):
         self,
         component_id: str,
         version: Optional[int] = None,
+        *,
+        active_parents_only: bool = False,
     ) -> List[Dict[str, Any]]:
         """Find all components that reference this component.
 
         Args:
             component_id: The component ID to find dependents of.
             version: Optional specific version. If None, finds links to any version.
+            active_parents_only: Exclude links owned by archived parent components.
 
         Returns:
             List of link dictionaries showing what depends on this component.
         """
         try:
             table = self._get_table(table_type="component_links")
+            components_table = self._get_table(table_type="components")
             if table is None:
+                return []
+            if active_parents_only and components_table is None:
                 return []
 
             with self.Session() as sess:
-                stmt = select(table).where(table.c.child_component_id == component_id)
-                if version is not None:
-                    stmt = stmt.where(table.c.child_version == version)
-
-                rows = sess.execute(stmt).mappings().all()
-                return [dict(r) for r in rows]
+                return self._component_dependents(
+                    sess,
+                    components_table,
+                    table,
+                    component_id,
+                    version=version,
+                    active_parents_only=active_parents_only,
+                )
 
         except Exception as e:
             log_error(f"Error getting dependents: {str(e)}")
@@ -5095,11 +5962,11 @@ class PostgresDb(BaseDb):
         component_id: str,
         version: Optional[int],
     ) -> Optional[int]:
-        """Resolve a version number, handling None as 'current'.
+        """Resolve an explicit version or the component's generic readable head.
 
         Args:
             component_id: The component ID.
-            version: Version number or None for current.
+            version: Version number or None for current/latest-draft fallback.
 
         Returns:
             Resolved version number, or None if component missing/deleted or no current.
@@ -5108,17 +5975,9 @@ class PostgresDb(BaseDb):
             return version
 
         try:
-            components_table = self._get_table(table_type="components")
-            if components_table is None:
-                return None
-
-            with self.Session() as sess:
-                return sess.execute(
-                    select(components_table.c.current_version).where(
-                        components_table.c.component_id == component_id,
-                        components_table.c.deleted_at.is_(None),
-                    )
-                ).scalar_one_or_none()
+            config = self.get_config(component_id)
+            resolved = config.get("version") if config is not None else None
+            return resolved if isinstance(resolved, int) else None
 
         except Exception as e:
             log_error(f"Error resolving version: {str(e)}")
@@ -5157,7 +6016,12 @@ class PostgresDb(BaseDb):
             if component is None:
                 return None
 
-            resolved_version = self._resolve_version(component_id, version)
+            if version is None and label is not None:
+                labeled = self.get_config(component_id, label=label)
+                resolved = labeled.get("version") if labeled is not None else None
+                resolved_version = resolved if isinstance(resolved, int) else None
+            else:
+                resolved_version = self._resolve_version(component_id, version)
             if resolved_version is None:
                 return None
 
@@ -5684,27 +6548,42 @@ class PostgresDb(BaseDb):
             with self.Session() as sess:
                 result = sess.execute(select(table).where(table.c.id == schedule_id)).fetchone()
                 return dict(result._mapping) if result else None
-        except Exception as e:
-            log_debug(f"Error getting schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule")
+            raise
 
-    def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
+    def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         try:
             table = self._get_table(table_type="schedules")
             if table is None:
                 return None
             with self.Session() as sess:
-                result = sess.execute(select(table).where(table.c.name == name)).fetchone()
+                query = select(table).where(table.c.name == name)
+                if managed_by is not None:
+                    query = query.where(table.c.managed_by == managed_by)
+                if owner_actor_id is not None:
+                    query = query.where(table.c.owner_actor_id == owner_actor_id)
+                if exclude_managed_by is not None:
+                    query = query.where(or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by))
+                result = sess.execute(query).fetchone()
                 return dict(result._mapping) if result else None
-        except Exception as e:
-            log_debug(f"Error getting schedule by name: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule by name")
+            raise
 
     def get_schedules(
         self,
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = self._get_table(table_type="schedules")
@@ -5715,6 +6594,10 @@ class PostgresDb(BaseDb):
                 base_query = select(table)
                 if enabled is not None:
                     base_query = base_query.where(table.c.enabled == enabled)
+                if exclude_managed_by is not None:
+                    base_query = base_query.where(
+                        or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by)
+                    )
 
                 # Get total count
                 count_stmt = select(func.count()).select_from(base_query.alias())
@@ -5727,20 +6610,27 @@ class PostgresDb(BaseDb):
                 stmt = base_query.order_by(table.c.created_at.desc()).limit(limit).offset(offset)
                 results = sess.execute(stmt).fetchall()
                 return [dict(row._mapping) for row in results], total_count
-        except Exception as e:
-            log_debug(f"Error listing schedules: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error listing schedules")
+            raise
 
     def create_schedule(self, schedule_data: Dict[str, Any]) -> Dict[str, Any]:
         try:
+            schedule_data.setdefault("pending_trigger_count", 0)
+            schedule_data.setdefault("manual_trigger_claimed", False)
             table = self._get_table(table_type="schedules", create_table_if_not_found=True)
             if table is None:
                 raise RuntimeError("Failed to get or create schedules table")
             with self.Session() as sess, sess.begin():
                 sess.execute(table.insert().values(**schedule_data))
             return schedule_data
-        except Exception as e:
-            log_error(f"Error creating schedule: {str(e)}")
+        except IntegrityError as error:
+            if _is_schedule_name_conflict(error, self.schedules_table_name, self.db_schema):
+                raise ScheduleNameConflictError(schedule_data["name"]) from None
+            log_error("Error creating schedule")
+            raise
+        except Exception:
+            log_error("Error creating schedule")
             raise
 
     def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -5752,9 +6642,56 @@ class PostgresDb(BaseDb):
             with self.Session() as sess, sess.begin():
                 sess.execute(table.update().where(table.c.id == schedule_id).values(**kwargs))
             return self.get_schedule(schedule_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule: {e}")
+        except IntegrityError as error:
+            name = kwargs.get("name")
+            if isinstance(name, str) and _is_schedule_name_conflict(error, self.schedules_table_name, self.db_schema):
+                raise ScheduleNameConflictError(name) from None
+            log_debug("Error updating schedule")
+            raise
+        except Exception:
+            log_debug("Error updating schedule")
+            raise
+
+    def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue one manual execution for a schedule."""
+        table = self._get_table(table_type="schedules")
+        if table is None:
             return None
+        with self.Session() as sess, sess.begin():
+            result = sess.execute(
+                update(table)
+                .where(table.c.id == schedule_id)
+                .values(
+                    pending_trigger_count=func.coalesce(table.c.pending_trigger_count, 0) + 1,
+                    updated_at=int(time.time()),
+                )
+                .returning(*table.c)
+            ).fetchone()
+            return dict(result._mapping) if result else None
+
+    def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules for one managed target."""
+        table = self._get_table(table_type="schedules")
+        if table is None:
+            return 0
+        with self.Session() as sess, sess.begin():
+            result = sess.execute(
+                table.update()
+                .where(
+                    table.c.managed_by == managed_by,
+                    table.c.target_type == target_type,
+                    table.c.target_id == target_id,
+                    table.c.enabled == True,  # noqa: E712
+                )
+                .values(enabled=False, updated_at=int(time.time()))
+            )
+            return int(result.rowcount or 0)
 
     def delete_schedule(self, schedule_id: str) -> bool:
         try:
@@ -5767,8 +6704,8 @@ class PostgresDb(BaseDb):
                     sess.execute(runs_table.delete().where(runs_table.c.schedule_id == schedule_id))
                 result = sess.execute(table.delete().where(table.c.id == schedule_id))
                 return result.rowcount > 0
-        except Exception as e:
-            log_debug(f"Error deleting schedule: {e}")
+        except Exception:
+            log_debug("Error deleting schedule")
             return False
 
     def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
@@ -5785,13 +6722,30 @@ class PostgresDb(BaseDb):
                     select(table.c.id)
                     .where(
                         table.c.enabled == True,  # noqa: E712
-                        table.c.next_run_at <= now,
+                        or_(
+                            table.c.manual_trigger_claimed == True,  # noqa: E712
+                            table.c.pending_trigger_count > 0,
+                            table.c.next_run_at <= now,
+                        ),
                         or_(
                             table.c.locked_by.is_(None),
                             table.c.locked_at <= stale_lock_threshold,
                         ),
                     )
-                    .order_by(table.c.next_run_at.asc())
+                    .order_by(
+                        case(
+                            (table.c.manual_trigger_claimed == True, 0),  # noqa: E712
+                            (
+                                and_(
+                                    table.c.pending_trigger_count > 0,
+                                    or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                ),
+                                1,
+                            ),
+                            else_=2,
+                        ),
+                        table.c.next_run_at.asc(),
+                    )
                     .limit(1)
                     .with_for_update(skip_locked=True)
                     .scalar_subquery()
@@ -5799,30 +6753,92 @@ class PostgresDb(BaseDb):
                 stmt = (
                     update(table)
                     .where(table.c.id == subq)
-                    .values(locked_by=worker_id, locked_at=now)
+                    .values(
+                        locked_by=worker_id,
+                        locked_at=now,
+                        pending_trigger_count=case(
+                            (
+                                and_(
+                                    table.c.manual_trigger_claimed == False,  # noqa: E712
+                                    table.c.pending_trigger_count > 0,
+                                    or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                ),
+                                table.c.pending_trigger_count - 1,
+                            ),
+                            else_=table.c.pending_trigger_count,
+                        ),
+                        manual_trigger_claimed=case(
+                            (table.c.manual_trigger_claimed == True, True),  # noqa: E712
+                            (table.c.next_run_at <= now, False),
+                            else_=True,
+                        ),
+                    )
                     .returning(*table.c)
                 )
                 result = sess.execute(stmt).fetchone()
                 if result is None:
                     return None
                 return dict(result._mapping)
-        except Exception as e:
-            log_debug(f"Error claiming schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error claiming schedule")
+            raise
 
-    def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
+    def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a claim only while its worker/timestamp fence still matches."""
+        table = self._get_table(table_type="schedules")
+        if table is None:
+            return None
+        renewed_at = max(int(time.time()), locked_at + 1)
+        with self.Session() as sess, sess.begin():
+            result = sess.execute(
+                table.update()
+                .where(
+                    table.c.id == schedule_id,
+                    table.c.locked_by == worker_id,
+                    table.c.locked_at == locked_at,
+                )
+                .values(locked_at=renewed_at)
+            )
+            return renewed_at if result.rowcount > 0 else None
+
+    def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
         try:
+            if (worker_id is None) != (locked_at is None):
+                return False
             table = self._get_table(table_type="schedules")
             if table is None:
                 return False
-            updates: Dict[str, Any] = {"locked_by": None, "locked_at": None, "updated_at": int(time.time())}
+            updates: Dict[str, Any] = {
+                "locked_by": None,
+                "locked_at": None,
+                "manual_trigger_claimed": False,
+                "updated_at": int(time.time()),
+            }
             if next_run_at is not None:
                 updates["next_run_at"] = next_run_at
             with self.Session() as sess, sess.begin():
-                result = sess.execute(table.update().where(table.c.id == schedule_id).values(**updates))
+                stmt = table.update().where(table.c.id == schedule_id)
+                if worker_id is None:
+                    stmt = stmt.where(table.c.manual_trigger_claimed == False)  # noqa: E712
+                else:
+                    stmt = stmt.where(table.c.locked_by == worker_id, table.c.locked_at == locked_at)
+                result = sess.execute(stmt.values(**updates))
                 return result.rowcount > 0
-        except Exception as e:
-            log_debug(f"Error releasing schedule: {e}")
+        except Exception:
+            log_debug("Error releasing schedule")
             return False
 
     def create_schedule_run(self, run_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -5833,8 +6849,8 @@ class PostgresDb(BaseDb):
             with self.Session() as sess, sess.begin():
                 sess.execute(table.insert().values(**run_data))
             return run_data
-        except Exception as e:
-            log_error(f"Error creating schedule run: {str(e)}")
+        except Exception:
+            log_error("Error creating schedule run")
             raise
 
     def update_schedule_run(self, schedule_run_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -5845,8 +6861,8 @@ class PostgresDb(BaseDb):
             with self.Session() as sess, sess.begin():
                 sess.execute(table.update().where(table.c.id == schedule_run_id).values(**kwargs))
             return self.get_schedule_run(schedule_run_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule run: {e}")
+        except Exception:
+            log_debug("Error updating schedule run")
             return None
 
     def get_schedule_run(self, run_id: str) -> Optional[Dict[str, Any]]:
@@ -5857,9 +6873,9 @@ class PostgresDb(BaseDb):
             with self.Session() as sess:
                 result = sess.execute(select(table).where(table.c.id == run_id)).fetchone()
                 return dict(result._mapping) if result else None
-        except Exception as e:
-            log_debug(f"Error getting schedule run: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule run")
+            raise
 
     def get_schedule_runs(
         self,
@@ -5889,9 +6905,9 @@ class PostgresDb(BaseDb):
                 )
                 results = sess.execute(stmt).fetchall()
                 return [dict(row._mapping) for row in results], total_count
-        except Exception as e:
-            log_debug(f"Error getting schedule runs: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error getting schedule runs")
+            raise
 
     # -- Job queue methods --
     #

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -50,7 +50,7 @@ from agno.db.schemas.mcp_oauth import (
     MCP_OAUTH_TRANSACTIONS,
 )
 from agno.db.schemas.memory import UserMemory
-from agno.db.schemas.scheduler import ScheduleNameConflictError
+from agno.db.schemas.scheduler import ScheduleNameConflictError, validate_schedule_update
 from agno.db.schemas.service_accounts import (
     resolve_service_account_sort_column,
     validate_service_account_update,
@@ -6646,6 +6646,7 @@ class PostgresDb(BaseDb):
             raise
 
     def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        validate_schedule_update(kwargs)
         try:
             table = self._get_table(table_type="schedules")
             if table is None:

--- a/libs/agno/agno/db/postgres/schemas.py
+++ b/libs/agno/agno/db/postgres/schemas.py
@@ -278,6 +278,16 @@ SCHEDULE_TABLE_SCHEMA = {
     "timeout_seconds": {"type": BigInteger, "nullable": False},
     "max_retries": {"type": BigInteger, "nullable": False},
     "retry_delay_seconds": {"type": BigInteger, "nullable": False},
+    "managed_by": {"type": String, "nullable": True, "index": True},
+    "owner_actor_id": {"type": String, "nullable": True, "index": True},
+    "target_type": {"type": String, "nullable": True},
+    "target_id": {"type": String, "nullable": True},
+    "created_by_run_id": {"type": String, "nullable": True},
+    "created_by_session_id": {"type": String, "nullable": True},
+    "updated_by_run_id": {"type": String, "nullable": True},
+    "updated_by_session_id": {"type": String, "nullable": True},
+    "pending_trigger_count": {"type": BigInteger, "nullable": False, "default": 0},
+    "manual_trigger_claimed": {"type": Boolean, "nullable": False, "default": False},
     "enabled": {"type": Boolean, "nullable": False, "default": True},
     "next_run_at": {"type": BigInteger, "nullable": True, "index": True},
     "locked_by": {"type": String, "nullable": True},
@@ -286,6 +296,18 @@ SCHEDULE_TABLE_SCHEMA = {
     "updated_at": {"type": BigInteger, "nullable": True},
     "__composite_indexes__": [
         {"name": "enabled_next_run_at", "columns": ["enabled", "next_run_at"]},
+    ],
+    "_partial_unique_indexes": [
+        {
+            "name": "uq_generic_name",
+            "columns": ["name"],
+            "where": "managed_by IS DISTINCT FROM 'studio'",
+        },
+        {
+            "name": "uq_studio_owner_name",
+            "columns": ["owner_actor_id", "name"],
+            "where": "managed_by = 'studio'",
+        },
     ],
 }
 

--- a/libs/agno/agno/db/postgres/utils.py
+++ b/libs/agno/agno/db/postgres/utils.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from agno.db.postgres.schemas import get_table_schema_definition
 from agno.db.schemas.culture import CulturalKnowledge
 from agno.utils.log import log_debug, log_error, log_warning
+from sqlalchemy.exc import IntegrityError
 
 try:
     from sqlalchemy import Table, func
@@ -454,4 +455,27 @@ def deserialize_cultural_knowledge(db_row: Dict[str, Any]) -> CulturalKnowledge:
             "agent_id": db_row.get("agent_id"),
             "team_id": db_row.get("team_id"),
         }
+    )
+
+
+def _is_schedule_name_conflict(error: IntegrityError, table_name: str, schema_name: str) -> bool:
+    """Match only the generic or actor-scoped schedule-name indexes."""
+    original = error.orig
+    cause = getattr(original, "__cause__", None)
+    sqlstate = (
+        getattr(original, "sqlstate", None) or getattr(original, "pgcode", None) or getattr(cause, "sqlstate", None)
+    )
+    diagnostic = getattr(original, "diag", None)
+    constraint_name = getattr(diagnostic, "constraint_name", None) or getattr(cause, "constraint_name", None)
+    reported_table = getattr(diagnostic, "table_name", None) or getattr(cause, "table_name", None)
+    reported_schema = getattr(diagnostic, "schema_name", None) or getattr(cause, "schema_name", None)
+    return (
+        sqlstate == "23505"
+        and constraint_name
+        in {
+            f"{table_name}_uq_generic_name",
+            f"{table_name}_uq_studio_owner_name",
+        }
+        and reported_table == table_name
+        and reported_schema == schema_name
     )

--- a/libs/agno/agno/db/postgres/utils.py
+++ b/libs/agno/agno/db/postgres/utils.py
@@ -6,12 +6,12 @@ from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from sqlalchemy import Engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from agno.db.postgres.schemas import get_table_schema_definition
 from agno.db.schemas.culture import CulturalKnowledge
 from agno.utils.log import log_debug, log_error, log_warning
-from sqlalchemy.exc import IntegrityError
 
 try:
     from sqlalchemy import Table, func

--- a/libs/agno/agno/db/schemas/scheduler.py
+++ b/libs/agno/agno/db/schemas/scheduler.py
@@ -20,6 +20,47 @@ class ScheduleNameConflictError(ValueError):
         super().__init__(f"Schedule with name '{name}' already exists")
 
 
+# Columns update_schedule may modify: the schedule's own public definition plus its
+# run state (enabled, next_run_at). Everything else is server-owned — provenance
+# (managed_by, owner_actor_id, target/created-by/updated-by fields), durable trigger
+# state (pending_trigger_count, manual_trigger_claimed) and the worker lock pair
+# (locked_by, locked_at) move only through their dedicated primitives. Shared by every
+# DB backend's update_schedule so the guardrail cannot drift between them.
+SCHEDULE_MUTABLE_COLUMNS = frozenset(
+    {
+        "name",
+        "description",
+        "method",
+        "endpoint",
+        "payload",
+        "cron_expr",
+        "timezone",
+        "timeout_seconds",
+        "max_retries",
+        "retry_delay_seconds",
+        "enabled",
+        "next_run_at",
+    }
+)
+
+
+def validate_schedule_update(updates: Dict[str, Any]) -> None:
+    """Reject an update payload that is empty or touches a server-owned column.
+
+    Raises ValueError so misuse fails loudly at the call site instead of reaching the
+    database (or being swallowed by an adapter's catch-all error handling).
+    """
+    if not updates:
+        raise ValueError("update_schedule requires at least one column to update")
+    disallowed = set(updates) - SCHEDULE_MUTABLE_COLUMNS
+    if disallowed:
+        raise ValueError(
+            f"update_schedule cannot modify {sorted(disallowed)}: "
+            f"only {sorted(SCHEDULE_MUTABLE_COLUMNS)} are mutable; "
+            "provenance, trigger and lock state move only through their dedicated APIs"
+        )
+
+
 @dataclass
 class Schedule:
     """Model for a scheduled job."""

--- a/libs/agno/agno/db/schemas/scheduler.py
+++ b/libs/agno/agno/db/schemas/scheduler.py
@@ -1,7 +1,23 @@
+import base64
+import re
+import unicodedata
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from agno.utils.dttm import now_epoch_s, to_epoch_s
+
+STUDIO_SCHEDULE_MANAGED_BY = "studio"
+STUDIO_SCHEDULE_ACTOR_HEADER = "X-Agno-Studio-Schedule-Actor"
+_STUDIO_SCHEDULE_ACTOR_ENCODING = "v1."
+_BASE64URL_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class ScheduleNameConflictError(ValueError):
+    """Raised when a schedule write violates the database-unique name constraint."""
+
+    def __init__(self, name: str):
+        self.name = name
+        super().__init__(f"Schedule with name '{name}' already exists")
 
 
 @dataclass
@@ -19,6 +35,22 @@ class Schedule:
     timeout_seconds: int = 3600
     max_retries: int = 0
     retry_delay_seconds: int = 60
+    # Server-owned control-plane provenance. Generic schedule APIs never accept
+    # or mutate these fields; Studio writes them through its trusted catalog DB.
+    managed_by: Optional[str] = None
+    owner_actor_id: Optional[str] = None
+    target_type: Optional[str] = None
+    target_id: Optional[str] = None
+    created_by_run_id: Optional[str] = None
+    created_by_session_id: Optional[str] = None
+    updated_by_run_id: Optional[str] = None
+    updated_by_session_id: Optional[str] = None
+    # Manual triggers are durable work, not a temporary rewrite of
+    # ``next_run_at``. A claim atomically moves one pending trigger into the
+    # in-flight marker so a stale lock can recover it without consuming a
+    # second trigger.
+    pending_trigger_count: int = 0
+    manual_trigger_claimed: bool = False
     enabled: bool = True
     next_run_at: Optional[int] = None
     locked_by: Optional[str] = None
@@ -34,6 +66,8 @@ class Schedule:
             self.next_run_at = int(self.next_run_at)
         if self.locked_at is not None:
             self.locked_at = int(self.locked_at)
+        self.pending_trigger_count = max(0, int(self.pending_trigger_count or 0))
+        self.manual_trigger_claimed = bool(self.manual_trigger_claimed)
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to dict. Preserves None values (important for DB updates)."""
@@ -49,6 +83,16 @@ class Schedule:
             "timeout_seconds": self.timeout_seconds,
             "max_retries": self.max_retries,
             "retry_delay_seconds": self.retry_delay_seconds,
+            "managed_by": self.managed_by,
+            "owner_actor_id": self.owner_actor_id,
+            "target_type": self.target_type,
+            "target_id": self.target_id,
+            "created_by_run_id": self.created_by_run_id,
+            "created_by_session_id": self.created_by_session_id,
+            "updated_by_run_id": self.updated_by_run_id,
+            "updated_by_session_id": self.updated_by_session_id,
+            "pending_trigger_count": self.pending_trigger_count,
+            "manual_trigger_claimed": self.manual_trigger_claimed,
             "enabled": self.enabled,
             "next_run_at": self.next_run_at,
             "locked_by": self.locked_by,
@@ -72,6 +116,16 @@ class Schedule:
             "timeout_seconds",
             "max_retries",
             "retry_delay_seconds",
+            "managed_by",
+            "owner_actor_id",
+            "target_type",
+            "target_id",
+            "created_by_run_id",
+            "created_by_session_id",
+            "updated_by_run_id",
+            "updated_by_session_id",
+            "pending_trigger_count",
+            "manual_trigger_claimed",
             "enabled",
             "next_run_at",
             "locked_by",
@@ -81,6 +135,56 @@ class Schedule:
         }
         filtered = {k: v for k, v in data.items() if k in valid_keys}
         return cls(**filtered)
+
+
+def is_studio_managed_schedule(schedule: Union[Schedule, Mapping[str, Any]]) -> bool:
+    """Return whether a record carries server-owned Studio provenance."""
+    managed_by = schedule.managed_by if isinstance(schedule, Schedule) else schedule.get("managed_by")
+    return managed_by == STUDIO_SCHEDULE_MANAGED_BY
+
+
+def is_valid_studio_schedule_actor_id(actor_id: Any) -> bool:
+    """Return whether an opaque actor ID is safe to delegate.
+
+    Actor IDs may contain Unicode. Header transport is handled separately by
+    :func:`encode_studio_schedule_actor_id`; raw control, formatting, surrogate,
+    and line-separator characters are rejected so control-like or
+    non-canonical header values never become principals.
+    """
+    if not isinstance(actor_id, str) or not actor_id or actor_id != actor_id.strip() or len(actor_id) > 255:
+        return False
+    try:
+        encoded_size = len(actor_id.encode("utf-8"))
+    except UnicodeEncodeError:
+        return False
+    if encoded_size > 1024:
+        return False
+    return not any(unicodedata.category(character) in {"Cc", "Cf", "Cs", "Zl", "Zp"} for character in actor_id)
+
+
+def encode_studio_schedule_actor_id(actor_id: str) -> str:
+    """Encode one validated opaque actor ID into an ASCII-only header value."""
+    if not is_valid_studio_schedule_actor_id(actor_id):
+        raise ValueError("Invalid delegated scheduler actor")
+    encoded = base64.urlsafe_b64encode(actor_id.encode("utf-8")).decode("ascii").rstrip("=")
+    return f"{_STUDIO_SCHEDULE_ACTOR_ENCODING}{encoded}"
+
+
+def decode_studio_schedule_actor_id(value: Any) -> str:
+    """Decode and validate the canonical internal scheduler actor header."""
+    if not isinstance(value, str) or not value.startswith(_STUDIO_SCHEDULE_ACTOR_ENCODING):
+        raise ValueError("Invalid delegated scheduler actor")
+    encoded = value[len(_STUDIO_SCHEDULE_ACTOR_ENCODING) :]
+    if not encoded or _BASE64URL_RE.fullmatch(encoded) is None:
+        raise ValueError("Invalid delegated scheduler actor")
+    try:
+        padding = "=" * (-len(encoded) % 4)
+        actor_id = base64.b64decode(encoded + padding, altchars=b"-_", validate=True).decode("utf-8")
+    except (UnicodeDecodeError, ValueError):
+        raise ValueError("Invalid delegated scheduler actor") from None
+    if not is_valid_studio_schedule_actor_id(actor_id) or encode_studio_schedule_actor_id(actor_id) != value:
+        raise ValueError("Invalid delegated scheduler actor")
+    return actor_id
 
 
 @dataclass

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -21,6 +21,7 @@ from agno.db.schemas.service_accounts import (
 )
 from agno.db.sqlite.schemas import get_table_schema_definition
 from agno.db.sqlite.utils import (
+    _is_schedule_name_conflict,
     abulk_upsert_metrics,
     ais_table_available,
     ais_valid_table,
@@ -60,14 +61,6 @@ try:
     from sqlalchemy.schema import Index, UniqueConstraint
 except ImportError:
     raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
-
-
-def _is_schedule_name_conflict(error: IntegrityError, table_name: str) -> bool:
-    """Match only the generic or actor-scoped schedule-name indexes."""
-    return str(error.orig) in {
-        f"UNIQUE constraint failed: {table_name}.name",
-        f"UNIQUE constraint failed: {table_name}.owner_actor_id, {table_name}.name",
-    }
 
 
 class AsyncSqliteDb(AsyncBaseDb):

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -14,7 +14,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
-from agno.db.schemas.scheduler import ScheduleNameConflictError
+from agno.db.schemas.scheduler import ScheduleNameConflictError, validate_schedule_update
 from agno.db.schemas.service_accounts import (
     resolve_service_account_sort_column,
     validate_service_account_update,
@@ -4490,6 +4490,7 @@ class AsyncSqliteDb(AsyncBaseDb):
             raise
 
     async def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        validate_schedule_update(kwargs)
         try:
             table = await self._get_table(table_type="schedules")
             if table is None:

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -71,6 +71,8 @@ def _is_schedule_name_conflict(error: IntegrityError, table_name: str) -> bool:
 
 
 class AsyncSqliteDb(AsyncBaseDb):
+    supports_component_persistence = False
+    component_catalog_api_version = 1
     scheduler_api_version = 2
 
     def __init__(
@@ -4280,6 +4282,7 @@ class AsyncSqliteDb(AsyncBaseDb):
         guard: Optional[ComponentVersionGuard] = None,
         require_no_dependents: bool = True,
         projection: Optional[ComponentProjection] = None,
+        expected_component_type: Optional[ComponentType] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4314,6 +4317,8 @@ class AsyncSqliteDb(AsyncBaseDb):
         component_id: str,
         version: Optional[int] = None,
         label: Optional[str] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4346,6 +4351,8 @@ class AsyncSqliteDb(AsyncBaseDb):
         self,
         component_id: str,
         include_config: bool = False,
+        *,
+        include_deleted: bool = False,
     ) -> List[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -5,17 +5,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union, cast
 from uuid import uuid4
 
-from sqlalchemy import or_
-
 if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
 
-from agno.db.base import AsyncBaseDb, ComponentType, SessionType
+from agno.db.base import AsyncBaseDb, ComponentProjection, ComponentType, ComponentVersionGuard, SessionType
 from agno.db.migrations.manager import MigrationManager
 from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import ScheduleNameConflictError
 from agno.db.schemas.service_accounts import (
     resolve_service_account_sort_column,
     validate_service_account_update,
@@ -54,15 +53,26 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
 
 try:
-    from sqlalchemy import Column, ForeignKey, MetaData, String, Table, func, select, text
+    from sqlalchemy import Column, ForeignKey, MetaData, String, Table, and_, case, func, or_, select, text
     from sqlalchemy.dialects import sqlite
+    from sqlalchemy.exc import IntegrityError
     from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
     from sqlalchemy.schema import Index, UniqueConstraint
 except ImportError:
     raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
 
 
+def _is_schedule_name_conflict(error: IntegrityError, table_name: str) -> bool:
+    """Match only the generic or actor-scoped schedule-name indexes."""
+    return str(error.orig) in {
+        f"UNIQUE constraint failed: {table_name}.name",
+        f"UNIQUE constraint failed: {table_name}.owner_actor_id, {table_name}.name",
+    }
+
+
 class AsyncSqliteDb(AsyncBaseDb):
+    scheduler_api_version = 2
+
     def __init__(
         self,
         db_file: Optional[str] = None,
@@ -4246,6 +4256,8 @@ class AsyncSqliteDb(AsyncBaseDb):
         self,
         component_id: str,
         component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4255,6 +4267,7 @@ class AsyncSqliteDb(AsyncBaseDb):
         component_type: Optional[ComponentType] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
+        current_version: Optional[int] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         raise NotImplementedError("Component methods not yet supported for async databases")
@@ -4263,6 +4276,10 @@ class AsyncSqliteDb(AsyncBaseDb):
         self,
         component_id: str,
         hard_delete: bool = False,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        require_no_dependents: bool = True,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4309,6 +4326,9 @@ class AsyncSqliteDb(AsyncBaseDb):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> Dict[str, Any]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4316,6 +4336,9 @@ class AsyncSqliteDb(AsyncBaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4330,6 +4353,9 @@ class AsyncSqliteDb(AsyncBaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4345,6 +4371,8 @@ class AsyncSqliteDb(AsyncBaseDb):
         self,
         component_id: str,
         version: Optional[int] = None,
+        *,
+        active_parents_only: bool = False,
     ) -> List[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -4366,28 +4394,43 @@ class AsyncSqliteDb(AsyncBaseDb):
                 result = await sess.execute(select(table).where(table.c.id == schedule_id))
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
-        except Exception as e:
-            log_debug(f"Error getting schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule")
+            raise
 
-    async def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
+    async def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         try:
             table = await self._get_table(table_type="schedules")
             if table is None:
                 return None
             async with self.async_session_factory() as sess:
-                result = await sess.execute(select(table).where(table.c.name == name))
+                query = select(table).where(table.c.name == name)
+                if managed_by is not None:
+                    query = query.where(table.c.managed_by == managed_by)
+                if owner_actor_id is not None:
+                    query = query.where(table.c.owner_actor_id == owner_actor_id)
+                if exclude_managed_by is not None:
+                    query = query.where(or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by))
+                result = await sess.execute(query)
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
-        except Exception as e:
-            log_debug(f"Error getting schedule by name: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule by name")
+            raise
 
     async def get_schedules(
         self,
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = await self._get_table(table_type="schedules")
@@ -4398,6 +4441,10 @@ class AsyncSqliteDb(AsyncBaseDb):
                 base_query = select(table)
                 if enabled is not None:
                     base_query = base_query.where(table.c.enabled == enabled)
+                if exclude_managed_by is not None:
+                    base_query = base_query.where(
+                        or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by)
+                    )
 
                 # Get total count
                 count_stmt = select(func.count()).select_from(base_query.alias())
@@ -4411,12 +4458,14 @@ class AsyncSqliteDb(AsyncBaseDb):
                 stmt = base_query.order_by(table.c.created_at.desc()).limit(limit).offset(offset)
                 result = await sess.execute(stmt)
                 return [dict(row._mapping) for row in result.fetchall()], total_count
-        except Exception as e:
-            log_debug(f"Error listing schedules: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error listing schedules")
+            raise
 
     async def create_schedule(self, schedule_data: Dict[str, Any]) -> Dict[str, Any]:
         try:
+            schedule_data.setdefault("pending_trigger_count", 0)
+            schedule_data.setdefault("manual_trigger_claimed", False)
             table = await self._get_table(table_type="schedules", create_table_if_not_found=True)
             if table is None:
                 raise RuntimeError("Failed to get or create schedules table")
@@ -4424,8 +4473,13 @@ class AsyncSqliteDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.insert().values(**schedule_data))
             return schedule_data
-        except Exception as e:
-            log_error(f"Error creating schedule: {str(e)}")
+        except IntegrityError as error:
+            if _is_schedule_name_conflict(error, self.schedules_table_name):
+                raise ScheduleNameConflictError(schedule_data["name"]) from None
+            log_error("Error creating schedule")
+            raise
+        except Exception:
+            log_error("Error creating schedule")
             raise
 
     async def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -4438,9 +4492,59 @@ class AsyncSqliteDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.update().where(table.c.id == schedule_id).values(**kwargs))
             return await self.get_schedule(schedule_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule: {e}")
+        except IntegrityError as error:
+            name = kwargs.get("name")
+            if isinstance(name, str) and _is_schedule_name_conflict(error, self.schedules_table_name):
+                raise ScheduleNameConflictError(name) from None
+            log_debug("Error updating schedule")
+            raise
+        except Exception:
+            log_debug("Error updating schedule")
+            raise
+
+    async def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue one manual execution for a schedule."""
+        table = await self._get_table(table_type="schedules")
+        if table is None:
             return None
+        async with self.async_session_factory() as sess:
+            async with sess.begin():
+                result = await sess.execute(
+                    table.update()
+                    .where(table.c.id == schedule_id)
+                    .values(
+                        pending_trigger_count=func.coalesce(table.c.pending_trigger_count, 0) + 1,
+                        updated_at=int(time.time()),
+                    )
+                )
+                if result.rowcount == 0:  # type: ignore[attr-defined]
+                    return None
+        return await self.get_schedule(schedule_id)
+
+    async def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules for one managed target."""
+        table = await self._get_table(table_type="schedules")
+        if table is None:
+            return 0
+        async with self.async_session_factory() as sess:
+            async with sess.begin():
+                result = await sess.execute(
+                    table.update()
+                    .where(
+                        table.c.managed_by == managed_by,
+                        table.c.target_type == target_type,
+                        table.c.target_id == target_id,
+                        table.c.enabled == True,  # noqa: E712
+                    )
+                    .values(enabled=False, updated_at=int(time.time()))
+                )
+                return int(result.rowcount or 0)  # type: ignore[attr-defined]
 
     async def delete_schedule(self, schedule_id: str) -> bool:
         try:
@@ -4454,8 +4558,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                         await sess.execute(runs_table.delete().where(runs_table.c.schedule_id == schedule_id))
                     result = await sess.execute(table.delete().where(table.c.id == schedule_id))
                     return result.rowcount > 0  # type: ignore[attr-defined]
-        except Exception as e:
-            log_debug(f"Error deleting schedule: {e}")
+        except Exception:
+            log_debug("Error deleting schedule")
             return False
 
     async def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
@@ -4471,13 +4575,30 @@ class AsyncSqliteDb(AsyncBaseDb):
                         select(table)
                         .where(
                             table.c.enabled == True,  # noqa: E712
-                            table.c.next_run_at <= now,
+                            or_(
+                                table.c.manual_trigger_claimed == True,  # noqa: E712
+                                table.c.pending_trigger_count > 0,
+                                table.c.next_run_at <= now,
+                            ),
                             or_(
                                 table.c.locked_by.is_(None),
                                 table.c.locked_at <= stale_lock_threshold,
                             ),
                         )
-                        .order_by(table.c.next_run_at.asc())
+                        .order_by(
+                            case(
+                                (table.c.manual_trigger_claimed == True, 0),  # noqa: E712
+                                (
+                                    and_(
+                                        table.c.pending_trigger_count > 0,
+                                        or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                    ),
+                                    1,
+                                ),
+                                else_=2,
+                            ),
+                            table.c.next_run_at.asc(),
+                        )
                         .limit(1)
                     )
                     result = await sess.execute(stmt)
@@ -4489,36 +4610,105 @@ class AsyncSqliteDb(AsyncBaseDb):
                         table.update()
                         .where(
                             table.c.id == schedule["id"],
+                            table.c.enabled == True,  # noqa: E712
+                            or_(
+                                table.c.manual_trigger_claimed == True,  # noqa: E712
+                                table.c.pending_trigger_count > 0,
+                                table.c.next_run_at <= now,
+                            ),
                             or_(
                                 table.c.locked_by.is_(None),
                                 table.c.locked_at <= stale_lock_threshold,
                             ),
                         )
-                        .values(locked_by=worker_id, locked_at=now)
+                        .values(
+                            locked_by=worker_id,
+                            locked_at=now,
+                            pending_trigger_count=case(
+                                (
+                                    and_(
+                                        table.c.manual_trigger_claimed == False,  # noqa: E712
+                                        table.c.pending_trigger_count > 0,
+                                        or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                    ),
+                                    table.c.pending_trigger_count - 1,
+                                ),
+                                else_=table.c.pending_trigger_count,
+                            ),
+                            manual_trigger_claimed=case(
+                                (table.c.manual_trigger_claimed == True, True),  # noqa: E712
+                                (table.c.next_run_at <= now, False),
+                                else_=True,
+                            ),
+                        )
                     )
                     if claim_result.rowcount == 0:  # type: ignore[attr-defined]
                         return None
-                    schedule["locked_by"] = worker_id
-                    schedule["locked_at"] = now
-                    return schedule
-        except Exception as e:
-            log_debug(f"Error claiming schedule: {e}")
-            return None
+                    claimed_result = await sess.execute(select(table).where(table.c.id == schedule["id"]))
+                    claimed = claimed_result.fetchone()
+                    return dict(claimed._mapping) if claimed else None
+        except Exception:
+            log_debug("Error claiming schedule")
+            raise
 
-    async def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
+    async def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a claim only while its worker/timestamp fence still matches."""
+        table = await self._get_table(table_type="schedules")
+        if table is None:
+            return None
+        renewed_at = max(int(time.time()), locked_at + 1)
+        async with self.async_session_factory() as sess:
+            async with sess.begin():
+                result = await sess.execute(
+                    table.update()
+                    .where(
+                        table.c.id == schedule_id,
+                        table.c.locked_by == worker_id,
+                        table.c.locked_at == locked_at,
+                    )
+                    .values(locked_at=renewed_at)
+                )
+                return renewed_at if result.rowcount > 0 else None  # type: ignore[attr-defined]
+
+    async def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
         try:
+            if (worker_id is None) != (locked_at is None):
+                return False
             table = await self._get_table(table_type="schedules")
             if table is None:
                 return False
-            updates: Dict[str, Any] = {"locked_by": None, "locked_at": None, "updated_at": int(time.time())}
+            updates: Dict[str, Any] = {
+                "locked_by": None,
+                "locked_at": None,
+                "manual_trigger_claimed": False,
+                "updated_at": int(time.time()),
+            }
             if next_run_at is not None:
                 updates["next_run_at"] = next_run_at
             async with self.async_session_factory() as sess:
                 async with sess.begin():
-                    result = await sess.execute(table.update().where(table.c.id == schedule_id).values(**updates))
+                    stmt = table.update().where(table.c.id == schedule_id)
+                    if worker_id is None:
+                        stmt = stmt.where(table.c.manual_trigger_claimed == False)  # noqa: E712
+                    else:
+                        stmt = stmt.where(table.c.locked_by == worker_id, table.c.locked_at == locked_at)
+                    result = await sess.execute(stmt.values(**updates))
                     return result.rowcount > 0  # type: ignore[attr-defined]
-        except Exception as e:
-            log_debug(f"Error releasing schedule: {e}")
+        except Exception:
+            log_debug("Error releasing schedule")
             return False
 
     async def create_schedule_run(self, run_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -4530,8 +4720,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.insert().values(**run_data))
             return run_data
-        except Exception as e:
-            log_error(f"Error creating schedule run: {str(e)}")
+        except Exception:
+            log_error("Error creating schedule run")
             raise
 
     async def update_schedule_run(self, schedule_run_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -4543,8 +4733,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.update().where(table.c.id == schedule_run_id).values(**kwargs))
             return await self.get_schedule_run(schedule_run_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule run: {e}")
+        except Exception:
+            log_debug("Error updating schedule run")
             return None
 
     async def get_schedule_run(self, run_id: str) -> Optional[Dict[str, Any]]:
@@ -4556,9 +4746,9 @@ class AsyncSqliteDb(AsyncBaseDb):
                 result = await sess.execute(select(table).where(table.c.id == run_id))
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
-        except Exception as e:
-            log_debug(f"Error getting schedule run: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule run")
+            raise
 
     async def get_schedule_runs(
         self,
@@ -4589,9 +4779,9 @@ class AsyncSqliteDb(AsyncBaseDb):
                 )
                 result = await sess.execute(stmt)
                 return [dict(row._mapping) for row in result.fetchall()], total_count
-        except Exception as e:
-            log_debug(f"Error getting schedule runs: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error getting schedule runs")
+            raise
 
     # -- Approval methods --
 

--- a/libs/agno/agno/db/sqlite/schemas.py
+++ b/libs/agno/agno/db/sqlite/schemas.py
@@ -267,6 +267,16 @@ SCHEDULE_TABLE_SCHEMA = {
     "timeout_seconds": {"type": BigInteger, "nullable": False},
     "max_retries": {"type": BigInteger, "nullable": False},
     "retry_delay_seconds": {"type": BigInteger, "nullable": False},
+    "managed_by": {"type": String, "nullable": True, "index": True},
+    "owner_actor_id": {"type": String, "nullable": True, "index": True},
+    "target_type": {"type": String, "nullable": True},
+    "target_id": {"type": String, "nullable": True},
+    "created_by_run_id": {"type": String, "nullable": True},
+    "created_by_session_id": {"type": String, "nullable": True},
+    "updated_by_run_id": {"type": String, "nullable": True},
+    "updated_by_session_id": {"type": String, "nullable": True},
+    "pending_trigger_count": {"type": BigInteger, "nullable": False, "default": 0},
+    "manual_trigger_claimed": {"type": Boolean, "nullable": False, "default": False},
     "enabled": {"type": Boolean, "nullable": False, "default": True},
     "next_run_at": {"type": BigInteger, "nullable": True, "index": True},
     "locked_by": {"type": String, "nullable": True},
@@ -275,6 +285,20 @@ SCHEDULE_TABLE_SCHEMA = {
     "updated_at": {"type": BigInteger, "nullable": True},
     "__composite_indexes__": [
         {"name": "enabled_next_run_at", "columns": ["enabled", "next_run_at"]},
+    ],
+    # Generic and Studio schedules occupy separate name namespaces. Studio
+    # names are unique only for one authenticated actor.
+    "_partial_unique_indexes": [
+        {
+            "name": "uq_generic_name",
+            "columns": ["name"],
+            "where": "managed_by IS NULL OR managed_by <> 'studio'",
+        },
+        {
+            "name": "uq_studio_owner_name",
+            "columns": ["owner_actor_id", "name"],
+            "where": "managed_by = 'studio'",
+        },
     ],
 }
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -39,7 +39,7 @@ from agno.db.schemas.mcp_oauth import (
     MCP_OAUTH_TRANSACTIONS,
 )
 from agno.db.schemas.memory import UserMemory
-from agno.db.schemas.scheduler import ScheduleNameConflictError
+from agno.db.schemas.scheduler import ScheduleNameConflictError, validate_schedule_update
 from agno.db.schemas.service_accounts import (
     resolve_service_account_sort_column,
     validate_service_account_update,
@@ -6477,6 +6477,7 @@ class SqliteDb(BaseDb):
             raise
 
     def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        validate_schedule_update(kwargs)
         try:
             table = self._get_table(table_type="schedules")
             if table is None:

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -4575,6 +4575,7 @@ class SqliteDb(BaseDb):
         guard: Optional[ComponentVersionGuard] = None,
         require_no_dependents: bool = True,
         projection: Optional[ComponentProjection] = None,
+        expected_component_type: Optional[ComponentType] = None,
     ) -> bool:
         """Delete a component and all its configs/links.
 
@@ -4586,6 +4587,7 @@ class SqliteDb(BaseDb):
                 default). Soft deletion considers active parents; hard deletion
                 considers every parent.
             projection: Component fields to update atomically with a soft deletion.
+            expected_component_type: Optional identity invariant.
 
         Returns:
             True if deleted, False if not found.
@@ -4603,13 +4605,21 @@ class SqliteDb(BaseDb):
 
             with self._component_write_session() as sess:
                 existing = sess.execute(
-                    select(components_table.c.component_id, components_table.c.current_version).where(
+                    select(
+                        components_table.c.component_id,
+                        components_table.c.component_type,
+                        components_table.c.current_version,
+                    ).where(
                         components_table.c.component_id == component_id,
                         *([] if hard_delete else [components_table.c.deleted_at.is_(None)]),
                     )
                 ).fetchone()
                 if existing is None:
                     return False
+                if expected_component_type is not None and existing.component_type != expected_component_type.value:
+                    raise ValueError(
+                        f"Component {component_id} has type {existing.component_type}, not {expected_component_type.value}"
+                    )
 
                 if configs_table is not None:
                     actual = self._component_version_state(
@@ -4956,6 +4966,8 @@ class SqliteDb(BaseDb):
         component_id: str,
         version: Optional[int] = None,
         label: Optional[str] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Get a config by component ID and version or label.
 
@@ -4965,6 +4977,7 @@ class SqliteDb(BaseDb):
                 the current published version or the latest draft when the
                 component has never been published.
             label: Config label to lookup. Ignored if version is provided.
+            include_deleted: Allow reading config history for an archived component.
 
         Returns:
             Config dictionary or None if not found.
@@ -4977,17 +4990,13 @@ class SqliteDb(BaseDb):
                 return None
 
             with self.Session() as sess:
-                # Always verify component exists and is not deleted
-                component_row = (
-                    sess.execute(
-                        select(components_table.c.current_version, components_table.c.component_id).where(
-                            components_table.c.component_id == component_id,
-                            components_table.c.deleted_at.is_(None),
-                        )
-                    )
-                    .mappings()
-                    .one_or_none()
-                )
+                component_query = select(
+                    components_table.c.current_version,
+                    components_table.c.component_id,
+                ).where(components_table.c.component_id == component_id)
+                if not include_deleted:
+                    component_query = component_query.where(components_table.c.deleted_at.is_(None))
+                component_row = sess.execute(component_query).mappings().one_or_none()
 
                 if component_row is None:
                     return None
@@ -5570,12 +5579,15 @@ class SqliteDb(BaseDb):
         self,
         component_id: str,
         include_config: bool = False,
+        *,
+        include_deleted: bool = False,
     ) -> List[Dict[str, Any]]:
         """List all config versions for a component.
 
         Args:
             component_id: The component ID.
             include_config: If True, include full config blob. Otherwise just metadata.
+            include_deleted: Allow listing config history for an archived component.
 
         Returns:
             List of config dictionaries, newest first.
@@ -5589,13 +5601,12 @@ class SqliteDb(BaseDb):
                 return []
 
             with self.Session() as sess:
-                # Verify component exists and is not deleted
-                exists = sess.execute(
-                    select(components_table.c.component_id).where(
-                        components_table.c.component_id == component_id,
-                        components_table.c.deleted_at.is_(None),
-                    )
-                ).fetchone()
+                component_query = select(components_table.c.component_id).where(
+                    components_table.c.component_id == component_id
+                )
+                if not include_deleted:
+                    component_query = component_query.where(components_table.c.deleted_at.is_(None))
+                exists = sess.execute(component_query).fetchone()
 
                 if exists is None:
                     return []
@@ -5827,6 +5838,9 @@ class SqliteDb(BaseDb):
         component_id: str,
         version: Optional[int] = None,
         label: Optional[str] = None,
+        *,
+        _visited: Optional[Set[Tuple[str, int]]] = None,
+        _max_depth: int = 50,
     ) -> Optional[Dict[str, Any]]:
         """Load a component with its full resolved graph.
 
@@ -5839,6 +5853,9 @@ class SqliteDb(BaseDb):
             Dictionary with component, config, links, and resolved children.
         """
         try:
+            if _max_depth <= 0:
+                return None
+
             # Get component
             component = self.get_component(component_id)
             if component is None:
@@ -5854,6 +5871,21 @@ class SqliteDb(BaseDb):
                 resolved_version = self.resolve_version(component_id, version)
             if resolved_version is None:
                 return None
+
+            # Track only the active recursion path. Copying before descent
+            # detects real cycles without treating a shared child in a DAG as
+            # a cycle in its second branch.
+            active_path = set(_visited or set())
+            node_key = (component_id, resolved_version)
+            if node_key in active_path:
+                return {
+                    "component": component,
+                    "config": self.get_config(component_id, version=resolved_version),
+                    "children": [],
+                    "resolved_versions": {component_id: resolved_version},
+                    "cycle_detected": True,
+                }
+            active_path.add(node_key)
 
             # Get config
             config = self.get_config(component_id, version=resolved_version)
@@ -5877,6 +5909,8 @@ class SqliteDb(BaseDb):
                 child_graph = self.load_component_graph(
                     link["child_component_id"],
                     version=child_version,
+                    _visited=active_path,
+                    _max_depth=_max_depth - 1,
                 )
 
                 if child_graph:

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -46,6 +46,7 @@ from agno.db.schemas.service_accounts import (
 )
 from agno.db.sqlite.schemas import get_table_schema_definition
 from agno.db.sqlite.utils import (
+    _is_schedule_name_conflict,
     apply_sorting,
     bulk_upsert_metrics,
     calculate_date_metrics,
@@ -98,14 +99,6 @@ def _shared_table_init_lock(database_key: str) -> RLock:
     """Return one in-process lazy-DDL lock for every physical database."""
     with _TABLE_INIT_LOCKS_GUARD:
         return _TABLE_INIT_LOCKS.setdefault(database_key, RLock())
-
-
-def _is_schedule_name_conflict(error: IntegrityError, table_name: str) -> bool:
-    """Match only the generic or actor-scoped schedule-name indexes."""
-    return str(error.orig) in {
-        f"UNIQUE constraint failed: {table_name}.name",
-        f"UNIQUE constraint failed: {table_name}.owner_actor_id, {table_name}.name",
-    }
 
 
 def _is_in_memory_sqlite_url(db_url: str) -> bool:

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -1,15 +1,31 @@
 import json
 import time
+from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union, cast
+from threading import RLock
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Literal, Optional, Sequence, Set, Tuple, Union, cast
 from uuid import uuid4
 
 if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
 
 from agno.db import mcp_oauth_store
-from agno.db.base import BaseDb, ComponentType, SessionType
+from agno.db.base import (
+    DELETED_CONFIG_STAGE,
+    BaseDb,
+    ComponentAlreadyExistsError,
+    ComponentCycleError,
+    ComponentDependencyError,
+    ComponentDependencyUnavailableError,
+    ComponentDraftRequiredError,
+    ComponentLastConfigError,
+    ComponentProjection,
+    ComponentType,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+    SessionType,
+)
 from agno.db.migrations.manager import MigrationManager
 from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
@@ -23,6 +39,7 @@ from agno.db.schemas.mcp_oauth import (
     MCP_OAUTH_TRANSACTIONS,
 )
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import ScheduleNameConflictError
 from agno.db.schemas.service_accounts import (
     resolve_service_account_sort_column,
     validate_service_account_update,
@@ -62,16 +79,49 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
 
 try:
-    from sqlalchemy import Column, MetaData, String, Table, func, or_, select, text
+    from sqlalchemy import Column, MetaData, String, Table, and_, case, func, or_, select, text
     from sqlalchemy.dialects import sqlite
-    from sqlalchemy.engine import Engine, create_engine
+    from sqlalchemy.engine import Engine, create_engine, make_url
+    from sqlalchemy.exc import IntegrityError
     from sqlalchemy.orm import scoped_session, sessionmaker
+    from sqlalchemy.pool import StaticPool
     from sqlalchemy.schema import ForeignKey, Index, UniqueConstraint
 except ImportError:
     raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
 
 
+_TABLE_INIT_LOCKS_GUARD = RLock()
+_TABLE_INIT_LOCKS: Dict[str, RLock] = {}
+
+
+def _shared_table_init_lock(database_key: str) -> RLock:
+    """Return one in-process lazy-DDL lock for every physical database."""
+    with _TABLE_INIT_LOCKS_GUARD:
+        return _TABLE_INIT_LOCKS.setdefault(database_key, RLock())
+
+
+def _is_schedule_name_conflict(error: IntegrityError, table_name: str) -> bool:
+    """Match only the generic or actor-scoped schedule-name indexes."""
+    return str(error.orig) in {
+        f"UNIQUE constraint failed: {table_name}.name",
+        f"UNIQUE constraint failed: {table_name}.owner_actor_id, {table_name}.name",
+    }
+
+
+def _is_in_memory_sqlite_url(db_url: str) -> bool:
+    """Return whether a SQLite URL addresses an in-process memory database."""
+    try:
+        url = make_url(db_url)
+    except Exception:
+        return False
+    return url.get_backend_name() == "sqlite" and url.database in (None, "", ":memory:")
+
+
 class SqliteDb(BaseDb):
+    supports_component_persistence = True
+    component_catalog_api_version = 2
+    scheduler_api_version = 2
+
     def __init__(
         self,
         db_file: Optional[str] = None,
@@ -114,7 +164,8 @@ class SqliteDb(BaseDb):
 
         Args:
             db_file (Optional[str]): The database file to connect to.
-            db_engine (Optional[Engine]): The SQLAlchemy database engine to use.
+            db_engine (Optional[Engine]): The SQLAlchemy database engine to use. Caller-owned engines are used as-is;
+                in-memory engines need ``StaticPool`` and ``check_same_thread=False`` for worker-thread access.
             db_url (Optional[str]): The database URL to connect to.
             session_table (Optional[str]): Name of the table to store Agent, Team and Workflow sessions.
             runs_table (Optional[str]): Name of the table to store the runs of each session.
@@ -177,7 +228,19 @@ class SqliteDb(BaseDb):
         _engine: Optional[Engine] = db_engine
         if _engine is None:
             if db_url is not None:
-                _engine = create_engine(db_url)
+                if _is_in_memory_sqlite_url(db_url):
+                    # Scheduler sync DB calls run in worker threads. A normal
+                    # in-memory SQLite engine creates one isolated database per
+                    # connection and enforces same-thread access, so configure
+                    # internally-created memory engines as a single shared
+                    # thread-safe connection.
+                    _engine = create_engine(
+                        db_url,
+                        connect_args={"check_same_thread": False},
+                        poolclass=StaticPool,
+                    )
+                else:
+                    _engine = create_engine(db_url)
             elif db_file is not None:
                 db_path = Path(db_file).resolve()
                 db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -194,6 +257,7 @@ class SqliteDb(BaseDb):
         self.db_url: Optional[str] = db_url
         self.db_file: Optional[str] = db_file
         self.metadata: MetaData = MetaData()
+        self._table_init_lock = _shared_table_init_lock(self.db_engine.url.render_as_string(hide_password=True))
 
         # SQLite ignores FOREIGN KEY constraints by default — enable them on
         # every new connection so agno_runs.session_id → sessions.session_id
@@ -452,9 +516,22 @@ class SqliteDb(BaseDb):
             # Create table
             table_created = False
             if not self.table_exists(table_name):
-                table.create(self.db_engine, checkfirst=True)
-                log_debug(f"Successfully created table '{table_name}'")
-                table_created = True
+                try:
+                    table.create(self.db_engine, checkfirst=True)
+                    log_debug(f"Successfully created table '{table_name}'")
+                    table_created = True
+                except Exception:
+                    # The shared lock covers multiple SqliteDb objects in this
+                    # process. A second process can still win between the
+                    # existence check and CREATE, so accept only that exact
+                    # race and validate the table it created.
+                    if not self.table_exists(table_name) or not is_valid_table(
+                        db_engine=self.db_engine,
+                        table_name=table_name,
+                        table_type=table_type,
+                    ):
+                        raise
+                    log_debug(f"Table '{table_name}' was created concurrently")
             else:
                 log_debug(f"Table '{table_name}' already exists, skipping creation")
 
@@ -702,6 +779,18 @@ class SqliteDb(BaseDb):
             raise ValueError(f"Unknown table type: '{table_type}'")
 
     def _get_or_create_table(
+        self,
+        table_name: str,
+        table_type: str,
+        create_table_if_not_found: Optional[bool] = False,
+    ) -> Optional[Table]:
+        # A shared SqliteDb can receive simultaneous first writes from Studio
+        # worker threads. Serialize lazy SQLAlchemy metadata definitions so the
+        # database-level checkfirst path is reached instead of racing in-memory.
+        with self._table_init_lock:
+            return self._get_or_create_table_unlocked(table_name, table_type, create_table_if_not_found)
+
+    def _get_or_create_table_unlocked(
         self,
         table_name: str,
         table_type: str,
@@ -4051,16 +4140,284 @@ class SqliteDb(BaseDb):
             raise e
 
     # --- Components ---
+    @contextmanager
+    def _component_write_session(self) -> Iterator[Any]:
+        """Open a serialized SQLite write transaction for component state."""
+        with self.Session() as sess:
+            sess.connection().exec_driver_sql("BEGIN IMMEDIATE")
+            try:
+                yield sess
+                sess.commit()
+            except Exception:
+                sess.rollback()
+                raise
+
+    @staticmethod
+    def _component_version_state(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        component_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[ComponentVersionGuard]:
+        stmt = select(components_table.c.current_version).where(components_table.c.component_id == component_id)
+        if not include_deleted:
+            stmt = stmt.where(components_table.c.deleted_at.is_(None))
+        component = sess.execute(stmt).fetchone()
+        if component is None:
+            return None
+        latest_version = sess.execute(
+            select(func.max(configs_table.c.version)).where(
+                configs_table.c.component_id == component_id,
+                configs_table.c.stage != DELETED_CONFIG_STAGE,
+            )
+        ).scalar()
+        return ComponentVersionGuard(
+            latest_version=latest_version,
+            current_version=component.current_version,
+        )
+
+    @staticmethod
+    def _check_component_guard(
+        component_id: str,
+        expected: Optional[ComponentVersionGuard],
+        actual: ComponentVersionGuard,
+    ) -> None:
+        if expected is not None and expected != actual:
+            raise ComponentVersionConflictError(component_id, expected=expected, actual=actual)
+
+    @staticmethod
+    def _projection_values(projection: Optional[ComponentProjection]) -> Dict[str, Any]:
+        if projection is None:
+            return {}
+        allowed = {"name", "description", "metadata"}
+        unknown = set(projection) - allowed
+        if unknown:
+            raise ValueError(f"Invalid component projection fields: {sorted(unknown)}")
+        return dict(projection)
+
+    @staticmethod
+    def _validate_component_links(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        links: Optional[List[Dict[str, Any]]],
+        *,
+        require_published: bool,
+    ) -> None:
+        for link in links or []:
+            child_id = link.get("child_component_id")
+            child_version = link.get("child_version")
+            if not child_id or child_version is None:
+                raise ValueError("Each component link requires child_component_id and child_version")
+            child = sess.execute(
+                select(components_table.c.component_type, configs_table.c.stage)
+                .select_from(
+                    components_table.join(
+                        configs_table,
+                        (configs_table.c.component_id == components_table.c.component_id)
+                        & (configs_table.c.version == child_version),
+                    )
+                )
+                .where(
+                    components_table.c.component_id == child_id,
+                    components_table.c.deleted_at.is_(None),
+                    configs_table.c.stage != DELETED_CONFIG_STAGE,
+                )
+            ).fetchone()
+            if child is None:
+                raise ValueError(f"Linked component version not found: {child_id} v{child_version}")
+            if require_published and child.stage != "published":
+                raise ValueError(f"Linked component version is not published: {child_id} v{child_version}")
+
+            expected_type = None
+            link_kind = link.get("link_kind")
+            if link_kind == "step_agent":
+                expected_type = ComponentType.AGENT.value
+            elif link_kind == "step_team":
+                expected_type = ComponentType.TEAM.value
+            elif link_kind == "step_workflow":
+                expected_type = ComponentType.WORKFLOW.value
+            elif link_kind == "member" and isinstance(link.get("meta"), dict):
+                expected_type = link["meta"].get("type")
+            if expected_type is not None and child.component_type != expected_type:
+                raise ValueError(
+                    f"Linked component {child_id} has type {child.component_type}, expected {expected_type}"
+                )
+
+    @staticmethod
+    def _validate_restore_dependencies(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        links_table: Any,
+        component_id: str,
+        version: int,
+    ) -> None:
+        """Require every version reachable from a restored published root to remain runnable."""
+        unavailable: List[Dict[str, Any]] = []
+        unavailable_keys: Set[Tuple[str, int, str, int, str]] = set()
+        seen: Set[Tuple[str, int]] = {(component_id, version)}
+        pending: List[Tuple[str, int]] = [(component_id, version)]
+
+        while pending:
+            parent_id, parent_version = pending.pop()
+            links = sess.execute(
+                select(
+                    links_table.c.child_component_id,
+                    links_table.c.child_version,
+                )
+                .where(
+                    links_table.c.parent_component_id == parent_id,
+                    links_table.c.parent_version == parent_version,
+                )
+                .order_by(links_table.c.child_component_id, links_table.c.child_version)
+            ).fetchall()
+
+            for link in reversed(links):
+                child_id = link.child_component_id
+                child_version = link.child_version
+                child = sess.execute(
+                    select(components_table.c.deleted_at).where(components_table.c.component_id == child_id)
+                ).fetchone()
+
+                reason: Optional[str] = None
+                if child is None:
+                    reason = "component_missing"
+                elif child.deleted_at is not None:
+                    reason = "component_archived"
+                else:
+                    child_stage = sess.execute(
+                        select(configs_table.c.stage).where(
+                            configs_table.c.component_id == child_id,
+                            configs_table.c.version == child_version,
+                        )
+                    ).scalar_one_or_none()
+                    if child_stage is None or child_stage == DELETED_CONFIG_STAGE:
+                        reason = "version_missing"
+                    elif child_stage != "published":
+                        reason = "version_not_published"
+
+                if reason is not None:
+                    unavailable_key = (parent_id, parent_version, child_id, child_version, reason)
+                    if unavailable_key not in unavailable_keys:
+                        unavailable_keys.add(unavailable_key)
+                        unavailable.append(
+                            {
+                                "component_id": child_id,
+                                "version": child_version,
+                                "referenced_by": {
+                                    "component_id": parent_id,
+                                    "version": parent_version,
+                                },
+                                "reason": reason,
+                            }
+                        )
+                    continue
+
+                child_key = (child_id, child_version)
+                if child_key not in seen:
+                    seen.add(child_key)
+                    pending.append(child_key)
+
+        if unavailable:
+            raise ComponentDependencyUnavailableError(component_id, unavailable)
+
+    @staticmethod
+    def _validate_component_acyclic(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        links_table: Any,
+        component_id: str,
+        version: int,
+        links: List[Dict[str, Any]],
+    ) -> None:
+        """Reject a proposed link set that closes a component-level cycle.
+
+        Every visible config of an active component contributes edges to the
+        dependency graph. Treating the graph as component-level prevents two
+        draft versions from creating reciprocal dependencies that would make
+        both components impossible to archive safely.
+        """
+        rows = sess.execute(
+            select(
+                links_table.c.parent_component_id,
+                links_table.c.parent_version,
+                links_table.c.child_component_id,
+            )
+            .select_from(
+                links_table.join(
+                    configs_table,
+                    (configs_table.c.component_id == links_table.c.parent_component_id)
+                    & (configs_table.c.version == links_table.c.parent_version),
+                ).join(
+                    components_table,
+                    components_table.c.component_id == links_table.c.parent_component_id,
+                )
+            )
+            .where(
+                configs_table.c.stage != DELETED_CONFIG_STAGE,
+                components_table.c.deleted_at.is_(None),
+            )
+        ).fetchall()
+
+        adjacency: Dict[str, Set[str]] = {}
+        for row in rows:
+            if row.parent_component_id == component_id and row.parent_version == version:
+                continue
+            adjacency.setdefault(row.parent_component_id, set()).add(row.child_component_id)
+        for link in links:
+            child_id = link.get("child_component_id")
+            if child_id:
+                adjacency.setdefault(component_id, set()).add(child_id)
+
+        seen = {component_id}
+        pending: List[Tuple[str, List[str]]] = [(component_id, [component_id])]
+        while pending:
+            node, path = pending.pop()
+            for child_id in reversed(sorted(adjacency.get(node, set()))):
+                if child_id == component_id:
+                    raise ComponentCycleError(component_id, [*path, child_id])
+                if child_id in seen:
+                    continue
+                seen.add(child_id)
+                pending.append((child_id, [*path, child_id]))
+
+    @staticmethod
+    def _component_dependents(
+        sess: Any,
+        components_table: Any,
+        links_table: Any,
+        component_id: str,
+        *,
+        version: Optional[int] = None,
+        active_parents_only: bool = False,
+    ) -> List[Dict[str, Any]]:
+        stmt = select(links_table).where(links_table.c.child_component_id == component_id)
+        if version is not None:
+            stmt = stmt.where(links_table.c.child_version == version)
+        if active_parents_only:
+            stmt = stmt.join(
+                components_table,
+                components_table.c.component_id == links_table.c.parent_component_id,
+            ).where(components_table.c.deleted_at.is_(None))
+        return [dict(row._mapping) for row in sess.execute(stmt).fetchall()]
+
     def get_component(
         self,
         component_id: str,
         component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Get a component by ID.
 
         Args:
             component_id: The component ID.
             component_type: Optional type filter (agent|team|workflow).
+            include_deleted: Include a soft-deleted component in the lookup.
 
         Returns:
             Component dictionary or None if not found.
@@ -4071,10 +4428,9 @@ class SqliteDb(BaseDb):
                 return None
 
             with self.Session() as sess:
-                stmt = select(table).where(
-                    table.c.component_id == component_id,
-                    table.c.deleted_at.is_(None),
-                )
+                stmt = select(table).where(table.c.component_id == component_id)
+                if not include_deleted:
+                    stmt = stmt.where(table.c.deleted_at.is_(None))
                 if component_type is not None:
                     stmt = stmt.where(table.c.component_type == component_type.value)
 
@@ -4083,6 +4439,36 @@ class SqliteDb(BaseDb):
 
         except Exception as e:
             log_error(f"Error getting component: {str(e)}")
+            raise
+
+    def get_components(
+        self,
+        component_ids: Set[str],
+        component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Get a bounded set of component rows in one query."""
+        if not component_ids:
+            return []
+        try:
+            table = getattr(self, "components_table", None)
+            if table is None:
+                table = self._get_table(table_type="components")
+            if table is None:
+                return []
+
+            with self.Session() as sess:
+                stmt = select(table).where(table.c.component_id.in_(component_ids))
+                if not include_deleted:
+                    stmt = stmt.where(table.c.deleted_at.is_(None))
+                if component_type is not None:
+                    stmt = stmt.where(table.c.component_type == component_type.value)
+                stmt = stmt.order_by(table.c.component_id)
+                return [dict(row._mapping) for row in sess.execute(stmt).fetchall()]
+
+        except Exception as e:
+            log_error(f"Error getting components: {str(e)}")
             raise
 
     def upsert_component(
@@ -4101,32 +4487,41 @@ class SqliteDb(BaseDb):
             component_type: Type (agent|team|workflow). Required for create, optional for update.
             name: Display name.
             description: Optional description.
-            current_version: Optional current version.
+            current_version: Reserved. Use set_current_version for guarded,
+                projection-synchronized current-pointer changes.
             metadata: Optional metadata dict.
 
         Returns:
             Created/updated component dictionary.
 
         Raises:
-            ValueError: If creating and component_type is not provided.
+            ValueError: If creating and component_type is not provided, or if
+                current_version is supplied.
         """
+        if current_version is not None:
+            raise ValueError("current_version can only be changed with set_current_version")
+
         try:
             table = self._get_table(table_type="components", create_table_if_not_found=True)
             if table is None:
                 raise ValueError("Components table not found")
 
-            with self.Session() as sess, sess.begin():
+            with self._component_write_session() as sess:
+                requested_type = (
+                    component_type.value
+                    if component_type is not None and hasattr(component_type, "value")
+                    else component_type
+                )
                 existing = sess.execute(select(table).where(table.c.component_id == component_id)).fetchone()
 
                 if existing is None:
                     # Create new component
                     if component_type is None:
                         raise ValueError("component_type is required when creating a new component")
-
                     sess.execute(
                         table.insert().values(
                             component_id=component_id,
-                            component_type=component_type.value if hasattr(component_type, "value") else component_type,
+                            component_type=requested_type,
                             name=name or component_id,
                             description=description,
                             current_version=None,
@@ -4137,47 +4532,35 @@ class SqliteDb(BaseDb):
                     log_debug(f"Created component {component_id}")
 
                 elif existing.deleted_at is not None:
-                    # Reactivate soft-deleted
-                    if component_type is None:
-                        raise ValueError("component_type is required when reactivating a deleted component")
-
-                    sess.execute(
-                        table.update()
-                        .where(table.c.component_id == component_id)
-                        .values(
-                            component_type=component_type.value if hasattr(component_type, "value") else component_type,
-                            name=name or component_id,
-                            description=description,
-                            current_version=None,
-                            metadata=metadata,
-                            updated_at=int(time.time()),
-                            deleted_at=None,
-                        )
-                    )
-                    log_debug(f"Reactivated component {component_id}")
+                    raise ValueError(f"Component {component_id} is archived and remains reserved")
 
                 else:
                     # Update existing
-                    updates: Dict[str, Any] = {"updated_at": int(time.time())}
-                    if component_type is not None:
-                        updates["component_type"] = (
-                            component_type.value if hasattr(component_type, "value") else component_type
+                    if requested_type is not None and requested_type != existing.component_type:
+                        raise ValueError(
+                            f"Component {component_id} has type {existing.component_type}, not {requested_type}"
                         )
+                    updates: Dict[str, Any] = {"updated_at": int(time.time())}
                     if name is not None:
                         updates["name"] = name
                     if description is not None:
                         updates["description"] = description
-                    if current_version is not None:
-                        updates["current_version"] = current_version
                     if metadata is not None:
                         updates["metadata"] = metadata
 
                     sess.execute(table.update().where(table.c.component_id == component_id).values(**updates))
                     log_debug(f"Updated component {component_id}")
 
-            result = self.get_component(component_id)
-            if result is None:
-                raise ValueError(f"Failed to get component {component_id} after upsert")
+                result_row = sess.execute(
+                    select(table).where(
+                        table.c.component_id == component_id,
+                        table.c.deleted_at.is_(None),
+                    )
+                ).fetchone()
+                if result_row is None:
+                    raise ValueError(f"Failed to get component {component_id} during upsert")
+                result = dict(result_row._mapping)
+
             return result
 
         except Exception as e:
@@ -4188,12 +4571,21 @@ class SqliteDb(BaseDb):
         self,
         component_id: str,
         hard_delete: bool = False,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        require_no_dependents: bool = True,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Delete a component and all its configs/links.
 
         Args:
             component_id: The component ID.
             hard_delete: If True, permanently delete. Otherwise soft-delete.
+            guard: Optional expected latest/current version state.
+            require_no_dependents: Refuse deletion while referenced (the safe
+                default). Soft deletion considers active parents; hard deletion
+                considers every parent.
+            projection: Component fields to update atomically with a soft deletion.
 
         Returns:
             True if deleted, False if not found.
@@ -4206,7 +4598,42 @@ class SqliteDb(BaseDb):
             if components_table is None:
                 return False
 
-            with self.Session() as sess, sess.begin():
+            if hard_delete and projection is not None:
+                raise ValueError("projection is not supported for hard delete")
+
+            with self._component_write_session() as sess:
+                existing = sess.execute(
+                    select(components_table.c.component_id, components_table.c.current_version).where(
+                        components_table.c.component_id == component_id,
+                        *([] if hard_delete else [components_table.c.deleted_at.is_(None)]),
+                    )
+                ).fetchone()
+                if existing is None:
+                    return False
+
+                if configs_table is not None:
+                    actual = self._component_version_state(
+                        sess,
+                        components_table,
+                        configs_table,
+                        component_id,
+                        include_deleted=hard_delete,
+                    )
+                    if actual is None:
+                        return False
+                    self._check_component_guard(component_id, guard, actual)
+
+                if require_no_dependents and links_table is not None:
+                    dependents = self._component_dependents(
+                        sess,
+                        components_table,
+                        links_table,
+                        component_id,
+                        active_parents_only=not hard_delete,
+                    )
+                    if dependents:
+                        raise ComponentDependencyError(component_id, dependents)
+
                 if hard_delete:
                     # Delete links where this component is parent or child
                     if links_table is not None:
@@ -4220,18 +4647,82 @@ class SqliteDb(BaseDb):
                         components_table.delete().where(components_table.c.component_id == component_id)
                     )
                 else:
-                    # Soft delete
                     now = int(time.time())
+                    updates: Dict[str, Any] = {"deleted_at": now, "updated_at": now}
+                    updates.update(self._projection_values(projection))
                     result = sess.execute(
                         components_table.update()
-                        .where(components_table.c.component_id == component_id)
-                        .values(deleted_at=now)
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                        .values(**updates)
                     )
 
             return result.rowcount > 0
 
         except Exception as e:
             log_error(f"Error deleting component: {str(e)}")
+            raise
+
+    def restore_component(
+        self,
+        component_id: str,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+    ) -> bool:
+        """Restore one archived component with an optional CAS guard."""
+        try:
+            components_table = self._get_table(table_type="components")
+            configs_table = self._get_table(table_type="component_configs")
+            links_table = self._get_table(table_type="component_links")
+            if components_table is None or configs_table is None:
+                return False
+
+            with self._component_write_session() as sess:
+                actual = self._component_version_state(
+                    sess,
+                    components_table,
+                    configs_table,
+                    component_id,
+                    include_deleted=True,
+                )
+                if actual is None:
+                    return False
+                archived = sess.execute(
+                    select(components_table.c.deleted_at).where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_not(None),
+                    )
+                ).fetchone()
+                if archived is None:
+                    return False
+                self._check_component_guard(component_id, guard, actual)
+                if actual.current_version is not None and links_table is not None:
+                    self._validate_restore_dependencies(
+                        sess,
+                        components_table,
+                        configs_table,
+                        links_table,
+                        component_id,
+                        actual.current_version,
+                    )
+
+                updates: Dict[str, Any] = {"deleted_at": None, "updated_at": int(time.time())}
+                updates.update(self._projection_values(projection))
+                result = sess.execute(
+                    components_table.update()
+                    .where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_not(None),
+                    )
+                    .values(**updates)
+                )
+                return result.rowcount > 0
+
+        except Exception as e:
+            log_error(f"Error restoring component: {str(e)}")
             raise
 
     def list_components(
@@ -4348,14 +4839,14 @@ class SqliteDb(BaseDb):
             if configs_table is None:
                 raise ValueError("Component configs table not found")
 
-            with self.Session() as sess, sess.begin():
+            with self._component_write_session() as sess:
                 # Check if component already exists
                 existing = sess.execute(
                     select(components_table.c.component_id).where(components_table.c.component_id == component_id)
                 ).scalar_one_or_none()
 
                 if existing is not None:
-                    raise ValueError(f"Component {component_id} already exists")
+                    raise ComponentAlreadyExistsError(component_id)
 
                 # Check label uniqueness
                 if label is not None:
@@ -4370,6 +4861,25 @@ class SqliteDb(BaseDb):
 
                 now = int(time.time())
                 version = 1
+
+                if links is not None and links_table is not None:
+                    self._validate_component_acyclic(
+                        sess,
+                        components_table,
+                        configs_table,
+                        links_table,
+                        component_id,
+                        version,
+                        links,
+                    )
+
+                self._validate_component_links(
+                    sess,
+                    components_table,
+                    configs_table,
+                    links,
+                    require_published=stage == "published",
+                )
 
                 # Create component
                 sess.execute(
@@ -4414,14 +4924,25 @@ class SqliteDb(BaseDb):
                             )
                         )
 
-            # Fetch and return both
-            component = self.get_component(component_id)
-            config_result = self.get_config(component_id, version=version)
-
-            if component is None:
-                raise ValueError(f"Failed to get component {component_id} after creation")
-            if config_result is None:
-                raise ValueError(f"Failed to get config for {component_id} after creation")
+                component_row = sess.execute(
+                    select(components_table).where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_(None),
+                    )
+                ).fetchone()
+                config_row = sess.execute(
+                    select(configs_table).where(
+                        configs_table.c.component_id == component_id,
+                        configs_table.c.version == version,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    )
+                ).fetchone()
+                if component_row is None:
+                    raise ValueError(f"Failed to get component {component_id} during creation")
+                if config_row is None:
+                    raise ValueError(f"Failed to get config for {component_id} during creation")
+                component = dict(component_row._mapping)
+                config_result = dict(config_row._mapping)
 
             return component, config_result
 
@@ -4440,7 +4961,9 @@ class SqliteDb(BaseDb):
 
         Args:
             component_id: The component ID.
-            version: Specific version number. If None, uses current or latest draft.
+            version: Specific version number. If omitted with no label, uses
+                the current published version or the latest draft when the
+                component has never been published.
             label: Config label to lookup. Ignored if version is provided.
 
         Returns:
@@ -4488,7 +5011,6 @@ class SqliteDb(BaseDb):
                         configs_table.c.version == current_version,
                     )
                 else:
-                    # No current_version set (draft only) - get the latest version
                     stmt = (
                         select(configs_table)
                         .where(configs_table.c.component_id == component_id)
@@ -4496,11 +5018,137 @@ class SqliteDb(BaseDb):
                         .limit(1)
                     )
 
+                stmt = stmt.where(configs_table.c.stage != DELETED_CONFIG_STAGE)
                 result = sess.execute(stmt).fetchone()
                 return dict(result._mapping) if result else None
 
         except Exception as e:
             log_error(f"Error getting config: {str(e)}")
+            raise
+
+    def get_current_config(self, component_id: str) -> Optional[Dict[str, Any]]:
+        """Get only the current published config for an active component."""
+        try:
+            configs_table = self._get_table(table_type="component_configs")
+            components_table = self._get_table(table_type="components")
+            if configs_table is None or components_table is None:
+                return None
+
+            with self.Session() as sess:
+                row = sess.execute(
+                    select(configs_table)
+                    .select_from(
+                        components_table.join(
+                            configs_table,
+                            (configs_table.c.component_id == components_table.c.component_id)
+                            & (configs_table.c.version == components_table.c.current_version),
+                        )
+                    )
+                    .where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_(None),
+                        configs_table.c.stage == "published",
+                    )
+                ).fetchone()
+                return dict(row._mapping) if row else None
+
+        except Exception as e:
+            log_error(f"Error getting current config: {str(e)}")
+            raise
+
+    def get_latest_config(
+        self,
+        component_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Get the latest visible config, optionally for an archived component."""
+        try:
+            configs_table = self._get_table(table_type="component_configs")
+            components_table = self._get_table(table_type="components")
+            if configs_table is None or components_table is None:
+                return None
+
+            with self.Session() as sess:
+                component_stmt = select(components_table.c.component_id).where(
+                    components_table.c.component_id == component_id
+                )
+                if not include_deleted:
+                    component_stmt = component_stmt.where(components_table.c.deleted_at.is_(None))
+                if sess.execute(component_stmt).fetchone() is None:
+                    return None
+
+                row = sess.execute(
+                    select(configs_table)
+                    .where(
+                        configs_table.c.component_id == component_id,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    )
+                    .order_by(configs_table.c.version.desc())
+                    .limit(1)
+                ).fetchone()
+                return dict(row._mapping) if row else None
+
+        except Exception as e:
+            log_error(f"Error getting latest config: {str(e)}")
+            raise
+
+    def get_latest_configs(
+        self,
+        component_ids: Set[str],
+        *,
+        include_deleted: bool = False,
+    ) -> Dict[str, Optional[Dict[str, Any]]]:
+        """Get one latest visible config per requested component in one query."""
+        if not component_ids:
+            return {}
+        try:
+            configs_table = getattr(self, "component_configs_table", None)
+            if configs_table is None:
+                configs_table = self._get_table(table_type="component_configs")
+            components_table = getattr(self, "components_table", None)
+            if components_table is None:
+                components_table = self._get_table(table_type="components")
+            if configs_table is None or components_table is None:
+                return {component_id: None for component_id in component_ids}
+
+            latest_versions = (
+                select(
+                    configs_table.c.component_id,
+                    func.max(configs_table.c.version).label("latest_version"),
+                )
+                .where(
+                    configs_table.c.component_id.in_(component_ids),
+                    configs_table.c.stage != DELETED_CONFIG_STAGE,
+                )
+                .group_by(configs_table.c.component_id)
+                .subquery()
+            )
+            with self.Session() as sess:
+                stmt = (
+                    select(configs_table)
+                    .select_from(
+                        configs_table.join(
+                            latest_versions,
+                            (configs_table.c.component_id == latest_versions.c.component_id)
+                            & (configs_table.c.version == latest_versions.c.latest_version),
+                        ).join(
+                            components_table,
+                            components_table.c.component_id == configs_table.c.component_id,
+                        )
+                    )
+                    .where(components_table.c.component_id.in_(component_ids))
+                )
+                if not include_deleted:
+                    stmt = stmt.where(components_table.c.deleted_at.is_(None))
+                result: Dict[str, Optional[Dict[str, Any]]] = {component_id: None for component_id in component_ids}
+                for row in sess.execute(stmt).fetchall():
+                    config_row = dict(row._mapping)
+                    result[config_row["component_id"]] = config_row
+                return result
+
+        except Exception as e:
+            log_error(f"Error getting latest configs: {str(e)}")
             raise
 
     def upsert_config(
@@ -4512,22 +5160,36 @@ class SqliteDb(BaseDb):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+        restore_if_deleted: bool = False,
+        expected_component_type: Optional[ComponentType] = None,
     ) -> Dict[str, Any]:
         """Create or update a config version for a component.
 
         Rules:
-            - Draft configs can be edited freely
+            - Stored config versions are immutable
+            - The latest draft may transition to published with a guard
             - Published configs are immutable
             - Publishing a config automatically sets it as current_version
 
         Args:
             component_id: The component ID.
-            config: The config data. Required for create, optional for update.
-            version: If None, creates new version. If provided, updates that version.
+            config: The config data. Required when appending a version.
+            version: If None, appends a version. If provided, publishes that draft.
             label: Optional human-readable label.
             stage: "draft" or "published". Defaults to "draft" for new configs.
             notes: Optional notes.
             links: Optional list of links. Each link must have child_version set.
+            guard: Optional expected latest/current version state. Guarded writes
+                append a version or publish the latest draft; they never edit a draft in place.
+            projection: Component fields to update atomically when publishing.
+                When omitted, they are derived from the target config.
+            restore_if_deleted: Restore an archived component in the same
+                transaction as this config mutation.
+            expected_component_type: Optional component type to validate under
+                the component write lock.
 
         Returns:
             Created/updated config dictionary.
@@ -4549,23 +5211,40 @@ class SqliteDb(BaseDb):
             if configs_table is None:
                 raise ValueError("Component configs table not found")
 
-            with self.Session() as sess, sess.begin():
-                # Verify component exists and is not deleted
-                component = sess.execute(
-                    select(components_table.c.component_id).where(
-                        components_table.c.component_id == component_id,
-                        components_table.c.deleted_at.is_(None),
-                    )
-                ).fetchone()
-
-                if component is None:
+            with self._component_write_session() as sess:
+                actual = self._component_version_state(
+                    sess,
+                    components_table,
+                    configs_table,
+                    component_id,
+                    include_deleted=restore_if_deleted,
+                )
+                if actual is None:
                     raise ValueError(f"Component {component_id} not found")
+                self._check_component_guard(component_id, guard, actual)
+                is_archived = False
+                if restore_if_deleted:
+                    is_archived = (
+                        sess.execute(
+                            select(components_table.c.deleted_at).where(components_table.c.component_id == component_id)
+                        ).scalar_one()
+                        is not None
+                    )
+                if expected_component_type is not None:
+                    actual_type = sess.execute(
+                        select(components_table.c.component_type).where(components_table.c.component_id == component_id)
+                    ).scalar_one()
+                    if actual_type != expected_component_type.value:
+                        raise ValueError(
+                            f"Component {component_id} has type {actual_type}, not {expected_component_type.value}"
+                        )
 
                 # Label uniqueness check
                 if label is not None:
                     label_query = select(configs_table.c.version).where(
                         configs_table.c.component_id == component_id,
                         configs_table.c.label == label,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
                     )
                     if version is not None:
                         label_query = label_query.where(configs_table.c.version != version)
@@ -4573,65 +5252,62 @@ class SqliteDb(BaseDb):
                     if sess.execute(label_query).first():
                         raise ValueError(f"Label '{label}' already exists for {component_id}")
 
-                # Validate links have child_version
-                if links:
-                    for link in links:
-                        if link.get("child_version") is None:
-                            raise ValueError(f"child_version is required for link to {link['child_component_id']}")
-
                 if version is None:
                     if config is None:
                         raise ValueError("config is required when creating a new version")
 
-                    # Default to draft for new configs
-                    if stage is None:
-                        stage = "draft"
-
-                    max_version = sess.execute(
-                        select(configs_table.c.version)
-                        .where(configs_table.c.component_id == component_id)
-                        .order_by(configs_table.c.version.desc())
-                        .limit(1)
+                    final_stage = stage or "draft"
+                    target_config = config
+                    high_water = sess.execute(
+                        select(func.max(configs_table.c.version)).where(configs_table.c.component_id == component_id)
                     ).scalar()
-
-                    final_version = (max_version or 0) + 1
+                    final_version = (high_water or 0) + 1
 
                     sess.execute(
                         configs_table.insert().values(
                             component_id=component_id,
                             version=final_version,
                             label=label,
-                            stage=stage,
+                            stage=final_stage,
                             config=config,
                             notes=notes,
                             created_at=int(time.time()),
                         )
                     )
                 else:
-                    existing = sess.execute(
-                        select(configs_table.c.version, configs_table.c.stage).where(
-                            configs_table.c.component_id == component_id,
-                            configs_table.c.version == version,
+                    existing = (
+                        sess.execute(
+                            select(configs_table.c.version, configs_table.c.stage, configs_table.c.config).where(
+                                configs_table.c.component_id == component_id,
+                                configs_table.c.version == version,
+                            )
                         )
-                    ).fetchone()
+                        .mappings()
+                        .one_or_none()
+                    )
 
                     if existing is None:
                         raise ValueError(f"Config {component_id} v{version} not found")
 
-                    # Published configs are immutable
-                    if existing.stage == "published":
+                    if existing["stage"] == DELETED_CONFIG_STAGE:
+                        raise ValueError(f"Config {component_id} v{version} not found")
+
+                    if existing["stage"] == "published":
                         raise ValueError(f"Cannot update published config {component_id} v{version}")
 
-                    # Build update dict with only provided fields
-                    updates: Dict[str, Any] = {"updated_at": int(time.time())}
-                    if label is not None:
-                        updates["label"] = label
-                    if stage is not None:
-                        updates["stage"] = stage
-                    if config is not None:
-                        updates["config"] = config
-                    if notes is not None:
-                        updates["notes"] = notes
+                    if guard is None:
+                        raise ValueError("Publishing an existing draft requires a component version guard")
+                    if version != actual.latest_version:
+                        raise ValueError("A guarded publish can only target the latest config version")
+                    if stage != "published":
+                        raise ValueError("An existing config version is immutable; only guarded publication is allowed")
+                    if any(value is not None for value in (config, label, notes)):
+                        raise ValueError("A guarded publish cannot mutate config, label, or notes")
+
+                    target_config = existing["config"]
+                    if not isinstance(target_config, dict):
+                        raise ValueError(f"Config {component_id} v{version} payload must be an object")
+                    final_stage = "published"
 
                     sess.execute(
                         configs_table.update()
@@ -4639,9 +5315,38 @@ class SqliteDb(BaseDb):
                             configs_table.c.component_id == component_id,
                             configs_table.c.version == version,
                         )
-                        .values(**updates)
+                        .values(stage="published", updated_at=int(time.time()))
                     )
                     final_version = version
+
+                links_to_validate = links
+                if final_stage == "published" and links_to_validate is None and links_table is not None:
+                    links_to_validate = [
+                        dict(row._mapping)
+                        for row in sess.execute(
+                            select(links_table).where(
+                                links_table.c.parent_component_id == component_id,
+                                links_table.c.parent_version == final_version,
+                            )
+                        ).fetchall()
+                    ]
+                if links_to_validate is not None and links_table is not None:
+                    self._validate_component_acyclic(
+                        sess,
+                        components_table,
+                        configs_table,
+                        links_table,
+                        component_id,
+                        final_version,
+                        links_to_validate,
+                    )
+                self._validate_component_links(
+                    sess,
+                    components_table,
+                    configs_table,
+                    links_to_validate,
+                    require_published=final_stage == "published",
+                )
 
                 if links is not None and links_table is not None:
                     sess.execute(
@@ -4665,19 +5370,72 @@ class SqliteDb(BaseDb):
                             )
                         )
 
-                # Determine final stage (could be from update or create)
-                final_stage = stage if stage is not None else (existing.stage if version is not None else "draft")
-
-                if final_stage == "published":
+                if restore_if_deleted and is_archived:
+                    restored_version = final_version if final_stage == "published" else actual.current_version
+                    if restored_version is not None and links_table is not None:
+                        self._validate_restore_dependencies(
+                            sess,
+                            components_table,
+                            configs_table,
+                            links_table,
+                            component_id,
+                            restored_version,
+                        )
+                    # Reactivation is part of this write transaction. Any
+                    # label, graph, projection, or config failure rolls it back
+                    # together with the attempted config append.
                     sess.execute(
                         components_table.update()
                         .where(components_table.c.component_id == component_id)
-                        .values(current_version=final_version, updated_at=int(time.time()))
+                        .values(deleted_at=None, updated_at=int(time.time()))
                     )
 
-            result = self.get_config(component_id, version=final_version)
-            if result is None:
-                raise ValueError(f"Failed to get config {component_id} v{final_version} after upsert")
+                if final_stage == "published":
+                    effective_projection = projection
+                    if effective_projection is None:
+                        effective_projection = self._projection_from_config(target_config)
+                    component_updates: Dict[str, Any] = {
+                        "current_version": final_version,
+                        "updated_at": int(time.time()),
+                    }
+                    component_updates.update(self._projection_values(effective_projection))
+                    sess.execute(
+                        components_table.update()
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                        .values(**component_updates)
+                    )
+                elif projection is not None:
+                    # Before the first publication the component row is a
+                    # projection of the latest draft. The conditional update
+                    # makes a projection based on a stale pre-write read safe:
+                    # a concurrent publication wins without rejecting the
+                    # otherwise valid draft append.
+                    component_updates = {"updated_at": int(time.time())}
+                    component_updates.update(self._projection_values(projection))
+                    sess.execute(
+                        components_table.update()
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                            components_table.c.current_version.is_(None),
+                        )
+                        .values(**component_updates)
+                    )
+
+                result_row = sess.execute(
+                    select(configs_table).where(
+                        configs_table.c.component_id == component_id,
+                        configs_table.c.version == final_version,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    )
+                ).fetchone()
+                if result_row is None:
+                    raise ValueError(f"Failed to get config {component_id} v{final_version} during upsert")
+                result = dict(result_row._mapping)
+
             return result
 
         except Exception as e:
@@ -4688,6 +5446,9 @@ class SqliteDb(BaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Delete a specific config version.
 
@@ -4697,12 +5458,15 @@ class SqliteDb(BaseDb):
         Args:
             component_id: The component ID.
             version: The version to delete.
+            guard: Optional expected latest/current version state.
+            projection: Component fields to update atomically with deletion.
 
         Returns:
             True if deleted, False if not found.
 
         Raises:
-            ValueError: If attempting to delete a published or current config.
+            ComponentDraftRequiredError: If attempting to delete a published config.
+            ValueError: If attempting to delete the current config.
         """
         try:
             configs_table = self._get_table(table_type="component_configs")
@@ -4712,8 +5476,12 @@ class SqliteDb(BaseDb):
             if configs_table is None or components_table is None:
                 return False
 
-            with self.Session() as sess, sess.begin():
-                # Get config stage and check if it's current
+            with self._component_write_session() as sess:
+                actual = self._component_version_state(sess, components_table, configs_table, component_id)
+                if actual is None:
+                    return False
+                self._check_component_guard(component_id, guard, actual)
+
                 config_row = sess.execute(
                     select(configs_table.c.stage).where(
                         configs_table.c.component_id == component_id,
@@ -4724,15 +5492,36 @@ class SqliteDb(BaseDb):
                 if config_row is None:
                     return False
 
-                # Check if it's current version
-                current = sess.execute(
-                    select(components_table.c.current_version).where(components_table.c.component_id == component_id)
-                ).fetchone()
+                if config_row.stage == DELETED_CONFIG_STAGE:
+                    return False
+                if config_row.stage == "published":
+                    raise ComponentDraftRequiredError(component_id, version)
 
-                if current and current.current_version == version:
+                if actual.current_version == version:
                     raise ValueError(f"Cannot delete current config {component_id} v{version}")
 
-                # Delete associated links
+                if links_table is not None:
+                    dependents = self._component_dependents(
+                        sess,
+                        components_table,
+                        links_table,
+                        component_id,
+                        version=version,
+                    )
+                    if dependents:
+                        raise ComponentDependencyError(component_id, dependents, version=version)
+
+                visible_count = sess.execute(
+                    select(func.count())
+                    .select_from(configs_table)
+                    .where(
+                        configs_table.c.component_id == component_id,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    )
+                ).scalar_one()
+                if visible_count <= 1:
+                    raise ComponentLastConfigError(component_id, version)
+
                 if links_table is not None:
                     sess.execute(
                         links_table.delete().where(
@@ -4741,13 +5530,35 @@ class SqliteDb(BaseDb):
                         )
                     )
 
-                # Delete the config
+                # Keep a hidden tombstone so this version number is never
+                # reused by a later draft (which would create an ABA hole for
+                # stale publish commands).
                 sess.execute(
-                    configs_table.delete().where(
+                    configs_table.update()
+                    .where(
                         configs_table.c.component_id == component_id,
                         configs_table.c.version == version,
                     )
+                    .values(
+                        label=None,
+                        stage=DELETED_CONFIG_STAGE,
+                        config={},
+                        notes=None,
+                        updated_at=int(time.time()),
+                    )
                 )
+
+                component_updates = self._projection_values(projection)
+                if component_updates:
+                    component_updates["updated_at"] = int(time.time())
+                    sess.execute(
+                        components_table.update()
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                        .values(**component_updates)
+                    )
 
             return True
 
@@ -4803,7 +5614,10 @@ class SqliteDb(BaseDb):
                         configs_table.c.updated_at,
                     )
 
-                stmt = stmt.where(configs_table.c.component_id == component_id).order_by(configs_table.c.version.desc())
+                stmt = stmt.where(
+                    configs_table.c.component_id == component_id,
+                    configs_table.c.stage != DELETED_CONFIG_STAGE,
+                ).order_by(configs_table.c.version.desc())
 
                 results = sess.execute(stmt).fetchall()
                 return [dict(row._mapping) for row in results]
@@ -4816,6 +5630,9 @@ class SqliteDb(BaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Set a specific published version as current.
 
@@ -4826,6 +5643,9 @@ class SqliteDb(BaseDb):
         Args:
             component_id: The component ID.
             version: The version to set as current (must be published).
+            guard: Optional expected latest/current version state.
+            projection: Component fields to update atomically with the current pointer.
+                When omitted, they are derived from the target config.
 
         Returns:
             True if successful, False if component or version not found.
@@ -4840,41 +5660,55 @@ class SqliteDb(BaseDb):
             if configs_table is None or components_table is None:
                 return False
 
-            with self.Session() as sess, sess.begin():
-                # Verify component exists and is not deleted
-                component_exists = sess.execute(
-                    select(components_table.c.component_id).where(
-                        components_table.c.component_id == component_id,
-                        components_table.c.deleted_at.is_(None),
-                    )
-                ).fetchone()
-
-                if component_exists is None:
+            with self._component_write_session() as sess:
+                actual = self._component_version_state(sess, components_table, configs_table, component_id)
+                if actual is None:
                     return False
+                self._check_component_guard(component_id, guard, actual)
 
-                # Verify version exists and get stage
-                stage = sess.execute(
-                    select(configs_table.c.stage).where(
-                        configs_table.c.component_id == component_id,
-                        configs_table.c.version == version,
+                # Read the target payload in the same serialized transaction as
+                # the pointer update so an omitted projection can be derived
+                # from the exact version becoming current.
+                target = (
+                    sess.execute(
+                        select(configs_table.c.stage, configs_table.c.config).where(
+                            configs_table.c.component_id == component_id,
+                            configs_table.c.version == version,
+                        )
                     )
-                ).fetchone()
+                    .mappings()
+                    .one_or_none()
+                )
 
-                if stage is None:
+                if target is None:
                     return False
 
                 # Only published configs can be set as current
-                if stage.stage != "published":
+                if target["stage"] != "published":
                     raise ValueError(
                         f"Cannot set draft config {component_id} v{version} as current. "
                         "Only published configs can be current."
                     )
 
-                # Update pointer
+                effective_projection = projection
+                if effective_projection is None:
+                    target_config = target["config"]
+                    if not isinstance(target_config, dict):
+                        raise ValueError(f"Config {component_id} v{version} payload must be an object")
+                    effective_projection = self._projection_from_config(target_config)
+
+                updates: Dict[str, Any] = {
+                    "current_version": version,
+                    "updated_at": int(time.time()),
+                }
+                updates.update(self._projection_values(effective_projection))
                 sess.execute(
                     components_table.update()
-                    .where(components_table.c.component_id == component_id)
-                    .values(current_version=version, updated_at=int(time.time()))
+                    .where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_(None),
+                    )
+                    .values(**updates)
                 )
 
             log_debug(f"Set {component_id} current version to {version}")
@@ -4929,28 +5763,34 @@ class SqliteDb(BaseDb):
         self,
         component_id: str,
         version: Optional[int] = None,
+        *,
+        active_parents_only: bool = False,
     ) -> List[Dict[str, Any]]:
         """Find all components that reference this component.
 
         Args:
             component_id: The component ID to find dependents of.
             version: Optional specific version. If None, finds links to any version.
+            active_parents_only: Exclude links owned by soft-deleted parents.
 
         Returns:
             List of link dictionaries showing what depends on this component.
         """
         try:
-            table = self._get_table(table_type="component_links")
-            if table is None:
+            links_table = self._get_table(table_type="component_links")
+            components_table = self._get_table(table_type="components")
+            if links_table is None or components_table is None:
                 return []
 
             with self.Session() as sess:
-                stmt = select(table).where(table.c.child_component_id == component_id)
-                if version is not None:
-                    stmt = stmt.where(table.c.child_version == version)
-
-                results = sess.execute(stmt).fetchall()
-                return [dict(row._mapping) for row in results]
+                return self._component_dependents(
+                    sess,
+                    components_table,
+                    links_table,
+                    component_id,
+                    version=version,
+                    active_parents_only=active_parents_only,
+                )
 
         except Exception as e:
             log_error(f"Error getting dependents: {str(e)}")
@@ -4961,11 +5801,11 @@ class SqliteDb(BaseDb):
         component_id: str,
         version: Optional[int],
     ) -> Optional[int]:
-        """Resolve a version number, handling NULL (current) case.
+        """Resolve an explicit version or the component's generic readable head.
 
         Args:
             component_id: The component ID.
-            version: Version number or None for current.
+            version: Version number or None for current/latest-draft fallback.
 
         Returns:
             Resolved version number or None if component not found.
@@ -4974,15 +5814,9 @@ class SqliteDb(BaseDb):
             return version
 
         try:
-            components_table = self._get_table(table_type="components")
-            if components_table is None:
-                return None
-
-            with self.Session() as sess:
-                result = sess.execute(
-                    select(components_table.c.current_version).where(components_table.c.component_id == component_id)
-                ).scalar()
-                return result
+            config = self.get_config(component_id)
+            resolved = config.get("version") if config is not None else None
+            return resolved if isinstance(resolved, int) else None
 
         except Exception as e:
             log_error(f"Error resolving version: {str(e)}")
@@ -5010,8 +5844,14 @@ class SqliteDb(BaseDb):
             if component is None:
                 return None
 
-            # Resolve version
-            resolved_version = self.resolve_version(component_id, version)
+            # Resolve version. A label is an explicit catalog read; otherwise
+            # use the generic current/latest-draft semantics.
+            if version is None and label is not None:
+                labeled = self.get_config(component_id, label=label)
+                resolved = labeled.get("version") if labeled is not None else None
+                resolved_version = resolved if isinstance(resolved, int) else None
+            else:
+                resolved_version = self.resolve_version(component_id, version)
             if resolved_version is None:
                 return None
 
@@ -5517,27 +6357,42 @@ class SqliteDb(BaseDb):
             with self.Session() as sess:
                 result = sess.execute(select(table).where(table.c.id == schedule_id)).fetchone()
                 return dict(result._mapping) if result else None
-        except Exception as e:
-            log_debug(f"Error getting schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule")
+            raise
 
-    def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
+    def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         try:
             table = self._get_table(table_type="schedules")
             if table is None:
                 return None
             with self.Session() as sess:
-                result = sess.execute(select(table).where(table.c.name == name)).fetchone()
+                query = select(table).where(table.c.name == name)
+                if managed_by is not None:
+                    query = query.where(table.c.managed_by == managed_by)
+                if owner_actor_id is not None:
+                    query = query.where(table.c.owner_actor_id == owner_actor_id)
+                if exclude_managed_by is not None:
+                    query = query.where(or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by))
+                result = sess.execute(query).fetchone()
                 return dict(result._mapping) if result else None
-        except Exception as e:
-            log_debug(f"Error getting schedule by name: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule by name")
+            raise
 
     def get_schedules(
         self,
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = self._get_table(table_type="schedules")
@@ -5548,6 +6403,10 @@ class SqliteDb(BaseDb):
                 base_query = select(table)
                 if enabled is not None:
                     base_query = base_query.where(table.c.enabled == enabled)
+                if exclude_managed_by is not None:
+                    base_query = base_query.where(
+                        or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by)
+                    )
 
                 # Get total count
                 count_stmt = select(func.count()).select_from(base_query.alias())
@@ -5560,20 +6419,27 @@ class SqliteDb(BaseDb):
                 stmt = base_query.order_by(table.c.created_at.desc()).limit(limit).offset(offset)
                 results = sess.execute(stmt).fetchall()
                 return [dict(row._mapping) for row in results], total_count
-        except Exception as e:
-            log_debug(f"Error listing schedules: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error listing schedules")
+            raise
 
     def create_schedule(self, schedule_data: Dict[str, Any]) -> Dict[str, Any]:
         try:
+            schedule_data.setdefault("pending_trigger_count", 0)
+            schedule_data.setdefault("manual_trigger_claimed", False)
             table = self._get_table(table_type="schedules", create_table_if_not_found=True)
             if table is None:
                 raise RuntimeError("Failed to get or create schedules table")
             with self.Session() as sess, sess.begin():
                 sess.execute(table.insert().values(**schedule_data))
             return schedule_data
-        except Exception as e:
-            log_error(f"Error creating schedule: {str(e)}")
+        except IntegrityError as error:
+            if _is_schedule_name_conflict(error, self.schedules_table_name):
+                raise ScheduleNameConflictError(schedule_data["name"]) from None
+            log_error("Error creating schedule")
+            raise
+        except Exception:
+            log_error("Error creating schedule")
             raise
 
     def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -5585,9 +6451,57 @@ class SqliteDb(BaseDb):
             with self.Session() as sess, sess.begin():
                 sess.execute(table.update().where(table.c.id == schedule_id).values(**kwargs))
             return self.get_schedule(schedule_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule: {e}")
+        except IntegrityError as error:
+            name = kwargs.get("name")
+            if isinstance(name, str) and _is_schedule_name_conflict(error, self.schedules_table_name):
+                raise ScheduleNameConflictError(name) from None
+            log_debug("Error updating schedule")
+            raise
+        except Exception:
+            log_debug("Error updating schedule")
+            raise
+
+    def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue one manual execution for a schedule."""
+        table = self._get_table(table_type="schedules")
+        if table is None:
             return None
+        with self.Session() as sess, sess.begin():
+            result = sess.execute(
+                table.update()
+                .where(table.c.id == schedule_id)
+                .values(
+                    pending_trigger_count=func.coalesce(table.c.pending_trigger_count, 0) + 1,
+                    updated_at=int(time.time()),
+                )
+            )
+            if result.rowcount == 0:
+                return None
+        return self.get_schedule(schedule_id)
+
+    def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules for one managed target."""
+        table = self._get_table(table_type="schedules")
+        if table is None:
+            return 0
+        with self.Session() as sess, sess.begin():
+            result = sess.execute(
+                table.update()
+                .where(
+                    table.c.managed_by == managed_by,
+                    table.c.target_type == target_type,
+                    table.c.target_id == target_id,
+                    table.c.enabled == True,  # noqa: E712
+                )
+                .values(enabled=False, updated_at=int(time.time()))
+            )
+            return int(result.rowcount or 0)
 
     def delete_schedule(self, schedule_id: str) -> bool:
         try:
@@ -5600,8 +6514,8 @@ class SqliteDb(BaseDb):
                     sess.execute(runs_table.delete().where(runs_table.c.schedule_id == schedule_id))
                 result = sess.execute(table.delete().where(table.c.id == schedule_id))
                 return result.rowcount > 0
-        except Exception as e:
-            log_debug(f"Error deleting schedule: {e}")
+        except Exception:
+            log_debug("Error deleting schedule")
             return False
 
     def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
@@ -5617,13 +6531,30 @@ class SqliteDb(BaseDb):
                     select(table)
                     .where(
                         table.c.enabled == True,  # noqa: E712
-                        table.c.next_run_at <= now,
+                        or_(
+                            table.c.manual_trigger_claimed == True,  # noqa: E712
+                            table.c.pending_trigger_count > 0,
+                            table.c.next_run_at <= now,
+                        ),
                         or_(
                             table.c.locked_by.is_(None),
                             table.c.locked_at <= stale_lock_threshold,
                         ),
                     )
-                    .order_by(table.c.next_run_at.asc())
+                    .order_by(
+                        case(
+                            (table.c.manual_trigger_claimed == True, 0),  # noqa: E712
+                            (
+                                and_(
+                                    table.c.pending_trigger_count > 0,
+                                    or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                ),
+                                1,
+                            ),
+                            else_=2,
+                        ),
+                        table.c.next_run_at.asc(),
+                    )
                     .limit(1)
                 )
                 row = sess.execute(stmt).fetchone()
@@ -5635,35 +6566,102 @@ class SqliteDb(BaseDb):
                     table.update()
                     .where(
                         table.c.id == schedule["id"],
+                        table.c.enabled == True,  # noqa: E712
+                        or_(
+                            table.c.manual_trigger_claimed == True,  # noqa: E712
+                            table.c.pending_trigger_count > 0,
+                            table.c.next_run_at <= now,
+                        ),
                         or_(
                             table.c.locked_by.is_(None),
                             table.c.locked_at <= stale_lock_threshold,
                         ),
                     )
-                    .values(locked_by=worker_id, locked_at=now)
+                    .values(
+                        locked_by=worker_id,
+                        locked_at=now,
+                        pending_trigger_count=case(
+                            (
+                                and_(
+                                    table.c.manual_trigger_claimed == False,  # noqa: E712
+                                    table.c.pending_trigger_count > 0,
+                                    or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                ),
+                                table.c.pending_trigger_count - 1,
+                            ),
+                            else_=table.c.pending_trigger_count,
+                        ),
+                        manual_trigger_claimed=case(
+                            (table.c.manual_trigger_claimed == True, True),  # noqa: E712
+                            (table.c.next_run_at <= now, False),
+                            else_=True,
+                        ),
+                    )
                 )
                 if result.rowcount == 0:
                     return None
-                schedule["locked_by"] = worker_id
-                schedule["locked_at"] = now
-                return schedule
-        except Exception as e:
-            log_debug(f"Error claiming schedule: {e}")
-            return None
+                claimed = sess.execute(select(table).where(table.c.id == schedule["id"])).fetchone()
+                return dict(claimed._mapping) if claimed else None
+        except Exception:
+            log_debug("Error claiming schedule")
+            raise
 
-    def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
+    def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a claim only while its worker/timestamp fence still matches."""
+        table = self._get_table(table_type="schedules")
+        if table is None:
+            return None
+        renewed_at = max(int(time.time()), locked_at + 1)
+        with self.Session() as sess, sess.begin():
+            result = sess.execute(
+                table.update()
+                .where(
+                    table.c.id == schedule_id,
+                    table.c.locked_by == worker_id,
+                    table.c.locked_at == locked_at,
+                )
+                .values(locked_at=renewed_at)
+            )
+            return renewed_at if result.rowcount > 0 else None
+
+    def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
         try:
+            if (worker_id is None) != (locked_at is None):
+                return False
             table = self._get_table(table_type="schedules")
             if table is None:
                 return False
-            updates: Dict[str, Any] = {"locked_by": None, "locked_at": None, "updated_at": int(time.time())}
+            updates: Dict[str, Any] = {
+                "locked_by": None,
+                "locked_at": None,
+                "manual_trigger_claimed": False,
+                "updated_at": int(time.time()),
+            }
             if next_run_at is not None:
                 updates["next_run_at"] = next_run_at
             with self.Session() as sess, sess.begin():
-                result = sess.execute(table.update().where(table.c.id == schedule_id).values(**updates))
+                stmt = table.update().where(table.c.id == schedule_id)
+                if worker_id is None:
+                    stmt = stmt.where(table.c.manual_trigger_claimed == False)  # noqa: E712
+                else:
+                    stmt = stmt.where(table.c.locked_by == worker_id, table.c.locked_at == locked_at)
+                result = sess.execute(stmt.values(**updates))
                 return result.rowcount > 0
-        except Exception as e:
-            log_debug(f"Error releasing schedule: {e}")
+        except Exception:
+            log_debug("Error releasing schedule")
             return False
 
     def create_schedule_run(self, run_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -5674,8 +6672,8 @@ class SqliteDb(BaseDb):
             with self.Session() as sess, sess.begin():
                 sess.execute(table.insert().values(**run_data))
             return run_data
-        except Exception as e:
-            log_error(f"Error creating schedule run: {str(e)}")
+        except Exception:
+            log_error("Error creating schedule run")
             raise
 
     def update_schedule_run(self, schedule_run_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -5686,8 +6684,8 @@ class SqliteDb(BaseDb):
             with self.Session() as sess, sess.begin():
                 sess.execute(table.update().where(table.c.id == schedule_run_id).values(**kwargs))
             return self.get_schedule_run(schedule_run_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule run: {e}")
+        except Exception:
+            log_debug("Error updating schedule run")
             return None
 
     def get_schedule_run(self, run_id: str) -> Optional[Dict[str, Any]]:
@@ -5698,9 +6696,9 @@ class SqliteDb(BaseDb):
             with self.Session() as sess:
                 result = sess.execute(select(table).where(table.c.id == run_id)).fetchone()
                 return dict(result._mapping) if result else None
-        except Exception as e:
-            log_debug(f"Error getting schedule run: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule run")
+            raise
 
     def get_schedule_runs(
         self,
@@ -5730,9 +6728,9 @@ class SqliteDb(BaseDb):
                 )
                 results = sess.execute(stmt).fetchall()
                 return [dict(row._mapping) for row in results], total_count
-        except Exception as e:
-            log_debug(f"Error getting schedule runs: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error getting schedule runs")
+            raise
 
     # -- Approval methods --
 

--- a/libs/agno/agno/db/sqlite/utils.py
+++ b/libs/agno/agno/db/sqlite/utils.py
@@ -4,12 +4,12 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.sqlite.schemas import get_table_schema_definition
 from agno.utils.log import log_debug, log_error, log_warning
-from sqlalchemy.exc import IntegrityError
 
 try:
     from sqlalchemy import Table, func

--- a/libs/agno/agno/db/sqlite/utils.py
+++ b/libs/agno/agno/db/sqlite/utils.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.sqlite.schemas import get_table_schema_definition
 from agno.utils.log import log_debug, log_error, log_warning
+from sqlalchemy.exc import IntegrityError
 
 try:
     from sqlalchemy import Table, func
@@ -439,3 +440,11 @@ def deserialize_cultural_knowledge_from_db(db_row: Dict[str, Any]) -> CulturalKn
             "team_id": db_row.get("team_id"),
         }
     )
+
+
+def _is_schedule_name_conflict(error: IntegrityError, table_name: str) -> bool:
+    """Match only the generic or actor-scoped schedule-name indexes."""
+    return str(error.orig) in {
+        f"UNIQUE constraint failed: {table_name}.name",
+        f"UNIQUE constraint failed: {table_name}.owner_actor_id, {table_name}.name",
+    }

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -2,6 +2,7 @@
 
 import json
 import time
+from copy import deepcopy
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from uuid import UUID
@@ -12,7 +13,7 @@ from agno.run.base import HISTORY_SKIP_STATUSES as _RUN_HISTORY_SKIP_STATUSES
 from agno.utils.log import log_error, log_warning
 
 if TYPE_CHECKING:
-    from agno.db.base import AsyncBaseDb, BaseDb, SessionType
+    from agno.db.base import AsyncBaseDb, BaseDb, ComponentProjection, ComponentType, SessionType
     from agno.registry.registry import Registry
     from agno.session import Session
 
@@ -48,6 +49,142 @@ DB_TABLE_NAME_KEYS: frozenset = frozenset(
         "mcp_oauth_keys_table",
     }
 )
+
+
+def save_component_config(
+    db: "BaseDb",
+    *,
+    component_id: str,
+    component_type: "ComponentType",
+    name: Optional[str],
+    description: Optional[str],
+    metadata: Optional[Dict[str, Any]],
+    config: Dict[str, Any],
+    stage: str,
+    label: Optional[str] = None,
+    notes: Optional[str] = None,
+    links: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Persist a component config through the adapter's declared catalog contract.
+
+    A component's first config is created in the same transaction as its
+    component row when the adapter supports the 2.9 atomic primitive. Legacy
+    custom adapters fall back to their pre-2.9 upsert sequence. Later published
+    configs atomically update the denormalized component fields with the
+    current-version pointer. A draft updates the projection only while the
+    component has never had a published version; once published, later drafts
+    cannot leak into the current projection.
+
+    A concurrent creator may occupy the ID between the initial lookup and the
+    insert. In that case, validate the winning row and continue through the
+    existing-component path, matching the append-on-save behavior of the
+    component APIs.
+    """
+    from agno.db.base import ComponentAlreadyExistsError, ComponentType
+
+    if stage not in {"draft", "published"}:
+        raise ValueError(f"Invalid stage: {stage}")
+
+    effective_name = name or component_id
+    # A config version owns the complete denormalized catalog projection. Keep
+    # explicit nulls in the immutable payload so a future rollback can clear a
+    # description or metadata introduced by a newer version. Serializers often
+    # omit None values, and mutating their dictionary here would leak storage
+    # concerns back into the live component.
+    config = deepcopy(config)
+    config.update(
+        {
+            "name": effective_name,
+            "description": description,
+            "metadata": deepcopy(metadata),
+        }
+    )
+
+    catalog_api_version = getattr(db, "component_catalog_api_version", 1)
+    if catalog_api_version < 2:
+        # The compatibility path must use the exact pre-2.9 call shapes. In
+        # particular, do not probe new keyword-only parameters and then catch
+        # TypeError: a third-party override rejects those arguments before any
+        # NotImplementedError fallback can run.
+        component = db.get_component(component_id)
+        if component is not None:
+            actual_type = component.get("component_type")
+            if isinstance(actual_type, ComponentType):
+                actual_type = actual_type.value
+            if actual_type is not None and actual_type != component_type.value:
+                raise ValueError(f"Component {component_id} has type {actual_type}, not {component_type.value}")
+
+        log_warning(
+            f"Database {type(db).__name__} uses component catalog API v1; component and config writes are not atomic"
+        )
+        db.upsert_component(
+            component_id=component_id,
+            component_type=component_type,
+            name=effective_name,
+            description=description,
+            metadata=metadata,
+        )
+        return db.upsert_config(
+            component_id=component_id,
+            config=config,
+            label=label,
+            stage=stage,
+            notes=notes,
+            links=links,
+        )
+
+    component = db.get_component(component_id, include_deleted=True)
+
+    if component is None:
+        try:
+            _, config_row = db.create_component_with_config(
+                component_id=component_id,
+                component_type=component_type,
+                name=effective_name,
+                description=description,
+                metadata=metadata,
+                config=config,
+                label=label,
+                stage=stage,
+                notes=notes,
+                links=links,
+            )
+            return config_row
+        except ComponentAlreadyExistsError:
+            component = db.get_component(component_id, include_deleted=True)
+            if component is None:
+                raise
+
+    actual_type = component.get("component_type")
+    if isinstance(actual_type, ComponentType):
+        actual_type = actual_type.value
+    expected_type = component_type.value
+    if actual_type != expected_type:
+        raise ValueError(f"Component {component_id} has type {actual_type}, not {expected_type}")
+
+    restore_if_deleted = component.get("deleted_at") is not None
+
+    # Always provide the complete desired projection. Version-2 adapters make
+    # the draft-only decision while holding the component write lock, so a
+    # concurrent publish between the read above and this append cannot turn a
+    # valid draft save into a false conflict or leak draft metadata.
+    projection: "ComponentProjection" = {
+        "name": effective_name,
+        "description": description,
+        "metadata": metadata,
+    }
+
+    return db.upsert_config(
+        component_id=component_id,
+        config=config,
+        label=label,
+        stage=stage,
+        notes=notes,
+        links=links,
+        projection=projection,
+        restore_if_deleted=restore_if_deleted,
+        expected_component_type=component_type,
+    )
 
 
 def detect_session_type(record: Dict[str, Any]) -> str:

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -171,6 +171,34 @@ def bind_component_version_guard_after_append(
     )
 
 
+def resolve_component_id(db: "BaseDb", name: Optional[str], component_type: "ComponentType") -> str:
+    """Derive a component id from a name, adopting an existing legacy-slug row.
+
+    Components saved before the single-segment slug contract derived their ids
+    with generate_id_from_name. When only that row exists, re-deriving with the
+    stricter slug would fork the catalog, so the persisted identity wins.
+
+    Archived legacy rows deliberately do not adopt: a deleted component's name
+    mints a fresh strict-slug identity. Construction and initialize keep the
+    plain strict derivation on purpose - probing belongs only where a db is
+    already in hand at persistence time.
+    """
+    from agno.utils.string import generate_component_id_from_name, generate_id_from_name
+
+    component_id = generate_component_id_from_name(name)
+    if not name:
+        return component_id
+    legacy_id = generate_id_from_name(name)
+    if legacy_id == component_id:
+        return component_id
+    if (
+        db.get_component(component_id, component_type) is None
+        and db.get_component(legacy_id, component_type) is not None
+    ):
+        return legacy_id
+    return component_id
+
+
 def save_component_config(
     db: "BaseDb",
     *,

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -4,6 +4,7 @@ import json
 import time
 from copy import deepcopy
 from datetime import date, datetime
+from hashlib import sha256
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
@@ -13,7 +14,14 @@ from agno.run.base import HISTORY_SKIP_STATUSES as _RUN_HISTORY_SKIP_STATUSES
 from agno.utils.log import log_error, log_warning
 
 if TYPE_CHECKING:
-    from agno.db.base import AsyncBaseDb, BaseDb, ComponentProjection, ComponentType, SessionType
+    from agno.db.base import (
+        AsyncBaseDb,
+        BaseDb,
+        ComponentProjection,
+        ComponentType,
+        ComponentVersionGuard,
+        SessionType,
+    )
     from agno.registry.registry import Registry
     from agno.session import Session
 
@@ -51,6 +59,118 @@ DB_TABLE_NAME_KEYS: frozenset = frozenset(
 )
 
 
+_COMPONENT_VERSION_GUARD_ATTR = "_agno_component_version_guard"
+_COMPONENT_VERSION_GUARD_DB_ATTR = "_agno_component_version_guard_db"
+
+
+def _component_guard_db_identity(db: "BaseDb") -> Any:
+    """Return a stable identity for equivalent database instances.
+
+    Persisted components may reconstruct their serialized database into a new
+    Python object. Object identity would discard the guard in that normal load
+    path, while ``BaseDb.id`` alone does not distinguish two SQLite files.
+    """
+    try:
+        serialized = json.dumps(db.to_dict(), sort_keys=True, default=str, separators=(",", ":"))
+        identity: Tuple[Any, ...] = (type(db), sha256(serialized.encode()).digest())
+        engine = getattr(db, "db_engine", None)
+        url = getattr(engine, "url", None)
+        if (
+            url is not None
+            and str(url).startswith("sqlite")
+            and getattr(url, "database", None)
+            in {
+                None,
+                "",
+                ":memory:",
+            }
+        ):
+            # Identically configured in-memory SQLite engines are independent
+            # databases, unlike two connections to the same file or server.
+            identity += (id(engine),)
+        return identity
+    except Exception:
+        # A catalog-v2 third-party adapter with a broken serializer should
+        # still fail closed when a different database object is supplied.
+        return (type(db), id(db))
+
+
+def get_bound_component_version_guard(component: Any, db: "BaseDb") -> Optional["ComponentVersionGuard"]:
+    """Return the catalog-v2 state captured on a persisted component object."""
+    if getattr(component, _COMPONENT_VERSION_GUARD_DB_ATTR, None) != _component_guard_db_identity(db):
+        return None
+    return getattr(component, _COMPONENT_VERSION_GUARD_ATTR, None)
+
+
+def bind_component_version_guard(
+    component: Any,
+    db: "BaseDb",
+    *,
+    latest_version: Optional[int],
+    current_version: Optional[int],
+) -> "ComponentVersionGuard":
+    """Attach compare-and-set state without adding it to serialized configs."""
+    from agno.db.base import ComponentVersionGuard
+
+    guard = ComponentVersionGuard(latest_version=latest_version, current_version=current_version)
+    setattr(component, _COMPONENT_VERSION_GUARD_ATTR, guard)
+    setattr(component, _COMPONENT_VERSION_GUARD_DB_ATTR, _component_guard_db_identity(db))
+    return guard
+
+
+def capture_component_version_guard(
+    component: Any,
+    db: "BaseDb",
+    component_id: str,
+    *,
+    include_deleted: bool = False,
+    expected_config_version: Optional[int] = None,
+) -> Optional["ComponentVersionGuard"]:
+    """Capture the active catalog state on an object returned from persistence."""
+    if getattr(db, "component_catalog_api_version", 1) < 2:
+        return None
+    component_row = db.get_component(component_id, include_deleted=include_deleted)
+    if component_row is None:
+        return None
+    latest = db.get_latest_config(component_id, include_deleted=include_deleted)
+    latest_version = latest.get("version") if isinstance(latest, dict) else None
+    current_version = component_row.get("current_version")
+    if expected_config_version is not None and expected_config_version != latest_version:
+        # The row was replaced between the config read and this state read, or
+        # the caller loaded the published/historical snapshot while a newer
+        # draft exists. Do not attach fresh state to stale data; a later
+        # mutation must supply an explicit guard and will otherwise fail closed.
+        return None
+    return bind_component_version_guard(
+        component,
+        db,
+        latest_version=latest_version if isinstance(latest_version, int) else None,
+        current_version=current_version,
+    )
+
+
+def bind_component_version_guard_after_append(
+    component: Any,
+    db: "BaseDb",
+    *,
+    previous: Optional["ComponentVersionGuard"],
+    version: int,
+    stage: str,
+) -> "ComponentVersionGuard":
+    """Advance an object's guard to exactly the state produced by its append."""
+    current_version = (
+        version
+        if stage == "published"
+        else (previous.current_version if previous is not None and version != 1 else None)
+    )
+    return bind_component_version_guard(
+        component,
+        db,
+        latest_version=version,
+        current_version=current_version,
+    )
+
+
 def save_component_config(
     db: "BaseDb",
     *,
@@ -64,6 +184,7 @@ def save_component_config(
     label: Optional[str] = None,
     notes: Optional[str] = None,
     links: Optional[List[Dict[str, Any]]] = None,
+    guard: Optional["ComponentVersionGuard"] = None,
 ) -> Dict[str, Any]:
     """Persist a component config through the adapter's declared catalog contract.
 
@@ -76,11 +197,15 @@ def save_component_config(
     cannot leak into the current projection.
 
     A concurrent creator may occupy the ID between the initial lookup and the
-    insert. In that case, validate the winning row and continue through the
-    existing-component path, matching the append-on-save behavior of the
-    component APIs.
+    insert. In that case the call continues through the existing-component
+    path, where a missing or stale guard rejects appending to the winner.
     """
-    from agno.db.base import ComponentAlreadyExistsError, ComponentType
+    from agno.db.base import (
+        ComponentAlreadyExistsError,
+        ComponentArchivedError,
+        ComponentType,
+        ComponentVersionGuardRequiredError,
+    )
 
     if stage not in {"draft", "published"}:
         raise ValueError(f"Invalid stage: {stage}")
@@ -162,7 +287,10 @@ def save_component_config(
     if actual_type != expected_type:
         raise ValueError(f"Component {component_id} has type {actual_type}, not {expected_type}")
 
-    restore_if_deleted = component.get("deleted_at") is not None
+    if component.get("deleted_at") is not None:
+        raise ComponentArchivedError(component_id)
+    if guard is None:
+        raise ComponentVersionGuardRequiredError(component_id)
 
     # Always provide the complete desired projection. Version-2 adapters make
     # the draft-only decision while holding the component write lock, so a
@@ -181,8 +309,8 @@ def save_component_config(
         stage=stage,
         notes=notes,
         links=links,
+        guard=guard,
         projection=projection,
-        restore_if_deleted=restore_if_deleted,
         expected_component_type=component_type,
     )
 

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -242,11 +242,6 @@ def _get_disabled_feature_router(prefix: str, tag: str, requires: str) -> APIRou
     return router
 
 
-def _supports_component_routes(db: Union[BaseDb, AsyncBaseDb]) -> bool:
-    """Return whether this DB can safely back the synchronous Components API."""
-    return supports_component_routes(db)
-
-
 class AgentOS:
     def __init__(
         self,
@@ -650,7 +645,7 @@ class AgentOS:
         ]
         # Routes that require a database
         if self.db is not None:
-            if _supports_component_routes(self.db):
+            if supports_component_routes(self.db):
                 updated_routers.append(get_components_router(os_db=self.db, registry=self.registry))
             else:
                 updated_routers.append(
@@ -1193,7 +1188,7 @@ class AgentOS:
         ]
         # Routes that require a database
         if self.db is not None:
-            if _supports_component_routes(self.db):
+            if supports_component_routes(self.db):
                 routers.append(get_components_router(os_db=self.db, registry=self.registry))
             else:
                 routers.append(

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -50,7 +50,7 @@ from agno.os.job_queue import apply_queue_config, queue_lifespan
 from agno.os.router import get_base_router, get_info_router, get_websocket_router
 from agno.os.routers.agents import get_agent_router
 from agno.os.routers.approvals import get_approval_router
-from agno.os.routers.components import get_components_router
+from agno.os.routers.components import get_components_router, supports_component_routes
 from agno.os.routers.database import get_database_router
 from agno.os.routers.evals import get_eval_router
 from agno.os.routers.health import get_health_router
@@ -240,6 +240,11 @@ def _get_disabled_feature_router(prefix: str, tag: str, requires: str) -> APIRou
         raise HTTPException(status_code=503, detail=detail)
 
     return router
+
+
+def _supports_component_routes(db: Union[BaseDb, AsyncBaseDb]) -> bool:
+    """Return whether this DB can safely back the synchronous Components API."""
+    return supports_component_routes(db)
 
 
 class AgentOS:
@@ -513,7 +518,7 @@ class AgentOS:
 
         # Track MCP tools declared on the registry so they connect in the same
         # lifespan as agent/team/workflow MCP tools (e.g. for components created
-        # from registry tools via StudioTool)
+        # from registry tools via StudioTools)
         collect_mcp_tools_from_registry(self.registry, self.mcp_tools)
 
         # Check for duplicate IDs
@@ -645,10 +650,14 @@ class AgentOS:
         ]
         # Routes that require a database
         if self.db is not None:
-            if isinstance(self.db, BaseDb):
+            if _supports_component_routes(self.db):
                 updated_routers.append(get_components_router(os_db=self.db, registry=self.registry))
             else:
-                updated_routers.append(_get_disabled_feature_router("/components", "Components", "sync db (BaseDb)"))
+                updated_routers.append(
+                    _get_disabled_feature_router(
+                        "/components", "Components", "sync db with component persistence support"
+                    )
+                )
             updated_routers.append(get_schedule_router(os_db=self.db, settings=self.settings))
             updated_routers.append(get_approval_router(os_db=self.db, settings=self.settings))
             updated_routers.append(get_service_accounts_router(os_db=self.db, settings=self.settings))
@@ -1184,10 +1193,14 @@ class AgentOS:
         ]
         # Routes that require a database
         if self.db is not None:
-            if isinstance(self.db, BaseDb):
+            if _supports_component_routes(self.db):
                 routers.append(get_components_router(os_db=self.db, registry=self.registry))
             else:
-                routers.append(_get_disabled_feature_router("/components", "Components", "sync db (BaseDb)"))
+                routers.append(
+                    _get_disabled_feature_router(
+                        "/components", "Components", "sync db with component persistence support"
+                    )
+                )
             routers.append(get_schedule_router(os_db=self.db, settings=self.settings))
             routers.append(get_approval_router(os_db=self.db, settings=self.settings))
             routers.append(get_service_accounts_router(os_db=self.db, settings=self.settings))

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -85,7 +85,7 @@ from agno.registry import Registry
 from agno.remote.base import RemoteDb, RemoteKnowledge
 from agno.team import RemoteTeam, Team, TeamFactory
 from agno.utils.log import log_debug, log_error, log_info, log_warning
-from agno.utils.string import generate_id, generate_id_from_name
+from agno.utils.string import generate_component_id_from_name, generate_id
 from agno.workflow import RemoteWorkflow, Workflow, WorkflowFactory
 
 if TYPE_CHECKING:
@@ -868,7 +868,7 @@ class AgentOS:
             collect_mcp_tools_from_workflow(workflow, self.mcp_tools)
 
             if not workflow.id:
-                workflow.id = generate_id_from_name(workflow.name)
+                workflow.id = generate_component_id_from_name(workflow.name)
 
             # Required for the built-in routes to work
             workflow.store_events = True

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -1807,7 +1807,12 @@ def get_agent_router(
 
         try:
             agent = get_agent_by_id(
-                agent_id=agent_id, agents=os.agents, db=os.db, registry=os.registry, create_fresh=True
+                agent_id=agent_id,
+                agents=os.agents,
+                db=os.db,
+                registry=os.registry,
+                create_fresh=True,
+                published_only=False,
             )  # type: ignore[assignment]
         except ComponentRehydrationError as rehydration_error:
             raise HTTPException(status_code=rehydration_error.status_code, detail=str(rehydration_error))

--- a/libs/agno/agno/os/routers/components/__init__.py
+++ b/libs/agno/agno/os/routers/components/__init__.py
@@ -1,3 +1,3 @@
-from agno.os.routers.components.components import get_components_router
+from agno.os.routers.components.components import get_components_router, supports_component_routes
 
-__all__ = ["get_components_router"]
+__all__ = ["get_components_router", "supports_component_routes"]

--- a/libs/agno/agno/os/routers/components/components.py
+++ b/libs/agno/agno/os/routers/components/components.py
@@ -11,6 +11,7 @@ from agno.db.base import (
     ComponentAlreadyExistsError,
     ComponentCycleError,
     ComponentDependencyError,
+    ComponentDependencyUnavailableError,
     ComponentDraftRequiredError,
     ComponentLastConfigError,
     ComponentProjection,
@@ -26,6 +27,7 @@ from agno.os.schema import (
     ComponentCreate,
     ComponentDelete,
     ComponentResponse,
+    ComponentRestore,
     ComponentType,
     ComponentUpdate,
     ConfigCreate,
@@ -42,7 +44,7 @@ from agno.os.schema import (
 from agno.os.settings import AgnoAPISettings
 from agno.registry import Registry
 from agno.utils.log import log_error, log_warning
-from agno.utils.string import generate_id_from_name
+from agno.utils.string import generate_component_id_from_name
 
 logger = logging.getLogger(__name__)
 
@@ -165,17 +167,22 @@ def _reject_reserved_studio_config(config: Dict[str, Any]) -> None:
         )
 
 
-def _reject_studio_owned_mutation(db: BaseDb, component_id: str) -> None:
+def _reject_studio_owned_mutation(db: BaseDb, component_id: str, *, include_deleted: bool = False) -> None:
     """Prevent generic lifecycle routes from mutating any Studio-owned version.
 
     Ownership is derived from immutable config history rather than only the
     latest/current pointer. That keeps this boundary effective even if a raw
     config was appended before the boundary existed.
     """
-    for config_row in db.list_configs(component_id, include_config=True):
-        config = config_row.get("config")
-        if isinstance(config, dict) and _STUDIO_CONFIG_KEY in config:
-            raise HTTPException(status_code=409, detail=_STUDIO_WRITE_CONFLICT)
+    kwargs = {"include_deleted": True} if include_deleted else {}
+    for config_row in db.list_configs(component_id, include_config=True, **kwargs):
+        _reject_studio_owned_config(config_row)
+
+
+def _reject_studio_owned_config(config_row: Dict[str, Any]) -> None:
+    config = config_row.get("config")
+    if isinstance(config, dict) and _STUDIO_CONFIG_KEY in config:
+        raise HTTPException(status_code=409, detail=_STUDIO_WRITE_CONFLICT)
 
 
 def _resolve_db_in_config(
@@ -610,7 +617,7 @@ def attach_routes(
         try:
             component_id = body.component_id
             if component_id is None:
-                component_id = generate_id_from_name(body.name)
+                component_id = generate_component_id_from_name(body.name)
 
             # Prepare config - ensure it's a dict and resolve db reference
             config = deepcopy(body.config or {})
@@ -850,6 +857,57 @@ def attach_routes(
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             log_error(f"Error deleting component: {str(e)}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.post(
+        "/components/{component_id}/restore",
+        status_code=204,
+        operation_id="restore_component",
+        summary="Restore Component",
+        description="Restore a guarded soft-archived component without reusing its ID or history.",
+    )
+    async def restore_component(
+        component_id: str = Path(description="Component ID"),
+        body: ComponentRestore = Body(description="Guarded restore request"),
+    ) -> None:
+        try:
+            component = db.get_component(component_id, include_deleted=True)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            if component.get("deleted_at") is None:
+                raise HTTPException(status_code=409, detail=f"Component {component_id} is not archived")
+            _reject_studio_owned_mutation(db, component_id, include_deleted=True)
+
+            projection_version = component.get("current_version")
+            if projection_version is None:
+                projection_version = body.guard.latest_version
+            config_row = db.get_config(
+                component_id,
+                version=projection_version,
+                include_deleted=True,
+            )
+            if config_row is None or not isinstance(config_row.get("config"), dict):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Config {component_id} v{projection_version} cannot provide a restore projection",
+                )
+            _reject_studio_owned_config(config_row)
+
+            restored = db.restore_component(
+                component_id,
+                guard=_version_guard(body.guard.latest_version, body.guard.current_version),
+                projection=_projection_from_config(config_row["config"], fallback=component),
+            )
+            if not restored:
+                raise HTTPException(status_code=409, detail=f"Component {component_id} is not archived")
+        except HTTPException:
+            raise
+        except (ComponentDependencyUnavailableError, ComponentVersionConflictError) as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except Exception as e:
+            log_error(f"Error restoring component: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
 
     @router.get(

--- a/libs/agno/agno/os/routers/components/components.py
+++ b/libs/agno/agno/os/routers/components/components.py
@@ -43,12 +43,12 @@ from agno.os.schema import (
 )
 from agno.os.settings import AgnoAPISettings
 from agno.registry import Registry
+from agno.tools.studio import _STUDIO_CONFIG_KEY
 from agno.utils.log import log_error, log_warning
 from agno.utils.string import generate_component_id_from_name
 
 logger = logging.getLogger(__name__)
 
-_STUDIO_CONFIG_KEY = "_agno_studio"
 _STUDIO_WRITE_CONFLICT = "Studio-owned components must be mutated through StudioTools."
 _LEGACY_COMPONENT_METHODS = (
     "get_component",

--- a/libs/agno/agno/os/routers/components/components.py
+++ b/libs/agno/agno/os/routers/components/components.py
@@ -1160,7 +1160,9 @@ def attach_routes(
         response_model=ComponentConfigResponse,
         response_model_exclude_none=True,
         status_code=200,
-        operation_id="get_config",
+        # "get_config" belongs to the core /config route; a unique id here keeps
+        # the served OpenAPI document valid for client generators.
+        operation_id="get_config_version",
         summary="Get Config Version",
         description="Get a specific config version by number.",
     )

--- a/libs/agno/agno/os/routers/components/components.py
+++ b/libs/agno/agno/os/routers/components/components.py
@@ -1,10 +1,22 @@
 import logging
 import time
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
 
-from agno.db.base import AsyncBaseDb, BaseDb
+from agno.db.base import (
+    AsyncBaseDb,
+    BaseDb,
+    ComponentAlreadyExistsError,
+    ComponentCycleError,
+    ComponentDependencyError,
+    ComponentDraftRequiredError,
+    ComponentLastConfigError,
+    ComponentProjection,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+)
 from agno.db.base import ComponentType as DbComponentType
 from agno.db.utils import DB_TABLE_NAME_KEYS
 from agno.os.auth import get_authentication_dependency
@@ -12,15 +24,18 @@ from agno.os.schema import (
     BadRequestResponse,
     ComponentConfigResponse,
     ComponentCreate,
+    ComponentDelete,
     ComponentResponse,
     ComponentType,
     ComponentUpdate,
     ConfigCreate,
+    ConfigDelete,
     ConfigUpdate,
     InternalServerErrorResponse,
     NotFoundResponse,
     PaginatedResponse,
     PaginationInfo,
+    SetCurrentConfig,
     UnauthenticatedResponse,
     ValidationErrorResponse,
 )
@@ -30,6 +45,137 @@ from agno.utils.log import log_error, log_warning
 from agno.utils.string import generate_id_from_name
 
 logger = logging.getLogger(__name__)
+
+_STUDIO_CONFIG_KEY = "_agno_studio"
+_STUDIO_WRITE_CONFLICT = "Studio-owned components must be mutated through StudioTools."
+_LEGACY_COMPONENT_METHODS = (
+    "get_component",
+    "upsert_component",
+    "delete_component",
+    "list_components",
+    "get_config",
+    "upsert_config",
+    "delete_config",
+    "list_configs",
+    "set_current_version",
+)
+
+
+def supports_component_routes(db: Union[BaseDb, AsyncBaseDb]) -> bool:
+    """Return whether a DB implements a complete sync component catalog.
+
+    Catalog v2 is an explicit capability because its guarded, atomic contract
+    cannot be inferred from method names. Catalog v1 predates the capability
+    flag, so retain adapters that override the complete legacy method set even
+    when they inherit the old ``False`` default.
+    """
+    if not isinstance(db, BaseDb):
+        return False
+    if getattr(db, "component_catalog_api_version", 1) >= 2:
+        return bool(getattr(db, "supports_component_persistence", False))
+    if getattr(db, "supports_component_persistence", False):
+        return True
+
+    db_type = type(db)
+    return all(
+        getattr(db_type, method_name, None) is not getattr(BaseDb, method_name)
+        for method_name in _LEGACY_COMPONENT_METHODS
+    )
+
+
+def _version_guard(latest_version: Optional[int], current_version: Optional[int]) -> ComponentVersionGuard:
+    return ComponentVersionGuard(latest_version=latest_version, current_version=current_version)
+
+
+def _projection_from_config(
+    config: Dict[str, Any], *, fallback: Optional[Dict[str, Any]] = None
+) -> ComponentProjection:
+    """Build the complete component projection owned by one config version."""
+    fallback = fallback or {}
+    name = config.get("name")
+    if not isinstance(name, str):
+        name = fallback.get("name")
+    if not isinstance(name, str):
+        raise ValueError("Component config must resolve to a string name")
+
+    description = config.get("description") if "description" in config else fallback.get("description")
+    if description is not None and not isinstance(description, str):
+        description = fallback.get("description")
+    if description is not None and not isinstance(description, str):
+        description = None
+
+    metadata = config.get("metadata") if "metadata" in config else fallback.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        metadata = fallback.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        metadata = None
+
+    return ComponentProjection(
+        name=name,
+        description=description,
+        metadata=deepcopy(metadata),
+    )
+
+
+def _canonicalize_component_config(config: Dict[str, Any], *, fallback: Dict[str, Any]) -> Dict[str, Any]:
+    """Embed a complete immutable projection in a generic config payload."""
+    canonical = deepcopy(config)
+    canonical.update(_projection_from_config(canonical, fallback=fallback))
+    return canonical
+
+
+def _project_component_response(
+    component: Dict[str, Any], projection: ComponentProjection, *, current_version: int
+) -> Dict[str, Any]:
+    """Build the state committed by a pointer mutation without a post-commit read."""
+    projected = dict(component)
+    projected.update(projection)
+    projected["current_version"] = current_version
+    return projected
+
+
+def _append_component_metadata_patch(
+    config: Dict[str, Any],
+    *,
+    patch: ComponentUpdate,
+) -> Dict[str, Any]:
+    """Copy a generic config and apply the metadata-only edit contract."""
+    fields = patch.model_fields_set - {"guard"}
+    if not fields:
+        raise ValueError("Component update must contain at least one field in addition to guard")
+    if "name" in fields and (patch.name is None or not patch.name.strip()):
+        raise ValueError("Component name cannot be null or blank")
+
+    result = deepcopy(config)
+    if "name" in fields:
+        result["name"] = patch.name
+    if "description" in fields:
+        result["description"] = patch.description
+    if "metadata" in fields:
+        result["metadata"] = deepcopy(patch.metadata)
+    return result
+
+
+def _reject_reserved_studio_config(config: Dict[str, Any]) -> None:
+    """Keep the Studio manifest namespace exclusive to the typed control plane."""
+    if _STUDIO_CONFIG_KEY in config:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Config key '{_STUDIO_CONFIG_KEY}' is reserved for StudioTools.",
+        )
+
+
+def _reject_studio_owned_mutation(db: BaseDb, component_id: str) -> None:
+    """Prevent generic lifecycle routes from mutating any Studio-owned version.
+
+    Ownership is derived from immutable config history rather than only the
+    latest/current pointer. That keeps this boundary effective even if a raw
+    config was appended before the boundary existed.
+    """
+    for config_row in db.list_configs(component_id, include_config=True):
+        config = config_row.get("config")
+        if isinstance(config, dict) and _STUDIO_CONFIG_KEY in config:
+            raise HTTPException(status_code=409, detail=_STUDIO_WRITE_CONFLICT)
 
 
 def _resolve_db_in_config(
@@ -91,6 +237,8 @@ def _resolve_member_links(
     config: Dict[str, Any],
     db: BaseDb,
     registry: Optional[Registry] = None,
+    *,
+    require_published_pins: bool = False,
 ) -> Tuple[List[Dict[str, Any]], List[str]]:
     """Build ``component_links`` rows for a team config's ``members``.
 
@@ -103,7 +251,10 @@ def _resolve_member_links(
       current version) so the component graph reflects the team structure.
     - Members that are code-defined components (registered with the AgentOS
       instance but not persisted as DB components) are resolved from the
-      registry at load time and therefore do not get a link row.
+      registry at load time and therefore do not get a link row for drafts.
+      Published configs require durable exact-version pins, so code-defined
+      and draft-only members are rejected when ``require_published_pins`` is
+      true.
     - Members that resolve to neither are returned as unresolved so the caller
       can surface an error instead of silently creating a team with no members.
 
@@ -113,23 +264,31 @@ def _resolve_member_links(
     links: List[Dict[str, Any]] = []
     unresolved: List[str] = []
 
-    members = config.get("members") or []
+    members = config["members"] if "members" in config else []
+    if not isinstance(members, list):
+        raise ValueError("Team config.members must be a list")
+
     for position, member in enumerate(members):
         if not isinstance(member, dict):
-            continue
+            raise ValueError(f"Team config.members[{position}] must be an object")
 
         member_type = member.get("type")
         if member_type == "agent":
             child_id = member.get("agent_id")
+            if "team_id" in member:
+                raise ValueError(f"Team config.members[{position}] must declare exactly one of agent_id or team_id")
             in_registry = bool(registry and child_id and registry.get_agent(child_id) is not None)
         elif member_type == "team":
             child_id = member.get("team_id")
+            if "agent_id" in member:
+                raise ValueError(f"Team config.members[{position}] must declare exactly one of agent_id or team_id")
             in_registry = bool(registry and child_id and registry.get_team(child_id) is not None)
         else:
-            continue
+            raise ValueError(f"Team config.members[{position}].type must be 'agent' or 'team'")
 
-        if not child_id:
-            continue
+        if not isinstance(child_id, str) or not child_id:
+            reference_field = "agent_id" if member_type == "agent" else "team_id"
+            raise ValueError(f"Team config.members[{position}].{reference_field} must be a non-empty string")
 
         # Prefer a persisted DB component: create a link so the graph is complete.
         child_component = db.get_component(child_id)
@@ -146,16 +305,210 @@ def _resolve_member_links(
                         "meta": {"type": member_type},
                     }
                 )
-            # A draft-only component (no current_version) still exists; leave it
-            # to be resolved at load time rather than flagging it as unresolved.
+            elif require_published_pins:
+                unresolved.append(child_id)
+            # A draft-only component (no current_version) may still be used by
+            # a draft parent and resolved after it is published.
             continue
 
-        # Not a DB component. If it is a code-defined component it will be
-        # resolved from the registry at load time; otherwise it is unresolved.
-        if not in_registry:
+        # A code-defined component can be resolved only by the live registry,
+        # so it is valid for drafts but cannot satisfy a durable published pin.
+        if require_published_pins or not in_registry:
             unresolved.append(child_id)
 
     return links, unresolved
+
+
+def _published_member_pin_error(team_name: str, unresolved: List[str]) -> str:
+    return (
+        f"Cannot publish team '{team_name}': the following members do not have durable published versions: "
+        f"{', '.join(unresolved)}. Publish DB-backed members first; code-defined members are supported only in "
+        "drafts."
+    )
+
+
+def _unresolved_member_error(team_name: str, unresolved: List[str]) -> str:
+    return (
+        f"Cannot create team '{team_name}': the following members could not be resolved: {', '.join(unresolved)}. "
+        "Referenced agents/teams must exist as components or be registered with the AgentOS instance."
+    )
+
+
+def _component_type_value(component: Dict[str, Any]) -> Optional[str]:
+    component_type = component.get("component_type")
+    if isinstance(component_type, DbComponentType):
+        return component_type.value
+    return component_type if isinstance(component_type, str) else None
+
+
+_WORKFLOW_CONTAINER_FIELDS: Dict[str, Tuple[str, ...]] = {
+    "Parallel": ("steps",),
+    "Loop": ("steps",),
+    "Steps": ("steps",),
+    "Condition": ("steps", "else_steps"),
+    "Router": ("choices",),
+}
+_WORKFLOW_STEP_REFS: Dict[str, Tuple[str, str]] = {
+    "agent_id": ("step_agent", DbComponentType.AGENT.value),
+    "team_id": ("step_team", DbComponentType.TEAM.value),
+    "workflow_id": ("step_workflow", DbComponentType.WORKFLOW.value),
+}
+
+
+def _resolve_workflow_links(
+    config: Dict[str, Any],
+    db: BaseDb,
+    registry: Optional[Registry] = None,
+    *,
+    require_published_pins: bool = False,
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Validate a serialized workflow graph and derive its component links.
+
+    The generic components API accepts raw workflow dictionaries, so link rows
+    are a server-owned projection of ``config.steps``.  Drafts may reference a
+    draft-only DB component or a live registry component without a durable
+    link.  Published workflows require every component step to resolve to the
+    child's exact current published version.
+
+    Nested workflow containers are walked recursively.  Unknown container
+    types, malformed lists, ambiguous Step executors, unresolved functions,
+    and duplicate link keys fail closed before any database mutation.
+    """
+    if "steps" not in config:
+        steps: Any = []
+    else:
+        steps = config["steps"]
+    if not isinstance(steps, list):
+        raise ValueError("Workflow config.steps must be a list")
+
+    links: List[Dict[str, Any]] = []
+    unresolved: List[str] = []
+    seen_link_keys: set[Tuple[str, str]] = set()
+    position = 0
+
+    def _walk(step: Any, path: str) -> None:
+        nonlocal position
+        if not isinstance(step, dict):
+            raise ValueError(f"Workflow {path} must be an object")
+
+        step_type = step.get("type", "Step")
+        if not isinstance(step_type, str) or not step_type:
+            raise ValueError(f"Workflow {path}.type must be a non-empty string")
+
+        if step_type in _WORKFLOW_CONTAINER_FIELDS:
+            unexpected_refs = [key for key in (*_WORKFLOW_STEP_REFS, "executor_ref") if key in step]
+            if unexpected_refs:
+                raise ValueError(
+                    f"Workflow {path} is a {step_type} container and cannot declare executor references: "
+                    f"{', '.join(unexpected_refs)}"
+                )
+            for field in _WORKFLOW_CONTAINER_FIELDS[step_type]:
+                children = step.get(field)
+                if children is None and step_type == "Condition" and field == "else_steps":
+                    continue
+                if not isinstance(children, list):
+                    raise ValueError(f"Workflow {path}.{field} must be a list")
+                for child_position, child in enumerate(children):
+                    _walk(child, f"{path}.{field}[{child_position}]")
+            return
+
+        if step_type != "Step":
+            raise ValueError(f"Workflow {path} has unsupported step type '{step_type}'")
+
+        reference_fields = [key for key in (*_WORKFLOW_STEP_REFS, "executor_ref") if key in step]
+        if len(reference_fields) != 1:
+            raise ValueError(
+                f"Workflow {path} must declare exactly one of agent_id, team_id, workflow_id, or executor_ref"
+            )
+        reference_field = reference_fields[0]
+        reference = step[reference_field]
+        if not isinstance(reference, str) or not reference:
+            raise ValueError(f"Workflow {path}.{reference_field} must be a non-empty string")
+
+        leaf_position = position
+        position += 1
+
+        if reference_field == "executor_ref":
+            function_matches = (
+                [function for function in registry.functions if function.__name__ == reference]
+                if registry is not None
+                else []
+            )
+            if len(function_matches) > 1:
+                raise ValueError(
+                    f"Workflow {path}.executor_ref is ambiguous: multiple registered functions are named {reference!r}"
+                )
+            if len(function_matches) != 1:
+                unresolved.append(reference)
+            return
+
+        link_kind, expected_type = _WORKFLOW_STEP_REFS[reference_field]
+        child_component = db.get_component(reference)
+        if child_component is not None:
+            actual_type = _component_type_value(child_component)
+            if actual_type != expected_type:
+                raise ValueError(
+                    f"Workflow {path}.{reference_field} references {reference!r}, which is a "
+                    f"{actual_type or 'component of unknown type'} instead of a {expected_type}"
+                )
+            child_version = child_component.get("current_version")
+            if child_version is None:
+                if require_published_pins:
+                    unresolved.append(reference)
+                return
+            if not isinstance(child_version, int):
+                raise ValueError(f"Workflow child {reference!r} has an invalid current_version")
+
+            link_key = step.get("step_id") or step.get("name")
+            if not isinstance(link_key, str) or not link_key:
+                raise ValueError(
+                    f"Workflow {path} must have a non-empty step_id or name when it references a component"
+                )
+            key = (link_kind, link_key)
+            if key in seen_link_keys:
+                raise ValueError(f"Workflow contains duplicate {link_kind} link key {link_key!r}")
+            seen_link_keys.add(key)
+            links.append(
+                {
+                    "link_kind": link_kind,
+                    "link_key": link_key,
+                    "child_component_id": reference,
+                    "child_version": child_version,
+                    "position": leaf_position,
+                }
+            )
+            return
+
+        # Registry-backed agents and teams can be rehydrated only while the
+        # live registry is present, so they remain a draft-only convenience.
+        in_registry = False
+        if registry is not None and reference_field == "agent_id":
+            in_registry = registry.get_agent(reference) is not None
+        elif registry is not None and reference_field == "team_id":
+            in_registry = registry.get_team(reference) is not None
+        if require_published_pins or not in_registry:
+            unresolved.append(reference)
+
+    for step_position, step in enumerate(steps):
+        _walk(step, f"config.steps[{step_position}]")
+
+    return links, unresolved
+
+
+def _published_workflow_pin_error(workflow_name: str, unresolved: List[str]) -> str:
+    return (
+        f"Cannot publish workflow '{workflow_name}': the following step references do not have durable "
+        f"published versions: {', '.join(unresolved)}. Publish DB-backed agents, teams, and workflows first; "
+        "code-defined components are supported only in drafts."
+    )
+
+
+def _unresolved_workflow_ref_error(workflow_name: str, unresolved: List[str]) -> str:
+    return (
+        f"Cannot create workflow '{workflow_name}': the following step references could not be resolved: "
+        f"{', '.join(unresolved)}. Component steps must exist in the catalog or live registry, and function "
+        "steps must be registered with the AgentOS instance."
+    )
 
 
 def get_components_router(
@@ -184,6 +537,18 @@ def attach_routes(
     # Component routes require sync database
     if not isinstance(os_db, BaseDb):
         raise ValueError("Component routes require a sync database (BaseDb), not an async database.")
+    if not supports_component_routes(os_db):
+        raise ValueError("Component routes require a database with component persistence support.")
+    if getattr(os_db, "component_catalog_api_version", 1) < 2:
+        # Keep the old adapter calls and HTTP semantics isolated: accepting a
+        # v2 guard and then ignoring it would falsely advertise atomicity.
+        from agno.os.routers.components.legacy import attach_legacy_routes
+
+        log_warning(
+            f"Database {type(os_db).__name__} uses component catalog API v1; "
+            "serving the legacy unguarded Components API"
+        )
+        return attach_legacy_routes(router=router, db=os_db, registry=registry)
     db: BaseDb = os_db  # Type narrowed after isinstance check
 
     @router.get(
@@ -248,33 +613,65 @@ def attach_routes(
                 component_id = generate_id_from_name(body.name)
 
             # Prepare config - ensure it's a dict and resolve db reference
-            config = body.config or {}
+            config = deepcopy(body.config or {})
+            # ComponentCreate's top-level catalog fields are authoritative for
+            # version one. Persist them in the immutable config so a later
+            # rollback can restore null description/metadata as well as name.
+            config.update(
+                {
+                    "name": body.name,
+                    "description": body.description,
+                    "metadata": deepcopy(body.metadata),
+                }
+            )
+            _reject_reserved_studio_config(config)
             config = _resolve_db_in_config(config, db, registry)
 
             # Resolve member references into component links so the component
             # graph reflects the team structure (implements the members TODO).
             links: Optional[List[Dict[str, Any]]] = None
             if body.component_type == ComponentType.TEAM:
-                members = config.get("members")
-                if not members or len(members) == 0:
+                member_links, unresolved = _resolve_member_links(
+                    config,
+                    db,
+                    registry,
+                    require_published_pins=body.stage == "published",
+                )
+                members = config["members"] if "members" in config else []
+                if len(members) == 0:
                     log_warning(
                         f"Creating team '{body.name}' without members. "
                         "If this is unintended, add members to the config."
                     )
                 else:
-                    member_links, unresolved = _resolve_member_links(config, db, registry)
                     # Surface unresolved members instead of silently creating a
                     # team whose members render as "unknown" in the UI.
                     if unresolved:
+                        if body.stage == "published":
+                            detail = _published_member_pin_error(body.name, unresolved)
+                        else:
+                            detail = _unresolved_member_error(body.name, unresolved)
                         raise HTTPException(
                             status_code=400,
-                            detail=(
-                                f"Cannot create team '{body.name}': the following members could not be "
-                                f"resolved: {', '.join(unresolved)}. Referenced agents/teams must exist "
-                                "as components or be registered with the AgentOS instance."
-                            ),
+                            detail=detail,
                         )
                     links = member_links or None
+            elif body.component_type == ComponentType.WORKFLOW:
+                require_published_pins = body.stage == "published"
+                workflow_links, unresolved = _resolve_workflow_links(
+                    config,
+                    db,
+                    registry,
+                    require_published_pins=require_published_pins,
+                )
+                if unresolved:
+                    detail = (
+                        _published_workflow_pin_error(body.name, unresolved)
+                        if require_published_pins
+                        else _unresolved_workflow_ref_error(body.name, unresolved)
+                    )
+                    raise HTTPException(status_code=400, detail=detail)
+                links = workflow_links or None
 
             component, _config = db.create_component_with_config(
                 component_id=component_id,
@@ -292,6 +689,10 @@ def attach_routes(
             return ComponentResponse(**component)
         except HTTPException:
             raise
+        except ComponentAlreadyExistsError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except ComponentCycleError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
@@ -323,38 +724,81 @@ def attach_routes(
 
     @router.patch(
         "/components/{component_id}",
-        response_model=ComponentResponse,
+        response_model=ComponentConfigResponse,
         response_model_exclude_none=True,
         status_code=200,
         operation_id="update_component",
-        summary="Update Component",
-        description="Partially update a component by ID.",
+        summary="Append Component Metadata Draft",
+        description="Copy the latest config and append a guarded metadata-only draft edit.",
     )
     async def update_component(
         component_id: str = Path(description="Component ID"),
-        body: ComponentUpdate = Body(description="Component fields to update"),
-    ) -> ComponentResponse:
+        body: ComponentUpdate = Body(description="Guarded component metadata edit"),
+    ) -> ComponentConfigResponse:
         try:
             existing = db.get_component(component_id)
             if existing is None:
                 raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            _reject_studio_owned_mutation(db, component_id)
 
-            update_kwargs: Dict[str, Any] = {"component_id": component_id}
-            if body.name is not None:
-                update_kwargs["name"] = body.name
-            if body.description is not None:
-                update_kwargs["description"] = body.description
-            if body.metadata is not None:
-                update_kwargs["metadata"] = body.metadata
-            if body.current_version is not None:
-                update_kwargs["current_version"] = body.current_version
-            if body.component_type is not None:
-                update_kwargs["component_type"] = DbComponentType(body.component_type)
+            latest_version = body.guard.latest_version
+            if latest_version is None:
+                raise HTTPException(status_code=409, detail="Component update requires the latest config version")
+            latest = db.get_config(component_id, version=latest_version)
+            if latest is None:
+                raise HTTPException(status_code=409, detail=f"Latest config {component_id} v{latest_version} not found")
+            latest_config = latest.get("config")
+            if not isinstance(latest_config, dict):
+                raise HTTPException(status_code=400, detail=f"Config {component_id} v{latest_version} is invalid")
 
-            component = db.upsert_component(**update_kwargs)
-            return ComponentResponse(**component)
+            component_type = _component_type_value(existing)
+            if component_type is None:
+                raise HTTPException(status_code=400, detail=f"Component {component_id} has an invalid type")
+            config = _append_component_metadata_patch(
+                _canonicalize_component_config(latest_config, fallback=existing),
+                patch=body,
+            )
+
+            if component_type == DbComponentType.TEAM.value:
+                _, unresolved = _resolve_member_links(config, db, registry)
+                if unresolved:
+                    team_name = config.get("name") or existing.get("name") or component_id
+                    raise HTTPException(
+                        status_code=400,
+                        detail=_unresolved_member_error(str(team_name), unresolved),
+                    )
+            elif component_type == DbComponentType.WORKFLOW.value:
+                _, unresolved = _resolve_workflow_links(config, db, registry)
+                if unresolved:
+                    workflow_name = config.get("name") or existing.get("name") or component_id
+                    raise HTTPException(
+                        status_code=400,
+                        detail=_unresolved_workflow_ref_error(str(workflow_name), unresolved),
+                    )
+
+            # Metadata-only edits copy the exact graph owned by the guarded
+            # source version. Publication is the explicit point at which Team
+            # and Workflow references are re-resolved to current exact pins.
+            links = db.get_links(component_id, latest_version)
+
+            projection = (
+                _projection_from_config(config, fallback=existing) if existing.get("current_version") is None else None
+            )
+            appended = db.upsert_config(
+                component_id=component_id,
+                config=config,
+                stage="draft",
+                links=links,
+                guard=_version_guard(body.guard.latest_version, body.guard.current_version),
+                projection=projection,
+            )
+            return ComponentConfigResponse(**appended)
         except HTTPException:
             raise
+        except ComponentVersionConflictError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except ComponentCycleError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
@@ -370,13 +814,40 @@ def attach_routes(
     )
     async def delete_component(
         component_id: str = Path(description="Component ID"),
+        body: ComponentDelete = Body(description="Guarded soft-archive request"),
     ) -> None:
         try:
-            deleted = db.delete_component(component_id)
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            _reject_studio_owned_mutation(db, component_id)
+
+            projection_version = component.get("current_version")
+            if projection_version is None:
+                projection_version = body.guard.latest_version
+            if projection_version is None:
+                raise HTTPException(status_code=409, detail="Component archive requires the latest config version")
+            projection_config = db.get_config(component_id, version=projection_version)
+            if projection_config is None or not isinstance(projection_config.get("config"), dict):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Config {component_id} v{projection_version} cannot provide an archive projection",
+                )
+
+            deleted = db.delete_component(
+                component_id,
+                hard_delete=False,
+                guard=_version_guard(body.guard.latest_version, body.guard.current_version),
+                projection=_projection_from_config(projection_config["config"], fallback=component),
+            )
             if not deleted:
                 raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
         except HTTPException:
             raise
+        except (ComponentDependencyError, ComponentVersionConflictError) as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             log_error(f"Error deleting component: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -415,9 +886,71 @@ def attach_routes(
         body: ConfigCreate = Body(description="Config data"),
     ) -> ComponentConfigResponse:
         try:
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            _reject_studio_owned_mutation(db, component_id)
+
             # Resolve db from config if present
-            config_data = body.config or {}
+            config_data = _canonicalize_component_config(body.config or {}, fallback=component)
+            _reject_reserved_studio_config(config_data)
             config_data = _resolve_db_in_config(config_data, db, registry)
+
+            links = body.links
+            component_type = _component_type_value(component)
+            if component_type == DbComponentType.TEAM.value:
+                if body.links is not None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Team links are derived from config.members and must not be supplied by the caller.",
+                    )
+                require_published_pins = body.stage == "published"
+                member_links, unresolved = _resolve_member_links(
+                    config_data,
+                    db,
+                    registry,
+                    require_published_pins=require_published_pins,
+                )
+                if unresolved:
+                    team_name = config_data.get("name")
+                    if not isinstance(team_name, str) or not team_name:
+                        team_name = component.get("name") or component_id
+                    detail = (
+                        _published_member_pin_error(team_name, unresolved)
+                        if require_published_pins
+                        else _unresolved_member_error(team_name, unresolved)
+                    )
+                    raise HTTPException(status_code=400, detail=detail)
+                links = member_links or None
+            elif component_type == DbComponentType.WORKFLOW.value:
+                if body.links is not None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Workflow links are derived from config.steps and must not be supplied by the caller.",
+                    )
+                require_published_pins = body.stage == "published"
+                workflow_links, unresolved = _resolve_workflow_links(
+                    config_data,
+                    db,
+                    registry,
+                    require_published_pins=require_published_pins,
+                )
+                if unresolved:
+                    workflow_name = config_data.get("name")
+                    if not isinstance(workflow_name, str) or not workflow_name:
+                        workflow_name = component.get("name") or component_id
+                    detail = (
+                        _published_workflow_pin_error(workflow_name, unresolved)
+                        if require_published_pins
+                        else _unresolved_workflow_ref_error(workflow_name, unresolved)
+                    )
+                    raise HTTPException(status_code=400, detail=detail)
+                links = workflow_links or None
+            elif body.links is not None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Agent configs do not support component links; links are owned by Team and Workflow config.",
+                )
 
             config = db.upsert_config(
                 component_id=component_id,
@@ -426,9 +959,21 @@ def attach_routes(
                 label=body.label,
                 stage=body.stage,
                 notes=body.notes,
-                links=body.links,
+                links=links,
+                guard=_version_guard(body.guard.latest_version, body.guard.current_version),
+                projection=(
+                    _projection_from_config(config_data, fallback=component)
+                    if body.stage == "published" or component.get("current_version") is None
+                    else None
+                ),
             )
             return ComponentConfigResponse(**config)
+        except HTTPException:
+            raise
+        except ComponentVersionConflictError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except ComponentCycleError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
@@ -441,30 +986,88 @@ def attach_routes(
         response_model_exclude_none=True,
         status_code=200,
         operation_id="update_config",
-        summary="Update Draft Config",
-        description="Update an existing draft config. Cannot update published configs.",
+        summary="Publish Draft Config",
+        description="Publish the latest draft config without mutating its payload.",
     )
     async def update_config(
         component_id: str = Path(description="Component ID"),
         version: int = Path(description="Version number"),
-        body: ConfigUpdate = Body(description="Config fields to update"),
+        body: ConfigUpdate = Body(description="Guarded draft publication request"),
     ) -> ComponentConfigResponse:
         try:
-            # Resolve db from config if present
-            config_data = body.config
-            if config_data is not None:
-                config_data = _resolve_db_in_config(config_data, db, registry)
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            _reject_studio_owned_mutation(db, component_id)
+
+            target = db.get_config(component_id, version=version)
+            if target is None:
+                raise HTTPException(status_code=404, detail=f"Config {component_id} v{version} not found")
+
+            component_type = _component_type_value(component)
+            is_team = component_type == DbComponentType.TEAM.value
+            is_workflow = component_type == DbComponentType.WORKFLOW.value
+            links: List[Dict[str, Any]] = []
+            target_config: Dict[str, Any] = {}
+            if is_team or is_workflow:
+                target_config_data = target.get("config")
+                if not isinstance(target_config_data, dict):
+                    raise HTTPException(status_code=400, detail=f"Config {component_id} v{version} is invalid")
+                target_config = target_config_data
+
+            if is_team:
+                member_links, unresolved = _resolve_member_links(
+                    target_config,
+                    db,
+                    registry,
+                    require_published_pins=True,
+                )
+                if unresolved:
+                    team_name = target_config.get("name")
+                    if not isinstance(team_name, str) or not team_name:
+                        team_name = component.get("name") or component_id
+                    raise HTTPException(
+                        status_code=400,
+                        detail=_published_member_pin_error(team_name, unresolved),
+                    )
+                links = member_links
+            elif is_workflow:
+                workflow_links, unresolved = _resolve_workflow_links(
+                    target_config,
+                    db,
+                    registry,
+                    require_published_pins=True,
+                )
+                if unresolved:
+                    workflow_name = target_config.get("name")
+                    if not isinstance(workflow_name, str) or not workflow_name:
+                        workflow_name = component.get("name") or component_id
+                    raise HTTPException(
+                        status_code=400,
+                        detail=_published_workflow_pin_error(workflow_name, unresolved),
+                    )
+                links = workflow_links
+
+            upsert_kwargs: Dict[str, Any] = {
+                "component_id": component_id,
+                "version": version,
+                "stage": body.stage,
+                "guard": _version_guard(body.guard.latest_version, body.guard.current_version),
+                "projection": _projection_from_config(target["config"], fallback=component),
+            }
+            if is_team or is_workflow:
+                upsert_kwargs["links"] = links
 
             config = db.upsert_config(
-                component_id=component_id,
-                version=version,  # Always update existing
-                config=config_data,
-                label=body.label,
-                stage=body.stage,
-                notes=body.notes,
-                links=body.links,
+                **upsert_kwargs,
             )
             return ComponentConfigResponse(**config)
+        except HTTPException:
+            raise
+        except ComponentVersionConflictError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except ComponentCycleError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
@@ -484,7 +1087,7 @@ def attach_routes(
         component_id: str = Path(description="Component ID"),
     ) -> ComponentConfigResponse:
         try:
-            config = db.get_config(component_id)
+            config = db.get_current_config(component_id=component_id)
             if config is None:
                 raise HTTPException(status_code=404, detail=f"No current config for {component_id}")
             return ComponentConfigResponse(**config)
@@ -529,14 +1132,50 @@ def attach_routes(
     async def delete_config_version(
         component_id: str = Path(description="Component ID"),
         version: int = Path(description="Version number"),
+        body: ConfigDelete = Body(description="Guarded draft-version deletion request"),
     ) -> None:
         try:
-            # Resolve version number
-            deleted = db.delete_config(component_id, version=version)
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            _reject_studio_owned_mutation(db, component_id)
+
+            projection_config: Optional[Dict[str, Any]] = None
+            current_version = component.get("current_version")
+            if isinstance(current_version, int):
+                current = db.get_config(component_id, version=current_version)
+                if current is not None and isinstance(current.get("config"), dict):
+                    projection_config = current["config"]
+            else:
+                remaining = [
+                    row
+                    for row in db.list_configs(component_id, include_config=True)
+                    if row.get("version") != version and isinstance(row.get("config"), dict)
+                ]
+                if remaining:
+                    projection_config = remaining[0]["config"]
+
+            deleted = db.delete_config(
+                component_id,
+                version=version,
+                guard=_version_guard(body.guard.latest_version, body.guard.current_version),
+                projection=(
+                    _projection_from_config(projection_config, fallback=component)
+                    if projection_config is not None
+                    else None
+                ),
+            )
             if not deleted:
                 raise HTTPException(status_code=404, detail=f"Config {component_id} v{version} not found")
         except HTTPException:
             raise
+        except (
+            ComponentDependencyError,
+            ComponentDraftRequiredError,
+            ComponentLastConfigError,
+            ComponentVersionConflictError,
+        ) as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
@@ -555,22 +1194,35 @@ def attach_routes(
     async def set_current_config(
         component_id: str = Path(description="Component ID"),
         version: int = Path(description="Version number"),
+        body: SetCurrentConfig = Body(description="Guarded current-version update"),
     ) -> ComponentResponse:
         try:
-            success = db.set_current_version(component_id, version=version)
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            _reject_studio_owned_mutation(db, component_id)
+
+            target = db.get_config(component_id, version=version)
+            if target is None:
+                raise HTTPException(status_code=404, detail=f"Config {component_id} v{version} not found")
+            projection = _projection_from_config(target["config"], fallback=component)
+
+            success = db.set_current_version(
+                component_id,
+                version=version,
+                guard=_version_guard(body.guard.latest_version, body.guard.current_version),
+                projection=projection,
+            )
             if not success:
                 raise HTTPException(
                     status_code=404, detail=f"Component {component_id} or config version {version} not found"
                 )
 
-            # Fetch and return updated component
-            component = db.get_component(component_id)
-            if component is None:
-                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
-
-            return ComponentResponse(**component)
+            return ComponentResponse(**_project_component_response(component, projection, current_version=version))
         except HTTPException:
             raise
+        except ComponentVersionConflictError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:

--- a/libs/agno/agno/os/routers/components/legacy.py
+++ b/libs/agno/agno/os/routers/components/legacy.py
@@ -24,7 +24,7 @@ from agno.os.schema import (
 )
 from agno.registry import Registry
 from agno.utils.log import log_error, log_warning
-from agno.utils.string import generate_id_from_name
+from agno.utils.string import generate_component_id_from_name
 
 
 class LegacyComponentCreate(BaseModel):
@@ -128,7 +128,7 @@ def attach_legacy_routes(router: APIRouter, db: BaseDb, registry: Optional[Regis
     )
     async def create_component(body: LegacyComponentCreate) -> ComponentResponse:
         try:
-            component_id = body.component_id or generate_id_from_name(body.name)
+            component_id = body.component_id or generate_component_id_from_name(body.name)
             config = _resolve_db_in_config(deepcopy(body.config or {}), db, registry)
 
             links: Optional[List[Dict[str, Any]]] = None

--- a/libs/agno/agno/os/routers/components/legacy.py
+++ b/libs/agno/agno/os/routers/components/legacy.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Body, HTTPException, Path, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from agno.db.base import BaseDb
 from agno.db.base import ComponentType as DbComponentType
@@ -30,6 +30,8 @@ from agno.utils.string import generate_component_id_from_name
 class LegacyComponentCreate(BaseModel):
     """Pre-2.9 component plus initial mutable config request."""
 
+    model_config = ConfigDict(extra="forbid")
+
     name: str = Field(..., description="Display name")
     component_id: Optional[str] = None
     component_type: ComponentType
@@ -45,6 +47,8 @@ class LegacyComponentCreate(BaseModel):
 class LegacyComponentUpdate(BaseModel):
     """Unguarded catalog-v1 component-row patch."""
 
+    model_config = ConfigDict(extra="forbid")
+
     name: Optional[str] = None
     description: Optional[str] = None
     component_type: Optional[str] = None
@@ -54,6 +58,8 @@ class LegacyComponentUpdate(BaseModel):
 
 class LegacyConfigCreate(BaseModel):
     """Unguarded catalog-v1 config append."""
+
+    model_config = ConfigDict(extra="forbid")
 
     config: Dict[str, Any] = Field(..., description="The configuration data")
     version: Optional[int] = None
@@ -66,6 +72,8 @@ class LegacyConfigCreate(BaseModel):
 
 class LegacyConfigUpdate(BaseModel):
     """Mutable catalog-v1 draft config patch."""
+
+    model_config = ConfigDict(extra="forbid")
 
     config: Optional[Dict[str, Any]] = None
     label: Optional[str] = None
@@ -362,7 +370,9 @@ def attach_legacy_routes(router: APIRouter, db: BaseDb, registry: Optional[Regis
         response_model=ComponentConfigResponse,
         response_model_exclude_none=True,
         status_code=200,
-        operation_id="get_config",
+        # "get_config" belongs to the core /config route; a unique id here keeps
+        # the served OpenAPI document valid for client generators.
+        operation_id="get_config_version",
         summary="Get Config Version (Legacy Catalog)",
     )
     async def get_config_version(

--- a/libs/agno/agno/os/routers/components/legacy.py
+++ b/libs/agno/agno/os/routers/components/legacy.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Body, HTTPException, Path, Query
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 from agno.db.base import BaseDb
 from agno.db.base import ComponentType as DbComponentType
@@ -30,7 +30,6 @@ from agno.utils.string import generate_component_id_from_name
 class LegacyComponentCreate(BaseModel):
     """Pre-2.9 component plus initial mutable config request."""
 
-    model_config = ConfigDict(extra="forbid")
 
     name: str = Field(..., description="Display name")
     component_id: Optional[str] = None
@@ -47,7 +46,6 @@ class LegacyComponentCreate(BaseModel):
 class LegacyComponentUpdate(BaseModel):
     """Unguarded catalog-v1 component-row patch."""
 
-    model_config = ConfigDict(extra="forbid")
 
     name: Optional[str] = None
     description: Optional[str] = None
@@ -59,7 +57,6 @@ class LegacyComponentUpdate(BaseModel):
 class LegacyConfigCreate(BaseModel):
     """Unguarded catalog-v1 config append."""
 
-    model_config = ConfigDict(extra="forbid")
 
     config: Dict[str, Any] = Field(..., description="The configuration data")
     version: Optional[int] = None
@@ -73,7 +70,6 @@ class LegacyConfigCreate(BaseModel):
 class LegacyConfigUpdate(BaseModel):
     """Mutable catalog-v1 draft config patch."""
 
-    model_config = ConfigDict(extra="forbid")
 
     config: Optional[Dict[str, Any]] = None
     label: Optional[str] = None

--- a/libs/agno/agno/os/routers/components/legacy.py
+++ b/libs/agno/agno/os/routers/components/legacy.py
@@ -1,0 +1,439 @@
+"""Compatibility Components API for pre-2.9 database adapters.
+
+Catalog-v1 adapters expose independent, unguarded component/config writes.
+Keep those request and call shapes separate from the guarded catalog-v2 router
+so OpenAPI never promises compare-and-set or atomic lifecycle semantics that a
+legacy adapter cannot provide.
+"""
+
+import time
+from copy import deepcopy
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Body, HTTPException, Path, Query
+from pydantic import BaseModel, Field
+
+from agno.db.base import BaseDb
+from agno.db.base import ComponentType as DbComponentType
+from agno.os.schema import (
+    ComponentConfigResponse,
+    ComponentResponse,
+    ComponentType,
+    PaginatedResponse,
+    PaginationInfo,
+)
+from agno.registry import Registry
+from agno.utils.log import log_error, log_warning
+from agno.utils.string import generate_id_from_name
+
+
+class LegacyComponentCreate(BaseModel):
+    """Pre-2.9 component plus initial mutable config request."""
+
+    name: str = Field(..., description="Display name")
+    component_id: Optional[str] = None
+    component_type: ComponentType
+    description: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    config: Optional[Dict[str, Any]] = None
+    label: Optional[str] = None
+    stage: str = "draft"
+    notes: Optional[str] = None
+    set_current: bool = True
+
+
+class LegacyComponentUpdate(BaseModel):
+    """Unguarded catalog-v1 component-row patch."""
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    component_type: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    current_version: Optional[int] = None
+
+
+class LegacyConfigCreate(BaseModel):
+    """Unguarded catalog-v1 config append."""
+
+    config: Dict[str, Any] = Field(..., description="The configuration data")
+    version: Optional[int] = None
+    label: Optional[str] = None
+    stage: str = "draft"
+    notes: Optional[str] = None
+    links: Optional[List[Dict[str, Any]]] = None
+    set_current: bool = True
+
+
+class LegacyConfigUpdate(BaseModel):
+    """Mutable catalog-v1 draft config patch."""
+
+    config: Optional[Dict[str, Any]] = None
+    label: Optional[str] = None
+    stage: Optional[str] = None
+    notes: Optional[str] = None
+    links: Optional[List[Dict[str, Any]]] = None
+
+
+def attach_legacy_routes(router: APIRouter, db: BaseDb, registry: Optional[Registry] = None) -> APIRouter:
+    """Attach the exact unguarded API supported by catalog-v1 adapters."""
+    # Imported lazily by the v2 module after it has finished initialization,
+    # avoiding a module cycle while reusing its DB-reference resolver.
+    from agno.os.routers.components.components import _resolve_db_in_config, _resolve_member_links
+
+    @router.get(
+        "/components",
+        response_model=PaginatedResponse[ComponentResponse],
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="list_components",
+        summary="List Components (Legacy Catalog)",
+        description="Retrieve components from an unguarded catalog-v1 database adapter.",
+    )
+    async def list_components(
+        component_type: Optional[ComponentType] = Query(None, description="Filter by type"),
+        page: int = Query(1, ge=1, description="Page number"),
+        limit: int = Query(20, ge=1, le=100, description="Items per page"),
+    ) -> PaginatedResponse[ComponentResponse]:
+        try:
+            start_time_ms = time.time() * 1000
+            exclude_ids = registry.get_all_component_ids() if registry else None
+            components, total_count = db.list_components(
+                component_type=DbComponentType(component_type.value) if component_type else None,
+                limit=limit,
+                offset=(page - 1) * limit,
+                exclude_component_ids=exclude_ids or None,
+            )
+            return PaginatedResponse(
+                data=[ComponentResponse(**component) for component in components],
+                meta=PaginationInfo(
+                    page=page,
+                    limit=limit,
+                    total_pages=(total_count + limit - 1) // limit,
+                    total_count=total_count,
+                    search_time_ms=round(time.time() * 1000 - start_time_ms, 2),
+                ),
+            )
+        except Exception as error:
+            log_error(f"Error listing components through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.post(
+        "/components",
+        response_model=ComponentResponse,
+        response_model_exclude_none=True,
+        status_code=201,
+        operation_id="create_component",
+        summary="Create Component (Legacy Catalog)",
+        description="Create a component and config with two non-atomic catalog-v1 writes.",
+    )
+    async def create_component(body: LegacyComponentCreate) -> ComponentResponse:
+        try:
+            component_id = body.component_id or generate_id_from_name(body.name)
+            config = _resolve_db_in_config(deepcopy(body.config or {}), db, registry)
+
+            links: Optional[List[Dict[str, Any]]] = None
+            if body.component_type == ComponentType.TEAM:
+                members = config.get("members") or []
+                if not members:
+                    log_warning(
+                        f"Creating team '{body.name}' without members. If this is unintended, add members "
+                        "to the config."
+                    )
+                else:
+                    member_links, unresolved = _resolve_member_links(config, db, registry)
+                    if unresolved:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=(
+                                f"Cannot create team '{body.name}': the following members could not be "
+                                f"resolved: {', '.join(unresolved)}. Referenced agents/teams must exist "
+                                "as components or be registered with the AgentOS instance."
+                            ),
+                        )
+                    links = member_links or None
+
+            component = db.upsert_component(
+                component_id=component_id,
+                component_type=DbComponentType(body.component_type.value),
+                name=body.name,
+                description=body.description,
+                metadata=body.metadata,
+            )
+            db.upsert_config(
+                component_id=component_id,
+                config=config,
+                label=body.label,
+                stage=body.stage,
+                notes=body.notes,
+                links=links,
+            )
+            return ComponentResponse(**component)
+        except HTTPException:
+            raise
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error))
+        except Exception as error:
+            log_error(f"Error creating component through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.get(
+        "/components/{component_id}",
+        response_model=ComponentResponse,
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="get_component",
+        summary="Get Component (Legacy Catalog)",
+    )
+    async def get_component(component_id: str = Path(description="Component ID")) -> ComponentResponse:
+        try:
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            return ComponentResponse(**component)
+        except HTTPException:
+            raise
+        except Exception as error:
+            log_error(f"Error getting component through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.patch(
+        "/components/{component_id}",
+        response_model=ComponentResponse,
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="update_component",
+        summary="Update Component (Legacy Catalog)",
+        description="Apply an unguarded catalog-v1 component-row patch.",
+    )
+    async def update_component(
+        component_id: str = Path(description="Component ID"),
+        body: LegacyComponentUpdate = Body(description="Unguarded component fields"),
+    ) -> ComponentResponse:
+        try:
+            if db.get_component(component_id) is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+
+            update_kwargs: Dict[str, Any] = {"component_id": component_id}
+            if body.name is not None:
+                update_kwargs["name"] = body.name
+            if body.description is not None:
+                update_kwargs["description"] = body.description
+            if body.metadata is not None:
+                update_kwargs["metadata"] = body.metadata
+            if body.current_version is not None:
+                update_kwargs["current_version"] = body.current_version
+            if body.component_type is not None:
+                update_kwargs["component_type"] = DbComponentType(body.component_type)
+            return ComponentResponse(**db.upsert_component(**update_kwargs))
+        except HTTPException:
+            raise
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error))
+        except Exception as error:
+            log_error(f"Error updating component through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.delete(
+        "/components/{component_id}",
+        status_code=204,
+        operation_id="delete_component",
+        summary="Delete Component (Legacy Catalog)",
+        description="Delete a component without v2 dependency or version guards.",
+    )
+    async def delete_component(component_id: str = Path(description="Component ID")) -> None:
+        try:
+            if not db.delete_component(component_id):
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+        except HTTPException:
+            raise
+        except Exception as error:
+            log_error(f"Error deleting component through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.get(
+        "/components/{component_id}/configs",
+        response_model=List[ComponentConfigResponse],
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="list_configs",
+        summary="List Configs (Legacy Catalog)",
+    )
+    async def list_configs(
+        component_id: str = Path(description="Component ID"),
+        include_config: bool = Query(True, description="Include full config blob"),
+    ) -> List[ComponentConfigResponse]:
+        try:
+            return [
+                ComponentConfigResponse(**config)
+                for config in db.list_configs(component_id, include_config=include_config)
+            ]
+        except Exception as error:
+            log_error(f"Error listing configs through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.post(
+        "/components/{component_id}/configs",
+        response_model=ComponentConfigResponse,
+        response_model_exclude_none=True,
+        status_code=201,
+        operation_id="create_config",
+        summary="Create Config Version (Legacy Catalog)",
+        description="Append an unguarded catalog-v1 config version.",
+    )
+    async def create_config(
+        component_id: str = Path(description="Component ID"),
+        body: LegacyConfigCreate = Body(description="Unguarded config data"),
+    ) -> ComponentConfigResponse:
+        try:
+            config_data = _resolve_db_in_config(deepcopy(body.config), db, registry)
+            config = db.upsert_config(
+                component_id=component_id,
+                version=None,
+                config=config_data,
+                label=body.label,
+                stage=body.stage,
+                notes=body.notes,
+                links=body.links,
+            )
+            return ComponentConfigResponse(**config)
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error))
+        except Exception as error:
+            log_error(f"Error creating config through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.patch(
+        "/components/{component_id}/configs/{version}",
+        response_model=ComponentConfigResponse,
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="update_config",
+        summary="Update Draft Config (Legacy Catalog)",
+        description="Mutate a draft through the unguarded catalog-v1 contract.",
+    )
+    async def update_config(
+        component_id: str = Path(description="Component ID"),
+        version: int = Path(description="Version number"),
+        body: LegacyConfigUpdate = Body(description="Unguarded config fields"),
+    ) -> ComponentConfigResponse:
+        try:
+            config_data = deepcopy(body.config)
+            if config_data is not None:
+                config_data = _resolve_db_in_config(config_data, db, registry)
+            config = db.upsert_config(
+                component_id=component_id,
+                version=version,
+                config=config_data,
+                label=body.label,
+                stage=body.stage,
+                notes=body.notes,
+                links=body.links,
+            )
+            return ComponentConfigResponse(**config)
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error))
+        except Exception as error:
+            log_error(f"Error updating config through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.get(
+        "/components/{component_id}/configs/current",
+        response_model=ComponentConfigResponse,
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="get_current_config",
+        summary="Get Current Config (Legacy Catalog)",
+        description="Resolve the adapter's historical default config selection.",
+    )
+    async def get_current_config(component_id: str = Path(description="Component ID")) -> ComponentConfigResponse:
+        try:
+            config = db.get_config(component_id)
+            if config is None:
+                raise HTTPException(status_code=404, detail=f"No current config for {component_id}")
+            return ComponentConfigResponse(**config)
+        except HTTPException:
+            raise
+        except Exception as error:
+            log_error(f"Error getting current config through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.get(
+        "/components/{component_id}/configs/{version}",
+        response_model=ComponentConfigResponse,
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="get_config",
+        summary="Get Config Version (Legacy Catalog)",
+    )
+    async def get_config_version(
+        component_id: str = Path(description="Component ID"),
+        version: int = Path(description="Version number"),
+    ) -> ComponentConfigResponse:
+        try:
+            config = db.get_config(component_id, version=version)
+            if config is None:
+                raise HTTPException(status_code=404, detail=f"Config {component_id} v{version} not found")
+            return ComponentConfigResponse(**config)
+        except HTTPException:
+            raise
+        except Exception as error:
+            log_error(f"Error getting config through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.delete(
+        "/components/{component_id}/configs/{version}",
+        status_code=204,
+        operation_id="delete_config",
+        summary="Delete Config Version (Legacy Catalog)",
+        description="Delete a draft without a v2 compare-and-set guard.",
+    )
+    async def delete_config_version(
+        component_id: str = Path(description="Component ID"),
+        version: int = Path(description="Version number"),
+    ) -> None:
+        try:
+            if not db.delete_config(component_id, version=version):
+                raise HTTPException(status_code=404, detail=f"Config {component_id} v{version} not found")
+        except HTTPException:
+            raise
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error))
+        except Exception as error:
+            log_error(f"Error deleting config through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.post(
+        "/components/{component_id}/configs/{version}/set-current",
+        response_model=ComponentResponse,
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="set_current_config",
+        summary="Set Current Config Version (Legacy Catalog)",
+        description="Move the current pointer without a v2 compare-and-set guard.",
+    )
+    async def set_current_config(
+        component_id: str = Path(description="Component ID"),
+        version: int = Path(description="Version number"),
+    ) -> ComponentResponse:
+        try:
+            if not db.set_current_version(component_id, version=version):
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Component {component_id} or config version {version} not found",
+                )
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            return ComponentResponse(**component)
+        except HTTPException:
+            raise
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error))
+        except Exception as error:
+            log_error(f"Error setting current config through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    return router
+
+
+__all__ = ["attach_legacy_routes"]

--- a/libs/agno/agno/os/routers/components/legacy.py
+++ b/libs/agno/agno/os/routers/components/legacy.py
@@ -80,8 +80,7 @@ class LegacyConfigUpdate(BaseModel):
 
 def attach_legacy_routes(router: APIRouter, db: BaseDb, registry: Optional[Registry] = None) -> APIRouter:
     """Attach the exact unguarded API supported by catalog-v1 adapters."""
-    # Imported lazily by the v2 module after it has finished initialization,
-    # avoiding a module cycle while reusing its DB-reference resolver.
+    # Reuse the v2 module's DB-reference resolvers rather than duplicating them.
     from agno.os.routers.components.components import _resolve_db_in_config, _resolve_member_links
 
     @router.get(

--- a/libs/agno/agno/os/routers/schedules/router.py
+++ b/libs/agno/agno/os/routers/schedules/router.py
@@ -7,6 +7,11 @@ from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from agno.db.schemas.scheduler import (
+    STUDIO_SCHEDULE_MANAGED_BY,
+    ScheduleNameConflictError,
+    is_studio_managed_schedule,
+)
 from agno.os.routers.schedules.schema import (
     ScheduleCreate,
     ScheduleResponse,
@@ -69,6 +74,22 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
             return fn(*args, **kwargs)
         except NotImplementedError:
             raise HTTPException(status_code=503, detail="Scheduler not supported by the configured database")
+        except ScheduleNameConflictError as exc:
+            # The preflight name check is advisory. The database constraint is
+            # the race-safe authority for concurrent creates and renames.
+            raise HTTPException(status_code=409, detail=str(exc))
+
+    def _generic_namespace_kwargs() -> Dict[str, str]:
+        version = getattr(os_db, "scheduler_api_version", 1)
+        if isinstance(version, int) and version >= 2:
+            return {"exclude_managed_by": STUDIO_SCHEDULE_MANAGED_BY}
+        return {}
+
+    async def _get_generic_schedule(schedule_id: str) -> Optional[Dict[str, Any]]:
+        schedule = await _db_call("get_schedule", schedule_id)
+        if schedule is None or is_studio_managed_schedule(schedule):
+            return None
+        return schedule
 
     # ------------------------------------------------------------------
     # Endpoints
@@ -81,7 +102,13 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         page: int = Query(1, ge=1),
         _: bool = Depends(auth_dependency),
     ) -> PaginatedResponse[ScheduleResponse]:
-        schedules, total_count = await _db_call("get_schedules", enabled=enabled, limit=limit, page=page)
+        schedules, total_count = await _db_call(
+            "get_schedules",
+            enabled=enabled,
+            limit=limit,
+            page=page,
+            **_generic_namespace_kwargs(),
+        )
         total_pages = (total_count + limit - 1) // limit if total_count > 0 else 0
         return PaginatedResponse(
             data=schedules,
@@ -107,7 +134,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
             raise HTTPException(status_code=422, detail=f"Invalid timezone: {body.timezone}")
 
         # Check name uniqueness
-        existing = await _db_call("get_schedule_by_name", body.name)
+        existing = await _db_call("get_schedule_by_name", body.name, **_generic_namespace_kwargs())
         if existing is not None:
             raise HTTPException(status_code=409, detail=f"Schedule with name '{body.name}' already exists")
 
@@ -144,7 +171,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         schedule_id: str,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
-        schedule = await _db_call("get_schedule", schedule_id)
+        schedule = await _get_generic_schedule(schedule_id)
         if schedule is None:
             raise HTTPException(status_code=404, detail="Schedule not found")
         return schedule
@@ -155,7 +182,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         body: ScheduleUpdate,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
-        existing = await _db_call("get_schedule", schedule_id)
+        existing = await _get_generic_schedule(schedule_id)
         if existing is None:
             raise HTTPException(status_code=404, detail="Schedule not found")
 
@@ -180,7 +207,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
 
         # Validate name uniqueness if changing
         if "name" in updates and updates["name"] != existing["name"]:
-            dup = await _db_call("get_schedule_by_name", updates["name"])
+            dup = await _db_call("get_schedule_by_name", updates["name"], **_generic_namespace_kwargs())
             if dup is not None:
                 raise HTTPException(status_code=409, detail=f"Schedule with name '{updates['name']}' already exists")
 
@@ -194,7 +221,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         schedule_id: str,
         _: bool = Depends(auth_dependency),
     ) -> None:
-        existing = await _db_call("get_schedule", schedule_id)
+        existing = await _get_generic_schedule(schedule_id)
         if existing is None:
             raise HTTPException(status_code=404, detail="Schedule not found")
         deleted = await _db_call("delete_schedule", schedule_id)
@@ -206,7 +233,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         schedule_id: str,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
-        existing = await _db_call("get_schedule", schedule_id)
+        existing = await _get_generic_schedule(schedule_id)
         if existing is None:
             raise HTTPException(status_code=404, detail="Schedule not found")
 
@@ -225,7 +252,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         schedule_id: str,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
-        existing = await _db_call("get_schedule", schedule_id)
+        existing = await _get_generic_schedule(schedule_id)
         if existing is None:
             raise HTTPException(status_code=404, detail="Schedule not found")
 
@@ -241,7 +268,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         request: Request,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
-        existing = await _db_call("get_schedule", schedule_id)
+        existing = await _get_generic_schedule(schedule_id)
         if existing is None:
             raise HTTPException(status_code=404, detail="Schedule not found")
 
@@ -262,7 +289,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         page: int = Query(1, ge=1),
         _: bool = Depends(auth_dependency),
     ) -> PaginatedResponse[ScheduleRunResponse]:
-        existing = await _db_call("get_schedule", schedule_id)
+        existing = await _get_generic_schedule(schedule_id)
         if existing is None:
             raise HTTPException(status_code=404, detail="Schedule not found")
         runs, total_count = await _db_call("get_schedule_runs", schedule_id, limit=limit, page=page)
@@ -283,6 +310,9 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         run_id: str,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
+        existing = await _get_generic_schedule(schedule_id)
+        if existing is None:
+            raise HTTPException(status_code=404, detail="Schedule not found")
         run = await _db_call("get_schedule_run", run_id)
         if run is None or run.get("schedule_id") != schedule_id:
             raise HTTPException(status_code=404, detail="Schedule run not found")

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -617,7 +617,10 @@ def get_team_router(
         files: Optional[List[UploadFile]] = File(
             None, description="Files to upload (images, audio, video, or documents)"
         ),
-        version: Optional[int] = Form(None, description="Team version to use for this run"),
+        version: Optional[int] = Form(
+            None,
+            description="Exact Team version to use for this run, including a draft version for explicit preview",
+        ),
         background: bool = Form(
             False, description="Run in background and return immediately with run metadata (requires database)"
         ),
@@ -1853,7 +1856,14 @@ def get_team_router(
             return TeamResponse.from_factory(factory)
 
         try:
-            team = get_team_by_id(team_id=team_id, teams=os.teams, db=os.db, registry=registry, create_fresh=True)  # type: ignore[assignment]
+            team = get_team_by_id(
+                team_id=team_id,
+                teams=os.teams,
+                db=os.db,
+                registry=registry,
+                create_fresh=True,
+                published_only=False,
+            )  # type: ignore[assignment]
         except ComponentRehydrationError as rehydration_error:
             raise HTTPException(status_code=rehydration_error.status_code, detail=str(rehydration_error))
         except Exception as e:

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1413,6 +1413,7 @@ def get_workflow_router(
                 registry=os.registry,
                 create_fresh=True,
                 version=version,
+                published_only=False,
             )  # type: ignore[assignment]
         except ComponentRehydrationError as rehydration_error:
             raise HTTPException(status_code=rehydration_error.status_code, detail=str(rehydration_error))
@@ -1476,7 +1477,10 @@ def get_workflow_router(
             None, description="Session ID for conversation continuity. If not provided, a new session is created"
         ),
         user_id: Optional[str] = Form(None, description="User identifier for tracking and personalization"),
-        version: Optional[int] = Form(None, description="Workflow version to use for this run"),
+        version: Optional[int] = Form(
+            None,
+            description="Exact Workflow version to use for this run, including a draft version for explicit preview",
+        ),
         factory_input: Optional[str] = Form(
             None,
             description="JSON object with factory-specific parameters for dynamic workflow construction",

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, Generic, List, Literal, Optional, TypeVar, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from agno.agent import Agent
 from agno.agent.factory import AgentFactory
@@ -826,6 +826,19 @@ class ComponentCreate(BaseModel):
     stage: Literal["draft", "published"] = Field("draft", description="Stage: 'draft' or 'published'")
     notes: Optional[str] = Field(None, description="Optional notes")
 
+    @field_validator("component_id")
+    @classmethod
+    def validate_component_id_segment(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        if not value or value in {".", ".."}:
+            raise ValueError("component_id must be a non-empty URL path segment")
+        if any(char in value for char in ("/", "\\", "?", "#", "%")):
+            raise ValueError("component_id must be a single URL path segment")
+        if any(ord(char) < 32 or ord(char) == 127 for char in value):
+            raise ValueError("component_id cannot contain control characters")
+        return value
+
 
 class ComponentResponse(BaseModel):
     component_id: str
@@ -897,6 +910,14 @@ class SetCurrentConfig(BaseModel):
 
 class ComponentDelete(BaseModel):
     """Guarded soft-archive request."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    guard: ComponentVersionGuardRequest = Field(..., description="Expected component version state")
+
+
+class ComponentRestore(BaseModel):
+    """Guarded restore request for an archived component."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -811,6 +811,8 @@ class ComponentType(str, Enum):
 
 
 class ComponentCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: str = Field(..., description="Display name")
     component_id: Optional[str] = Field(
         None, description="Unique identifier for the entity. Auto-generated from name if not provided."
@@ -821,9 +823,8 @@ class ComponentCreate(BaseModel):
     # Config parameters are optional, but if provided, they will be used to create the initial config
     config: Optional[Dict[str, Any]] = Field(None, description="Optional configuration")
     label: Optional[str] = Field(None, description="Optional label (e.g., 'stable')")
-    stage: str = Field("draft", description="Stage: 'draft' or 'published'")
+    stage: Literal["draft", "published"] = Field("draft", description="Stage: 'draft' or 'published'")
     notes: Optional[str] = Field(None, description="Optional notes")
-    set_current: bool = Field(True, description="Set as current version")
 
 
 class ComponentResponse(BaseModel):
@@ -837,14 +838,24 @@ class ComponentResponse(BaseModel):
     updated_at: Optional[int] = None
 
 
+class ComponentVersionGuardRequest(BaseModel):
+    """Required compare-and-set state for a component config mutation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    latest_version: int = Field(..., ge=1, description="Expected latest visible config version")
+    current_version: Optional[int] = Field(..., ge=1, description="Expected current published config version")
+
+
 class ConfigCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     config: Dict[str, Any] = Field(..., description="The configuration data")
-    version: Optional[int] = Field(None, description="Optional version number")
     label: Optional[str] = Field(None, description="Optional label (e.g., 'stable')")
-    stage: str = Field("draft", description="Stage: 'draft' or 'published'")
+    stage: Literal["draft", "published"] = Field("draft", description="Stage: 'draft' or 'published'")
     notes: Optional[str] = Field(None, description="Optional notes")
     links: Optional[List[Dict[str, Any]]] = Field(None, description="Optional links to child components")
-    set_current: bool = Field(True, description="Set as current version")
+    guard: ComponentVersionGuardRequest = Field(..., description="Expected component version state")
 
 
 class ComponentConfigResponse(BaseModel):
@@ -852,26 +863,52 @@ class ComponentConfigResponse(BaseModel):
     version: int
     label: Optional[str] = None
     stage: str
-    config: Dict[str, Any]
+    config: Optional[Dict[str, Any]] = None
     notes: Optional[str] = None
     created_at: int
     updated_at: Optional[int] = None
 
 
 class ComponentUpdate(BaseModel):
-    name: Optional[str] = None
+    """Guarded metadata edit that appends a new draft config version."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: Optional[str] = Field(None, min_length=1)
     description: Optional[str] = None
-    component_type: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
-    current_version: Optional[int] = None
+    guard: ComponentVersionGuardRequest = Field(..., description="Expected component version state")
 
 
 class ConfigUpdate(BaseModel):
-    config: Optional[Dict[str, Any]] = None
-    label: Optional[str] = None
-    stage: Optional[str] = None
-    notes: Optional[str] = None
-    links: Optional[List[Dict[str, Any]]] = None
+    """Publish an existing latest draft without mutating its immutable payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    stage: Literal["published"]
+    guard: ComponentVersionGuardRequest = Field(..., description="Expected component version state")
+
+
+class SetCurrentConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    guard: ComponentVersionGuardRequest = Field(..., description="Expected component version state")
+
+
+class ComponentDelete(BaseModel):
+    """Guarded soft-archive request."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    guard: ComponentVersionGuardRequest = Field(..., description="Expected component version state")
+
+
+class ConfigDelete(BaseModel):
+    """Guarded draft-version deletion request."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    guard: ComponentVersionGuardRequest = Field(..., description="Expected component version state")
 
 
 class RegistryResourceType(str, Enum):

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -1224,6 +1224,7 @@ def get_agent_by_id(
     create_fresh: bool = False,
     ctx: Optional[RequestContext] = None,
     strict: bool = True,
+    published_only: bool = True,
 ) -> Optional[Union[Agent, RemoteAgent, AgentProtocol]]:
     """Get an agent by ID, optionally creating a fresh instance for request isolation.
 
@@ -1242,6 +1243,9 @@ def get_agent_by_id(
         strict: If True (the default here, unlike the from_dict/load APIs), a
             db-backed agent whose references cannot be rehydrated raises
             instead of loading degraded
+        published_only: If True (the runtime-safe default), an unversioned DB
+            lookup resolves only the current published config. Detail reads
+            explicitly disable this to expose a draft-only component.
 
     Returns:
         The agent instance (shared or fresh copy based on create_fresh)
@@ -1278,7 +1282,14 @@ def get_agent_by_id(
         from agno.agent.agent import get_agent_by_id as get_agent_by_id_db
 
         try:
-            db_agent = get_agent_by_id_db(db=db, id=agent_id, version=version, registry=registry, strict=strict)
+            db_agent = get_agent_by_id_db(
+                db=db,
+                id=agent_id,
+                version=version,
+                registry=registry,
+                strict=strict,
+                published_only=published_only,
+            )
             return db_agent
         except ComponentRehydrationError:
             # Broken is not "not found": propagate so the caller can refuse loudly.
@@ -1299,8 +1310,9 @@ async def get_agent_by_id_async(
     create_fresh: bool = False,
     ctx: Optional[RequestContext] = None,
     strict: bool = True,
+    published_only: bool = True,
 ) -> Optional[Union[Agent, RemoteAgent, AgentProtocol]]:
-    """Async variant of get_agent_by_id that supports async factories."""
+    """Async resolver; DB lookups default to current published runtime state."""
     if agent_id is None:
         return None
 
@@ -1328,7 +1340,14 @@ async def get_agent_by_id_async(
         from agno.agent.agent import get_agent_by_id as get_agent_by_id_db
 
         try:
-            db_agent = get_agent_by_id_db(db=db, id=agent_id, version=version, registry=registry, strict=strict)
+            db_agent = get_agent_by_id_db(
+                db=db,
+                id=agent_id,
+                version=version,
+                registry=registry,
+                strict=strict,
+                published_only=published_only,
+            )
             return db_agent
         except ComponentRehydrationError:
             # Broken is not "not found": propagate so the caller can refuse loudly.
@@ -1349,6 +1368,7 @@ def get_team_by_id(
     registry: Optional[Registry] = None,
     ctx: Optional[RequestContext] = None,
     strict: bool = True,
+    published_only: bool = True,
 ) -> Optional[Union[Team, RemoteTeam]]:
     """Get a team by ID, optionally creating a fresh instance for request isolation.
 
@@ -1366,6 +1386,9 @@ def get_team_by_id(
         strict: If True (the default here, unlike the from_dict/load APIs), a
             db-backed team whose members or references cannot be rehydrated
             raises instead of loading degraded
+        published_only: If True (the runtime-safe default), an unversioned DB
+            lookup resolves only the current published config. Detail reads
+            explicitly disable this to expose a draft-only component.
 
     Returns:
         The team instance (shared or fresh copy based on create_fresh)
@@ -1395,7 +1418,14 @@ def get_team_by_id(
         from agno.team.team import get_team_by_id as get_team_by_id_db
 
         try:
-            db_team = get_team_by_id_db(db=db, id=team_id, version=version, registry=registry, strict=strict)
+            db_team = get_team_by_id_db(
+                db=db,
+                id=team_id,
+                version=version,
+                registry=registry,
+                strict=strict,
+                published_only=published_only,
+            )
             return db_team
         except ComponentRehydrationError:
             # Broken is not "not found": propagate so the caller can refuse loudly.
@@ -1416,8 +1446,9 @@ async def get_team_by_id_async(
     registry: Optional[Registry] = None,
     ctx: Optional[RequestContext] = None,
     strict: bool = True,
+    published_only: bool = True,
 ) -> Optional[Union[Team, RemoteTeam]]:
-    """Async variant of get_team_by_id that supports async factories."""
+    """Async resolver; DB lookups default to current published runtime state."""
     if team_id is None:
         return None
 
@@ -1439,7 +1470,14 @@ async def get_team_by_id_async(
         from agno.team.team import get_team_by_id as get_team_by_id_db
 
         try:
-            db_team = get_team_by_id_db(db=db, id=team_id, version=version, registry=registry, strict=strict)
+            db_team = get_team_by_id_db(
+                db=db,
+                id=team_id,
+                version=version,
+                registry=registry,
+                strict=strict,
+                published_only=published_only,
+            )
             return db_team
         except ComponentRehydrationError:
             # Broken is not "not found": propagate so the caller can refuse loudly.
@@ -1460,6 +1498,7 @@ def get_workflow_by_id(
     registry: Optional[Registry] = None,
     ctx: Optional[RequestContext] = None,
     strict: bool = True,
+    published_only: bool = True,
 ) -> Optional[Union[Workflow, RemoteWorkflow]]:
     """Get a workflow by ID, optionally creating a fresh instance for request isolation.
 
@@ -1480,6 +1519,9 @@ def get_workflow_by_id(
         strict: If True (the default here, unlike the from_dict/load APIs), a
             db-backed workflow whose references cannot be rehydrated raises
             instead of loading degraded
+        published_only: If True (the runtime-safe default), an unversioned DB
+            lookup resolves only the current published config. Detail reads
+            explicitly disable this to expose a draft-only component.
 
     Returns:
         The workflow instance (shared or fresh copy based on create_fresh)
@@ -1512,7 +1554,12 @@ def get_workflow_by_id(
 
         try:
             db_workflow = get_workflow_by_id_db(
-                db=db, id=workflow_id, version=version, registry=registry, strict=strict
+                db=db,
+                id=workflow_id,
+                version=version,
+                registry=registry,
+                strict=strict,
+                published_only=published_only,
             )
             return db_workflow
         except ComponentRehydrationError:
@@ -1534,8 +1581,9 @@ async def get_workflow_by_id_async(
     registry: Optional[Registry] = None,
     ctx: Optional[RequestContext] = None,
     strict: bool = True,
+    published_only: bool = True,
 ) -> Optional[Union[Workflow, RemoteWorkflow]]:
-    """Async variant of get_workflow_by_id that supports async factories."""
+    """Async resolver; DB lookups default to current published runtime state."""
     if workflow_id is None:
         return None
 
@@ -1560,7 +1608,12 @@ async def get_workflow_by_id_async(
 
         try:
             db_workflow = get_workflow_by_id_db(
-                db=db, id=workflow_id, version=version, registry=registry, strict=strict
+                db=db,
+                id=workflow_id,
+                version=version,
+                registry=registry,
+                strict=strict,
+                published_only=published_only,
             )
             return db_workflow
         except ComponentRehydrationError:
@@ -1865,7 +1918,7 @@ def collect_mcp_tools_from_registry(registry: Optional[Registry], mcp_tools: Lis
     Registry tools are not attached to any agent, team or workflow, so the
     other collectors never see them. They still must be connected in the
     AgentOS lifespan: components created from registry tools (e.g. via
-    StudioTool) serialize a toolkit's functions at persist time, and an
+    StudioTools) serialize a toolkit's functions at persist time, and an
     unconnected MCP toolkit has none -- its tools would be silently dropped.
     """
     if registry is None or not registry.tools:

--- a/libs/agno/agno/scheduler/manager.py
+++ b/libs/agno/agno/scheduler/manager.py
@@ -6,7 +6,12 @@ import time
 from typing import Any, Dict, List, Literal, Optional
 from uuid import uuid4
 
-from agno.db.schemas.scheduler import Schedule, ScheduleRun
+from agno.db.schemas.scheduler import (
+    STUDIO_SCHEDULE_MANAGED_BY,
+    Schedule,
+    ScheduleRun,
+    is_studio_managed_schedule,
+)
 from agno.utils.log import log_debug, log_warning
 
 # Valid DB method names for the scheduler
@@ -99,6 +104,25 @@ class ScheduleManager:
             return []
         return [ScheduleRun.from_dict(d) if isinstance(d, dict) else d for d in data]
 
+    def _generic_namespace_kwargs(self) -> Dict[str, str]:
+        """Scope scheduler-v2 name/list reads away from Studio-owned rows."""
+        version = getattr(self.db, "scheduler_api_version", 1)
+        if isinstance(version, int) and version >= 2:
+            return {"exclude_managed_by": STUDIO_SCHEDULE_MANAGED_BY}
+        return {}
+
+    def _get_generic_schedule(self, schedule_id: str) -> Optional[Schedule]:
+        schedule = self._to_schedule(self._call("get_schedule", schedule_id))
+        if schedule is None or is_studio_managed_schedule(schedule):
+            return None
+        return schedule
+
+    async def _aget_generic_schedule(self, schedule_id: str) -> Optional[Schedule]:
+        schedule = self._to_schedule(await self._acall("get_schedule", schedule_id))
+        if schedule is None or is_studio_managed_schedule(schedule):
+            return None
+        return schedule
+
     # --- Sync API ---
 
     def create(
@@ -134,7 +158,7 @@ class ScheduleManager:
         if not validate_timezone(timezone):
             raise ValueError(f"Invalid timezone: {timezone}")
 
-        existing = self._to_schedule(self._call("get_schedule_by_name", name))
+        existing = self._to_schedule(self._call("get_schedule_by_name", name, **self._generic_namespace_kwargs()))
         if existing is not None:
             if if_exists == "skip":
                 log_debug(f"Schedule '{name}' already exists, skipping")
@@ -192,26 +216,36 @@ class ScheduleManager:
 
     def list(self, enabled: Optional[bool] = None, limit: int = 100, page: int = 1) -> List[Schedule]:
         """List all schedules."""
-        result = self._call("get_schedules", enabled=enabled, limit=limit, page=page)
+        result = self._call(
+            "get_schedules",
+            enabled=enabled,
+            limit=limit,
+            page=page,
+            **self._generic_namespace_kwargs(),
+        )
         # get_schedules returns (schedules_list, total_count) tuple
         schedules_data = result[0] if isinstance(result, tuple) else result
         return self._to_schedule_list(schedules_data)
 
     def get(self, schedule_id: str) -> Optional[Schedule]:
         """Get a schedule by ID."""
-        return self._to_schedule(self._call("get_schedule", schedule_id))
+        return self._get_generic_schedule(schedule_id)
 
     def update(self, schedule_id: str, **kwargs: Any) -> Optional[Schedule]:
         """Update a schedule."""
+        if self._get_generic_schedule(schedule_id) is None:
+            return None
         return self._to_schedule(self._call("update_schedule", schedule_id, **kwargs))
 
     def delete(self, schedule_id: str) -> bool:
         """Delete a schedule."""
+        if self._get_generic_schedule(schedule_id) is None:
+            return False
         return self._call("delete_schedule", schedule_id)
 
     def enable(self, schedule_id: str) -> Optional[Schedule]:
         """Enable a schedule and compute next run."""
-        schedule = self._to_schedule(self._call("get_schedule", schedule_id))
+        schedule = self._get_generic_schedule(schedule_id)
         if schedule is None:
             return None
         from agno.scheduler.cron import compute_next_run
@@ -221,6 +255,8 @@ class ScheduleManager:
 
     def disable(self, schedule_id: str) -> Optional[Schedule]:
         """Disable a schedule."""
+        if self._get_generic_schedule(schedule_id) is None:
+            return None
         return self._to_schedule(self._call("update_schedule", schedule_id, enabled=False))
 
     def trigger(self, schedule_id: str) -> None:
@@ -238,6 +274,8 @@ class ScheduleManager:
 
     def get_runs(self, schedule_id: str, limit: int = 20, page: int = 1) -> List[ScheduleRun]:
         """Get run history for a schedule."""
+        if self._get_generic_schedule(schedule_id) is None:
+            return []
         result = self._call("get_schedule_runs", schedule_id, limit=limit, page=page)
         # get_schedule_runs returns (runs_list, total_count) tuple
         runs_data = result[0] if isinstance(result, tuple) else result
@@ -278,7 +316,9 @@ class ScheduleManager:
         if not validate_timezone(timezone):
             raise ValueError(f"Invalid timezone: {timezone}")
 
-        existing = self._to_schedule(await self._acall("get_schedule_by_name", name))
+        existing = self._to_schedule(
+            await self._acall("get_schedule_by_name", name, **self._generic_namespace_kwargs())
+        )
         if existing is not None:
             if if_exists == "skip":
                 log_debug(f"Schedule '{name}' already exists, skipping")
@@ -336,26 +376,36 @@ class ScheduleManager:
 
     async def alist(self, enabled: Optional[bool] = None, limit: int = 100, page: int = 1) -> List[Schedule]:
         """Async list all schedules."""
-        result = await self._acall("get_schedules", enabled=enabled, limit=limit, page=page)
+        result = await self._acall(
+            "get_schedules",
+            enabled=enabled,
+            limit=limit,
+            page=page,
+            **self._generic_namespace_kwargs(),
+        )
         # get_schedules returns (schedules_list, total_count) tuple
         schedules_data = result[0] if isinstance(result, tuple) else result
         return self._to_schedule_list(schedules_data)
 
     async def aget(self, schedule_id: str) -> Optional[Schedule]:
         """Async get a schedule by ID."""
-        return self._to_schedule(await self._acall("get_schedule", schedule_id))
+        return await self._aget_generic_schedule(schedule_id)
 
     async def aupdate(self, schedule_id: str, **kwargs: Any) -> Optional[Schedule]:
         """Async update a schedule."""
+        if await self._aget_generic_schedule(schedule_id) is None:
+            return None
         return self._to_schedule(await self._acall("update_schedule", schedule_id, **kwargs))
 
     async def adelete(self, schedule_id: str) -> bool:
         """Async delete a schedule."""
+        if await self._aget_generic_schedule(schedule_id) is None:
+            return False
         return await self._acall("delete_schedule", schedule_id)
 
     async def aenable(self, schedule_id: str) -> Optional[Schedule]:
         """Async enable a schedule."""
-        schedule = self._to_schedule(await self._acall("get_schedule", schedule_id))
+        schedule = await self._aget_generic_schedule(schedule_id)
         if schedule is None:
             return None
         from agno.scheduler.cron import compute_next_run
@@ -367,10 +417,14 @@ class ScheduleManager:
 
     async def adisable(self, schedule_id: str) -> Optional[Schedule]:
         """Async disable a schedule."""
+        if await self._aget_generic_schedule(schedule_id) is None:
+            return None
         return self._to_schedule(await self._acall("update_schedule", schedule_id, enabled=False))
 
     async def aget_runs(self, schedule_id: str, limit: int = 20, page: int = 1) -> List[ScheduleRun]:
         """Async get run history for a schedule."""
+        if await self._aget_generic_schedule(schedule_id) is None:
+            return []
         result = await self._acall("get_schedule_runs", schedule_id, limit=limit, page=page)
         # get_schedule_runs returns (runs_list, total_count) tuple
         runs_data = result[0] if isinstance(result, tuple) else result

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -57,7 +57,7 @@ from agno.utils.log import (
     use_team_logger,
 )
 from agno.utils.safe_formatter import SafeFormatter
-from agno.utils.string import generate_id_from_name
+from agno.utils.string import generate_component_id_from_name
 
 
 def __init__(
@@ -447,7 +447,7 @@ def set_id(team: "Team") -> None:
     If the name is not provided, generate a random UUID.
     """
     if team.id is None:
-        team.id = generate_id_from_name(team.name)
+        team.id = generate_component_id_from_name(team.name)
 
 
 def _set_debug(team: "Team", debug_mode: Optional[bool] = None) -> None:

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -32,6 +32,7 @@ from agno.db.utils import (
     bind_component_version_guard_after_append,
     capture_component_version_guard,
     get_bound_component_version_guard,
+    resolve_component_id,
     resolve_db_from_config,
     save_component_config,
 )
@@ -63,7 +64,6 @@ from agno.utils.log import (
     log_warning,
 )
 from agno.utils.merge_dict import merge_dictionaries
-from agno.utils.string import generate_component_id_from_name
 
 # ---------------------------------------------------------------------------
 # Run output accessors
@@ -1417,7 +1417,7 @@ def save(
     if not isinstance(db_, BaseDb):
         raise ValueError("Async databases not yet supported for save(). Use a sync database.")
     if team.id is None:
-        team.id = generate_component_id_from_name(team.name)
+        team.id = resolve_component_id(db_, team.name, ComponentType.TEAM)
 
     mutation_guard = guard or get_bound_component_version_guard(team, db_)
 

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel
 
 from agno.agent import Agent
 from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, SessionType
-from agno.db.utils import resolve_db_from_config
+from agno.db.utils import resolve_db_from_config, save_component_config
 from agno.exceptions import ComponentPinError, ComponentRehydrationError
 from agno.metrics import RunMetrics, SessionMetrics
 from agno.models.base import Model
@@ -1426,18 +1426,13 @@ def save(
                 }
             )
 
-        # Create or update component
-        db_.upsert_component(
+        config = save_component_config(
+            db_,
             component_id=team.id,
             component_type=ComponentType.TEAM,
             name=getattr(team, "name", team.id),
             description=getattr(team, "description", None),
             metadata=getattr(team, "metadata", None),
-        )
-
-        # Create or update config with links
-        config = db_.upsert_config(
-            component_id=team.id,
             config=team.to_dict(),
             links=all_links if all_links else None,
             label=label,
@@ -1580,6 +1575,7 @@ def delete(
     *,
     db: Optional["BaseDb"] = None,
     hard_delete: bool = False,
+    require_no_dependents: bool = True,
 ) -> bool:
     """
     Delete the team component.
@@ -1587,9 +1583,18 @@ def delete(
     Args:
         db: The database to delete the component from.
         hard_delete: Whether to hard delete the component.
+        require_no_dependents: Refuse deletion while another active component
+            references this team. Setting this to False bypasses dependency
+            validation and can leave active components with dangling links;
+            use it only for a deliberate repair or migration. Catalog-v1
+            adapters retain their historical unguarded deletion behavior.
 
     Returns:
         True if the component was deleted, False otherwise.
+
+    Raises:
+        ComponentDependencyError: If a dependent component references this
+            team and require_no_dependents is True.
     """
     db_ = db or team.db
     if not db_:
@@ -1599,7 +1604,15 @@ def delete(
     if team.id is None:
         raise ValueError("Cannot delete team without an id")
 
-    return db_.delete_component(component_id=team.id, hard_delete=hard_delete)
+    if getattr(db_, "component_catalog_api_version", 1) < 2:
+        # Preserve the exact pre-2.9 adapter call shape. Third-party catalog-v1
+        # implementations cannot accept the v2-only keyword-only policy.
+        return db_.delete_component(component_id=team.id, hard_delete=hard_delete)
+    return db_.delete_component(
+        component_id=team.id,
+        hard_delete=hard_delete,
+        require_no_dependents=require_no_dependents,
+    )
 
 
 def get_session_metrics(team: "Team", session_id: Optional[str] = None):

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -20,8 +20,21 @@ from typing import (
 from pydantic import BaseModel
 
 from agno.agent import Agent
-from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, SessionType
-from agno.db.utils import resolve_db_from_config, save_component_config
+from agno.db.base import (
+    AsyncBaseDb,
+    BaseDb,
+    ComponentType,
+    ComponentVersionGuard,
+    ComponentVersionGuardRequiredError,
+    SessionType,
+)
+from agno.db.utils import (
+    bind_component_version_guard_after_append,
+    capture_component_version_guard,
+    get_bound_component_version_guard,
+    resolve_db_from_config,
+    save_component_config,
+)
 from agno.exceptions import ComponentPinError, ComponentRehydrationError
 from agno.metrics import RunMetrics, SessionMetrics
 from agno.models.base import Model
@@ -50,7 +63,7 @@ from agno.utils.log import (
     log_warning,
 )
 from agno.utils.merge_dict import merge_dictionaries
-from agno.utils.string import generate_id_from_name
+from agno.utils.string import generate_component_id_from_name
 
 # ---------------------------------------------------------------------------
 # Run output accessors
@@ -1380,6 +1393,7 @@ def save(
     stage: str = "published",
     label: Optional[str] = None,
     notes: Optional[str] = None,
+    guard: Optional[ComponentVersionGuard] = None,
 ) -> Optional[int]:
     """
     Save the team component and config to the database, including member agents/teams.
@@ -1389,6 +1403,8 @@ def save(
         stage: The stage of the component. Defaults to "published".
         label: The label of the component.
         notes: The notes of the component.
+        guard: Explicit catalog-v2 compare-and-set state. Loaded and
+            previously saved objects reuse their captured guard automatically.
 
     Returns:
         Optional[int]: The version number of the saved config.
@@ -1401,18 +1417,36 @@ def save(
     if not isinstance(db_, BaseDb):
         raise ValueError("Async databases not yet supported for save(). Use a sync database.")
     if team.id is None:
-        team.id = generate_id_from_name(team.name)
+        team.id = generate_component_id_from_name(team.name)
+
+    mutation_guard = guard or get_bound_component_version_guard(team, db_)
 
     try:
         # Collect all links for members
         all_links: List[Dict[str, Any]] = []
+        saved_member_guards: Dict[str, ComponentVersionGuard] = {}
 
         # Save each member (Agent or nested Team) and collect links
         # Only iterate if members is a static list (not a callable factory)
         members_list = team.members if isinstance(team.members, list) else []
         for position, member in enumerate(members_list):
-            # Save member first - returns version
-            member_version = member.save(db=db_, stage=stage, label=label, notes=notes)
+            # A component may intentionally appear more than once in one
+            # aggregate save. Carry forward only the guard produced earlier in
+            # this operation; an unrelated detached object still fails closed.
+            member_guard = get_bound_component_version_guard(member, db_)
+            if member_guard is None and member.id is not None:
+                member_guard = saved_member_guards.get(member.id)
+            member_version = member.save(
+                db=db_,
+                stage=stage,
+                label=label,
+                notes=notes,
+                guard=member_guard,
+            )
+            if member.id is not None:
+                saved_guard = get_bound_component_version_guard(member, db_)
+                if saved_guard is not None:
+                    saved_member_guards[member.id] = saved_guard
 
             # Add link
             all_links.append(
@@ -1438,9 +1472,18 @@ def save(
             label=label,
             stage=stage,
             notes=notes,
+            guard=mutation_guard,
         )
-
-        return config["version"]
+        version = config["version"]
+        if isinstance(version, int) and getattr(db_, "component_catalog_api_version", 1) >= 2:
+            bind_component_version_guard_after_append(
+                team,
+                db_,
+                previous=mutation_guard,
+                version=version,
+                stage=stage,
+            )
+        return version
 
     except Exception as e:
         log_error(f"Error saving Team to database: {str(e)}")
@@ -1480,6 +1523,13 @@ def _hydrate_from_graph(
         if strict:
             require_db_fallback_matches(config, db, "team", team.id)
         team.db = db
+
+    capture_component_version_guard(
+        team,
+        db,
+        team.id,
+        expected_config_version=graph["config"].get("version"),
+    )
 
     # Hydrate members directly from the already-loaded graph children. This
     # reuses the preloaded nested graphs and avoids extra DB round-trips for
@@ -1576,6 +1626,7 @@ def delete(
     db: Optional["BaseDb"] = None,
     hard_delete: bool = False,
     require_no_dependents: bool = True,
+    guard: Optional[ComponentVersionGuard] = None,
 ) -> bool:
     """
     Delete the team component.
@@ -1588,6 +1639,8 @@ def delete(
             validation and can leave active components with dangling links;
             use it only for a deliberate repair or migration. Catalog-v1
             adapters retain their historical unguarded deletion behavior.
+        guard: Explicit catalog-v2 compare-and-set state. Loaded and
+            previously saved objects reuse their captured guard automatically.
 
     Returns:
         True if the component was deleted, False otherwise.
@@ -1608,10 +1661,15 @@ def delete(
         # Preserve the exact pre-2.9 adapter call shape. Third-party catalog-v1
         # implementations cannot accept the v2-only keyword-only policy.
         return db_.delete_component(component_id=team.id, hard_delete=hard_delete)
+    mutation_guard = guard or get_bound_component_version_guard(team, db_)
+    if mutation_guard is None:
+        raise ComponentVersionGuardRequiredError(team.id)
     return db_.delete_component(
         component_id=team.id,
         hard_delete=hard_delete,
+        guard=mutation_guard,
         require_no_dependents=require_no_dependents,
+        expected_component_type=ComponentType.TEAM,
     )
 
 

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -23,7 +23,8 @@ from pydantic import BaseModel
 
 from agno.agent import Agent
 from agno.compression.manager import CompressionManager
-from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, UserMemory
+from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, ComponentVersionGuard, UserMemory
+from agno.db.utils import bind_component_version_guard, capture_component_version_guard
 from agno.eval.base import BaseEval
 from agno.filters import FilterExpr
 from agno.guardrails import BaseGuardrail
@@ -1561,8 +1562,9 @@ class Team:
         stage: str = "published",
         label: Optional[str] = None,
         notes: Optional[str] = None,
+        guard: Optional[ComponentVersionGuard] = None,
     ) -> Optional[int]:
-        return _storage.save(self, db=db, stage=stage, label=label, notes=notes)
+        return _storage.save(self, db=db, stage=stage, label=label, notes=notes, guard=guard)
 
     @classmethod
     def load(
@@ -1583,6 +1585,7 @@ class Team:
         db: Optional["BaseDb"] = None,
         hard_delete: bool = False,
         require_no_dependents: bool = True,
+        guard: Optional[ComponentVersionGuard] = None,
     ) -> bool:
         """Delete this team's persisted component.
 
@@ -1608,6 +1611,7 @@ class Team:
             db=db,
             hard_delete=hard_delete,
             require_no_dependents=require_no_dependents,
+            guard=guard,
         )
 
     # -*- Public convenience functions
@@ -1875,6 +1879,8 @@ def get_team_by_id(
                 require_db_fallback_matches(cfg, db, "team", id)
             team.db = db
 
+        capture_component_version_guard(team, db, id, expected_config_version=row.get("version"))
+
         return team
 
     except ComponentRehydrationError:
@@ -1923,6 +1929,12 @@ def get_teams(
                         team.id = component_id
                         team._version = config.get("version")
                         team._stage = config.get("stage")
+                        bind_component_version_guard(
+                            team,
+                            db,
+                            latest_version=config.get("version"),
+                            current_version=component.get("current_version"),
+                        )
                         teams.append(team)
             except Exception as e:
                 log_error(f"Error loading Team {component_id} from database: {str(e)}")

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -1582,8 +1582,33 @@ class Team:
         *,
         db: Optional["BaseDb"] = None,
         hard_delete: bool = False,
+        require_no_dependents: bool = True,
     ) -> bool:
-        return _storage.delete(self, db=db, hard_delete=hard_delete)
+        """Delete this team's persisted component.
+
+        Args:
+            db: The database to delete the component from.
+            hard_delete: Permanently delete the component and its history.
+            require_no_dependents: Refuse deletion while another component
+                references this team. Setting this to False bypasses
+                dependency validation and can leave active components with
+                dangling links; use it only for a deliberate repair or
+                migration. Catalog-v1 adapters retain their historical
+                unguarded deletion behavior.
+
+        Returns:
+            True if the component was deleted, False otherwise.
+
+        Raises:
+            ComponentDependencyError: If a dependent component references
+                this team and require_no_dependents is True.
+        """
+        return _storage.delete(
+            self,
+            db=db,
+            hard_delete=hard_delete,
+            require_no_dependents=require_no_dependents,
+        )
 
     # -*- Public convenience functions
     def get_run_output(
@@ -1785,6 +1810,7 @@ def get_team_by_id(
     label: Optional[str] = None,
     registry: Optional["Registry"] = None,
     strict: bool = False,
+    published_only: bool = False,
 ) -> Optional["Team"]:
     """
     Get a Team by id from the database.
@@ -1792,7 +1818,8 @@ def get_team_by_id(
     Resolution order:
     - if version is provided: load that version
     - elif label is provided: load that labeled version
-    - else: load component.current_version
+    - else: load the current published version, or the latest draft when the
+      component has never been published
 
     Args:
         db: Database handle.
@@ -1802,6 +1829,9 @@ def get_team_by_id(
         registry: Optional Registry for reconstructing unserializable components.
         strict: If True, unresolvable members and registry references
             raise ComponentRehydrationError; None strictly means the team was not found.
+        published_only: Resolve only the current published config when neither
+            an exact version nor label is supplied. Runtime dispatch uses this;
+            ordinary reads retain the draft-only fallback.
 
     Returns:
         Team instance or None.
@@ -1812,7 +1842,11 @@ def get_team_by_id(
     from agno.exceptions import ComponentRehydrationError
 
     try:
-        row = db.get_config(component_id=id, version=version, label=label)
+        row = (
+            db.get_current_config(component_id=id)
+            if published_only and version is None and label is None
+            else db.get_config(component_id=id, version=version, label=label)
+        )
         if row is None:
             return None
 
@@ -1875,7 +1909,7 @@ def get_teams(
         for component in components:
             component_id = component["component_id"]
             try:
-                config = db.get_config(component_id=component_id)
+                config = db.get_latest_config(component_id=component_id)
                 if config is not None:
                     team_config = config.get("config")
                     if team_config is not None:
@@ -1887,7 +1921,7 @@ def get_teams(
                         # per-version pin links are a detail-read concern.
                         team = Team.from_dict(team_config, db=db, registry=registry, strict=False)
                         team.id = component_id
-                        team._version = component.get("current_version")
+                        team._version = config.get("version")
                         team._stage = config.get("stage")
                         teams.append(team)
             except Exception as e:

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -58,17 +58,19 @@ Persistence:
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Union
 
 from agno.run import RunContext
 from agno.tools.function import Function
-from agno.tools.studio_runner import AmbiguousComponentNameError, StudioRunnerError, StudioRunnerTools, _slugify
+from agno.tools.studio_runner import AmbiguousComponentNameError, StudioRunnerError, StudioRunnerTools
 from agno.tools.toolkit import Toolkit
 from agno.utils.log import log_debug, logger
+from agno.utils.string import generate_component_id_from_name
 
 if TYPE_CHECKING:
     from agno.agent.agent import Agent
-    from agno.db.base import BaseDb, ComponentVersionGuard
+    from agno.db.base import BaseDb, ComponentProjection, ComponentVersionGuard
     from agno.models.base import Model
     from agno.registry.registry import Registry
     from agno.scheduler.manager import ScheduleManager
@@ -80,6 +82,8 @@ Component = Union["Agent", "Team", "Workflow"]
 TeamMember = Union["Agent", "Team"]
 
 _SCHEDULE_TARGET_TYPES = ("agent", "team", "workflow")
+_STUDIO_CONFIG_KEY = "_agno_studio"
+_STUDIO_CONFIG_MANIFEST = {"schema_version": 2, "request": {}}
 
 
 class StudioTools(Toolkit):
@@ -246,6 +250,9 @@ class StudioTools(Toolkit):
                 ]
             )
 
+        if self.enable_agents or self.enable_teams or self.enable_workflows:
+            tools.append(self.restore_component)
+
         # Versioning works on any component type, but is opt-in.
         if self.enable_versions:
             tools.extend(
@@ -312,6 +319,8 @@ class StudioTools(Toolkit):
                     (self.arun_workflow, "run_workflow"),
                 ]
             )
+        if self.enable_agents or self.enable_teams or self.enable_workflows:
+            async_tools.append((self.arestore_component, "restore_component"))
         if self.enable_versions:
             async_tools.extend(
                 [
@@ -522,8 +531,9 @@ class StudioTools(Toolkit):
         """Capture the exact config loaded by an edit and its catalog-v2 CAS state."""
         if self.db is None:
             return None, None
-        if not self.enable_versions or getattr(self.db, "component_catalog_api_version", 1) < 2:
-            return self._edit_base_version(component_id), None
+        if getattr(self.db, "component_catalog_api_version", 1) < 2:
+            base_version = self._edit_base_version(component_id)
+            return base_version, None
 
         from agno.db.base import ComponentVersionGuard
 
@@ -536,10 +546,76 @@ class StudioTools(Toolkit):
             row["version"] for row in configs if row.get("stage") == "draft" and isinstance(row.get("version"), int)
         ]
         current_version = component.get("current_version")
-        base_version = max(drafts) if drafts else current_version
+        base_version = max(drafts) if self.enable_versions and drafts else current_version
+        if base_version is None:
+            base_version = max(versions) if versions else None
         return base_version, ComponentVersionGuard(
             latest_version=max(versions) if versions else None,
             current_version=current_version,
+        )
+
+    def _require_studio_owned(
+        self,
+        component_id: str,
+        *,
+        version: Optional[int] = None,
+        include_deleted: bool = False,
+    ) -> Dict[str, Any]:
+        """Return a config only when it was written by this typed control plane."""
+        if self.db is None:
+            raise ValueError("StudioTools has no db configured")
+        if getattr(self.db, "component_catalog_api_version", 1) >= 2:
+            row = self.db.get_config(
+                component_id=component_id,
+                version=version,
+                include_deleted=include_deleted,
+            )
+        else:
+            if include_deleted:
+                raise ValueError("Explicit restore requires component catalog API v2")
+            row = self.db.get_config(component_id=component_id, version=version)
+        candidates = [row]
+        if getattr(self.db, "component_catalog_api_version", 1) >= 2:
+            candidates.extend(
+                self.db.list_configs(
+                    component_id,
+                    include_config=True,
+                    include_deleted=include_deleted,
+                )
+            )
+        else:
+            candidates.extend(self.db.list_configs(component_id, include_config=True))
+        owned = any(
+            isinstance(candidate, dict)
+            and isinstance(candidate.get("config"), dict)
+            and _STUDIO_CONFIG_KEY in candidate["config"]
+            for candidate in candidates
+        )
+        if not isinstance(row, dict) or not isinstance(row.get("config"), dict) or not owned:
+            raise ValueError(
+                f"Cannot mutate component '{component_id}': only Studio-created components are editable by StudioTools"
+            )
+        return row
+
+    def _component_guard(
+        self,
+        component_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> tuple[Dict[str, Any], "ComponentVersionGuard"]:
+        """Capture component state for one guarded Studio mutation."""
+        if self.db is None:
+            raise ValueError("StudioTools has no db configured")
+        from agno.db.base import ComponentVersionGuard
+
+        component = self.db.get_component(component_id, include_deleted=include_deleted)
+        if component is None:
+            raise ValueError(f"Component not found: {component_id}")
+        latest = self.db.get_latest_config(component_id, include_deleted=include_deleted)
+        latest_version = latest.get("version") if isinstance(latest, dict) else None
+        return component, ComponentVersionGuard(
+            latest_version=latest_version if isinstance(latest_version, int) else None,
+            current_version=component.get("current_version"),
         )
 
     def _find_agent_for_edit(
@@ -1008,9 +1084,8 @@ class StudioTools(Toolkit):
                 message = f"Db not found: {db_id}" if db_id is not None else "StudioTools has no db configured."
                 return json.dumps({"error": message})
 
-            agent_id = self._unique_component_id(name, db)
             agent = Agent(
-                id=agent_id,
+                id=generate_component_id_from_name(name),
                 name=name,
                 model=model,
                 tools=tools or None,
@@ -1022,7 +1097,7 @@ class StudioTools(Toolkit):
                 add_datetime_to_context=add_datetime_to_context,
             )
 
-            version = _persist_only(agent, db)
+            agent_id, version = self._create_component(agent, db)
             log_debug(f"StudioTools created agent id={agent_id} version={version}")
             return json.dumps(
                 {
@@ -1100,9 +1175,8 @@ class StudioTools(Toolkit):
                 members, member_pins = self._bind_members_to_target_db(members, db)
             except ValueError as e:
                 return json.dumps({"error": str(e)})
-            team_id = self._unique_component_id(name, db)
             team = Team(
-                id=team_id,
+                id=generate_component_id_from_name(name),
                 name=name,
                 model=model,
                 members=members,
@@ -1114,7 +1188,11 @@ class StudioTools(Toolkit):
                 add_datetime_to_context=add_datetime_to_context,
             )
 
-            version = _persist_only(team, db, links=self._links_for_component(team, db=db, pinned_versions=member_pins))
+            team_id, version = self._create_component(
+                team,
+                db,
+                links=self._links_for_component(team, db=db, pinned_versions=member_pins),
+            )
             log_debug(f"StudioTools created team id={team_id} members={member_ids} version={version}")
             return json.dumps(
                 {
@@ -1166,17 +1244,18 @@ class StudioTools(Toolkit):
                 step_pins = self._bind_steps_to_target_db(steps, db)
             except ValueError as e:
                 return json.dumps({"error": str(e)})
-            workflow_id = self._unique_component_id(name, db)
             workflow = Workflow(
-                id=workflow_id,
+                id=generate_component_id_from_name(name),
                 name=name,
                 description=description,
                 steps=steps,
                 db=db,
             )
 
-            version = _persist_only(
-                workflow, db, links=self._links_for_component(workflow, db=db, pinned_versions=step_pins)
+            workflow_id, version = self._create_component(
+                workflow,
+                db,
+                links=self._links_for_component(workflow, db=db, pinned_versions=step_pins),
             )
             log_debug(f"StudioTools created workflow id={workflow_id} steps={len(steps)} version={version}")
             return json.dumps(
@@ -1596,9 +1675,12 @@ class StudioTools(Toolkit):
                 if match is None:
                     return json.dumps({"error": f"Version not found: {component_id} v{target}"})
                 if match.get("stage") == "published":
+                    self._require_studio_owned(component_id, version=target)
                     if not catalog_v2:
                         self._sync_component_row(component_id, target)
                     return json.dumps({"status": "already_published", "id": component_id, "version": target})
+
+            self._require_studio_owned(component_id, version=target)
 
             if catalog_v2:
                 result = self.db.upsert_config(
@@ -1636,7 +1718,31 @@ class StudioTools(Toolkit):
         if self.db is None:
             return json.dumps({"error": "StudioTools has no db configured."})
         try:
-            ok = self.db.set_current_version(component_id, version=version)
+            catalog_v2 = getattr(self.db, "component_catalog_api_version", 1) >= 2
+            self._require_studio_owned(component_id, version=version)
+            if catalog_v2:
+                from agno.db.base import ComponentVersionGuard
+
+                component = self.db.get_component(component_id)
+                if component is None:
+                    return json.dumps({"error": f"Component not found: {component_id}"})
+                configs = self.db.list_configs(component_id, include_config=False)
+                latest_version = max(
+                    (config["version"] for config in configs if isinstance(config.get("version"), int)),
+                    default=None,
+                )
+                ok = self.db.set_current_version(
+                    component_id,
+                    version=version,
+                    guard=ComponentVersionGuard(
+                        latest_version=latest_version,
+                        current_version=component.get("current_version"),
+                    ),
+                )
+            else:
+                # Catalog-v1 adapters predate keyword-only guards. Preserve
+                # their exact call shape instead of probing and catching TypeError.
+                ok = self.db.set_current_version(component_id, version=version)
             if not ok:
                 return json.dumps({"error": f"Component or version not found: {component_id} v{version}"})
             return json.dumps({"status": "set_current", "id": component_id, "version": version})
@@ -1654,7 +1760,12 @@ class StudioTools(Toolkit):
         if self.db is None:
             return json.dumps({"error": "StudioTools has no db configured."})
         try:
-            deleted = self.db.delete_config(component_id, version=version)
+            self._require_studio_owned(component_id, version=version)
+            if getattr(self.db, "component_catalog_api_version", 1) >= 2:
+                _, guard = self._component_guard(component_id)
+                deleted = self.db.delete_config(component_id, version=version, guard=guard)
+            else:
+                deleted = self.db.delete_config(component_id, version=version)
             if not deleted:
                 return json.dumps({"error": f"Version not found: {component_id} v{version}"})
             return json.dumps({"status": "deleted", "id": component_id, "version": version})
@@ -1666,8 +1777,42 @@ class StudioTools(Toolkit):
     # Delete
     # ------------------------------------------------------------------
 
+    def _archive_studio_component(self, component_id: str, component_type: Any, noun: str) -> str:
+        """Archive a typed Studio component with the state observed here."""
+        if self.db is None:
+            return json.dumps({"error": "StudioTools has no db configured; cannot delete components."})
+
+        component = self.db.get_component(component_id, component_type=component_type)
+        if component is None:
+            resolved = self._runner_tools._resolve_db_id_by_name_or_slug(component_type.value, component_id)
+            if resolved is not None:
+                return json.dumps(
+                    {"error": f"Delete requires the exact id: '{component_id}' resolves to '{resolved}'."}
+                )
+            return json.dumps({"error": f"{noun} not found: {component_id}"})
+
+        catalog_v2 = getattr(self.db, "component_catalog_api_version", 1) >= 2
+        if catalog_v2:
+            component, guard = self._component_guard(component_id)
+            target_version = component.get("current_version") or guard.latest_version
+            self._require_studio_owned(component_id, version=target_version)
+            deleted = self.db.delete_component(
+                component_id,
+                hard_delete=False,
+                guard=guard,
+                expected_component_type=component_type,
+            )
+            status = "archived"
+        else:
+            self._require_studio_owned(component_id)
+            deleted = self.db.delete_component(component_id, hard_delete=True)
+            status = "deleted"
+        if not deleted:
+            return json.dumps({"error": f"{noun} not found: {component_id}"})
+        return json.dumps({"status": status, "id": component_id})
+
     def delete_agent(self, agent_id: str) -> str:
-        """Hard-delete an agent DB component.
+        """Archive a Studio-created agent DB component.
 
         Args:
             agent_id (str): The exact id of the agent to delete. Display names
@@ -1678,24 +1823,13 @@ class StudioTools(Toolkit):
         try:
             from agno.db.base import ComponentType
 
-            component = self.db.get_component(agent_id, component_type=ComponentType.AGENT)
-            if component is None:
-                resolved = self._runner_tools._resolve_db_id_by_name_or_slug("agent", agent_id)
-                if resolved is not None:
-                    return json.dumps(
-                        {"error": f"Delete requires the exact id: '{agent_id}' resolves to '{resolved}'."}
-                    )
-                return json.dumps({"error": f"Agent not found: {agent_id}"})
-            deleted = self.db.delete_component(agent_id, hard_delete=True)
-            if not deleted:
-                return json.dumps({"error": f"Agent not found: {agent_id}"})
-            return json.dumps({"status": "deleted", "id": agent_id})
+            return self._archive_studio_component(agent_id, ComponentType.AGENT, "Agent")
         except Exception as e:
             logger.exception("Failed to delete agent")
             return json.dumps({"error": str(e) or type(e).__name__})
 
     def delete_team(self, team_id: str) -> str:
-        """Hard-delete a team component.
+        """Archive a Studio-created team component.
 
         Args:
             team_id (str): The exact id of the team to delete. Display names
@@ -1706,22 +1840,13 @@ class StudioTools(Toolkit):
         try:
             from agno.db.base import ComponentType
 
-            component = self.db.get_component(team_id, component_type=ComponentType.TEAM)
-            if component is None:
-                resolved = self._runner_tools._resolve_db_id_by_name_or_slug("team", team_id)
-                if resolved is not None:
-                    return json.dumps({"error": f"Delete requires the exact id: '{team_id}' resolves to '{resolved}'."})
-                return json.dumps({"error": f"Team not found: {team_id}"})
-            deleted = self.db.delete_component(team_id, hard_delete=True)
-            if not deleted:
-                return json.dumps({"error": f"Team not found: {team_id}"})
-            return json.dumps({"status": "deleted", "id": team_id})
+            return self._archive_studio_component(team_id, ComponentType.TEAM, "Team")
         except Exception as e:
             logger.exception("Failed to delete team")
             return json.dumps({"error": str(e) or type(e).__name__})
 
     def delete_workflow(self, workflow_id: str) -> str:
-        """Hard-delete a workflow component.
+        """Archive a Studio-created workflow component.
 
         Args:
             workflow_id (str): The exact id of the workflow to delete. Display
@@ -1732,20 +1857,53 @@ class StudioTools(Toolkit):
         try:
             from agno.db.base import ComponentType
 
-            component = self.db.get_component(workflow_id, component_type=ComponentType.WORKFLOW)
-            if component is None:
-                resolved = self._runner_tools._resolve_db_id_by_name_or_slug("workflow", workflow_id)
-                if resolved is not None:
-                    return json.dumps(
-                        {"error": f"Delete requires the exact id: '{workflow_id}' resolves to '{resolved}'."}
-                    )
-                return json.dumps({"error": f"Workflow not found: {workflow_id}"})
-            deleted = self.db.delete_component(workflow_id, hard_delete=True)
-            if not deleted:
-                return json.dumps({"error": f"Workflow not found: {workflow_id}"})
-            return json.dumps({"status": "deleted", "id": workflow_id})
+            return self._archive_studio_component(workflow_id, ComponentType.WORKFLOW, "Workflow")
         except Exception as e:
             logger.exception("Failed to delete workflow")
+            return json.dumps({"error": str(e) or type(e).__name__})
+
+    def restore_component(self, component_id: str) -> str:
+        """Restore an archived Studio-created component by exact id.
+
+        Args:
+            component_id (str): Exact archived component id. Display names do not resolve.
+        """
+        if self.db is None:
+            return json.dumps({"error": "StudioTools has no db configured; cannot restore components."})
+        if getattr(self.db, "component_catalog_api_version", 1) < 2:
+            return json.dumps({"error": "Explicit restore requires component catalog API v2"})
+        try:
+            component, guard = self._component_guard(component_id, include_deleted=True)
+            if component.get("deleted_at") is None:
+                return json.dumps({"status": "already_active", "id": component_id})
+
+            enabled = {
+                "agent": self.enable_agents,
+                "team": self.enable_teams,
+                "workflow": self.enable_workflows,
+            }
+            component_type = component.get("component_type")
+            if not isinstance(component_type, str) or not enabled.get(component_type, False):
+                return json.dumps({"error": f"{component_type or 'unknown'} operations are not enabled"})
+
+            projection_version = component.get("current_version") or guard.latest_version
+            config_row = self._require_studio_owned(
+                component_id,
+                version=projection_version,
+                include_deleted=True,
+            )
+            config = config_row["config"]
+            projection: "ComponentProjection" = {
+                "name": config.get("name") or component.get("name") or component_id,
+                "description": config.get("description"),
+                "metadata": deepcopy(config.get("metadata")),
+            }
+            restored = self.db.restore_component(component_id, guard=guard, projection=projection)
+            if not restored:
+                return json.dumps({"error": f"Component is not archived: {component_id}"})
+            return json.dumps({"status": "restored", "id": component_id})
+        except Exception as e:
+            logger.exception("Failed to restore component")
             return json.dumps({"error": str(e) or type(e).__name__})
 
     # ------------------------------------------------------------------
@@ -2131,6 +2289,10 @@ class StudioTools(Toolkit):
         """Async variant of delete_workflow."""
         return await self._run_sync_tool(self.delete_workflow, workflow_id)
 
+    async def arestore_component(self, component_id: str) -> str:
+        """Async variant of restore_component."""
+        return await self._run_sync_tool(self.restore_component, component_id)
+
     async def acreate_schedule(
         self,
         name: str,
@@ -2162,19 +2324,53 @@ class StudioTools(Toolkit):
 
         return await asyncio.to_thread(function, *args, **kwargs)
 
-    def _unique_component_id(self, name: str, db: "BaseDb") -> str:
-        """Return a unique id in the DB component namespace.
+    def _create_component(
+        self,
+        component: Component,
+        db: "BaseDb",
+        links: Optional[List[Dict[str, Any]]] = None,
+    ) -> tuple[str, Optional[int]]:
+        """Create one top-level Studio component without a split transaction.
 
-        Components use ``component_id`` as the primary key, so agents, teams,
-        and workflows intentionally share one id namespace.
+        Catalog-v2 creation reserves the ID and writes version one atomically.
+        If a concurrent creator wins the candidate ID, retry with the next
+        suffix instead of appending a second version to the winner's component.
+        Catalog-v1 adapters retain their historical non-atomic call shapes.
         """
-        base = _slugify(name)
-        candidate = base
-        suffix = 2
-        while self._component_id_exists(candidate, db):
-            candidate = f"{base}-{suffix}"
+        from agno.db.base import ComponentAlreadyExistsError
+
+        name = getattr(component, "name", None)
+        if not isinstance(name, str) or not name:
+            raise ValueError("Component has no name")
+
+        base = generate_component_id_from_name(name)
+        suffix = 1
+        while True:
+            component_id = base if suffix == 1 else f"{base}-{suffix}"
             suffix += 1
-        return candidate
+            if self._component_id_exists(component_id, db):
+                continue
+            component.id = component_id
+
+            if getattr(db, "component_catalog_api_version", 1) < 2:
+                return component_id, _persist_only(component, db, links=links)
+
+            try:
+                _, config_row = db.create_component_with_config(
+                    component_id=component_id,
+                    component_type=_component_type(component),
+                    name=name,
+                    description=getattr(component, "description", None),
+                    metadata=getattr(component, "metadata", None),
+                    config=_canonical_component_config(component),
+                    stage="published",
+                    links=links,
+                )
+                return component_id, config_row.get("version")
+            except ComponentAlreadyExistsError:
+                # The candidate was free at the read above but was reserved by
+                # another creator before our atomic insert. Try the next ID.
+                continue
 
     def _get_schedule_manager(self) -> "ScheduleManager":
         """The shared SchedulerTools instance's manager."""
@@ -2213,9 +2409,11 @@ class StudioTools(Toolkit):
             if (
                 getattr(component, "id", None) == component_id
                 or component_name == component_id
-                or (component_name is not None and _slugify(component_name) == component_id)
+                or (component_name is not None and generate_component_id_from_name(component_name) == component_id)
             ):
                 return True
+        if getattr(db, "component_catalog_api_version", 1) >= 2:
+            return db.get_component(component_id, include_deleted=True) is not None
         return db.get_component(component_id) is not None
 
     def _bind_child_to_target_db(
@@ -2534,7 +2732,7 @@ class StudioTools(Toolkit):
         load dropped (unless this edit replaced that key), and re-emits the
         member/step links so the new version stays pinned.
         """
-        config = _component_to_dict(component)
+        config = _studio_component_config(_component_to_dict(component))
         replaced = replaced_keys or set()
         component_id = getattr(component, "id", None)
         self._preserve_unresolved_keys(component_id, config, replaced, base_version)
@@ -2549,7 +2747,7 @@ class StudioTools(Toolkit):
         if self.enable_versions:
             version = self._upsert_draft(component, config=config, links=links, guard=guard)
             return {"draft_version": version, "stage": "draft"}
-        version = _persist_only(component, self.db, config=config, links=links)
+        version = _persist_only(component, self.db, config=config, links=links, guard=guard)
         return {"version": version, "stage": "published"}
 
     def _preserve_unresolved_keys(
@@ -2766,11 +2964,13 @@ class StudioTools(Toolkit):
                 metadata=getattr(component, "metadata", None),
             )
 
+        draft_config = _studio_component_config(config if config is not None else _component_to_dict(component))
+
         if not catalog_v2:
             result = self.db.upsert_config(
                 component_id=component_id,
                 version=self._latest_draft_version(component_id),
-                config=config if config is not None else _component_to_dict(component),
+                config=draft_config,
                 stage="draft",
                 links=links,
             )
@@ -2781,7 +2981,7 @@ class StudioTools(Toolkit):
 
         result = self.db.upsert_config(
             component_id=component_id,
-            config=config if config is not None else _component_to_dict(component),
+            config=draft_config,
             stage="draft",
             links=links,
             guard=guard,
@@ -2833,6 +3033,7 @@ def _persist_only(
     stage: str = "published",
     config: Optional[Dict[str, Any]] = None,
     links: Optional[List[Dict[str, Any]]] = None,
+    guard: Optional["ComponentVersionGuard"] = None,
 ) -> Optional[int]:
     """Save a component WITHOUT cascading to members or step agents.
 
@@ -2852,18 +3053,19 @@ def _persist_only(
     component_id = getattr(component, "id", None)
     if component_id is None:
         raise ValueError("Component has no id")
-    db.upsert_component(
+    from agno.db.utils import save_component_config
+
+    result = save_component_config(
+        db,
         component_id=component_id,
         component_type=_component_type(component),
         name=getattr(component, "name", component_id),
         description=getattr(component, "description", None),
         metadata=getattr(component, "metadata", None),
-    )
-    result = db.upsert_config(
-        component_id=component_id,
-        config=config if config is not None else _component_to_dict(component),
+        config=_studio_component_config(config if config is not None else _component_to_dict(component)),
         stage=stage,
         links=links,
+        guard=guard,
     )
     return result.get("version")
 
@@ -2944,6 +3146,26 @@ def _component_to_dict(component: Component, carry: Optional[Dict[str, Any]] = N
         # the edited one and wins.
         config.setdefault(key, value)
     return config
+
+
+def _canonical_component_config(component: Component) -> Dict[str, Any]:
+    """Embed the complete catalog projection in an immutable Studio config."""
+    config = _component_to_dict(component)
+    config.update(
+        {
+            "name": getattr(component, "name", None) or getattr(component, "id", None),
+            "description": getattr(component, "description", None),
+            "metadata": deepcopy(getattr(component, "metadata", None)),
+        }
+    )
+    return _studio_component_config(config)
+
+
+def _studio_component_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Stamp immutable ownership metadata on every Studio-written version."""
+    marked = deepcopy(config)
+    marked[_STUDIO_CONFIG_KEY] = deepcopy(_STUDIO_CONFIG_MANIFEST)
+    return marked
 
 
 # Backward-compatible alias. The toolkit was originally released as ``StudioTool``

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -20,8 +20,7 @@ Typical use:
 Semantics:
     * create_* persists a new component with a single published config.
     * edit_* loads the component, applies the patch, and saves it:
-      - with versions=True the edit is saved as a draft (an existing draft is
-        updated in place; otherwise a new draft version is created). Use
+      - with versions=True the edit is saved as a new immutable draft. Use
         publish_component() to promote the draft to published+current.
       - with versions=False (default) the edit is published immediately as a
         new current version. Each edit creates a new published version; prior
@@ -69,7 +68,7 @@ from agno.utils.log import log_debug, logger
 
 if TYPE_CHECKING:
     from agno.agent.agent import Agent
-    from agno.db.base import BaseDb
+    from agno.db.base import BaseDb, ComponentVersionGuard
     from agno.models.base import Model
     from agno.registry.registry import Registry
     from agno.scheduler.manager import ScheduleManager
@@ -519,38 +518,74 @@ class StudioTools(Toolkit):
     # draft when versioning is enabled, so successive partial edits accumulate
     # instead of each resetting to the published config.
 
-    def _find_agent_for_edit(self, agent_id: str) -> Optional["Agent"]:
+    def _edit_version_snapshot(self, component_id: str) -> tuple[Optional[int], Optional["ComponentVersionGuard"]]:
+        """Capture the exact config loaded by an edit and its catalog-v2 CAS state."""
+        if self.db is None:
+            return None, None
+        if not self.enable_versions or getattr(self.db, "component_catalog_api_version", 1) < 2:
+            return self._edit_base_version(component_id), None
+
+        from agno.db.base import ComponentVersionGuard
+
+        component = self.db.get_component(component_id)
+        if component is None:
+            return None, None
+        configs = self.db.list_configs(component_id, include_config=False)
+        versions = [row["version"] for row in configs if isinstance(row.get("version"), int)]
+        drafts = [
+            row["version"] for row in configs if row.get("stage") == "draft" and isinstance(row.get("version"), int)
+        ]
+        current_version = component.get("current_version")
+        base_version = max(drafts) if drafts else current_version
+        return base_version, ComponentVersionGuard(
+            latest_version=max(versions) if versions else None,
+            current_version=current_version,
+        )
+
+    def _find_agent_for_edit(
+        self, agent_id: str
+    ) -> tuple[Optional["Agent"], Optional[int], Optional["ComponentVersionGuard"]]:
         for a in self._iter_agents():
             if getattr(a, "id", None) == agent_id:
-                return a
+                return a, None, None
         if self._runner_tools._db_component_exists("agent", agent_id):
-            return self._load_agent_from_db(agent_id, version=self._edit_base_version(agent_id))
+            base_version, guard = self._edit_version_snapshot(agent_id)
+            return self._load_agent_from_db(agent_id, version=base_version), base_version, guard
         resolved = self._runner_tools._resolve_db_id_by_name_or_slug("agent", agent_id)
         if resolved is None:
-            return None
-        return self._load_agent_from_db(resolved, version=self._edit_base_version(resolved))
+            return None, None, None
+        base_version, guard = self._edit_version_snapshot(resolved)
+        return self._load_agent_from_db(resolved, version=base_version), base_version, guard
 
-    def _find_team_for_edit(self, team_id: str) -> Optional["Team"]:
+    def _find_team_for_edit(
+        self, team_id: str
+    ) -> tuple[Optional["Team"], Optional[int], Optional["ComponentVersionGuard"]]:
         for t in self._iter_teams():
             if getattr(t, "id", None) == team_id:
-                return t
+                return t, None, None
         if self._runner_tools._db_component_exists("team", team_id):
-            return self._load_team_from_db(team_id, version=self._edit_base_version(team_id))
+            base_version, guard = self._edit_version_snapshot(team_id)
+            return self._load_team_from_db(team_id, version=base_version), base_version, guard
         resolved = self._runner_tools._resolve_db_id_by_name_or_slug("team", team_id)
         if resolved is None:
-            return None
-        return self._load_team_from_db(resolved, version=self._edit_base_version(resolved))
+            return None, None, None
+        base_version, guard = self._edit_version_snapshot(resolved)
+        return self._load_team_from_db(resolved, version=base_version), base_version, guard
 
-    def _find_workflow_for_edit(self, workflow_id: str) -> Optional["Workflow"]:
+    def _find_workflow_for_edit(
+        self, workflow_id: str
+    ) -> tuple[Optional["Workflow"], Optional[int], Optional["ComponentVersionGuard"]]:
         for w in self._iter_workflows():
             if getattr(w, "id", None) == workflow_id:
-                return w
+                return w, None, None
         if self._runner_tools._db_component_exists("workflow", workflow_id):
-            return self._load_workflow_from_db(workflow_id, version=self._edit_base_version(workflow_id))
+            base_version, guard = self._edit_version_snapshot(workflow_id)
+            return self._load_workflow_from_db(workflow_id, version=base_version), base_version, guard
         resolved = self._runner_tools._resolve_db_id_by_name_or_slug("workflow", workflow_id)
         if resolved is None:
-            return None
-        return self._load_workflow_from_db(resolved, version=self._edit_base_version(resolved))
+            return None, None, None
+        base_version, guard = self._edit_version_snapshot(resolved)
+        return self._load_workflow_from_db(resolved, version=base_version), base_version, guard
 
     def _is_code_defined(self, component_id: str, candidates: List[Any], component_type: str) -> bool:
         """True if the identifier refers to a code-defined (registry/list) component.
@@ -1211,7 +1246,7 @@ class StudioTools(Toolkit):
                         f"Only Studio-created components are editable.{hint}"
                     }
                 )
-            agent = self._find_agent_for_edit(agent_id)
+            agent, edit_base_version, edit_guard = self._find_agent_for_edit(agent_id)
         except StudioRunnerError as e:
             return json.dumps({"error": str(e) or type(e).__name__})
         except Exception as e:
@@ -1251,7 +1286,12 @@ class StudioTools(Toolkit):
                 replaced_keys.add("tools")
             if model_id is not None:
                 replaced_keys.add("model")
-            result = self._save_edit(agent, replaced_keys=replaced_keys)
+            result = self._save_edit(
+                agent,
+                replaced_keys=replaced_keys,
+                base_version=edit_base_version,
+                guard=edit_guard,
+            )
             log_debug(f"StudioTools edited agent id={agent.id} result={result}")
             return json.dumps({"status": "edited", "id": getattr(agent, "id", None) or agent_id, **result})
         except Exception as e:
@@ -1307,7 +1347,7 @@ class StudioTools(Toolkit):
                         f"Only Studio-created components are editable.{hint}"
                     }
                 )
-            team = self._find_team_for_edit(team_id)
+            team, edit_base_version, edit_guard = self._find_team_for_edit(team_id)
         except StudioRunnerError as e:
             return json.dumps({"error": str(e) or type(e).__name__})
         except Exception as e:
@@ -1351,7 +1391,7 @@ class StudioTools(Toolkit):
                 # agents_list entry, for one. Re-serializing that rebuild would
                 # publish a roster silently shrunk by an unrelated edit.
                 resolved_id = getattr(team, "id", None) or team_id
-                row = self.db.get_config(component_id=resolved_id, version=self._edit_base_version(resolved_id))
+                row = self.db.get_config(component_id=resolved_id, version=edit_base_version)
                 stored_config = row.get("config") if isinstance(row, dict) else None
                 stored_members = (stored_config or {}).get("members") or []
                 rebuilt_members = team.members if isinstance(team.members, list) else []
@@ -1378,7 +1418,13 @@ class StudioTools(Toolkit):
                 replaced_keys.add("members")
             if model_id is not None:
                 replaced_keys.add("model")
-            result = self._save_edit(team, replaced_keys=replaced_keys, pinned_children=replaced_pins)
+            result = self._save_edit(
+                team,
+                replaced_keys=replaced_keys,
+                pinned_children=replaced_pins,
+                base_version=edit_base_version,
+                guard=edit_guard,
+            )
             log_debug(f"StudioTools edited team id={team.id} result={result}")
             return json.dumps({"status": "edited", "id": getattr(team, "id", None) or team_id, **result})
         except Exception as e:
@@ -1423,7 +1469,7 @@ class StudioTools(Toolkit):
                         f"Only Studio-created components are editable.{hint}"
                     }
                 )
-            wf = self._find_workflow_for_edit(workflow_id)
+            wf, edit_base_version, edit_guard = self._find_workflow_for_edit(workflow_id)
         except StudioRunnerError as e:
             return json.dumps({"error": str(e) or type(e).__name__})
         except Exception as e:
@@ -1457,6 +1503,8 @@ class StudioTools(Toolkit):
                 wf,
                 replaced_keys={"steps"} if step_specs is not None else None,
                 pinned_children=replaced_pins,
+                base_version=edit_base_version,
+                guard=edit_guard,
             )
             log_debug(f"StudioTools edited workflow id={wf.id} result={result}")
             return json.dumps({"status": "edited", "id": getattr(wf, "id", None) or workflow_id, **result})
@@ -1525,7 +1573,17 @@ class StudioTools(Toolkit):
         if self.db is None:
             return json.dumps({"error": "StudioTools has no db configured."})
         try:
+            from agno.db.base import ComponentVersionGuard
+
+            component = self.db.get_component(component_id)
+            if component is None:
+                return json.dumps({"error": f"Component not found: {component_id}"})
+            catalog_v2 = getattr(self.db, "component_catalog_api_version", 1) >= 2
             configs = self.db.list_configs(component_id, include_config=False)
+            latest_version = max(
+                (c["version"] for c in configs if isinstance(c.get("version"), int)),
+                default=None,
+            )
             target = version
             if target is None:
                 drafts = [c for c in configs if c.get("stage") == "draft"]
@@ -1538,12 +1596,25 @@ class StudioTools(Toolkit):
                 if match is None:
                     return json.dumps({"error": f"Version not found: {component_id} v{target}"})
                 if match.get("stage") == "published":
-                    self._sync_component_row(component_id, target)
+                    if not catalog_v2:
+                        self._sync_component_row(component_id, target)
                     return json.dumps({"status": "already_published", "id": component_id, "version": target})
 
-            result = self.db.upsert_config(component_id=component_id, version=target, stage="published")
+            if catalog_v2:
+                result = self.db.upsert_config(
+                    component_id=component_id,
+                    version=target,
+                    stage="published",
+                    guard=ComponentVersionGuard(
+                        latest_version=latest_version,
+                        current_version=component.get("current_version"),
+                    ),
+                )
+            else:
+                result = self.db.upsert_config(component_id=component_id, version=target, stage="published")
             published_version = result.get("version", target)
-            self._sync_component_row(component_id, published_version)
+            if not catalog_v2:
+                self._sync_component_row(component_id, published_version)
             return json.dumps(
                 {
                     "status": "published",
@@ -2449,6 +2520,8 @@ class StudioTools(Toolkit):
         component: Component,
         replaced_keys: Optional[Set[str]] = None,
         pinned_children: Optional[Dict[str, int]] = None,
+        base_version: Optional[int] = None,
+        guard: Optional["ComponentVersionGuard"] = None,
     ) -> Dict[str, Any]:
         """Persist an edited component.
 
@@ -2464,7 +2537,7 @@ class StudioTools(Toolkit):
         config = _component_to_dict(component)
         replaced = replaced_keys or set()
         component_id = getattr(component, "id", None)
-        self._preserve_unresolved_keys(component_id, config, replaced)
+        self._preserve_unresolved_keys(component_id, config, replaced, base_version)
         if replaced & {"members", "steps"}:
             # The edit replaced the composition: pin the new children at the
             # exact versions the binder rebuilt them from.
@@ -2472,20 +2545,24 @@ class StudioTools(Toolkit):
         else:
             # Untouched composition keeps the base version's pins verbatim,
             # including link kinds this walk does not reconstruct.
-            links = self._base_links(component_id)
+            links = self._base_links(component_id, base_version)
         if self.enable_versions:
-            version = self._upsert_draft(component, config=config, links=links)
+            version = self._upsert_draft(component, config=config, links=links, guard=guard)
             return {"draft_version": version, "stage": "draft"}
         version = _persist_only(component, self.db, config=config, links=links)
         return {"version": version, "stage": "published"}
 
     def _preserve_unresolved_keys(
-        self, component_id: Optional[str], config: Dict[str, Any], replaced_keys: Set[str]
+        self,
+        component_id: Optional[str],
+        config: Dict[str, Any],
+        replaced_keys: Set[str],
+        base_version: Optional[int],
     ) -> None:
         """Copy stored reference keys the lenient load dropped back into ``config``."""
         if self.db is None or component_id is None:
             return
-        base = self._runner_tools._load_config_from_db(component_id, version=self._edit_base_version(component_id))
+        base = self._runner_tools._load_config_from_db(component_id, version=base_version)
         if not isinstance(base, dict):
             raise ValueError(
                 f"Cannot edit '{component_id}': its stored config could not be read, so an edit would drop "
@@ -2508,12 +2585,12 @@ class StudioTools(Toolkit):
                 config[key] = base[key]
                 log_debug(f"StudioTools: preserving stored '{key}' the lenient load could not resolve.")
 
-    def _base_links(self, component_id: Optional[str]) -> Optional[List[Dict[str, Any]]]:
+    def _base_links(self, component_id: Optional[str], base_version: Optional[int]) -> Optional[List[Dict[str, Any]]]:
         """The base version's links, carried forward verbatim on an edit that
         did not replace the component's composition."""
         if self.db is None or component_id is None:
             return None
-        return self._runner_tools._load_links_from_db(component_id, version=self._edit_base_version(component_id))
+        return self._runner_tools._load_links_from_db(component_id, version=base_version)
 
     def _links_for_component(
         self,
@@ -2661,12 +2738,13 @@ class StudioTools(Toolkit):
         component: Component,
         config: Optional[Dict[str, Any]] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        guard: Optional["ComponentVersionGuard"] = None,
     ) -> Optional[int]:
-        """Save a component as a draft. Updates the latest draft in place, else creates one.
+        """Append an immutable draft using the component version observed by this edit.
 
         The component row's name/description/metadata are NOT updated here --
         draft-only changes must not leak into listings until the draft is
-        published (publish_component syncs the row).
+        published.
         """
         if self.db is None:
             raise ValueError("db is required for draft persistence")
@@ -2675,7 +2753,11 @@ class StudioTools(Toolkit):
         if component_id is None:
             raise ValueError("Component has no id")
 
-        if self.db.get_component(component_id) is None:
+        catalog_v2 = getattr(self.db, "component_catalog_api_version", 1) >= 2
+        component_row = self.db.get_component(component_id)
+        if component_row is None:
+            if catalog_v2:
+                raise ValueError(f"Component not found: {component_id}")
             self.db.upsert_component(
                 component_id=component_id,
                 component_type=_component_type(component),
@@ -2684,19 +2766,30 @@ class StudioTools(Toolkit):
                 metadata=getattr(component, "metadata", None),
             )
 
-        # Reuse an existing draft if there is one; otherwise create a new draft version.
+        if not catalog_v2:
+            result = self.db.upsert_config(
+                component_id=component_id,
+                version=self._latest_draft_version(component_id),
+                config=config if config is not None else _component_to_dict(component),
+                stage="draft",
+                links=links,
+            )
+            return result.get("version")
+
+        if guard is None:
+            raise ValueError("A catalog-v2 draft append requires a component version guard")
+
         result = self.db.upsert_config(
             component_id=component_id,
-            version=self._latest_draft_version(component_id),
             config=config if config is not None else _component_to_dict(component),
             stage="draft",
             links=links,
+            guard=guard,
         )
         return result.get("version")
 
     def _sync_component_row(self, component_id: str, version: Optional[int]) -> None:
-        """Bring the component row's name/description/metadata in line with a
-        newly published config version."""
+        """Sync legacy catalog-v1 projections after a publication."""
         if self.db is None:
             return
         from agno.db.base import ComponentType

--- a/libs/agno/agno/tools/studio_runner.py
+++ b/libs/agno/agno/tools/studio_runner.py
@@ -106,6 +106,7 @@ from agno.run import RunContext
 from agno.run.utils import run_status_string, serialized_paused_requirements
 from agno.tools.toolkit import Toolkit
 from agno.utils.log import logger
+from agno.utils.string import generate_component_id_from_name
 
 if TYPE_CHECKING:
     from agno.agent.agent import Agent
@@ -126,10 +127,7 @@ _GRAPH_DEPTH_CAP = 32
 
 def _slugify(name: str) -> str:
     """Component ids are slugified names (shared with StudioTools' create path)."""
-    slug = "".join(c.lower() if c.isalnum() else "-" for c in name.strip())
-    while "--" in slug:
-        slug = slug.replace("--", "-")
-    return slug.strip("-") or "component"
+    return generate_component_id_from_name(name)
 
 
 class StudioRunnerError(Exception):

--- a/libs/agno/agno/utils/string.py
+++ b/libs/agno/agno/utils/string.py
@@ -315,6 +315,23 @@ def generate_id_from_name(name: Optional[str] = None) -> str:
         return generate_human_readable_id()
 
 
+def generate_component_id_from_name(name: Optional[str] = None) -> str:
+    """Generate a new component ID that is safe as one REST path segment.
+
+    ``generate_id_from_name`` remains unchanged because its historical output
+    is persisted outside the component catalog too. Existing component IDs
+    remain addressable exactly; only newly derived component IDs use this
+    stricter contract.
+    """
+    if name:
+        slug = "".join(char.lower() if char.isalnum() else "-" for char in name.strip())
+        slug = re.sub(r"-+", "-", slug).strip("-")
+        return slug or "component"
+    from agno.utils.names import generate_human_readable_id
+
+    return generate_human_readable_id()
+
+
 def sanitize_postgres_string(value: Optional[str]) -> Optional[str]:
     """Remove illegal chars from string values to prevent PostgreSQL encoding errors.
 

--- a/libs/agno/agno/utils/string.py
+++ b/libs/agno/agno/utils/string.py
@@ -304,6 +304,10 @@ def generate_id_from_name(name: Optional[str] = None) -> str:
         name (str): The name string to generate the ID from.
     """
     if name:
+        # This exact transformation is a persisted identity contract. Agents,
+        # teams, workflows, Studio, and the Components API have historically
+        # derived IDs with it, so tightening the slug shape here would silently
+        # point an existing name at a different catalog row.
         return name.lower().replace(" ", "-").replace("_", "-")
     else:
         from agno.utils.names import generate_human_readable_id

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 from agno.agent.agent import Agent
 from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, SessionType
-from agno.db.utils import resolve_db_from_config
+from agno.db.utils import resolve_db_from_config, save_component_config
 from agno.exceptions import InputCheckError, OutputCheckError, RunCancelledException
 from agno.media import Audio, File, Image, Video
 from agno.models.message import Message
@@ -1167,6 +1167,13 @@ class Workflow:
                         link.get("child_component_id"),
                         link.get("child_version"),
                     ):
+                        # Preserve the historical warn-and-keep-first behavior
+                        # when dropping this row cannot discard a distinct pin.
+                        log_warning(
+                            f"Workflow '{self.id}': dropping duplicate {link.get('link_kind')} link for "
+                            f"key '{link.get('link_key')}' (child '{link.get('child_component_id')}'); "
+                            "give steps distinct names so each pin is kept."
+                        )
                         continue
                     # A save that silently drops one of two different pins
                     # would float that child to its latest version forever.
@@ -1181,15 +1188,13 @@ class Workflow:
                 deduped_links.append(link)
             all_links = deduped_links
 
-            db_.upsert_component(
+            config = save_component_config(
+                db_,
                 component_id=self.id,
                 component_type=ComponentType.WORKFLOW,
                 name=self.name,
                 description=self.description,
                 metadata=self.metadata,
-            )
-            config = db_.upsert_config(
-                component_id=self.id,
                 config=self.to_dict(),
                 links=all_links,
                 label=label,
@@ -1269,6 +1274,7 @@ class Workflow:
         *,
         db: Optional["BaseDb"] = None,
         hard_delete: bool = False,
+        require_no_dependents: bool = True,
     ) -> bool:
         """
         Delete the workflow component.
@@ -1276,9 +1282,19 @@ class Workflow:
         Args:
             db: The database to delete the workflow from.
             hard_delete: Whether to hard delete the workflow.
+            require_no_dependents: Refuse deletion while another active
+                component references this workflow. Setting this to False
+                bypasses dependency validation and can leave active components
+                with dangling links; use it only for a deliberate repair or
+                migration. Catalog-v1 adapters retain their historical
+                unguarded deletion behavior.
 
         Returns:
             True if the workflow was deleted, False otherwise.
+
+        Raises:
+            ComponentDependencyError: If a dependent component references
+                this workflow and require_no_dependents is True.
         """
         db_ = db or self.db
         if not db_:
@@ -1288,7 +1304,15 @@ class Workflow:
         if self.id is None:
             raise ValueError("Cannot delete workflow without an id")
 
-        return db_.delete_component(component_id=self.id, hard_delete=hard_delete)
+        if getattr(db_, "component_catalog_api_version", 1) < 2:
+            # Preserve the exact pre-2.9 adapter call shape. Third-party
+            # catalog-v1 implementations cannot accept the v2-only policy.
+            return db_.delete_component(component_id=self.id, hard_delete=hard_delete)
+        return db_.delete_component(
+            component_id=self.id,
+            hard_delete=hard_delete,
+            require_no_dependents=require_no_dependents,
+        )
 
     async def aget_run_output(
         self, run_id: str, session_id: Optional[str] = None, user_id: Optional[str] = None
@@ -11232,6 +11256,7 @@ def get_workflow_by_id(
     label: Optional[str] = None,
     registry: Optional["Registry"] = None,
     strict: bool = False,
+    published_only: bool = False,
 ) -> Optional["Workflow"]:
     """
     Get a Workflow by id from the database (new entities/configs schema).
@@ -11239,7 +11264,8 @@ def get_workflow_by_id(
     Resolution order:
     - if version is provided: load that version
     - elif label is provided: load that labeled version
-    - else: load entity.current_version
+    - else: load the current published version, or the latest draft when the
+      component has never been published
 
     Args:
         db: Database handle.
@@ -11249,6 +11275,9 @@ def get_workflow_by_id(
         registry: Optional Registry for reconstructing unserializable components.
         strict: If True, unresolvable registry references raise
             ComponentRehydrationError; None strictly means the workflow was not found.
+        published_only: Resolve only the current published config when neither
+            an exact version nor label is supplied. Runtime dispatch uses this;
+            ordinary reads retain the draft-only fallback.
 
     Returns:
         Workflow instance or None.
@@ -11259,7 +11288,11 @@ def get_workflow_by_id(
     from agno.exceptions import ComponentRehydrationError
 
     try:
-        row = db.get_config(component_id=id, version=version, label=label)
+        row = (
+            db.get_current_config(component_id=id)
+            if published_only and version is None and label is None
+            else db.get_config(component_id=id, version=version, label=label)
+        )
         if row is None:
             return None
 
@@ -11312,7 +11345,7 @@ def get_workflows(
         components, _ = db.list_components(component_type=ComponentType.WORKFLOW)
         for component in components:
             try:
-                config = db.get_config(component_id=component["component_id"])
+                config = db.get_latest_config(component_id=component["component_id"])
                 if config is not None:
                     workflow_config = config.get("config")
                     if workflow_config is not None:
@@ -11323,7 +11356,7 @@ def get_workflows(
                         # components so they stay visible and fixable.
                         workflow = Workflow.from_dict(workflow_config, db=db, registry=registry, strict=False)
                         workflow.id = component_id
-                        workflow._version = component.get("current_version")
+                        workflow._version = config.get("version")
                         workflow._stage = config.get("stage")
                         workflows.append(workflow)
             except Exception as e:

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -44,6 +44,7 @@ from agno.db.utils import (
     bind_component_version_guard_after_append,
     capture_component_version_guard,
     get_bound_component_version_guard,
+    resolve_component_id,
     resolve_db_from_config,
     save_component_config,
 )
@@ -1105,7 +1106,7 @@ class Workflow:
         if not isinstance(db_, BaseDb):
             raise ValueError("Async databases not yet supported for save(). Use a sync database.")
         if self.id is None:
-            self.id = generate_component_id_from_name(self.name)
+            self.id = resolve_component_id(db_, self.name, ComponentType.WORKFLOW)
 
         mutation_guard = guard or get_bound_component_version_guard(self, db_)
 

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -29,8 +29,24 @@ if TYPE_CHECKING:
     from agno.os.managers import WebSocketHandler
 
 from agno.agent.agent import Agent
-from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, SessionType
-from agno.db.utils import resolve_db_from_config, save_component_config
+from agno.db.base import (
+    AsyncBaseDb,
+    BaseDb,
+    ComponentArchivedError,
+    ComponentType,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+    ComponentVersionGuardRequiredError,
+    SessionType,
+)
+from agno.db.utils import (
+    bind_component_version_guard,
+    bind_component_version_guard_after_append,
+    capture_component_version_guard,
+    get_bound_component_version_guard,
+    resolve_db_from_config,
+    save_component_config,
+)
 from agno.exceptions import InputCheckError, OutputCheckError, RunCancelledException
 from agno.media import Audio, File, Image, Video
 from agno.models.message import Message
@@ -116,7 +132,7 @@ from agno.utils.print_response.workflow import (
     print_response,
     print_response_stream,
 )
-from agno.utils.string import generate_id_from_name
+from agno.utils.string import generate_component_id_from_name
 from agno.workflow.agent import WorkflowAgent
 from agno.workflow.condition import Condition
 from agno.workflow.loop import Loop
@@ -553,7 +569,7 @@ class Workflow:
 
     def set_id(self) -> None:
         if self.id is None:
-            self.id = generate_id_from_name(self.name)
+            self.id = generate_component_id_from_name(self.name)
 
     def _has_async_db(self) -> bool:
         return self.db is not None and isinstance(self.db, AsyncBaseDb)
@@ -1067,6 +1083,7 @@ class Workflow:
         stage: str = "published",
         label: Optional[str] = None,
         notes: Optional[str] = None,
+        guard: Optional[ComponentVersionGuard] = None,
     ) -> Optional[int]:
         """
         Save the workflow component and config.
@@ -1076,6 +1093,8 @@ class Workflow:
             stage: The stage of the component. Defaults to "published".
             label: The label of the component.
             notes: The notes of the component.
+            guard: Explicit catalog-v2 compare-and-set state. Loaded and
+                previously saved objects reuse their captured guard automatically.
 
         Returns:
             Optional[int]: The version number of the saved config.
@@ -1086,10 +1105,13 @@ class Workflow:
         if not isinstance(db_, BaseDb):
             raise ValueError("Async databases not yet supported for save(). Use a sync database.")
         if self.id is None:
-            self.id = generate_id_from_name(self.name)
+            self.id = generate_component_id_from_name(self.name)
+
+        mutation_guard = guard or get_bound_component_version_guard(self, db_)
 
         # Track saved entity versions for pinning links
         saved_versions: Dict[str, int] = {}
+        saved_child_guards: Dict[str, ComponentVersionGuard] = {}
 
         # Collect all links
         all_links: List[Dict[str, Any]] = []
@@ -1104,27 +1126,58 @@ class Workflow:
             if isinstance(step, Step):
                 # Save agent if present
                 if step.agent and isinstance(step.agent, Agent):
+                    child_guard = get_bound_component_version_guard(step.agent, db_)
+                    if child_guard is None and step.agent.id is not None:
+                        child_guard = saved_child_guards.get(step.agent.id)
                     agent_version = step.agent.save(
                         db=db_,
                         stage=stage,
                         label=label,
                         notes=notes,
+                        guard=child_guard,
                     )
                     if step.agent.id is not None and agent_version is not None:
                         saved_versions[step.agent.id] = agent_version
+                        saved_guard = get_bound_component_version_guard(step.agent, db_)
+                        if saved_guard is not None:
+                            saved_child_guards[step.agent.id] = saved_guard
 
                 # Save team if present
                 if step.team and isinstance(step.team, Team):
-                    team_version = step.team.save(db=db_, stage=stage, label=label, notes=notes)
+                    child_guard = get_bound_component_version_guard(step.team, db_)
+                    if child_guard is None and step.team.id is not None:
+                        child_guard = saved_child_guards.get(step.team.id)
+                    team_version = step.team.save(
+                        db=db_,
+                        stage=stage,
+                        label=label,
+                        notes=notes,
+                        guard=child_guard,
+                    )
                     if step.team.id is not None and team_version is not None:
                         saved_versions[step.team.id] = team_version
+                        saved_guard = get_bound_component_version_guard(step.team, db_)
+                        if saved_guard is not None:
+                            saved_child_guards[step.team.id] = saved_guard
 
                 # Save nested workflow if present; without a saved version its
                 # step_workflow link cannot be written and the save would fail.
                 if step.workflow is not None and isinstance(step.workflow, Workflow):
-                    workflow_version = step.workflow.save(db=db_, stage=stage, label=label, notes=notes)
+                    child_guard = get_bound_component_version_guard(step.workflow, db_)
+                    if child_guard is None and step.workflow.id is not None:
+                        child_guard = saved_child_guards.get(step.workflow.id)
+                    workflow_version = step.workflow.save(
+                        db=db_,
+                        stage=stage,
+                        label=label,
+                        notes=notes,
+                        guard=child_guard,
+                    )
                     if step.workflow.id is not None and workflow_version is not None:
                         saved_versions[step.workflow.id] = workflow_version
+                        saved_guard = get_bound_component_version_guard(step.workflow, db_)
+                        if saved_guard is not None:
+                            saved_child_guards[step.workflow.id] = saved_guard
 
                 # Add links with position and pinned version
                 for link in step.get_links(position=position):
@@ -1200,11 +1253,25 @@ class Workflow:
                 label=label,
                 stage=stage,
                 notes=notes,
+                guard=mutation_guard,
             )
+            saved_version = config.get("version")
+            if isinstance(saved_version, int) and getattr(db_, "component_catalog_api_version", 1) >= 2:
+                bind_component_version_guard_after_append(
+                    self,
+                    db_,
+                    previous=mutation_guard,
+                    version=saved_version,
+                    stage=stage,
+                )
+            return saved_version
 
-            return config.get("version")
-
-        except WorkflowLinkCollisionError:
+        except (
+            ComponentArchivedError,
+            ComponentVersionConflictError,
+            ComponentVersionGuardRequiredError,
+            WorkflowLinkCollisionError,
+        ):
             # The refusal must reach the caller: returning None here would
             # read as an I/O failure and hide that the snapshot was rejected.
             raise
@@ -1267,6 +1334,8 @@ class Workflow:
                 require_db_fallback_matches(config, db, "workflow", id)
             workflow.db = db
 
+        capture_component_version_guard(workflow, db, id, expected_config_version=data.get("version"))
+
         return workflow
 
     def delete(
@@ -1275,6 +1344,7 @@ class Workflow:
         db: Optional["BaseDb"] = None,
         hard_delete: bool = False,
         require_no_dependents: bool = True,
+        guard: Optional[ComponentVersionGuard] = None,
     ) -> bool:
         """
         Delete the workflow component.
@@ -1288,6 +1358,8 @@ class Workflow:
                 with dangling links; use it only for a deliberate repair or
                 migration. Catalog-v1 adapters retain their historical
                 unguarded deletion behavior.
+            guard: Explicit catalog-v2 compare-and-set state. Loaded and
+                previously saved objects reuse their captured guard automatically.
 
         Returns:
             True if the workflow was deleted, False otherwise.
@@ -1308,10 +1380,15 @@ class Workflow:
             # Preserve the exact pre-2.9 adapter call shape. Third-party
             # catalog-v1 implementations cannot accept the v2-only policy.
             return db_.delete_component(component_id=self.id, hard_delete=hard_delete)
+        mutation_guard = guard or get_bound_component_version_guard(self, db_)
+        if mutation_guard is None:
+            raise ComponentVersionGuardRequiredError(self.id)
         return db_.delete_component(
             component_id=self.id,
             hard_delete=hard_delete,
+            guard=mutation_guard,
             require_no_dependents=require_no_dependents,
+            expected_component_type=ComponentType.WORKFLOW,
         )
 
     async def aget_run_output(
@@ -11321,6 +11398,8 @@ def get_workflow_by_id(
                 require_db_fallback_matches(cfg, db, "workflow", id)
             workflow.db = db
 
+        capture_component_version_guard(workflow, db, id, expected_config_version=row.get("version"))
+
         return workflow
 
     except ComponentRehydrationError:
@@ -11358,6 +11437,12 @@ def get_workflows(
                         workflow.id = component_id
                         workflow._version = config.get("version")
                         workflow._stage = config.get("stage")
+                        bind_component_version_guard(
+                            workflow,
+                            db,
+                            latest_version=config.get("version"),
+                            current_version=component.get("current_version"),
+                        )
                         workflows.append(workflow)
             except Exception as e:
                 component_id = component.get("component_id", "unknown")

--- a/libs/agno/tests/integration/db/async_mongo/test_scheduler.py
+++ b/libs/agno/tests/integration/db/async_mongo/test_scheduler.py
@@ -1,0 +1,111 @@
+"""Scheduler Studio-namespace tests against a live async MongoDB.
+
+Mirrors the sqlite/postgres namespace coverage for the Mongo backend. No
+mocks: MongoDB at localhost:27017 must be up, and if it is not these tests
+ERROR rather than skip.
+"""
+
+import time
+import uuid
+
+import pytest
+
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY, ScheduleNameConflictError
+
+
+def _make_schedule(**overrides):
+    now = int(time.time())
+    d = {
+        "id": str(uuid.uuid4()),
+        "name": f"test-schedule-{uuid.uuid4().hex[:6]}",
+        "description": "Integration test schedule",
+        "method": "POST",
+        "endpoint": "/agents/a1/runs",
+        "payload": None,
+        "cron_expr": "0 9 * * *",
+        "timezone": "UTC",
+        "timeout_seconds": 3600,
+        "max_retries": 0,
+        "retry_delay_seconds": 60,
+        "enabled": True,
+        "next_run_at": now + 3600,
+        "locked_by": None,
+        "locked_at": None,
+        "created_at": now,
+        "updated_at": None,
+    }
+    d.update(overrides)
+    return d
+
+
+@pytest.mark.asyncio
+async def test_generic_and_studio_names_are_isolated_per_actor(async_mongo_db_real):
+    db = async_mongo_db_real
+    generic = _make_schedule(name="shared-name")
+    studio_a = _make_schedule(
+        name="shared-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+    )
+    studio_b = _make_schedule(
+        name="shared-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-b",
+    )
+    await db.create_schedule(generic)
+    await db.create_schedule(studio_a)
+    await db.create_schedule(studio_b)
+
+    found = await db.get_schedule_by_name("shared-name", exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY)
+    assert found["id"] == generic["id"]
+    scoped = await db.get_schedule_by_name(
+        "shared-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+    )
+    assert scoped["id"] == studio_a["id"]
+    with pytest.raises(ScheduleNameConflictError):
+        await db.create_schedule(
+            _make_schedule(
+                name="shared-name",
+                managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+                owner_actor_id="actor-a",
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_excludes_studio_before_count_and_pagination(async_mongo_db_real):
+    db = async_mongo_db_real
+    studio = _make_schedule(
+        name="aaa-studio-hidden",
+        created_at=3,
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="studio-actor",
+        target_type="agent",
+        target_id="studio-agent",
+    )
+    ordinary_first = _make_schedule(name="bbb-ordinary-first", created_at=2)
+    ordinary_second = _make_schedule(name="ccc-ordinary-second", created_at=1)
+    await db.create_schedule(studio)
+    await db.create_schedule(ordinary_first)
+    await db.create_schedule(ordinary_second)
+
+    unfiltered, unfiltered_count = await db.get_schedules()
+    assert studio["id"] in {schedule["id"] for schedule in unfiltered}
+    assert unfiltered_count == 3
+
+    page_one, total_count = await db.get_schedules(
+        limit=1,
+        page=1,
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+    page_two, second_total_count = await db.get_schedules(
+        limit=1,
+        page=2,
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+
+    assert total_count == second_total_count == 2
+    assert [schedule["id"] for schedule in page_one] == [ordinary_first["id"]]
+    assert [schedule["id"] for schedule in page_two] == [ordinary_second["id"]]

--- a/libs/agno/tests/integration/db/async_mongo/test_scheduler.py
+++ b/libs/agno/tests/integration/db/async_mongo/test_scheduler.py
@@ -109,3 +109,44 @@ async def test_list_excludes_studio_before_count_and_pagination(async_mongo_db_r
     assert total_count == second_total_count == 2
     assert [schedule["id"] for schedule in page_one] == [ordinary_first["id"]]
     assert [schedule["id"] for schedule in page_two] == [ordinary_second["id"]]
+
+
+@pytest.mark.asyncio
+async def test_name_scope_conditions_compose_conjunctively(async_mongo_db_real):
+    """managed_by and exclude_managed_by must AND, matching the SQL adapters.
+
+    A row cannot be studio and not-studio at once, so the contradictory pair
+    returns None; an unrelated exclusion must not clobber the equality.
+    """
+    db = async_mongo_db_real
+    generic = _make_schedule(name="scoped-name")
+    studio = _make_schedule(
+        name="scoped-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+    )
+    await db.create_schedule(generic)
+    await db.create_schedule(studio)
+
+    contradictory = await db.get_schedule_by_name(
+        "scoped-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+    assert contradictory is None
+
+    contradictory_scoped = await db.get_schedule_by_name(
+        "scoped-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+    assert contradictory_scoped is None
+
+    compatible = await db.get_schedule_by_name(
+        "scoped-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        exclude_managed_by="other-namespace",
+    )
+    assert compatible is not None
+    assert compatible["id"] == studio["id"]

--- a/libs/agno/tests/integration/db/async_postgres/test_scheduler.py
+++ b/libs/agno/tests/integration/db/async_postgres/test_scheduler.py
@@ -1,0 +1,126 @@
+"""Scheduler Studio-namespace tests against a live async PostgreSQL.
+
+Async twin of tests/integration/db/postgres/test_scheduler.py's namespace
+coverage. No mocks: the DB at localhost:5532 must be up, and if it is not
+these tests ERROR rather than skip.
+"""
+
+import time
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from agno.db.postgres import AsyncPostgresDb
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY, ScheduleNameConflictError
+
+DB_URL = "postgresql+psycopg_async://ai:ai@localhost:5532/ai"
+
+
+@pytest_asyncio.fixture
+async def db():
+    schema = f"test_scheduler_apg_{uuid.uuid4().hex[:8]}"
+    database = AsyncPostgresDb(db_url=DB_URL, db_schema=schema)
+    yield database
+    engine = create_async_engine(DB_URL)
+    async with engine.begin() as connection:
+        await connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+    await engine.dispose()
+
+
+def _make_schedule(**overrides):
+    now = int(time.time())
+    d = {
+        "id": str(uuid.uuid4()),
+        "name": f"test-schedule-{uuid.uuid4().hex[:6]}",
+        "description": "Integration test schedule",
+        "method": "POST",
+        "endpoint": "/agents/a1/runs",
+        "payload": None,
+        "cron_expr": "0 9 * * *",
+        "timezone": "UTC",
+        "timeout_seconds": 3600,
+        "max_retries": 0,
+        "retry_delay_seconds": 60,
+        "enabled": True,
+        "next_run_at": now + 3600,
+        "locked_by": None,
+        "locked_at": None,
+        "created_at": now,
+        "updated_at": None,
+    }
+    d.update(overrides)
+    return d
+
+
+@pytest.mark.asyncio
+async def test_generic_and_studio_names_are_isolated_per_actor(db):
+    generic = _make_schedule(name="shared-name")
+    studio_a = _make_schedule(
+        name="shared-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+    )
+    studio_b = _make_schedule(
+        name="shared-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-b",
+    )
+    await db.create_schedule(generic)
+    await db.create_schedule(studio_a)
+    await db.create_schedule(studio_b)
+
+    found = await db.get_schedule_by_name("shared-name", exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY)
+    assert found["id"] == generic["id"]
+    scoped = await db.get_schedule_by_name(
+        "shared-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+    )
+    assert scoped["id"] == studio_a["id"]
+    with pytest.raises(ScheduleNameConflictError):
+        await db.create_schedule(
+            _make_schedule(
+                name="shared-name",
+                managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+                owner_actor_id="actor-a",
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_excludes_studio_before_count_and_pagination(db):
+    studio = _make_schedule(
+        name="aaa-studio-hidden",
+        created_at=3,
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="studio-actor",
+        target_type="agent",
+        target_id="studio-agent",
+    )
+    ordinary_first = _make_schedule(name="bbb-ordinary-first", created_at=2)
+    ordinary_second = _make_schedule(name="ccc-ordinary-second", created_at=1)
+    await db.create_schedule(studio)
+    await db.create_schedule(ordinary_first)
+    await db.create_schedule(ordinary_second)
+
+    unfiltered, unfiltered_count = await db.get_schedules()
+    assert studio["id"] in {schedule["id"] for schedule in unfiltered}
+    assert unfiltered_count == 3
+
+    page_one, total_count = await db.get_schedules(
+        limit=1,
+        page=1,
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+    page_two, second_total_count = await db.get_schedules(
+        limit=1,
+        page=2,
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+
+    assert total_count == second_total_count == 2
+    assert [schedule["id"] for schedule in page_one] == [ordinary_first["id"]]
+    assert [schedule["id"] for schedule in page_two] == [ordinary_second["id"]]

--- a/libs/agno/tests/integration/db/mongo/conftest.py
+++ b/libs/agno/tests/integration/db/mongo/conftest.py
@@ -1,0 +1,37 @@
+"""Fixtures for sync MongoDb integration tests"""
+
+import uuid
+
+import pytest
+
+# Require the sync driver; mirror async_mongo/conftest.py's import guard.
+try:
+    import pymongo
+
+    PYMONGO_AVAILABLE = True
+except ImportError:
+    PYMONGO_AVAILABLE = False
+
+if not PYMONGO_AVAILABLE:
+    pytest.skip("pymongo not installed", allow_module_level=True)
+
+from agno.db.mongo import MongoDb
+
+MONGO_URL = "mongodb://mongoadmin:secret@localhost:27017"
+
+
+@pytest.fixture
+def mongo_db_real():
+    """MongoDb against the real MongoDB at localhost:27017 (mongoadmin/secret).
+
+    A dedicated database per test, dropped afterwards. If the service is down
+    the first operation errors — deliberately no reachability skip.
+    """
+    db_name = f"test_agno_mongo_{uuid.uuid4().hex[:8]}"
+    db = MongoDb(db_url=MONGO_URL, db_name=db_name)
+
+    yield db
+
+    client = pymongo.MongoClient(MONGO_URL)
+    client.drop_database(db_name)
+    client.close()

--- a/libs/agno/tests/integration/db/mongo/test_scheduler.py
+++ b/libs/agno/tests/integration/db/mongo/test_scheduler.py
@@ -107,3 +107,43 @@ def test_list_excludes_studio_before_count_and_pagination(mongo_db_real):
     assert total_count == second_total_count == 2
     assert [schedule["id"] for schedule in page_one] == [ordinary_first["id"]]
     assert [schedule["id"] for schedule in page_two] == [ordinary_second["id"]]
+
+
+def test_name_scope_conditions_compose_conjunctively(mongo_db_real):
+    """managed_by and exclude_managed_by must AND, matching the SQL adapters.
+
+    A row cannot be studio and not-studio at once, so the contradictory pair
+    returns None; an unrelated exclusion must not clobber the equality.
+    """
+    db = mongo_db_real
+    generic = _make_schedule(name="scoped-name")
+    studio = _make_schedule(
+        name="scoped-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+    )
+    db.create_schedule(generic)
+    db.create_schedule(studio)
+
+    contradictory = db.get_schedule_by_name(
+        "scoped-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+    assert contradictory is None
+
+    contradictory_scoped = db.get_schedule_by_name(
+        "scoped-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+    assert contradictory_scoped is None
+
+    compatible = db.get_schedule_by_name(
+        "scoped-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        exclude_managed_by="other-namespace",
+    )
+    assert compatible is not None
+    assert compatible["id"] == studio["id"]

--- a/libs/agno/tests/integration/db/mongo/test_scheduler.py
+++ b/libs/agno/tests/integration/db/mongo/test_scheduler.py
@@ -1,0 +1,109 @@
+"""Scheduler Studio-namespace tests against a live sync MongoDB.
+
+Mirrors the sqlite/postgres namespace coverage for the Mongo backend. No
+mocks: MongoDB at localhost:27017 must be up, and if it is not these tests
+ERROR rather than skip.
+"""
+
+import time
+import uuid
+
+import pytest
+
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY, ScheduleNameConflictError
+
+
+def _make_schedule(**overrides):
+    now = int(time.time())
+    d = {
+        "id": str(uuid.uuid4()),
+        "name": f"test-schedule-{uuid.uuid4().hex[:6]}",
+        "description": "Integration test schedule",
+        "method": "POST",
+        "endpoint": "/agents/a1/runs",
+        "payload": None,
+        "cron_expr": "0 9 * * *",
+        "timezone": "UTC",
+        "timeout_seconds": 3600,
+        "max_retries": 0,
+        "retry_delay_seconds": 60,
+        "enabled": True,
+        "next_run_at": now + 3600,
+        "locked_by": None,
+        "locked_at": None,
+        "created_at": now,
+        "updated_at": None,
+    }
+    d.update(overrides)
+    return d
+
+
+def test_generic_and_studio_names_are_isolated_per_actor(mongo_db_real):
+    db = mongo_db_real
+    generic = _make_schedule(name="shared-name")
+    studio_a = _make_schedule(
+        name="shared-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+    )
+    studio_b = _make_schedule(
+        name="shared-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-b",
+    )
+    db.create_schedule(generic)
+    db.create_schedule(studio_a)
+    db.create_schedule(studio_b)
+
+    found = db.get_schedule_by_name("shared-name", exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY)
+    assert found["id"] == generic["id"]
+    scoped = db.get_schedule_by_name(
+        "shared-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+    )
+    assert scoped["id"] == studio_a["id"]
+    with pytest.raises(ScheduleNameConflictError):
+        db.create_schedule(
+            _make_schedule(
+                name="shared-name",
+                managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+                owner_actor_id="actor-a",
+            )
+        )
+
+
+def test_list_excludes_studio_before_count_and_pagination(mongo_db_real):
+    db = mongo_db_real
+    studio = _make_schedule(
+        name="aaa-studio-hidden",
+        created_at=3,
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="studio-actor",
+        target_type="agent",
+        target_id="studio-agent",
+    )
+    ordinary_first = _make_schedule(name="bbb-ordinary-first", created_at=2)
+    ordinary_second = _make_schedule(name="ccc-ordinary-second", created_at=1)
+    db.create_schedule(studio)
+    db.create_schedule(ordinary_first)
+    db.create_schedule(ordinary_second)
+
+    unfiltered, unfiltered_count = db.get_schedules()
+    assert studio["id"] in {schedule["id"] for schedule in unfiltered}
+    assert unfiltered_count == 3
+
+    page_one, total_count = db.get_schedules(
+        limit=1,
+        page=1,
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+    page_two, second_total_count = db.get_schedules(
+        limit=1,
+        page=2,
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+
+    assert total_count == second_total_count == 2
+    assert [schedule["id"] for schedule in page_one] == [ordinary_first["id"]]
+    assert [schedule["id"] for schedule in page_two] == [ordinary_second["id"]]

--- a/libs/agno/tests/integration/db/postgres/test_component_lifecycle.py
+++ b/libs/agno/tests/integration/db/postgres/test_component_lifecycle.py
@@ -36,6 +36,61 @@ def _component_link(child_id: str, *, link_key: str = "step_0") -> Dict[str, Any
     }
 
 
+def _insert_raw_component_link(db: PostgresDb, parent_id: str, child_id: str, *, link_key: str) -> None:
+    links_table = db._get_table(table_type="component_links", create_table_if_not_found=True)
+    assert links_table is not None
+    with db.Session() as session, session.begin():
+        session.execute(
+            links_table.insert().values(
+                parent_component_id=parent_id,
+                parent_version=1,
+                link_kind="step_agent",
+                link_key=link_key,
+                child_component_id=child_id,
+                child_version=1,
+                position=0,
+            )
+        )
+
+
+def test_postgres_load_component_graph_bounds_malformed_cycle(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "graph-cycle-a")
+    _create_component(postgres_db_real, "graph-cycle-b")
+    _insert_raw_component_link(postgres_db_real, "graph-cycle-a", "graph-cycle-b", link_key="to-b")
+    _insert_raw_component_link(postgres_db_real, "graph-cycle-b", "graph-cycle-a", link_key="to-a")
+
+    graph = postgres_db_real.load_component_graph("graph-cycle-a")
+
+    assert graph is not None
+    cycle = graph["children"][0]["graph"]["children"][0]["graph"]
+    assert cycle["component"]["component_id"] == "graph-cycle-a"
+    assert cycle["cycle_detected"] is True
+    assert cycle["children"] == []
+
+
+def test_postgres_load_component_graph_expands_shared_child_in_each_dag_branch(
+    postgres_db_real: PostgresDb,
+) -> None:
+    _create_component(postgres_db_real, "graph-shared")
+    _create_component(postgres_db_real, "graph-left", links=[_component_link("graph-shared")])
+    _create_component(postgres_db_real, "graph-right", links=[_component_link("graph-shared")])
+    _create_component(
+        postgres_db_real,
+        "graph-root",
+        links=[
+            _component_link("graph-left", link_key="left"),
+            _component_link("graph-right", link_key="right"),
+        ],
+    )
+
+    graph = postgres_db_real.load_component_graph("graph-root")
+
+    assert graph is not None
+    shared_graphs = [branch["graph"]["children"][0]["graph"] for branch in graph["children"]]
+    assert [item["component"]["component_id"] for item in shared_graphs] == ["graph-shared", "graph-shared"]
+    assert all("cycle_detected" not in item for item in shared_graphs)
+
+
 def _create_component(
     db: PostgresDb,
     component_id: str,
@@ -625,6 +680,9 @@ def test_postgres_restore_component_is_guarded_and_preserves_history(postgres_db
     assert postgres_db_real.delete_component("restored-agent", guard=_guard(1, 1))
 
     assert postgres_db_real.get_config("restored-agent") is None
+    archived_config = postgres_db_real.get_config("restored-agent", version=1, include_deleted=True)
+    assert archived_config is not None
+    assert archived_config["version"] == 1
     archived_latest = postgres_db_real.get_latest_config("restored-agent", include_deleted=True)
     assert archived_latest is not None
     assert archived_latest["version"] == 1
@@ -830,6 +888,12 @@ def test_postgres_expected_component_type_rejects_replaced_identity(postgres_db_
             config={"name": "Agent payload"},
             stage="published",
             projection={"name": "Agent payload"},
+            expected_component_type=ComponentType.AGENT,
+        )
+    with pytest.raises(ValueError, match="has type team, not agent"):
+        postgres_db_real.delete_component(
+            "replaced-identity",
+            guard=_guard(1, 1),
             expected_component_type=ComponentType.AGENT,
         )
 

--- a/libs/agno/tests/integration/db/postgres/test_component_lifecycle.py
+++ b/libs/agno/tests/integration/db/postgres/test_component_lifecycle.py
@@ -1,0 +1,975 @@
+"""PostgreSQL integration tests for guarded component lifecycle operations."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+from typing import Any, Dict, List, Optional, cast
+
+import pytest
+from sqlalchemy import event
+
+from agno.db.base import (
+    DELETED_CONFIG_STAGE,
+    ComponentAlreadyExistsError,
+    ComponentCycleError,
+    ComponentDependencyError,
+    ComponentDependencyUnavailableError,
+    ComponentDraftRequiredError,
+    ComponentProjection,
+    ComponentType,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+)
+from agno.db.postgres.postgres import PostgresDb
+
+
+def _guard(latest_version: Optional[int], current_version: Optional[int]) -> ComponentVersionGuard:
+    return ComponentVersionGuard(latest_version=latest_version, current_version=current_version)
+
+
+def _component_link(child_id: str, *, link_key: str = "step_0") -> Dict[str, Any]:
+    return {
+        "link_kind": "step_agent",
+        "link_key": link_key,
+        "child_component_id": child_id,
+        "child_version": 1,
+        "position": 0,
+    }
+
+
+def _create_component(
+    db: PostgresDb,
+    component_id: str,
+    *,
+    component_type: ComponentType = ComponentType.AGENT,
+    stage: str = "published",
+    name: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
+    links: Optional[List[Dict[str, Any]]] = None,
+) -> None:
+    db.create_component_with_config(
+        component_id=component_id,
+        component_type=component_type,
+        name=name or component_id,
+        config=config or {"name": name or component_id},
+        stage=stage,
+        links=links,
+    )
+
+
+def test_postgres_generic_read_falls_back_to_latest_draft_and_guarded_append_conflicts(
+    postgres_db_real: PostgresDb,
+) -> None:
+    _create_component(postgres_db_real, "draft-only-agent", stage="draft")
+    assert postgres_db_real.get_current_config("draft-only-agent") is None
+    draft = postgres_db_real.get_config("draft-only-agent")
+    assert draft is not None
+    assert draft["version"] == 1
+    assert postgres_db_real.get_latest_config("draft-only-agent") == draft
+
+    _create_component(postgres_db_real, "guarded-agent", config={"instructions": "published"})
+    created = postgres_db_real.upsert_config(
+        "guarded-agent",
+        config={"instructions": "writer one"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    assert created["version"] == 2
+
+    with pytest.raises(ComponentVersionConflictError):
+        postgres_db_real.upsert_config(
+            "guarded-agent",
+            config={"instructions": "stale writer"},
+            stage="draft",
+            guard=_guard(1, 1),
+        )
+
+
+def test_postgres_bulk_component_reads_are_complete_bounded_and_single_query(
+    postgres_db_real: PostgresDb,
+) -> None:
+    _create_component(postgres_db_real, "bulk-active", name="Published", config={"name": "Published"})
+    postgres_db_real.upsert_config(
+        "bulk-active",
+        config={"name": "Draft"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    _create_component(
+        postgres_db_real,
+        "bulk-team",
+        component_type=ComponentType.TEAM,
+    )
+    _create_component(postgres_db_real, "bulk-archived")
+    assert postgres_db_real.delete_component("bulk-archived")
+
+    statements: List[str] = []
+
+    def record_statement(_conn: Any, _cursor: Any, statement: str, _parameters: Any, _context: Any, _many: bool):
+        statements.append(statement)
+
+    event.listen(postgres_db_real.db_engine, "before_cursor_execute", record_statement)
+    try:
+        rows = postgres_db_real.get_components(
+            {"bulk-active", "bulk-team", "bulk-archived", "bulk-missing"},
+            include_deleted=True,
+        )
+    finally:
+        event.remove(postgres_db_real.db_engine, "before_cursor_execute", record_statement)
+
+    assert [row["component_id"] for row in rows] == ["bulk-active", "bulk-archived", "bulk-team"]
+    assert len(statements) == 1
+    assert statements[0].lstrip().upper().startswith("SELECT")
+    assert [
+        row["component_id"]
+        for row in postgres_db_real.get_components(
+            {"bulk-active", "bulk-team", "bulk-archived"},
+            component_type=ComponentType.AGENT,
+        )
+    ] == ["bulk-active"]
+    assert postgres_db_real.get_components(set()) == []
+
+    statements.clear()
+    event.listen(postgres_db_real.db_engine, "before_cursor_execute", record_statement)
+    try:
+        latest = postgres_db_real.get_latest_configs(
+            {"bulk-active", "bulk-archived", "bulk-missing"},
+        )
+    finally:
+        event.remove(postgres_db_real.db_engine, "before_cursor_execute", record_statement)
+
+    assert set(latest) == {"bulk-active", "bulk-archived", "bulk-missing"}
+    assert latest["bulk-active"] is not None
+    assert latest["bulk-active"]["version"] == 2
+    assert latest["bulk-active"]["stage"] == "draft"
+    assert latest["bulk-archived"] is None
+    assert latest["bulk-missing"] is None
+    assert len(statements) == 1
+    assert statements[0].lstrip().upper().startswith("SELECT")
+
+    archived_latest = postgres_db_real.get_latest_configs({"bulk-archived"}, include_deleted=True)
+    assert archived_latest["bulk-archived"] is not None
+    assert archived_latest["bulk-archived"]["version"] == 1
+    assert postgres_db_real.get_latest_configs(set()) == {}
+
+
+def test_postgres_draft_projection_tracks_latest_only_until_first_publish(postgres_db_real: PostgresDb) -> None:
+    _create_component(
+        postgres_db_real,
+        "draft-projection",
+        stage="draft",
+        name="Draft one",
+        config={"name": "Draft one"},
+    )
+
+    postgres_db_real.upsert_config(
+        "draft-projection",
+        config={"name": "Draft two"},
+        stage="draft",
+        projection={"name": "Draft two"},
+    )
+    component = postgres_db_real.get_component("draft-projection")
+    assert component is not None
+    assert component["current_version"] is None
+    assert component["name"] == "Draft two"
+
+    postgres_db_real.upsert_config(
+        "draft-projection",
+        config={"name": "Published"},
+        stage="published",
+        projection={"name": "Published"},
+    )
+    latest_draft = postgres_db_real.upsert_config(
+        "draft-projection",
+        config={"name": "Must not leak"},
+        stage="draft",
+        projection={"name": "Must not leak"},
+    )
+
+    component = postgres_db_real.get_component("draft-projection")
+    assert component is not None
+    assert component["current_version"] == 3
+    assert component["name"] == "Published"
+    assert latest_draft["version"] == 4
+    assert postgres_db_real.get_latest_config("draft-projection") == latest_draft
+    assert postgres_db_real.get_current_config("draft-projection")["version"] == 3  # type: ignore[index]
+
+
+def test_postgres_only_draft_cannot_be_deleted_into_a_zombie(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "sole-draft", stage="draft")
+
+    with pytest.raises(ValueError, match="last config.*archive"):
+        postgres_db_real.delete_config("sole-draft", 1, guard=_guard(1, None))
+
+    assert [row["version"] for row in postgres_db_real.list_configs("sole-draft")] == [1]
+    assert postgres_db_real.get_config("sole-draft", version=1) is not None
+    assert postgres_db_real.delete_component("sole-draft", guard=_guard(1, None)) is True
+
+
+def test_postgres_generic_update_cannot_move_current_pointer(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "pointer-agent", name="Version one")
+    postgres_db_real.upsert_config(
+        "pointer-agent",
+        config={"name": "Version two"},
+        stage="published",
+        projection={"name": "Version two"},
+    )
+
+    with pytest.raises(ValueError, match="set_current_version"):
+        postgres_db_real.upsert_component("pointer-agent", current_version=1)
+
+    component = postgres_db_real.get_component("pointer-agent")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Version two"
+
+
+def test_postgres_mutation_results_are_captured_before_commit(
+    postgres_db_real: PostgresDb,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_public_read(*args: object, **kwargs: object) -> None:
+        raise AssertionError("mutation must not perform a post-commit public read")
+
+    monkeypatch.setattr(postgres_db_real, "get_component", fail_public_read)
+    monkeypatch.setattr(postgres_db_real, "get_config", fail_public_read)
+
+    component, initial = postgres_db_real.create_component_with_config(
+        component_id="atomic-response",
+        component_type=ComponentType.AGENT,
+        name="Initial",
+        config={"name": "Initial"},
+        stage="published",
+    )
+    updated = postgres_db_real.upsert_component("atomic-response", name="Updated")
+    draft = postgres_db_real.upsert_config(
+        "atomic-response",
+        config={"name": "Draft"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    assert component["component_id"] == "atomic-response"
+    assert initial["version"] == 1
+    assert updated["name"] == "Updated"
+    assert draft["version"] == 2
+    assert draft["stage"] == "draft"
+
+
+def test_postgres_publish_and_rollback_update_pointer_and_projection(postgres_db_real: PostgresDb) -> None:
+    _create_component(
+        postgres_db_real,
+        "release-agent",
+        name="Version one",
+        config={"instructions": "v1"},
+    )
+    draft = postgres_db_real.upsert_config(
+        "release-agent",
+        config={"instructions": "v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    published = postgres_db_real.upsert_config(
+        "release-agent",
+        version=draft["version"],
+        stage="published",
+        guard=_guard(2, 1),
+        projection={"name": "Version two", "metadata": {"release": 2}},
+    )
+    assert published["stage"] == "published"
+
+    component = postgres_db_real.get_component("release-agent")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Version two"
+    assert component["metadata"] == {"release": 2}
+
+    assert postgres_db_real.set_current_version(
+        "release-agent",
+        1,
+        guard=_guard(2, 2),
+        projection={"name": "Version one", "metadata": {"release": 1}},
+    )
+    component = postgres_db_real.get_component("release-agent")
+    assert component is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Version one"
+
+    with pytest.raises(ComponentDraftRequiredError, match="only draft configs") as exc:
+        postgres_db_real.delete_config("release-agent", 2, guard=_guard(2, 1))
+
+    assert exc.value.component_id == "release-agent"
+    assert exc.value.version == 2
+
+
+def test_postgres_existing_draft_is_immutable_and_publish_derives_projection(postgres_db_real: PostgresDb) -> None:
+    postgres_db_real.create_component_with_config(
+        component_id="immutable-draft",
+        component_type=ComponentType.AGENT,
+        name="Catalog placeholder",
+        config={
+            "name": "Locked draft",
+            "description": "Derived from the stored payload",
+            "metadata": {"release": 1},
+            "instructions": "original",
+        },
+        description="Catalog placeholder",
+        metadata={"release": 0},
+        stage="draft",
+    )
+
+    with pytest.raises(ValueError, match="requires a component version guard"):
+        postgres_db_real.upsert_config(
+            "immutable-draft",
+            version=1,
+            config={"name": "mutated"},
+            stage="draft",
+        )
+    with pytest.raises(ValueError, match="cannot mutate config"):
+        postgres_db_real.upsert_config(
+            "immutable-draft",
+            version=1,
+            config={"name": "mutated"},
+            stage="published",
+            guard=_guard(1, None),
+        )
+
+    published = postgres_db_real.upsert_config(
+        "immutable-draft",
+        version=1,
+        stage="published",
+        guard=_guard(1, None),
+    )
+    component = postgres_db_real.get_component("immutable-draft")
+
+    assert published["config"]["instructions"] == "original"
+    assert component is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Locked draft"
+    assert component["description"] == "Derived from the stored payload"
+    assert component["metadata"] == {"release": 1}
+
+
+def test_postgres_publish_and_set_current_derive_projection_from_target_config(
+    postgres_db_real: PostgresDb,
+) -> None:
+    postgres_db_real.create_component_with_config(
+        component_id="derived-pointer",
+        component_type=ComponentType.AGENT,
+        name="Version one",
+        config={"name": "Version one", "description": "First", "metadata": {"release": 1}},
+        description="First",
+        metadata={"release": 1},
+        stage="published",
+    )
+
+    postgres_db_real.upsert_config(
+        "derived-pointer",
+        config={"name": "Version two", "description": "Second", "metadata": {"release": 2}},
+        stage="published",
+    )
+    component = postgres_db_real.get_component("derived-pointer")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Version two"
+    assert component["description"] == "Second"
+    assert component["metadata"] == {"release": 2}
+
+    assert postgres_db_real.set_current_version("derived-pointer", 1, guard=_guard(2, 2))
+    component = postgres_db_real.get_component("derived-pointer")
+    assert component is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Version one"
+    assert component["description"] == "First"
+    assert component["metadata"] == {"release": 1}
+
+
+def test_postgres_draft_delete_and_projection_are_one_transaction(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "audited-delete", config={"instructions": "v1"})
+    postgres_db_real.upsert_config(
+        "audited-delete",
+        config={"instructions": "discard me"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    invalid_projection = cast(ComponentProjection, {"unknown_field": "must fail"})
+    with pytest.raises(ValueError, match="projection"):
+        postgres_db_real.delete_config(
+            "audited-delete",
+            2,
+            guard=_guard(2, 1),
+            projection=invalid_projection,
+        )
+
+    assert postgres_db_real.get_config("audited-delete", version=2) is not None
+    assert postgres_db_real.delete_config(
+        "audited-delete",
+        2,
+        guard=_guard(2, 1),
+        projection={"metadata": {"last_action": "delete_version"}},
+    )
+    component = postgres_db_real.get_component("audited-delete")
+    assert component is not None
+    assert component["metadata"] == {"last_action": "delete_version"}
+    assert postgres_db_real.get_config("audited-delete", version=2) is None
+
+
+def test_postgres_deleted_draft_tombstone_allows_visible_state_cas_without_version_reuse(
+    postgres_db_real: PostgresDb,
+) -> None:
+    """Deleting v2 restores visible latest=v1, but its audit tombstone reserves v2 forever."""
+    _create_component(postgres_db_real, "aba-agent")
+    postgres_db_real.upsert_config(
+        "aba-agent",
+        config={"instructions": "discarded v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    assert postgres_db_real.delete_config("aba-agent", 2, guard=_guard(2, 1))
+
+    configs_table = postgres_db_real._get_table(table_type="component_configs")
+    assert configs_table is not None
+    with postgres_db_real.Session() as session:
+        tombstone = (
+            session.execute(
+                configs_table.select().where(
+                    configs_table.c.component_id == "aba-agent",
+                    configs_table.c.version == 2,
+                )
+            )
+            .mappings()
+            .one()
+        )
+    assert tombstone["stage"] == DELETED_CONFIG_STAGE
+    assert tombstone["config"] == {}
+    assert tombstone["updated_at"] is not None
+
+    # Guards intentionally compare visible lifecycle state. After deleting the
+    # only draft, latest=v1/current=v1 is fresh again; the high-water mark still
+    # makes this append v3 rather than overwriting or reusing the audited v2.
+    replacement = postgres_db_real.upsert_config(
+        "aba-agent",
+        config={"instructions": "replacement"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    assert replacement["version"] == 3
+    assert postgres_db_real.get_config("aba-agent", version=2) is None
+    with postgres_db_real.Session() as session:
+        history = session.execute(
+            configs_table.select().where(configs_table.c.component_id == "aba-agent").order_by(configs_table.c.version)
+        ).fetchall()
+    assert [(row.version, row.stage) for row in history] == [
+        (1, "published"),
+        (2, DELETED_CONFIG_STAGE),
+        (3, "draft"),
+    ]
+    with pytest.raises(ValueError, match="not found"):
+        postgres_db_real.upsert_config(
+            "aba-agent",
+            version=2,
+            stage="published",
+            guard=_guard(3, 1),
+            projection={"name": "Must not publish"},
+        )
+
+
+def test_postgres_publish_revalidates_stored_links(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "draft-child-for-publish", stage="draft")
+    _create_component(postgres_db_real, "parent-for-publish", component_type=ComponentType.TEAM)
+    postgres_db_real.upsert_config(
+        "parent-for-publish",
+        config={"members": ["draft-child-for-publish"]},
+        stage="draft",
+        guard=_guard(1, 1),
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "draft-child-for-publish",
+                "child_version": 1,
+                "position": 0,
+                "meta": {"type": "agent"},
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="not published"):
+        postgres_db_real.upsert_config(
+            "parent-for-publish",
+            version=2,
+            stage="published",
+            guard=_guard(2, 1),
+            projection={"name": "Must remain draft"},
+        )
+
+    parent = postgres_db_real.get_component("parent-for-publish")
+    draft = postgres_db_real.get_config("parent-for-publish", version=2)
+    assert parent is not None
+    assert draft is not None
+    assert parent["current_version"] == 1
+    assert draft["stage"] == "draft"
+
+
+def test_postgres_guarded_publish_atomically_derives_and_persists_links(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "published-child-for-derived-link")
+    _create_component(
+        postgres_db_real,
+        "draft-parent-for-derived-link",
+        component_type=ComponentType.TEAM,
+        stage="draft",
+    )
+
+    published = postgres_db_real.upsert_config(
+        "draft-parent-for-derived-link",
+        version=1,
+        stage="published",
+        guard=_guard(1, None),
+        projection={"name": "Published parent"},
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "published-child-for-derived-link",
+                "child_version": 1,
+                "position": 0,
+                "meta": {"type": "agent"},
+            }
+        ],
+    )
+
+    assert published["stage"] == "published"
+    component = postgres_db_real.get_component("draft-parent-for-derived-link")
+    assert component is not None and component["current_version"] == 1
+    links = postgres_db_real.get_links("draft-parent-for-derived-link", 1)
+    assert [(link["child_component_id"], link["child_version"]) for link in links] == [
+        ("published-child-for-derived-link", 1)
+    ]
+
+
+def test_postgres_rejects_unpublished_child_pin_atomically(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "draft-child", stage="draft")
+
+    with pytest.raises(ValueError, match="not published"):
+        _create_component(
+            postgres_db_real,
+            "invalid-parent",
+            component_type=ComponentType.TEAM,
+            links=[
+                {
+                    "link_kind": "member",
+                    "link_key": "member_0",
+                    "child_component_id": "draft-child",
+                    "child_version": 1,
+                    "position": 0,
+                    "meta": {"type": "agent"},
+                }
+            ],
+        )
+
+    assert postgres_db_real.get_component("invalid-parent", include_deleted=True) is None
+    assert postgres_db_real.get_config("invalid-parent", version=1) is None
+
+
+def test_postgres_archive_is_dependency_safe_and_archived_ids_remain_occupied(
+    postgres_db_real: PostgresDb,
+) -> None:
+    _create_component(postgres_db_real, "child-agent")
+    _create_component(
+        postgres_db_real,
+        "parent-team",
+        component_type=ComponentType.TEAM,
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "child-agent",
+                "child_version": 1,
+                "position": 0,
+                "meta": {"type": "agent"},
+            }
+        ],
+    )
+
+    with pytest.raises(ComponentDependencyError):
+        postgres_db_real.delete_component(
+            "child-agent",
+            guard=_guard(1, 1),
+            require_no_dependents=True,
+        )
+
+    assert postgres_db_real.delete_component(
+        "parent-team",
+        guard=_guard(1, 1),
+        require_no_dependents=True,
+    )
+    assert postgres_db_real.get_dependents("child-agent", active_parents_only=True) == []
+    assert postgres_db_real.delete_component(
+        "child-agent",
+        guard=_guard(1, 1),
+        require_no_dependents=True,
+        projection={"name": "Archived child", "metadata": {"release": 1}},
+    )
+    archived = postgres_db_real.get_component("child-agent", include_deleted=True)
+    assert archived is not None
+    assert archived["name"] == "Archived child"
+    assert archived["metadata"] == {"release": 1}
+
+    with pytest.raises(ComponentAlreadyExistsError):
+        _create_component(postgres_db_real, "child-agent", name="Replacement")
+
+
+def test_postgres_restore_component_is_guarded_and_preserves_history(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "restored-agent", name="Published")
+    assert postgres_db_real.delete_component("restored-agent", guard=_guard(1, 1))
+
+    assert postgres_db_real.get_config("restored-agent") is None
+    archived_latest = postgres_db_real.get_latest_config("restored-agent", include_deleted=True)
+    assert archived_latest is not None
+    assert archived_latest["version"] == 1
+
+    with pytest.raises(ComponentVersionConflictError):
+        postgres_db_real.restore_component("restored-agent", guard=_guard(0, 1))
+    assert postgres_db_real.get_component("restored-agent") is None
+
+    assert postgres_db_real.restore_component(
+        "restored-agent",
+        guard=_guard(1, 1),
+        projection={"name": "Restored", "description": "Same identity", "metadata": {"restored": True}},
+    )
+    restored = postgres_db_real.get_component("restored-agent")
+    assert restored is not None
+    assert restored["name"] == "Restored"
+    assert restored["description"] == "Same identity"
+    assert restored["metadata"] == {"restored": True}
+    assert postgres_db_real.get_current_config("restored-agent")["version"] == 1  # type: ignore[index]
+    assert [row["version"] for row in postgres_db_real.list_configs("restored-agent")] == [1]
+
+
+def test_postgres_restore_rejects_an_archived_pinned_dependency_but_allows_draft_only_components(
+    postgres_db_real: PostgresDb,
+) -> None:
+    _create_component(postgres_db_real, "restore-child")
+    _create_component(
+        postgres_db_real,
+        "restore-parent",
+        component_type=ComponentType.WORKFLOW,
+        links=[_component_link("restore-child")],
+    )
+    assert postgres_db_real.delete_component("restore-parent", guard=_guard(1, 1))
+    assert postgres_db_real.delete_component("restore-child", guard=_guard(1, 1))
+
+    with pytest.raises(ComponentDependencyUnavailableError) as unavailable:
+        postgres_db_real.restore_component("restore-parent", guard=_guard(1, 1))
+
+    assert unavailable.value.component_id == "restore-parent"
+    assert unavailable.value.dependencies == [
+        {
+            "component_id": "restore-child",
+            "version": 1,
+            "referenced_by": {"component_id": "restore-parent", "version": 1},
+            "reason": "component_archived",
+        }
+    ]
+    parent = postgres_db_real.get_component("restore-parent", include_deleted=True)
+    assert parent is not None and parent["deleted_at"] is not None
+
+    assert postgres_db_real.restore_component("restore-child", guard=_guard(1, 1))
+    assert postgres_db_real.restore_component("restore-parent", guard=_guard(1, 1))
+
+    _create_component(postgres_db_real, "restore-draft", stage="draft")
+    assert postgres_db_real.delete_component("restore-draft", guard=_guard(1, None))
+    assert postgres_db_real.restore_component("restore-draft", guard=_guard(1, None))
+    restored_draft = postgres_db_real.get_component("restore-draft")
+    assert restored_draft is not None and restored_draft["current_version"] is None
+
+
+def test_postgres_restore_and_dependency_archive_race_never_exposes_a_broken_graph(
+    postgres_db_real: PostgresDb,
+) -> None:
+    _create_component(postgres_db_real, "restore-race-child")
+    _create_component(
+        postgres_db_real,
+        "restore-race-parent",
+        component_type=ComponentType.WORKFLOW,
+        links=[_component_link("restore-race-child")],
+    )
+    assert postgres_db_real.delete_component("restore-race-parent", guard=_guard(1, 1))
+    ready = Barrier(2)
+
+    def restore_parent() -> str:
+        ready.wait()
+        try:
+            postgres_db_real.restore_component("restore-race-parent", guard=_guard(1, 1))
+        except ComponentDependencyUnavailableError:
+            return "restore_blocked"
+        return "restored"
+
+    def archive_child() -> str:
+        ready.wait()
+        try:
+            postgres_db_real.delete_component("restore-race-child", guard=_guard(1, 1))
+        except ComponentDependencyError:
+            return "archive_blocked"
+        return "archived"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        restore_future = executor.submit(restore_parent)
+        archive_future = executor.submit(archive_child)
+        outcomes = {restore_future.result(timeout=10), archive_future.result(timeout=10)}
+
+    assert outcomes in ({"restored", "archive_blocked"}, {"restore_blocked", "archived"})
+    parent_is_active = postgres_db_real.get_component("restore-race-parent") is not None
+    child_is_active = postgres_db_real.get_component("restore-race-child") is not None
+    if outcomes == {"restored", "archive_blocked"}:
+        assert parent_is_active and child_is_active
+    else:
+        assert not parent_is_active and not child_is_active
+
+
+def test_postgres_atomic_restore_and_draft_append_roll_back_when_the_current_graph_is_unavailable(
+    postgres_db_real: PostgresDb,
+) -> None:
+    _create_component(postgres_db_real, "restore-append-child")
+    _create_component(
+        postgres_db_real,
+        "restore-append-parent",
+        component_type=ComponentType.WORKFLOW,
+        links=[_component_link("restore-append-child")],
+    )
+    assert postgres_db_real.delete_component("restore-append-parent", guard=_guard(1, 1))
+    assert postgres_db_real.delete_component("restore-append-child", guard=_guard(1, 1))
+
+    with pytest.raises(ComponentDependencyUnavailableError):
+        postgres_db_real.upsert_config(
+            "restore-append-parent",
+            config={"name": "Draft edit"},
+            stage="draft",
+            guard=_guard(1, 1),
+            restore_if_deleted=True,
+            expected_component_type=ComponentType.WORKFLOW,
+        )
+
+    parent = postgres_db_real.get_component("restore-append-parent", include_deleted=True)
+    assert parent is not None and parent["deleted_at"] is not None
+    latest = postgres_db_real.get_latest_config("restore-append-parent", include_deleted=True)
+    assert latest is not None and latest["version"] == 1
+
+    _create_component(postgres_db_real, "restore-repair-child")
+    repaired = postgres_db_real.upsert_config(
+        "restore-append-parent",
+        config={"name": "Published repair"},
+        stage="published",
+        guard=_guard(1, 1),
+        links=[_component_link("restore-repair-child")],
+        restore_if_deleted=True,
+        expected_component_type=ComponentType.WORKFLOW,
+    )
+    assert repaired["version"] == 2
+    parent = postgres_db_real.get_component("restore-append-parent")
+    assert parent is not None and parent["current_version"] == 2
+    assert postgres_db_real.get_component("restore-append-child") is None
+
+
+def test_postgres_atomic_restore_and_append_rolls_back_on_duplicate_label(
+    postgres_db_real: PostgresDb,
+) -> None:
+    postgres_db_real.create_component_with_config(
+        component_id="restore-append-agent",
+        component_type=ComponentType.AGENT,
+        name="Version one",
+        config={"name": "Version one"},
+        stage="published",
+        label="stable",
+    )
+    assert postgres_db_real.delete_component("restore-append-agent", guard=_guard(1, 1))
+
+    with pytest.raises(ValueError, match="Label 'stable' already exists"):
+        postgres_db_real.upsert_config(
+            "restore-append-agent",
+            config={"name": "Rejected version"},
+            stage="published",
+            label="stable",
+            projection={"name": "Rejected version"},
+            restore_if_deleted=True,
+        )
+
+    assert postgres_db_real.get_component("restore-append-agent") is None
+    archived = postgres_db_real.get_component("restore-append-agent", include_deleted=True)
+    assert archived is not None and archived["deleted_at"] is not None
+    assert postgres_db_real.get_latest_config("restore-append-agent", include_deleted=True)["version"] == 1  # type: ignore[index]
+
+    appended = postgres_db_real.upsert_config(
+        "restore-append-agent",
+        config={"name": "Version two"},
+        stage="published",
+        label="next",
+        projection={"name": "Version two"},
+        restore_if_deleted=True,
+    )
+    assert appended["version"] == 2
+    restored = postgres_db_real.get_component("restore-append-agent")
+    assert restored is not None
+    assert restored["current_version"] == 2
+    assert restored["name"] == "Version two"
+
+
+def test_postgres_expected_component_type_rejects_replaced_identity(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "replaced-identity", component_type=ComponentType.AGENT)
+    assert postgres_db_real.delete_component(
+        "replaced-identity",
+        hard_delete=True,
+        require_no_dependents=False,
+    )
+    _create_component(postgres_db_real, "replaced-identity", component_type=ComponentType.TEAM)
+
+    with pytest.raises(ValueError, match="has type team, not agent"):
+        postgres_db_real.upsert_config(
+            "replaced-identity",
+            config={"name": "Agent payload"},
+            stage="published",
+            projection={"name": "Agent payload"},
+            expected_component_type=ComponentType.AGENT,
+        )
+
+    component = postgres_db_real.get_component("replaced-identity")
+    assert component is not None
+    assert component["component_type"] == ComponentType.TEAM.value
+    assert component["current_version"] == 1
+    assert [row["version"] for row in postgres_db_real.list_configs("replaced-identity")] == [1]
+
+
+def test_postgres_draft_with_inbound_pin_cannot_be_deleted(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "pinned-draft", stage="draft")
+    _create_component(postgres_db_real, "legacy-parent", component_type=ComponentType.TEAM)
+
+    links_table = postgres_db_real._get_table(table_type="component_links", create_table_if_not_found=True)
+    assert links_table is not None
+    with postgres_db_real.Session() as sess, sess.begin():
+        sess.execute(
+            links_table.insert().values(
+                parent_component_id="legacy-parent",
+                parent_version=1,
+                link_kind="member",
+                link_key="member_0",
+                child_component_id="pinned-draft",
+                child_version=1,
+                position=0,
+            )
+        )
+
+    with pytest.raises(ComponentDependencyError):
+        postgres_db_real.delete_config("pinned-draft", 1, guard=_guard(1, None))
+
+
+def test_postgres_concurrent_guarded_appends_yield_one_conflict(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "concurrent-agent")
+    ready = Barrier(2)
+
+    def append_draft(instructions: str) -> str:
+        ready.wait()
+        try:
+            postgres_db_real.upsert_config(
+                "concurrent-agent",
+                config={"instructions": instructions},
+                stage="draft",
+                guard=_guard(1, 1),
+            )
+        except ComponentVersionConflictError:
+            return "conflict"
+        return "created"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(append_draft, ["writer one", "writer two"]))
+
+    assert sorted(outcomes) == ["conflict", "created"]
+    assert [config["version"] for config in postgres_db_real.list_configs("concurrent-agent")] == [2, 1]
+
+
+def test_postgres_atomic_create_rejects_self_cycle_without_rows(postgres_db_real: PostgresDb) -> None:
+    with pytest.raises(ComponentCycleError) as exc:
+        _create_component(
+            postgres_db_real,
+            "self-cycle",
+            component_type=ComponentType.WORKFLOW,
+            stage="draft",
+            links=[_component_link("self-cycle")],
+        )
+
+    assert exc.value.cycle_path == ["self-cycle", "self-cycle"]
+    assert postgres_db_real.get_component("self-cycle", include_deleted=True) is None
+    assert postgres_db_real.get_config("self-cycle", version=1) is None
+
+
+def test_postgres_two_node_and_multi_node_cycles_fail_transactionally(postgres_db_real: PostgresDb) -> None:
+    for component_id in ("cycle-a", "cycle-b", "cycle-c"):
+        _create_component(postgres_db_real, component_id)
+
+    postgres_db_real.upsert_config(
+        "cycle-a",
+        config={"child": "cycle-b"},
+        stage="draft",
+        guard=_guard(1, 1),
+        links=[_component_link("cycle-b")],
+    )
+    with pytest.raises(ComponentCycleError) as two_node:
+        postgres_db_real.upsert_config(
+            "cycle-b",
+            config={"child": "cycle-a"},
+            stage="draft",
+            guard=_guard(1, 1),
+            links=[_component_link("cycle-a")],
+        )
+    assert two_node.value.cycle_path == ["cycle-b", "cycle-a", "cycle-b"]
+    assert [row["version"] for row in postgres_db_real.list_configs("cycle-b")] == [1]
+
+    postgres_db_real.upsert_config(
+        "cycle-b",
+        config={"child": "cycle-c"},
+        stage="draft",
+        guard=_guard(1, 1),
+        links=[_component_link("cycle-c")],
+    )
+    with pytest.raises(ComponentCycleError) as multi_node:
+        postgres_db_real.upsert_config(
+            "cycle-c",
+            config={"child": "cycle-a"},
+            stage="draft",
+            guard=_guard(1, 1),
+            links=[_component_link("cycle-a")],
+        )
+    assert multi_node.value.cycle_path == ["cycle-c", "cycle-a", "cycle-b", "cycle-c"]
+    assert [row["version"] for row in postgres_db_real.list_configs("cycle-c")] == [1]
+
+
+def test_postgres_cross_parent_link_writes_commit_at_most_one_edge(postgres_db_real: PostgresDb) -> None:
+    """A->B and B->A writes serialize, and the second edge fails as a cycle."""
+    _create_component(postgres_db_real, "graph-a")
+    _create_component(postgres_db_real, "graph-b")
+    ready = Barrier(2)
+
+    def append_link(parent_id: str, child_id: str) -> str:
+        ready.wait()
+        try:
+            postgres_db_real.upsert_config(
+                parent_id,
+                config={"child": child_id},
+                stage="draft",
+                guard=_guard(1, 1),
+                links=[_component_link(child_id)],
+            )
+        except ComponentCycleError:
+            return "cycle"
+        return "created"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        a_to_b = executor.submit(append_link, "graph-a", "graph-b")
+        b_to_a = executor.submit(append_link, "graph-b", "graph-a")
+        outcomes = [a_to_b.result(timeout=10), b_to_a.result(timeout=10)]
+
+    assert sorted(outcomes) == ["created", "cycle"]
+    created_versions = sum(
+        len(postgres_db_real.list_configs(component_id)) - 1 for component_id in ("graph-a", "graph-b")
+    )
+    assert created_versions == 1

--- a/libs/agno/tests/integration/db/postgres/test_schedule_migration_v2_9.py
+++ b/libs/agno/tests/integration/db/postgres/test_schedule_migration_v2_9.py
@@ -1,0 +1,412 @@
+"""Live PostgreSQL coverage for the v2.9 schedule migration."""
+
+import time
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from agno.db.migrations.versions import v2_9_0
+from agno.db.postgres import AsyncPostgresDb, PostgresDb
+from agno.db.schemas.scheduler import ScheduleNameConflictError
+
+
+def _manual_claim_schedule(schedule_id: str) -> dict:
+    return {
+        "id": schedule_id,
+        "name": schedule_id,
+        "method": "POST",
+        "endpoint": "/external",
+        "cron_expr": "0 9 * * *",
+        "timezone": "UTC",
+        "timeout_seconds": 3600,
+        "max_retries": 0,
+        "retry_delay_seconds": 60,
+        "enabled": True,
+        "next_run_at": int(time.time()) + 9999,
+        "created_at": int(time.time()),
+    }
+
+
+def _assert_sync_stale_manual_recovery(db: PostgresDb) -> None:
+    schedule = _manual_claim_schedule(f"manual-{uuid.uuid4().hex}")
+    now = int(time.time())
+    future = now + 9999
+    db.create_schedule(schedule)
+    try:
+        db.trigger_schedule(schedule["id"])
+        abandoned = db.claim_due_schedule("dead-worker")
+        assert abandoned is not None and abandoned["manual_trigger_claimed"] is True
+
+        stale_fence = now - 600
+        db.update_schedule(schedule["id"], locked_at=stale_fence)
+        with patch("agno.db.postgres.postgres.time.time", return_value=stale_fence):
+            renewed_at = db.renew_schedule_claim(
+                schedule["id"],
+                worker_id="dead-worker",
+                locked_at=stale_fence,
+            )
+        assert renewed_at == stale_fence + 1
+        assert not db.release_schedule(schedule["id"], worker_id="dead-worker", locked_at=stale_fence)
+
+        db.update_schedule(schedule["id"], locked_at=now - 600, next_run_at=now - 1)
+        recovered = db.claim_due_schedule("recovery-worker")
+        assert recovered is not None
+        assert recovered["pending_trigger_count"] == 0
+        assert recovered["manual_trigger_claimed"] is True
+        assert not db.release_schedule(
+            schedule["id"],
+            worker_id=abandoned["locked_by"],
+            locked_at=abandoned["locked_at"],
+        )
+        assert db.release_schedule(
+            schedule["id"],
+            worker_id=recovered["locked_by"],
+            locked_at=recovered["locked_at"],
+        )
+
+        cron_claim = db.claim_due_schedule("cron-worker")
+        assert cron_claim is not None and cron_claim["manual_trigger_claimed"] is False
+        assert db.release_schedule(
+            schedule["id"],
+            next_run_at=future,
+            worker_id=cron_claim["locked_by"],
+            locked_at=cron_claim["locked_at"],
+        )
+        assert db.claim_due_schedule("extra-worker") is None
+    finally:
+        db.delete_schedule(schedule["id"])
+
+
+def test_postgres_schedule_migration_is_reversible_and_preserves_legacy_rows(
+    postgres_db_real: PostgresDb,
+) -> None:
+    schema = postgres_db_real.db_schema
+    table_name = postgres_db_real.schedules_table_name
+    runs_table_name = postgres_db_real.schedule_runs_table_name
+    qualified_table = f'"{schema}"."{table_name}"'
+    qualified_runs_table = f'"{schema}"."{runs_table_name}"'
+
+    with postgres_db_real.Session() as session, session.begin():
+        session.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
+        session.execute(text(f"DROP TABLE IF EXISTS {qualified_runs_table} CASCADE"))
+        session.execute(text(f"DROP TABLE IF EXISTS {qualified_table} CASCADE"))
+        session.execute(
+            text(
+                f"""
+                CREATE TABLE {qualified_table} (
+                    id VARCHAR PRIMARY KEY NOT NULL,
+                    name VARCHAR NOT NULL,
+                    description VARCHAR,
+                    method VARCHAR NOT NULL,
+                    endpoint VARCHAR NOT NULL,
+                    payload JSON,
+                    cron_expr VARCHAR NOT NULL,
+                    timezone VARCHAR NOT NULL,
+                    timeout_seconds BIGINT NOT NULL,
+                    max_retries BIGINT NOT NULL,
+                    retry_delay_seconds BIGINT NOT NULL,
+                    enabled BOOLEAN NOT NULL,
+                    next_run_at BIGINT,
+                    locked_by VARCHAR,
+                    locked_at BIGINT,
+                    created_at BIGINT NOT NULL,
+                    updated_at BIGINT
+                )
+                """
+            )
+        )
+        session.execute(
+            text(
+                f"""
+                INSERT INTO {qualified_table} (
+                    id, name, method, endpoint, cron_expr, timezone,
+                    timeout_seconds, max_retries, retry_delay_seconds,
+                    enabled, created_at
+                ) VALUES
+                    ('legacy-1', 'legacy-one', 'POST', '/external', '0 9 * * *', 'UTC', 3600, 0, 60, true, 1),
+                    ('legacy-2', 'legacy-two', 'POST', '/external', '0 10 * * *', 'UTC', 3600, 0, 60, true, 1)
+                """
+            )
+        )
+
+    assert v2_9_0.up(postgres_db_real, "schedules", table_name) is True
+
+    with postgres_db_real.Session() as session:
+        columns = {
+            row.column_name
+            for row in session.execute(
+                text(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = :schema AND table_name = :table_name
+                    """
+                ),
+                {"schema": schema, "table_name": table_name},
+            )
+        }
+        legacy_row = session.execute(
+            text(
+                f"""
+                SELECT managed_by, owner_actor_id, target_type, target_id
+                FROM {qualified_table}
+                WHERE id = 'legacy-1'
+                """
+            )
+        ).one()
+        indexes = {
+            row.indexname
+            for row in session.execute(
+                text(
+                    """
+                    SELECT indexname
+                    FROM pg_indexes
+                    WHERE schemaname = :schema AND tablename = :table_name
+                    """
+                ),
+                {"schema": schema, "table_name": table_name},
+            )
+        }
+
+    assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+    assert tuple(legacy_row) == (None, None, None, None)
+    assert {
+        f"{table_name}_uq_generic_name",
+        f"{table_name}_uq_studio_owner_name",
+    }.issubset(indexes)
+
+    with pytest.raises(IntegrityError):
+        with postgres_db_real.Session() as session, session.begin():
+            session.execute(
+                text(
+                    f"""
+                    INSERT INTO {qualified_table} (
+                        id, name, method, endpoint, cron_expr, timezone,
+                        timeout_seconds, max_retries, retry_delay_seconds,
+                        enabled, created_at
+                    ) VALUES (
+                        'duplicate-name', 'legacy-one', 'POST', '/external',
+                        '0 11 * * *', 'UTC', 3600, 0, 60, true, 1
+                    )
+                    """
+                )
+            )
+
+    duplicate_schedule = {
+        "id": "adapter-duplicate-name",
+        "name": "legacy-one",
+        "method": "POST",
+        "endpoint": "/external",
+        "cron_expr": "0 11 * * *",
+        "timezone": "UTC",
+        "timeout_seconds": 3600,
+        "max_retries": 0,
+        "retry_delay_seconds": 60,
+        "enabled": True,
+        "created_at": 1,
+    }
+    with pytest.raises(ScheduleNameConflictError, match="legacy-one"):
+        postgres_db_real.create_schedule(duplicate_schedule)
+    with pytest.raises(ScheduleNameConflictError, match="legacy-one"):
+        postgres_db_real.update_schedule("legacy-2", name="legacy-one")
+
+    with postgres_db_real.Session() as session, session.begin():
+        session.execute(
+            text(
+                f"""
+                UPDATE {qualified_table}
+                SET managed_by = 'studio',
+                    owner_actor_id = 'actor-1',
+                    target_type = 'agent',
+                    target_id = 'private-agent',
+                    payload = '{{"message": "private prompt"}}'
+                WHERE id = 'legacy-2'
+                """
+            )
+        )
+        session.execute(
+            text(
+                f"""
+                CREATE TABLE {qualified_runs_table} (
+                    id VARCHAR PRIMARY KEY NOT NULL,
+                    schedule_id VARCHAR NOT NULL REFERENCES {qualified_table}(id) ON DELETE CASCADE,
+                    input JSON,
+                    output JSON
+                )
+                """
+            )
+        )
+        session.execute(
+            text(
+                f"""
+                INSERT INTO {qualified_runs_table} (id, schedule_id, input, output)
+                VALUES (
+                    'studio-run',
+                    'legacy-2',
+                    '{{"message": "private prompt"}}',
+                    '{{"content": "private response"}}'
+                )
+                """
+            )
+        )
+
+    with pytest.raises(ValueError, match="Cannot remove Studio schedule provenance"):
+        v2_9_0.down(postgres_db_real, "schedules", table_name)
+
+    with postgres_db_real.Session() as session, session.begin():
+        protected_schedule = session.execute(
+            text(f"SELECT managed_by, owner_actor_id, payload FROM {qualified_table} WHERE id = 'legacy-2'")
+        ).one()
+        protected_run = session.execute(
+            text(f"SELECT input, output FROM {qualified_runs_table} WHERE id = 'studio-run'")
+        ).one()
+        columns_after_refusal = {
+            row.column_name
+            for row in session.execute(
+                text(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = :schema AND table_name = :table_name
+                    """
+                ),
+                {"schema": schema, "table_name": table_name},
+            )
+        }
+        indexes_after_refusal = {
+            row.indexname
+            for row in session.execute(
+                text(
+                    """
+                    SELECT indexname
+                    FROM pg_indexes
+                    WHERE schemaname = :schema AND tablename = :table_name
+                    """
+                ),
+                {"schema": schema, "table_name": table_name},
+            )
+        }
+        session.execute(text(f"DELETE FROM {qualified_table} WHERE id = 'legacy-2'"))
+
+    assert tuple(protected_schedule[:2]) == ("studio", "actor-1")
+    assert protected_schedule.payload == {"message": "private prompt"}
+    assert protected_run.input == {"message": "private prompt"}
+    assert protected_run.output == {"content": "private response"}
+    assert set(v2_9_0._V2_9_COLUMNS).issubset(columns_after_refusal)
+    assert {
+        f"{table_name}_uq_generic_name",
+        f"{table_name}_uq_studio_owner_name",
+    }.issubset(indexes_after_refusal)
+
+    assert v2_9_0.down(postgres_db_real, "schedules", table_name) is True
+
+    with postgres_db_real.Session() as session, session.begin():
+        columns_after = {
+            row.column_name
+            for row in session.execute(
+                text(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = :schema AND table_name = :table_name
+                    """
+                ),
+                {"schema": schema, "table_name": table_name},
+            )
+        }
+        indexes_after = {
+            row.indexname
+            for row in session.execute(
+                text(
+                    """
+                    SELECT indexname
+                    FROM pg_indexes
+                    WHERE schemaname = :schema AND tablename = :table_name
+                    """
+                ),
+                {"schema": schema, "table_name": table_name},
+            )
+        }
+        session.execute(
+            text(
+                f"""
+                INSERT INTO {qualified_table} (
+                    id, name, method, endpoint, cron_expr, timezone,
+                    timeout_seconds, max_retries, retry_delay_seconds,
+                    enabled, created_at
+                ) VALUES (
+                    'duplicate-after-down', 'legacy-one', 'POST', '/external',
+                    '0 12 * * *', 'UTC', 3600, 0, 60, true, 1
+                )
+                """
+            )
+        )
+
+    assert set(v2_9_0._V2_9_COLUMNS).isdisjoint(columns_after)
+    assert f"{table_name}_uq_generic_name" not in indexes_after
+    assert f"{table_name}_uq_studio_owner_name" not in indexes_after
+
+
+def test_postgres_stale_manual_claim_is_recovered_exactly_once(postgres_db_real: PostgresDb) -> None:
+    _assert_sync_stale_manual_recovery(postgres_db_real)
+
+
+@pytest.mark.asyncio
+async def test_async_postgres_stale_manual_claim_is_recovered_exactly_once() -> None:
+    schema = f"test_schedule_async_{uuid.uuid4().hex[:8]}"
+    db = AsyncPostgresDb(
+        db_url="postgresql+psycopg_async://ai:ai@localhost:5532/ai",
+        db_schema=schema,
+    )
+    schedule = _manual_claim_schedule(f"manual-{uuid.uuid4().hex}")
+    now = int(time.time())
+    future = now + 9999
+    try:
+        await db.create_schedule(schedule)
+        await db.trigger_schedule(schedule["id"])
+        abandoned = await db.claim_due_schedule("dead-worker")
+        assert abandoned is not None and abandoned["manual_trigger_claimed"] is True
+
+        stale_fence = now - 600
+        await db.update_schedule(schedule["id"], locked_at=stale_fence)
+        with patch("agno.db.postgres.async_postgres.time.time", return_value=stale_fence):
+            renewed_at = await db.renew_schedule_claim(
+                schedule["id"],
+                worker_id="dead-worker",
+                locked_at=stale_fence,
+            )
+        assert renewed_at == stale_fence + 1
+        assert not await db.release_schedule(schedule["id"], worker_id="dead-worker", locked_at=stale_fence)
+
+        await db.update_schedule(schedule["id"], locked_at=now - 600, next_run_at=now - 1)
+        recovered = await db.claim_due_schedule("recovery-worker")
+        assert recovered is not None
+        assert recovered["pending_trigger_count"] == 0
+        assert recovered["manual_trigger_claimed"] is True
+        assert not await db.release_schedule(
+            schedule["id"],
+            worker_id=abandoned["locked_by"],
+            locked_at=abandoned["locked_at"],
+        )
+        assert await db.release_schedule(
+            schedule["id"],
+            worker_id=recovered["locked_by"],
+            locked_at=recovered["locked_at"],
+        )
+
+        cron_claim = await db.claim_due_schedule("cron-worker")
+        assert cron_claim is not None and cron_claim["manual_trigger_claimed"] is False
+        assert await db.release_schedule(
+            schedule["id"],
+            next_run_at=future,
+            worker_id=cron_claim["locked_by"],
+            locked_at=cron_claim["locked_at"],
+        )
+        assert await db.claim_due_schedule("extra-worker") is None
+    finally:
+        async with db.db_engine.begin() as connection:
+            await connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        await db.close()

--- a/libs/agno/tests/integration/db/postgres/test_schedule_migration_v2_9.py
+++ b/libs/agno/tests/integration/db/postgres/test_schedule_migration_v2_9.py
@@ -5,7 +5,7 @@ import uuid
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import create_engine, text
 from sqlalchemy.exc import IntegrityError
 
 from agno.db.migrations.versions import v2_9_0
@@ -424,3 +424,153 @@ async def test_async_postgres_stale_manual_claim_is_recovered_exactly_once() -> 
         async with db.db_engine.begin() as connection:
             await connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
         await db.close()
+
+
+@pytest.mark.asyncio
+async def test_async_postgres_schedule_migration_is_reversible_and_preserves_legacy_rows() -> None:
+    """Live async twin of the sync reversibility test above.
+
+    The unit dispatch test monkeypatches every _migrate_async_*/_revert_async_*
+    seam, so this is the only place the real async migration bodies execute
+    against a real database.
+    """
+    schema = f"test_sched_amig_{uuid.uuid4().hex[:8]}"
+    db = AsyncPostgresDb(
+        db_url="postgresql+psycopg_async://ai:ai@localhost:5532/ai",
+        db_schema=schema,
+    )
+    table_name = db.schedules_table_name
+    qualified_table = f'"{schema}"."{table_name}"'
+
+    probe = create_engine("postgresql+psycopg://ai:ai@localhost:5532/ai")
+    try:
+        with probe.begin() as conn:
+            conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
+            conn.execute(
+                text(
+                    f"""
+                    CREATE TABLE {qualified_table} (
+                        id VARCHAR PRIMARY KEY NOT NULL,
+                        name VARCHAR NOT NULL,
+                        description VARCHAR,
+                        method VARCHAR NOT NULL,
+                        endpoint VARCHAR NOT NULL,
+                        payload JSON,
+                        cron_expr VARCHAR NOT NULL,
+                        timezone VARCHAR NOT NULL,
+                        timeout_seconds BIGINT NOT NULL,
+                        max_retries BIGINT NOT NULL,
+                        retry_delay_seconds BIGINT NOT NULL,
+                        enabled BOOLEAN NOT NULL,
+                        next_run_at BIGINT,
+                        locked_by VARCHAR,
+                        locked_at BIGINT,
+                        created_at BIGINT NOT NULL,
+                        updated_at BIGINT
+                    )
+                    """
+                )
+            )
+            conn.execute(
+                text(
+                    f"""
+                    INSERT INTO {qualified_table} (
+                        id, name, method, endpoint, cron_expr, timezone,
+                        timeout_seconds, max_retries, retry_delay_seconds,
+                        enabled, created_at
+                    ) VALUES
+                        ('legacy-1', 'legacy-one', 'POST', '/external', '0 9 * * *', 'UTC', 3600, 0, 60, true, 1),
+                        ('legacy-2', 'legacy-two', 'POST', '/external', '0 10 * * *', 'UTC', 3600, 0, 60, true, 1)
+                    """
+                )
+            )
+
+        assert await v2_9_0.async_up(db, "schedules", table_name) is True
+
+        def _columns():
+            with probe.connect() as conn:
+                return {
+                    row.column_name
+                    for row in conn.execute(
+                        text(
+                            """
+                            SELECT column_name FROM information_schema.columns
+                            WHERE table_schema = :schema AND table_name = :table_name
+                            """
+                        ),
+                        {"schema": schema, "table_name": table_name},
+                    )
+                }
+
+        def _indexes():
+            with probe.connect() as conn:
+                return {
+                    row.indexname
+                    for row in conn.execute(
+                        text("SELECT indexname FROM pg_indexes WHERE schemaname = :schema AND tablename = :table_name"),
+                        {"schema": schema, "table_name": table_name},
+                    )
+                }
+
+        assert set(v2_9_0._V2_9_COLUMNS).issubset(_columns())
+        assert {f"{table_name}_uq_generic_name", f"{table_name}_uq_studio_owner_name"}.issubset(_indexes())
+        with probe.connect() as conn:
+            legacy_row = conn.execute(
+                text(f"SELECT managed_by, owner_actor_id, target_type, target_id FROM {qualified_table} WHERE id = 'legacy-1'")
+            ).one()
+        assert tuple(legacy_row) == (None, None, None, None)
+
+        with pytest.raises(ScheduleNameConflictError, match="legacy-one"):
+            await db.create_schedule(
+                {
+                    "id": "dup-generic",
+                    "name": "legacy-one",
+                    "method": "POST",
+                    "endpoint": "/external",
+                    "cron_expr": "0 11 * * *",
+                    "timezone": "UTC",
+                    "timeout_seconds": 3600,
+                    "max_retries": 0,
+                    "retry_delay_seconds": 60,
+                    "enabled": True,
+                    "created_at": 1,
+                }
+            )
+        with pytest.raises(ScheduleNameConflictError, match="legacy-one"):
+            await db.update_schedule("legacy-2", name="legacy-one")
+
+        with probe.begin() as conn:
+            conn.execute(
+                text(f"UPDATE {qualified_table} SET managed_by = 'studio', owner_actor_id = 'actor-1' WHERE id = 'legacy-2'")
+            )
+        with pytest.raises(ValueError, match="Cannot remove Studio schedule provenance"):
+            await v2_9_0.async_down(db, "schedules", table_name)
+        assert set(v2_9_0._V2_9_COLUMNS).issubset(_columns())
+
+        with probe.begin() as conn:
+            conn.execute(
+                text(f"UPDATE {qualified_table} SET managed_by = NULL, owner_actor_id = NULL WHERE id = 'legacy-2'")
+            )
+        assert await v2_9_0.async_down(db, "schedules", table_name) is True
+        assert set(v2_9_0._V2_9_COLUMNS).isdisjoint(_columns())
+        assert f"{table_name}_uq_generic_name" not in _indexes()
+        assert f"{table_name}_uq_studio_owner_name" not in _indexes()
+        with probe.begin() as conn:
+            conn.execute(
+                text(
+                    f"""
+                    INSERT INTO {qualified_table} (
+                        id, name, method, endpoint, cron_expr, timezone,
+                        timeout_seconds, max_retries, retry_delay_seconds,
+                        enabled, created_at
+                    ) VALUES (
+                        'duplicate-after-down', 'legacy-one', 'POST', '/external',
+                        '0 12 * * *', 'UTC', 3600, 0, 60, true, 1
+                    )
+                    """
+                )
+            )
+    finally:
+        with probe.begin() as conn:
+            conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        probe.dispose()

--- a/libs/agno/tests/integration/db/postgres/test_schedule_migration_v2_9.py
+++ b/libs/agno/tests/integration/db/postgres/test_schedule_migration_v2_9.py
@@ -30,7 +30,6 @@ def _manual_claim_schedule(schedule_id: str) -> dict:
     }
 
 
-
 def _force_schedule_row(db, schedule_id, **cols):
     """Rig lock/run state directly at the table: update_schedule guards these columns."""
     table = db._get_table(table_type="schedules")
@@ -43,6 +42,7 @@ async def _aforce_schedule_row(db, schedule_id, **cols):
     async with db.async_session_factory() as sess:
         async with sess.begin():
             await sess.execute(table.update().where(table.c.id == schedule_id).values(**cols))
+
 
 def _assert_sync_stale_manual_recovery(db: PostgresDb) -> None:
     schedule = _manual_claim_schedule(f"manual-{uuid.uuid4().hex}")
@@ -516,7 +516,9 @@ async def test_async_postgres_schedule_migration_is_reversible_and_preserves_leg
         assert {f"{table_name}_uq_generic_name", f"{table_name}_uq_studio_owner_name"}.issubset(_indexes())
         with probe.connect() as conn:
             legacy_row = conn.execute(
-                text(f"SELECT managed_by, owner_actor_id, target_type, target_id FROM {qualified_table} WHERE id = 'legacy-1'")
+                text(
+                    f"SELECT managed_by, owner_actor_id, target_type, target_id FROM {qualified_table} WHERE id = 'legacy-1'"
+                )
             ).one()
         assert tuple(legacy_row) == (None, None, None, None)
 
@@ -541,7 +543,9 @@ async def test_async_postgres_schedule_migration_is_reversible_and_preserves_leg
 
         with probe.begin() as conn:
             conn.execute(
-                text(f"UPDATE {qualified_table} SET managed_by = 'studio', owner_actor_id = 'actor-1' WHERE id = 'legacy-2'")
+                text(
+                    f"UPDATE {qualified_table} SET managed_by = 'studio', owner_actor_id = 'actor-1' WHERE id = 'legacy-2'"
+                )
             )
         with pytest.raises(ValueError, match="Cannot remove Studio schedule provenance"):
             await v2_9_0.async_down(db, "schedules", table_name)

--- a/libs/agno/tests/integration/db/postgres/test_schedule_migration_v2_9.py
+++ b/libs/agno/tests/integration/db/postgres/test_schedule_migration_v2_9.py
@@ -30,6 +30,20 @@ def _manual_claim_schedule(schedule_id: str) -> dict:
     }
 
 
+
+def _force_schedule_row(db, schedule_id, **cols):
+    """Rig lock/run state directly at the table: update_schedule guards these columns."""
+    table = db._get_table(table_type="schedules")
+    with db.Session() as sess, sess.begin():
+        sess.execute(table.update().where(table.c.id == schedule_id).values(**cols))
+
+
+async def _aforce_schedule_row(db, schedule_id, **cols):
+    table = await db._get_table(table_type="schedules")
+    async with db.async_session_factory() as sess:
+        async with sess.begin():
+            await sess.execute(table.update().where(table.c.id == schedule_id).values(**cols))
+
 def _assert_sync_stale_manual_recovery(db: PostgresDb) -> None:
     schedule = _manual_claim_schedule(f"manual-{uuid.uuid4().hex}")
     now = int(time.time())
@@ -41,7 +55,7 @@ def _assert_sync_stale_manual_recovery(db: PostgresDb) -> None:
         assert abandoned is not None and abandoned["manual_trigger_claimed"] is True
 
         stale_fence = now - 600
-        db.update_schedule(schedule["id"], locked_at=stale_fence)
+        _force_schedule_row(db, schedule["id"], locked_at=stale_fence)
         with patch("agno.db.postgres.postgres.time.time", return_value=stale_fence):
             renewed_at = db.renew_schedule_claim(
                 schedule["id"],
@@ -51,7 +65,7 @@ def _assert_sync_stale_manual_recovery(db: PostgresDb) -> None:
         assert renewed_at == stale_fence + 1
         assert not db.release_schedule(schedule["id"], worker_id="dead-worker", locked_at=stale_fence)
 
-        db.update_schedule(schedule["id"], locked_at=now - 600, next_run_at=now - 1)
+        _force_schedule_row(db, schedule["id"], locked_at=now - 600, next_run_at=now - 1)
         recovered = db.claim_due_schedule("recovery-worker")
         assert recovered is not None
         assert recovered["pending_trigger_count"] == 0
@@ -371,7 +385,7 @@ async def test_async_postgres_stale_manual_claim_is_recovered_exactly_once() -> 
         assert abandoned is not None and abandoned["manual_trigger_claimed"] is True
 
         stale_fence = now - 600
-        await db.update_schedule(schedule["id"], locked_at=stale_fence)
+        await _aforce_schedule_row(db, schedule["id"], locked_at=stale_fence)
         with patch("agno.db.postgres.async_postgres.time.time", return_value=stale_fence):
             renewed_at = await db.renew_schedule_claim(
                 schedule["id"],
@@ -381,7 +395,7 @@ async def test_async_postgres_stale_manual_claim_is_recovered_exactly_once() -> 
         assert renewed_at == stale_fence + 1
         assert not await db.release_schedule(schedule["id"], worker_id="dead-worker", locked_at=stale_fence)
 
-        await db.update_schedule(schedule["id"], locked_at=now - 600, next_run_at=now - 1)
+        await _aforce_schedule_row(db, schedule["id"], locked_at=now - 600, next_run_at=now - 1)
         recovered = await db.claim_due_schedule("recovery-worker")
         assert recovered is not None
         assert recovered["pending_trigger_count"] == 0

--- a/libs/agno/tests/integration/db/postgres/test_scheduler.py
+++ b/libs/agno/tests/integration/db/postgres/test_scheduler.py
@@ -1,0 +1,161 @@
+"""Scheduler integration tests against a live PostgreSQL.
+
+Mirrors tests/integration/db/sqlite/test_scheduler.py's Studio-namespace
+coverage (the filter code is shared, the backends are not) and adds a real
+thread-contention claim race. No mocks: the DB at localhost:5532 must be up,
+and if it is not these tests ERROR rather than skip.
+"""
+
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
+import pytest
+from sqlalchemy import text
+
+from agno.db.postgres import PostgresDb
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY, ScheduleNameConflictError
+
+DB_URL = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+
+@pytest.fixture
+def db():
+    schema = f"test_scheduler_pg_{uuid.uuid4().hex[:8]}"
+    database = PostgresDb(db_url=DB_URL, db_schema=schema)
+    yield database
+    with database.Session() as session, session.begin():
+        session.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+
+
+def _make_schedule(**overrides):
+    now = int(time.time())
+    d = {
+        "id": str(uuid.uuid4()),
+        "name": f"test-schedule-{uuid.uuid4().hex[:6]}",
+        "description": "Integration test schedule",
+        "method": "POST",
+        "endpoint": "/agents/a1/runs",
+        "payload": None,
+        "cron_expr": "0 9 * * *",
+        "timezone": "UTC",
+        "timeout_seconds": 3600,
+        "max_retries": 0,
+        "retry_delay_seconds": 60,
+        "enabled": True,
+        "next_run_at": now + 3600,
+        "locked_by": None,
+        "locked_at": None,
+        "created_at": now,
+        "updated_at": None,
+    }
+    d.update(overrides)
+    return d
+
+
+def test_generic_and_studio_names_are_isolated_per_actor(db):
+    generic = _make_schedule(name="shared-name")
+    studio_a = _make_schedule(
+        name="shared-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+    )
+    studio_b = _make_schedule(
+        name="shared-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-b",
+    )
+    db.create_schedule(generic)
+    db.create_schedule(studio_a)
+    db.create_schedule(studio_b)
+
+    assert db.get_schedule_by_name("shared-name", exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY)["id"] == generic["id"]
+    assert (
+        db.get_schedule_by_name(
+            "shared-name",
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            owner_actor_id="actor-a",
+        )["id"]
+        == studio_a["id"]
+    )
+    with pytest.raises(ScheduleNameConflictError):
+        db.create_schedule(
+            _make_schedule(
+                name="shared-name",
+                managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+                owner_actor_id="actor-a",
+            )
+        )
+
+
+def test_list_excludes_studio_before_count_and_pagination(db):
+    studio = _make_schedule(
+        name="aaa-studio-hidden",
+        created_at=3,
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="studio-actor",
+        target_type="agent",
+        target_id="studio-agent",
+    )
+    ordinary_first = _make_schedule(name="bbb-ordinary-first", created_at=2)
+    ordinary_second = _make_schedule(name="ccc-ordinary-second", created_at=1)
+    db.create_schedule(studio)
+    db.create_schedule(ordinary_first)
+    db.create_schedule(ordinary_second)
+
+    # Positive first: the studio row exists and IS visible without the filter,
+    # so the exclusions below cannot pass vacuously.
+    unfiltered, unfiltered_count = db.get_schedules()
+    assert studio["id"] in {schedule["id"] for schedule in unfiltered}
+    assert unfiltered_count == 3
+
+    page_one, total_count = db.get_schedules(
+        limit=1,
+        page=1,
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+    page_two, second_total_count = db.get_schedules(
+        limit=1,
+        page=2,
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+
+    assert total_count == second_total_count == 2
+    assert [schedule["id"] for schedule in page_one] == [ordinary_first["id"]]
+    assert [schedule["id"] for schedule in page_two] == [ordinary_second["id"]]
+
+
+def test_concurrent_claim_due_schedule_grants_each_schedule_exactly_once(db):
+    """8 workers race for 3 due schedules; every schedule is claimed exactly once.
+
+    Two rounds on purpose: round one runs against empty lock state, round two
+    against rows carrying the lock/release history the first round wrote.
+    """
+    now = int(time.time())
+    schedule_ids = []
+    for i in range(3):
+        schedule = _make_schedule(name=f"due-{i}", next_run_at=now - 5)
+        db.create_schedule(schedule)
+        schedule_ids.append(schedule["id"])
+
+    workers = 8
+    for round_no in (1, 2):
+        ready = Barrier(workers)
+
+        def claim(worker_idx):
+            ready.wait(timeout=10)
+            row = db.claim_due_schedule(f"worker-{round_no}-{worker_idx}")
+            return None if row is None else row["id"]
+
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            outcomes = list(executor.map(claim, range(workers)))
+
+        claimed = [claimed_id for claimed_id in outcomes if claimed_id is not None]
+        assert sorted(claimed) == sorted(schedule_ids), (
+            f"round {round_no}: expected each of {len(schedule_ids)} schedules claimed exactly once, "
+            f"got {outcomes}"
+        )
+
+        for schedule_id in schedule_ids:
+            assert db.release_schedule(schedule_id, next_run_at=now - 5) is True

--- a/libs/agno/tests/integration/db/postgres/test_scheduler.py
+++ b/libs/agno/tests/integration/db/postgres/test_scheduler.py
@@ -153,8 +153,7 @@ def test_concurrent_claim_due_schedule_grants_each_schedule_exactly_once(db):
 
         claimed = [claimed_id for claimed_id in outcomes if claimed_id is not None]
         assert sorted(claimed) == sorted(schedule_ids), (
-            f"round {round_no}: expected each of {len(schedule_ids)} schedules claimed exactly once, "
-            f"got {outcomes}"
+            f"round {round_no}: expected each of {len(schedule_ids)} schedules claimed exactly once, got {outcomes}"
         )
 
         for schedule_id in schedule_ids:

--- a/libs/agno/tests/integration/db/sqlite/test_component_lifecycle.py
+++ b/libs/agno/tests/integration/db/sqlite/test_component_lifecycle.py
@@ -80,6 +80,59 @@ def _component_link(child_id: str, *, link_key: str = "step_0") -> Dict[str, obj
     }
 
 
+def _insert_raw_component_link(db: SqliteDb, parent_id: str, child_id: str, *, link_key: str) -> None:
+    links_table = db._get_table(table_type="component_links", create_table_if_not_found=True)
+    assert links_table is not None
+    with db.Session() as session, session.begin():
+        session.execute(
+            links_table.insert().values(
+                parent_component_id=parent_id,
+                parent_version=1,
+                link_kind="step_agent",
+                link_key=link_key,
+                child_component_id=child_id,
+                child_version=1,
+                position=0,
+            )
+        )
+
+
+def test_load_component_graph_bounds_malformed_cycle(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "graph-cycle-a")
+    _create_component(sqlite_db_real, "graph-cycle-b")
+    _insert_raw_component_link(sqlite_db_real, "graph-cycle-a", "graph-cycle-b", link_key="to-b")
+    _insert_raw_component_link(sqlite_db_real, "graph-cycle-b", "graph-cycle-a", link_key="to-a")
+
+    graph = sqlite_db_real.load_component_graph("graph-cycle-a")
+
+    assert graph is not None
+    cycle = graph["children"][0]["graph"]["children"][0]["graph"]
+    assert cycle["component"]["component_id"] == "graph-cycle-a"
+    assert cycle["cycle_detected"] is True
+    assert cycle["children"] == []
+
+
+def test_load_component_graph_expands_shared_child_in_each_dag_branch(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "graph-shared")
+    _create_component(sqlite_db_real, "graph-left", links=[_component_link("graph-shared")])
+    _create_component(sqlite_db_real, "graph-right", links=[_component_link("graph-shared")])
+    _create_component(
+        sqlite_db_real,
+        "graph-root",
+        links=[
+            _component_link("graph-left", link_key="left"),
+            _component_link("graph-right", link_key="right"),
+        ],
+    )
+
+    graph = sqlite_db_real.load_component_graph("graph-root")
+
+    assert graph is not None
+    shared_graphs = [branch["graph"]["children"][0]["graph"] for branch in graph["children"]]
+    assert [item["component"]["component_id"] for item in shared_graphs] == ["graph-shared", "graph-shared"]
+    assert all("cycle_detected" not in item for item in shared_graphs)
+
+
 def test_generic_read_falls_back_to_latest_draft_but_current_read_does_not(sqlite_db_real: SqliteDb) -> None:
     _create_component(sqlite_db_real, "draft-agent", stage="draft")
 
@@ -1047,6 +1100,9 @@ def test_restore_component_is_guarded_and_preserves_history(sqlite_db_real: Sqli
     assert sqlite_db_real.delete_component("restored-agent", guard=_guard(1, 1))
 
     assert sqlite_db_real.get_config("restored-agent") is None
+    archived_config = sqlite_db_real.get_config("restored-agent", version=1, include_deleted=True)
+    assert archived_config is not None
+    assert archived_config["version"] == 1
     archived_latest = sqlite_db_real.get_latest_config("restored-agent", include_deleted=True)
     assert archived_latest is not None
     assert archived_latest["version"] == 1
@@ -1248,6 +1304,12 @@ def test_expected_component_type_rejects_replaced_identity(sqlite_db_real: Sqlit
             config={"name": "Agent payload"},
             stage="published",
             projection={"name": "Agent payload"},
+            expected_component_type=ComponentType.AGENT,
+        )
+    with pytest.raises(ValueError, match="has type team, not agent"):
+        sqlite_db_real.delete_component(
+            "replaced-identity",
+            guard=_guard(1, 1),
             expected_component_type=ComponentType.AGENT,
         )
 

--- a/libs/agno/tests/integration/db/sqlite/test_component_lifecycle.py
+++ b/libs/agno/tests/integration/db/sqlite/test_component_lifecycle.py
@@ -1,0 +1,1258 @@
+"""SQLite integration tests for guarded component lifecycle operations."""
+
+import multiprocessing
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier
+from typing import Any, Dict, List, Optional, cast
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.exc import IntegrityError
+
+from agno.db.base import (
+    DELETED_CONFIG_STAGE,
+    ComponentAlreadyExistsError,
+    ComponentCycleError,
+    ComponentDependencyError,
+    ComponentDependencyUnavailableError,
+    ComponentDraftRequiredError,
+    ComponentProjection,
+    ComponentType,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+)
+from agno.db.sqlite.sqlite import SqliteDb
+
+
+def _first_component_write_in_process(
+    db_file: str,
+    component_id: str,
+    ready: Any,
+    results: Any,
+) -> None:
+    try:
+        db = SqliteDb(db_file=db_file)
+        ready.wait(timeout=10)
+        db.create_component_with_config(
+            component_id=component_id,
+            component_type=ComponentType.AGENT,
+            name=component_id,
+            config={"name": component_id},
+            stage="draft",
+        )
+        results.put(("created", component_id))
+    except Exception as exc:
+        results.put(("error", f"{type(exc).__name__}: {exc}"))
+
+
+def _create_component(
+    db: SqliteDb,
+    component_id: str,
+    *,
+    component_type: ComponentType = ComponentType.AGENT,
+    stage: str = "published",
+    name: Optional[str] = None,
+    config: Optional[Dict[str, object]] = None,
+    links: Optional[List[Dict[str, object]]] = None,
+) -> None:
+    db.create_component_with_config(
+        component_id=component_id,
+        component_type=component_type,
+        name=name or component_id,
+        config=config or {"name": name or component_id},
+        stage=stage,
+        links=links,
+    )
+
+
+def _guard(latest_version: Optional[int], current_version: Optional[int]) -> ComponentVersionGuard:
+    return ComponentVersionGuard(latest_version=latest_version, current_version=current_version)
+
+
+def _component_link(child_id: str, *, link_key: str = "step_0") -> Dict[str, object]:
+    return {
+        "link_kind": "step_agent",
+        "link_key": link_key,
+        "child_component_id": child_id,
+        "child_version": 1,
+        "position": 0,
+    }
+
+
+def test_generic_read_falls_back_to_latest_draft_but_current_read_does_not(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "draft-agent", stage="draft")
+
+    component = sqlite_db_real.get_component("draft-agent")
+    assert component is not None
+    assert component["current_version"] is None
+    assert sqlite_db_real.get_current_config("draft-agent") is None
+
+    draft = sqlite_db_real.get_config("draft-agent")
+    assert draft is not None
+    assert draft["version"] == 1
+    assert draft["stage"] == "draft"
+    assert sqlite_db_real.get_latest_config("draft-agent") == draft
+
+
+def test_bulk_component_reads_are_complete_bounded_and_single_query(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "bulk-active", name="Published", config={"name": "Published"})
+    sqlite_db_real.upsert_config(
+        "bulk-active",
+        config={"name": "Draft"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    _create_component(
+        sqlite_db_real,
+        "bulk-team",
+        component_type=ComponentType.TEAM,
+    )
+    _create_component(sqlite_db_real, "bulk-archived")
+    assert sqlite_db_real.delete_component("bulk-archived")
+
+    statements: List[str] = []
+
+    def record_statement(_conn: Any, _cursor: Any, statement: str, _parameters: Any, _context: Any, _many: bool):
+        statements.append(statement)
+
+    event.listen(sqlite_db_real.db_engine, "before_cursor_execute", record_statement)
+    try:
+        rows = sqlite_db_real.get_components(
+            {"bulk-active", "bulk-team", "bulk-archived", "bulk-missing"},
+            include_deleted=True,
+        )
+    finally:
+        event.remove(sqlite_db_real.db_engine, "before_cursor_execute", record_statement)
+
+    assert [row["component_id"] for row in rows] == ["bulk-active", "bulk-archived", "bulk-team"]
+    assert len(statements) == 1
+    assert statements[0].lstrip().upper().startswith("SELECT")
+    assert [
+        row["component_id"]
+        for row in sqlite_db_real.get_components(
+            {"bulk-active", "bulk-team", "bulk-archived"},
+            component_type=ComponentType.AGENT,
+        )
+    ] == ["bulk-active"]
+    assert sqlite_db_real.get_components(set()) == []
+
+    statements.clear()
+    event.listen(sqlite_db_real.db_engine, "before_cursor_execute", record_statement)
+    try:
+        latest = sqlite_db_real.get_latest_configs(
+            {"bulk-active", "bulk-archived", "bulk-missing"},
+        )
+    finally:
+        event.remove(sqlite_db_real.db_engine, "before_cursor_execute", record_statement)
+
+    assert set(latest) == {"bulk-active", "bulk-archived", "bulk-missing"}
+    assert latest["bulk-active"] is not None
+    assert latest["bulk-active"]["version"] == 2
+    assert latest["bulk-active"]["stage"] == "draft"
+    assert latest["bulk-archived"] is None
+    assert latest["bulk-missing"] is None
+    assert len(statements) == 1
+    assert statements[0].lstrip().upper().startswith("SELECT")
+
+    archived_latest = sqlite_db_real.get_latest_configs({"bulk-archived"}, include_deleted=True)
+    assert archived_latest["bulk-archived"] is not None
+    assert archived_latest["bulk-archived"]["version"] == 1
+    assert sqlite_db_real.get_latest_configs(set()) == {}
+
+
+def test_draft_projection_tracks_latest_only_until_first_publish(sqlite_db_real: SqliteDb) -> None:
+    _create_component(
+        sqlite_db_real,
+        "draft-projection",
+        stage="draft",
+        name="Draft one",
+        config={"name": "Draft one"},
+    )
+
+    sqlite_db_real.upsert_config(
+        "draft-projection",
+        config={"name": "Draft two"},
+        stage="draft",
+        projection={"name": "Draft two"},
+    )
+    component = sqlite_db_real.get_component("draft-projection")
+    assert component is not None
+    assert component["current_version"] is None
+    assert component["name"] == "Draft two"
+
+    sqlite_db_real.upsert_config(
+        "draft-projection",
+        config={"name": "Published"},
+        stage="published",
+        projection={"name": "Published"},
+    )
+    latest_draft = sqlite_db_real.upsert_config(
+        "draft-projection",
+        config={"name": "Must not leak"},
+        stage="draft",
+        projection={"name": "Must not leak"},
+    )
+
+    component = sqlite_db_real.get_component("draft-projection")
+    assert component is not None
+    assert component["current_version"] == 3
+    assert component["name"] == "Published"
+    assert latest_draft["version"] == 4
+    assert sqlite_db_real.get_latest_config("draft-projection") == latest_draft
+    assert sqlite_db_real.get_current_config("draft-projection")["version"] == 3  # type: ignore[index]
+
+
+def test_only_draft_cannot_be_deleted_into_a_zombie(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "sole-draft", stage="draft")
+
+    with pytest.raises(ValueError, match="last config.*archive"):
+        sqlite_db_real.delete_config(
+            "sole-draft",
+            1,
+            guard=_guard(1, None),
+        )
+
+    assert [row["version"] for row in sqlite_db_real.list_configs("sole-draft")] == [1]
+    assert sqlite_db_real.get_config("sole-draft", version=1) is not None
+    assert sqlite_db_real.delete_component("sole-draft", guard=_guard(1, None)) is True
+
+
+def test_generic_component_update_cannot_move_current_pointer(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "pointer-agent", name="Version one")
+    sqlite_db_real.upsert_config(
+        "pointer-agent",
+        config={"name": "Version two"},
+        stage="published",
+        projection={"name": "Version two"},
+    )
+
+    with pytest.raises(ValueError, match="set_current_version"):
+        sqlite_db_real.upsert_component("pointer-agent", current_version=1)
+
+    component = sqlite_db_real.get_component("pointer-agent")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Version two"
+
+
+def test_mutation_results_are_captured_before_commit(
+    sqlite_db_real: SqliteDb,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_public_read(*args: object, **kwargs: object) -> None:
+        raise AssertionError("mutation must not perform a post-commit public read")
+
+    monkeypatch.setattr(sqlite_db_real, "get_component", fail_public_read)
+    monkeypatch.setattr(sqlite_db_real, "get_config", fail_public_read)
+
+    component, initial = sqlite_db_real.create_component_with_config(
+        component_id="atomic-response",
+        component_type=ComponentType.AGENT,
+        name="Initial",
+        config={"name": "Initial"},
+        stage="published",
+    )
+    assert component["component_id"] == "atomic-response"
+    assert initial["version"] == 1
+
+    updated = sqlite_db_real.upsert_component("atomic-response", name="Updated")
+    draft = sqlite_db_real.upsert_config(
+        "atomic-response",
+        config={"name": "Draft"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    assert updated["name"] == "Updated"
+    assert draft["version"] == 2
+    assert draft["stage"] == "draft"
+
+
+def test_guarded_draft_append_rejects_stale_writer_and_in_place_mutation(sqlite_db_real: SqliteDb) -> None:
+    _create_component(
+        sqlite_db_real,
+        "guarded-agent",
+        config={"instructions": "published"},
+    )
+
+    draft = sqlite_db_real.upsert_config(
+        component_id="guarded-agent",
+        config={"instructions": "first writer"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    assert draft["version"] == 2
+
+    with pytest.raises(ComponentVersionConflictError) as conflict:
+        sqlite_db_real.upsert_config(
+            component_id="guarded-agent",
+            config={"instructions": "stale writer"},
+            stage="draft",
+            guard=_guard(1, 1),
+        )
+
+    assert conflict.value.expected == _guard(1, 1)
+    assert conflict.value.actual == _guard(2, 1)
+
+    with pytest.raises(ValueError):
+        sqlite_db_real.upsert_config(
+            component_id="guarded-agent",
+            version=2,
+            config={"instructions": "in-place mutation"},
+            guard=_guard(2, 1),
+        )
+
+    published = sqlite_db_real.get_config("guarded-agent", version=1)
+    persisted_draft = sqlite_db_real.get_config("guarded-agent", version=2)
+    assert published is not None
+    assert persisted_draft is not None
+    assert published["config"] == {"instructions": "published"}
+    assert persisted_draft["config"] == {"instructions": "first writer"}
+    assert [config["version"] for config in sqlite_db_real.list_configs("guarded-agent")] == [2, 1]
+
+
+def test_concurrent_guarded_appends_serialize_to_success_and_conflict(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "concurrent-agent", config={"instructions": "published"})
+    ready = Barrier(2)
+
+    def append_draft(instructions: str) -> str:
+        ready.wait()
+        try:
+            sqlite_db_real.upsert_config(
+                component_id="concurrent-agent",
+                config={"instructions": instructions},
+                stage="draft",
+                guard=_guard(1, 1),
+            )
+        except ComponentVersionConflictError:
+            return "conflict"
+        return "created"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(append_draft, ["writer one", "writer two"]))
+
+    assert sorted(outcomes) == ["conflict", "created"]
+    configs = sqlite_db_real.list_configs("concurrent-agent", include_config=True)
+    assert [config["version"] for config in configs] == [2, 1]
+    assert configs[0]["config"]["instructions"] in {"writer one", "writer two"}
+
+
+def test_atomic_create_rejects_self_cycle_without_rows(sqlite_db_real: SqliteDb) -> None:
+    with pytest.raises(ComponentCycleError) as exc:
+        _create_component(
+            sqlite_db_real,
+            "self-cycle",
+            component_type=ComponentType.WORKFLOW,
+            stage="draft",
+            links=[_component_link("self-cycle")],
+        )
+
+    assert exc.value.cycle_path == ["self-cycle", "self-cycle"]
+    assert sqlite_db_real.get_component("self-cycle", include_deleted=True) is None
+    assert sqlite_db_real.get_config("self-cycle", version=1) is None
+
+
+def test_two_node_and_multi_node_cycles_fail_transactionally(sqlite_db_real: SqliteDb) -> None:
+    for component_id in ("cycle-a", "cycle-b", "cycle-c"):
+        _create_component(sqlite_db_real, component_id)
+
+    sqlite_db_real.upsert_config(
+        "cycle-a",
+        config={"child": "cycle-b"},
+        stage="draft",
+        guard=_guard(1, 1),
+        links=[_component_link("cycle-b")],
+    )
+    with pytest.raises(ComponentCycleError) as two_node:
+        sqlite_db_real.upsert_config(
+            "cycle-b",
+            config={"child": "cycle-a"},
+            stage="draft",
+            guard=_guard(1, 1),
+            links=[_component_link("cycle-a")],
+        )
+    assert two_node.value.cycle_path == ["cycle-b", "cycle-a", "cycle-b"]
+    assert [row["version"] for row in sqlite_db_real.list_configs("cycle-b")] == [1]
+
+    sqlite_db_real.upsert_config(
+        "cycle-b",
+        config={"child": "cycle-c"},
+        stage="draft",
+        guard=_guard(1, 1),
+        links=[_component_link("cycle-c")],
+    )
+    with pytest.raises(ComponentCycleError) as multi_node:
+        sqlite_db_real.upsert_config(
+            "cycle-c",
+            config={"child": "cycle-a"},
+            stage="draft",
+            guard=_guard(1, 1),
+            links=[_component_link("cycle-a")],
+        )
+    assert multi_node.value.cycle_path == ["cycle-c", "cycle-a", "cycle-b", "cycle-c"]
+    assert [row["version"] for row in sqlite_db_real.list_configs("cycle-c")] == [1]
+
+
+def test_concurrent_cross_component_edges_commit_at_most_one(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "cross-a")
+    _create_component(sqlite_db_real, "cross-b")
+    ready = Barrier(2)
+
+    def append_link(parent_id: str, child_id: str) -> str:
+        ready.wait()
+        try:
+            sqlite_db_real.upsert_config(
+                parent_id,
+                config={"child": child_id},
+                stage="draft",
+                guard=_guard(1, 1),
+                links=[_component_link(child_id)],
+            )
+        except ComponentCycleError:
+            return "cycle"
+        return "created"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(lambda pair: append_link(*pair), [("cross-a", "cross-b"), ("cross-b", "cross-a")]))
+
+    assert sorted(outcomes) == ["created", "cycle"]
+    created_versions = sum(
+        len(sqlite_db_real.list_configs(component_id)) - 1 for component_id in ("cross-a", "cross-b")
+    )
+    assert created_versions == 1
+
+
+def test_first_component_write_is_safe_across_processes(tmp_path: Path) -> None:
+    db_file = str(tmp_path / "multi-process-components.db")
+    context = multiprocessing.get_context("spawn")
+    ready = context.Barrier(2)
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_first_component_write_in_process,
+            args=(db_file, component_id, ready, results),
+        )
+        for component_id in ("process-a", "process-b")
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=20)
+
+    assert all(not process.is_alive() for process in processes)
+    assert all(process.exitcode == 0 for process in processes)
+    outcomes = sorted(results.get(timeout=5) for _ in processes)
+    assert outcomes == [("created", "process-a"), ("created", "process-b")]
+
+    db = SqliteDb(db_file=db_file)
+    rows, total = db.list_components(limit=10)
+    assert total == 2
+    assert {row["component_id"] for row in rows} == {"process-a", "process-b"}
+
+
+def test_publish_updates_stage_current_pointer_and_projection_together(sqlite_db_real: SqliteDb) -> None:
+    _create_component(
+        sqlite_db_real,
+        "publish-agent",
+        name="Published name",
+        config={"instructions": "v1"},
+    )
+    draft = sqlite_db_real.upsert_config(
+        component_id="publish-agent",
+        config={"instructions": "v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    projection: ComponentProjection = {
+        "name": "Draft promoted",
+        "description": "Projected from version two",
+        "metadata": {"release": 2},
+    }
+
+    published = sqlite_db_real.upsert_config(
+        component_id="publish-agent",
+        version=draft["version"],
+        stage="published",
+        guard=_guard(2, 1),
+        projection=projection,
+    )
+
+    assert published["stage"] == "published"
+    assert published["config"] == {"instructions": "v2"}
+    component = sqlite_db_real.get_component("publish-agent")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Draft promoted"
+    assert component["description"] == "Projected from version two"
+    assert component["metadata"] == {"release": 2}
+    assert sqlite_db_real.get_config("publish-agent") == published
+
+
+def test_existing_draft_payload_is_immutable_and_publish_derives_projection(sqlite_db_real: SqliteDb) -> None:
+    sqlite_db_real.create_component_with_config(
+        component_id="immutable-draft",
+        component_type=ComponentType.AGENT,
+        name="Catalog placeholder",
+        config={
+            "name": "Locked draft",
+            "description": "Derived from the stored payload",
+            "metadata": {"release": 1},
+            "instructions": "original",
+        },
+        description="Catalog placeholder",
+        metadata={"release": 0},
+        stage="draft",
+    )
+
+    with pytest.raises(ValueError, match="requires a component version guard"):
+        sqlite_db_real.upsert_config(
+            "immutable-draft",
+            version=1,
+            config={"name": "mutated"},
+            stage="draft",
+        )
+    with pytest.raises(ValueError, match="cannot mutate config"):
+        sqlite_db_real.upsert_config(
+            "immutable-draft",
+            version=1,
+            config={"name": "mutated"},
+            stage="published",
+            guard=_guard(1, None),
+        )
+
+    published = sqlite_db_real.upsert_config(
+        "immutable-draft",
+        version=1,
+        stage="published",
+        guard=_guard(1, None),
+    )
+    component = sqlite_db_real.get_component("immutable-draft")
+
+    assert published["config"]["instructions"] == "original"
+    assert component is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Locked draft"
+    assert component["description"] == "Derived from the stored payload"
+    assert component["metadata"] == {"release": 1}
+
+
+def test_publish_and_set_current_derive_projection_from_target_config(sqlite_db_real: SqliteDb) -> None:
+    sqlite_db_real.create_component_with_config(
+        component_id="derived-pointer",
+        component_type=ComponentType.AGENT,
+        name="Version one",
+        config={"name": "Version one", "description": "First", "metadata": {"release": 1}},
+        description="First",
+        metadata={"release": 1},
+        stage="published",
+    )
+
+    sqlite_db_real.upsert_config(
+        "derived-pointer",
+        config={"name": "Version two", "description": "Second", "metadata": {"release": 2}},
+        stage="published",
+    )
+    component = sqlite_db_real.get_component("derived-pointer")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Version two"
+    assert component["description"] == "Second"
+    assert component["metadata"] == {"release": 2}
+
+    assert sqlite_db_real.set_current_version("derived-pointer", 1, guard=_guard(2, 2))
+    component = sqlite_db_real.get_component("derived-pointer")
+    assert component is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Version one"
+    assert component["description"] == "First"
+    assert component["metadata"] == {"release": 1}
+
+
+def test_projection_failure_rolls_back_publish_transition(sqlite_db_real: SqliteDb) -> None:
+    _create_component(
+        sqlite_db_real,
+        "invalid-projection-agent",
+        name="Original name",
+        config={"instructions": "v1"},
+    )
+    sqlite_db_real.upsert_config(
+        component_id="invalid-projection-agent",
+        config={"instructions": "v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    invalid_projection = cast(ComponentProjection, {"unknown_field": "must fail"})
+    with pytest.raises(ValueError, match="projection"):
+        sqlite_db_real.upsert_config(
+            component_id="invalid-projection-agent",
+            version=2,
+            stage="published",
+            guard=_guard(2, 1),
+            projection=invalid_projection,
+        )
+
+    component = sqlite_db_real.get_component("invalid-projection-agent")
+    draft = sqlite_db_real.get_config("invalid-projection-agent", version=2)
+    assert component is not None
+    assert draft is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Original name"
+    assert draft["stage"] == "draft"
+
+
+def test_stale_publish_guard_leaves_draft_and_component_projection_unchanged(sqlite_db_real: SqliteDb) -> None:
+    _create_component(
+        sqlite_db_real,
+        "stale-publish-agent",
+        name="Original name",
+        config={"instructions": "v1"},
+    )
+    sqlite_db_real.upsert_config(
+        component_id="stale-publish-agent",
+        config={"instructions": "v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    with pytest.raises(ComponentVersionConflictError):
+        sqlite_db_real.upsert_config(
+            component_id="stale-publish-agent",
+            version=2,
+            stage="published",
+            guard=_guard(1, 1),
+            projection={"name": "Must not leak"},
+        )
+
+    component = sqlite_db_real.get_component("stale-publish-agent")
+    draft = sqlite_db_real.get_config("stale-publish-agent", version=2)
+    assert component is not None
+    assert draft is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Original name"
+    assert draft["stage"] == "draft"
+
+
+def test_rollback_updates_current_pointer_and_projection_together(sqlite_db_real: SqliteDb) -> None:
+    _create_component(
+        sqlite_db_real,
+        "rollback-agent",
+        name="Version one",
+        config={"instructions": "v1"},
+    )
+    sqlite_db_real.upsert_config(
+        component_id="rollback-agent",
+        config={"instructions": "v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    sqlite_db_real.upsert_config(
+        component_id="rollback-agent",
+        version=2,
+        stage="published",
+        guard=_guard(2, 1),
+        projection={"name": "Version two", "metadata": {"release": 2}},
+    )
+
+    did_rollback = sqlite_db_real.set_current_version(
+        component_id="rollback-agent",
+        version=1,
+        guard=_guard(2, 2),
+        projection={"name": "Version one", "description": "Restored", "metadata": {"release": 1}},
+    )
+
+    assert did_rollback is True
+    component = sqlite_db_real.get_component("rollback-agent")
+    assert component is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Version one"
+    assert component["description"] == "Restored"
+    assert component["metadata"] == {"release": 1}
+    current = sqlite_db_real.get_config("rollback-agent")
+    assert current is not None
+    assert current["version"] == 1
+
+
+def test_non_current_published_config_cannot_be_deleted(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "published-delete-agent", config={"instructions": "v1"})
+    sqlite_db_real.upsert_config(
+        component_id="published-delete-agent",
+        config={"instructions": "v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    sqlite_db_real.upsert_config(
+        component_id="published-delete-agent",
+        version=2,
+        stage="published",
+        guard=_guard(2, 1),
+        projection={"name": "Version two"},
+    )
+    sqlite_db_real.set_current_version(
+        component_id="published-delete-agent",
+        version=1,
+        guard=_guard(2, 2),
+        projection={"name": "Version one"},
+    )
+
+    with pytest.raises(ComponentDraftRequiredError, match="only draft configs") as exc:
+        sqlite_db_real.delete_config(
+            component_id="published-delete-agent",
+            version=2,
+            guard=_guard(2, 1),
+        )
+
+    assert exc.value.component_id == "published-delete-agent"
+    assert exc.value.version == 2
+
+    assert sqlite_db_real.get_config("published-delete-agent", version=2) is not None
+
+
+def test_draft_delete_and_projection_are_one_transaction(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "audited-delete", config={"instructions": "v1"})
+    sqlite_db_real.upsert_config(
+        component_id="audited-delete",
+        config={"instructions": "discard me"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    invalid_projection = cast(ComponentProjection, {"unknown_field": "must fail"})
+    with pytest.raises(ValueError, match="projection"):
+        sqlite_db_real.delete_config(
+            "audited-delete",
+            2,
+            guard=_guard(2, 1),
+            projection=invalid_projection,
+        )
+
+    assert sqlite_db_real.get_config("audited-delete", version=2) is not None
+    assert sqlite_db_real.delete_config(
+        "audited-delete",
+        2,
+        guard=_guard(2, 1),
+        projection={"metadata": {"last_action": "delete_version"}},
+    )
+    component = sqlite_db_real.get_component("audited-delete")
+    assert component is not None
+    assert component["metadata"] == {"last_action": "delete_version"}
+    assert sqlite_db_real.get_config("audited-delete", version=2) is None
+
+
+def test_deleted_draft_tombstone_allows_visible_state_cas_without_version_reuse(sqlite_db_real: SqliteDb) -> None:
+    """Deleting v2 restores visible latest=v1, but its audit tombstone reserves v2 forever."""
+    _create_component(sqlite_db_real, "aba-agent")
+    sqlite_db_real.upsert_config(
+        "aba-agent",
+        config={"instructions": "discarded v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    assert sqlite_db_real.delete_config("aba-agent", 2, guard=_guard(2, 1))
+
+    configs_table = sqlite_db_real._get_table(table_type="component_configs")
+    assert configs_table is not None
+    with sqlite_db_real.Session() as session:
+        tombstone = (
+            session.execute(
+                configs_table.select().where(
+                    configs_table.c.component_id == "aba-agent",
+                    configs_table.c.version == 2,
+                )
+            )
+            .mappings()
+            .one()
+        )
+    assert tombstone["stage"] == DELETED_CONFIG_STAGE
+    assert tombstone["config"] == {}
+    assert tombstone["updated_at"] is not None
+
+    # Guards intentionally compare visible lifecycle state. After deleting the
+    # only draft, latest=v1/current=v1 is fresh again; the high-water mark still
+    # makes this append v3 rather than overwriting or reusing the audited v2.
+    replacement = sqlite_db_real.upsert_config(
+        "aba-agent",
+        config={"instructions": "replacement"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    assert replacement["version"] == 3
+    assert sqlite_db_real.get_config("aba-agent", version=2) is None
+    with sqlite_db_real.Session() as session:
+        history = session.execute(
+            configs_table.select().where(configs_table.c.component_id == "aba-agent").order_by(configs_table.c.version)
+        ).fetchall()
+    assert [(row.version, row.stage) for row in history] == [
+        (1, "published"),
+        (2, DELETED_CONFIG_STAGE),
+        (3, "draft"),
+    ]
+    with pytest.raises(ValueError, match="not found"):
+        sqlite_db_real.upsert_config(
+            "aba-agent",
+            version=2,
+            stage="published",
+            guard=_guard(3, 1),
+            projection={"name": "Must not publish"},
+        )
+
+
+def test_publishing_existing_draft_revalidates_stored_links(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "draft-child-for-publish", stage="draft")
+    _create_component(sqlite_db_real, "parent-for-publish", component_type=ComponentType.TEAM)
+    sqlite_db_real.upsert_config(
+        "parent-for-publish",
+        config={"members": ["draft-child-for-publish"]},
+        stage="draft",
+        guard=_guard(1, 1),
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "draft-child-for-publish",
+                "child_version": 1,
+                "position": 0,
+                "meta": {"type": "agent"},
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="not published"):
+        sqlite_db_real.upsert_config(
+            "parent-for-publish",
+            version=2,
+            stage="published",
+            guard=_guard(2, 1),
+            projection={"name": "Must remain draft"},
+        )
+
+    parent = sqlite_db_real.get_component("parent-for-publish")
+    draft = sqlite_db_real.get_config("parent-for-publish", version=2)
+    assert parent is not None
+    assert draft is not None
+    assert parent["current_version"] == 1
+    assert draft["stage"] == "draft"
+
+
+def test_guarded_publish_can_atomically_derive_and_persist_links(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "published-child-for-derived-link")
+    _create_component(
+        sqlite_db_real,
+        "draft-parent-for-derived-link",
+        component_type=ComponentType.TEAM,
+        stage="draft",
+    )
+
+    published = sqlite_db_real.upsert_config(
+        "draft-parent-for-derived-link",
+        version=1,
+        stage="published",
+        guard=_guard(1, None),
+        projection={"name": "Published parent"},
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "published-child-for-derived-link",
+                "child_version": 1,
+                "position": 0,
+                "meta": {"type": "agent"},
+            }
+        ],
+    )
+
+    assert published["stage"] == "published"
+    component = sqlite_db_real.get_component("draft-parent-for-derived-link")
+    assert component is not None and component["current_version"] == 1
+    links = sqlite_db_real.get_links("draft-parent-for-derived-link", 1)
+    assert [(link["child_component_id"], link["child_version"]) for link in links] == [
+        ("published-child-for-derived-link", 1)
+    ]
+
+
+def test_draft_config_with_inbound_pin_cannot_be_deleted(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "pinned-draft", stage="draft")
+    _create_component(
+        sqlite_db_real,
+        "legacy-parent",
+        component_type=ComponentType.TEAM,
+    )
+
+    # Simulate a legacy or externally inserted link to isolate the inbound-pin
+    # deletion guard. New writes must reject links to unpublished children.
+    links_table = sqlite_db_real._get_table(table_type="component_links", create_table_if_not_found=True)
+    assert links_table is not None
+    with sqlite_db_real.Session() as sess, sess.begin():
+        sess.execute(
+            links_table.insert().values(
+                parent_component_id="legacy-parent",
+                parent_version=1,
+                link_kind="member",
+                link_key="member_0",
+                child_component_id="pinned-draft",
+                child_version=1,
+                position=0,
+            )
+        )
+
+    with pytest.raises(ComponentDependencyError) as dependency:
+        sqlite_db_real.delete_config(
+            component_id="pinned-draft",
+            version=1,
+            guard=_guard(1, None),
+        )
+
+    assert dependency.value.component_id == "pinned-draft"
+    assert dependency.value.version == 1
+    assert sqlite_db_real.get_config("pinned-draft", version=1) is not None
+
+
+def test_create_rejects_unpublished_child_pin_without_parent_rows(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "draft-child", stage="draft")
+
+    with pytest.raises(ValueError, match="not published"):
+        _create_component(
+            sqlite_db_real,
+            "invalid-parent",
+            component_type=ComponentType.TEAM,
+            links=[
+                {
+                    "link_kind": "member",
+                    "link_key": "member_0",
+                    "child_component_id": "draft-child",
+                    "child_version": 1,
+                    "position": 0,
+                    "meta": {"type": "agent"},
+                }
+            ],
+        )
+
+    assert sqlite_db_real.get_component("invalid-parent", include_deleted=True) is None
+    assert sqlite_db_real.get_config("invalid-parent", version=1) is None
+    assert sqlite_db_real.get_links("invalid-parent", version=1) == []
+
+
+def test_link_insert_failure_rolls_back_atomic_component_create(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "published-child")
+    duplicate_link: Dict[str, object] = {
+        "link_kind": "member",
+        "link_key": "member_0",
+        "child_component_id": "published-child",
+        "child_version": 1,
+        "position": 0,
+        "meta": {"type": "agent"},
+    }
+
+    with pytest.raises(IntegrityError):
+        _create_component(
+            sqlite_db_real,
+            "rolled-back-parent",
+            component_type=ComponentType.TEAM,
+            links=[duplicate_link, dict(duplicate_link)],
+        )
+
+    assert sqlite_db_real.get_component("rolled-back-parent", include_deleted=True) is None
+    assert sqlite_db_real.get_config("rolled-back-parent", version=1) is None
+    assert sqlite_db_real.get_links("rolled-back-parent", version=1) == []
+
+
+def test_archive_is_dependency_safe_and_ignores_archived_parents(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "child-agent")
+    _create_component(
+        sqlite_db_real,
+        "parent-team",
+        component_type=ComponentType.TEAM,
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "child-agent",
+                "child_version": 1,
+                "position": 0,
+                "meta": {"type": "agent"},
+            }
+        ],
+    )
+
+    with pytest.raises(ComponentDependencyError) as dependency:
+        sqlite_db_real.delete_component(
+            "child-agent",
+            guard=_guard(1, 1),
+            require_no_dependents=True,
+        )
+
+    assert dependency.value.component_id == "child-agent"
+    assert sqlite_db_real.get_component("child-agent") is not None
+
+    assert sqlite_db_real.delete_component(
+        "parent-team",
+        guard=_guard(1, 1),
+        require_no_dependents=True,
+    )
+    assert sqlite_db_real.get_dependents("child-agent")
+    assert sqlite_db_real.get_dependents("child-agent", active_parents_only=True) == []
+
+    assert sqlite_db_real.delete_component(
+        "child-agent",
+        guard=_guard(1, 1),
+        require_no_dependents=True,
+    )
+    assert sqlite_db_real.get_component("child-agent") is None
+    archived_child = sqlite_db_real.get_component("child-agent", include_deleted=True)
+    assert archived_child is not None
+    assert archived_child["deleted_at"] is not None
+
+
+def test_archived_component_id_remains_occupied(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "occupied-agent")
+    assert sqlite_db_real.delete_component(
+        "occupied-agent",
+        guard=_guard(1, 1),
+        require_no_dependents=True,
+        projection={
+            "name": "Archived projection",
+            "description": "Last published view",
+            "metadata": {"release": 1},
+        },
+    )
+    assert sqlite_db_real.delete_component("occupied-agent") is False
+    with pytest.raises(ValueError, match="hard delete"):
+        sqlite_db_real.delete_component(
+            "occupied-agent",
+            hard_delete=True,
+            projection={"name": "Must not apply"},
+        )
+
+    with pytest.raises(ComponentAlreadyExistsError):
+        _create_component(
+            sqlite_db_real,
+            "occupied-agent",
+            name="Replacement",
+            config={"instructions": "replacement"},
+        )
+
+    archived = sqlite_db_real.get_component("occupied-agent", include_deleted=True)
+    assert archived is not None
+    assert archived["name"] == "Archived projection"
+    assert archived["description"] == "Last published view"
+    assert archived["metadata"] == {"release": 1}
+    assert archived["deleted_at"] is not None
+
+
+def test_restore_component_is_guarded_and_preserves_history(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "restored-agent", name="Published")
+    assert sqlite_db_real.delete_component("restored-agent", guard=_guard(1, 1))
+
+    assert sqlite_db_real.get_config("restored-agent") is None
+    archived_latest = sqlite_db_real.get_latest_config("restored-agent", include_deleted=True)
+    assert archived_latest is not None
+    assert archived_latest["version"] == 1
+
+    with pytest.raises(ComponentVersionConflictError):
+        sqlite_db_real.restore_component("restored-agent", guard=_guard(0, 1))
+    assert sqlite_db_real.get_component("restored-agent") is None
+
+    assert sqlite_db_real.restore_component(
+        "restored-agent",
+        guard=_guard(1, 1),
+        projection={"name": "Restored", "description": "Same identity", "metadata": {"restored": True}},
+    )
+    restored = sqlite_db_real.get_component("restored-agent")
+    assert restored is not None
+    assert restored["name"] == "Restored"
+    assert restored["description"] == "Same identity"
+    assert restored["metadata"] == {"restored": True}
+    assert sqlite_db_real.get_current_config("restored-agent")["version"] == 1  # type: ignore[index]
+    assert [row["version"] for row in sqlite_db_real.list_configs("restored-agent")] == [1]
+
+
+def test_restore_rejects_an_archived_pinned_dependency_but_allows_draft_only_components(
+    sqlite_db_real: SqliteDb,
+) -> None:
+    _create_component(sqlite_db_real, "restore-child")
+    _create_component(
+        sqlite_db_real,
+        "restore-parent",
+        component_type=ComponentType.WORKFLOW,
+        links=[_component_link("restore-child")],
+    )
+    assert sqlite_db_real.delete_component("restore-parent", guard=_guard(1, 1))
+    assert sqlite_db_real.delete_component("restore-child", guard=_guard(1, 1))
+
+    with pytest.raises(ComponentDependencyUnavailableError) as unavailable:
+        sqlite_db_real.restore_component("restore-parent", guard=_guard(1, 1))
+
+    assert unavailable.value.component_id == "restore-parent"
+    assert unavailable.value.dependencies == [
+        {
+            "component_id": "restore-child",
+            "version": 1,
+            "referenced_by": {"component_id": "restore-parent", "version": 1},
+            "reason": "component_archived",
+        }
+    ]
+    parent = sqlite_db_real.get_component("restore-parent", include_deleted=True)
+    assert parent is not None and parent["deleted_at"] is not None
+
+    assert sqlite_db_real.restore_component("restore-child", guard=_guard(1, 1))
+    assert sqlite_db_real.restore_component("restore-parent", guard=_guard(1, 1))
+
+    _create_component(sqlite_db_real, "restore-draft", stage="draft")
+    assert sqlite_db_real.delete_component("restore-draft", guard=_guard(1, None))
+    assert sqlite_db_real.restore_component("restore-draft", guard=_guard(1, None))
+    restored_draft = sqlite_db_real.get_component("restore-draft")
+    assert restored_draft is not None and restored_draft["current_version"] is None
+
+
+def test_restore_and_dependency_archive_race_never_exposes_a_broken_graph(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "restore-race-child")
+    _create_component(
+        sqlite_db_real,
+        "restore-race-parent",
+        component_type=ComponentType.WORKFLOW,
+        links=[_component_link("restore-race-child")],
+    )
+    assert sqlite_db_real.delete_component("restore-race-parent", guard=_guard(1, 1))
+    ready = Barrier(2)
+
+    def restore_parent() -> str:
+        ready.wait()
+        try:
+            sqlite_db_real.restore_component("restore-race-parent", guard=_guard(1, 1))
+        except ComponentDependencyUnavailableError:
+            return "restore_blocked"
+        return "restored"
+
+    def archive_child() -> str:
+        ready.wait()
+        try:
+            sqlite_db_real.delete_component("restore-race-child", guard=_guard(1, 1))
+        except ComponentDependencyError:
+            return "archive_blocked"
+        return "archived"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        restore_future = executor.submit(restore_parent)
+        archive_future = executor.submit(archive_child)
+        outcomes = {restore_future.result(timeout=10), archive_future.result(timeout=10)}
+
+    assert outcomes in ({"restored", "archive_blocked"}, {"restore_blocked", "archived"})
+    parent_is_active = sqlite_db_real.get_component("restore-race-parent") is not None
+    child_is_active = sqlite_db_real.get_component("restore-race-child") is not None
+    if outcomes == {"restored", "archive_blocked"}:
+        assert parent_is_active and child_is_active
+    else:
+        assert not parent_is_active and not child_is_active
+
+
+def test_atomic_restore_and_draft_append_roll_back_when_the_current_graph_is_unavailable(
+    sqlite_db_real: SqliteDb,
+) -> None:
+    _create_component(sqlite_db_real, "restore-append-child")
+    _create_component(
+        sqlite_db_real,
+        "restore-append-parent",
+        component_type=ComponentType.WORKFLOW,
+        links=[_component_link("restore-append-child")],
+    )
+    assert sqlite_db_real.delete_component("restore-append-parent", guard=_guard(1, 1))
+    assert sqlite_db_real.delete_component("restore-append-child", guard=_guard(1, 1))
+
+    with pytest.raises(ComponentDependencyUnavailableError):
+        sqlite_db_real.upsert_config(
+            "restore-append-parent",
+            config={"name": "Draft edit"},
+            stage="draft",
+            guard=_guard(1, 1),
+            restore_if_deleted=True,
+            expected_component_type=ComponentType.WORKFLOW,
+        )
+
+    parent = sqlite_db_real.get_component("restore-append-parent", include_deleted=True)
+    assert parent is not None and parent["deleted_at"] is not None
+    latest = sqlite_db_real.get_latest_config("restore-append-parent", include_deleted=True)
+    assert latest is not None and latest["version"] == 1
+
+    _create_component(sqlite_db_real, "restore-repair-child")
+    repaired = sqlite_db_real.upsert_config(
+        "restore-append-parent",
+        config={"name": "Published repair"},
+        stage="published",
+        guard=_guard(1, 1),
+        links=[_component_link("restore-repair-child")],
+        restore_if_deleted=True,
+        expected_component_type=ComponentType.WORKFLOW,
+    )
+    assert repaired["version"] == 2
+    parent = sqlite_db_real.get_component("restore-append-parent")
+    assert parent is not None and parent["current_version"] == 2
+    assert sqlite_db_real.get_component("restore-append-child") is None
+
+
+def test_atomic_restore_and_append_rolls_back_on_duplicate_label(sqlite_db_real: SqliteDb) -> None:
+    sqlite_db_real.create_component_with_config(
+        component_id="restore-append-agent",
+        component_type=ComponentType.AGENT,
+        name="Version one",
+        config={"name": "Version one"},
+        stage="published",
+        label="stable",
+    )
+    assert sqlite_db_real.delete_component("restore-append-agent", guard=_guard(1, 1))
+
+    with pytest.raises(ValueError, match="Label 'stable' already exists"):
+        sqlite_db_real.upsert_config(
+            "restore-append-agent",
+            config={"name": "Rejected version"},
+            stage="published",
+            label="stable",
+            projection={"name": "Rejected version"},
+            restore_if_deleted=True,
+        )
+
+    assert sqlite_db_real.get_component("restore-append-agent") is None
+    archived = sqlite_db_real.get_component("restore-append-agent", include_deleted=True)
+    assert archived is not None and archived["deleted_at"] is not None
+    assert sqlite_db_real.get_latest_config("restore-append-agent", include_deleted=True)["version"] == 1  # type: ignore[index]
+
+    appended = sqlite_db_real.upsert_config(
+        "restore-append-agent",
+        config={"name": "Version two"},
+        stage="published",
+        label="next",
+        projection={"name": "Version two"},
+        restore_if_deleted=True,
+    )
+    assert appended["version"] == 2
+    restored = sqlite_db_real.get_component("restore-append-agent")
+    assert restored is not None
+    assert restored["current_version"] == 2
+    assert restored["name"] == "Version two"
+
+
+def test_expected_component_type_rejects_replaced_identity(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "replaced-identity", component_type=ComponentType.AGENT)
+    assert sqlite_db_real.delete_component(
+        "replaced-identity",
+        hard_delete=True,
+        require_no_dependents=False,
+    )
+    _create_component(sqlite_db_real, "replaced-identity", component_type=ComponentType.TEAM)
+
+    with pytest.raises(ValueError, match="has type team, not agent"):
+        sqlite_db_real.upsert_config(
+            "replaced-identity",
+            config={"name": "Agent payload"},
+            stage="published",
+            projection={"name": "Agent payload"},
+            expected_component_type=ComponentType.AGENT,
+        )
+
+    component = sqlite_db_real.get_component("replaced-identity")
+    assert component is not None
+    assert component["component_type"] == ComponentType.TEAM.value
+    assert component["current_version"] == 1
+    assert [row["version"] for row in sqlite_db_real.list_configs("replaced-identity")] == [1]

--- a/libs/agno/tests/integration/db/sqlite/test_scheduler.py
+++ b/libs/agno/tests/integration/db/sqlite/test_scheduler.py
@@ -77,7 +77,6 @@ def _make_run(schedule_id, **overrides):
 # =============================================================================
 
 
-
 def _force_schedule_row(db, schedule_id, **cols):
     """Rig lock/run state directly at the table: update_schedule guards these columns."""
     table = db._get_table(table_type="schedules")

--- a/libs/agno/tests/integration/db/sqlite/test_scheduler.py
+++ b/libs/agno/tests/integration/db/sqlite/test_scheduler.py
@@ -77,6 +77,21 @@ def _make_run(schedule_id, **overrides):
 # =============================================================================
 
 
+
+def _force_schedule_row(db, schedule_id, **cols):
+    """Rig lock/run state directly at the table: update_schedule guards these columns."""
+    table = db._get_table(table_type="schedules")
+    with db.Session() as sess, sess.begin():
+        sess.execute(table.update().where(table.c.id == schedule_id).values(**cols))
+
+
+async def _aforce_schedule_row(db, schedule_id, **cols):
+    table = await db._get_table(table_type="schedules")
+    async with db.async_session_factory() as sess:
+        async with sess.begin():
+            await sess.execute(table.update().where(table.c.id == schedule_id).values(**cols))
+
+
 class TestScheduleCRUD:
     def test_create_and_get(self, db):
         sched = _make_schedule()
@@ -371,7 +386,7 @@ class TestClaimAndRelease:
 
         # The worker dies. By the time its lock is stale, the cron occurrence
         # is also due; recovery must finish the manual unit first.
-        db.update_schedule(sched["id"], locked_at=now - 600, next_run_at=now - 1)
+        _force_schedule_row(db, sched["id"], locked_at=now - 600, next_run_at=now - 1)
         recovered = db.claim_due_schedule("recovery-worker")
         assert recovered is not None
         assert recovered["pending_trigger_count"] == 0
@@ -560,7 +575,7 @@ async def test_async_stale_manual_claim_is_recovered_exactly_once(tmp_path):
         abandoned = await db.claim_due_schedule("dead-worker")
         assert abandoned is not None and abandoned["manual_trigger_claimed"] is True
 
-        await db.update_schedule(sched["id"], locked_at=now - 600, next_run_at=now - 1)
+        await _aforce_schedule_row(db, sched["id"], locked_at=now - 600, next_run_at=now - 1)
         recovered = await db.claim_due_schedule("recovery-worker")
         assert recovered is not None
         assert recovered["pending_trigger_count"] == 0

--- a/libs/agno/tests/integration/db/sqlite/test_scheduler.py
+++ b/libs/agno/tests/integration/db/sqlite/test_scheduler.py
@@ -7,7 +7,9 @@ import uuid
 
 import pytest
 
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY, ScheduleNameConflictError
 from agno.db.sqlite import SqliteDb
+from agno.db.sqlite.async_sqlite import AsyncSqliteDb
 
 
 @pytest.fixture
@@ -99,6 +101,42 @@ class TestScheduleCRUD:
         result = db.get_schedule_by_name("nonexistent")
         assert result is None
 
+    def test_generic_and_studio_names_are_isolated_per_actor(self, db):
+        generic = _make_schedule(name="shared-name")
+        studio_a = _make_schedule(
+            name="shared-name",
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            owner_actor_id="actor-a",
+        )
+        studio_b = _make_schedule(
+            name="shared-name",
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            owner_actor_id="actor-b",
+        )
+        db.create_schedule(generic)
+        db.create_schedule(studio_a)
+        db.create_schedule(studio_b)
+
+        assert (
+            db.get_schedule_by_name("shared-name", exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY)["id"] == generic["id"]
+        )
+        assert (
+            db.get_schedule_by_name(
+                "shared-name",
+                managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+                owner_actor_id="actor-a",
+            )["id"]
+            == studio_a["id"]
+        )
+        with pytest.raises(ScheduleNameConflictError):
+            db.create_schedule(
+                _make_schedule(
+                    name="shared-name",
+                    managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+                    owner_actor_id="actor-a",
+                )
+            )
+
     def test_get_not_found(self, db):
         result = db.get_schedule("nonexistent-id")
         assert result is None
@@ -116,6 +154,36 @@ class TestScheduleCRUD:
         assert s1["id"] in ids
         assert s2["id"] in ids
 
+    def test_list_excludes_studio_before_count_and_pagination(self, db):
+        studio = _make_schedule(
+            name="aaa-studio-hidden",
+            created_at=3,
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            owner_actor_id="studio-actor",
+            target_type="agent",
+            target_id="studio-agent",
+        )
+        ordinary_first = _make_schedule(name="bbb-ordinary-first", created_at=2)
+        ordinary_second = _make_schedule(name="ccc-ordinary-second", created_at=1)
+        db.create_schedule(studio)
+        db.create_schedule(ordinary_first)
+        db.create_schedule(ordinary_second)
+
+        page_one, total_count = db.get_schedules(
+            limit=1,
+            page=1,
+            exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        )
+        page_two, second_total_count = db.get_schedules(
+            limit=1,
+            page=2,
+            exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        )
+
+        assert total_count == second_total_count == 2
+        assert [schedule["id"] for schedule in page_one] == [ordinary_first["id"]]
+        assert [schedule["id"] for schedule in page_two] == [ordinary_second["id"]]
+
     def test_update_schedule(self, db):
         sched = _make_schedule()
         db.create_schedule(sched)
@@ -124,6 +192,51 @@ class TestScheduleCRUD:
         assert updated is not None
         assert updated["description"] == "Updated description"
         assert updated["updated_at"] is not None
+
+    def test_disable_schedules_for_target_is_atomic_and_scoped(self, db):
+        matching = [
+            _make_schedule(
+                name=f"studio-target-{index}",
+                managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+                owner_actor_id="actor-a",
+                target_type="agent",
+                target_id="agent-a",
+            )
+            for index in range(101)
+        ]
+        other_target = _make_schedule(
+            name="studio-other-target",
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            owner_actor_id="actor-a",
+            target_type="agent",
+            target_id="agent-b",
+        )
+        generic_same_target = _make_schedule(
+            name="generic-same-target",
+            target_type="agent",
+            target_id="agent-a",
+        )
+        for schedule in [*matching, other_target, generic_same_target]:
+            db.create_schedule(schedule)
+
+        disabled = db.disable_schedules_for_target(
+            "agent",
+            "agent-a",
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        )
+
+        assert disabled == 101
+        assert (
+            db.disable_schedules_for_target(
+                "agent",
+                "agent-a",
+                managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            )
+            == 0
+        )
+        assert all(db.get_schedule(schedule["id"])["enabled"] is False for schedule in matching)
+        assert db.get_schedule(other_target["id"])["enabled"] is True
+        assert db.get_schedule(generic_same_target["id"])["enabled"] is True
 
     def test_delete_schedule(self, db):
         sched = _make_schedule()
@@ -167,6 +280,135 @@ class TestEnabledFilter:
 
 
 class TestClaimAndRelease:
+    def test_manual_trigger_survives_an_in_flight_release_and_is_consumed_once(self, db):
+        future = int(time.time()) + 9999
+        sched = _make_schedule(
+            next_run_at=future,
+            enabled=True,
+            locked_by="worker-1",
+            locked_at=int(time.time()),
+        )
+        db.create_schedule(sched)
+
+        queued = db.trigger_schedule(sched["id"])
+        assert queued is not None and queued["pending_trigger_count"] == 1
+        assert db.claim_due_schedule("worker-2") is None
+
+        assert (
+            db.release_schedule(
+                sched["id"],
+                next_run_at=future,
+                worker_id="worker-1",
+                locked_at=sched["locked_at"],
+            )
+            is True
+        )
+        claimed = db.claim_due_schedule("worker-2")
+        assert claimed is not None
+        assert claimed["id"] == sched["id"]
+        assert claimed["pending_trigger_count"] == 0
+        assert claimed["manual_trigger_claimed"] is True
+        assert claimed["next_run_at"] == future
+
+        assert (
+            db.release_schedule(
+                sched["id"],
+                worker_id=claimed["locked_by"],
+                locked_at=claimed["locked_at"],
+            )
+            is True
+        )
+        assert db.claim_due_schedule("worker-3") is None
+
+    def test_due_cron_and_manual_trigger_are_claimed_as_two_executions(self, db):
+        now = int(time.time())
+        future = now + 9999
+        sched = _make_schedule(next_run_at=now - 1, enabled=True)
+        db.create_schedule(sched)
+        assert db.trigger_schedule(sched["id"])["pending_trigger_count"] == 1
+
+        cron_claim = db.claim_due_schedule("cron-worker")
+        assert cron_claim is not None
+        assert cron_claim["pending_trigger_count"] == 1
+        assert cron_claim["manual_trigger_claimed"] is False
+        assert (
+            db.release_schedule(
+                sched["id"],
+                next_run_at=future,
+                worker_id=cron_claim["locked_by"],
+                locked_at=cron_claim["locked_at"],
+            )
+            is True
+        )
+
+        manual_claim = db.claim_due_schedule("manual-worker")
+        assert manual_claim is not None
+        assert manual_claim["pending_trigger_count"] == 0
+        assert manual_claim["manual_trigger_claimed"] is True
+        assert manual_claim["next_run_at"] == future
+
+        assert (
+            db.release_schedule(
+                sched["id"],
+                worker_id=manual_claim["locked_by"],
+                locked_at=manual_claim["locked_at"],
+            )
+            is True
+        )
+        assert db.claim_due_schedule("extra-worker") is None
+
+    def test_stale_manual_claim_is_recovered_once_without_swallowing_due_cron(self, db):
+        now = int(time.time())
+        future = now + 9999
+        sched = _make_schedule(next_run_at=future, enabled=True)
+        db.create_schedule(sched)
+        db.trigger_schedule(sched["id"])
+
+        abandoned = db.claim_due_schedule("dead-worker")
+        assert abandoned is not None
+        assert abandoned["pending_trigger_count"] == 0
+        assert abandoned["manual_trigger_claimed"] is True
+
+        # The worker dies. By the time its lock is stale, the cron occurrence
+        # is also due; recovery must finish the manual unit first.
+        db.update_schedule(sched["id"], locked_at=now - 600, next_run_at=now - 1)
+        recovered = db.claim_due_schedule("recovery-worker")
+        assert recovered is not None
+        assert recovered["pending_trigger_count"] == 0
+        assert recovered["manual_trigger_claimed"] is True
+
+        assert (
+            db.release_schedule(
+                sched["id"],
+                worker_id=abandoned["locked_by"],
+                locked_at=abandoned["locked_at"],
+            )
+            is False
+        )
+        assert db.get_schedule(sched["id"])["manual_trigger_claimed"] is True
+
+        assert (
+            db.release_schedule(
+                sched["id"],
+                worker_id=recovered["locked_by"],
+                locked_at=recovered["locked_at"],
+            )
+            is True
+        )
+        cron_claim = db.claim_due_schedule("cron-worker")
+        assert cron_claim is not None
+        assert cron_claim["manual_trigger_claimed"] is False
+        assert (
+            db.release_schedule(
+                sched["id"],
+                next_run_at=future,
+                worker_id=cron_claim["locked_by"],
+                locked_at=cron_claim["locked_at"],
+            )
+            is True
+        )
+        assert db.claim_due_schedule("extra-worker") is None
+
     def test_claim_due_schedule(self, db):
         now = int(time.time())
         sched = _make_schedule(next_run_at=now - 10, enabled=True)
@@ -237,6 +479,185 @@ class TestClaimAndRelease:
         assert refreshed["locked_by"] is None
         assert refreshed["locked_at"] is None
         assert refreshed["next_run_at"] == next_run
+
+    def test_renew_schedule_claim_rotates_fence_without_touching_manual_work(self, db, monkeypatch):
+        sched = _make_schedule(
+            locked_by="worker-1",
+            locked_at=100,
+            pending_trigger_count=2,
+            manual_trigger_claimed=True,
+        )
+        db.create_schedule(sched)
+
+        monkeypatch.setattr("agno.db.sqlite.sqlite.time.time", lambda: 100)
+        renewed_at = db.renew_schedule_claim(
+            sched["id"],
+            worker_id="worker-1",
+            locked_at=100,
+        )
+
+        assert renewed_at == 101
+        refreshed = db.get_schedule(sched["id"])
+        assert refreshed["pending_trigger_count"] == 2
+        assert refreshed["manual_trigger_claimed"] is True
+        assert not db.release_schedule(sched["id"], worker_id="worker-1", locked_at=100)
+        assert db.release_schedule(sched["id"], worker_id="worker-1", locked_at=renewed_at)
+
+
+@pytest.mark.asyncio
+async def test_async_due_cron_and_manual_trigger_are_claimed_as_two_executions(tmp_path):
+    db = AsyncSqliteDb(db_file=str(tmp_path / "async-due-and-manual.db"))
+    now = int(time.time())
+    future = now + 9999
+    sched = _make_schedule(next_run_at=now - 1, enabled=True)
+    try:
+        await db.create_schedule(sched)
+        queued = await db.trigger_schedule(sched["id"])
+        assert queued is not None and queued["pending_trigger_count"] == 1
+
+        cron_claim = await db.claim_due_schedule("cron-worker")
+        assert cron_claim is not None
+        assert cron_claim["pending_trigger_count"] == 1
+        assert cron_claim["manual_trigger_claimed"] is False
+        assert (
+            await db.release_schedule(
+                sched["id"],
+                next_run_at=future,
+                worker_id=cron_claim["locked_by"],
+                locked_at=cron_claim["locked_at"],
+            )
+            is True
+        )
+
+        manual_claim = await db.claim_due_schedule("manual-worker")
+        assert manual_claim is not None
+        assert manual_claim["pending_trigger_count"] == 0
+        assert manual_claim["manual_trigger_claimed"] is True
+        assert manual_claim["next_run_at"] == future
+
+        assert (
+            await db.release_schedule(
+                sched["id"],
+                worker_id=manual_claim["locked_by"],
+                locked_at=manual_claim["locked_at"],
+            )
+            is True
+        )
+        assert await db.claim_due_schedule("extra-worker") is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_async_stale_manual_claim_is_recovered_exactly_once(tmp_path):
+    db = AsyncSqliteDb(db_file=str(tmp_path / "async-stale-manual.db"))
+    now = int(time.time())
+    future = now + 9999
+    sched = _make_schedule(next_run_at=future, enabled=True)
+    try:
+        await db.create_schedule(sched)
+        await db.trigger_schedule(sched["id"])
+        abandoned = await db.claim_due_schedule("dead-worker")
+        assert abandoned is not None and abandoned["manual_trigger_claimed"] is True
+
+        await db.update_schedule(sched["id"], locked_at=now - 600, next_run_at=now - 1)
+        recovered = await db.claim_due_schedule("recovery-worker")
+        assert recovered is not None
+        assert recovered["pending_trigger_count"] == 0
+        assert recovered["manual_trigger_claimed"] is True
+
+        assert (
+            await db.release_schedule(
+                sched["id"],
+                worker_id=abandoned["locked_by"],
+                locked_at=abandoned["locked_at"],
+            )
+            is False
+        )
+        assert (
+            await db.release_schedule(
+                sched["id"],
+                worker_id=recovered["locked_by"],
+                locked_at=recovered["locked_at"],
+            )
+            is True
+        )
+
+        cron_claim = await db.claim_due_schedule("cron-worker")
+        assert cron_claim is not None and cron_claim["manual_trigger_claimed"] is False
+        assert (
+            await db.release_schedule(
+                sched["id"],
+                next_run_at=future,
+                worker_id=cron_claim["locked_by"],
+                locked_at=cron_claim["locked_at"],
+            )
+            is True
+        )
+        assert await db.claim_due_schedule("extra-worker") is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_async_renew_schedule_claim_rotates_fence_without_touching_manual_work(tmp_path, monkeypatch):
+    db = AsyncSqliteDb(db_file=str(tmp_path / "async-heartbeat.db"))
+    sched = _make_schedule(
+        locked_by="worker-1",
+        locked_at=100,
+        pending_trigger_count=2,
+        manual_trigger_claimed=True,
+    )
+    try:
+        await db.create_schedule(sched)
+
+        monkeypatch.setattr("agno.db.sqlite.async_sqlite.time.time", lambda: 100)
+        renewed_at = await db.renew_schedule_claim(
+            sched["id"],
+            worker_id="worker-1",
+            locked_at=100,
+        )
+
+        assert renewed_at == 101
+        refreshed = await db.get_schedule(sched["id"])
+        assert refreshed["pending_trigger_count"] == 2
+        assert refreshed["manual_trigger_claimed"] is True
+        assert not await db.release_schedule(sched["id"], worker_id="worker-1", locked_at=100)
+        assert await db.release_schedule(sched["id"], worker_id="worker-1", locked_at=renewed_at)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_async_disable_schedules_for_target_is_atomic_and_scoped(tmp_path):
+    db = AsyncSqliteDb(db_file=str(tmp_path / "async-disable-target.db"))
+    matching = _make_schedule(
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+        target_type="workflow",
+        target_id="workflow-a",
+    )
+    unrelated = _make_schedule(
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+        target_type="workflow",
+        target_id="workflow-b",
+    )
+    try:
+        await db.create_schedule(matching)
+        await db.create_schedule(unrelated)
+
+        disabled = await db.disable_schedules_for_target(
+            "workflow",
+            "workflow-a",
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        )
+
+        assert disabled == 1
+        assert (await db.get_schedule(matching["id"]))["enabled"] is False
+        assert (await db.get_schedule(unrelated["id"]))["enabled"] is True
+    finally:
+        await db.close()
 
 
 # =============================================================================

--- a/libs/agno/tests/integration/db/sqlite/test_scheduler.py
+++ b/libs/agno/tests/integration/db/sqlite/test_scheduler.py
@@ -824,3 +824,43 @@ class TestFullLifecycle:
         # Delete
         assert db.delete_schedule(sched["id"]) is True
         assert db.get_schedule(sched["id"]) is None
+
+
+def test_name_scope_conditions_compose_conjunctively(db):
+    """managed_by and exclude_managed_by must AND, matching the SQL adapters.
+
+    A row cannot be studio and not-studio at once, so the contradictory pair
+    returns None; an unrelated exclusion must not clobber the equality.
+    """
+    db = db
+    generic = _make_schedule(name="scoped-name")
+    studio = _make_schedule(
+        name="scoped-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+    )
+    db.create_schedule(generic)
+    db.create_schedule(studio)
+
+    contradictory = db.get_schedule_by_name(
+        "scoped-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+    assert contradictory is None
+
+    contradictory_scoped = db.get_schedule_by_name(
+        "scoped-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+        exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+    )
+    assert contradictory_scoped is None
+
+    compatible = db.get_schedule_by_name(
+        "scoped-name",
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        exclude_managed_by="other-namespace",
+    )
+    assert compatible is not None
+    assert compatible["id"] == studio["id"]

--- a/libs/agno/tests/unit/agent/test_agent_config.py
+++ b/libs/agno/tests/unit/agent/test_agent_config.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agno.agent.agent import Agent, get_agent_by_id, get_agents
-from agno.db.base import BaseDb, ComponentType
+from agno.db.base import BaseDb, ComponentType, ComponentVersionGuard
 from agno.registry import Registry
 
 # =============================================================================
@@ -640,13 +640,15 @@ class TestAgentSave:
             "deleted_at": None,
         }
         mock_db.upsert_config.return_value = {"version": 2}
+        guard = ComponentVersionGuard(latest_version=1, current_version=1)
 
         basic_agent.db = mock_db
-        version = basic_agent.save()
+        version = basic_agent.save(guard=guard)
 
         mock_db.upsert_config.assert_called_once()
         call_args = mock_db.upsert_config.call_args
         assert call_args.kwargs["component_id"] == "test-agent"
+        assert call_args.kwargs["guard"] == guard
         assert "config" in call_args.kwargs
         assert call_args.kwargs["projection"] == {
             "name": "Test Agent",
@@ -824,35 +826,50 @@ class TestAgentDelete:
     def test_delete_calls_delete_component(self, basic_agent, mock_db):
         """Test delete calls delete_component."""
         mock_db.delete_component.return_value = True
+        guard = ComponentVersionGuard(latest_version=1, current_version=1)
 
         basic_agent.db = mock_db
-        result = basic_agent.delete()
+        result = basic_agent.delete(guard=guard)
 
         mock_db.delete_component.assert_called_once_with(
-            component_id="test-agent", hard_delete=False, require_no_dependents=True
+            component_id="test-agent",
+            hard_delete=False,
+            guard=guard,
+            require_no_dependents=True,
+            expected_component_type=ComponentType.AGENT,
         )
         assert result is True
 
     def test_delete_with_hard_delete(self, basic_agent, mock_db):
         """Test delete with hard_delete flag."""
         mock_db.delete_component.return_value = True
+        guard = ComponentVersionGuard(latest_version=1, current_version=1)
 
         basic_agent.db = mock_db
-        result = basic_agent.delete(hard_delete=True)
+        result = basic_agent.delete(hard_delete=True, guard=guard)
 
         mock_db.delete_component.assert_called_once_with(
-            component_id="test-agent", hard_delete=True, require_no_dependents=True
+            component_id="test-agent",
+            hard_delete=True,
+            guard=guard,
+            require_no_dependents=True,
+            expected_component_type=ComponentType.AGENT,
         )
         assert result is True
 
     def test_delete_can_explicitly_bypass_dependency_check(self, basic_agent, mock_db):
         """Test delete forwards the dangerous dependency-check escape hatch."""
         basic_agent.db = mock_db
+        guard = ComponentVersionGuard(latest_version=1, current_version=1)
 
-        assert basic_agent.delete(require_no_dependents=False) is True
+        assert basic_agent.delete(require_no_dependents=False, guard=guard) is True
 
         mock_db.delete_component.assert_called_once_with(
-            component_id="test-agent", hard_delete=False, require_no_dependents=False
+            component_id="test-agent",
+            hard_delete=False,
+            guard=guard,
+            require_no_dependents=False,
+            expected_component_type=ComponentType.AGENT,
         )
 
     def test_delete_uses_exact_catalog_v1_signature(self, basic_agent, mock_db):
@@ -874,7 +891,10 @@ class TestAgentDelete:
         """Test delete uses explicitly provided db."""
         mock_db.delete_component.return_value = True
 
-        result = basic_agent.delete(db=mock_db)
+        result = basic_agent.delete(
+            db=mock_db,
+            guard=ComponentVersionGuard(latest_version=1, current_version=1),
+        )
 
         mock_db.delete_component.assert_called_once()
         assert result is True
@@ -889,7 +909,7 @@ class TestAgentDelete:
         mock_db.delete_component.return_value = False
 
         basic_agent.db = mock_db
-        result = basic_agent.delete()
+        result = basic_agent.delete(guard=ComponentVersionGuard(latest_version=1, current_version=1))
 
         assert result is False
 

--- a/libs/agno/tests/unit/agent/test_agent_config.py
+++ b/libs/agno/tests/unit/agent/test_agent_config.py
@@ -40,12 +40,17 @@ def mock_db():
     """Create a mock database instance that passes isinstance(db, BaseDb)."""
     MockDbClass = _create_mock_db_class()
     db = MockDbClass()
+    db.component_catalog_api_version = 2
 
     # Configure common mock methods
+    db.get_component = MagicMock(return_value=None)
+    db.create_component_with_config = MagicMock(return_value=({"component_id": "test-agent"}, {"version": 1}))
     db.upsert_component = MagicMock()
     db.upsert_config = MagicMock(return_value={"version": 1})
     db.delete_component = MagicMock(return_value=True)
     db.get_config = MagicMock()
+    db.get_current_config = db.get_config
+    db.get_latest_config = db.get_config
     db.list_components = MagicMock()
     db.to_dict = MagicMock(return_value={"type": "postgres", "id": "test-db"})
 
@@ -612,24 +617,28 @@ class TestAgentKnowledgeRoundtrip:
 class TestAgentSave:
     """Tests for Agent.save() method."""
 
-    def test_save_calls_upsert_component(self, basic_agent, mock_db):
-        """Test save calls upsert_component with correct parameters."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+    def test_save_creates_component_and_initial_config_atomically(self, basic_agent, mock_db):
+        """Test first save creates the component and config together."""
         basic_agent.db = mock_db
         version = basic_agent.save()
 
-        mock_db.upsert_component.assert_called_once_with(
-            component_id="test-agent",
-            component_type=ComponentType.AGENT,
-            name="Test Agent",
-            description="A test agent for unit testing",
-            metadata=None,
-        )
+        call_args = mock_db.create_component_with_config.call_args
+        assert call_args.kwargs["component_id"] == "test-agent"
+        assert call_args.kwargs["component_type"] == ComponentType.AGENT
+        assert call_args.kwargs["name"] == "Test Agent"
+        assert call_args.kwargs["description"] == "A test agent for unit testing"
+        assert call_args.kwargs["config"]["id"] == "test-agent"
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_not_called()
         assert version == 1
 
-    def test_save_calls_upsert_config(self, basic_agent, mock_db):
-        """Test save calls upsert_config with agent config."""
+    def test_existing_save_upserts_config_with_projection(self, basic_agent, mock_db):
+        """Test a published save updates config and projection together."""
+        mock_db.get_component.return_value = {
+            "component_id": "test-agent",
+            "component_type": "agent",
+            "deleted_at": None,
+        }
         mock_db.upsert_config.return_value = {"version": 2}
 
         basic_agent.db = mock_db
@@ -639,46 +648,44 @@ class TestAgentSave:
         call_args = mock_db.upsert_config.call_args
         assert call_args.kwargs["component_id"] == "test-agent"
         assert "config" in call_args.kwargs
+        assert call_args.kwargs["projection"] == {
+            "name": "Test Agent",
+            "description": "A test agent for unit testing",
+            "metadata": None,
+        }
         assert version == 2
 
     def test_save_with_explicit_db(self, basic_agent, mock_db):
         """Test save uses explicitly provided db."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
         version = basic_agent.save(db=mock_db)
 
-        mock_db.upsert_component.assert_called_once()
-        mock_db.upsert_config.assert_called_once()
+        mock_db.create_component_with_config.assert_called_once()
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_not_called()
         assert version == 1
 
     def test_save_with_label(self, basic_agent, mock_db):
-        """Test save passes label to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes the label to the atomic create."""
         basic_agent.db = mock_db
         basic_agent.save(label="production")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["label"] == "production"
 
     def test_save_with_stage(self, basic_agent, mock_db):
-        """Test save passes stage to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes the stage to the atomic create."""
         basic_agent.db = mock_db
         basic_agent.save(stage="draft")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["stage"] == "draft"
 
     def test_save_with_notes(self, basic_agent, mock_db):
-        """Test save passes notes to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes notes to the atomic create."""
         basic_agent.db = mock_db
         basic_agent.save(notes="Initial version")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["notes"] == "Initial version"
 
     def test_save_without_db_raises_error(self, basic_agent):
@@ -688,19 +695,17 @@ class TestAgentSave:
 
     def test_save_generates_id_from_name(self, mock_db):
         """Test save generates id from name if not provided."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
         agent = Agent(name="My Test Agent", db=mock_db)
         agent.save()
 
         # ID should be generated from name
         assert agent.id is not None
-        call_args = mock_db.upsert_component.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["component_id"] is not None
 
     def test_save_handles_db_error(self, basic_agent, mock_db):
         """Test save raises error when database operation fails."""
-        mock_db.upsert_component.side_effect = Exception("Database error")
+        mock_db.create_component_with_config.side_effect = Exception("Database error")
 
         basic_agent.db = mock_db
 
@@ -786,14 +791,14 @@ class TestAgentLoad:
         """Test that store_history_messages=True survives save/load round-trip."""
         agent = Agent(id="persist-agent", name="Persist Agent", store_history_messages=True, db=mock_db)
 
-        # Capture the config passed to upsert_config during save
+        # Capture the config passed to the atomic first-save operation.
         saved_config = {}
 
         def capture_config(**kwargs):
             saved_config.update(kwargs.get("config", {}))
-            return {"version": 1}
+            return {"component_id": "persist-agent"}, {"version": 1}
 
-        mock_db.upsert_config.side_effect = capture_config
+        mock_db.create_component_with_config.side_effect = capture_config
         agent.save()
 
         assert saved_config.get("store_history_messages") is True
@@ -823,7 +828,9 @@ class TestAgentDelete:
         basic_agent.db = mock_db
         result = basic_agent.delete()
 
-        mock_db.delete_component.assert_called_once_with(component_id="test-agent", hard_delete=False)
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-agent", hard_delete=False, require_no_dependents=True
+        )
         assert result is True
 
     def test_delete_with_hard_delete(self, basic_agent, mock_db):
@@ -833,8 +840,35 @@ class TestAgentDelete:
         basic_agent.db = mock_db
         result = basic_agent.delete(hard_delete=True)
 
-        mock_db.delete_component.assert_called_once_with(component_id="test-agent", hard_delete=True)
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-agent", hard_delete=True, require_no_dependents=True
+        )
         assert result is True
+
+    def test_delete_can_explicitly_bypass_dependency_check(self, basic_agent, mock_db):
+        """Test delete forwards the dangerous dependency-check escape hatch."""
+        basic_agent.db = mock_db
+
+        assert basic_agent.delete(require_no_dependents=False) is True
+
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-agent", hard_delete=False, require_no_dependents=False
+        )
+
+    def test_delete_uses_exact_catalog_v1_signature(self, basic_agent, mock_db):
+        """The v2 dependency keyword must never reach a legacy override."""
+        calls = []
+
+        def legacy_delete(component_id, hard_delete=False):
+            calls.append((component_id, hard_delete))
+            return True
+
+        mock_db.component_catalog_api_version = 1
+        mock_db.delete_component = legacy_delete
+        basic_agent.db = mock_db
+
+        assert basic_agent.delete(require_no_dependents=False) is True
+        assert calls == [("test-agent", False)]
 
     def test_delete_with_explicit_db(self, basic_agent, mock_db):
         """Test delete uses explicitly provided db."""
@@ -877,6 +911,21 @@ class TestGetAgentById:
         assert agent is not None
         assert agent.id == "found-agent"
         assert agent.name == "Found Agent"
+        mock_db.get_config.assert_called_once_with(component_id="found-agent", label=None, version=None)
+
+    def test_get_agent_by_id_returns_a_draft_only_component(self, tmp_path):
+        """An ordinary by-id read retains the pre-2.9 draft fallback."""
+        from agno.db.sqlite import SqliteDb
+
+        db = SqliteDb(db_file=str(tmp_path / "draft-only-agent.db"))
+        assert Agent(id="draft-agent", name="Draft Agent", db=db).save(stage="draft") == 1
+        assert db.get_current_config("draft-agent") is None
+
+        loaded = get_agent_by_id(db=db, id="draft-agent")
+
+        assert loaded is not None
+        assert loaded.id == "draft-agent"
+        assert loaded.name == "Draft Agent"
 
     def test_get_agent_by_id_with_version(self, mock_db):
         """Test get_agent_by_id retrieves specific version."""
@@ -959,16 +1008,20 @@ class TestGetAgents:
             ],
             None,
         )
-        mock_db.get_config.side_effect = [
-            {"config": {"id": "agent-1", "name": "Agent 1"}},
-            {"config": {"id": "agent-2", "name": "Agent 2"}},
-        ]
+        mock_db.get_latest_config = MagicMock(
+            side_effect=[
+                {"config": {"id": "agent-1", "name": "Agent 1"}},
+                {"config": {"id": "agent-2", "name": "Agent 2"}},
+            ]
+        )
 
         agents = get_agents(db=mock_db)
 
         assert len(agents) == 2
         assert agents[0].id == "agent-1"
         assert agents[1].id == "agent-2"
+        assert mock_db.get_latest_config.call_count == 2
+        mock_db.get_config.assert_not_called()
 
     def test_get_agents_filters_by_type(self, mock_db):
         """Test get_agents filters by AGENT component type."""

--- a/libs/agno/tests/unit/db/test_async_component_stubs.py
+++ b/libs/agno/tests/unit/db/test_async_component_stubs.py
@@ -1,0 +1,68 @@
+"""Async adapters must refuse component-catalog calls loudly and uniformly.
+
+Catalog v2 is sync-only; the async adapters' contract is a typed
+NotImplementedError on every component method — never an AttributeError
+(which reads as a bug, not a boundary) and never an async stub (calling an
+async def without await returns an un-awaited coroutine and silently
+no-ops at the real call sites, e.g. workflow.py's db.get_config).
+"""
+
+import inspect
+
+import pytest
+
+from agno.db.base import ComponentType
+
+COMPONENT_METHOD_CALLS = {
+    "get_component": {"component_id": "c1"},
+    "get_components": {"component_ids": ["c1"]},
+    "upsert_component": {"component_id": "c1"},
+    "delete_component": {"component_id": "c1"},
+    "restore_component": {"component_id": "c1"},
+    "list_components": {},
+    "create_component_with_config": {
+        "component_id": "c1",
+        "component_type": ComponentType.AGENT,
+        "name": "c1",
+        "config": {"name": "c1"},
+    },
+    "get_config": {"component_id": "c1"},
+    "get_current_config": {"component_id": "c1"},
+    "get_latest_config": {"component_id": "c1"},
+    "get_latest_configs": {"component_ids": ["c1"]},
+    "upsert_config": {"component_id": "c1"},
+    "delete_config": {"component_id": "c1", "version": 1},
+    "list_configs": {"component_id": "c1"},
+    "set_current_version": {"component_id": "c1", "version": 1},
+    "get_links": {"component_id": "c1", "version": 1},
+    "get_dependents": {"component_id": "c1"},
+    "load_component_graph": {"component_id": "c1"},
+}
+
+
+@pytest.fixture(params=["async_sqlite", "async_postgres", "async_mongo"])
+def async_db(request, tmp_path):
+    """Adapter instances built without touching any service."""
+    if request.param == "async_sqlite":
+        from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+
+        return AsyncSqliteDb(db_file=str(tmp_path / "stub.db"))
+    if request.param == "async_postgres":
+        from agno.db.postgres.async_postgres import AsyncPostgresDb
+
+        return AsyncPostgresDb(db_url="postgresql+psycopg_async://ai:ai@localhost:5532/ai")
+    from agno.db.mongo.async_mongo import AsyncMongoDb
+
+    return AsyncMongoDb(db_url="mongodb://mongoadmin:secret@localhost:27017", db_name="stub_probe")
+
+
+@pytest.mark.parametrize("method_name", sorted(COMPONENT_METHOD_CALLS))
+def test_component_method_raises_not_implemented(async_db, method_name):
+    method = getattr(async_db, method_name, None)
+    assert method is not None, f"{type(async_db).__name__}.{method_name} is missing entirely (AttributeError surface)"
+    assert not inspect.iscoroutinefunction(method), (
+        f"{type(async_db).__name__}.{method_name} is async def: called without await it returns "
+        "an un-awaited coroutine and silently no-ops instead of raising"
+    )
+    with pytest.raises(NotImplementedError):
+        method(**COMPONENT_METHOD_CALLS[method_name])

--- a/libs/agno/tests/unit/db/test_component_save_atomicity.py
+++ b/libs/agno/tests/unit/db/test_component_save_atomicity.py
@@ -5,7 +5,15 @@ from typing import Any, Dict, List, Optional
 import pytest
 
 from agno.agent.agent import Agent, get_agent_by_id, get_agents
-from agno.db.base import BaseDb, ComponentDependencyError, ComponentType
+from agno.db.base import (
+    BaseDb,
+    ComponentArchivedError,
+    ComponentDependencyError,
+    ComponentType,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+    ComponentVersionGuardRequiredError,
+)
 from agno.db.sqlite import SqliteDb
 from agno.os.utils import (
     get_agent_by_id as get_runtime_agent_by_id,
@@ -17,7 +25,7 @@ from agno.os.utils import (
     get_workflow_by_id as get_runtime_workflow_by_id,
 )
 from agno.team.team import Team, get_team_by_id, get_teams
-from agno.utils.string import generate_id_from_name
+from agno.utils.string import generate_component_id_from_name
 from agno.workflow.workflow import Workflow, get_workflow_by_id, get_workflows
 
 
@@ -56,6 +64,9 @@ class _LegacyComponentSqliteDb(SqliteDb):
 
     def create_component_with_config(self, *args, **kwargs):
         raise AssertionError("catalog API v1 must not probe the v2 atomic primitive")
+
+    def delete_component(self, component_id: str, hard_delete: bool = False) -> bool:
+        return super().delete_component(component_id=component_id, hard_delete=hard_delete)
 
 
 class _BrokenAtomicSqliteDb(SqliteDb):
@@ -121,6 +132,30 @@ class _ReplaceDuringReadSqliteDb(SqliteDb):
                 stage="published",
             )
         return component
+
+
+class _PublishBetweenLoadAndGuardSqliteDb(SqliteDb):
+    """Publish after a load reads config but before it captures CAS state."""
+
+    publish_before_next_get_component = False
+
+    def get_component(
+        self,
+        component_id: str,
+        component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        if self.publish_before_next_get_component:
+            self.publish_before_next_get_component = False
+            super().upsert_config(
+                component_id,
+                config={"id": component_id, "name": "Concurrent publication"},
+                stage="published",
+                guard=ComponentVersionGuard(latest_version=1, current_version=1),
+                projection={"name": "Concurrent publication"},
+            )
+        return super().get_component(component_id, component_type, include_deleted=include_deleted)
 
 
 def _assert_no_component_or_configs(db: SqliteDb, component_id: str) -> None:
@@ -248,6 +283,8 @@ def test_first_save_falls_back_for_legacy_custom_component_adapter(tmp_path) -> 
     assert component["current_version"] == 1
     assert config is not None and config["stage"] == "published"
 
+    assert agent.delete(db=db) is True
+
 
 def test_base_bulk_read_fallback_preserves_legacy_scalar_signatures(tmp_path) -> None:
     db = _LegacyComponentSqliteDb(db_file=str(tmp_path / "legacy-bulk-read-adapter.db"))
@@ -318,14 +355,22 @@ def test_draft_only_projection_tracks_latest_draft_then_freezes_after_publish(tm
     assert component["metadata"] == {"revision": 3}
 
 
-def test_save_restores_archived_component_and_appends_history(tmp_path) -> None:
-    db = SqliteDb(db_file=str(tmp_path / "restore-on-save.db"))
+def test_save_requires_explicit_restore_then_appends_history(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "explicit-restore-before-save.db"))
     agent = Agent(id="restorable-agent", name="Version one", description="Before archive", db=db)
     assert agent.save(stage="published") == 1
     assert agent.delete() is True
 
     agent.name = "Version two"
     agent.description = "After restore"
+    with pytest.raises(ComponentArchivedError, match="restore it explicitly"):
+        agent.save(stage="published")
+
+    assert db.restore_component(
+        "restorable-agent",
+        guard=ComponentVersionGuard(latest_version=1, current_version=1),
+        projection={"name": "Version one", "description": "Before archive", "metadata": None},
+    )
     assert agent.save(stage="published") == 2
 
     component = db.get_component("restorable-agent")
@@ -343,7 +388,7 @@ def test_failed_save_does_not_restore_archived_component(tmp_path) -> None:
     assert agent.delete() is True
 
     agent.name = "Rejected version"
-    with pytest.raises(ValueError, match="Label 'stable' already exists"):
+    with pytest.raises(ComponentArchivedError, match="restore it explicitly"):
         agent.save(stage="published", label="stable")
 
     assert db.get_component("archived-agent") is None
@@ -380,7 +425,8 @@ def test_public_delete_dependency_check_has_explicit_escape_hatch(tmp_path) -> N
             }
         ],
     )
-    child = Agent(id="child-agent", db=db)
+    child = Agent.load("child-agent", db=db)
+    assert child is not None
 
     with pytest.raises(ComponentDependencyError):
         child.delete()
@@ -389,14 +435,15 @@ def test_public_delete_dependency_check_has_explicit_escape_hatch(tmp_path) -> N
     assert db.get_component("child-agent") is None
 
 
-def test_draft_save_survives_publish_after_initial_component_read(tmp_path) -> None:
+def test_draft_save_rejects_publish_after_captured_component_state(tmp_path) -> None:
     db = _PublishDuringReadSqliteDb(db_file=str(tmp_path / "publish-race.db"))
     agent = Agent(id="race-agent", name="Initial draft", db=db)
     assert agent.save(stage="draft") == 1
 
     agent.name = "Later draft"
     db.publish_during_next_get = True
-    assert agent.save(stage="draft") == 3
+    with pytest.raises(ComponentVersionConflictError):
+        agent.save(stage="draft")
 
     component = db.get_component("race-agent")
     assert component is not None
@@ -405,9 +452,151 @@ def test_draft_save_survives_publish_after_initial_component_read(tmp_path) -> N
     assert db.get_current_config("race-agent")["version"] == 2  # type: ignore[index]
     latest = db.get_latest_config("race-agent")
     assert latest is not None
-    assert latest["version"] == 3
-    assert latest["stage"] == "draft"
-    assert latest["config"]["name"] == "Later draft"
+    assert latest["version"] == 2
+    assert latest["stage"] == "published"
+
+
+def test_two_loaded_agents_cannot_overwrite_each_others_snapshot(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "stale-loaded-agent.db"))
+    original = Agent(id="guarded-agent", name="Original", db=db)
+    assert original.save() == 1
+
+    first = Agent.load("guarded-agent", db=db)
+    stale = Agent.load("guarded-agent", db=db)
+    assert first is not None and stale is not None
+
+    first.name = "Winner"
+    assert first.save() == 2
+    stale.name = "Stale loser"
+    with pytest.raises(ComponentVersionConflictError):
+        stale.save()
+
+    current = db.get_current_config("guarded-agent")
+    assert current is not None
+    assert current["version"] == 2
+    assert current["config"]["name"] == "Winner"
+
+
+def test_loaded_team_and_workflow_saves_reject_stale_snapshots(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "stale-team-workflow.db"))
+    team = Team(id="guarded-team", name="Team", members=[], db=db)
+    workflow = Workflow(id="guarded-workflow", name="Workflow", db=db)
+    assert team.save() == 1
+    assert workflow.save() == 1
+
+    first_team = Team.load("guarded-team", db=db)
+    stale_team = Team.load("guarded-team", db=db)
+    first_workflow = Workflow.load("guarded-workflow", db=db)
+    stale_workflow = Workflow.load("guarded-workflow", db=db)
+    assert first_team is not None and stale_team is not None
+    assert first_workflow is not None and stale_workflow is not None
+
+    first_team.name = "Winning team"
+    assert first_team.save() == 2
+    stale_team.name = "Stale team"
+    with pytest.raises(ComponentVersionConflictError):
+        stale_team.save()
+
+    first_workflow.name = "Winning workflow"
+    assert first_workflow.save() == 2
+    stale_workflow.name = "Stale workflow"
+    with pytest.raises(ComponentVersionConflictError):
+        stale_workflow.save()
+
+
+def test_stale_loaded_object_cannot_archive_newer_version(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "stale-delete.db"))
+    assert Agent(id="stale-delete", name="Original", db=db).save() == 1
+    writer = Agent.load("stale-delete", db=db)
+    stale_deleter = Agent.load("stale-delete", db=db)
+    assert writer is not None and stale_deleter is not None
+
+    writer.name = "Newer"
+    assert writer.save() == 2
+
+    with pytest.raises(ComponentVersionConflictError):
+        stale_deleter.delete()
+    assert db.get_component("stale-delete") is not None
+
+
+def test_public_delete_validates_component_type_inside_transaction(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "delete-type.db"))
+    assert Team(id="shared-delete-id", name="Team", members=[], db=db).save() == 1
+    wrong_type = Agent(id="shared-delete-id", name="Not the team", db=db)
+
+    with pytest.raises(ValueError, match="has type team, not agent"):
+        wrong_type.delete(guard=ComponentVersionGuard(latest_version=1, current_version=1))
+
+    component = db.get_component("shared-delete-id")
+    assert component is not None
+    assert component["component_type"] == ComponentType.TEAM.value
+
+
+def test_existing_id_requires_loaded_or_explicit_guard(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "guard-required.db"))
+    assert Agent(id="guard-required", name="Original", db=db).save() == 1
+
+    unattached = Agent(id="guard-required", name="Overwrite", db=db)
+    with pytest.raises(ComponentVersionGuardRequiredError):
+        unattached.save()
+
+
+def test_captured_guard_cannot_be_reused_against_a_different_database(tmp_path) -> None:
+    db_a = SqliteDb(db_file=str(tmp_path / "guard-db-a.db"))
+    db_b = SqliteDb(db_file=str(tmp_path / "guard-db-b.db"))
+    from_a = Agent(id="same-id", name="Database A", db=db_a)
+    assert from_a.save() == 1
+    assert Agent(id="same-id", name="Database B", db=db_b).save() == 1
+
+    from_a.name = "Cross-db overwrite"
+    with pytest.raises(ComponentVersionGuardRequiredError):
+        from_a.save(db=db_b)
+
+    assert db_b.get_current_config("same-id")["config"]["name"] == "Database B"
+
+
+def test_captured_guard_distinguishes_independent_in_memory_databases() -> None:
+    db_a = SqliteDb(db_url="sqlite://")
+    db_b = SqliteDb(db_url="sqlite://")
+    from_a = Agent(id="same-memory-id", name="Database A", db=db_a)
+    assert from_a.save() == 1
+    assert Agent(id="same-memory-id", name="Database B", db=db_b).save() == 1
+
+    from_a.name = "Cross-db overwrite"
+    with pytest.raises(ComponentVersionGuardRequiredError):
+        from_a.save(db=db_b)
+
+    assert db_b.get_current_config("same-memory-id")["config"]["name"] == "Database B"
+
+
+def test_load_does_not_attach_fresh_guard_to_replaced_config_snapshot(tmp_path) -> None:
+    db = _PublishBetweenLoadAndGuardSqliteDb(db_file=str(tmp_path / "load-guard-race.db"))
+    assert Agent(id="load-race", name="Version one", db=db).save() == 1
+    db.publish_before_next_get_component = True
+
+    stale = Agent.load("load-race", db=db)
+    assert stale is not None
+    stale.name = "Must not overwrite"
+
+    with pytest.raises(ComponentVersionGuardRequiredError):
+        stale.save()
+    assert db.get_current_config("load-race")["config"]["name"] == "Concurrent publication"
+
+
+def test_load_of_published_snapshot_cannot_silently_overwrite_newer_draft(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "load-with-draft.db"))
+    original = Agent(id="load-with-draft", name="Published", db=db)
+    assert original.save() == 1
+    assert original.save(stage="draft") == 2
+
+    published = Agent.load("load-with-draft", db=db)
+    assert published is not None
+    assert published.name == "Published"
+    published.name = "Must not skip the draft"
+
+    with pytest.raises(ComponentVersionGuardRequiredError):
+        published.save()
+    assert db.get_latest_config("load-with-draft")["version"] == 2  # type: ignore[index]
 
 
 def test_save_rejects_component_type_replacement_after_initial_read(tmp_path) -> None:
@@ -428,14 +617,14 @@ def test_save_rejects_component_type_replacement_after_initial_read(tmp_path) ->
     assert [row["version"] for row in db.list_configs("replaced-component")] == [1]
 
 
-def test_direct_component_saves_share_the_historical_name_id_contract(tmp_path) -> None:
+def test_direct_component_saves_share_the_url_safe_name_id_contract(tmp_path) -> None:
     name = "R&D Jörg"
-    expected = generate_id_from_name(name)
+    expected = generate_component_id_from_name(name)
     agent = Agent(name=name, db=SqliteDb(db_file=str(tmp_path / "agent-id.db")))
     team = Team(name=name, members=[], db=SqliteDb(db_file=str(tmp_path / "team-id.db")))
     workflow = Workflow(name=name, db=SqliteDb(db_file=str(tmp_path / "workflow-id.db")))
 
-    assert expected == "r&d-jörg"
+    assert expected == "r-d-jörg"
     assert agent.save(stage="draft") == 1
     assert team.save(stage="draft") == 1
     assert workflow.save(stage="draft") == 1

--- a/libs/agno/tests/unit/db/test_component_save_atomicity.py
+++ b/libs/agno/tests/unit/db/test_component_save_atomicity.py
@@ -657,3 +657,68 @@ def test_draft_only_components_load_list_and_read_but_do_not_runtime_resolve(tmp
     assert get_runtime_agent_by_id("draft-agent", db=db) is None
     assert get_runtime_team_by_id("draft-team", db=db) is None
     assert get_runtime_workflow_by_id("draft-workflow", db=db) is None
+
+
+def test_agent_unpinned_save_adopts_legacy_slug_identity(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "agent-legacy-slug.db"))
+    # Row persisted under the pre-single-segment derivation of "Analyst v2.5".
+    assert Agent(id="analyst-v2.5", name="Analyst v2.5", db=db).save() == 1
+
+    agent = Agent(name="Analyst v2.5", db=db)
+    with pytest.raises(ComponentVersionGuardRequiredError):
+        agent.save()
+    assert agent.id == "analyst-v2.5"
+    assert db.get_component("analyst-v2-5") is None
+
+    loaded = Agent.load("analyst-v2.5", db=db)
+    assert loaded is not None
+    assert loaded.save() == 2
+
+
+def test_team_unpinned_save_adopts_legacy_slug_identity(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "team-legacy-slug.db"))
+    assert Team(id="analyst-v2.5", name="Analyst v2.5", members=[], db=db).save() == 1
+
+    team = Team(name="Analyst v2.5", members=[], db=db)
+    with pytest.raises(ComponentVersionGuardRequiredError):
+        team.save()
+    assert team.id == "analyst-v2.5"
+    assert db.get_component("analyst-v2-5") is None
+
+    loaded = Team.load("analyst-v2.5", db=db)
+    assert loaded is not None
+    assert loaded.save() == 2
+
+
+def test_workflow_unpinned_save_adopts_legacy_slug_identity(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "workflow-legacy-slug.db"))
+    assert Workflow(id="analyst-v2.5", name="Analyst v2.5", db=db).save() == 1
+
+    workflow = Workflow(name="Analyst v2.5", db=db)
+    with pytest.raises(ComponentVersionGuardRequiredError):
+        workflow.save()
+    assert workflow.id == "analyst-v2.5"
+    assert db.get_component("analyst-v2-5") is None
+
+    loaded = Workflow.load("analyst-v2.5", db=db)
+    assert loaded is not None
+    assert loaded.save() == 2
+
+
+def test_unpinned_save_without_legacy_row_uses_strict_slug(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "fresh-strict-slug.db"))
+    agent = Agent(name="Analyst v2.5", db=db)
+    assert agent.save() == 1
+    assert agent.id == "analyst-v2-5"
+    assert db.get_component("analyst-v2.5") is None
+
+
+def test_unpinned_save_prefers_strict_slug_row_when_both_exist(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "forked-slug.db"))
+    assert Agent(id="analyst-v2.5", name="Analyst v2.5", db=db).save() == 1
+    assert Agent(id="analyst-v2-5", name="Analyst v2.5", db=db).save() == 1
+
+    agent = Agent(name="Analyst v2.5", db=db)
+    with pytest.raises(ComponentVersionGuardRequiredError):
+        agent.save()
+    assert agent.id == "analyst-v2-5"

--- a/libs/agno/tests/unit/db/test_component_save_atomicity.py
+++ b/libs/agno/tests/unit/db/test_component_save_atomicity.py
@@ -1,0 +1,470 @@
+"""Regression tests for atomic component/config saves through core objects."""
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from agno.agent.agent import Agent, get_agent_by_id, get_agents
+from agno.db.base import BaseDb, ComponentDependencyError, ComponentType
+from agno.db.sqlite import SqliteDb
+from agno.os.utils import (
+    get_agent_by_id as get_runtime_agent_by_id,
+)
+from agno.os.utils import (
+    get_team_by_id as get_runtime_team_by_id,
+)
+from agno.os.utils import (
+    get_workflow_by_id as get_runtime_workflow_by_id,
+)
+from agno.team.team import Team, get_team_by_id, get_teams
+from agno.utils.string import generate_id_from_name
+from agno.workflow.workflow import Workflow, get_workflow_by_id, get_workflows
+
+
+class _LegacyComponentSqliteDb(SqliteDb):
+    """Custom adapter exposing only the exact pre-2.9 catalog signatures."""
+
+    supports_component_persistence = False
+    component_catalog_api_version = 1
+
+    def get_component(
+        self,
+        component_id: str,
+        component_type: Optional[ComponentType] = None,
+    ) -> Optional[Dict[str, Any]]:
+        return super().get_component(component_id, component_type)
+
+    def upsert_config(
+        self,
+        component_id: str,
+        config: Optional[Dict[str, Any]] = None,
+        version: Optional[int] = None,
+        label: Optional[str] = None,
+        stage: Optional[str] = None,
+        notes: Optional[str] = None,
+        links: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        return super().upsert_config(
+            component_id=component_id,
+            config=config,
+            version=version,
+            label=label,
+            stage=stage,
+            notes=notes,
+            links=links,
+        )
+
+    def create_component_with_config(self, *args, **kwargs):
+        raise AssertionError("catalog API v1 must not probe the v2 atomic primitive")
+
+
+class _BrokenAtomicSqliteDb(SqliteDb):
+    """An opted-in adapter must not silently downgrade atomic creation."""
+
+    def create_component_with_config(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class _PublishDuringReadSqliteDb(SqliteDb):
+    """Inject a publication after save's initial read to reproduce the race."""
+
+    publish_during_next_get = False
+
+    def get_component(
+        self,
+        component_id: str,
+        component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        component = super().get_component(
+            component_id,
+            component_type,
+            include_deleted=include_deleted,
+        )
+        if self.publish_during_next_get and component is not None:
+            self.publish_during_next_get = False
+            super().upsert_config(
+                component_id,
+                config={"id": component_id, "name": "Published concurrently"},
+                stage="published",
+                projection={"name": "Published concurrently"},
+            )
+        return component
+
+
+class _ReplaceDuringReadSqliteDb(SqliteDb):
+    """Replace an ID after save's optimistic read to reproduce identity ABA."""
+
+    replace_during_next_get = False
+
+    def get_component(
+        self,
+        component_id: str,
+        component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        component = super().get_component(
+            component_id,
+            component_type,
+            include_deleted=include_deleted,
+        )
+        if self.replace_during_next_get and component is not None:
+            self.replace_during_next_get = False
+            super().delete_component(component_id, hard_delete=True, require_no_dependents=False)
+            super().create_component_with_config(
+                component_id=component_id,
+                component_type=ComponentType.TEAM,
+                name="Replacement team",
+                config={"name": "Replacement team", "members": []},
+                stage="published",
+            )
+        return component
+
+
+def _assert_no_component_or_configs(db: SqliteDb, component_id: str) -> None:
+    assert db.get_component(component_id, include_deleted=True) is None
+    assert db.list_configs(component_id, include_config=True) == []
+
+
+def _assert_original_projection_and_config(db: SqliteDb, component_id: str) -> None:
+    component = db.get_component(component_id)
+    assert component is not None
+    assert component["name"] == "Version one"
+    assert component["description"] == "Original description"
+    assert component["metadata"] == {"revision": 1}
+    assert component["current_version"] == 1
+
+    configs = db.list_configs(component_id, include_config=True)
+    assert len(configs) == 1
+    assert configs[0]["version"] == 1
+    assert configs[0]["label"] == "stable"
+    assert configs[0]["config"]["name"] == "Version one"
+    assert configs[0]["config"]["description"] == "Original description"
+    assert configs[0]["config"]["metadata"] == {"revision": 1}
+
+
+def test_agent_first_save_invalid_stage_leaves_no_orphan(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "agent-invalid-stage.db"))
+    agent = Agent(id="atomic-agent", name="Agent")
+
+    with pytest.raises(ValueError, match="Invalid stage"):
+        agent.save(db=db, stage="invalid")
+
+    _assert_no_component_or_configs(db, "atomic-agent")
+
+
+def test_team_first_save_invalid_stage_leaves_no_orphan(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "team-invalid-stage.db"))
+    team = Team(id="atomic-team", name="Team", members=[])
+
+    with pytest.raises(ValueError, match="Invalid stage"):
+        team.save(db=db, stage="invalid")
+
+    _assert_no_component_or_configs(db, "atomic-team")
+
+
+def test_workflow_first_save_invalid_stage_leaves_no_orphan(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "workflow-invalid-stage.db"))
+    workflow = Workflow(id="atomic-workflow", name="Workflow")
+
+    assert workflow.save(db=db, stage="invalid") is None
+
+    _assert_no_component_or_configs(db, "atomic-workflow")
+
+
+def test_agent_duplicate_label_does_not_drift_published_projection(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "agent-duplicate-label.db"))
+    agent = Agent(
+        id="atomic-agent",
+        name="Version one",
+        description="Original description",
+        metadata={"revision": 1},
+    )
+    assert agent.save(db=db, stage="published", label="stable") == 1
+
+    agent.name = "Version two"
+    agent.description = "Changed description"
+    agent.metadata = {"revision": 2}
+    with pytest.raises(ValueError, match="Label 'stable' already exists"):
+        agent.save(db=db, stage="published", label="stable")
+
+    _assert_original_projection_and_config(db, "atomic-agent")
+
+
+def test_team_duplicate_label_does_not_drift_published_projection(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "team-duplicate-label.db"))
+    team = Team(
+        id="atomic-team",
+        name="Version one",
+        description="Original description",
+        metadata={"revision": 1},
+        members=[],
+    )
+    assert team.save(db=db, stage="published", label="stable") == 1
+
+    team.name = "Version two"
+    team.description = "Changed description"
+    team.metadata = {"revision": 2}
+    with pytest.raises(ValueError, match="Label 'stable' already exists"):
+        team.save(db=db, stage="published", label="stable")
+
+    _assert_original_projection_and_config(db, "atomic-team")
+
+
+def test_workflow_duplicate_label_does_not_drift_published_projection(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "workflow-duplicate-label.db"))
+    workflow = Workflow(
+        id="atomic-workflow",
+        name="Version one",
+        description="Original description",
+        metadata={"revision": 1},
+    )
+    assert workflow.save(db=db, stage="published", label="stable") == 1
+
+    workflow.name = "Version two"
+    workflow.description = "Changed description"
+    workflow.metadata = {"revision": 2}
+    assert workflow.save(db=db, stage="published", label="stable") is None
+
+    _assert_original_projection_and_config(db, "atomic-workflow")
+
+
+def test_first_save_falls_back_for_legacy_custom_component_adapter(tmp_path) -> None:
+    db = _LegacyComponentSqliteDb(db_file=str(tmp_path / "legacy-component-adapter.db"))
+    agent = Agent(
+        id="legacy-agent",
+        name="Legacy adapter agent",
+        description="Saved through the compatibility path",
+    )
+
+    assert agent.save(db=db, stage="published") == 1
+
+    component = db.get_component("legacy-agent")
+    config = db.get_config("legacy-agent", version=1)
+    assert component is not None
+    assert component["name"] == "Legacy adapter agent"
+    assert component["current_version"] == 1
+    assert config is not None and config["stage"] == "published"
+
+
+def test_base_bulk_read_fallback_preserves_legacy_scalar_signatures(tmp_path) -> None:
+    db = _LegacyComponentSqliteDb(db_file=str(tmp_path / "legacy-bulk-read-adapter.db"))
+    agent = Agent(id="legacy-bulk-agent", name="Legacy bulk agent")
+    assert agent.save(db=db, stage="published") == 1
+
+    components = BaseDb.get_components(
+        db,
+        {"legacy-bulk-agent", "missing-agent"},
+        component_type=ComponentType.AGENT,
+    )
+    latest = BaseDb.get_latest_configs(db, {"legacy-bulk-agent", "missing-agent"})
+
+    assert [component["component_id"] for component in components] == ["legacy-bulk-agent"]
+    assert set(latest) == {"legacy-bulk-agent", "missing-agent"}
+    assert latest["legacy-bulk-agent"] is not None
+    assert latest["legacy-bulk-agent"]["version"] == 1
+    assert latest["missing-agent"] is None
+
+
+def test_opted_in_atomic_adapter_cannot_silently_use_legacy_fallback(tmp_path) -> None:
+    db = _BrokenAtomicSqliteDb(db_file=str(tmp_path / "broken-atomic-adapter.db"))
+    agent = Agent(id="broken-atomic-agent", name="Broken atomic adapter")
+
+    with pytest.raises(NotImplementedError):
+        agent.save(db=db, stage="published")
+
+    _assert_no_component_or_configs(db, "broken-atomic-agent")
+
+
+def test_draft_only_projection_tracks_latest_draft_then_freezes_after_publish(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "draft-projection.db"))
+    agent = Agent(
+        id="draft-projection-agent",
+        name="Draft one",
+        description="First draft",
+        metadata={"revision": 1},
+    )
+    assert agent.save(db=db, stage="draft") == 1
+
+    agent.name = "Draft two"
+    agent.description = "Second draft"
+    agent.metadata = {"revision": 2}
+    assert agent.save(db=db, stage="draft") == 2
+
+    component = db.get_component("draft-projection-agent")
+    assert component is not None
+    assert component["current_version"] is None
+    assert component["name"] == "Draft two"
+    assert component["description"] == "Second draft"
+    assert component["metadata"] == {"revision": 2}
+
+    agent.name = "Published"
+    agent.description = "Published description"
+    agent.metadata = {"revision": 3}
+    assert agent.save(db=db, stage="published") == 3
+
+    agent.name = "Unpublished draft"
+    agent.description = "Must not leak"
+    agent.metadata = {"revision": 4}
+    assert agent.save(db=db, stage="draft") == 4
+
+    component = db.get_component("draft-projection-agent")
+    assert component is not None
+    assert component["current_version"] == 3
+    assert component["name"] == "Published"
+    assert component["description"] == "Published description"
+    assert component["metadata"] == {"revision": 3}
+
+
+def test_save_restores_archived_component_and_appends_history(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "restore-on-save.db"))
+    agent = Agent(id="restorable-agent", name="Version one", description="Before archive", db=db)
+    assert agent.save(stage="published") == 1
+    assert agent.delete() is True
+
+    agent.name = "Version two"
+    agent.description = "After restore"
+    assert agent.save(stage="published") == 2
+
+    component = db.get_component("restorable-agent")
+    assert component is not None
+    assert component["deleted_at"] is None
+    assert component["current_version"] == 2
+    assert component["name"] == "Version two"
+    assert [row["version"] for row in db.list_configs("restorable-agent")] == [2, 1]
+
+
+def test_failed_save_does_not_restore_archived_component(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "failed-restore-on-save.db"))
+    agent = Agent(id="archived-agent", name="Version one", db=db)
+    assert agent.save(stage="published", label="stable") == 1
+    assert agent.delete() is True
+
+    agent.name = "Rejected version"
+    with pytest.raises(ValueError, match="Label 'stable' already exists"):
+        agent.save(stage="published", label="stable")
+
+    assert db.get_component("archived-agent") is None
+    archived = db.get_component("archived-agent", include_deleted=True)
+    assert archived is not None
+    assert archived["deleted_at"] is not None
+    latest = db.get_latest_config("archived-agent", include_deleted=True)
+    assert latest is not None
+    assert latest["version"] == 1
+
+
+def test_public_delete_dependency_check_has_explicit_escape_hatch(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "delete-dependency.db"))
+    db.create_component_with_config(
+        component_id="child-agent",
+        component_type=ComponentType.AGENT,
+        name="Child",
+        config={"name": "Child"},
+        stage="published",
+    )
+    db.create_component_with_config(
+        component_id="parent-team",
+        component_type=ComponentType.TEAM,
+        name="Parent",
+        config={"name": "Parent"},
+        stage="published",
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "child-agent",
+                "child_version": 1,
+                "position": 0,
+            }
+        ],
+    )
+    child = Agent(id="child-agent", db=db)
+
+    with pytest.raises(ComponentDependencyError):
+        child.delete()
+
+    assert child.delete(require_no_dependents=False) is True
+    assert db.get_component("child-agent") is None
+
+
+def test_draft_save_survives_publish_after_initial_component_read(tmp_path) -> None:
+    db = _PublishDuringReadSqliteDb(db_file=str(tmp_path / "publish-race.db"))
+    agent = Agent(id="race-agent", name="Initial draft", db=db)
+    assert agent.save(stage="draft") == 1
+
+    agent.name = "Later draft"
+    db.publish_during_next_get = True
+    assert agent.save(stage="draft") == 3
+
+    component = db.get_component("race-agent")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Published concurrently"
+    assert db.get_current_config("race-agent")["version"] == 2  # type: ignore[index]
+    latest = db.get_latest_config("race-agent")
+    assert latest is not None
+    assert latest["version"] == 3
+    assert latest["stage"] == "draft"
+    assert latest["config"]["name"] == "Later draft"
+
+
+def test_save_rejects_component_type_replacement_after_initial_read(tmp_path) -> None:
+    db = _ReplaceDuringReadSqliteDb(db_file=str(tmp_path / "component-type-race.db"))
+    agent = Agent(id="replaced-component", name="Original agent", db=db)
+    assert agent.save(stage="published") == 1
+
+    db.replace_during_next_get = True
+    agent.name = "Must not reach the replacement"
+    with pytest.raises(ValueError, match="has type team, not agent"):
+        agent.save(stage="published")
+
+    component = db.get_component("replaced-component")
+    assert component is not None
+    assert component["component_type"] == ComponentType.TEAM.value
+    assert component["name"] == "Replacement team"
+    assert component["current_version"] == 1
+    assert [row["version"] for row in db.list_configs("replaced-component")] == [1]
+
+
+def test_direct_component_saves_share_the_historical_name_id_contract(tmp_path) -> None:
+    name = "R&D Jörg"
+    expected = generate_id_from_name(name)
+    agent = Agent(name=name, db=SqliteDb(db_file=str(tmp_path / "agent-id.db")))
+    team = Team(name=name, members=[], db=SqliteDb(db_file=str(tmp_path / "team-id.db")))
+    workflow = Workflow(name=name, db=SqliteDb(db_file=str(tmp_path / "workflow-id.db")))
+
+    assert expected == "r&d-jörg"
+    assert agent.save(stage="draft") == 1
+    assert team.save(stage="draft") == 1
+    assert workflow.save(stage="draft") == 1
+    assert agent.id == expected
+    assert team.id == expected
+    assert workflow.id == expected
+
+
+def test_draft_only_components_load_list_and_read_but_do_not_runtime_resolve(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "draft-read-contract.db"))
+    agent = Agent(id="draft-agent", name="Draft agent", db=db)
+    team = Team(id="draft-team", name="Draft team", members=[], db=db)
+    workflow = Workflow(id="draft-workflow", name="Draft workflow", db=db)
+    assert agent.save(stage="draft") == 1
+    assert team.save(stage="draft") == 1
+    assert workflow.save(stage="draft") == 1
+
+    assert Agent.load("draft-agent", db=db) is not None
+    assert Team.load("draft-team", db=db) is not None
+    assert Workflow.load("draft-workflow", db=db) is not None
+
+    assert get_agent_by_id(db, "draft-agent") is not None
+    assert get_team_by_id(db, "draft-team") is not None
+    assert get_workflow_by_id(db, "draft-workflow") is not None
+
+    assert [item.id for item in get_agents(db)] == ["draft-agent"]
+    assert [item.id for item in get_teams(db)] == ["draft-team"]
+    assert [item.id for item in get_workflows(db)] == ["draft-workflow"]
+
+    assert get_runtime_agent_by_id("draft-agent", db=db) is None
+    assert get_runtime_team_by_id("draft-team", db=db) is None
+    assert get_runtime_workflow_by_id("draft-workflow", db=db) is None

--- a/libs/agno/tests/unit/db/test_mongo_scheduler.py
+++ b/libs/agno/tests/unit/db/test_mongo_scheduler.py
@@ -488,11 +488,7 @@ def test_schedule_index_migration_uses_distinct_key_before_dropping_legacy_autho
     collection.list_indexes.return_value = [{"name": "name_1", "key": {"name": 1}, "unique": True}]
     created_names = []
 
-    def create_index(keys, **options):
-        # Real upgraded MongoDB collections reject a replacement index that
-        # reuses the legacy key pattern with different partial options.
-        if keys == [("name", 1)] and options.get("name") == "uq_generic_name":
-            raise RuntimeError("cannot coexist with legacy same-key index")
+    def create_index(_keys, **options):
         created_names.append(options.get("name"))
 
     def drop_index(index_name):
@@ -505,6 +501,9 @@ def test_schedule_index_migration_uses_distinct_key_before_dropping_legacy_autho
 
     create_collection_indexes(collection, "schedules")
 
+    # Pin the exact compound key: pre-5.0 servers reject a second index that
+    # reuses the legacy {name: 1} key pattern, so create-before-drop is only
+    # safe because the replacement's key and name differ from the legacy one's.
     generic_call = next(
         call for call in collection.create_index.call_args_list if call.kwargs.get("name") == "uq_generic_name"
     )
@@ -533,9 +532,7 @@ async def test_async_schedule_index_migration_uses_distinct_key_before_dropping_
     )
     created_names = []
 
-    async def create_index(keys, **options):
-        if keys == [("name", 1)] and options.get("name") == "uq_generic_name":
-            raise RuntimeError("cannot coexist with legacy same-key index")
+    async def create_index(_keys, **options):
         created_names.append(options.get("name"))
 
     async def drop_index(index_name):

--- a/libs/agno/tests/unit/db/test_mongo_scheduler.py
+++ b/libs/agno/tests/unit/db/test_mongo_scheduler.py
@@ -4,6 +4,7 @@ import pytest
 
 from agno.db.mongo import AsyncMongoDb, MongoDb
 from agno.db.mongo.schemas import get_collection_indexes
+from agno.db.mongo.utils import create_collection_indexes, create_collection_indexes_async
 
 
 @pytest.fixture
@@ -138,6 +139,31 @@ def test_mongo_update_schedule_updates_and_returns_schedule(monkeypatch: pytest.
     assert collection.update_one.call_count == 1
 
 
+def test_mongo_disable_schedules_for_target_is_atomic_and_scoped(monkeypatch: pytest.MonkeyPatch):
+    db = MongoDb(db_client=MagicMock(), db_name="test_db")  # type: ignore[arg-type]
+    collection = Mock()
+    update_result = Mock(modified_count=101)
+    collection.update_many.return_value = update_result
+    monkeypatch.setattr(db, "_get_collection", lambda table_type: collection)
+
+    disabled = db.disable_schedules_for_target(
+        "agent",
+        "agent-a",
+        managed_by="studio",
+    )
+
+    assert disabled == 101
+    query, update = collection.update_many.call_args.args
+    assert query == {
+        "managed_by": "studio",
+        "target_type": "agent",
+        "target_id": "agent-a",
+        "enabled": True,
+    }
+    assert update["$set"]["enabled"] is False
+    assert isinstance(update["$set"]["updated_at"], int)
+
+
 def test_mongo_delete_schedule_cascades_runs(monkeypatch: pytest.MonkeyPatch):
     db = MongoDb(db_client=MagicMock(), db_name="test_db")  # type: ignore[arg-type]
     schedules_collection = Mock()
@@ -183,6 +209,87 @@ def test_mongo_claim_due_schedule_returns_claimed_schedule(monkeypatch: pytest.M
         "locked_by": "worker-1",
     }
     assert collection.find_one_and_update.call_count == 1
+
+
+def test_mongo_claims_due_cron_without_consuming_pending_manual_work(monkeypatch: pytest.MonkeyPatch):
+    db = MongoDb(db_client=MagicMock(), db_name="test_db")  # type: ignore[arg-type]
+    collection = Mock()
+    collection.find_one_and_update.side_effect = [
+        None,
+        None,
+        {
+            "_id": "mongo-id",
+            "id": "sched-1",
+            "enabled": True,
+            "next_run_at": 123,
+            "pending_trigger_count": 1,
+            "locked_by": "worker-1",
+        },
+    ]
+    monkeypatch.setattr(db, "_get_collection", lambda table_type: collection)
+
+    result = db.claim_due_schedule("worker-1", lock_grace_seconds=300)
+
+    assert result is not None and result["pending_trigger_count"] == 1
+    recovery_query, recovery_update = collection.find_one_and_update.call_args_list[0].args[:2]
+    manual_query, manual_update = collection.find_one_and_update.call_args_list[1].args[:2]
+    cron_query, cron_update = collection.find_one_and_update.call_args_list[2].args[:2]
+    assert recovery_query["manual_trigger_claimed"] is True
+    assert "$inc" not in recovery_update
+    assert "$nor" in manual_query
+    assert "$inc" in manual_update
+    assert "next_run_at" in cron_query
+    assert "$inc" not in cron_update
+
+
+def test_mongo_recovers_stale_manual_claim_without_consuming_another_trigger(monkeypatch: pytest.MonkeyPatch):
+    db = MongoDb(db_client=MagicMock(), db_name="test_db")  # type: ignore[arg-type]
+    collection = Mock()
+    collection.find_one_and_update.return_value = {
+        "_id": "mongo-id",
+        "id": "sched-1",
+        "enabled": True,
+        "next_run_at": 123,
+        "pending_trigger_count": 0,
+        "manual_trigger_claimed": True,
+        "locked_by": "recovery-worker",
+        "locked_at": 456,
+    }
+    monkeypatch.setattr(db, "_get_collection", lambda table_type: collection)
+
+    recovered = db.claim_due_schedule("recovery-worker", lock_grace_seconds=300)
+
+    assert recovered is not None and recovered["manual_trigger_claimed"] is True
+    query, update = collection.find_one_and_update.call_args.args[:2]
+    assert query["manual_trigger_claimed"] is True
+    assert "$inc" not in update
+
+    collection.update_one.return_value = Mock(matched_count=1)
+    assert db.release_schedule("sched-1", worker_id="recovery-worker", locked_at=456) is True
+    release_query, release_update = collection.update_one.call_args.args
+    assert release_query == {"id": "sched-1", "locked_by": "recovery-worker", "locked_at": 456}
+    assert release_update["$set"]["manual_trigger_claimed"] is False
+    assert "next_run_at" not in release_update["$set"]
+
+
+def test_mongo_renews_only_the_exact_claim_fence(monkeypatch: pytest.MonkeyPatch):
+    db = MongoDb(db_client=MagicMock(), db_name="test_db")  # type: ignore[arg-type]
+    collection = Mock()
+    collection.find_one_and_update.return_value = {"id": "sched-1"}
+    monkeypatch.setattr(db, "_get_collection", lambda table_type: collection)
+    monkeypatch.setattr("agno.db.mongo.mongo.time.time", lambda: 123)
+
+    renewed_at = db.renew_schedule_claim("sched-1", worker_id="worker-1", locked_at=123)
+
+    assert renewed_at == 124
+    query, update = collection.find_one_and_update.call_args.args
+    assert query == {"id": "sched-1", "locked_by": "worker-1", "locked_at": 123}
+    assert update["$set"]["locked_at"] == renewed_at
+    assert "manual_trigger_claimed" not in update["$set"]
+    assert "pending_trigger_count" not in update["$set"]
+    collection.update_one.side_effect = [Mock(matched_count=0), Mock(matched_count=1)]
+    assert not db.release_schedule("sched-1", worker_id="worker-1", locked_at=123)
+    assert db.release_schedule("sched-1", worker_id="worker-1", locked_at=renewed_at)
 
 
 def test_mongo_release_schedule_unlocks_and_returns_true(monkeypatch: pytest.MonkeyPatch):
@@ -308,9 +415,144 @@ def test_scheduler_index_schemas_registered():
     schedule_runs_indexes = get_collection_indexes("schedule_runs")
 
     assert any(i.get("key") == "id" and i.get("unique") for i in schedules_indexes)
-    assert any(i.get("key") == "name" and i.get("unique") for i in schedules_indexes)
+    assert any(
+        i.get("key") == [("name", 1), ("managed_by", 1)]
+        and i.get("unique")
+        and i.get("name") == "uq_generic_name"
+        and i.get("partialFilterExpression") == {"managed_by": None}
+        for i in schedules_indexes
+    )
+    assert any(
+        i.get("key") == [("owner_actor_id", 1), ("name", 1)]
+        and i.get("unique")
+        and i.get("name") == "uq_studio_owner_name"
+        for i in schedules_indexes
+    )
+    assert any(i.get("key") == "pending_trigger_count" for i in schedules_indexes)
+    assert any(i.get("key") == "manual_trigger_claimed" for i in schedules_indexes)
     assert any(i.get("key") == "id" and i.get("unique") for i in schedule_runs_indexes)
     assert any(i.get("key") == "schedule_id" for i in schedule_runs_indexes)
+
+
+def test_schedule_index_migration_fails_loudly_before_dropping_legacy_authority():
+    collection = MagicMock()
+    collection.list_indexes.return_value = [{"name": "name_1", "key": {"name": 1}, "unique": True}]
+
+    def create_index(_keys, **options):
+        if options.get("name") == "uq_studio_owner_name":
+            raise RuntimeError("cannot build actor index")
+
+    collection.create_index.side_effect = create_index
+
+    with pytest.raises(RuntimeError, match="actor index"):
+        create_collection_indexes(collection, "schedules")
+
+    collection.drop_index.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_schedule_index_migration_fails_loudly_before_dropping_legacy_authority():
+    class AsyncCursor:
+        def __init__(self, rows):
+            self.rows = iter(rows)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self.rows)
+            except StopIteration:
+                raise StopAsyncIteration
+
+    collection = MagicMock()
+    collection.list_indexes = AsyncMock(
+        return_value=AsyncCursor([{"name": "name_1", "key": {"name": 1}, "unique": True}])
+    )
+
+    async def create_index(_keys, **options):
+        if options.get("name") == "uq_studio_owner_name":
+            raise RuntimeError("cannot build actor index")
+
+    collection.create_index = AsyncMock(side_effect=create_index)
+    collection.drop_index = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="actor index"):
+        await create_collection_indexes_async(collection, "schedules")
+
+    collection.drop_index.assert_not_awaited()
+
+
+def test_schedule_index_migration_uses_distinct_key_before_dropping_legacy_authority():
+    collection = MagicMock()
+    collection.list_indexes.return_value = [{"name": "name_1", "key": {"name": 1}, "unique": True}]
+    created_names = []
+
+    def create_index(keys, **options):
+        # Real upgraded MongoDB collections reject a replacement index that
+        # reuses the legacy key pattern with different partial options.
+        if keys == [("name", 1)] and options.get("name") == "uq_generic_name":
+            raise RuntimeError("cannot coexist with legacy same-key index")
+        created_names.append(options.get("name"))
+
+    def drop_index(index_name):
+        assert "uq_generic_name" in created_names
+        assert "uq_studio_owner_name" in created_names
+        assert index_name == "name_1"
+
+    collection.create_index.side_effect = create_index
+    collection.drop_index.side_effect = drop_index
+
+    create_collection_indexes(collection, "schedules")
+
+    generic_call = next(
+        call for call in collection.create_index.call_args_list if call.kwargs.get("name") == "uq_generic_name"
+    )
+    assert generic_call.args[0] == [("name", 1), ("managed_by", 1)]
+    collection.drop_index.assert_called_once_with("name_1")
+
+
+@pytest.mark.asyncio
+async def test_async_schedule_index_migration_uses_distinct_key_before_dropping_legacy_authority():
+    class AsyncCursor:
+        def __init__(self, rows):
+            self.rows = iter(rows)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self.rows)
+            except StopIteration:
+                raise StopAsyncIteration
+
+    collection = MagicMock()
+    collection.list_indexes = AsyncMock(
+        return_value=AsyncCursor([{"name": "name_1", "key": {"name": 1}, "unique": True}])
+    )
+    created_names = []
+
+    async def create_index(keys, **options):
+        if keys == [("name", 1)] and options.get("name") == "uq_generic_name":
+            raise RuntimeError("cannot coexist with legacy same-key index")
+        created_names.append(options.get("name"))
+
+    async def drop_index(index_name):
+        assert "uq_generic_name" in created_names
+        assert "uq_studio_owner_name" in created_names
+        assert index_name == "name_1"
+
+    collection.create_index = AsyncMock(side_effect=create_index)
+    collection.drop_index = AsyncMock(side_effect=drop_index)
+
+    await create_collection_indexes_async(collection, "schedules")
+
+    generic_call = next(
+        call for call in collection.create_index.call_args_list if call.kwargs.get("name") == "uq_generic_name"
+    )
+    assert generic_call.args[0] == [("name", 1), ("managed_by", 1)]
+    collection.drop_index.assert_awaited_once_with("name_1")
 
 
 def test_async_mongo_constructor_maps_scheduler_collections():
@@ -428,6 +670,33 @@ async def test_async_mongo_update_schedule_updates_and_returns_schedule(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_async_mongo_disable_schedules_for_target_is_atomic_and_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_db")
+    collection = AsyncMock()
+    collection.update_many.return_value = MagicMock(modified_count=2)
+    monkeypatch.setattr(db, "_get_collection", AsyncMock(return_value=collection))
+
+    disabled = await db.disable_schedules_for_target(
+        "team",
+        "team-a",
+        managed_by="studio",
+    )
+
+    assert disabled == 2
+    query, update = collection.update_many.call_args.args
+    assert query == {
+        "managed_by": "studio",
+        "target_type": "team",
+        "target_id": "team-a",
+        "enabled": True,
+    }
+    assert update["$set"]["enabled"] is False
+    assert isinstance(update["$set"]["updated_at"], int)
+
+
+@pytest.mark.asyncio
 async def test_async_mongo_delete_schedule_cascades_runs(monkeypatch: pytest.MonkeyPatch):
     db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_db")
     schedules_collection = AsyncMock()
@@ -474,6 +743,94 @@ async def test_async_mongo_claim_due_schedule_returns_claimed_schedule(monkeypat
         "locked_by": "worker-1",
     }
     collection.find_one_and_update.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_mongo_claims_due_cron_without_consuming_pending_manual_work(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_db")
+    collection = AsyncMock()
+    collection.find_one_and_update.side_effect = [
+        None,
+        None,
+        {
+            "_id": "mongo-id",
+            "id": "sched-1",
+            "enabled": True,
+            "next_run_at": 123,
+            "pending_trigger_count": 1,
+            "locked_by": "worker-1",
+        },
+    ]
+    monkeypatch.setattr(db, "_get_collection", AsyncMock(return_value=collection))
+
+    result = await db.claim_due_schedule("worker-1", lock_grace_seconds=300)
+
+    assert result is not None and result["pending_trigger_count"] == 1
+    recovery_query, recovery_update = collection.find_one_and_update.call_args_list[0].args[:2]
+    manual_query, manual_update = collection.find_one_and_update.call_args_list[1].args[:2]
+    cron_query, cron_update = collection.find_one_and_update.call_args_list[2].args[:2]
+    assert recovery_query["manual_trigger_claimed"] is True
+    assert "$inc" not in recovery_update
+    assert "$nor" in manual_query
+    assert "$inc" in manual_update
+    assert "next_run_at" in cron_query
+    assert "$inc" not in cron_update
+
+
+@pytest.mark.asyncio
+async def test_async_mongo_recovers_stale_manual_claim_without_consuming_another_trigger(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_db")
+    collection = AsyncMock()
+    collection.find_one_and_update.return_value = {
+        "_id": "mongo-id",
+        "id": "sched-1",
+        "enabled": True,
+        "next_run_at": 123,
+        "pending_trigger_count": 0,
+        "manual_trigger_claimed": True,
+        "locked_by": "recovery-worker",
+        "locked_at": 456,
+    }
+    monkeypatch.setattr(db, "_get_collection", AsyncMock(return_value=collection))
+
+    recovered = await db.claim_due_schedule("recovery-worker", lock_grace_seconds=300)
+
+    assert recovered is not None and recovered["manual_trigger_claimed"] is True
+    query, update = collection.find_one_and_update.call_args.args[:2]
+    assert query["manual_trigger_claimed"] is True
+    assert "$inc" not in update
+
+    collection.update_one.return_value = MagicMock(matched_count=1)
+    assert await db.release_schedule("sched-1", worker_id="recovery-worker", locked_at=456) is True
+    release_query, release_update = collection.update_one.call_args.args
+    assert release_query == {"id": "sched-1", "locked_by": "recovery-worker", "locked_at": 456}
+    assert release_update["$set"]["manual_trigger_claimed"] is False
+    assert "next_run_at" not in release_update["$set"]
+
+
+@pytest.mark.asyncio
+async def test_async_mongo_renews_only_the_exact_claim_fence(monkeypatch: pytest.MonkeyPatch):
+    db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_db")
+    collection = AsyncMock()
+    collection.find_one_and_update.return_value = {"id": "sched-1"}
+    monkeypatch.setattr(db, "_get_collection", AsyncMock(return_value=collection))
+    monkeypatch.setattr("agno.db.mongo.async_mongo.time.time", lambda: 123)
+
+    renewed_at = await db.renew_schedule_claim("sched-1", worker_id="worker-1", locked_at=123)
+
+    assert renewed_at == 124
+    query, update = collection.find_one_and_update.call_args.args
+    assert query == {"id": "sched-1", "locked_by": "worker-1", "locked_at": 123}
+    assert update["$set"]["locked_at"] == renewed_at
+    assert "manual_trigger_claimed" not in update["$set"]
+    assert "pending_trigger_count" not in update["$set"]
+    collection.update_one.side_effect = [MagicMock(matched_count=0), MagicMock(matched_count=1)]
+    assert not await db.release_schedule("sched-1", worker_id="worker-1", locked_at=123)
+    assert await db.release_schedule("sched-1", worker_id="worker-1", locked_at=renewed_at)
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/db/test_postgres_component_reactivation.py
+++ b/libs/agno/tests/unit/db/test_postgres_component_reactivation.py
@@ -1,4 +1,4 @@
-"""Regression coverage for PostgreSQL component reactivation."""
+"""Regression coverage for PostgreSQL component reactivation boundaries."""
 
 from unittest.mock import patch
 
@@ -34,14 +34,17 @@ def postgres_components_db(tmp_path):
     def get_table(table_type, create_table_if_not_found=False):
         return components if table_type == "components" else None
 
-    with patch.object(db, "_get_table", side_effect=get_table):
+    with (
+        patch.object(db, "_get_table", side_effect=get_table),
+        patch.object(db, "_lock_component_graph_writes"),
+    ):
         yield db
 
     db.Session.remove()
     engine.dispose()
 
 
-def test_upsert_component_reactivates_soft_deleted_component(postgres_components_db):
+def test_upsert_component_does_not_reactivate_soft_deleted_component(postgres_components_db):
     db = postgres_components_db
 
     created = db.upsert_component(
@@ -58,17 +61,15 @@ def test_upsert_component_reactivates_soft_deleted_component(postgres_components
     assert total == 1
     assert deleted_rows[0]["deleted_at"] is not None
 
-    reactivated = db.upsert_component(
-        component_id="agent-1",
-        component_type=ComponentType.AGENT,
-        name="after",
-    )
-
-    assert reactivated["component_id"] == "agent-1"
-    assert reactivated["component_type"] == ComponentType.AGENT.value
-    assert reactivated["name"] == "after"
-    assert reactivated["deleted_at"] is None
+    with pytest.raises(ValueError, match="archived and remains reserved"):
+        db.upsert_component(
+            component_id="agent-1",
+            component_type=ComponentType.AGENT,
+            name="after",
+        )
 
     all_rows, total = db.list_components(include_deleted=True)
     assert total == 1
     assert [row["component_id"] for row in all_rows] == ["agent-1"]
+    assert all_rows[0]["name"] == "before"
+    assert all_rows[0]["deleted_at"] is not None

--- a/libs/agno/tests/unit/db/test_schedule_migration_v2_9.py
+++ b/libs/agno/tests/unit/db/test_schedule_migration_v2_9.py
@@ -1,0 +1,603 @@
+"""Schedule provenance and uniqueness migration tests for 2.9."""
+
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import text
+
+from agno.db.migrations.manager import MigrationManager
+from agno.db.migrations.versions import v2_9_0
+from agno.db.postgres import AsyncPostgresDb, PostgresDb
+from agno.db.schemas.scheduler import ScheduleNameConflictError
+from agno.db.sqlite import SqliteDb
+from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+
+
+def _create_legacy_schedule_table(path: Path, names: list[str]) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE agno_schedules (
+                id TEXT PRIMARY KEY NOT NULL,
+                name TEXT NOT NULL,
+                description TEXT,
+                method TEXT NOT NULL,
+                endpoint TEXT NOT NULL,
+                payload JSON,
+                cron_expr TEXT NOT NULL,
+                timezone TEXT NOT NULL,
+                timeout_seconds BIGINT NOT NULL,
+                max_retries BIGINT NOT NULL,
+                retry_delay_seconds BIGINT NOT NULL,
+                enabled BOOLEAN NOT NULL,
+                next_run_at BIGINT,
+                locked_by TEXT,
+                locked_at BIGINT,
+                created_at BIGINT NOT NULL,
+                updated_at BIGINT
+            )
+            """
+        )
+        for index, name in enumerate(names):
+            connection.execute(
+                """
+                INSERT INTO agno_schedules (
+                    id, name, method, endpoint, cron_expr, timezone,
+                    timeout_seconds, max_retries, retry_delay_seconds,
+                    enabled, created_at
+                ) VALUES (?, ?, 'POST', '/external', '0 9 * * *', 'UTC', 3600, 0, 60, 1, 1)
+                """,
+                (f"schedule-{index}", name),
+            )
+
+
+def _studio_schedule(schedule_id: str = "studio-schedule") -> dict:
+    return {
+        "id": schedule_id,
+        "name": "Private Studio schedule",
+        "method": "POST",
+        "endpoint": "/agents/private-agent/runs",
+        "payload": {"message": "private prompt"},
+        "cron_expr": "0 9 * * *",
+        "timezone": "UTC",
+        "timeout_seconds": 3600,
+        "max_retries": 0,
+        "retry_delay_seconds": 60,
+        "managed_by": "studio",
+        "owner_actor_id": "actor-1",
+        "target_type": "agent",
+        "target_id": "private-agent",
+        "enabled": True,
+        "created_at": 1,
+    }
+
+
+def _studio_schedule_run(schedule_id: str = "studio-schedule") -> dict:
+    return {
+        "id": "studio-run",
+        "schedule_id": schedule_id,
+        "attempt": 1,
+        "status": "success",
+        "input": {"message": "private prompt"},
+        "output": {"content": "private response"},
+        "created_at": 1,
+    }
+
+
+def _generic_schedule(schedule_id: str = "generic-schedule") -> dict:
+    schedule = _studio_schedule(schedule_id)
+    schedule.update(
+        name="Generic schedule",
+        endpoint="/external",
+        payload=None,
+        managed_by=None,
+        owner_actor_id=None,
+        target_type=None,
+        target_id=None,
+    )
+    return schedule
+
+
+def _install_caller_owned_schedule_schema(path: Path) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.execute("ALTER TABLE agno_schedules ADD COLUMN caller_note TEXT DEFAULT 'keep-me'")
+        connection.execute("CREATE INDEX caller_schedule_endpoint_idx ON agno_schedules (endpoint)")
+        connection.execute(
+            "CREATE TABLE caller_schedule_audit (schedule_id TEXT NOT NULL, old_note TEXT, new_note TEXT)"
+        )
+        connection.execute(
+            """
+            CREATE TRIGGER caller_schedule_update_audit
+            AFTER UPDATE ON agno_schedules
+            BEGIN
+                INSERT INTO caller_schedule_audit (schedule_id, old_note, new_note)
+                VALUES (OLD.id, OLD.caller_note, NEW.caller_note);
+            END
+            """
+        )
+
+
+def _sqlite_schedule_state(path: Path) -> tuple:
+    with sqlite3.connect(path) as connection:
+        schema = tuple(
+            connection.execute(
+                """
+                SELECT type, name, tbl_name, sql
+                FROM sqlite_master
+                WHERE tbl_name = 'agno_schedules'
+                   OR name IN ('agno_schedules', 'caller_schedule_audit', 'agno_schedules__v2_9_down')
+                ORDER BY type, name
+                """
+            )
+        )
+        columns = tuple(connection.execute("PRAGMA table_xinfo(agno_schedules)"))
+        schedule = connection.execute("SELECT * FROM agno_schedules WHERE id='generic-schedule'").fetchone()
+        audit_rows = tuple(connection.execute("SELECT * FROM caller_schedule_audit"))
+    return schema, columns, schedule, audit_rows
+
+
+def test_sync_sqlite_upgrade_preserves_generic_rows_and_enforces_unique_names(tmp_path: Path):
+    class CustomSqliteDb(SqliteDb):
+        pass
+
+    db_path = tmp_path / "legacy-sync.sqlite"
+    _create_legacy_schedule_table(db_path, ["legacy-one", "legacy-two"])
+    db = CustomSqliteDb(db_file=str(db_path))
+
+    assert v2_9_0.up(db, "schedules", db.schedules_table_name) is True
+    assert v2_9_0.up(db, "schedules", db.schedules_table_name) is False
+
+    with sqlite3.connect(db_path) as connection:
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+        row = connection.execute(
+            "SELECT managed_by, owner_actor_id, target_type, target_id FROM agno_schedules WHERE id='schedule-0'"
+        ).fetchone()
+        unique_indexes = {
+            index[1] for index in connection.execute("PRAGMA index_list(agno_schedules)") if index[2] == 1
+        }
+
+    assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+    assert row == (None, None, None, None)
+    assert {
+        "agno_schedules_uq_generic_name",
+        "agno_schedules_uq_studio_owner_name",
+    }.issubset(unique_indexes)
+
+    first = db.get_schedule("schedule-0")
+    assert first is not None
+    assert first["managed_by"] is None
+    with pytest.raises(ScheduleNameConflictError):
+        db.update_schedule("schedule-1", name="legacy-one")
+    assert v2_9_0.down(db, "schedules", db.schedules_table_name) is True
+
+
+def test_sync_sqlite_down_refuses_caller_owned_schema_without_partial_changes(tmp_path: Path):
+    db_path = tmp_path / "caller-schema-sync.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    db.create_schedule(_generic_schedule())
+    _install_caller_owned_schedule_schema(db_path)
+    state_before = _sqlite_schedule_state(db_path)
+
+    with pytest.raises(ValueError, match="caller-owned or unrecognized schema") as exc_info:
+        v2_9_0.down(db, "schedules", db.schedules_table_name)
+
+    message = str(exc_info.value)
+    assert "column 'caller_note'" in message
+    assert "index 'caller_schedule_endpoint_idx'" in message
+    assert "trigger 'caller_schedule_update_audit'" in message
+    assert _sqlite_schedule_state(db_path) == state_before
+
+
+def test_sync_sqlite_down_does_not_delete_a_caller_table_using_the_temporary_name(tmp_path: Path):
+    db_path = tmp_path / "caller-temp-table-sync.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    db.create_schedule(_generic_schedule())
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("CREATE TABLE agno_schedules__v2_9_down (secret TEXT NOT NULL)")
+        connection.execute("INSERT INTO agno_schedules__v2_9_down VALUES ('keep-me')")
+
+    with pytest.raises(ValueError, match="existing downgrade temporary object"):
+        v2_9_0.down(db, "schedules", db.schedules_table_name)
+
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("SELECT secret FROM agno_schedules__v2_9_down").fetchone() == ("keep-me",)
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+    assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+
+
+def test_sync_sqlite_down_refuses_to_expose_studio_schedule_and_run_history(tmp_path: Path):
+    db_path = tmp_path / "studio-sync.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    db.create_schedule(_studio_schedule())
+    db.create_schedule_run(_studio_schedule_run())
+
+    with pytest.raises(ValueError, match="Cannot remove Studio schedule provenance"):
+        v2_9_0.down(db, "schedules", db.schedules_table_name)
+
+    with sqlite3.connect(db_path) as connection:
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+        indexes = {row[1] for row in connection.execute("PRAGMA index_list(agno_schedules)")}
+        schedule = connection.execute(
+            "SELECT managed_by, owner_actor_id, payload FROM agno_schedules WHERE id='studio-schedule'"
+        ).fetchone()
+        run = connection.execute("SELECT input, output FROM agno_schedule_runs WHERE id='studio-run'").fetchone()
+
+    assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+    assert "agno_schedules_uq_studio_owner_name" in indexes
+    assert schedule is not None and schedule[:2] == ("studio", "actor-1")
+    assert run is not None
+
+    assert db.delete_schedule("studio-schedule") is True
+    assert v2_9_0.down(db, "schedules", db.schedules_table_name) is True
+
+
+def test_sync_sqlite_down_refuses_to_drop_pending_or_claimed_manual_work(tmp_path: Path):
+    db_path = tmp_path / "pending-trigger-sync.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    schedule = _studio_schedule("generic-schedule")
+    schedule.update(managed_by=None, owner_actor_id=None, next_run_at=2**62)
+    db.create_schedule(schedule)
+    assert db.trigger_schedule("generic-schedule")["pending_trigger_count"] == 1
+
+    with pytest.raises(ValueError, match="pending or claimed manual triggers"):
+        v2_9_0.down(db, "schedules", db.schedules_table_name)
+
+    claimed = db.claim_due_schedule("worker")
+    assert claimed is not None and claimed["pending_trigger_count"] == 0
+    assert claimed["manual_trigger_claimed"] is True
+    with pytest.raises(ValueError, match="pending or claimed manual triggers"):
+        v2_9_0.down(db, "schedules", db.schedules_table_name)
+
+    assert db.release_schedule(
+        "generic-schedule",
+        worker_id=claimed["locked_by"],
+        locked_at=claimed["locked_at"],
+    )
+    assert db.get_schedule("generic-schedule")["manual_trigger_claimed"] is False
+    assert v2_9_0.down(db, "schedules", db.schedules_table_name) is True
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_down_refuses_claimed_manual_work_then_succeeds_after_release(tmp_path: Path):
+    db = AsyncSqliteDb(db_file=str(tmp_path / "claimed-trigger-async.sqlite"))
+    schedule = _generic_schedule()
+    schedule["next_run_at"] = 2**62
+    try:
+        await db.create_schedule(schedule)
+        await db.trigger_schedule(schedule["id"])
+        claimed = await db.claim_due_schedule("worker")
+        assert claimed is not None
+        assert claimed["pending_trigger_count"] == 0
+        assert claimed["manual_trigger_claimed"] is True
+
+        with pytest.raises(ValueError, match="pending or claimed manual triggers"):
+            await v2_9_0.async_down(db, "schedules", db.schedules_table_name)
+
+        assert await db.release_schedule(
+            schedule["id"],
+            worker_id=claimed["locked_by"],
+            locked_at=claimed["locked_at"],
+        )
+        assert (await db.get_schedule(schedule["id"]))["manual_trigger_claimed"] is False
+        assert await v2_9_0.async_down(db, "schedules", db.schedules_table_name) is True
+    finally:
+        await db.close()
+
+
+def test_sync_sqlite_upgrade_fails_clearly_without_partially_migrating_duplicates(tmp_path: Path):
+    db_path = tmp_path / "legacy-duplicates.sqlite"
+    _create_legacy_schedule_table(db_path, ["duplicate", "duplicate"])
+    db = SqliteDb(db_file=str(db_path))
+
+    with pytest.raises(ValueError, match="duplicates already exist"):
+        v2_9_0.up(db, "schedules", db.schedules_table_name)
+
+    with sqlite3.connect(db_path) as connection:
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+    assert set(v2_9_0._V2_9_COLUMNS).isdisjoint(columns)
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_upgrade_preserves_generic_rows_and_enforces_unique_names(tmp_path: Path):
+    class CustomAsyncSqliteDb(AsyncSqliteDb):
+        pass
+
+    db_path = tmp_path / "legacy-async.sqlite"
+    _create_legacy_schedule_table(db_path, ["legacy-one"])
+    db = CustomAsyncSqliteDb(db_file=str(db_path))
+    try:
+        assert await v2_9_0.async_up(db, "schedules", db.schedules_table_name) is True
+        async with db.async_session_factory() as session:
+            columns = {row[1] for row in (await session.execute(text("PRAGMA table_info(agno_schedules)"))).fetchall()}
+            row = (
+                await session.execute(
+                    text("SELECT managed_by, owner_actor_id FROM agno_schedules WHERE id='schedule-0'")
+                )
+            ).fetchone()
+        assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+        assert tuple(row) == (None, None)
+        assert await v2_9_0.async_down(db, "schedules", db.schedules_table_name) is True
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_down_refuses_caller_owned_schema_without_partial_changes(tmp_path: Path):
+    db_path = tmp_path / "caller-schema-async.sqlite"
+    db = AsyncSqliteDb(db_file=str(db_path))
+    try:
+        await db.create_schedule(_generic_schedule())
+        _install_caller_owned_schedule_schema(db_path)
+        state_before = _sqlite_schedule_state(db_path)
+
+        with pytest.raises(ValueError, match="caller-owned or unrecognized schema") as exc_info:
+            await v2_9_0.async_down(db, "schedules", db.schedules_table_name)
+
+        message = str(exc_info.value)
+        assert "column 'caller_note'" in message
+        assert "index 'caller_schedule_endpoint_idx'" in message
+        assert "trigger 'caller_schedule_update_audit'" in message
+        assert _sqlite_schedule_state(db_path) == state_before
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_down_refuses_to_expose_studio_schedule_and_run_history(tmp_path: Path):
+    db_path = tmp_path / "studio-async.sqlite"
+    db = AsyncSqliteDb(db_file=str(db_path))
+    try:
+        await db.create_schedule(_studio_schedule())
+        await db.create_schedule_run(_studio_schedule_run())
+
+        with pytest.raises(ValueError, match="Cannot remove Studio schedule provenance"):
+            await v2_9_0.async_down(db, "schedules", db.schedules_table_name)
+
+        async with db.async_session_factory() as session:
+            columns = {row[1] for row in (await session.execute(text("PRAGMA table_info(agno_schedules)"))).fetchall()}
+            indexes = {row[1] for row in (await session.execute(text("PRAGMA index_list(agno_schedules)"))).fetchall()}
+            schedule = (
+                await session.execute(
+                    text("SELECT managed_by, owner_actor_id, payload FROM agno_schedules WHERE id='studio-schedule'")
+                )
+            ).fetchone()
+            run = (
+                await session.execute(text("SELECT input, output FROM agno_schedule_runs WHERE id='studio-run'"))
+            ).fetchone()
+
+        assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+        assert "agno_schedules_uq_studio_owner_name" in indexes
+        assert schedule is not None and tuple(schedule[:2]) == ("studio", "actor-1")
+        assert run is not None
+
+        assert await db.delete_schedule("studio-schedule") is True
+        assert await v2_9_0.async_down(db, "schedules", db.schedules_table_name) is True
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_manager_includes_schedule_tables(tmp_path: Path):
+    db_path = tmp_path / "legacy-manager.sqlite"
+    _create_legacy_schedule_table(db_path, ["legacy-one"])
+    db = SqliteDb(db_file=str(db_path))
+
+    await MigrationManager(db).up(target_version="2.9.0", table_type="schedules")
+
+    assert db.get_latest_schema_version(db.schedules_table_name) == "2.9.0"
+    assert db.get_schedule("schedule-0") is not None
+
+    await MigrationManager(db).down(target_version="2.5.6", table_type="schedules")
+
+    assert db.get_latest_schema_version(db.schedules_table_name) == "2.5.6"
+    with sqlite3.connect(db_path) as connection:
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+    assert set(v2_9_0._V2_9_COLUMNS).isdisjoint(columns)
+
+
+@pytest.mark.asyncio
+async def test_migration_manager_keeps_version_when_studio_downgrade_is_refused(tmp_path: Path):
+    db_path = tmp_path / "studio-manager.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    db.create_schedule(_studio_schedule())
+    db.create_schedule_run(_studio_schedule_run())
+    db.upsert_schema_version(db.schedules_table_name, "2.9.0")
+
+    with pytest.raises(ValueError, match="Cannot remove Studio schedule provenance"):
+        await MigrationManager(db).down(target_version="2.5.6", table_type="schedules")
+
+    assert db.get_latest_schema_version(db.schedules_table_name) == "2.9.0"
+    with sqlite3.connect(db_path) as connection:
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+        assert connection.execute("SELECT 1 FROM agno_schedule_runs WHERE id='studio-run'").fetchone() == (1,)
+    assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+
+
+@pytest.mark.asyncio
+async def test_sync_migration_manager_keeps_version_and_schema_when_caller_schema_is_refused(tmp_path: Path):
+    db_path = tmp_path / "caller-schema-manager-sync.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    db.create_schedule(_generic_schedule())
+    db.upsert_schema_version(db.schedules_table_name, "2.9.0")
+    _install_caller_owned_schedule_schema(db_path)
+    state_before = _sqlite_schedule_state(db_path)
+
+    with pytest.raises(ValueError, match="caller-owned or unrecognized schema"):
+        await MigrationManager(db).down(target_version="2.5.6", table_type="schedules")
+
+    assert db.get_latest_schema_version(db.schedules_table_name) == "2.9.0"
+    assert _sqlite_schedule_state(db_path) == state_before
+
+
+@pytest.mark.asyncio
+async def test_async_migration_manager_keeps_version_and_schema_when_caller_schema_is_refused(tmp_path: Path):
+    db_path = tmp_path / "caller-schema-manager-async.sqlite"
+    db = AsyncSqliteDb(db_file=str(db_path))
+    try:
+        await db.create_schedule(_generic_schedule())
+        await db.upsert_schema_version(db.schedules_table_name, "2.9.0")
+        _install_caller_owned_schedule_schema(db_path)
+        state_before = _sqlite_schedule_state(db_path)
+
+        with pytest.raises(ValueError, match="caller-owned or unrecognized schema"):
+            await MigrationManager(db).down(target_version="2.5.6", table_type="schedules")
+
+        assert await db.get_latest_schema_version(db.schedules_table_name) == "2.9.0"
+        assert _sqlite_schedule_state(db_path) == state_before
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_fresh_sqlite_scoped_indexes_are_reversible_without_losing_run_history(tmp_path: Path):
+    db_path = tmp_path / "fresh-manager.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    db.create_schedule(
+        {
+            "id": "schedule-0",
+            "name": "reusable-after-down",
+            "method": "POST",
+            "endpoint": "/external",
+            "cron_expr": "0 9 * * *",
+            "timezone": "UTC",
+            "timeout_seconds": 3600,
+            "max_retries": 0,
+            "retry_delay_seconds": 60,
+            "enabled": True,
+            "created_at": 1,
+        }
+    )
+    db.create_schedule_run(
+        {
+            "id": "run-0",
+            "schedule_id": "schedule-0",
+            "attempt": 1,
+            "status": "success",
+            "created_at": 1,
+        }
+    )
+
+    with sqlite3.connect(db_path) as connection:
+        indexes_before = {row[1] for row in connection.execute("PRAGMA index_list(agno_schedules)")}
+    assert "agno_schedules_uq_generic_name" in indexes_before
+    assert "agno_schedules_uq_studio_owner_name" in indexes_before
+
+    await MigrationManager(db).down(target_version="2.5.6", table_type="schedules")
+
+    with sqlite3.connect(db_path) as connection:
+        indexes_after = {row[1] for row in connection.execute("PRAGMA index_list(agno_schedules)")}
+        columns_after = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+        assert connection.execute("SELECT schedule_id FROM agno_schedule_runs WHERE id='run-0'").fetchone() == (
+            "schedule-0",
+        )
+        assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+        connection.execute(
+            """
+            INSERT INTO agno_schedules (
+                id, name, method, endpoint, cron_expr, timezone,
+                timeout_seconds, max_retries, retry_delay_seconds,
+                enabled, created_at
+            ) VALUES ('schedule-1', 'reusable-after-down', 'POST', '/external',
+                      '0 9 * * *', 'UTC', 3600, 0, 60, 1, 1)
+            """
+        )
+
+    assert "agno_schedules_uq_generic_name" not in indexes_after
+    assert "agno_schedules_uq_studio_owner_name" not in indexes_after
+    assert set(v2_9_0._V2_9_COLUMNS).isdisjoint(columns_after)
+    assert v2_9_0.down(db, "schedules", db.schedules_table_name) is False
+
+
+def test_sync_sqlite_down_is_safe_when_schedule_table_was_never_created(tmp_path: Path):
+    db = SqliteDb(db_file=str(tmp_path / "missing-sync.sqlite"))
+
+    assert v2_9_0.down(db, "schedules", db.schedules_table_name) is False
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_down_is_idempotent_and_missing_table_safe(tmp_path: Path):
+    db_path = tmp_path / "missing-async.sqlite"
+    db = AsyncSqliteDb(db_file=str(db_path))
+    try:
+        assert await v2_9_0.async_down(db, "schedules", db.schedules_table_name) is False
+        _create_legacy_schedule_table(db_path, ["legacy-one"])
+        assert await v2_9_0.async_up(db, "schedules", db.schedules_table_name) is True
+        assert await v2_9_0.async_down(db, "schedules", db.schedules_table_name) is True
+        assert await v2_9_0.async_down(db, "schedules", db.schedules_table_name) is False
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_manager_does_not_log_backend_exception_details(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    db = SqliteDb(db_file=str(tmp_path / "redaction.sqlite"))
+    secret = "postgresql://admin:private-password@internal.example/agno"
+    logs: list[str] = []
+
+    def fail_migration(_db, _table_type: str, _table_name: str) -> bool:
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(v2_9_0, "up", fail_migration)
+    monkeypatch.setattr("agno.db.migrations.manager.log_error", logs.append)
+
+    with pytest.raises(RuntimeError, match="private-password"):
+        await MigrationManager(db)._up_migration("v2_9_0", "schedules", db.schedules_table_name)
+
+    assert logs == ["Migration to version v2_9_0 failed"]
+    assert secret not in "".join(logs)
+
+
+@pytest.mark.asyncio
+async def test_postgres_dispatch_covers_sync_and_async(monkeypatch: pytest.MonkeyPatch):
+    calls: list[tuple[str, str]] = []
+
+    class CustomPostgresDb(PostgresDb):
+        pass
+
+    class CustomAsyncPostgresDb(AsyncPostgresDb):
+        pass
+
+    monkeypatch.setattr(
+        v2_9_0,
+        "_migrate_postgres",
+        lambda _db, table_name: calls.append(("sync", table_name)) or True,
+    )
+
+    async def migrate_async(_db, table_name: str) -> bool:
+        calls.append(("async", table_name))
+        return True
+
+    monkeypatch.setattr(v2_9_0, "_migrate_async_postgres", migrate_async)
+
+    monkeypatch.setattr(
+        v2_9_0,
+        "_revert_postgres",
+        lambda _db, table_name: calls.append(("sync-down", table_name)) or True,
+    )
+
+    async def revert_async(_db, table_name: str) -> bool:
+        calls.append(("async-down", table_name))
+        return True
+
+    monkeypatch.setattr(v2_9_0, "_revert_async_postgres", revert_async)
+
+    sync_db = object.__new__(CustomPostgresDb)
+    async_db = object.__new__(CustomAsyncPostgresDb)
+
+    assert v2_9_0.up(sync_db, "schedules", "agno_schedules") is True
+    assert await v2_9_0.async_up(async_db, "schedules", "agno_schedules") is True
+    assert v2_9_0.down(sync_db, "schedules", "agno_schedules") is True
+    assert await v2_9_0.async_down(async_db, "schedules", "agno_schedules") is True
+    assert calls == [
+        ("sync", "agno_schedules"),
+        ("async", "agno_schedules"),
+        ("sync-down", "agno_schedules"),
+        ("async-down", "agno_schedules"),
+    ]
+
+    assert v2_9_0.up(SimpleNamespace(), "sessions", "agno_sessions") is False  # type: ignore[arg-type]

--- a/libs/agno/tests/unit/db/test_schedule_name_conflicts.py
+++ b/libs/agno/tests/unit/db/test_schedule_name_conflicts.py
@@ -288,7 +288,10 @@ def _async_mongo_db(error: DuplicateKeyError, operation: str) -> AsyncMongoDb:
 
 
 @pytest.mark.parametrize("operation", ["create", "update"])
-@pytest.mark.parametrize("key_pattern", [{"name": 1}, {"owner_actor_id": 1, "name": 1}])
+@pytest.mark.parametrize(
+    "key_pattern",
+    [{"name": 1}, {"name": 1, "managed_by": 1}, {"owner_actor_id": 1, "name": 1}],
+)
 def test_mongo_maps_only_structured_schedule_name_key_pattern(operation, key_pattern):
     db = _sync_mongo_db(_mongo_duplicate_error(key_pattern), operation)
 
@@ -316,7 +319,10 @@ def test_mongo_does_not_map_misleading_message_for_id_key_pattern(operation):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("operation", ["create", "update"])
-@pytest.mark.parametrize("key_pattern", [{"name": 1}, {"owner_actor_id": 1, "name": 1}])
+@pytest.mark.parametrize(
+    "key_pattern",
+    [{"name": 1}, {"name": 1, "managed_by": 1}, {"owner_actor_id": 1, "name": 1}],
+)
 async def test_async_mongo_maps_only_structured_schedule_name_key_pattern(operation, key_pattern):
     db = _async_mongo_db(_mongo_duplicate_error(key_pattern), operation)
 

--- a/libs/agno/tests/unit/db/test_schedule_name_conflicts.py
+++ b/libs/agno/tests/unit/db/test_schedule_name_conflicts.py
@@ -1,0 +1,343 @@
+"""Backend contract tests for typed schedule-name uniqueness failures."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pymongo.errors import DuplicateKeyError
+from sqlalchemy.exc import IntegrityError
+
+from agno.db.mongo.async_mongo import AsyncMongoDb
+from agno.db.mongo.mongo import MongoDb
+from agno.db.postgres.async_postgres import AsyncPostgresDb
+from agno.db.postgres.postgres import PostgresDb
+from agno.db.schemas.scheduler import ScheduleNameConflictError
+from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+from agno.db.sqlite.sqlite import SqliteDb
+
+
+def _schedule(schedule_id: str, name: str) -> dict:
+    return {
+        "id": schedule_id,
+        "name": name,
+        "description": None,
+        "method": "POST",
+        "endpoint": "/agents/test/runs",
+        "payload": None,
+        "cron_expr": "0 9 * * *",
+        "timezone": "UTC",
+        "timeout_seconds": 3600,
+        "max_retries": 0,
+        "retry_delay_seconds": 60,
+        "enabled": True,
+        "next_run_at": None,
+        "locked_by": None,
+        "locked_at": None,
+        "created_at": 1,
+        "updated_at": None,
+    }
+
+
+@pytest.mark.parametrize(
+    "read",
+    [
+        lambda db: db.get_schedule("first"),
+        lambda db: db.get_schedule_by_name("shared-name"),
+        lambda db: db.get_schedules(),
+        lambda db: db.claim_due_schedule("worker"),
+        lambda db: db.get_schedule_run("run-1"),
+        lambda db: db.get_schedule_runs("first"),
+    ],
+)
+def test_sqlite_schedule_reads_propagate_backend_failures(tmp_path, read, caplog):
+    db = SqliteDb(db_file=str(tmp_path / "read-failure.db"), schedules_table="read_failure_schedules")
+    db.create_schedule(_schedule("first", "shared-name"))
+    db.create_schedule_run({"id": "run-1", "schedule_id": "first", "attempt": 1, "status": "success", "created_at": 1})
+    secret = "postgresql://admin:private-password@internal/agno"
+    db.Session = MagicMock(side_effect=RuntimeError(secret))  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="private-password"):
+        read(db)
+
+    assert secret not in caplog.text
+
+
+def test_sqlite_maps_only_schedule_name_integrity_errors(tmp_path):
+    db = SqliteDb(
+        db_file=str(tmp_path / "schedule-name-conflicts.db"),
+        schedules_table="typed_schedule_conflicts",
+    )
+    first = _schedule("first", "shared-name")
+    second = _schedule("second", "second-name")
+    db.create_schedule(first)
+
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        db.create_schedule(_schedule("duplicate-name", "shared-name"))
+
+    with pytest.raises(IntegrityError):
+        db.create_schedule(_schedule("first", "duplicate-id"))
+
+    db.create_schedule(second)
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        db.update_schedule("second", name="shared-name")
+
+    with pytest.raises(IntegrityError):
+        db.update_schedule("second", id="first")
+    assert db.get_schedule("second")["name"] == "second-name"
+
+    db.create_schedule({**_schedule("studio-a", "shared-name"), "managed_by": "studio", "owner_actor_id": "a"})
+    db.create_schedule({**_schedule("studio-b", "shared-name"), "managed_by": "studio", "owner_actor_id": "b"})
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        db.create_schedule(
+            {**_schedule("studio-a-duplicate", "shared-name"), "managed_by": "studio", "owner_actor_id": "a"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_maps_only_schedule_name_integrity_errors(tmp_path):
+    db = AsyncSqliteDb(
+        db_file=str(tmp_path / "async-schedule-name-conflicts.db"),
+        schedules_table="typed_async_schedule_conflicts",
+    )
+    first = _schedule("first", "shared-name")
+    second = _schedule("second", "second-name")
+    await db.create_schedule(first)
+
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        await db.create_schedule(_schedule("duplicate-name", "shared-name"))
+
+    with pytest.raises(IntegrityError):
+        await db.create_schedule(_schedule("first", "duplicate-id"))
+
+    await db.create_schedule(second)
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        await db.update_schedule("second", name="shared-name")
+
+    with pytest.raises(IntegrityError):
+        await db.update_schedule("second", id="first")
+    assert (await db.get_schedule("second"))["name"] == "second-name"
+    await db.db_engine.dispose()
+
+
+class _SyncFailingSession:
+    def __init__(self, error: Exception):
+        self.error = error
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def begin(self):
+        return self
+
+    def execute(self, *_args, **_kwargs):
+        raise self.error
+
+
+class _AsyncFailingSession:
+    def __init__(self, error: Exception):
+        self.error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    def begin(self):
+        return self
+
+    async def execute(self, *_args, **_kwargs):
+        raise self.error
+
+
+def _psycopg_integrity_error(
+    *, table_name: str = "test_schedules", constraint_name: str = "test_schedules_uq_generic_name"
+) -> IntegrityError:
+    original = RuntimeError("duplicate key")
+    original.sqlstate = "23505"  # type: ignore[attr-defined]
+    original.diag = SimpleNamespace(  # type: ignore[attr-defined]
+        constraint_name=constraint_name,
+        table_name=table_name,
+        schema_name="test_schema",
+    )
+    return IntegrityError("INSERT", {}, original)
+
+
+def _asyncpg_integrity_error(
+    *, table_name: str = "test_schedules", constraint_name: str = "test_schedules_uq_generic_name"
+) -> IntegrityError:
+    cause = RuntimeError("duplicate key")
+    cause.sqlstate = "23505"  # type: ignore[attr-defined]
+    cause.constraint_name = constraint_name  # type: ignore[attr-defined]
+    cause.table_name = table_name  # type: ignore[attr-defined]
+    cause.schema_name = "test_schema"  # type: ignore[attr-defined]
+    original = RuntimeError("asyncpg adapter integrity error")
+    original.sqlstate = "23505"  # type: ignore[attr-defined]
+    original.__cause__ = cause
+    return IntegrityError("INSERT", {}, original)
+
+
+def _sync_postgres_db(error: IntegrityError) -> PostgresDb:
+    db = object.__new__(PostgresDb)
+    db.schedules_table_name = "test_schedules"
+    db.db_schema = "test_schema"
+    db._get_table = MagicMock(return_value=MagicMock())  # type: ignore[method-assign]
+    db.Session = MagicMock(return_value=_SyncFailingSession(error))  # type: ignore[method-assign]
+    return db
+
+
+def _async_postgres_db(error: IntegrityError) -> AsyncPostgresDb:
+    db = object.__new__(AsyncPostgresDb)
+    db.schedules_table_name = "test_schedules"
+    db.db_schema = "test_schema"
+    db._get_table = AsyncMock(return_value=MagicMock())  # type: ignore[method-assign]
+    db.async_session_factory = MagicMock(return_value=_AsyncFailingSession(error))
+    return db
+
+
+@pytest.mark.parametrize("operation", ["create", "update"])
+@pytest.mark.parametrize("constraint_suffix", ["uq_generic_name", "uq_studio_owner_name"])
+def test_postgres_maps_exact_psycopg_schedule_name_constraint(operation, constraint_suffix):
+    db = _sync_postgres_db(_psycopg_integrity_error(constraint_name=f"test_schedules_{constraint_suffix}"))
+
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        if operation == "create":
+            db.create_schedule({"id": "loser", "name": "shared-name"})
+        else:
+            db.update_schedule("loser", name="shared-name")
+
+
+@pytest.mark.parametrize("operation", ["create", "update"])
+def test_postgres_does_not_map_same_constraint_reported_for_another_table(operation):
+    error = _psycopg_integrity_error(table_name="other_table")
+    db = _sync_postgres_db(error)
+
+    if operation == "create":
+        with pytest.raises(IntegrityError) as exc_info:
+            db.create_schedule({"id": "loser", "name": "shared-name"})
+        assert exc_info.value is error
+    else:
+        with pytest.raises(IntegrityError) as exc_info:
+            db.update_schedule("loser", name="shared-name")
+        assert exc_info.value is error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["create", "update"])
+@pytest.mark.parametrize("constraint_suffix", ["uq_generic_name", "uq_studio_owner_name"])
+async def test_async_postgres_maps_wrapped_asyncpg_schedule_name_constraint(operation, constraint_suffix):
+    db = _async_postgres_db(_asyncpg_integrity_error(constraint_name=f"test_schedules_{constraint_suffix}"))
+
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        if operation == "create":
+            await db.create_schedule({"id": "loser", "name": "shared-name"})
+        else:
+            await db.update_schedule("loser", name="shared-name")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["create", "update"])
+async def test_async_postgres_does_not_map_same_constraint_reported_for_another_table(operation):
+    error = _asyncpg_integrity_error(table_name="other_table")
+    db = _async_postgres_db(error)
+
+    if operation == "create":
+        with pytest.raises(IntegrityError) as exc_info:
+            await db.create_schedule({"id": "loser", "name": "shared-name"})
+        assert exc_info.value is error
+    else:
+        with pytest.raises(IntegrityError) as exc_info:
+            await db.update_schedule("loser", name="shared-name")
+        assert exc_info.value is error
+
+
+def _mongo_duplicate_error(key_pattern: dict) -> DuplicateKeyError:
+    return DuplicateKeyError(
+        "duplicate key",
+        11000,
+        {
+            "keyPattern": key_pattern,
+            "errmsg": "index: id_1 dup key: { id: ' index: name_1 dup key' }",
+        },
+    )
+
+
+def _sync_mongo_db(error: DuplicateKeyError, operation: str) -> MongoDb:
+    db = object.__new__(MongoDb)
+    collection = MagicMock()
+    if operation == "create":
+        collection.insert_one.side_effect = error
+    else:
+        collection.update_one.side_effect = error
+    db._get_collection = MagicMock(return_value=collection)  # type: ignore[method-assign]
+    return db
+
+
+def _async_mongo_db(error: DuplicateKeyError, operation: str) -> AsyncMongoDb:
+    db = object.__new__(AsyncMongoDb)
+    collection = AsyncMock()
+    if operation == "create":
+        collection.insert_one.side_effect = error
+    else:
+        collection.update_one.side_effect = error
+    db._get_collection = AsyncMock(return_value=collection)  # type: ignore[method-assign]
+    return db
+
+
+@pytest.mark.parametrize("operation", ["create", "update"])
+@pytest.mark.parametrize("key_pattern", [{"name": 1}, {"owner_actor_id": 1, "name": 1}])
+def test_mongo_maps_only_structured_schedule_name_key_pattern(operation, key_pattern):
+    db = _sync_mongo_db(_mongo_duplicate_error(key_pattern), operation)
+
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        if operation == "create":
+            db.create_schedule({"id": "loser", "name": "shared-name"})
+        else:
+            db.update_schedule("loser", name="shared-name")
+
+
+@pytest.mark.parametrize("operation", ["create", "update"])
+def test_mongo_does_not_map_misleading_message_for_id_key_pattern(operation):
+    error = _mongo_duplicate_error({"id": 1})
+    db = _sync_mongo_db(error, operation)
+
+    if operation == "create":
+        with pytest.raises(DuplicateKeyError) as exc_info:
+            db.create_schedule({"id": "loser", "name": "shared-name"})
+        assert exc_info.value is error
+    else:
+        with pytest.raises(DuplicateKeyError) as exc_info:
+            db.update_schedule("loser", name="shared-name")
+        assert exc_info.value is error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["create", "update"])
+@pytest.mark.parametrize("key_pattern", [{"name": 1}, {"owner_actor_id": 1, "name": 1}])
+async def test_async_mongo_maps_only_structured_schedule_name_key_pattern(operation, key_pattern):
+    db = _async_mongo_db(_mongo_duplicate_error(key_pattern), operation)
+
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        if operation == "create":
+            await db.create_schedule({"id": "loser", "name": "shared-name"})
+        else:
+            await db.update_schedule("loser", name="shared-name")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["create", "update"])
+async def test_async_mongo_does_not_map_misleading_message_for_id_key_pattern(operation):
+    error = _mongo_duplicate_error({"id": 1})
+    db = _async_mongo_db(error, operation)
+
+    if operation == "create":
+        with pytest.raises(DuplicateKeyError) as exc_info:
+            await db.create_schedule({"id": "loser", "name": "shared-name"})
+        assert exc_info.value is error
+    else:
+        with pytest.raises(DuplicateKeyError) as exc_info:
+            await db.update_schedule("loser", name="shared-name")
+        assert exc_info.value is error

--- a/libs/agno/tests/unit/db/test_schedule_name_conflicts.py
+++ b/libs/agno/tests/unit/db/test_schedule_name_conflicts.py
@@ -81,7 +81,10 @@ def test_sqlite_maps_only_schedule_name_integrity_errors(tmp_path):
     with pytest.raises(ScheduleNameConflictError, match="shared-name"):
         db.update_schedule("second", name="shared-name")
 
-    with pytest.raises(IntegrityError):
+    # id is server-owned: the update guard rejects it before any SQL runs, so a
+    # non-name IntegrityError can no longer be produced through this door at all
+    # (create_schedule above still proves raw IntegrityErrors propagate unmapped).
+    with pytest.raises(ValueError, match="cannot modify"):
         db.update_schedule("second", id="first")
     assert db.get_schedule("second")["name"] == "second-name"
 
@@ -113,7 +116,7 @@ async def test_async_sqlite_maps_only_schedule_name_integrity_errors(tmp_path):
     with pytest.raises(ScheduleNameConflictError, match="shared-name"):
         await db.update_schedule("second", name="shared-name")
 
-    with pytest.raises(IntegrityError):
+    with pytest.raises(ValueError, match="cannot modify"):
         await db.update_schedule("second", id="first")
     assert (await db.get_schedule("second"))["name"] == "second-name"
     await db.db_engine.dispose()

--- a/libs/agno/tests/unit/db/test_schedule_update_guard.py
+++ b/libs/agno/tests/unit/db/test_schedule_update_guard.py
@@ -1,0 +1,80 @@
+import pytest
+
+from agno.db.schemas.scheduler import SCHEDULE_MUTABLE_COLUMNS, validate_schedule_update
+
+
+class TestValidateScheduleUpdate:
+    def test_mutable_columns_pass(self):
+        validate_schedule_update({"cron_expr": "0 9 * * *", "enabled": False, "next_run_at": 1700000000})
+
+    def test_empty_update_rejected(self):
+        with pytest.raises(ValueError, match="at least one column"):
+            validate_schedule_update({})
+
+    @pytest.mark.parametrize(
+        "column",
+        [
+            "managed_by",
+            "owner_actor_id",
+            "target_type",
+            "target_id",
+            "created_by_run_id",
+            "created_by_session_id",
+            "updated_by_run_id",
+            "updated_by_session_id",
+            "pending_trigger_count",
+            "manual_trigger_claimed",
+            "locked_by",
+            "locked_at",
+        ],
+    )
+    def test_server_owned_columns_rejected(self, column):
+        with pytest.raises(ValueError, match="cannot modify"):
+            validate_schedule_update({column: "x"})
+
+    def test_server_owned_column_rejected_even_alongside_mutable_one(self):
+        with pytest.raises(ValueError, match="managed_by"):
+            validate_schedule_update({"description": "ok", "managed_by": "studio"})
+
+    def test_unknown_column_rejected(self):
+        with pytest.raises(ValueError, match="cannot modify"):
+            validate_schedule_update({"bckground": True})
+
+    def test_mutable_whitelist_is_exactly_the_public_surface(self):
+        assert SCHEDULE_MUTABLE_COLUMNS == {
+            "name",
+            "description",
+            "method",
+            "endpoint",
+            "payload",
+            "cron_expr",
+            "timezone",
+            "timeout_seconds",
+            "max_retries",
+            "retry_delay_seconds",
+            "enabled",
+            "next_run_at",
+        }
+
+
+def test_sqlite_update_schedule_enforces_guard(tmp_path):
+    from agno.db.sqlite import SqliteDb
+    from agno.scheduler.manager import ScheduleManager
+
+    db = SqliteDb(db_file=str(tmp_path / "guard.db"))
+    mgr = ScheduleManager(db)
+    schedule = mgr.create(name="guarded", cron="0 9 * * *", endpoint="/agents/a1/runs")
+
+    with pytest.raises(ValueError, match="managed_by"):
+        db.update_schedule(schedule.id, managed_by="studio", owner_actor_id="attacker")
+    with pytest.raises(ValueError, match="managed_by"):
+        mgr.update(schedule.id, managed_by="studio")
+
+    # Nothing was written and the row is still generically visible.
+    raw = db.get_schedule(schedule.id)
+    assert raw["managed_by"] is None
+    assert mgr.get(schedule.id) is not None
+
+    # The legitimate surface still works, including SchedulerTools' trigger rewrite.
+    assert mgr.update(schedule.id, next_run_at=1700000000).next_run_at == 1700000000
+    mgr.close()

--- a/libs/agno/tests/unit/os/routers/test_components_router.py
+++ b/libs/agno/tests/unit/os/routers/test_components_router.py
@@ -7,6 +7,7 @@ Tests cover:
 - GET /components/{component_id} - Get component
 - PATCH /components/{component_id} - Update component
 - DELETE /components/{component_id} - Delete component
+- POST /components/{component_id}/restore - Restore component
 - GET /components/{component_id}/configs - List configs
 - POST /components/{component_id}/configs - Create config
 - GET /components/{component_id}/configs/current - Get current config
@@ -26,6 +27,7 @@ from agno.agent import Agent
 from agno.db.base import (
     BaseDb,
     ComponentDependencyError,
+    ComponentDependencyUnavailableError,
     ComponentDraftRequiredError,
     ComponentLastConfigError,
     ComponentType,
@@ -186,6 +188,7 @@ def mock_db():
     db.get_component = MagicMock()
     db.upsert_component = MagicMock()
     db.delete_component = MagicMock()
+    db.restore_component = MagicMock()
     db.create_component_with_config = MagicMock()
     db.list_configs = MagicMock()
     db.get_config = MagicMock()
@@ -233,6 +236,24 @@ def _guard(latest_version=1, current_version=1):
 
 
 class TestComponentPersistenceCapability:
+    def test_builtin_component_catalog_v2_support_matrix_is_explicit(self):
+        from agno.db.postgres.async_postgres import AsyncPostgresDb
+        from agno.db.postgres.postgres import PostgresDb
+        from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+
+        assert supports_component_routes(SqliteDb.__new__(SqliteDb)) is True
+        assert supports_component_routes(PostgresDb.__new__(PostgresDb)) is True
+        assert supports_component_routes(AsyncSqliteDb.__new__(AsyncSqliteDb)) is False
+        assert supports_component_routes(AsyncPostgresDb.__new__(AsyncPostgresDb)) is False
+
+    def test_mongo_component_catalog_is_explicitly_unsupported(self):
+        pytest.importorskip("pymongo")
+        from agno.db.mongo.async_mongo import AsyncMongoDb
+        from agno.db.mongo.mongo import MongoDb
+
+        assert supports_component_routes(MongoDb.__new__(MongoDb)) is False
+        assert supports_component_routes(AsyncMongoDb.__new__(AsyncMongoDb)) is False
+
     def test_router_rejects_unsupported_sync_db(self, settings):
         unsupported_db = _create_mock_db_class()()
 
@@ -270,16 +291,16 @@ class TestComponentPersistenceCapability:
         )
 
         assert created.status_code == 201
-        assert created.json()["component_id"] == "analyst-v2.5"
+        assert created.json()["component_id"] == "analyst-v2-5"
         assert db.calls[0][:4] == (
             "upsert_component",
-            "analyst-v2.5",
+            "analyst-v2-5",
             ComponentType.AGENT,
             "Analyst v2.5",
         )
         assert db.calls[1] == (
             "upsert_config",
-            "analyst-v2.5",
+            "analyst-v2-5",
             {"instructions": "Review"},
             None,
             None,
@@ -288,13 +309,13 @@ class TestComponentPersistenceCapability:
             None,
         )
 
-        current = client.get("/components/analyst-v2.5/configs/current")
+        current = client.get("/components/analyst-v2-5/configs/current")
         assert current.status_code == 200
-        assert db.calls[-1] == ("get_config", "analyst-v2.5", None, None)
+        assert db.calls[-1] == ("get_config", "analyst-v2-5", None, None)
 
-        deleted = client.delete("/components/analyst-v2.5")
+        deleted = client.delete("/components/analyst-v2-5")
         assert deleted.status_code == 204
-        assert db.calls[-1] == ("delete_component", "analyst-v2.5", False)
+        assert db.calls[-1] == ("delete_component", "analyst-v2-5", False)
 
     def test_agentos_mounts_the_detected_v1_router(self):
         db = _create_legacy_catalog_db()
@@ -388,6 +409,15 @@ class TestListComponents:
 
 
 class TestCreateComponent:
+    @pytest.mark.parametrize("component_id", ["research/review", "..", "encoded%2Fslash"])
+    def test_create_rejects_component_id_that_is_not_one_url_segment(self, client, component_id):
+        response = client.post(
+            "/components",
+            json={"component_id": component_id, "name": "Unsafe", "component_type": "agent"},
+        )
+
+        assert response.status_code == 422
+
     """Tests for POST /components endpoint."""
 
     def test_create_component_success(self, client, mock_db):
@@ -455,7 +485,7 @@ class TestCreateComponent:
         )
 
         assert response.status_code == 201
-        assert direct_id == "r&d-jörg"
+        assert direct_id == "r-d-jörg"
         call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["component_id"] == direct_id
 
@@ -862,6 +892,88 @@ class TestDeleteComponent:
         mock_db.delete_component.assert_not_called()
 
 
+class TestRestoreComponent:
+    """Tests for POST /components/{component_id}/restore."""
+
+    def test_restore_component_success(self, client, mock_db):
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "name": "Archived",
+            "current_version": 1,
+            "deleted_at": 123,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "stage": "published",
+            "config": {"name": "Published", "description": None, "metadata": {"release": 1}},
+        }
+        mock_db.restore_component.return_value = True
+
+        response = client.post("/components/agent-1/restore", json=_guard(2, 1))
+
+        assert response.status_code == 204
+        mock_db.get_component.assert_called_once_with("agent-1", include_deleted=True)
+        mock_db.get_config.assert_called_once_with("agent-1", version=1, include_deleted=True)
+        mock_db.restore_component.assert_called_once_with(
+            "agent-1",
+            guard=ComponentVersionGuard(latest_version=2, current_version=1),
+            projection={"name": "Published", "description": None, "metadata": {"release": 1}},
+        )
+
+    def test_restore_component_not_found(self, client, mock_db):
+        mock_db.get_component.return_value = None
+
+        response = client.post("/components/missing/restore", json=_guard())
+
+        assert response.status_code == 404
+        mock_db.restore_component.assert_not_called()
+
+    def test_restore_component_requires_archived_row(self, client, mock_db):
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "current_version": 1,
+            "deleted_at": None,
+        }
+
+        response = client.post("/components/agent-1/restore", json=_guard())
+
+        assert response.status_code == 409
+        mock_db.restore_component.assert_not_called()
+
+    def test_restore_component_dependency_conflict_is_stable(self, client, mock_db):
+        mock_db.get_component.return_value = {
+            "component_id": "team-1",
+            "component_type": "team",
+            "name": "Team",
+            "current_version": 1,
+            "deleted_at": 123,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "team-1",
+            "version": 1,
+            "stage": "published",
+            "config": {"name": "Team"},
+        }
+        mock_db.restore_component.side_effect = ComponentDependencyUnavailableError(
+            "team-1",
+            [{"child_component_id": "agent-1", "child_version": 2}],
+        )
+
+        response = client.post("/components/team-1/restore", json=_guard())
+
+        assert response.status_code == 409
+        assert "pinned dependency" in response.json()["detail"]
+
+    def test_restore_component_requires_guard(self, client, mock_db):
+        response = client.post("/components/agent-1/restore", json={})
+
+        assert response.status_code == 422
+        mock_db.restore_component.assert_not_called()
+
+
 class TestGuardedGenericLifecycle:
     """Real SQLite regressions for append-only edits, CAS, and soft archive."""
 
@@ -1045,9 +1157,55 @@ class TestGuardedGenericLifecycle:
         assert "reserved for StudioTools" in response.json()["detail"]
         assert db.get_component("guarded-agent") is None
 
+    def test_archive_restore_then_save_preserves_identity_and_history(self, sqlite_client):
+        client, db = sqlite_client
+        assert self._create(client, stage="published").status_code == 201
+        assert client.request("DELETE", "/components/guarded-agent", json=_guard(1, 1)).status_code == 204
+
+        reserved = self._create(client, stage="published", name="Replacement")
+        assert reserved.status_code == 409
+
+        restored = client.post("/components/guarded-agent/restore", json=_guard(1, 1))
+        assert restored.status_code == 204
+        assert db.get_component("guarded-agent") is not None
+        assert db.get_config("guarded-agent", version=1)["config"]["name"] == "Version one"
+
+        restored_agent = Agent.load("guarded-agent", db=db)
+        assert restored_agent is not None
+        restored_agent.name = "Saved after restore"
+        restored_agent.description = None
+        saved = restored_agent.save(stage="published")
+        assert saved == 2
+        assert [row["version"] for row in db.list_configs("guarded-agent")] == [2, 1]
+        assert db.get_component("guarded-agent")["name"] == "Saved after restore"
+
 
 class TestStudioWriteIsolation:
     """The generic Components API is read-only for Studio-owned records."""
+
+    def test_actual_studio_create_is_rejected_by_generic_mutation_route(self, sqlite_client):
+        from agno.tools.studio import StudioTools
+
+        client, db = sqlite_client
+        studio = StudioTools(
+            registry=Registry(models=[OpenAIResponses(id="gpt-5.4")], dbs=[db]),
+            db=db,
+        )
+        created = studio.create_agent(name="Studio agent", instructions="original", model_id="gpt-5.4")
+        assert '"status": "created"' in created
+
+        stored = db.get_config("studio-agent", version=1)
+        assert stored is not None
+        assert stored["config"]["_agno_studio"]["schema_version"] == 2
+
+        response = client.patch(
+            "/components/studio-agent",
+            json={"description": "generic overwrite", **_guard(1, 1)},
+        )
+
+        assert response.status_code == 409
+        assert "Studio-owned" in response.json()["detail"]
+        assert [row["version"] for row in db.list_configs("studio-agent")] == [1]
 
     def test_generic_config_append_cannot_claim_studio_manifest_namespace(self, sqlite_client):
         client, db = sqlite_client
@@ -1079,6 +1237,61 @@ class TestStudioWriteIsolation:
         assert response.status_code == 400
         assert "reserved for StudioTools" in response.json()["detail"]
         assert [row["version"] for row in db.list_configs("generic-agent")] == [1]
+
+    def test_generic_restore_cannot_reactivate_archived_studio_component(self, sqlite_client):
+        client, db = sqlite_client
+        db.create_component_with_config(
+            component_id="studio-agent",
+            component_type=ComponentType.AGENT,
+            name="Studio agent",
+            config={
+                "id": "studio-agent",
+                "name": "Studio agent",
+                "_agno_studio": {"schema_version": 2, "request": {}},
+            },
+            stage="published",
+        )
+        assert db.delete_component(
+            "studio-agent",
+            guard=ComponentVersionGuard(latest_version=1, current_version=1),
+        )
+
+        response = client.post("/components/studio-agent/restore", json=_guard(1, 1))
+
+        assert response.status_code == 409
+        assert "Studio-owned" in response.json()["detail"]
+        assert db.get_component("studio-agent") is None
+        assert db.get_component("studio-agent", include_deleted=True)["deleted_at"] is not None
+
+    def test_generic_restore_detects_studio_ownership_in_archived_draft_history(self, sqlite_client):
+        client, db = sqlite_client
+        db.create_component_with_config(
+            component_id="transitional-agent",
+            component_type=ComponentType.AGENT,
+            name="Transitional agent",
+            config={"id": "transitional-agent", "name": "Transitional agent"},
+            stage="published",
+        )
+        db.upsert_config(
+            "transitional-agent",
+            config={
+                "id": "transitional-agent",
+                "name": "Studio draft",
+                "_agno_studio": {"schema_version": 2, "request": {}},
+            },
+            stage="draft",
+            guard=ComponentVersionGuard(latest_version=1, current_version=1),
+        )
+        assert db.delete_component(
+            "transitional-agent",
+            guard=ComponentVersionGuard(latest_version=2, current_version=1),
+        )
+
+        response = client.post("/components/transitional-agent/restore", json=_guard(2, 1))
+
+        assert response.status_code == 409
+        assert "Studio-owned" in response.json()["detail"]
+        assert db.get_component("transitional-agent") is None
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/os/routers/test_components_router.py
+++ b/libs/agno/tests/unit/os/routers/test_components_router.py
@@ -22,9 +22,23 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from agno.db.base import BaseDb, ComponentType
-from agno.os.routers.components import get_components_router
+from agno.agent import Agent
+from agno.db.base import (
+    BaseDb,
+    ComponentDependencyError,
+    ComponentDraftRequiredError,
+    ComponentLastConfigError,
+    ComponentType,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+)
+from agno.db.in_memory import InMemoryDb
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.routers.components import get_components_router, supports_component_routes
 from agno.os.settings import AgnoAPISettings
+from agno.registry import Registry
 
 # =============================================================================
 # Fixtures
@@ -41,11 +55,132 @@ def _create_mock_db_class():
     return type("MockDb", (BaseDb,), abstract_methods)
 
 
+def _create_legacy_catalog_db():
+    """Build a catalog-v1 adapter with the exact pre-2.9 method signatures."""
+    MockDbClass = _create_mock_db_class()
+
+    class LegacyCatalogDb(MockDbClass):
+        component_catalog_api_version = 1
+        # Deliberately inherit supports_component_persistence=False: the flag
+        # did not exist when third-party adapters implemented this contract.
+
+        def __init__(self):
+            super().__init__(id="legacy-catalog")
+            self.calls = []
+            self.component = None
+            self.config = None
+
+        def get_component(self, component_id, component_type=None):
+            self.calls.append(("get_component", component_id, component_type))
+            return self.component
+
+        def upsert_component(
+            self,
+            component_id,
+            component_type=None,
+            name=None,
+            description=None,
+            current_version=None,
+            metadata=None,
+        ):
+            self.calls.append(
+                (
+                    "upsert_component",
+                    component_id,
+                    component_type,
+                    name,
+                    description,
+                    current_version,
+                    metadata,
+                )
+            )
+            self.component = {
+                "component_id": component_id,
+                "component_type": component_type,
+                "name": name,
+                "description": description,
+                "current_version": current_version,
+                "metadata": metadata,
+                "created_at": 1,
+            }
+            return self.component
+
+        def delete_component(self, component_id, hard_delete=False):
+            self.calls.append(("delete_component", component_id, hard_delete))
+            self.component = None
+            return True
+
+        def list_components(
+            self,
+            component_type=None,
+            include_deleted=False,
+            limit=20,
+            offset=0,
+            exclude_component_ids=None,
+        ):
+            self.calls.append(
+                (
+                    "list_components",
+                    component_type,
+                    include_deleted,
+                    limit,
+                    offset,
+                    exclude_component_ids,
+                )
+            )
+            return ([self.component] if self.component is not None else [], int(self.component is not None))
+
+        def get_config(self, component_id, version=None, label=None):
+            self.calls.append(("get_config", component_id, version, label))
+            return self.config
+
+        def upsert_config(
+            self,
+            component_id,
+            config=None,
+            version=None,
+            label=None,
+            stage=None,
+            notes=None,
+            links=None,
+        ):
+            self.calls.append(("upsert_config", component_id, config, version, label, stage, notes, links))
+            self.config = {
+                "component_id": component_id,
+                "version": version or 1,
+                "label": label,
+                "stage": stage or "draft",
+                "config": config or {},
+                "notes": notes,
+                "created_at": 1,
+            }
+            return self.config
+
+        def delete_config(self, component_id, version):
+            self.calls.append(("delete_config", component_id, version))
+            self.config = None
+            return True
+
+        def list_configs(self, component_id, include_config=False):
+            self.calls.append(("list_configs", component_id, include_config))
+            return [self.config] if self.config is not None else []
+
+        def set_current_version(self, component_id, version):
+            self.calls.append(("set_current_version", component_id, version))
+            if self.component is not None:
+                self.component["current_version"] = version
+            return self.component is not None
+
+    return LegacyCatalogDb()
+
+
 @pytest.fixture
 def mock_db():
     """Create a mock database instance."""
     MockDbClass = _create_mock_db_class()
     db = MockDbClass()
+    db.supports_component_persistence = True
+    db.component_catalog_api_version = 2
     db.id = "test-db"
     db.list_components = MagicMock()
     db.get_component = MagicMock()
@@ -54,9 +189,12 @@ def mock_db():
     db.create_component_with_config = MagicMock()
     db.list_configs = MagicMock()
     db.get_config = MagicMock()
+    db.get_current_config = db.get_config
+    db.get_latest_config = db.get_config
     db.upsert_config = MagicMock()
     db.delete_config = MagicMock()
     db.set_current_version = MagicMock()
+    db.get_links = MagicMock(return_value=[])
     db.to_dict = MagicMock(return_value={"type": "postgres", "id": "test-db"})
     return db
 
@@ -74,6 +212,116 @@ def client(mock_db, settings):
     router = get_components_router(os_db=mock_db, settings=settings)
     app.include_router(router)
     return TestClient(app)
+
+
+@pytest.fixture
+def sqlite_client(tmp_path, settings):
+    """Create a components router backed by the real SQLite persistence layer."""
+    db = SqliteDb(db_file=str(tmp_path / "components-router.db"))
+    app = FastAPI()
+    app.include_router(get_components_router(os_db=db, settings=settings))
+    return TestClient(app), db
+
+
+def _guard(latest_version=1, current_version=1):
+    return {"guard": {"latest_version": latest_version, "current_version": current_version}}
+
+
+# =============================================================================
+# Router Capability Tests
+# =============================================================================
+
+
+class TestComponentPersistenceCapability:
+    def test_router_rejects_unsupported_sync_db(self, settings):
+        unsupported_db = _create_mock_db_class()()
+
+        with pytest.raises(ValueError, match="component persistence support"):
+            get_components_router(os_db=unsupported_db, settings=settings)
+
+    def test_complete_v1_override_is_detected_without_the_new_capability_flag(self):
+        from agno.os.app import _supports_component_routes
+
+        db = _create_legacy_catalog_db()
+
+        assert db.supports_component_persistence is False
+        assert supports_component_routes(db) is True
+        assert _supports_component_routes(db) is True
+
+        # A v2 adapter must explicitly opt into its stronger contract; method
+        # names alone cannot prove guarded atomic semantics.
+        db.component_catalog_api_version = 2
+        assert supports_component_routes(db) is False
+
+    def test_v1_router_keeps_legacy_http_and_exact_adapter_call_shapes(self, settings):
+        db = _create_legacy_catalog_db()
+        app = FastAPI()
+        app.include_router(get_components_router(os_db=db, settings=settings))
+        client = TestClient(app)
+
+        schema = app.openapi()
+        component_path = schema["paths"]["/components/{component_id}"]
+        assert "Legacy Catalog" in component_path["patch"]["summary"]
+        assert "requestBody" not in component_path["delete"]
+
+        created = client.post(
+            "/components",
+            json={"name": "Analyst v2.5", "component_type": "agent", "config": {"instructions": "Review"}},
+        )
+
+        assert created.status_code == 201
+        assert created.json()["component_id"] == "analyst-v2.5"
+        assert db.calls[0][:4] == (
+            "upsert_component",
+            "analyst-v2.5",
+            ComponentType.AGENT,
+            "Analyst v2.5",
+        )
+        assert db.calls[1] == (
+            "upsert_config",
+            "analyst-v2.5",
+            {"instructions": "Review"},
+            None,
+            None,
+            "draft",
+            None,
+            None,
+        )
+
+        current = client.get("/components/analyst-v2.5/configs/current")
+        assert current.status_code == 200
+        assert db.calls[-1] == ("get_config", "analyst-v2.5", None, None)
+
+        deleted = client.delete("/components/analyst-v2.5")
+        assert deleted.status_code == 204
+        assert db.calls[-1] == ("delete_component", "analyst-v2.5", False)
+
+    def test_agentos_mounts_the_detected_v1_router(self):
+        db = _create_legacy_catalog_db()
+        app = AgentOS(db=db, telemetry=False).get_app()
+
+        response = TestClient(app).get("/components")
+
+        assert response.status_code == 200
+        assert response.json()["data"] == []
+
+    def test_agentos_mounts_disabled_router_for_unsupported_sync_db(self):
+        agent_os = AgentOS(db=InMemoryDb(), telemetry=False)
+
+        response = TestClient(agent_os.get_app()).get("/components")
+
+        assert response.status_code == 503
+        assert "component persistence support" in response.json()["detail"]
+
+    def test_agentos_reprovision_keeps_unsupported_sync_db_disabled(self):
+        agent_os = AgentOS(db=InMemoryDb(), telemetry=False)
+        app = agent_os.get_app()
+
+        agent_os._reprovision_routers(app)
+        response = TestClient(app).get("/components")
+
+        assert response.status_code == 503
+        assert "component persistence support" in response.json()["detail"]
 
 
 # =============================================================================
@@ -185,6 +433,32 @@ class TestCreateComponent:
         call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["component_id"] == "my-agent"
 
+    def test_generated_id_matches_direct_agent_save(self, client, mock_db, tmp_path):
+        """REST and direct saves retain the same historical identity key."""
+        name = "R&D Jörg"
+        direct_agent = Agent(name=name, db=SqliteDb(db_file=str(tmp_path / "direct-id.db")))
+        assert direct_agent.save(stage="draft") == 1
+        direct_id = direct_agent.id
+        mock_db.create_component_with_config.return_value = (
+            {
+                "component_id": direct_id,
+                "name": name,
+                "component_type": "agent",
+                "created_at": 1234567890,
+            },
+            {"version": 1},
+        )
+
+        response = client.post(
+            "/components",
+            json={"name": name, "component_type": "agent"},
+        )
+
+        assert response.status_code == 201
+        assert direct_id == "r&d-jörg"
+        call_args = mock_db.create_component_with_config.call_args
+        assert call_args.kwargs["component_id"] == direct_id
+
     def test_create_component_with_explicit_id(self, client, mock_db):
         """Test create_component uses provided component_id."""
         mock_db.create_component_with_config.return_value = (
@@ -215,6 +489,15 @@ class TestCreateComponent:
         )
 
         assert response.status_code == 400
+
+    def test_create_component_rejects_removed_set_current_field(self, client, mock_db):
+        response = client.post(
+            "/components",
+            json={"name": "Test", "component_type": "agent", "set_current": False},
+        )
+
+        assert response.status_code == 422
+        mock_db.create_component_with_config.assert_not_called()
 
     def test_create_team_persists_links_for_db_members(self, client, mock_db):
         """Test create_component builds component links for DB-persisted members."""
@@ -248,7 +531,7 @@ class TestCreateComponent:
         ]
 
     def test_create_team_with_registry_member_succeeds_without_link(self, mock_db, settings):
-        """Test create_component allows a code-defined (registry) member with no link."""
+        """Draft teams may use a code-defined registry member without a durable link."""
         from agno.agent.agent import Agent
         from agno.registry import Registry
 
@@ -270,6 +553,76 @@ class TestCreateComponent:
                 "name": "My Team",
                 "component_type": "team",
                 "component_id": "my-team",
+                "config": {"id": "my-team", "members": [{"type": "agent", "agent_id": "member-agent"}]},
+            },
+        )
+
+        assert response.status_code == 201
+        assert mock_db.create_component_with_config.call_args.kwargs["links"] is None
+
+    def test_create_published_team_rejects_code_defined_member_without_durable_pin(self, mock_db, settings):
+        """A live registry object is not an exact version pin for publication."""
+        from agno.agent.agent import Agent
+        from agno.registry import Registry
+
+        mock_db.get_component.return_value = None
+        registry = Registry(agents=[Agent(id="member-agent", name="Member Agent")])
+
+        app = FastAPI()
+        app.include_router(get_components_router(os_db=mock_db, settings=settings, registry=registry))
+        client = TestClient(app)
+
+        response = client.post(
+            "/components",
+            json={
+                "name": "My Team",
+                "component_type": "team",
+                "component_id": "my-team",
+                "stage": "published",
+                "config": {"id": "my-team", "members": [{"type": "agent", "agent_id": "member-agent"}]},
+            },
+        )
+
+        assert response.status_code == 400
+        assert "durable published versions" in response.json()["detail"]
+        assert "member-agent" in response.json()["detail"]
+        mock_db.create_component_with_config.assert_not_called()
+
+    def test_create_published_team_rejects_draft_only_db_member(self, client, mock_db):
+        """A DB component without a current published version cannot be pinned."""
+        mock_db.get_component.return_value = {"component_id": "member-agent", "current_version": None}
+
+        response = client.post(
+            "/components",
+            json={
+                "name": "My Team",
+                "component_type": "team",
+                "component_id": "my-team",
+                "stage": "published",
+                "config": {"id": "my-team", "members": [{"type": "agent", "agent_id": "member-agent"}]},
+            },
+        )
+
+        assert response.status_code == 400
+        assert "durable published versions" in response.json()["detail"]
+        assert "member-agent" in response.json()["detail"]
+        mock_db.create_component_with_config.assert_not_called()
+
+    def test_create_draft_team_allows_draft_only_db_member_without_link(self, client, mock_db):
+        """Draft composition remains flexible until every child can be pinned."""
+        mock_db.get_component.return_value = {"component_id": "member-agent", "current_version": None}
+        mock_db.create_component_with_config.return_value = (
+            {"component_id": "my-team", "name": "My Team", "component_type": "team", "created_at": 1},
+            {"version": 1},
+        )
+
+        response = client.post(
+            "/components",
+            json={
+                "name": "My Team",
+                "component_type": "team",
+                "component_id": "my-team",
+                "stage": "draft",
                 "config": {"id": "my-team", "members": [{"type": "agent", "agent_id": "member-agent"}]},
             },
         )
@@ -344,33 +697,91 @@ class TestUpdateComponent:
     """Tests for PATCH /components/{component_id} endpoint."""
 
     def test_update_component_success(self, client, mock_db):
-        """Test update_component updates component."""
+        """A metadata edit appends a guarded draft and leaves the projection alone."""
         mock_db.get_component.return_value = {
             "component_id": "agent-1",
             "name": "Old Name",
             "component_type": "agent",
+            "current_version": 1,
             "created_at": 1234567890,
         }
-        mock_db.upsert_component.return_value = {
+        mock_db.get_config.return_value = {
             "component_id": "agent-1",
-            "name": "New Name",
-            "component_type": "agent",
+            "version": 1,
+            "stage": "published",
+            "config": {"id": "agent-1", "name": "Old Name", "instructions": "Help"},
             "created_at": 1234567890,
+        }
+        mock_db.upsert_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "stage": "draft",
+            "config": {"id": "agent-1", "name": "New Name", "instructions": "Help"},
+            "created_at": 1234567891,
         }
 
-        response = client.patch("/components/agent-1", json={"name": "New Name"})
+        response = client.patch("/components/agent-1", json={"name": "New Name", **_guard(1, 1)})
 
         assert response.status_code == 200
         data = response.json()
-        assert data["name"] == "New Name"
+        assert data["version"] == 2
+        assert data["stage"] == "draft"
+        assert data["config"]["name"] == "New Name"
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_called_once_with(
+            component_id="agent-1",
+            config={
+                "id": "agent-1",
+                "name": "New Name",
+                "instructions": "Help",
+                "description": None,
+                "metadata": None,
+            },
+            stage="draft",
+            links=[],
+            guard=ComponentVersionGuard(latest_version=1, current_version=1),
+            projection=None,
+        )
 
     def test_update_component_not_found(self, client, mock_db):
         """Test update_component returns 404 when not found."""
         mock_db.get_component.return_value = None
 
-        response = client.patch("/components/nonexistent", json={"name": "New Name"})
+        response = client.patch("/components/nonexistent", json={"name": "New Name", **_guard()})
 
         assert response.status_code == 404
+
+    def test_update_component_rejects_direct_current_pointer_mutation(self, client, mock_db):
+        """Current-version changes must use the guarded set-current endpoint."""
+        response = client.patch("/components/agent-1", json={"current_version": 2, **_guard()})
+
+        assert response.status_code == 422
+        mock_db.upsert_component.assert_not_called()
+
+    def test_update_component_requires_guard_and_nonempty_patch(self, client, mock_db):
+        assert client.patch("/components/agent-1", json={"name": "New Name"}).status_code == 422
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "current_version": 1,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "stage": "published",
+            "config": {"id": "agent-1", "name": "Agent"},
+        }
+        assert client.patch("/components/agent-1", json=_guard()).status_code == 400
+        mock_db.upsert_config.assert_not_called()
+
+    def test_update_component_guard_rejects_null_latest_version(self, client, mock_db):
+        response = client.patch(
+            "/components/agent-1",
+            json={"name": "New Name", "guard": {"latest_version": None, "current_version": None}},
+        )
+
+        assert response.status_code == 422
+        mock_db.upsert_config.assert_not_called()
 
 
 # =============================================================================
@@ -382,20 +793,292 @@ class TestDeleteComponent:
     """Tests for DELETE /components/{component_id} endpoint."""
 
     def test_delete_component_success(self, client, mock_db):
-        """Test delete_component deletes component."""
+        """Archive is guarded and projects the current published config."""
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "current_version": 1,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "stage": "published",
+            "config": {"name": "Published", "description": "Current", "metadata": {"release": 1}},
+        }
         mock_db.delete_component.return_value = True
 
-        response = client.delete("/components/agent-1")
+        response = client.request("DELETE", "/components/agent-1", json=_guard(2, 1))
 
         assert response.status_code == 204
+        mock_db.delete_component.assert_called_once_with(
+            "agent-1",
+            hard_delete=False,
+            guard=ComponentVersionGuard(latest_version=2, current_version=1),
+            projection={"name": "Published", "description": "Current", "metadata": {"release": 1}},
+        )
 
     def test_delete_component_not_found(self, client, mock_db):
         """Test delete_component returns 404 when not found."""
-        mock_db.delete_component.return_value = False
+        mock_db.get_component.return_value = None
 
-        response = client.delete("/components/nonexistent")
+        response = client.request("DELETE", "/components/nonexistent", json=_guard())
 
         assert response.status_code == 404
+
+    def test_delete_component_dependency_conflict_is_stable(self, client, mock_db):
+        """The dependency-safe default must not turn an expected conflict into 500."""
+        mock_db.delete_component.side_effect = ComponentDependencyError(
+            "agent-1",
+            [
+                {
+                    "parent_component_id": "team-1",
+                    "parent_version": 3,
+                    "link_kind": "member",
+                    "link_key": "member_0",
+                }
+            ],
+        )
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "current_version": 1,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "stage": "published",
+            "config": {"name": "Agent"},
+        }
+
+        response = client.request("DELETE", "/components/agent-1", json=_guard())
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == "Cannot delete agent-1: it is referenced by 1 component link(s)"
+
+    def test_delete_component_requires_guard(self, client, mock_db):
+        response = client.delete("/components/agent-1")
+
+        assert response.status_code == 422
+        mock_db.delete_component.assert_not_called()
+
+
+class TestGuardedGenericLifecycle:
+    """Real SQLite regressions for append-only edits, CAS, and soft archive."""
+
+    @staticmethod
+    def _agent_config(name: str, description: str | None, metadata: dict | None):
+        return {
+            "id": "guarded-agent",
+            "name": name,
+            "instructions": "Be useful",
+            "description": description,
+            "metadata": metadata,
+        }
+
+    def _create(self, client, *, stage: str, name: str = "Version one"):
+        return client.post(
+            "/components",
+            json={
+                "component_id": "guarded-agent",
+                "component_type": "agent",
+                "name": name,
+                "description": "Original description",
+                "metadata": {"revision": 1},
+                "stage": stage,
+                "config": self._agent_config(
+                    name,
+                    "Original description",
+                    {"revision": 1},
+                ),
+            },
+        )
+
+    @staticmethod
+    def _stored_config_versions(db, component_id: str):
+        table = db._get_table(table_type="component_configs")
+        assert table is not None
+        with db.Session() as session:
+            return [
+                row.version
+                for row in session.execute(
+                    table.select().where(table.c.component_id == component_id).order_by(table.c.version)
+                ).fetchall()
+            ]
+
+    def test_patch_appends_generic_draft_and_preserves_current_projection(self, sqlite_client):
+        client, db = sqlite_client
+        assert self._create(client, stage="published").status_code == 201
+
+        response = client.patch(
+            "/components/guarded-agent",
+            json={
+                "name": "Draft edit",
+                "description": None,
+                "metadata": {"revision": 2},
+                **_guard(1, 1),
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["version"] == 2
+        assert data["stage"] == "draft"
+        assert data["config"]["name"] == "Draft edit"
+        assert data["config"]["description"] is None
+        assert data["config"]["metadata"] == {"revision": 2}
+
+        component = db.get_component("guarded-agent")
+        assert component is not None
+        assert component["current_version"] == 1
+        assert component["name"] == "Version one"
+        assert component["description"] == "Original description"
+        assert component["metadata"] == {"revision": 1}
+
+        stale = client.patch(
+            "/components/guarded-agent",
+            json={"name": "Lost update", **_guard(1, 1)},
+        )
+        assert stale.status_code == 409
+        assert [row["version"] for row in db.list_configs("guarded-agent")] == [2, 1]
+
+    def test_archive_uses_current_projection_and_preserves_all_history(self, sqlite_client):
+        client, db = sqlite_client
+        assert self._create(client, stage="published").status_code == 201
+        assert (
+            client.patch(
+                "/components/guarded-agent",
+                json={"name": "Unpublished draft", "metadata": {"revision": 2}, **_guard(1, 1)},
+            ).status_code
+            == 200
+        )
+
+        response = client.request("DELETE", "/components/guarded-agent", json=_guard(2, 1))
+
+        assert response.status_code == 204
+        archived = db.get_component("guarded-agent", include_deleted=True)
+        assert archived is not None
+        assert archived["deleted_at"] is not None
+        assert archived["current_version"] == 1
+        assert archived["name"] == "Version one"
+        assert archived["metadata"] == {"revision": 1}
+        assert self._stored_config_versions(db, "guarded-agent") == [1, 2]
+
+    def test_draft_only_patch_and_archive_project_latest_draft(self, sqlite_client):
+        client, db = sqlite_client
+        assert self._create(client, stage="draft").status_code == 201
+        assert (
+            client.patch(
+                "/components/guarded-agent",
+                json={"name": "Latest draft", "metadata": {"revision": 2}, **_guard(1, None)},
+            ).status_code
+            == 200
+        )
+
+        component = db.get_component("guarded-agent")
+        assert component is not None
+        assert component["current_version"] is None
+        assert component["name"] == "Latest draft"
+        assert component["metadata"] == {"revision": 2}
+
+        assert (
+            client.request(
+                "DELETE",
+                "/components/guarded-agent",
+                json=_guard(2, None),
+            ).status_code
+            == 204
+        )
+        archived = db.get_component("guarded-agent", include_deleted=True)
+        assert archived is not None
+        assert archived["name"] == "Latest draft"
+        assert archived["metadata"] == {"revision": 2}
+        assert self._stored_config_versions(db, "guarded-agent") == [1, 2]
+
+    def test_delete_latest_draft_requires_fresh_guard_and_restores_draft_projection(self, sqlite_client):
+        client, db = sqlite_client
+        assert self._create(client, stage="draft").status_code == 201
+        assert (
+            client.patch(
+                "/components/guarded-agent",
+                json={"name": "Version two", "metadata": {"revision": 2}, **_guard(1, None)},
+            ).status_code
+            == 200
+        )
+
+        stale = client.request(
+            "DELETE",
+            "/components/guarded-agent/configs/2",
+            json=_guard(1, None),
+        )
+        assert stale.status_code == 409
+        assert db.get_config("guarded-agent", version=2) is not None
+
+        deleted = client.request(
+            "DELETE",
+            "/components/guarded-agent/configs/2",
+            json=_guard(2, None),
+        )
+        assert deleted.status_code == 204
+        assert db.get_config("guarded-agent", version=2) is None
+        component = db.get_component("guarded-agent")
+        assert component is not None
+        assert component["name"] == "Version one"
+        assert component["metadata"] == {"revision": 1}
+        assert self._stored_config_versions(db, "guarded-agent") == [1, 2]
+
+    def test_generic_creation_rejects_reserved_studio_manifest(self, sqlite_client):
+        client, db = sqlite_client
+        config = self._agent_config("Version one", "Original description", {"revision": 1})
+        config["_agno_studio"] = {"schema_version": 999, "request": {}}
+        response = client.post(
+            "/components",
+            json={
+                "component_id": "guarded-agent",
+                "component_type": "agent",
+                "name": "Version one",
+                "stage": "draft",
+                "config": config,
+            },
+        )
+
+        assert response.status_code == 400
+        assert "reserved for StudioTools" in response.json()["detail"]
+        assert db.get_component("guarded-agent") is None
+
+
+class TestStudioWriteIsolation:
+    """The generic Components API is read-only for Studio-owned records."""
+
+    def test_generic_config_append_cannot_claim_studio_manifest_namespace(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            client.post(
+                "/components",
+                json={
+                    "component_id": "generic-agent",
+                    "component_type": "agent",
+                    "name": "Generic agent",
+                    "config": {"id": "generic-agent", "name": "Generic agent"},
+                },
+            ).status_code
+            == 201
+        )
+
+        response = client.post(
+            "/components/generic-agent/configs",
+            json={
+                "config": {
+                    "id": "generic-agent",
+                    "name": "Forged Studio version",
+                    "_agno_studio": {"schema_version": 2, "request": {}},
+                },
+                **_guard(1, None),
+            },
+        )
+
+        assert response.status_code == 400
+        assert "reserved for StudioTools" in response.json()["detail"]
+        assert [row["version"] for row in db.list_configs("generic-agent")] == [1]
 
 
 # =============================================================================
@@ -420,12 +1103,27 @@ class TestListConfigs:
         assert len(data) == 2
 
     def test_list_configs_with_include_config(self, client, mock_db):
-        """Test list_configs passes include_config parameter."""
-        mock_db.list_configs.return_value = []
+        """Config summaries remain valid when the payload is intentionally omitted."""
+        mock_db.list_configs.return_value = [
+            {
+                "component_id": "agent-1",
+                "version": 2,
+                "stage": "published",
+                "created_at": 1234567890,
+            }
+        ]
 
         response = client.get("/components/agent-1/configs?include_config=false")
 
         assert response.status_code == 200
+        assert response.json() == [
+            {
+                "component_id": "agent-1",
+                "version": 2,
+                "stage": "published",
+                "created_at": 1234567890,
+            }
+        ]
         mock_db.list_configs.assert_called_once_with("agent-1", include_config=False)
 
 
@@ -449,12 +1147,170 @@ class TestCreateConfig:
 
         response = client.post(
             "/components/agent-1/configs",
-            json={"config": {"name": "Agent"}, "stage": "draft"},
+            json={"config": {"name": "Agent"}, "stage": "draft", **_guard()},
         )
 
         assert response.status_code == 201
         data = response.json()
         assert data["version"] == 1
+        mock_db.upsert_config.assert_called_once_with(
+            component_id="agent-1",
+            version=None,
+            config={"name": "Agent", "description": None, "metadata": None},
+            label=None,
+            stage="draft",
+            notes=None,
+            links=None,
+            guard=ComponentVersionGuard(latest_version=1, current_version=1),
+            projection=None,
+        )
+
+    def test_create_config_stores_inherited_fields_and_explicit_nulls(self, client, mock_db):
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "name": "Current name",
+            "description": "Current description",
+            "metadata": {"release": 1},
+            "current_version": 1,
+        }
+        mock_db.upsert_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "config": {"instructions": "v2"},
+            "stage": "draft",
+            "created_at": 1234567890,
+        }
+
+        response = client.post(
+            "/components/agent-1/configs",
+            json={"config": {"instructions": "v2", "description": None}, "stage": "draft", **_guard()},
+        )
+
+        assert response.status_code == 201
+        assert mock_db.upsert_config.call_args.kwargs["config"] == {
+            "instructions": "v2",
+            "name": "Current name",
+            "description": None,
+            "metadata": {"release": 1},
+        }
+
+    def test_create_config_requires_guard(self, client, mock_db):
+        response = client.post("/components/agent-1/configs", json={"config": {"name": "Agent"}})
+
+        assert response.status_code == 422
+        mock_db.upsert_config.assert_not_called()
+
+    def test_agent_config_rejects_caller_owned_component_links(self, client, mock_db):
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "current_version": 1,
+        }
+
+        response = client.post(
+            "/components/agent-1/configs",
+            json={
+                "config": {"name": "Agent"},
+                "links": [
+                    {
+                        "link_kind": "step_agent",
+                        "link_key": "forged",
+                        "child_component_id": "victim",
+                        "child_version": 1,
+                        "position": 0,
+                    }
+                ],
+                **_guard(),
+            },
+        )
+
+        assert response.status_code == 400
+        assert "do not support component links" in response.json()["detail"]
+        mock_db.upsert_config.assert_not_called()
+
+    def test_create_published_config_projects_catalog_fields(self, client, mock_db):
+        config = {
+            "name": "Published Agent",
+            "description": "Projected description",
+            "metadata": {"release": 2},
+            "instructions": "Be useful",
+        }
+        mock_db.upsert_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "config": config,
+            "stage": "published",
+            "created_at": 1234567890,
+        }
+
+        response = client.post(
+            "/components/agent-1/configs",
+            json={"config": config, "stage": "published", **_guard(1, 1)},
+        )
+
+        assert response.status_code == 201
+        assert mock_db.upsert_config.call_args.kwargs["projection"] == {
+            "name": "Published Agent",
+            "description": "Projected description",
+            "metadata": {"release": 2},
+        }
+
+    def test_create_draft_config_projects_catalog_fields_before_first_publish(self, client, mock_db):
+        config = {
+            "name": "Second draft",
+            "description": "Latest draft projection",
+            "metadata": {"revision": 2},
+        }
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "current_version": None,
+        }
+        mock_db.upsert_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "config": config,
+            "stage": "draft",
+            "created_at": 1234567890,
+        }
+
+        response = client.post(
+            "/components/agent-1/configs",
+            json={"config": config, "stage": "draft", **_guard(1, None)},
+        )
+
+        assert response.status_code == 201
+        assert mock_db.upsert_config.call_args.kwargs["projection"] == {
+            "name": "Second draft",
+            "description": "Latest draft projection",
+            "metadata": {"revision": 2},
+        }
+
+    def test_create_config_maps_stale_guard_to_conflict(self, client, mock_db):
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "name": "Agent",
+            "current_version": 1,
+        }
+        mock_db.upsert_config.side_effect = ComponentVersionConflictError(
+            "agent-1",
+            expected=ComponentVersionGuard(latest_version=1, current_version=1),
+            actual=ComponentVersionGuard(latest_version=2, current_version=1),
+        )
+
+        response = client.post("/components/agent-1/configs", json={"config": {}, **_guard()})
+
+        assert response.status_code == 409
+        assert "version conflict" in response.json()["detail"]
+
+    @pytest.mark.parametrize("removed_field", [{"version": 2}, {"set_current": False}])
+    def test_create_config_rejects_removed_noop_fields(self, client, mock_db, removed_field):
+        response = client.post("/components/agent-1/configs", json={"config": {}, **_guard(), **removed_field})
+
+        assert response.status_code == 422
+        mock_db.upsert_config.assert_not_called()
 
     def test_create_config_handles_value_error(self, client, mock_db):
         """Test create_config returns 400 on ValueError."""
@@ -462,10 +1318,734 @@ class TestCreateConfig:
 
         response = client.post(
             "/components/agent-1/configs",
-            json={"config": {}},
+            json={"config": {}, **_guard()},
         )
 
         assert response.status_code == 400
+
+
+class TestTeamLinkTrustBoundary:
+    """Published Team configs must derive durable member pins server-side."""
+
+    @staticmethod
+    def _create_component(
+        client,
+        *,
+        component_id: str,
+        component_type: str,
+        stage: str,
+        config: dict,
+    ):
+        return client.post(
+            "/components",
+            json={
+                "component_id": component_id,
+                "name": config.get("name", component_id),
+                "component_type": component_type,
+                "stage": stage,
+                "config": config,
+            },
+        )
+
+    def test_draft_team_promotion_rejects_draft_only_member(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="draft-child",
+                component_type="agent",
+                stage="draft",
+                config={"id": "draft-child", "name": "Draft child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="draft-team",
+                component_type="team",
+                stage="draft",
+                config={
+                    "id": "draft-team",
+                    "name": "Draft team",
+                    "members": [{"type": "agent", "agent_id": "draft-child"}],
+                },
+            ).status_code
+            == 201
+        )
+
+        response = client.patch(
+            "/components/draft-team/configs/1",
+            json={"stage": "published", **_guard(1, None)},
+        )
+
+        assert response.status_code == 400
+        assert "durable published versions" in response.json()["detail"]
+        component = db.get_component("draft-team")
+        draft = db.get_config("draft-team", version=1)
+        assert component is not None and component["current_version"] is None
+        assert draft is not None and draft["stage"] == "draft"
+        assert db.get_links("draft-team", 1) == []
+
+    def test_draft_team_promotion_derives_pin_after_member_is_published(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="child",
+                component_type="agent",
+                stage="draft",
+                config={"id": "child", "name": "Child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="team",
+                component_type="team",
+                stage="draft",
+                config={
+                    "id": "team",
+                    "name": "Team",
+                    "members": [{"type": "agent", "agent_id": "child"}],
+                },
+            ).status_code
+            == 201
+        )
+        assert db.get_links("team", 1) == []
+
+        child_publish = client.patch(
+            "/components/child/configs/1",
+            json={"stage": "published", **_guard(1, None)},
+        )
+        assert child_publish.status_code == 200
+
+        team_publish = client.patch(
+            "/components/team/configs/1",
+            json={"stage": "published", **_guard(1, None)},
+        )
+
+        assert team_publish.status_code == 200
+        assert team_publish.json()["stage"] == "published"
+        component = db.get_component("team")
+        assert component is not None and component["current_version"] == 1
+        links = db.get_links("team", 1)
+        assert [(link["child_component_id"], link["child_version"]) for link in links] == [("child", 1)]
+
+    def test_published_team_config_create_rejects_draft_only_member(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="draft-child",
+                component_type="agent",
+                stage="draft",
+                config={"id": "draft-child", "name": "Draft child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="team",
+                component_type="team",
+                stage="draft",
+                config={"id": "team", "name": "Team", "members": []},
+            ).status_code
+            == 201
+        )
+
+        response = client.post(
+            "/components/team/configs",
+            json={
+                "stage": "published",
+                "config": {
+                    "id": "team",
+                    "name": "Team",
+                    "members": [{"type": "agent", "agent_id": "draft-child"}],
+                },
+                **_guard(1, None),
+            },
+        )
+
+        assert response.status_code == 400
+        assert "durable published versions" in response.json()["detail"]
+        assert [row["version"] for row in db.list_configs("team")] == [1]
+
+    def test_team_config_create_rejects_caller_supplied_mismatched_links(self, sqlite_client):
+        client, db = sqlite_client
+        for child_id in ("member-a", "member-b"):
+            assert (
+                self._create_component(
+                    client,
+                    component_id=child_id,
+                    component_type="agent",
+                    stage="published",
+                    config={"id": child_id, "name": child_id},
+                ).status_code
+                == 201
+            )
+        assert (
+            self._create_component(
+                client,
+                component_id="team",
+                component_type="team",
+                stage="draft",
+                config={"id": "team", "name": "Team", "members": []},
+            ).status_code
+            == 201
+        )
+
+        response = client.post(
+            "/components/team/configs",
+            json={
+                "stage": "draft",
+                "config": {
+                    "id": "team",
+                    "name": "Team",
+                    "members": [{"type": "agent", "agent_id": "member-a"}],
+                },
+                "links": [
+                    {
+                        "link_kind": "member",
+                        "link_key": "member_0",
+                        "child_component_id": "member-b",
+                        "child_version": 1,
+                        "position": 0,
+                        "meta": {"type": "agent"},
+                    }
+                ],
+                **_guard(1, None),
+            },
+        )
+
+        assert response.status_code == 400
+        assert "derived from config.members" in response.json()["detail"]
+        assert [row["version"] for row in db.list_configs("team")] == [1]
+
+    def test_draft_team_config_keeps_flexible_member_and_persists_resolvable_pin(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="draft-child",
+                component_type="agent",
+                stage="draft",
+                config={"id": "draft-child", "name": "Draft child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="published-child",
+                component_type="agent",
+                stage="published",
+                config={"id": "published-child", "name": "Published child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="team",
+                component_type="team",
+                stage="draft",
+                config={"id": "team", "name": "Team", "members": []},
+            ).status_code
+            == 201
+        )
+
+        response = client.post(
+            "/components/team/configs",
+            json={
+                "stage": "draft",
+                "config": {
+                    "id": "team",
+                    "name": "Team",
+                    "members": [
+                        {"type": "agent", "agent_id": "draft-child"},
+                        {"type": "agent", "agent_id": "published-child"},
+                    ],
+                },
+                **_guard(1, None),
+            },
+        )
+
+        assert response.status_code == 201
+        assert response.json()["version"] == 2
+        links = db.get_links("team", 2)
+        assert [(link["link_key"], link["child_component_id"], link["child_version"]) for link in links] == [
+            ("member_1", "published-child", 1)
+        ]
+
+    @pytest.mark.parametrize(
+        "members,detail",
+        [
+            ({"type": "agent", "agent_id": "child"}, "must be a list"),
+            ({}, "must be a list"),
+            ("", "must be a list"),
+            (0, "must be a list"),
+            (False, "must be a list"),
+            (None, "must be a list"),
+            (["child"], "must be an object"),
+            ([{"type": "unknown", "agent_id": "child"}], "must be 'agent' or 'team'"),
+            ([{"type": "agent", "agent_id": ""}], "must be a non-empty string"),
+            (
+                [{"type": "agent", "agent_id": "child", "team_id": "other"}],
+                "exactly one of agent_id or team_id",
+            ),
+        ],
+    )
+    def test_team_members_fail_closed_before_component_creation(self, sqlite_client, members, detail):
+        client, db = sqlite_client
+
+        response = self._create_component(
+            client,
+            component_id="malformed-team",
+            component_type="team",
+            stage="draft",
+            config={"id": "malformed-team", "name": "Malformed team", "members": members},
+        )
+
+        assert response.status_code == 400
+        assert detail in response.json()["detail"]
+        assert db.get_component("malformed-team") is None
+
+    def test_explicit_empty_team_members_list_is_allowed(self, sqlite_client):
+        client, db = sqlite_client
+
+        response = self._create_component(
+            client,
+            component_id="empty-team",
+            component_type="team",
+            stage="draft",
+            config={"id": "empty-team", "name": "Empty team", "members": []},
+        )
+
+        assert response.status_code == 201
+        assert db.get_component("empty-team") is not None
+        assert db.get_links("empty-team", 1) == []
+
+
+class TestWorkflowLinkTrustBoundary:
+    """Workflow links are validated and derived from every nested Step."""
+
+    @staticmethod
+    def _create_component(
+        client,
+        *,
+        component_id: str,
+        component_type: str,
+        stage: str,
+        config: dict,
+    ):
+        return client.post(
+            "/components",
+            json={
+                "component_id": component_id,
+                "name": config.get("name", component_id),
+                "component_type": component_type,
+                "stage": stage,
+                "config": config,
+            },
+        )
+
+    def test_published_workflow_rejects_draft_only_step_component_atomically(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="draft-agent",
+                component_type="agent",
+                stage="draft",
+                config={"id": "draft-agent", "name": "Draft agent"},
+            ).status_code
+            == 201
+        )
+
+        response = self._create_component(
+            client,
+            component_id="published-workflow",
+            component_type="workflow",
+            stage="published",
+            config={
+                "id": "published-workflow",
+                "name": "Published workflow",
+                "steps": [{"type": "Step", "step_id": "draft-step", "name": "Draft step", "agent_id": "draft-agent"}],
+            },
+        )
+
+        assert response.status_code == 400
+        assert "durable published versions" in response.json()["detail"]
+        assert db.get_component("published-workflow") is None
+
+    def test_published_workflow_derives_exact_links_through_nested_branches(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="agent-child",
+                component_type="agent",
+                stage="published",
+                config={"id": "agent-child", "name": "Agent child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="team-child",
+                component_type="team",
+                stage="published",
+                config={"id": "team-child", "name": "Team child", "members": []},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="workflow-child",
+                component_type="workflow",
+                stage="published",
+                config={"id": "workflow-child", "name": "Workflow child", "steps": []},
+            ).status_code
+            == 201
+        )
+
+        response = self._create_component(
+            client,
+            component_id="workflow-parent",
+            component_type="workflow",
+            stage="published",
+            config={
+                "id": "workflow-parent",
+                "name": "Workflow parent",
+                "steps": [
+                    {
+                        "type": "Parallel",
+                        "name": "parallel",
+                        "steps": [
+                            {
+                                "type": "Step",
+                                "step_id": "agent-step",
+                                "name": "Agent step",
+                                "agent_id": "agent-child",
+                            },
+                            {
+                                "type": "Condition",
+                                "name": "condition",
+                                "steps": [
+                                    {
+                                        "type": "Step",
+                                        "step_id": "team-step",
+                                        "name": "Team step",
+                                        "team_id": "team-child",
+                                    }
+                                ],
+                                "else_steps": [
+                                    {
+                                        "type": "Router",
+                                        "name": "router",
+                                        "choices": [
+                                            {
+                                                "type": "Step",
+                                                "step_id": "workflow-step",
+                                                "name": "Workflow step",
+                                                "workflow_id": "workflow-child",
+                                            }
+                                        ],
+                                    }
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+
+        assert response.status_code == 201
+        links = sorted(db.get_links("workflow-parent", 1), key=lambda link: link["position"])
+        assert [
+            (
+                link["link_kind"],
+                link["link_key"],
+                link["child_component_id"],
+                link["child_version"],
+                link["position"],
+            )
+            for link in links
+        ] == [
+            ("step_agent", "agent-step", "agent-child", 1, 0),
+            ("step_team", "team-step", "team-child", 1, 1),
+            ("step_workflow", "workflow-step", "workflow-child", 1, 2),
+        ]
+
+    @pytest.mark.parametrize(
+        "bad_step",
+        [
+            {"type": "Mystery", "steps": []},
+            {
+                "type": "Step",
+                "step_id": "ambiguous",
+                "agent_id": "agent-child",
+                "team_id": "team-child",
+            },
+        ],
+    )
+    def test_malformed_workflow_reference_fails_closed_atomically(self, sqlite_client, bad_step):
+        client, db = sqlite_client
+
+        response = self._create_component(
+            client,
+            component_id="bad-workflow",
+            component_type="workflow",
+            stage="draft",
+            config={"id": "bad-workflow", "name": "Bad workflow", "steps": [bad_step]},
+        )
+
+        assert response.status_code == 400
+        assert db.get_component("bad-workflow") is None
+
+    def test_unregistered_function_step_fails_closed_atomically(self, sqlite_client):
+        client, db = sqlite_client
+
+        response = self._create_component(
+            client,
+            component_id="missing-function-workflow",
+            component_type="workflow",
+            stage="draft",
+            config={
+                "id": "missing-function-workflow",
+                "name": "Missing function workflow",
+                "steps": [{"type": "Step", "step_id": "function-step", "executor_ref": "not_registered"}],
+            },
+        )
+
+        assert response.status_code == 400
+        assert "not_registered" in response.json()["detail"]
+        assert db.get_component("missing-function-workflow") is None
+
+    def test_ambiguous_registered_function_step_fails_closed(self, tmp_path, settings):
+        def first_function():
+            return None
+
+        def second_function():
+            return None
+
+        first_function.__name__ = "duplicate_function"
+        second_function.__name__ = "duplicate_function"
+        db = SqliteDb(db_file=str(tmp_path / "ambiguous-workflow-function.db"))
+        app = FastAPI()
+        app.include_router(
+            get_components_router(
+                os_db=db,
+                settings=settings,
+                registry=Registry(functions=[first_function, second_function]),
+            )
+        )
+        client = TestClient(app)
+
+        response = self._create_component(
+            client,
+            component_id="ambiguous-function-workflow",
+            component_type="workflow",
+            stage="draft",
+            config={
+                "id": "ambiguous-function-workflow",
+                "name": "Ambiguous function workflow",
+                "steps": [{"type": "Step", "step_id": "function-step", "executor_ref": "duplicate_function"}],
+            },
+        )
+
+        assert response.status_code == 400
+        assert "ambiguous" in response.json()["detail"]
+        assert db.get_component("ambiguous-function-workflow") is None
+
+    def test_draft_workflow_keeps_draft_reference_flexible_and_pins_published_child(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="draft-child",
+                component_type="agent",
+                stage="draft",
+                config={"id": "draft-child", "name": "Draft child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="published-child",
+                component_type="agent",
+                stage="published",
+                config={"id": "published-child", "name": "Published child"},
+            ).status_code
+            == 201
+        )
+
+        response = self._create_component(
+            client,
+            component_id="draft-workflow",
+            component_type="workflow",
+            stage="draft",
+            config={
+                "id": "draft-workflow",
+                "name": "Draft workflow",
+                "steps": [
+                    {"type": "Step", "step_id": "draft-step", "agent_id": "draft-child"},
+                    {"type": "Step", "step_id": "published-step", "agent_id": "published-child"},
+                ],
+            },
+        )
+
+        assert response.status_code == 201
+        links = db.get_links("draft-workflow", 1)
+        assert [(link["link_key"], link["child_component_id"], link["child_version"]) for link in links] == [
+            ("published-step", "published-child", 1)
+        ]
+
+    def test_workflow_config_create_rejects_caller_supplied_links(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="workflow",
+                component_type="workflow",
+                stage="draft",
+                config={"id": "workflow", "name": "Workflow", "steps": []},
+            ).status_code
+            == 201
+        )
+
+        response = client.post(
+            "/components/workflow/configs",
+            json={
+                "config": {"id": "workflow", "name": "Workflow", "steps": []},
+                "links": [
+                    {
+                        "link_kind": "step_agent",
+                        "link_key": "forged",
+                        "child_component_id": "other",
+                        "child_version": 1,
+                        "position": 0,
+                    }
+                ],
+                **_guard(1, None),
+            },
+        )
+
+        assert response.status_code == 400
+        assert "derived from config.steps" in response.json()["detail"]
+        assert [row["version"] for row in db.list_configs("workflow")] == [1]
+
+    def test_workflow_promotion_derives_pin_after_child_is_published(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="child",
+                component_type="agent",
+                stage="draft",
+                config={"id": "child", "name": "Child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="workflow",
+                component_type="workflow",
+                stage="draft",
+                config={
+                    "id": "workflow",
+                    "name": "Workflow",
+                    "steps": [{"type": "Step", "step_id": "child-step", "agent_id": "child"}],
+                },
+            ).status_code
+            == 201
+        )
+        assert db.get_links("workflow", 1) == []
+
+        rejected = client.patch(
+            "/components/workflow/configs/1",
+            json={"stage": "published", **_guard(1, None)},
+        )
+        assert rejected.status_code == 400
+        assert db.get_links("workflow", 1) == []
+
+        assert (
+            client.patch(
+                "/components/child/configs/1",
+                json={"stage": "published", **_guard(1, None)},
+            ).status_code
+            == 200
+        )
+        published = client.patch(
+            "/components/workflow/configs/1",
+            json={"stage": "published", **_guard(1, None)},
+        )
+
+        assert published.status_code == 200
+        links = db.get_links("workflow", 1)
+        assert [(link["link_key"], link["child_component_id"], link["child_version"]) for link in links] == [
+            ("child-step", "child", 1)
+        ]
+
+    def test_metadata_patch_copies_guarded_workflow_pins_without_retargeting(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="child",
+                component_type="agent",
+                stage="published",
+                config={"id": "child", "name": "Child v1"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="workflow",
+                component_type="workflow",
+                stage="draft",
+                config={
+                    "id": "workflow",
+                    "name": "Workflow",
+                    "steps": [{"type": "Step", "step_id": "child-step", "agent_id": "child"}],
+                },
+            ).status_code
+            == 201
+        )
+        assert db.get_links("workflow", 1)[0]["child_version"] == 1
+
+        assert (
+            client.post(
+                "/components/child/configs",
+                json={
+                    "stage": "published",
+                    "config": {"id": "child", "name": "Child v2"},
+                    **_guard(1, 1),
+                },
+            ).status_code
+            == 201
+        )
+        assert db.get_component("child")["current_version"] == 2  # type: ignore[index]
+
+        patched = client.patch(
+            "/components/workflow",
+            json={"description": "Metadata-only edit", **_guard(1, None)},
+        )
+
+        assert patched.status_code == 200
+        assert patched.json()["version"] == 2
+        links = db.get_links("workflow", 2)
+        assert [(link["link_key"], link["child_component_id"], link["child_version"]) for link in links] == [
+            ("child-step", "child", 1)
+        ]
 
 
 # =============================================================================
@@ -478,23 +2058,27 @@ class TestGetCurrentConfig:
 
     def test_get_current_config_success(self, client, mock_db):
         """Test get_current_config returns current config."""
-        mock_db.get_config.return_value = {
-            "component_id": "agent-1",
-            "version": 2,
-            "config": {"name": "Agent"},
-            "stage": "published",
-            "created_at": 1234567890,
-        }
+        mock_db.get_current_config = MagicMock(
+            return_value={
+                "component_id": "agent-1",
+                "version": 2,
+                "config": {"name": "Agent"},
+                "stage": "published",
+                "created_at": 1234567890,
+            }
+        )
 
         response = client.get("/components/agent-1/configs/current")
 
         assert response.status_code == 200
         data = response.json()
         assert data["version"] == 2
+        mock_db.get_current_config.assert_called_once_with(component_id="agent-1")
+        mock_db.get_config.assert_not_called()
 
     def test_get_current_config_not_found(self, client, mock_db):
         """Test get_current_config returns 404 when no current config."""
-        mock_db.get_config.return_value = None
+        mock_db.get_current_config = MagicMock(return_value=None)
 
         response = client.get("/components/agent-1/configs/current")
 
@@ -543,31 +2127,92 @@ class TestUpdateConfig:
     """Tests for PATCH /components/{component_id}/configs/{version} endpoint."""
 
     def test_update_config_success(self, client, mock_db):
-        """Test update_config updates config version."""
+        """Test update_config publishes the latest draft with its projection."""
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "config": {
+                "name": "Updated Agent",
+                "description": "Version two",
+                "metadata": {"release": 2},
+            },
+            "stage": "draft",
+            "created_at": 1234567890,
+        }
         mock_db.upsert_config.return_value = {
             "component_id": "agent-1",
-            "version": 1,
+            "version": 2,
             "config": {"name": "Updated Agent"},
-            "stage": "draft",
+            "stage": "published",
             "created_at": 1234567890,
         }
 
         response = client.patch(
-            "/components/agent-1/configs/1",
-            json={"config": {"name": "Updated Agent"}},
+            "/components/agent-1/configs/2",
+            json={"stage": "published", **_guard(2, 1)},
         )
 
         assert response.status_code == 200
-        data = response.json()
-        assert data["config"]["name"] == "Updated Agent"
+        assert response.json()["stage"] == "published"
+        mock_db.upsert_config.assert_called_once_with(
+            component_id="agent-1",
+            version=2,
+            stage="published",
+            guard=ComponentVersionGuard(latest_version=2, current_version=1),
+            projection={
+                "name": "Updated Agent",
+                "description": "Version two",
+                "metadata": {"release": 2},
+            },
+        )
+
+    def test_update_config_requires_guard(self, client, mock_db):
+        response = client.patch("/components/agent-1/configs/2", json={"stage": "published"})
+
+        assert response.status_code == 422
+        mock_db.upsert_config.assert_not_called()
+
+    def test_update_config_maps_stale_guard_to_conflict(self, client, mock_db):
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "config": {"name": "Agent"},
+            "stage": "draft",
+            "created_at": 1234567890,
+        }
+        mock_db.upsert_config.side_effect = ComponentVersionConflictError(
+            "agent-1",
+            expected=ComponentVersionGuard(latest_version=2, current_version=1),
+            actual=ComponentVersionGuard(latest_version=3, current_version=1),
+        )
+
+        response = client.patch("/components/agent-1/configs/2", json={"stage": "published", **_guard(2, 1)})
+
+        assert response.status_code == 409
+
+    def test_update_config_rejects_payload_mutation(self, client, mock_db):
+        response = client.patch(
+            "/components/agent-1/configs/2",
+            json={"stage": "published", "config": {"name": "Changed"}, **_guard(2, 1)},
+        )
+
+        assert response.status_code == 422
+        mock_db.upsert_config.assert_not_called()
 
     def test_update_config_handles_value_error(self, client, mock_db):
         """Test update_config returns 400 on ValueError."""
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "config": {},
+            "stage": "draft",
+            "created_at": 1234567890,
+        }
         mock_db.upsert_config.side_effect = ValueError("Cannot update published config")
 
         response = client.patch(
             "/components/agent-1/configs/1",
-            json={"stage": "published"},
+            json={"stage": "published", **_guard()},
         )
 
         assert response.status_code == 400
@@ -581,29 +2226,91 @@ class TestUpdateConfig:
 class TestDeleteConfig:
     """Tests for DELETE /components/{component_id}/configs/{version} endpoint."""
 
+    @staticmethod
+    def _published_component(mock_db):
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "current_version": 1,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "stage": "published",
+            "config": {"name": "Published", "description": "Current"},
+        }
+
     def test_delete_config_success(self, client, mock_db):
         """Test delete_config deletes config version."""
+        self._published_component(mock_db)
         mock_db.delete_config.return_value = True
 
-        response = client.delete("/components/agent-1/configs/1")
+        response = client.request("DELETE", "/components/agent-1/configs/2", json=_guard(2, 1))
 
         assert response.status_code == 204
+        mock_db.delete_config.assert_called_once_with(
+            "agent-1",
+            version=2,
+            guard=ComponentVersionGuard(latest_version=2, current_version=1),
+            projection={"name": "Published", "description": "Current", "metadata": None},
+        )
 
     def test_delete_config_not_found(self, client, mock_db):
         """Test delete_config returns 404 when not found."""
+        self._published_component(mock_db)
         mock_db.delete_config.return_value = False
 
-        response = client.delete("/components/agent-1/configs/999")
+        response = client.request("DELETE", "/components/agent-1/configs/999", json=_guard())
 
         assert response.status_code == 404
 
     def test_delete_config_handles_value_error(self, client, mock_db):
         """Test delete_config returns 400 on ValueError."""
+        self._published_component(mock_db)
         mock_db.delete_config.side_effect = ValueError("Cannot delete current config")
 
-        response = client.delete("/components/agent-1/configs/1")
+        response = client.request("DELETE", "/components/agent-1/configs/1", json=_guard())
 
         assert response.status_code == 400
+
+    def test_delete_config_dependency_conflict_is_stable(self, client, mock_db):
+        self._published_component(mock_db)
+        mock_db.delete_config.side_effect = ComponentDependencyError(
+            "agent-1",
+            [{"parent_component_id": "team-1", "parent_version": 2}],
+            version=1,
+        )
+
+        response = client.request("DELETE", "/components/agent-1/configs/1", json=_guard())
+
+        assert response.status_code == 409
+        assert "referenced by 1 component link" in response.json()["detail"]
+
+    def test_delete_sole_last_config_conflict_is_stable(self, client, mock_db):
+        self._published_component(mock_db)
+        mock_db.delete_config.side_effect = ComponentLastConfigError("agent-1", 1)
+
+        response = client.request("DELETE", "/components/agent-1/configs/1", json=_guard())
+
+        assert response.status_code == 409
+        assert "last config" in response.json()["detail"]
+
+    def test_delete_published_config_conflict_is_stable(self, client, mock_db):
+        self._published_component(mock_db)
+        mock_db.delete_config.side_effect = ComponentDraftRequiredError("agent-1", 1)
+
+        response = client.request("DELETE", "/components/agent-1/configs/1", json=_guard())
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == (
+            "Cannot delete published config agent-1 v1; only draft configs can be deleted"
+        )
+
+    def test_delete_config_requires_guard(self, client, mock_db):
+        response = client.delete("/components/agent-1/configs/2")
+
+        assert response.status_code == 422
+        mock_db.delete_config.assert_not_called()
 
 
 # =============================================================================
@@ -614,36 +2321,211 @@ class TestDeleteConfig:
 class TestSetCurrentConfig:
     """Tests for POST /components/{component_id}/configs/{version}/set-current endpoint."""
 
+    def test_sqlite_rollback_restores_explicit_null_projection_from_canonical_v1(self, sqlite_client):
+        client, db = sqlite_client
+        component_id = "rollback-canonical-projection"
+
+        created = client.post(
+            "/components",
+            json={
+                "component_id": component_id,
+                "component_type": "agent",
+                "name": "Version one",
+                "stage": "published",
+                "config": {"id": component_id, "instructions": "v1"},
+            },
+        )
+        assert created.status_code == 201
+
+        version_two = client.post(
+            f"/components/{component_id}/configs",
+            json={
+                "config": {
+                    "id": component_id,
+                    "name": "Version two",
+                    "description": "Newer description",
+                    "metadata": {"release": 2},
+                    "instructions": "v2",
+                },
+                "stage": "published",
+                **_guard(1, 1),
+            },
+        )
+        assert version_two.status_code == 201
+
+        rolled_back = client.post(
+            f"/components/{component_id}/configs/1/set-current",
+            json=_guard(2, 2),
+        )
+
+        assert rolled_back.status_code == 200
+        assert rolled_back.json()["current_version"] == 1
+        assert rolled_back.json()["name"] == "Version one"
+        assert rolled_back.json().get("description") is None
+        assert rolled_back.json().get("metadata") is None
+
+        component = db.get_component(component_id)
+        version_one = db.get_config(component_id, version=1)
+        assert component is not None
+        assert version_one is not None
+        assert component["current_version"] == 1
+        assert component["name"] == "Version one"
+        assert component["description"] is None
+        assert component["metadata"] is None
+        assert version_one["config"]["name"] == "Version one"
+        assert version_one["config"]["description"] is None
+        assert version_one["config"]["metadata"] is None
+
+    def test_sqlite_rollback_restores_projection_from_direct_agent_save(self, sqlite_client):
+        client, db = sqlite_client
+        component_id = "direct-save-projection"
+        agent = Agent(
+            id=component_id,
+            name="Version one",
+            description=None,
+            metadata=None,
+            model=OpenAIResponses(id="gpt-5.4"),
+        )
+        assert agent.save(db=db) == 1
+        agent.name = "Version two"
+        agent.description = "Newer description"
+        agent.metadata = {"release": 2}
+        assert agent.save(db=db) == 2
+
+        rolled_back = client.post(
+            f"/components/{component_id}/configs/1/set-current",
+            json=_guard(2, 2),
+        )
+
+        assert rolled_back.status_code == 200
+        assert rolled_back.json()["current_version"] == 1
+        assert rolled_back.json()["name"] == "Version one"
+        assert rolled_back.json().get("description") is None
+        assert rolled_back.json().get("metadata") is None
+        component = db.get_component(component_id)
+        version_one = db.get_config(component_id, version=1)
+        assert component is not None
+        assert version_one is not None
+        assert component["name"] == "Version one"
+        assert component["description"] is None
+        assert component["metadata"] is None
+        assert version_one["config"]["name"] == "Version one"
+        assert version_one["config"]["description"] is None
+        assert version_one["config"]["metadata"] is None
+
     def test_set_current_config_success(self, client, mock_db):
         """Test set_current_config sets version as current."""
         mock_db.set_current_version.return_value = True
         mock_db.get_component.return_value = {
             "component_id": "agent-1",
-            "name": "Agent 1",
+            "name": "Agent 3",
+            "description": "Current description",
+            "metadata": {"release": 3},
             "component_type": "agent",
             "current_version": 3,
             "created_at": 1234567890,
         }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "config": {
+                "name": "Agent 1",
+                "description": "Restored description",
+                "metadata": {"release": 1},
+            },
+            "stage": "published",
+            "created_at": 1234567890,
+        }
 
-        response = client.post("/components/agent-1/configs/3/set-current")
+        response = client.post("/components/agent-1/configs/1/set-current", json=_guard(3, 3))
 
         assert response.status_code == 200
         data = response.json()
-        assert data["current_version"] == 3
+        assert data["current_version"] == 1
+        assert data["name"] == "Agent 1"
+        assert data["description"] == "Restored description"
+        assert data["metadata"] == {"release": 1}
+        mock_db.set_current_version.assert_called_once_with(
+            "agent-1",
+            version=1,
+            guard=ComponentVersionGuard(latest_version=3, current_version=3),
+            projection={
+                "name": "Agent 1",
+                "description": "Restored description",
+                "metadata": {"release": 1},
+            },
+        )
+        # The response is synthesized from the pre-mutation row and committed
+        # projection, so it cannot observe a later mutation through a re-read.
+        mock_db.get_component.assert_called_once_with("agent-1")
+        mock_db.get_config.assert_called_once_with("agent-1", version=1)
+
+    def test_set_current_config_requires_guard(self, client, mock_db):
+        response = client.post("/components/agent-1/configs/1/set-current")
+
+        assert response.status_code == 422
+        mock_db.set_current_version.assert_not_called()
 
     def test_set_current_config_not_found(self, client, mock_db):
         """Test set_current_config returns 404 when version not found."""
-        mock_db.set_current_version.return_value = False
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "name": "Agent 1",
+            "component_type": "agent",
+            "current_version": 1,
+            "created_at": 1234567890,
+        }
+        mock_db.get_config.return_value = None
 
-        response = client.post("/components/agent-1/configs/999/set-current")
+        response = client.post("/components/agent-1/configs/999/set-current", json=_guard())
 
         assert response.status_code == 404
+        mock_db.set_current_version.assert_not_called()
+
+    def test_set_current_config_maps_stale_guard_to_conflict(self, client, mock_db):
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "name": "Agent 1",
+            "component_type": "agent",
+            "current_version": 2,
+            "created_at": 1234567890,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "config": {"name": "Agent 1"},
+            "stage": "published",
+            "created_at": 1234567890,
+        }
+        mock_db.set_current_version.side_effect = ComponentVersionConflictError(
+            "agent-1",
+            expected=ComponentVersionGuard(latest_version=2, current_version=2),
+            actual=ComponentVersionGuard(latest_version=3, current_version=2),
+        )
+
+        response = client.post("/components/agent-1/configs/1/set-current", json=_guard(2, 2))
+
+        assert response.status_code == 409
 
     def test_set_current_config_handles_value_error(self, client, mock_db):
         """Test set_current_config returns 400 on ValueError."""
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "name": "Agent 1",
+            "component_type": "agent",
+            "current_version": 1,
+            "created_at": 1234567890,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "config": {"name": "Agent 2"},
+            "stage": "draft",
+            "created_at": 1234567890,
+        }
         mock_db.set_current_version.side_effect = ValueError("Version not published")
 
-        response = client.post("/components/agent-1/configs/1/set-current")
+        response = client.post("/components/agent-1/configs/2/set-current", json=_guard())
 
         assert response.status_code == 400
 

--- a/libs/agno/tests/unit/os/routers/test_components_router.py
+++ b/libs/agno/tests/unit/os/routers/test_components_router.py
@@ -261,13 +261,13 @@ class TestComponentPersistenceCapability:
             get_components_router(os_db=unsupported_db, settings=settings)
 
     def test_complete_v1_override_is_detected_without_the_new_capability_flag(self):
-        from agno.os.app import _supports_component_routes
+        from agno.os.routers.components import supports_component_routes
 
         db = _create_legacy_catalog_db()
 
         assert db.supports_component_persistence is False
         assert supports_component_routes(db) is True
-        assert _supports_component_routes(db) is True
+        assert supports_component_routes(db) is True
 
         # A v2 adapter must explicitly opt into its stronger contract; method
         # names alone cannot prove guarded atomic semantics.

--- a/libs/agno/tests/unit/os/routers/test_legacy_component_schemas.py
+++ b/libs/agno/tests/unit/os/routers/test_legacy_component_schemas.py
@@ -1,0 +1,35 @@
+"""The legacy component request models must reject unknown fields.
+
+The v2 models all set extra="forbid"; without it on the legacy models, a v2
+client talking to a v1-served deployment gets its guard silently dropped
+instead of a validation error.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from agno.os.routers.components.legacy import (
+    LegacyComponentCreate,
+    LegacyComponentUpdate,
+    LegacyConfigCreate,
+    LegacyConfigUpdate,
+)
+
+VALID_PAYLOADS = [
+    (LegacyComponentCreate, {"name": "a1", "component_type": "agent"}),
+    (LegacyComponentUpdate, {"name": "a1"}),
+    (LegacyConfigCreate, {"config": {"name": "a1"}}),
+    (LegacyConfigUpdate, {"config": {"name": "a1"}}),
+]
+
+
+@pytest.mark.parametrize("model,payload", VALID_PAYLOADS)
+def test_legacy_models_reject_unknown_fields(model, payload):
+    model(**payload)
+    with pytest.raises(ValidationError):
+        model(**payload, unexpected_field=1)
+
+
+def test_legacy_update_rejects_v2_guard_instead_of_dropping_it():
+    with pytest.raises(ValidationError):
+        LegacyComponentUpdate(name="a1", guard={"latest_version": 1, "current_version": 1})

--- a/libs/agno/tests/unit/os/routers/test_legacy_component_schemas.py
+++ b/libs/agno/tests/unit/os/routers/test_legacy_component_schemas.py
@@ -1,12 +1,12 @@
-"""The legacy component request models must reject unknown fields.
+"""The legacy component request models keep the pre-2.9 tolerance contract.
 
-The v2 models all set extra="forbid"; without it on the legacy models, a v2
-client talking to a v1-served deployment gets its guard silently dropped
-instead of a validation error.
+The legacy router exists to accept exact pre-2.9 call shapes, and the old
+API silently ignored unknown fields — so these models deliberately stay at
+pydantic's default extra behavior. The cost, accepted knowingly: a v2
+client's guard is dropped rather than rejected on the body-parsing routes.
 """
 
 import pytest
-from pydantic import ValidationError
 
 from agno.os.routers.components.legacy import (
     LegacyComponentCreate,
@@ -24,12 +24,12 @@ VALID_PAYLOADS = [
 
 
 @pytest.mark.parametrize("model,payload", VALID_PAYLOADS)
-def test_legacy_models_reject_unknown_fields(model, payload):
-    model(**payload)
-    with pytest.raises(ValidationError):
-        model(**payload, unexpected_field=1)
+def test_legacy_models_tolerate_unknown_fields(model, payload):
+    parsed = model(**payload, unexpected_field=1)
+    assert "unexpected_field" not in parsed.model_dump(exclude_unset=True)
 
 
-def test_legacy_update_rejects_v2_guard_instead_of_dropping_it():
-    with pytest.raises(ValidationError):
-        LegacyComponentUpdate(name="a1", guard={"latest_version": 1, "current_version": 1})
+def test_legacy_update_drops_a_v2_guard_silently():
+    parsed = LegacyComponentUpdate(name="a1", guard={"latest_version": 1, "current_version": 1})
+    assert not hasattr(parsed, "guard")
+    assert "guard" not in parsed.model_dump(exclude_unset=True)

--- a/libs/agno/tests/unit/os/routers/test_schedules_router.py
+++ b/libs/agno/tests/unit/os/routers/test_schedules_router.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from agno.db.schemas.scheduler import ScheduleNameConflictError
 from agno.os.routers.schedules import get_schedule_router
 from agno.os.settings import AgnoAPISettings
 
@@ -45,6 +46,7 @@ def _make_schedule_dict(**overrides):
 def mock_db():
     """Create a mock DB with schedule methods."""
     db = MagicMock()
+    db.scheduler_api_version = 2
     db.get_schedules = MagicMock(return_value=[])
     db.get_schedule = MagicMock(return_value=None)
     db.get_schedule_by_name = MagicMock(return_value=None)
@@ -81,6 +83,12 @@ class TestListSchedules:
         resp = client.get("/schedules")
         assert resp.status_code == 200
         assert resp.json()["data"] == []
+        mock_db.get_schedules.assert_called_once_with(
+            enabled=None,
+            limit=100,
+            page=1,
+            exclude_managed_by="studio",
+        )
 
     def test_returns_schedules(self, client, mock_db):
         schedules = [_make_schedule_dict(id="s1"), _make_schedule_dict(id="s2", name="second")]
@@ -125,6 +133,7 @@ class TestCreateSchedule:
         )
         assert resp.status_code == 201
         assert resp.json()["name"] == "new-sched"
+        mock_db.get_schedule_by_name.assert_called_once_with("new-sched", exclude_managed_by="studio")
         mock_db.create_schedule.assert_called_once()
 
     @patch("agno.scheduler.cron._require_pytz")
@@ -160,6 +169,25 @@ class TestCreateSchedule:
         )
         assert resp.status_code == 409
         assert "already exists" in resp.json()["detail"]
+
+    @patch("agno.scheduler.cron._require_pytz")
+    @patch("agno.scheduler.cron._require_croniter")
+    @patch("agno.scheduler.cron.validate_cron_expr", return_value=True)
+    @patch("agno.scheduler.cron.validate_timezone", return_value=True)
+    @patch("agno.scheduler.cron.compute_next_run", return_value=int(time.time()) + 60)
+    def test_create_constraint_race_maps_to_conflict(
+        self, mock_compute, mock_tz, mock_cron, mock_req_cron, mock_req_pytz, client, mock_db
+    ):
+        mock_db.get_schedule_by_name = MagicMock(return_value=None)
+        mock_db.create_schedule = MagicMock(side_effect=ScheduleNameConflictError("new-sched"))
+
+        resp = client.post(
+            "/schedules",
+            json={"name": "new-sched", "cron_expr": "0 9 * * *", "endpoint": "/test"},
+        )
+
+        assert resp.status_code == 409
+        assert "new-sched" in resp.json()["detail"]
 
 
 # =============================================================================
@@ -208,6 +236,16 @@ class TestUpdateSchedule:
         resp = client.patch("/schedules/sched-1", json={})
         assert resp.status_code == 200
         mock_db.update_schedule.assert_not_called()
+
+    def test_rename_constraint_race_maps_to_conflict(self, client, mock_db):
+        mock_db.get_schedule = MagicMock(return_value=_make_schedule_dict())
+        mock_db.get_schedule_by_name = MagicMock(return_value=None)
+        mock_db.update_schedule = MagicMock(side_effect=ScheduleNameConflictError("renamed"))
+
+        resp = client.patch("/schedules/sched-1", json={"name": "renamed"})
+
+        assert resp.status_code == 409
+        assert "renamed" in resp.json()["detail"]
 
 
 # =============================================================================
@@ -351,6 +389,7 @@ class TestGetScheduleRun:
             "error": None,
             "created_at": now,
         }
+        mock_db.get_schedule = MagicMock(return_value=_make_schedule_dict())
         mock_db.get_schedule_run = MagicMock(return_value=run)
         resp = client.get("/schedules/sched-1/runs/r1")
         assert resp.status_code == 200
@@ -369,9 +408,39 @@ class TestGetScheduleRun:
             "status": "success",
             "created_at": int(time.time()),
         }
+        mock_db.get_schedule = MagicMock(return_value=_make_schedule_dict())
         mock_db.get_schedule_run = MagicMock(return_value=run)
         resp = client.get("/schedules/sched-1/runs/r1")
         assert resp.status_code == 404
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "json_body"),
+    [
+        ("GET", "/schedules/studio-schedule", None),
+        ("PATCH", "/schedules/studio-schedule", {"description": "overwritten"}),
+        ("DELETE", "/schedules/studio-schedule", None),
+        ("POST", "/schedules/studio-schedule/enable", None),
+        ("POST", "/schedules/studio-schedule/disable", None),
+        ("POST", "/schedules/studio-schedule/trigger", None),
+        ("GET", "/schedules/studio-schedule/runs", None),
+        ("GET", "/schedules/studio-schedule/runs/run-1", None),
+    ],
+)
+def test_generic_routes_hide_studio_schedule_ids(client, mock_db, method, path, json_body):
+    mock_db.get_schedule.return_value = _make_schedule_dict(
+        id="studio-schedule",
+        managed_by="studio",
+        owner_actor_id="actor-1",
+    )
+
+    response = client.request(method, path, json=json_body)
+
+    assert response.status_code == 404
+    mock_db.update_schedule.assert_not_called()
+    mock_db.delete_schedule.assert_not_called()
+    mock_db.get_schedule_runs.assert_not_called()
+    mock_db.get_schedule_run.assert_not_called()
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/os/test_draft_component_visibility.py
+++ b/libs/agno/tests/unit/os/test_draft_component_visibility.py
@@ -1,0 +1,53 @@
+"""Draft catalog reads stay visible without becoming runtime-dispatchable."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.os import AgentOS
+from agno.os.utils import get_agent_by_id, get_team_by_id, get_workflow_by_id
+from agno.team import Team
+from agno.workflow import Workflow
+
+
+@pytest.fixture
+def draft_component_client(tmp_path) -> TestClient:
+    db = SqliteDb(db_file=str(tmp_path / "draft-component-routes.db"))
+    assert Agent(id="draft-agent", name="Draft Agent", db=db).save(stage="draft") == 1
+    assert Team(id="draft-team", name="Draft Team", members=[], db=db).save(stage="draft") == 1
+    assert Workflow(id="draft-workflow", name="Draft Workflow", db=db).save(stage="draft") == 1
+
+    return TestClient(AgentOS(id="draft-component-os", db=db, telemetry=False).get_app())
+
+
+@pytest.mark.parametrize(
+    ("detail_path", "run_path"),
+    [
+        ("/agents/draft-agent", "/agents/draft-agent/runs"),
+        ("/teams/draft-team", "/teams/draft-team/runs"),
+        ("/workflows/draft-workflow", "/workflows/draft-workflow/runs"),
+    ],
+)
+def test_draft_details_are_readable_but_run_dispatch_is_published_only(
+    draft_component_client: TestClient,
+    detail_path: str,
+    run_path: str,
+) -> None:
+    detail = draft_component_client.get(detail_path)
+    dispatched = draft_component_client.post(run_path, data={"message": "must not run", "stream": "false"})
+
+    assert detail.status_code == 200
+    assert dispatched.status_code == 404
+    assert dispatched.json()["detail"] in {"Agent not found", "Team not found", "Workflow not found"}
+
+
+def test_exact_version_explicitly_previews_draft_components(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "draft-component-preview.db"))
+    assert Agent(id="draft-agent", name="Draft Agent", db=db).save(stage="draft") == 1
+    assert Team(id="draft-team", name="Draft Team", members=[], db=db).save(stage="draft") == 1
+    assert Workflow(id="draft-workflow", name="Draft Workflow", db=db).save(stage="draft") == 1
+
+    assert get_agent_by_id("draft-agent", db=db, version=1) is not None
+    assert get_team_by_id("draft-team", db=db, version=1) is not None
+    assert get_workflow_by_id("draft-workflow", db=db, version=1) is not None

--- a/libs/agno/tests/unit/os/test_openapi_operation_ids.py
+++ b/libs/agno/tests/unit/os/test_openapi_operation_ids.py
@@ -1,0 +1,25 @@
+"""Every operationId served by a mounted AgentOS app must be unique.
+
+Duplicate operationIds make the emitted OpenAPI document invalid and cause
+SDK generators to overwrite or mangle one of the colliding methods.
+"""
+
+from collections import Counter
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.os import AgentOS
+
+
+def test_served_operation_ids_are_unique(tmp_path):
+    db = SqliteDb(db_file=str(tmp_path / "ops.db"))
+    app = AgentOS(agents=[Agent(name="op-probe", db=db)], db=db).get_app()
+    spec = app.openapi()
+    ids = [
+        operation["operationId"]
+        for methods in spec["paths"].values()
+        for operation in methods.values()
+        if isinstance(operation, dict) and operation.get("operationId")
+    ]
+    duplicates = {op_id: count for op_id, count in Counter(ids).items() if count > 1}
+    assert duplicates == {}, f"duplicate operationIds break OpenAPI client generation: {duplicates}"

--- a/libs/agno/tests/unit/scheduler/test_manager.py
+++ b/libs/agno/tests/unit/scheduler/test_manager.py
@@ -8,6 +8,7 @@ import pytest
 pytest.importorskip("croniter", reason="croniter not installed")
 pytest.importorskip("pytz", reason="pytz not installed")
 
+from agno.db.sqlite import SqliteDb  # noqa: E402
 from agno.scheduler.manager import ScheduleManager  # noqa: E402
 
 # =============================================================================
@@ -43,6 +44,7 @@ def _make_schedule(**overrides):
 @pytest.fixture
 def mock_db():
     db = MagicMock()
+    db.scheduler_api_version = 2
     db.get_schedule = MagicMock(return_value=_make_schedule())
     db.get_schedule_by_name = MagicMock(return_value=None)
     db.get_schedules = MagicMock(return_value=[_make_schedule()])
@@ -69,6 +71,7 @@ class TestManagerCreate:
         assert result.name == "new-sched"
         assert result.cron_expr == "0 9 * * *"
         assert result.enabled is True
+        mock_db.get_schedule_by_name.assert_called_once_with("new-sched", exclude_managed_by="studio")
         mock_db.create_schedule.assert_called_once()
 
     def test_create_invalid_cron(self, mgr):
@@ -107,11 +110,21 @@ class TestManagerList:
     def test_list_all(self, mgr, mock_db):
         result = mgr.list()
         assert len(result) == 1
-        mock_db.get_schedules.assert_called_once_with(enabled=None, limit=100, page=1)
+        mock_db.get_schedules.assert_called_once_with(
+            enabled=None,
+            limit=100,
+            page=1,
+            exclude_managed_by="studio",
+        )
 
     def test_list_with_filters(self, mgr, mock_db):
         mgr.list(enabled=True, limit=10, page=2)
-        mock_db.get_schedules.assert_called_once_with(enabled=True, limit=10, page=2)
+        mock_db.get_schedules.assert_called_once_with(
+            enabled=True,
+            limit=10,
+            page=2,
+            exclude_managed_by="studio",
+        )
 
 
 class TestManagerGet:
@@ -173,6 +186,38 @@ class TestManagerGetRuns:
         mock_db.get_schedule_runs.assert_called_once_with("sched-1", limit=5, page=2)
 
 
+def test_generic_manager_isolates_studio_schedule_by_name_and_id(tmp_path):
+    db = SqliteDb(db_file=str(tmp_path / "manager-namespace.db"))
+    studio_schedule = _make_schedule(
+        id="studio-schedule",
+        name="shared-name",
+        cron_expr="0 1 * * *",
+        managed_by="studio",
+        owner_actor_id="actor-1",
+    )
+    db.create_schedule(studio_schedule)
+    manager = ScheduleManager(db)
+
+    generic = manager.create(
+        name="shared-name",
+        cron="0 2 * * *",
+        endpoint="/agents/generic/runs",
+        if_exists="update",
+    )
+
+    assert generic.id != "studio-schedule"
+    assert generic.managed_by is None
+    assert [schedule.id for schedule in manager.list()] == [generic.id]
+    assert manager.get("studio-schedule") is None
+    assert manager.update("studio-schedule", description="overwritten") is None
+    assert manager.delete("studio-schedule") is False
+    assert manager.get_runs("studio-schedule") == []
+    stored_studio = db.get_schedule("studio-schedule")
+    assert stored_studio is not None
+    assert stored_studio["cron_expr"] == "0 1 * * *"
+    assert stored_studio["description"] is None
+
+
 class TestManagerCallMissingMethod:
     def test_missing_method(self, mgr, mock_db):
         del mock_db.get_schedule
@@ -192,6 +237,7 @@ class TestManagerCallMissingMethod:
 @pytest.fixture
 def mock_async_db():
     db = MagicMock()
+    db.scheduler_api_version = 2
     db.get_schedule = AsyncMock(return_value=_make_schedule())
     db.get_schedule_by_name = AsyncMock(return_value=None)
     db.get_schedules = AsyncMock(return_value=[_make_schedule()])
@@ -212,6 +258,10 @@ class TestAsyncCreate:
     async def test_acreate_success(self, async_mgr, mock_async_db):
         result = await async_mgr.acreate(name="async-sched", cron="0 9 * * *", endpoint="/test")
         assert result.name == "async-sched"
+        mock_async_db.get_schedule_by_name.assert_awaited_once_with(
+            "async-sched",
+            exclude_managed_by="studio",
+        )
         mock_async_db.create_schedule.assert_called_once()
 
     @pytest.mark.asyncio
@@ -231,6 +281,28 @@ class TestAsyncList:
     async def test_alist(self, async_mgr, mock_async_db):
         result = await async_mgr.alist()
         assert len(result) == 1
+        mock_async_db.get_schedules.assert_awaited_once_with(
+            enabled=None,
+            limit=100,
+            page=1,
+            exclude_managed_by="studio",
+        )
+
+
+class TestAsyncStudioIsolation:
+    @pytest.mark.asyncio
+    async def test_studio_schedule_is_hidden_from_id_mutations(self, async_mgr, mock_async_db):
+        mock_async_db.get_schedule.return_value = _make_schedule(managed_by="studio", owner_actor_id="actor-1")
+
+        assert await async_mgr.aget("sched-1") is None
+        assert await async_mgr.aupdate("sched-1", description="overwritten") is None
+        assert await async_mgr.adelete("sched-1") is False
+        assert await async_mgr.aenable("sched-1") is None
+        assert await async_mgr.adisable("sched-1") is None
+        assert await async_mgr.aget_runs("sched-1") == []
+        mock_async_db.update_schedule.assert_not_awaited()
+        mock_async_db.delete_schedule.assert_not_awaited()
+        mock_async_db.get_schedule_runs.assert_not_awaited()
 
 
 class TestAsyncGet:

--- a/libs/agno/tests/unit/scheduler/test_schedule_model.py
+++ b/libs/agno/tests/unit/scheduler/test_schedule_model.py
@@ -15,6 +15,8 @@ class TestSchedule:
         assert s.method == "POST"
         assert s.timezone == "UTC"
         assert s.enabled is True
+        assert s.pending_trigger_count == 0
+        assert s.manual_trigger_claimed is False
         assert s.created_at is not None
 
     def test_to_dict(self):
@@ -26,6 +28,7 @@ class TestSchedule:
         assert d["endpoint"] == "/test"
         assert d["method"] == "POST"
         assert d["enabled"] is True
+        assert d["manual_trigger_claimed"] is False
         assert "created_at" in d
 
     def test_from_dict(self):

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agno.agent.agent import Agent
-from agno.db.base import BaseDb, ComponentType
+from agno.db.base import BaseDb, ComponentType, ComponentVersionGuard
 from agno.db.sqlite import SqliteDb
 from agno.registry import Registry
 from agno.session import TeamSession
@@ -692,13 +692,15 @@ class TestTeamSave:
             "deleted_at": None,
         }
         mock_db.upsert_config.return_value = {"version": 2}
+        guard = ComponentVersionGuard(latest_version=1, current_version=1)
 
         basic_team.db = mock_db
-        version = basic_team.save()
+        version = basic_team.save(guard=guard)
 
         mock_db.upsert_config.assert_called_once()
         call_args = mock_db.upsert_config.call_args
         assert call_args.kwargs["component_id"] == "test-team"
+        assert call_args.kwargs["guard"] == guard
         assert "config" in call_args.kwargs
         assert call_args.kwargs["projection"] == {
             "name": "Test Team",
@@ -1103,35 +1105,50 @@ class TestTeamDelete:
     def test_delete_calls_delete_component(self, basic_team, mock_db):
         """Test delete calls delete_component."""
         mock_db.delete_component.return_value = True
+        guard = ComponentVersionGuard(latest_version=1, current_version=1)
 
         basic_team.db = mock_db
-        result = basic_team.delete()
+        result = basic_team.delete(guard=guard)
 
         mock_db.delete_component.assert_called_once_with(
-            component_id="test-team", hard_delete=False, require_no_dependents=True
+            component_id="test-team",
+            hard_delete=False,
+            guard=guard,
+            require_no_dependents=True,
+            expected_component_type=ComponentType.TEAM,
         )
         assert result is True
 
     def test_delete_with_hard_delete(self, basic_team, mock_db):
         """Test delete with hard_delete flag."""
         mock_db.delete_component.return_value = True
+        guard = ComponentVersionGuard(latest_version=1, current_version=1)
 
         basic_team.db = mock_db
-        result = basic_team.delete(hard_delete=True)
+        result = basic_team.delete(hard_delete=True, guard=guard)
 
         mock_db.delete_component.assert_called_once_with(
-            component_id="test-team", hard_delete=True, require_no_dependents=True
+            component_id="test-team",
+            hard_delete=True,
+            guard=guard,
+            require_no_dependents=True,
+            expected_component_type=ComponentType.TEAM,
         )
         assert result is True
 
     def test_delete_can_explicitly_bypass_dependency_check(self, basic_team, mock_db):
         """Test delete forwards the dangerous dependency-check escape hatch."""
         basic_team.db = mock_db
+        guard = ComponentVersionGuard(latest_version=1, current_version=1)
 
-        assert basic_team.delete(require_no_dependents=False) is True
+        assert basic_team.delete(require_no_dependents=False, guard=guard) is True
 
         mock_db.delete_component.assert_called_once_with(
-            component_id="test-team", hard_delete=False, require_no_dependents=False
+            component_id="test-team",
+            hard_delete=False,
+            guard=guard,
+            require_no_dependents=False,
+            expected_component_type=ComponentType.TEAM,
         )
 
     def test_delete_uses_exact_catalog_v1_signature(self, basic_team, mock_db):
@@ -1153,7 +1170,10 @@ class TestTeamDelete:
         """Test delete uses explicitly provided db."""
         mock_db.delete_component.return_value = True
 
-        result = basic_team.delete(db=mock_db)
+        result = basic_team.delete(
+            db=mock_db,
+            guard=ComponentVersionGuard(latest_version=1, current_version=1),
+        )
 
         mock_db.delete_component.assert_called_once()
         assert result is True
@@ -1168,7 +1188,7 @@ class TestTeamDelete:
         mock_db.delete_component.return_value = False
 
         basic_team.db = mock_db
-        result = basic_team.delete()
+        result = basic_team.delete(guard=ComponentVersionGuard(latest_version=1, current_version=1))
 
         assert result is False
 

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -28,6 +28,21 @@ from agno.team.team import Team, get_team_by_id, get_teams
 # =============================================================================
 
 
+def _corrupt_delete_config_row(db: SqliteDb, component_id: str, version: int) -> None:
+    """Simulate an externally corrupted pin without weakening the public API."""
+    configs_table = db._get_table(table_type="component_configs")
+    assert configs_table is not None
+    with db.Session() as session:
+        result = session.execute(
+            configs_table.delete().where(
+                configs_table.c.component_id == component_id,
+                configs_table.c.version == version,
+            )
+        )
+        session.commit()
+    assert result.rowcount == 1
+
+
 def _create_mock_db_class():
     """Create a concrete BaseDb subclass with all abstract methods stubbed."""
     abstract_methods = {}
@@ -43,12 +58,17 @@ def mock_db():
     """Create a mock database instance that passes isinstance(db, BaseDb)."""
     MockDbClass = _create_mock_db_class()
     db = MockDbClass()
+    db.component_catalog_api_version = 2
 
     # Configure common mock methods
+    db.get_component = MagicMock(return_value=None)
+    db.create_component_with_config = MagicMock(return_value=({"component_id": "test-team"}, {"version": 1}))
     db.upsert_component = MagicMock()
     db.upsert_config = MagicMock(return_value={"version": 1})
     db.delete_component = MagicMock(return_value=True)
     db.get_config = MagicMock()
+    db.get_current_config = db.get_config
+    db.get_latest_config = db.get_config
     db.list_components = MagicMock()
     db.upsert_component_link = MagicMock()
     db.load_component_graph = MagicMock()
@@ -649,24 +669,28 @@ class TestTeamFromDict:
 class TestTeamSave:
     """Tests for Team.save() method."""
 
-    def test_save_calls_upsert_component(self, basic_team, mock_db):
-        """Test save calls upsert_component with correct parameters."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+    def test_save_creates_component_and_initial_config_atomically(self, basic_team, mock_db):
+        """Test first save creates the component and config together."""
         basic_team.db = mock_db
         version = basic_team.save()
 
-        mock_db.upsert_component.assert_called_once_with(
-            component_id="test-team",
-            component_type=ComponentType.TEAM,
-            name="Test Team",
-            description="A test team for unit testing",
-            metadata=None,
-        )
+        call_args = mock_db.create_component_with_config.call_args
+        assert call_args.kwargs["component_id"] == "test-team"
+        assert call_args.kwargs["component_type"] == ComponentType.TEAM
+        assert call_args.kwargs["name"] == "Test Team"
+        assert call_args.kwargs["description"] == "A test team for unit testing"
+        assert call_args.kwargs["config"]["id"] == "test-team"
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_not_called()
         assert version == 1
 
-    def test_save_calls_upsert_config(self, basic_team, mock_db):
-        """Test save calls upsert_config with team config."""
+    def test_existing_save_upserts_config_with_projection(self, basic_team, mock_db):
+        """Test a published save updates config and projection together."""
+        mock_db.get_component.return_value = {
+            "component_id": "test-team",
+            "component_type": "team",
+            "deleted_at": None,
+        }
         mock_db.upsert_config.return_value = {"version": 2}
 
         basic_team.db = mock_db
@@ -676,6 +700,11 @@ class TestTeamSave:
         call_args = mock_db.upsert_config.call_args
         assert call_args.kwargs["component_id"] == "test-team"
         assert "config" in call_args.kwargs
+        assert call_args.kwargs["projection"] == {
+            "name": "Test Team",
+            "description": "A test team for unit testing",
+            "metadata": None,
+        }
         assert version == 2
 
     def test_save_with_members_saves_each_member(self, mock_db, member_agent):
@@ -709,8 +738,8 @@ class TestTeamSave:
         )
         team.save()
 
-        # Check that links were passed to upsert_config
-        call_args = mock_db.upsert_config.call_args
+        # Check that links were committed with the initial config
+        call_args = mock_db.create_component_with_config.call_args
         links = call_args.kwargs.get("links")
         assert links is not None
         assert len(links) == 1
@@ -721,33 +750,47 @@ class TestTeamSave:
 
     def test_save_with_explicit_db(self, basic_team, mock_db):
         """Test save uses explicitly provided db."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
         version = basic_team.save(db=mock_db)
 
-        mock_db.upsert_component.assert_called_once()
-        mock_db.upsert_config.assert_called_once()
+        mock_db.create_component_with_config.assert_called_once()
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_not_called()
         assert version == 1
 
     def test_save_with_label(self, basic_team, mock_db):
-        """Test save passes label to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes the label to the atomic create."""
         basic_team.db = mock_db
         basic_team.save(label="production")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["label"] == "production"
 
     def test_save_with_stage(self, basic_team, mock_db):
-        """Test save passes stage to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes the stage to the atomic create."""
         basic_team.db = mock_db
         basic_team.save(stage="draft")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["stage"] == "draft"
+
+    def test_save_draft_team_with_draft_member_on_real_sqlite(self, tmp_path):
+        """A draft composite may pin a draft child; publication validates it later."""
+        db = SqliteDb(db_file=str(tmp_path / "draft_team.db"))
+        member = Agent(id="draft-member", name="Draft Member")
+        team = Team(id="draft-team", name="Draft Team", members=[member], db=db)
+
+        version = team.save(stage="draft")
+
+        assert version == 1
+        assert db.get_config("draft-member", version=1)["stage"] == "draft"  # type: ignore[index]
+        assert db.get_config("draft-team", version=1)["stage"] == "draft"  # type: ignore[index]
+        links = db.get_links("draft-team", 1)
+        assert len(links) == 1
+        assert links[0]["link_kind"] == "member"
+        assert links[0]["link_key"] == "member_0"
+        assert links[0]["child_component_id"] == "draft-member"
+        assert links[0]["child_version"] == 1
+        assert links[0]["meta"] == {"type": "agent"}
 
     def test_save_without_db_raises_error(self, basic_team):
         """Test save raises error when no db is available."""
@@ -756,7 +799,7 @@ class TestTeamSave:
 
     def test_save_handles_db_error(self, basic_team, mock_db):
         """Test save raises error when database operation fails."""
-        mock_db.upsert_component.side_effect = Exception("Database error")
+        mock_db.create_component_with_config.side_effect = Exception("Database error")
 
         basic_team.db = mock_db
 
@@ -1064,7 +1107,9 @@ class TestTeamDelete:
         basic_team.db = mock_db
         result = basic_team.delete()
 
-        mock_db.delete_component.assert_called_once_with(component_id="test-team", hard_delete=False)
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-team", hard_delete=False, require_no_dependents=True
+        )
         assert result is True
 
     def test_delete_with_hard_delete(self, basic_team, mock_db):
@@ -1074,8 +1119,35 @@ class TestTeamDelete:
         basic_team.db = mock_db
         result = basic_team.delete(hard_delete=True)
 
-        mock_db.delete_component.assert_called_once_with(component_id="test-team", hard_delete=True)
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-team", hard_delete=True, require_no_dependents=True
+        )
         assert result is True
+
+    def test_delete_can_explicitly_bypass_dependency_check(self, basic_team, mock_db):
+        """Test delete forwards the dangerous dependency-check escape hatch."""
+        basic_team.db = mock_db
+
+        assert basic_team.delete(require_no_dependents=False) is True
+
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-team", hard_delete=False, require_no_dependents=False
+        )
+
+    def test_delete_uses_exact_catalog_v1_signature(self, basic_team, mock_db):
+        """The v2 dependency keyword must never reach a legacy override."""
+        calls = []
+
+        def legacy_delete(component_id, hard_delete=False):
+            calls.append((component_id, hard_delete))
+            return True
+
+        mock_db.component_catalog_api_version = 1
+        mock_db.delete_component = legacy_delete
+        basic_team.db = mock_db
+
+        assert basic_team.delete(require_no_dependents=False) is True
+        assert calls == [("test-team", False)]
 
     def test_delete_with_explicit_db(self, basic_team, mock_db):
         """Test delete uses explicitly provided db."""
@@ -1132,6 +1204,37 @@ class TestGetTeamById:
         assert team is not None
         assert team.id == "found-team"
         assert team.name == "Found Team"
+        mock_db.get_config.assert_called_once_with(component_id="found-team", version=None, label=None)
+
+    def test_get_team_by_id_returns_draft_only_team_and_member(self, tmp_path):
+        """Draft fallback also applies to an unpinned member loaded by Team.from_dict."""
+        db = SqliteDb(db_file=str(tmp_path / "draft-only-team.db"))
+        member = Agent(id="draft-member", name="Draft Member", db=db)
+        assert member.save(stage="draft") == 1
+        assert db.get_current_config("draft-member") is None
+
+        db.upsert_component(
+            component_id="draft-team",
+            component_type=ComponentType.TEAM,
+            name="Draft Team",
+        )
+        db.upsert_config(
+            component_id="draft-team",
+            stage="draft",
+            config={
+                "id": "draft-team",
+                "name": "Draft Team",
+                "members": [{"type": "agent", "agent_id": "draft-member"}],
+            },
+        )
+        assert db.get_current_config("draft-team") is None
+
+        loaded = get_team_by_id(db=db, id="draft-team")
+
+        assert loaded is not None
+        assert loaded.id == "draft-team"
+        assert len(loaded.members) == 1
+        assert loaded.members[0].id == "draft-member"
 
     def test_get_team_by_id_with_version(self, mock_db):
         """Test get_team_by_id retrieves specific version."""
@@ -1214,16 +1317,20 @@ class TestGetTeams:
             ],
             None,
         )
-        mock_db.get_config.side_effect = [
-            {"config": {"id": "team-1", "name": "Team 1"}},
-            {"config": {"id": "team-2", "name": "Team 2"}},
-        ]
+        mock_db.get_latest_config = MagicMock(
+            side_effect=[
+                {"config": {"id": "team-1", "name": "Team 1"}},
+                {"config": {"id": "team-2", "name": "Team 2"}},
+            ]
+        )
 
         teams = get_teams(db=mock_db)
 
         assert len(teams) == 2
         assert teams[0].id == "team-1"
         assert teams[1].id == "team-2"
+        assert mock_db.get_latest_config.call_count == 2
+        mock_db.get_config.assert_not_called()
 
     def test_get_teams_filters_by_type(self, mock_db):
         """Test get_teams filters by TEAM component type."""
@@ -1340,7 +1447,7 @@ class TestMemberPinFailures:
         member.save(db=db)
         links = db.get_links(component_id="pm-team", version=1)
         pinned = next(link for link in links if link["link_kind"] == "member")["child_version"]
-        assert db.delete_config(component_id="pm-member", version=pinned)
+        _corrupt_delete_config_row(db, "pm-member", pinned)
 
         with pytest.raises(ComponentRehydrationError, match=f"pins member agent 'pm-member' at version {pinned}"):
             get_team_by_id(db=db, id="pm-team", strict=True)
@@ -1357,7 +1464,7 @@ class TestMemberPinFailures:
         member.save(db=db)
         links = db.get_links(component_id="ps-team", version=1)
         pinned = next(link for link in links if link["link_kind"] == "member")["child_version"]
-        assert db.delete_config(component_id="ps-member", version=pinned)
+        _corrupt_delete_config_row(db, "ps-member", pinned)
         registry = Registry(agents=[Agent(id="ps-member", name="Code Member")])
 
         with pytest.raises(ComponentRehydrationError, match="pins member agent 'ps-member'"):

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -6,8 +6,10 @@ config persistence path is exercised, not mocked.
 
 import json
 import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from importlib.util import find_spec
+from threading import Barrier
 from typing import Any, Dict
 
 import pytest
@@ -125,6 +127,7 @@ class TestInitialization:
             "edit_agent",
             "delete_agent",
             "run_agent",
+            "restore_component",
         }
         assert expected == set(studio.functions.keys())
 
@@ -350,7 +353,7 @@ class TestCreateAgent:
         assert out["status"] == "created"
         assert out["tools"] == []
 
-    def test_slug_collisions_get_unique_ids(self, studio, db):
+    def test_canonical_id_collisions_get_unique_ids(self, studio, db):
         first = _loads(studio.create_agent(name="My Agent", instructions="i", model_id="gpt-5.4"))
         second = _loads(studio.create_agent(name="my-agent", instructions="i", model_id="gpt-5.4"))
         third = _loads(studio.create_agent(name="My--Agent", instructions="i", model_id="gpt-5.4"))
@@ -362,6 +365,61 @@ class TestCreateAgent:
         assert db.get_component("my-agent-2")["name"] == "my-agent"
         assert db.get_component("my-agent-3")["name"] == "My--Agent"
 
+    def test_generated_id_matches_direct_save(self, studio, tmp_path):
+        name = "R&D Jörg"
+        direct = Agent(name=name, db=SqliteDb(db_file=str(tmp_path / "direct-studio-id.db")))
+        assert direct.save(stage="draft") == 1
+
+        created = _loads(studio.create_agent(name=name, instructions="i", model_id="gpt-5.4"))
+
+        assert direct.id == "r-d-jörg"
+        assert created["id"] == direct.id
+
+    def test_create_persists_complete_null_projection(self, studio, db):
+        created = _loads(
+            studio.create_agent(
+                name="Projection Agent",
+                instructions="i",
+                model_id="gpt-5.4",
+                description=None,
+            )
+        )
+
+        config = db.get_config(created["id"], version=1)["config"]
+        assert config["name"] == "Projection Agent"
+        assert "description" in config and config["description"] is None
+        assert "metadata" in config and config["metadata"] is None
+
+    def test_concurrent_create_reserves_distinct_component_ids(self, studio, db, monkeypatch):
+        # Initialize the SQLite catalog before synchronizing the two inserts.
+        studio.create_agent(name="seed", instructions="i", model_id="gpt-5.4")
+        original_exists = studio._component_id_exists
+        ready = Barrier(2)
+
+        def synchronize_candidate(component_id, target_db):
+            exists = original_exists(component_id, target_db)
+            if component_id == "race-agent" and not exists:
+                ready.wait(timeout=5)
+            return exists
+
+        monkeypatch.setattr(studio, "_component_id_exists", synchronize_candidate)
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [
+                pool.submit(
+                    studio.create_agent,
+                    name="Race Agent",
+                    instructions=f"instructions-{index}",
+                    model_id="gpt-5.4",
+                )
+                for index in range(2)
+            ]
+        created = [_loads(future.result()) for future in futures]
+
+        assert sorted(result["id"] for result in created) == ["race-agent", "race-agent-2"]
+        for result in created:
+            versions = db.list_configs(result["id"], include_config=True)
+            assert [(row["version"], row["stage"]) for row in versions] == [(1, "published")]
+
     def test_component_ids_share_global_namespace(self, studio):
         studio.create_agent(name="member", instructions="i", model_id="gpt-5.4")
         team = _loads(studio.create_team(name="Reporter", instructions="i", member_ids=["member"], model_id="gpt-5.4"))
@@ -371,10 +429,10 @@ class TestCreateAgent:
         assert agent["id"] == "reporter-2"
 
     def test_persist_failure_returns_error(self, studio, db, monkeypatch):
-        def fail_upsert_config(*args, **kwargs):
+        def fail_atomic_create(*args, **kwargs):
             raise RuntimeError("persist failed")
 
-        monkeypatch.setattr(db, "upsert_config", fail_upsert_config)
+        monkeypatch.setattr(db, "create_component_with_config", fail_atomic_create)
 
         out = _loads(studio.create_agent(name="broken", instructions="i", model_id="gpt-5.4"))
         assert "error" in out
@@ -1043,6 +1101,40 @@ class TestEditWithoutVersioning:
         assert out["version"] == 3
         assert db.get_config("tutor")["version"] == 3
 
+    def test_default_edit_rejects_a_competing_publish(self, studio, db, monkeypatch):
+        from agno.db.base import ComponentVersionGuard
+
+        studio.create_agent(name="tutor", instructions="orig", model_id="gpt-5.4")
+        original_save = studio._save_edit
+
+        def save_after_competing_publish(*args, **kwargs):
+            stored = db.get_config("tutor", version=1)
+            assert stored is not None
+            competing = dict(stored["config"])
+            competing["description"] = "winner"
+            db.upsert_config(
+                component_id="tutor",
+                config=competing,
+                stage="published",
+                guard=ComponentVersionGuard(latest_version=1, current_version=1),
+            )
+            return original_save(*args, **kwargs)
+
+        monkeypatch.setattr(studio, "_save_edit", save_after_competing_publish)
+
+        out = _loads(studio.edit_agent("tutor", instructions="stale"))
+
+        assert "version conflict" in out["error"]
+        assert [row["version"] for row in db.list_configs("tutor")] == [2, 1]
+        assert db.get_current_config("tutor")["config"]["description"] == "winner"
+
+    def test_every_studio_written_version_carries_ownership_marker(self, studio, db):
+        studio.create_agent(name="tutor", instructions="orig", model_id="gpt-5.4")
+        studio.edit_agent("tutor", instructions="updated")
+
+        configs = db.list_configs("tutor", include_config=True)
+        assert [row["config"]["_agno_studio"]["schema_version"] for row in configs] == [2, 2]
+
 
 class TestEditTeam:
     def _setup(self, studio):
@@ -1261,6 +1353,47 @@ class TestVersioning:
         assert out["status"] == "set_current"
         assert out["version"] == 1
 
+    def test_set_current_version_rejects_concurrent_publication(self, studio_versioned, db, monkeypatch):
+        from agno.db.base import ComponentVersionGuard
+
+        self._create_and_edit(studio_versioned)
+        studio_versioned.publish_component("tutor")
+        original_set_current = db.set_current_version
+
+        def publish_before_rollback(*args, **kwargs):
+            current = db.get_config("tutor", version=2)
+            assert current is not None
+            competing = dict(current["config"])
+            competing["description"] = "concurrent publication"
+            db.upsert_config(
+                component_id="tutor",
+                config=competing,
+                stage="published",
+                guard=ComponentVersionGuard(latest_version=2, current_version=2),
+            )
+            return original_set_current(*args, **kwargs)
+
+        monkeypatch.setattr(db, "set_current_version", publish_before_rollback)
+        out = _loads(studio_versioned.set_current_version("tutor", 1))
+
+        assert "version conflict" in out["error"]
+        assert db.get_component("tutor")["current_version"] == 3
+
+    def test_set_current_version_restores_explicit_null_projection(self, studio_versioned, db):
+        studio_versioned.create_agent(
+            name="nullable",
+            instructions="original",
+            model_id="gpt-5.4",
+            description=None,
+        )
+        studio_versioned.edit_agent("nullable", description="new description")
+        studio_versioned.publish_component("nullable")
+
+        out = _loads(studio_versioned.set_current_version("nullable", 1))
+
+        assert out["status"] == "set_current"
+        assert db.get_component("nullable")["description"] is None
+
     def test_delete_draft_version(self, studio_versioned):
         self._create_and_edit(studio_versioned)
         out = _loads(studio_versioned.delete_version("tutor", 2))
@@ -1269,6 +1402,30 @@ class TestVersioning:
         versions = _loads(studio_versioned.list_versions("tutor"))
         assert versions["count"] == 1
         assert versions["versions"][0]["version"] == 1
+
+    def test_delete_draft_rejects_a_competing_append(self, studio_versioned, db, monkeypatch):
+        from agno.db.base import ComponentVersionGuard
+
+        self._create_and_edit(studio_versioned)
+        original_delete = db.delete_config
+
+        def delete_after_competing_append(*args, **kwargs):
+            base = db.get_config("tutor", version=2)
+            assert base is not None
+            db.upsert_config(
+                "tutor",
+                config=dict(base["config"]),
+                stage="draft",
+                guard=ComponentVersionGuard(latest_version=2, current_version=1),
+            )
+            return original_delete(*args, **kwargs)
+
+        monkeypatch.setattr(db, "delete_config", delete_after_competing_append)
+
+        out = _loads(studio_versioned.delete_version("tutor", 2))
+
+        assert "version conflict" in out["error"]
+        assert [row["version"] for row in db.list_configs("tutor")] == [3, 2, 1]
 
     def test_delete_published_version_returns_error(self, studio_versioned):
         self._create_and_edit(studio_versioned)
@@ -1457,12 +1614,25 @@ class TestDelete:
     def test_delete_agent_removes_from_db(self, studio, db):
         studio.create_agent(name="temp", instructions="i", model_id="gpt-5.4")
         out = _loads(studio.delete_agent("temp"))
-        assert out["status"] == "deleted"
+        assert out["status"] == "archived"
         assert db.get_component("temp") is None
 
     def test_delete_unknown_agent_returns_error(self, studio):
         out = _loads(studio.delete_agent("ghost"))
         assert "error" in out
+
+    def test_archive_reserves_id_and_explicit_restore_keeps_history(self, studio, db):
+        created = _loads(studio.create_agent(name="temp", instructions="i", model_id="gpt-5.4"))
+        assert created["id"] == "temp"
+        assert _loads(studio.delete_agent("temp"))["status"] == "archived"
+
+        replacement = _loads(studio.create_agent(name="temp", instructions="replacement", model_id="gpt-5.4"))
+        assert replacement["id"] == "temp-2"
+        restored = _loads(studio.restore_component("temp"))
+
+        assert restored == {"status": "restored", "id": "temp"}
+        assert db.get_component("temp") is not None
+        assert [row["version"] for row in db.list_configs("temp")] == [1]
 
     def test_delete_agent_only_deletes_db_component_when_live_agent_shadows_id(self, registry, db):
         studio = StudioTools(registry=registry, db=db)
@@ -1478,7 +1648,7 @@ class TestDelete:
         tool = StudioTools(registry=registry, db=db, agents_list=[ShadowAgent()])
 
         out = _loads(tool.delete_agent("temp"))
-        assert out["status"] == "deleted"
+        assert out["status"] == "archived"
         assert db.get_component("temp") is None
 
 

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -908,15 +908,15 @@ class TestEditAgent:
         assert out["stage"] == "draft"
         assert out["draft_version"] == 2
 
-    def test_second_edit_updates_same_draft_in_place(self, studio_versioned):
+    def test_second_edit_appends_an_immutable_draft(self, studio_versioned):
         self._create(studio_versioned)
         studio_versioned.edit_agent(agent_id="tutor", instructions="updated once")
         out = _loads(studio_versioned.edit_agent(agent_id="tutor", instructions="updated twice"))
-        assert out["draft_version"] == 2  # same draft, no new version
+        assert out["draft_version"] == 3
 
         versions = _loads(studio_versioned.list_versions("tutor"))
         stages = [v["stage"] for v in versions["versions"]]
-        assert stages.count("draft") == 1
+        assert stages.count("draft") == 2
         assert stages.count("published") == 1
 
     def test_successive_partial_edits_accumulate_in_draft(self, studio_versioned):
@@ -948,7 +948,7 @@ class TestEditAgent:
         assert got["add_history_to_context"] is True  # untouched from create
         assert got["num_history_runs"] == 7
 
-    def test_history_edit_accumulates_in_same_draft(self, studio_versioned):
+    def test_history_edit_accumulates_in_latest_draft(self, studio_versioned):
         self._create(studio_versioned)
         studio_versioned.edit_agent(agent_id="tutor", add_history_to_context=False)
         out = _loads(studio_versioned.edit_agent(agent_id="tutor", description="new description"))
@@ -956,6 +956,33 @@ class TestEditAgent:
         draft = _loads(studio_versioned.get_version("tutor", version=out["draft_version"]))
         assert "add_history_to_context" not in draft["config"]  # history off survives edit 2
         assert draft["config"]["description"] == "new description"
+
+    def test_edit_rejects_a_competing_append_after_its_snapshot(self, studio_versioned, db, monkeypatch):
+        from agno.db.base import ComponentVersionGuard
+
+        self._create(studio_versioned)
+        original_save = studio_versioned._save_edit
+
+        def save_after_competing_append(*args, **kwargs):
+            stored = db.get_config("tutor", version=1)
+            assert stored is not None
+            competing = dict(stored["config"])
+            competing["description"] = "competing edit"
+            db.upsert_config(
+                component_id="tutor",
+                config=competing,
+                stage="draft",
+                guard=ComponentVersionGuard(latest_version=1, current_version=1),
+            )
+            return original_save(*args, **kwargs)
+
+        monkeypatch.setattr(studio_versioned, "_save_edit", save_after_competing_append)
+        out = _loads(studio_versioned.edit_agent(agent_id="tutor", instructions="stale edit"))
+
+        assert "version conflict" in out["error"]
+        versions = sorted(db.list_configs("tutor", include_config=True), key=lambda row: row["version"])
+        assert [row["version"] for row in versions] == [1, 2]
+        assert versions[1]["config"]["description"] == "competing edit"
 
     def test_get_agent_reports_history_settings(self, studio):
         self._create(studio)
@@ -1162,6 +1189,60 @@ class TestVersioning:
         out = _loads(studio_versioned.publish_component("tutor", version=2))
         assert out["status"] == "already_published"
         assert out["version"] == 2
+
+    def test_publish_rejects_a_competing_append_after_its_snapshot(self, studio_versioned, db, monkeypatch):
+        from agno.db.base import ComponentVersionGuard
+
+        self._create_and_edit(studio_versioned)
+        original_upsert = db.upsert_config
+
+        def upsert_after_competing_append(*args, **kwargs):
+            stored = db.get_config("tutor", version=2)
+            assert stored is not None
+            competing = dict(stored["config"])
+            competing["description"] = "newer draft"
+            original_upsert(
+                component_id="tutor",
+                config=competing,
+                stage="draft",
+                guard=ComponentVersionGuard(latest_version=2, current_version=1),
+            )
+            return original_upsert(*args, **kwargs)
+
+        monkeypatch.setattr(db, "upsert_config", upsert_after_competing_append)
+        out = _loads(studio_versioned.publish_component("tutor"))
+
+        assert "version conflict" in out["error"]
+        assert db.get_component("tutor")["current_version"] == 1
+        versions = sorted(db.list_configs("tutor"), key=lambda row: row["version"])
+        assert [(row["version"], row["stage"]) for row in versions] == [
+            (1, "published"),
+            (2, "draft"),
+            (3, "draft"),
+        ]
+
+    def test_catalog_v1_bridge_keeps_legacy_upsert_call_shape(self, studio_versioned, db, monkeypatch):
+        self._create_and_edit(studio_versioned)
+        calls: list[Dict[str, Any]] = []
+
+        def capture_upsert(*args, **kwargs):
+            calls.append(kwargs)
+            return {"version": kwargs.get("version") or 3}
+
+        monkeypatch.setattr(db, "component_catalog_api_version", 1)
+        monkeypatch.setattr(db, "upsert_config", capture_upsert)
+
+        edited = _loads(studio_versioned.edit_agent("tutor", description="legacy edit"))
+        published = _loads(studio_versioned.publish_component("tutor"))
+
+        assert edited["status"] == "edited"
+        assert published["status"] == "published"
+        assert len(calls) == 2
+        assert calls[0]["version"] == 2
+        assert calls[0]["stage"] == "draft"
+        assert calls[1]["version"] == 2
+        assert calls[1]["stage"] == "published"
+        assert all("guard" not in call for call in calls)
 
     def test_publish_unknown_version_returns_error(self, studio_versioned):
         studio_versioned.create_agent(name="tutor", instructions="i", model_id="gpt-5.4")
@@ -1670,16 +1751,16 @@ class TestLifecycle:
         )
         assert out["db_version"] == 1
 
-        # Edit twice — should collapse into one draft
+        # Every edit appends an immutable draft and builds on the latest one.
         studio_versioned.edit_agent(agent_id="lc", instructions="edit1")
         studio_versioned.edit_agent(agent_id="lc", instructions="edit2")
 
         versions: list[Dict[str, Any]] = _loads(studio_versioned.list_versions("lc"))["versions"]
-        assert len(versions) == 2
+        assert len(versions) == 3
 
-        # Publish draft
+        # Publish the latest draft.
         pub = _loads(studio_versioned.publish_component("lc"))
-        assert pub["version"] == 2
+        assert pub["version"] == 3
 
         # Rollback
         rb = _loads(studio_versioned.set_current_version("lc", 1))

--- a/libs/agno/tests/unit/tools/test_studio_runner.py
+++ b/libs/agno/tests/unit/tools/test_studio_runner.py
@@ -1740,7 +1740,7 @@ class TestStudioEmbedding:
         out = _loads(studio.delete_agent("Radar Scout"))
         assert "error" in out
         assert "radar-scout" in out["error"]
-        assert _loads(studio.delete_agent("radar-scout"))["status"] == "deleted"
+        assert _loads(studio.delete_agent("radar-scout"))["status"] == "archived"
 
     def test_edit_reaches_db_component_shadowed_by_code_defined_name(self, registry, db):
         # A code-defined component NAMED like a DB component's id must not make
@@ -3056,7 +3056,8 @@ def test_dispatch_never_mixes_config_and_links_from_different_versions(tmp_path)
 
     db = SqliteDb(db_file=str(tmp_path / "race.db"))
     member = Agent(id="rv-m", name="M", description="v1")
-    Team(id="rv-t", name="T", members=[member]).save(db=db)
+    persisted_team = Team(id="rv-t", name="T", members=[member])
+    persisted_team.save(db=db)
 
     runner = StudioRunnerTools(registry=Registry(), db=db)
     real_get_config = db.get_config
@@ -3068,7 +3069,7 @@ def test_dispatch_never_mixes_config_and_links_from_different_versions(tmp_path)
             state["raced"] = True
             member.description = "v2"
             member.save(db=db)
-            Team(id="rv-t", name="T", members=[member]).save(db=db)
+            persisted_team.save(db=db)
         return row
 
     db.get_config = racy_get_config

--- a/libs/agno/tests/unit/utils/test_string.py
+++ b/libs/agno/tests/unit/utils/test_string.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 from agno.utils.string import (
     _extract_json_objects,
+    generate_component_id_from_name,
     generate_id_from_name,
     parse_response_model_str,
     sanitize_postgres_string,
@@ -395,6 +396,15 @@ def test_generate_id_from_name_with_name():
     assert generate_id_from_name("Research/Review") == "research/review"
     assert generate_id_from_name("  Repeated  Spaces  ") == "--repeated--spaces--"
     assert generate_id_from_name("日本語") == "日本語"
+
+
+def test_generate_component_id_from_name_is_one_url_segment():
+    assert generate_component_id_from_name("My Agent") == "my-agent"
+    assert generate_component_id_from_name("Analyst v2.5") == "analyst-v2-5"
+    assert generate_component_id_from_name("R&D Jörg") == "r-d-jörg"
+    assert generate_component_id_from_name("Research/Review") == "research-review"
+    assert generate_component_id_from_name("  Repeated  Spaces  ") == "repeated-spaces"
+    assert generate_component_id_from_name("///") == "component"
 
 
 def test_generate_id_from_name_without_name():

--- a/libs/agno/tests/unit/utils/test_string.py
+++ b/libs/agno/tests/unit/utils/test_string.py
@@ -386,10 +386,15 @@ def test_parse_json_with_python_code_in_value():
 
 
 def test_generate_id_from_name_with_name():
-    """Test that named IDs are deterministic kebab-case"""
+    """Named IDs preserve the historical persisted-identity transformation."""
     assert generate_id_from_name("My Agent") == "my-agent"
     assert generate_id_from_name("hello_world") == "hello-world"
     assert generate_id_from_name("UPPER") == "upper"
+    assert generate_id_from_name("Analyst v2.5") == "analyst-v2.5"
+    assert generate_id_from_name("R&D Jörg") == "r&d-jörg"
+    assert generate_id_from_name("Research/Review") == "research/review"
+    assert generate_id_from_name("  Repeated  Spaces  ") == "--repeated--spaces--"
+    assert generate_id_from_name("日本語") == "日本語"
 
 
 def test_generate_id_from_name_without_name():

--- a/libs/agno/tests/unit/workflow/test_workflow_config.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_config.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from agno.db.base import BaseDb, ComponentType
+from agno.db.base import BaseDb, ComponentType, ComponentVersionGuard
 from agno.registry import Registry
 from agno.workflow.workflow import Workflow, get_workflow_by_id, get_workflows
 
@@ -327,13 +327,15 @@ class TestWorkflowSave:
             "deleted_at": None,
         }
         mock_db.upsert_config.return_value = {"version": 2}
+        guard = ComponentVersionGuard(latest_version=1, current_version=1)
 
         basic_workflow.db = mock_db
-        version = basic_workflow.save()
+        version = basic_workflow.save(guard=guard)
 
         mock_db.upsert_config.assert_called_once()
         call_args = mock_db.upsert_config.call_args
         assert call_args.kwargs["component_id"] == "test-workflow"
+        assert call_args.kwargs["guard"] == guard
         assert "config" in call_args.kwargs
         assert call_args.kwargs["projection"] == {
             "name": "Test Workflow",
@@ -489,35 +491,50 @@ class TestWorkflowDelete:
     def test_delete_calls_delete_component(self, basic_workflow, mock_db):
         """Test delete calls delete_component."""
         mock_db.delete_component.return_value = True
+        guard = ComponentVersionGuard(latest_version=1, current_version=1)
 
         basic_workflow.db = mock_db
-        result = basic_workflow.delete()
+        result = basic_workflow.delete(guard=guard)
 
         mock_db.delete_component.assert_called_once_with(
-            component_id="test-workflow", hard_delete=False, require_no_dependents=True
+            component_id="test-workflow",
+            hard_delete=False,
+            guard=guard,
+            require_no_dependents=True,
+            expected_component_type=ComponentType.WORKFLOW,
         )
         assert result is True
 
     def test_delete_with_hard_delete(self, basic_workflow, mock_db):
         """Test delete with hard_delete flag."""
         mock_db.delete_component.return_value = True
+        guard = ComponentVersionGuard(latest_version=1, current_version=1)
 
         basic_workflow.db = mock_db
-        result = basic_workflow.delete(hard_delete=True)
+        result = basic_workflow.delete(hard_delete=True, guard=guard)
 
         mock_db.delete_component.assert_called_once_with(
-            component_id="test-workflow", hard_delete=True, require_no_dependents=True
+            component_id="test-workflow",
+            hard_delete=True,
+            guard=guard,
+            require_no_dependents=True,
+            expected_component_type=ComponentType.WORKFLOW,
         )
         assert result is True
 
     def test_delete_can_explicitly_bypass_dependency_check(self, basic_workflow, mock_db):
         """Test delete forwards the dangerous dependency-check escape hatch."""
         basic_workflow.db = mock_db
+        guard = ComponentVersionGuard(latest_version=1, current_version=1)
 
-        assert basic_workflow.delete(require_no_dependents=False) is True
+        assert basic_workflow.delete(require_no_dependents=False, guard=guard) is True
 
         mock_db.delete_component.assert_called_once_with(
-            component_id="test-workflow", hard_delete=False, require_no_dependents=False
+            component_id="test-workflow",
+            hard_delete=False,
+            guard=guard,
+            require_no_dependents=False,
+            expected_component_type=ComponentType.WORKFLOW,
         )
 
     def test_delete_uses_exact_catalog_v1_signature(self, basic_workflow, mock_db):
@@ -539,7 +556,10 @@ class TestWorkflowDelete:
         """Test delete uses explicitly provided db."""
         mock_db.delete_component.return_value = True
 
-        result = basic_workflow.delete(db=mock_db)
+        result = basic_workflow.delete(
+            db=mock_db,
+            guard=ComponentVersionGuard(latest_version=1, current_version=1),
+        )
 
         mock_db.delete_component.assert_called_once()
         assert result is True
@@ -554,7 +574,7 @@ class TestWorkflowDelete:
         mock_db.delete_component.return_value = False
 
         basic_workflow.db = mock_db
-        result = basic_workflow.delete()
+        result = basic_workflow.delete(guard=ComponentVersionGuard(latest_version=1, current_version=1))
 
         assert result is False
 

--- a/libs/agno/tests/unit/workflow/test_workflow_config.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_config.py
@@ -25,6 +25,21 @@ from agno.workflow.workflow import Workflow, get_workflow_by_id, get_workflows
 # =============================================================================
 
 
+def _corrupt_delete_config_row(db: Any, component_id: str, version: int) -> None:
+    """Simulate an externally corrupted pin without weakening the public API."""
+    configs_table = db._get_table(table_type="component_configs")
+    assert configs_table is not None
+    with db.Session() as session:
+        result = session.execute(
+            configs_table.delete().where(
+                configs_table.c.component_id == component_id,
+                configs_table.c.version == version,
+            )
+        )
+        session.commit()
+    assert result.rowcount == 1
+
+
 def _create_mock_db_class():
     """Create a concrete BaseDb subclass with all abstract methods stubbed."""
     abstract_methods = {}
@@ -40,12 +55,17 @@ def mock_db():
     """Create a mock database instance that passes isinstance(db, BaseDb)."""
     MockDbClass = _create_mock_db_class()
     db = MockDbClass()
+    db.component_catalog_api_version = 2
 
     # Configure common mock methods
+    db.get_component = MagicMock(return_value=None)
+    db.create_component_with_config = MagicMock(return_value=({"component_id": "test-workflow"}, {"version": 1}))
     db.upsert_component = MagicMock()
     db.upsert_config = MagicMock(return_value={"version": 1})
     db.delete_component = MagicMock(return_value=True)
     db.get_config = MagicMock()
+    db.get_current_config = db.get_config
+    db.get_latest_config = db.get_config
     db.list_components = MagicMock()
     db.get_links = MagicMock()
     db.to_dict = MagicMock(return_value={"type": "postgres", "id": "test-db"})
@@ -284,24 +304,28 @@ class TestWorkflowFromDict:
 class TestWorkflowSave:
     """Tests for Workflow.save() method."""
 
-    def test_save_calls_upsert_component(self, basic_workflow, mock_db):
-        """Test save calls upsert_component with correct parameters."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+    def test_save_creates_component_and_initial_config_atomically(self, basic_workflow, mock_db):
+        """Test first save creates the component and config together."""
         basic_workflow.db = mock_db
         version = basic_workflow.save()
 
-        mock_db.upsert_component.assert_called_once_with(
-            component_id="test-workflow",
-            component_type=ComponentType.WORKFLOW,
-            name="Test Workflow",
-            description="A test workflow for unit testing",
-            metadata=None,
-        )
+        call_args = mock_db.create_component_with_config.call_args
+        assert call_args.kwargs["component_id"] == "test-workflow"
+        assert call_args.kwargs["component_type"] == ComponentType.WORKFLOW
+        assert call_args.kwargs["name"] == "Test Workflow"
+        assert call_args.kwargs["description"] == "A test workflow for unit testing"
+        assert call_args.kwargs["config"]["id"] == "test-workflow"
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_not_called()
         assert version == 1
 
-    def test_save_calls_upsert_config(self, basic_workflow, mock_db):
-        """Test save calls upsert_config with workflow config."""
+    def test_existing_save_upserts_config_with_projection(self, basic_workflow, mock_db):
+        """Test a published save updates config and projection together."""
+        mock_db.get_component.return_value = {
+            "component_id": "test-workflow",
+            "component_type": "workflow",
+            "deleted_at": None,
+        }
         mock_db.upsert_config.return_value = {"version": 2}
 
         basic_workflow.db = mock_db
@@ -311,46 +335,44 @@ class TestWorkflowSave:
         call_args = mock_db.upsert_config.call_args
         assert call_args.kwargs["component_id"] == "test-workflow"
         assert "config" in call_args.kwargs
+        assert call_args.kwargs["projection"] == {
+            "name": "Test Workflow",
+            "description": "A test workflow for unit testing",
+            "metadata": None,
+        }
         assert version == 2
 
     def test_save_with_explicit_db(self, basic_workflow, mock_db):
         """Test save uses explicitly provided db."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
         version = basic_workflow.save(db=mock_db)
 
-        mock_db.upsert_component.assert_called_once()
-        mock_db.upsert_config.assert_called_once()
+        mock_db.create_component_with_config.assert_called_once()
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_not_called()
         assert version == 1
 
     def test_save_with_label(self, basic_workflow, mock_db):
-        """Test save passes label to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes the label to the atomic create."""
         basic_workflow.db = mock_db
         basic_workflow.save(label="production")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["label"] == "production"
 
     def test_save_with_stage(self, basic_workflow, mock_db):
-        """Test save passes stage to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes the stage to the atomic create."""
         basic_workflow.db = mock_db
         basic_workflow.save(stage="draft")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["stage"] == "draft"
 
     def test_save_with_notes(self, basic_workflow, mock_db):
-        """Test save passes notes to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes notes to the atomic create."""
         basic_workflow.db = mock_db
         basic_workflow.save(notes="Initial version")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["notes"] == "Initial version"
 
     def test_save_without_db_raises_error(self, basic_workflow):
@@ -388,7 +410,7 @@ class TestWorkflowSave:
 
     def test_save_returns_none_on_error(self, basic_workflow, mock_db):
         """Test save returns None when database operation fails."""
-        mock_db.upsert_component.side_effect = Exception("Database error")
+        mock_db.create_component_with_config.side_effect = Exception("Database error")
 
         basic_workflow.db = mock_db
         version = basic_workflow.save()
@@ -471,7 +493,9 @@ class TestWorkflowDelete:
         basic_workflow.db = mock_db
         result = basic_workflow.delete()
 
-        mock_db.delete_component.assert_called_once_with(component_id="test-workflow", hard_delete=False)
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-workflow", hard_delete=False, require_no_dependents=True
+        )
         assert result is True
 
     def test_delete_with_hard_delete(self, basic_workflow, mock_db):
@@ -481,8 +505,35 @@ class TestWorkflowDelete:
         basic_workflow.db = mock_db
         result = basic_workflow.delete(hard_delete=True)
 
-        mock_db.delete_component.assert_called_once_with(component_id="test-workflow", hard_delete=True)
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-workflow", hard_delete=True, require_no_dependents=True
+        )
         assert result is True
+
+    def test_delete_can_explicitly_bypass_dependency_check(self, basic_workflow, mock_db):
+        """Test delete forwards the dangerous dependency-check escape hatch."""
+        basic_workflow.db = mock_db
+
+        assert basic_workflow.delete(require_no_dependents=False) is True
+
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-workflow", hard_delete=False, require_no_dependents=False
+        )
+
+    def test_delete_uses_exact_catalog_v1_signature(self, basic_workflow, mock_db):
+        """The v2 dependency keyword must never reach a legacy override."""
+        calls = []
+
+        def legacy_delete(component_id, hard_delete=False):
+            calls.append((component_id, hard_delete))
+            return True
+
+        mock_db.component_catalog_api_version = 1
+        mock_db.delete_component = legacy_delete
+        basic_workflow.db = mock_db
+
+        assert basic_workflow.delete(require_no_dependents=False) is True
+        assert calls == [("test-workflow", False)]
 
     def test_delete_with_explicit_db(self, basic_workflow, mock_db):
         """Test delete uses explicitly provided db."""
@@ -529,6 +580,21 @@ class TestGetWorkflowById:
         assert workflow is not None
         assert workflow.id == "found-workflow"
         assert workflow.name == "Found Workflow"
+        mock_db.get_config.assert_called_once_with(component_id="found-workflow", version=None, label=None)
+
+    def test_get_workflow_by_id_returns_a_draft_only_component(self, tmp_path):
+        """An ordinary workflow lookup remains able to inspect a first draft."""
+        from agno.db.sqlite import SqliteDb
+
+        db = SqliteDb(db_file=str(tmp_path / "draft-only-workflow.db"))
+        assert Workflow(id="draft-workflow", name="Draft Workflow", db=db).save(stage="draft") == 1
+        assert db.get_current_config("draft-workflow") is None
+
+        loaded = get_workflow_by_id(db=db, id="draft-workflow")
+
+        assert loaded is not None
+        assert loaded.id == "draft-workflow"
+        assert loaded.name == "Draft Workflow"
 
     def test_get_workflow_by_id_with_version(self, mock_db):
         """Test get_workflow_by_id retrieves specific version."""
@@ -622,16 +688,20 @@ class TestGetWorkflows:
             ],
             None,
         )
-        mock_db.get_config.side_effect = [
-            {"config": {"id": "workflow-1", "name": "Workflow 1"}},
-            {"config": {"id": "workflow-2", "name": "Workflow 2"}},
-        ]
+        mock_db.get_latest_config = MagicMock(
+            side_effect=[
+                {"config": {"id": "workflow-1", "name": "Workflow 1"}},
+                {"config": {"id": "workflow-2", "name": "Workflow 2"}},
+            ]
+        )
 
         workflows = get_workflows(db=mock_db)
 
         assert len(workflows) == 2
         assert workflows[0].id == "workflow-1"
         assert workflows[1].id == "workflow-2"
+        assert mock_db.get_latest_config.call_count == 2
+        mock_db.get_config.assert_not_called()
 
     def test_get_workflows_filters_by_type(self, mock_db):
         """Test get_workflows filters by WORKFLOW component type."""
@@ -817,7 +887,7 @@ class TestStepPinFailures:
         member.save(db=db)
         links = db.get_links(component_id="dp-wf", version=1)
         pinned = next(link for link in links if link["link_kind"] == "step_agent")["child_version"]
-        assert db.delete_config(component_id="dp-agent", version=pinned)
+        _corrupt_delete_config_row(db, "dp-agent", pinned)
 
         lenient = get_workflow_by_id(db=db, id="dp-wf", strict=False)
         assert lenient is not None
@@ -878,7 +948,10 @@ class TestWritePathFidelity:
 
         db = SqliteDb(db_file=str(tmp_path / "noname.db"))
         Workflow(id="nn-wf", name="WF", steps=[Step(agent=Agent(id="nn-agent", name="A"))]).save(db=db)
-        db.delete_component("nn-agent", hard_delete=True)
+        # Deliberately corrupt the graph to exercise lenient degradation. The
+        # normal lifecycle is dependency-safe, so this test-only setup must
+        # explicitly bypass that guard.
+        db.delete_component("nn-agent", hard_delete=True, require_no_dependents=False)
 
         loaded = Workflow.load(id="nn-wf", db=db, strict=False)
 
@@ -1018,6 +1091,34 @@ class TestLenientRunHonesty:
 
 
 class TestSaveCollisions:
+    def test_save_warns_and_keeps_first_when_duplicate_links_have_the_same_pin(self, tmp_path, caplog):
+        from agno.agent.agent import Agent
+        from agno.db.sqlite import SqliteDb
+        from agno.workflow.loop import Loop
+        from agno.workflow.step import Step
+
+        db = SqliteDb(db_file=str(tmp_path / "same-pin.db"))
+        agent = Agent(id="same-pin-agent", name="Same Pin")
+        assert agent.save(db=db, stage="draft") == 1
+        agent.save = MagicMock(return_value=1)  # type: ignore[method-assign]
+        workflow = Workflow(
+            id="same-pin-workflow",
+            name="Same Pin Workflow",
+            steps=[
+                Loop(name="left", steps=[Step(step_id="shared", name="shared", agent=agent)]),
+                Loop(name="right", steps=[Step(step_id="shared", name="shared", agent=agent)]),
+            ],
+        )
+
+        with caplog.at_level("WARNING"):
+            assert workflow.save(db=db, stage="draft") == 1
+
+        assert "dropping duplicate step_agent link" in caplog.text
+        links = db.get_links(component_id="same-pin-workflow", version=1)
+        assert len(links) == 1
+        assert links[0]["child_component_id"] == "same-pin-agent"
+        assert links[0]["child_version"] == 1
+
     def test_save_fails_loudly_when_two_pins_collide_on_one_key(self, tmp_path):
         from agno.agent.agent import Agent
         from agno.db.sqlite import SqliteDb


### PR DESCRIPTION
## Summary

This PR introduces the AgentOS persistence contract for versioned components and schedules. It changes component configuration from mutable upserts into an immutable, guarded lifecycle; defines archive, restore, publication, and dependency behavior; implements component catalog v2 for synchronous SQLite and PostgreSQL; and keeps scheduler persistence aligned across SQLite, PostgreSQL, MongoDB, sync, and async paths.

### Component lifecycle

- Component identity is created once, and each edit appends a new immutable configuration version.
- Draft detail reads remain possible, while an unversioned runtime load resolves only a published version.
- Save, publish, rollback, and delete use compare-and-set guards so a stale caller cannot silently replace or archive newer state.
- Archive keeps the component ID reserved; restore is explicit and guarded. Agent, Team, and Workflow deletion respects dependency links.
- Dependency links are stored and validated, including cycle prevention, bounded cycle-safe reads, valid shared-child DAGs, and exact version relationships.
- Component ID derivation is consistent and single-segment across framework `save()`, REST, and Studio callers for newly minted ids; an unpinned `save()` adopts an existing legacy-derivation row instead of forking it (see Review hardening).

### Database and router contract

- Component catalog v2 is an explicit adapter capability with atomic create, immutable version append, guarded publication, rollback projections, links, archive, and restore.
- Synchronous SQLite and PostgreSQL implement and advertise catalog v2. MongoDB and the async built-ins explicitly remain catalog v1 / unsupported for component routes in this foundation; their scheduler-v2 support is unchanged.
- Third-party adapters that only implement the catalog-v1 surface continue through exact legacy call shapes instead of receiving unsupported v2 keyword arguments.
- Reversible 2.9 migrations cover the built-in persistence schemas, including scheduler upgrade and downgrade behavior.
- The transitional flat Studio consumer creates atomically, stamps ownership on every written version, uses guarded lifecycle mutations, reserves archived IDs, and exposes explicit restore.
- Generic Components routes reject Studio-owned writes and restores, including ownership markers found only in archived history.

### Scheduler persistence

- Adds persisted ownership and provenance to distinguish Studio-managed schedules from generic schedules.
- Generic manager and REST operations exclude Studio-owned rows for name, list, and ID-based operations in sync and async paths.
- Adds durable manual-trigger state and fenced lease/claim primitives for the scheduler worker loop landing in #9457; nothing in this PR consumes them yet.
- Keeps database schema, indexes, serialization, and migration behavior aligned across the built-in adapters.
- Typed database name conflicts map to HTTP 409, including concurrent create/rename races and MongoDB's compound generic-name index.

### Review boundary

Review this PR as the persistence and router foundation. It intentionally does not introduce the typed `StudioTools` request/result API or change the scheduler worker execution loop. Those are separate concerns layered on top of this storage contract. `ScheduleManager.trigger()` ships as a guarded no-op here; its "use the REST endpoint" guidance is transitional and is superseded when the durable-trigger consumer lands later in the stack.

### Current review status

Both verified Greptile follow-ups are addressed in the branch:

- Generic scheduler consumers now exclude and refuse Studio-owned schedules ([discussion](https://github.com/agno-agi/agno/pull/9455#discussion_r3762125165)).
- Sync and async MongoDB conflict detection recognizes the compound generic schedule key ([discussion](https://github.com/agno-agi/agno/pull/9455#discussion_r3762125169)).

The GitHub review threads remain unresolved for maintainers to verify and resolve.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Validation

- 721 focused component, Studio, framework serialization, REST, scheduler-manager, ID, and SQLite lifecycle tests passed.
- 291 scheduler, SchedulerTools, Mongo scheduler, conflict-translation, and schedule-router tests passed.
- 28 live PostgreSQL component lifecycle, concurrency, archive/restore, dependency, graph, and CAS tests passed.
- 3 live PostgreSQL v2.9 migration upgrade/downgrade tests and 47 unit migration tests passed.
- `./scripts/format.sh`, `./scripts/validate.sh`, and `git diff --check` passed; core and agnoctl mypy checks were clean.
- The branch is the original three commits plus review-hardening commits, rebased onto `feat/v3.0@8bab879a7` with no merge commits.

## Review hardening

Commits added on top of the original three during maintainer review, each verified by execution:

- `update_schedule` is now allow-listed in every adapter (`SCHEDULE_MUTABLE_COLUMNS`): provenance, trigger, and lock columns can no longer be rewritten through a generic update, closing a promotion path into the Studio namespace.
- Unpinned `save()` adopts a component's pre-single-segment catalog row (`"Analyst v2.5"` → existing `analyst-v2.5`) instead of silently forking the catalog under the stricter slug; create paths and runtime id stamping keep the new contract.
- `AsyncBaseDb` gained the component-method default stubs so the async adapters fail uniformly instead of drifting between `AttributeError` and `NotImplementedError`.
- Mongo: `get_schedule_by_name` composes `managed_by` filters conjunctively instead of overwriting, the scheduler index comment records the real server-version boundaries (same-key coexistence >= 5.0, `$or` partial filters >= 6.0, pymongo floor 4.2), and the migration tests pin the create-before-drop ordering rather than engine behavior.
- Backend test gaps closed: Postgres `exclude_managed_by` integration coverage, a sync Mongo integration folder, async-Postgres live migration, and a real-concurrency lease-claim race test.

## Stack context

This is the persistence layer at the base of a three-PR review stack:

1. **#9455 — component catalog and scheduler persistence**
2. #9456 — typed Studio control plane
3. #9457 — scheduler execution and retry behavior

The descriptions above are the complete review scope for this PR; the stack note only records merge order.

Implementation was generated with Codex under author-directed API design, stack selection, testing, and review.