### PR TITLE
feat: add typed Studio control plane

### DIFF
--- a/cookbook/05_agent_os/22_studio/README.md
+++ b/cookbook/05_agent_os/22_studio/README.md
@@ -1,22 +1,22 @@
 # Studio
 
-`StudioTools` lets an Agent compose persisted Agents, Teams, and Workflows from
-the live objects in an AgentOS `Registry`, and `StudioRunnerTools` dispatches
-what was built. This lesson separates five concerns: standalone composition,
-composition served by AgentOS, human-in-the-loop control, dispatch, and the
-Registry/Components HTTP contracts.
+`StudioTools` is the typed, authorization-gated control plane for composing
+persisted Agents, Teams, and Workflows from an AgentOS `Registry`.
+`StudioRunnerTools` is the data plane that dispatches those components. This
+lesson keeps composition, lifecycle management, dispatch, human-in-the-loop
+control, and the Registry/Components HTTP contracts distinct.
 
 ## Files
 
 | File | What it teaches |
 |---|---|
-| `standalone_studio_agent.py` | Create, edit, inspect, and publish a versioned Agent without starting AgentOS. |
-| `studio_tools_agent.py` | Serve a Studio Agent beside code-defined Agents and create a component over HTTP. |
+| `standalone_studio_agent.py` | Create, inspect, edit, and publish a versioned Agent without starting AgentOS. |
+| `studio_tools_agent.py` | Serve an authorized Studio Agent beside code-defined Agents and create a typed component over HTTP. |
 | `studio_hitl_agent.py` | Resolve structured feedback, free-text input, and confirmation pauses in a console process. |
 | `studio_hitl_agent_os.py` | Resolve the same pauses through AgentOS run and continuation endpoints. |
-| `registry_and_components.py` | Read `GET /registry` and complete a persisted component CRUD lifecycle. |
+| `registry_and_components.py` | Inspect the separate Registry and persisted Components HTTP contracts. |
 | `studio_runner_dispatcher.py` | Dispatch Studio-built components from a runner-only Agent with `StudioRunnerTools`. |
-| `studio_runner_direct.py` | Call the runner's list/run tools directly and observe the registry guard's refusal. |
+| `studio_runner_direct.py` | Call runner tools directly and observe the registry guard's refusal. |
 
 ## Prerequisites
 
@@ -29,23 +29,193 @@ export ANTHROPIC_API_KEY=...
 ```
 
 All examples use synchronous `SqliteDb` databases under `22_studio/tmp/`.
-StudioTools persistence and the `/components` router require a synchronous
+`StudioTools` receives one catalog `db` at construction, and every create,
+read, lifecycle, and dispatch operation uses that same database. A request
+cannot select a different database.
+
+Studio persistence and the `/components` router require a synchronous
 `BaseDb`. If AgentOS receives an async database, it exposes a disabled
 `/components` surface instead. `GET /registry` is independent of component
 persistence and only requires `AgentOS(registry=...)`.
 
+## The typed StudioTools contract
+
+### Fix the catalog and authorize every call
+
+`StudioTools` is an administrative surface. Its constructor requires an
+explicit authorization callback in addition to the Registry and fixed catalog
+database:
+
+```python
+from agno.run import RunContext
+from agno.tools.studio import StudioAccess, StudioAction, StudioTools
+from agno.tools.studio_schema import ModelRef
+
+
+def authorize_studio_admin(
+    run_context: RunContext,
+    _access: StudioAccess,
+    _action: StudioAction,
+) -> bool:
+    return run_context.user_id == "studio-admin"
+
+
+studio_tools = StudioTools(
+    registry=registry,
+    db=db,
+    authorize=authorize_studio_admin,
+    default_model=ModelRef(
+        id="gpt-5.5",
+        provider="OpenAI",
+        name="OpenAIResponses",
+    ),
+)
+```
+
+AgentOS injects its framework-managed `RunContext` into every model-initiated
+tool call. Calls fail closed if that context is missing, the callback rejects
+the action, or the callback raises. A direct Python caller must supply a real
+`RunContext` to the `_agno_run_context` parameter; do not treat model-supplied
+user or tenant fields as authorization evidence.
+
+### Discover exact references, then compose typed requests
+
+Call `list_models`, `list_tools`, and `list_functions`, then copy their exact
+typed references. `ModelRef` identifies a registered model. `ToolRef`
+distinguishes a whole toolkit from one function in a toolkit.
+
+The create tools each accept one declarative request object:
+
+```python
+from agno.tools.studio_schema import (
+    AgentCreate,
+    AgentWorkflowStep,
+    ComponentRef,
+    FunctionWorkflowStep,
+    ModelRef,
+    TeamCreate,
+    ToolRef,
+    WorkflowCreate,
+)
+
+researcher = AgentCreate(
+    component_id="researcher",
+    name="Researcher",
+    instructions="Research the topic and cite sources.",
+    model=ModelRef(
+        id="gpt-5.5",
+        provider="OpenAI",
+        name="OpenAIResponses",
+    ),
+    tools=[ToolRef(kind="toolkit", name="calculator")],
+)
+
+editors = TeamCreate(
+    component_id="editors",
+    name="Editors",
+    instructions="Review the research before publication.",
+    members=[
+        ComponentRef(
+            component_type="agent",
+            component_id="researcher",
+            version=1,
+        )
+    ],
+)
+
+editorial_flow = WorkflowCreate(
+    component_id="editorial-flow",
+    name="Editorial flow",
+    steps=[
+        AgentWorkflowStep(
+            kind="agent",
+            step_id="research",
+            name="Research",
+            component_id="researcher",
+            version=1,
+        ),
+        FunctionWorkflowStep(
+            kind="function",
+            step_id="publish",
+            name="Publish",
+            function_name="publish_copy",
+        ),
+    ],
+)
+```
+
+`AgentCreate`, `TeamCreate`, and `WorkflowCreate` reject unknown fields rather
+than silently ignoring misspellings. Team members are typed `ComponentRef`
+values, and workflow steps use a discriminated `kind`. A draft may explore a
+code-defined component, but a published Team or Workflow must point to stored,
+published component versions.
+
+`component_id` is the stable control-plane identity. Studio derives a
+deterministic slug from `name` when it is omitted and never invents a suffixed
+id on collision. Creates reject an existing id by default; set
+`request.if_exists="return_existing"` only for an idempotent retry whose
+normalized request, component type, and requested stage are identical. This is
+operation policy and is not persisted as component configuration.
+
+### Use the draft-first, CAS-guarded lifecycle
+
+Creates save a draft unless `save_as="published"` is explicit. The normal
+reviewable lifecycle is:
+
+1. `create_agent(request)` creates draft v1. Team and Workflow creation follow
+   the same pattern.
+2. `publish_component(component_id, version=1,
+   expected_current_version=None)` publishes the draft and makes it current.
+3. `edit_agent(component_id, patch, expected_version=1)` appends draft v2.
+   Edits use typed `AgentPatch`, `TeamPatch`, or `WorkflowPatch` objects.
+4. `publish_component(component_id, version=2,
+   expected_current_version=1)` publishes the reviewed edit.
+5. `set_current_version(component_id, version=1,
+   expected_current_version=2)` rolls back by making an older immutable
+   published version current.
+
+The `expected_version`, `expected_current_version`, and
+`expected_latest_version` arguments are compare-and-swap guards. On a conflict,
+read the latest state and retry only after deciding that the change is still
+correct.
+
+When StudioTools is mounted on an Agent, create and edit calls require framework
+confirmation even when they save a draft, because the same tools can publish
+through `save_as`. Publication, rollback, draft deletion, archive, and restore calls are
+confirmation-gated too. The Agent pauses before the exact tool execution;
+inspect its arguments, confirm or reject it, and continue the same run. Direct
+Python method calls are trusted administrative calls and must enforce an
+equivalent approval boundary in their host application.
+
+Whole components are retired with the type-specific `archive_agent`,
+`archive_team`, or `archive_workflow` call and an
+`expected_current_version` guard. Archive is dependency-safe and does not hard
+delete the component or release its id for a fresh create. Restore an archived
+component with the matching `restore_agent`, `restore_team`, or
+`restore_workflow` call and the same current-version guard. Restore changes
+catalog visibility only; schedules remain a separate explicit policy surface.
+`delete_version` is narrower: it removes one
+unreferenced draft using `expected_latest_version`; it does not delete a
+published version or an entire component.
+
+All component control-plane and schedule operations return a typed
+`StudioResult`. Check `ok`, `status`, and either `data` or `error`; do not parse
+display strings as an API contract. Only the `run_*` data-plane tools retain
+their JSON string contracts.
+
 ## Run standalone composition
 
 The standalone example uses `claude-sonnet-4-6` as the Studio Agent and carries
-out a full published-v1 to draft-v2 to published-v2 lifecycle:
+out a published-v1 to draft-v2 to published-v2 lifecycle:
 
 ```bash
 .venvs/demo/bin/python cookbook/05_agent_os/22_studio/standalone_studio_agent.py
 ```
 
-`versions=True` is opt-in. With it, `edit_agent`, `edit_team`, and
-`edit_workflow` write a draft that `publish_component` must promote. Without
-versioning, edits publish a new current version immediately.
+The example's authorizer permits only its explicit demo admin user, and the run
+supplies that user identity so the Agent runtime can inject it into the tool's
+`RunContext`. It explicitly confirms the paused create, publish, edit, and
+second publish executions before checking the final database state.
 
 ## Run the AgentOS Studio Agent
 
@@ -63,35 +233,38 @@ Then run its repeatable HTTP client from another terminal:
 
 Each server defaults to port 7777. Set `PORT` for the server and
 `AGENT_OS_BASE_URL` for its client when that port is already occupied.
+The HTTP Studio examples enable AgentOS authorization and mint a short-lived,
+audience-bound development JWT for their `--demo` clients. The verified token
+subject becomes the `RunContext.user_id`; the clients never submit an actor id
+as form data. Set `JWT_VERIFICATION_KEY` to use your own local signing key. In
+production, replace the development issuer with your normal identity provider.
 
 Passing `agents_list` to `StudioTools` makes those code-defined Agents available
 to Team and Workflow composition and auto-enables their operations. A
-Studio-created component is persisted in the database; it is not appended to
-the code-defined Agent list.
+Studio-created component is persisted in the fixed catalog; it is not appended
+to the code-defined Agent list.
 
 ## Run the dispatcher
 
-`StudioRunnerTools` is the dispatch half of the Studio: it lists the components
-in the platform database and runs one by id, with no create/edit/delete
-surface. Mount it on a router or team lead that should hand work to built
-components without holding the Studio's mutation tools. Runs execute as the
-current user, keep one session per component per conversation, pin
+`StudioRunnerTools` is the dispatch half of the Studio: it lists components in
+the platform database and runs one by id, without exposing lifecycle mutation
+tools. Mount it on a router or team lead that should hand work to built
+components without holding Studio administration authority. Runs execute as
+the current user, keep one session per component per conversation, pin
 `stream=False`, and relay PAUSED results with their requirements.
 
-Mount it instead of `StudioTools`, not alongside it. The two share `list_agents`,
-`list_teams`, `list_workflows` and `run_agent`, plus `run_team` and
-`run_workflow` once teams or workflows are enabled (passing an `agents_list`
-enables both), and the tool namespace is flat, so the toolkit listed first wins
-those names and the other is skipped with a warning.
+Mount it instead of `StudioTools`, not alongside it. The two share component
+list and run tool names, and the toolkit listed first wins duplicate names
+while the other is skipped with a warning.
 
 ```bash
 .venvs/demo/bin/python cookbook/05_agent_os/22_studio/studio_runner_dispatcher.py
 ```
 
-The direct example calls the same tools as plain methods and shows the
-registry guard: a runner constructed without the registry refuses components
-whose stored configs reference registry-backed resources (tools, knowledge,
-code-defined members), because the rebuild would silently drop them.
+The direct example calls the same tools as plain methods and shows the registry
+guard: a runner constructed without the Registry refuses components whose
+stored configs reference registry-backed resources, because rebuilding them
+would silently drop those resources.
 
 ```bash
 .venvs/demo/bin/python cookbook/05_agent_os/22_studio/studio_runner_direct.py
@@ -99,17 +272,20 @@ code-defined members), because the rebuild would silently drop them.
 
 ## Console versus AgentOS HITL
 
-The pause/resume mechanics used here (`RunRequirement`, `continue_run`, the
+The pause/resume mechanics used here (`RunRequirement`, `continue_run`, and the
 `/continue` route) are taught in
 [`../05_human_in_the_loop/`](../05_human_in_the_loop/); this folder only
 applies them to Studio composition.
 
-Both HITL examples deliberately start with only a component name. The Studio
-Agent must:
+Both HITL examples deliberately start with an underspecified component. The
+Studio Agent must:
 
 1. ask a structured, multi-select tool question;
 2. request free-text Agent instructions;
-3. pause for confirmation on the exact `create_agent` call.
+3. pause for confirmation on the exact typed `create_agent` call.
+
+`StudioTools` marks `create_agent` for confirmation automatically; the examples
+do not need to add it to `requires_confirmation_tools`.
 
 The console lesson resolves live `RunRequirement` objects and calls
 `Agent.continue_run()`:
@@ -147,22 +323,27 @@ Start the catalog server:
 .venvs/demo/bin/python cookbook/05_agent_os/22_studio/registry_and_components.py
 ```
 
-Run its live CRUD client:
+Run its live client:
 
 ```bash
 .venvs/demo/bin/python cookbook/05_agent_os/22_studio/registry_and_components.py --demo
 ```
 
-The two surfaces have different ownership:
+The two HTTP surfaces have different ownership:
 
 - `GET /registry` describes live, code-defined tools, models, databases,
   schemas, functions, and reusable components. It is read-only and supports
   `resource_type`, partial `name`, `page`, and `limit` filters.
-- `/components` owns persisted component metadata and versioned configuration.
-  The example executes `POST /components`, filtered `GET /components`,
-  `GET /components/{id}`, `PATCH /components/{id}`,
-  `GET /components/{id}/configs/current`, and `DELETE /components/{id}`.
+- `/components` exposes persisted component metadata and configuration records
+  to platform clients. It is lower-level than the model-facing StudioTools
+  lifecycle.
 
-The Components API also provides config-version create, read, update, delete,
-and set-current routes. Published configs are immutable; draft configs can be
-updated or deleted, and only a published version can become current.
+Studio-owned records have a single lifecycle writer. They remain readable
+through `/components`, but generic create-config, publish, rollback, delete,
+metadata-edit, and archive requests return a conflict for those records. Use
+the typed StudioTools lifecycle instead; generic clients cannot claim Studio
+ownership by supplying the reserved `_agno_studio` manifest key.
+
+For Studio administration, use the typed, authorized lifecycle described
+above: drafts, CAS-guarded publication and rollback, dependency-safe
+archive/restore, and draft-only `delete_version`.

--- a/cookbook/05_agent_os/22_studio/registry_and_components.py
+++ b/cookbook/05_agent_os/22_studio/registry_and_components.py
@@ -3,8 +3,10 @@ Inspect Registry resources and manage persisted components
 ==========================================================
 
 The Registry endpoint lists code-defined primitives. The Components endpoints
-manage versioned Agent, Team, and Workflow configurations in the AgentOS
-database. Components require a synchronous BaseDb; this example uses SqliteDb.
+manage guarded, versioned Agent, Team, and Workflow configurations in the
+AgentOS database. Metadata edits append a draft, publishing moves the current
+pointer, and DELETE soft-archives the component with compare-and-set guards.
+Components require a synchronous BaseDb; this example uses SqliteDb.
 
 Prerequisites: none for the HTTP demo; provider keys are needed only to run the catalog Agent
 Run: .venvs/demo/bin/python cookbook/05_agent_os/22_studio/registry_and_components.py
@@ -13,15 +15,18 @@ Try: run this file with --demo in another terminal
 
 import argparse
 import os
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from uuid import uuid4
 
 import httpx
+import jwt
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.anthropic import Claude
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
+from agno.os.config import AuthorizationConfig
 from agno.registry import Registry
 from agno.tools.calculator import CalculatorTools
 
@@ -31,6 +36,29 @@ from agno.tools.calculator import CalculatorTools
 
 PORT = int(os.getenv("PORT", "7777"))
 BASE_URL = os.getenv("AGENT_OS_BASE_URL", f"http://127.0.0.1:{PORT}")
+OS_ID = "registry-components-os"
+ADMIN_USER_ID = "components-admin"
+JWT_SECRET = os.getenv(
+    "JWT_VERIFICATION_KEY",
+    "registry-components-development-secret-at-least-256-bits-long",
+)
+
+
+def make_admin_token() -> str:
+    """Mint a short-lived, audience-bound token for the local HTTP demo."""
+    now = datetime.now(UTC)
+    return jwt.encode(
+        {
+            "sub": ADMIN_USER_ID,
+            "aud": OS_ID,
+            "scopes": ["agent_os:admin"],
+            "iat": now,
+            "exp": now + timedelta(minutes=15),
+        },
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+
 
 DB_DIR = Path(__file__).parent / "tmp"
 DB_DIR.mkdir(exist_ok=True)
@@ -59,12 +87,18 @@ catalog_agent = Agent(
 )
 
 agent_os = AgentOS(
-    id="registry-components-os",
+    id=OS_ID,
     name="Registry and Components AgentOS",
-    description="Read-only Registry discovery plus persisted component CRUD.",
+    description="Read-only Registry discovery plus a guarded persisted-component lifecycle.",
     agents=[catalog_agent],
     registry=registry,
     db=db,
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+    ),
 )
 app = agent_os.get_app()
 
@@ -75,7 +109,7 @@ app = agent_os.get_app()
 
 
 def run_demo() -> None:
-    """List registry resources and complete one component CRUD lifecycle."""
+    """List registry resources, append and publish a draft, then soft-archive it."""
     component_id = f"registry-crud-agent-{uuid4().hex[:8]}"
     component_name = "Registry CRUD Agent"
     component_config = Agent(
@@ -85,7 +119,11 @@ def run_demo() -> None:
         instructions="Answer catalog questions in one sentence.",
     ).to_dict()
 
-    with httpx.Client(base_url=BASE_URL, timeout=60.0) as client:
+    with httpx.Client(
+        base_url=BASE_URL,
+        timeout=60.0,
+        headers={"Authorization": f"Bearer {make_admin_token()}"},
+    ) as client:
         registry_response = client.get("/registry", params={"limit": 100})
         registry_response.raise_for_status()
         registry_payload = registry_response.json()
@@ -134,32 +172,69 @@ def run_demo() -> None:
                 "name": "Updated Registry CRUD Agent",
                 "description": "Updated through PATCH /components/{component_id}.",
                 "metadata": {"owner": "cookbook", "reviewed": True},
+                "guard": {"latest_version": 1, "current_version": 1},
             },
         )
         update_response.raise_for_status()
-        updated = update_response.json()
-        if updated["name"] != "Updated Registry CRUD Agent":
-            raise RuntimeError(f"Component update did not persist: {updated}")
+        draft = update_response.json()
+        if (
+            draft["version"] != 2
+            or draft["stage"] != "draft"
+            or draft["config"]["name"] != "Updated Registry CRUD Agent"
+        ):
+            raise RuntimeError(f"PATCH did not append the expected draft: {draft}")
 
         config_response = client.get(f"/components/{component_id}/configs/current")
         config_response.raise_for_status()
-        current_config = config_response.json()
-        if current_config["version"] != 1 or current_config["stage"] != "published":
-            raise RuntimeError(f"Unexpected current config: {current_config}")
+        pre_publish_current = config_response.json()
+        if (
+            pre_publish_current["version"] != 1
+            or pre_publish_current["stage"] != "published"
+        ):
+            raise RuntimeError(
+                f"Draft edit moved the current pointer: {pre_publish_current}"
+            )
 
-        delete_response = client.delete(f"/components/{component_id}")
+        publish_response = client.patch(
+            f"/components/{component_id}/configs/2",
+            json={
+                "stage": "published",
+                "guard": {"latest_version": 2, "current_version": 1},
+            },
+        )
+        publish_response.raise_for_status()
+        published = publish_response.json()
+        if published["version"] != 2 or published["stage"] != "published":
+            raise RuntimeError(f"Draft publication failed: {published}")
+
+        current_response = client.get(f"/components/{component_id}")
+        current_response.raise_for_status()
+        current = current_response.json()
+        if (
+            current["current_version"] != 2
+            or current["name"] != "Updated Registry CRUD Agent"
+        ):
+            raise RuntimeError(
+                f"Published projection did not move atomically: {current}"
+            )
+
+        delete_response = client.request(
+            "DELETE",
+            f"/components/{component_id}",
+            json={"guard": {"latest_version": 2, "current_version": 2}},
+        )
         if delete_response.status_code != 204:
             raise RuntimeError(
-                f"Expected DELETE 204, got {delete_response.status_code}"
+                f"Expected archive 204, got {delete_response.status_code}"
             )
         if client.get(f"/components/{component_id}").status_code != 404:
-            raise RuntimeError("Deleted component remained visible")
+            raise RuntimeError("Archived component remained visible")
 
     print(f"Registry resources: {registry_payload['meta']['total_count']}")
     print(f"Created: {created['component_id']} v{created['current_version']}")
-    print(f"Updated name: {updated['name']}")
-    print(f"Current config: v{current_config['version']} ({current_config['stage']})")
-    print("Deleted component: HTTP 204; follow-up GET: HTTP 404")
+    print(f"Appended draft: v{draft['version']} ({draft['stage']})")
+    print(f"Published current: v{current['current_version']} as {current['name']}")
+    print("Soft-archived component: HTTP 204; follow-up GET: HTTP 404")
 
 
 if __name__ == "__main__":

--- a/cookbook/05_agent_os/22_studio/standalone_studio_agent.py
+++ b/cookbook/05_agent_os/22_studio/standalone_studio_agent.py
@@ -19,8 +19,11 @@ from agno.db.sqlite import SqliteDb
 from agno.models.anthropic import Claude
 from agno.models.openai import OpenAIResponses
 from agno.registry import Registry
+from agno.run import RunContext
+from agno.run.agent import RunOutput
 from agno.tools.calculator import CalculatorTools
-from agno.tools.studio import StudioTools
+from agno.tools.studio import StudioAccess, StudioAction, StudioTools
+from agno.tools.studio_schema import ModelRef
 
 # ---------------------------------------------------------------------------
 # Create Standalone Studio Agent
@@ -28,6 +31,18 @@ from agno.tools.studio import StudioTools
 
 DB_DIR = Path(__file__).parent / "tmp"
 DB_DIR.mkdir(exist_ok=True)
+
+STUDIO_ADMIN_USER_ID = "studio-admin"
+
+
+def authorize_studio_admin(
+    run_context: RunContext,
+    _access: StudioAccess,
+    _action: StudioAction,
+) -> bool:
+    """Limit the administrative Studio surface to the demo admin."""
+    return run_context.user_id == STUDIO_ADMIN_USER_ID
+
 
 db = SqliteDb(
     id="standalone-studio-db",
@@ -52,13 +67,19 @@ studio_agent = Agent(
         StudioTools(
             registry=registry,
             db=db,
-            default_model_id="gpt-5.5",
-            versions=True,
+            authorize=authorize_studio_admin,
+            default_model=ModelRef(
+                id="gpt-5.5",
+                provider="OpenAI",
+                name="OpenAIResponses",
+            ),
         )
     ],
     instructions=[
         "Follow the requested StudioTools sequence exactly.",
-        "Use only exact model and tool names returned by discovery.",
+        "Copy exact ModelRef and ToolRef values returned by discovery.",
+        "Creates are drafts unless save_as='published' is explicit.",
+        "Use the returned version and current version as lifecycle CAS guards.",
         "Do not stop until the requested draft has been published.",
     ],
     db=db,
@@ -71,6 +92,84 @@ studio_agent = Agent(
 # ---------------------------------------------------------------------------
 
 
+def continue_expected_lifecycle(
+    run: RunOutput,
+    component_id: str,
+) -> RunOutput:
+    """Confirm and continue only the exact lifecycle requested by the demo."""
+    expected_actions = [
+        ("create_agent", None, None),
+        ("publish_component", 1, None),
+        ("edit_agent", None, 1),
+        ("publish_component", 2, 1),
+    ]
+    rounds = 0
+    confirmed_actions: list[str] = []
+    while run.is_paused:
+        active_requirements = run.active_requirements
+        if not active_requirements:
+            raise RuntimeError("Paused Studio run returned no active requirements")
+
+        for requirement in active_requirements:
+            if len(confirmed_actions) >= len(expected_actions):
+                raise RuntimeError(f"Unexpected extra Studio pause: {requirement}")
+            tool = requirement.tool_execution
+            tool_args = tool.tool_args if tool is not None else None
+            expected_name, expected_version, expected_current = expected_actions[
+                len(confirmed_actions)
+            ]
+            if (
+                not requirement.needs_confirmation
+                or tool is None
+                or tool.tool_name != expected_name
+                or not isinstance(tool_args, dict)
+            ):
+                raise RuntimeError(f"Unexpected Studio pause: {requirement}")
+
+            if expected_name == "create_agent":
+                request = tool_args.get("request")
+                valid_args = (
+                    isinstance(request, dict)
+                    and request.get("component_id") == component_id
+                    and tool_args.get("save_as", "draft") == "draft"
+                )
+            elif expected_name == "edit_agent":
+                valid_args = (
+                    tool_args.get("component_id") == component_id
+                    and tool_args.get("expected_version") == expected_current
+                    and tool_args.get("save_as", "draft") == "draft"
+                )
+            else:
+                valid_args = (
+                    tool_args.get("component_id") == component_id
+                    and tool_args.get("version") == expected_version
+                    and tool_args.get("expected_current_version") == expected_current
+                )
+            if not valid_args:
+                raise RuntimeError(f"Unexpected {expected_name} arguments: {tool_args}")
+
+            print(f"Confirming {expected_name}: {tool_args}")
+            requirement.confirm()
+            confirmed_actions.append(expected_name)
+
+        run = studio_agent.continue_run(
+            run_id=run.run_id,
+            requirements=run.requirements,
+            user_id=STUDIO_ADMIN_USER_ID,
+        )
+        rounds += 1
+        if rounds > 6:
+            raise RuntimeError(
+                "Studio Agent did not finish after six lifecycle continuations"
+            )
+    if len(confirmed_actions) != len(expected_actions):
+        raise RuntimeError(
+            f"Expected confirmations {[action[0] for action in expected_actions]}, "
+            f"got {confirmed_actions}"
+        )
+    return run
+
+
 def run_studio_lifecycle() -> None:
     """Create, edit, inspect, and publish one versioned Agent."""
     component_id = f"studio-math-tutor-{uuid4().hex[:8]}"
@@ -78,16 +177,24 @@ def run_studio_lifecycle() -> None:
         (
             "Complete this exact sequence without asking follow-up questions: "
             "call list_models and list_tools; "
-            f"create an agent named '{component_id}' with model "
-            "'claude-sonnet-4-6', tool 'calculator', and instructions "
-            "'Teach arithmetic step by step.'; "
+            "call create_agent with an AgentCreate request whose component_id is "
+            f"'{component_id}', name is 'Studio Math Tutor', instructions are "
+            "'Teach arithmetic step by step.', model is the exact discovered "
+            "Claude ModelRef, and tools contains the exact calculator toolkit "
+            "ToolRef; keep the default draft; "
+            f"call publish_component for '{component_id}' with version=1 and "
+            "expected_current_version=null; "
             f"call get_agent for '{component_id}'; "
-            "edit its instructions to 'Teach arithmetic step by step and explain "
-            "every intermediate result.'; "
+            f"call edit_agent for '{component_id}' with expected_version=1 and an "
+            "AgentPatch that changes instructions to 'Teach arithmetic step by "
+            "step and explain every intermediate result.'; "
             f"call list_versions for '{component_id}'; "
-            f"then publish_component for '{component_id}'. Do not run the new agent."
-        )
+            f"then call publish_component for '{component_id}' with version=2 and "
+            "expected_current_version=1. Do not run the new agent."
+        ),
+        user_id=STUDIO_ADMIN_USER_ID,
     )
+    response = continue_expected_lifecycle(response, component_id)
 
     component = db.get_component(component_id)
     versions = db.list_configs(component_id, include_config=False)

--- a/cookbook/05_agent_os/22_studio/studio_hitl_agent.py
+++ b/cookbook/05_agent_os/22_studio/studio_hitl_agent.py
@@ -21,8 +21,10 @@ from agno.db.sqlite import SqliteDb
 from agno.models.anthropic import Claude
 from agno.models.openai import OpenAIResponses
 from agno.registry import Registry
+from agno.run import RunContext
 from agno.tools.calculator import CalculatorTools
-from agno.tools.studio import StudioTools
+from agno.tools.studio import StudioAccess, StudioAction, StudioTools
+from agno.tools.studio_schema import ModelRef
 from agno.tools.user_control_flow import UserControlFlowTools
 from agno.tools.user_feedback import UserFeedbackTools
 
@@ -31,6 +33,17 @@ from agno.tools.user_feedback import UserFeedbackTools
 # ---------------------------------------------------------------------------
 
 AUTO_INSTRUCTIONS = "Explain reliable research methods in concise steps."
+STUDIO_ADMIN_USER_ID = "studio-admin"
+
+
+def authorize_studio_admin(
+    run_context: RunContext,
+    _access: StudioAccess,
+    _action: StudioAction,
+) -> bool:
+    """Limit the administrative Studio surface to the demo admin."""
+    return run_context.user_id == STUDIO_ADMIN_USER_ID
+
 
 DB_DIR = Path(__file__).parent / "tmp"
 DB_DIR.mkdir(exist_ok=True)
@@ -58,22 +71,26 @@ studio_agent = Agent(
         StudioTools(
             registry=registry,
             db=db,
-            default_model_id="gpt-5.5",
-            requires_confirmation_tools=["create_agent"],
+            authorize=authorize_studio_admin,
+            default_model=ModelRef(
+                id="gpt-5.5",
+                provider="OpenAI",
+                name="OpenAIResponses",
+            ),
         ),
         UserFeedbackTools(),
         UserControlFlowTools(),
     ],
     instructions=[
         "Help the user compose one Agent from registry primitives.",
-        "Call list_tools, list_models, and list_dbs first.",
+        "Call list_tools and list_models first; Studio already has one fixed catalog database.",
         "If tools are missing, call ask_user with one multi-select question whose "
         "options are exact names returned by list_tools.",
         "If instructions are missing, call get_user_input with one string field.",
         "Do not combine the missing tool and instruction questions in chat.",
-        "Use the exact database id returned by list_dbs when creating the Agent. "
-        "Never pass an empty string or the word 'default' as db_id.",
-        "Call create_agent only after both answers are available.",
+        "Translate each selected tool into the exact ToolRef returned by list_tools.",
+        "Call create_agent with one AgentCreate request only after both answers are available.",
+        "Keep the new component as a draft; publication is a separate admin decision.",
     ],
     db=db,
     markdown=True,
@@ -121,11 +138,25 @@ def resolve_input(requirement: Any, auto: bool) -> None:
     requirement.provide_user_input(values)
 
 
-def resolve_confirmation(requirement: Any, auto: bool) -> bool:
+def resolve_confirmation(requirement: Any, auto: bool, component_id: str) -> bool:
     """Approve or reject the pending create_agent call."""
     tool = requirement.tool_execution
     if tool is None:
         raise RuntimeError("Confirmation requirement did not include a tool")
+    tool_args = tool.tool_args
+    request = tool_args.get("request") if isinstance(tool_args, dict) else None
+    requested_id = (
+        request.get("component_id") or request.get("name")
+        if isinstance(request, dict)
+        else None
+    )
+    if (
+        tool.tool_name != "create_agent"
+        or requested_id != component_id
+        or not isinstance(tool_args, dict)
+        or tool_args.get("save_as", "draft") != "draft"
+    ):
+        raise RuntimeError(f"Unexpected Studio confirmation: {tool}")
     print(f"\nConfirmation needed: {tool.tool_name}")
     print(f"Arguments: {tool.tool_args}")
     approved = auto or input("Approve? (y/n): ").strip().lower() == "y"
@@ -139,7 +170,10 @@ def resolve_confirmation(requirement: Any, auto: bool) -> bool:
 def run_console_demo(auto: bool = False) -> None:
     """Resolve feedback, input, and confirmation pauses in one run."""
     component_id = f"console-research-buddy-{uuid4().hex[:8]}"
-    run = studio_agent.run(f"Create an agent called '{component_id}'.")
+    run = studio_agent.run(
+        f"Create an agent called '{component_id}'.",
+        user_id=STUDIO_ADMIN_USER_ID,
+    )
     observed: list[str] = []
     confirmation_approved: bool | None = None
     rounds = 0
@@ -156,7 +190,11 @@ def run_console_demo(auto: bool = False) -> None:
                 resolve_input(requirement, auto)
                 observed.append("user_input")
             elif requirement.needs_confirmation:
-                confirmation_approved = resolve_confirmation(requirement, auto)
+                confirmation_approved = resolve_confirmation(
+                    requirement,
+                    auto,
+                    component_id,
+                )
                 observed.append("confirmation")
             else:
                 raise RuntimeError(f"Unsupported requirement: {requirement}")
@@ -164,6 +202,7 @@ def run_console_demo(auto: bool = False) -> None:
         run = studio_agent.continue_run(
             run_id=run.run_id,
             requirements=run.requirements,
+            user_id=STUDIO_ADMIN_USER_ID,
         )
         rounds += 1
         if rounds > 6:
@@ -177,6 +216,14 @@ def run_console_demo(auto: bool = False) -> None:
     component = db.get_component(component_id)
     if confirmation_approved and component is None:
         raise RuntimeError("Confirmed create_agent call did not persist the component")
+    if confirmation_approved:
+        config = db.get_config(component_id, version=1)
+        if component is None or component.get("current_version") is not None:
+            raise RuntimeError(
+                f"Expected a non-current draft component, got {component}"
+            )
+        if config is None or config.get("stage") != "draft":
+            raise RuntimeError(f"Expected draft version 1, got {config}")
     if confirmation_approved is False and component is not None:
         raise RuntimeError(
             "Rejected create_agent call unexpectedly persisted a component"

--- a/cookbook/05_agent_os/22_studio/studio_hitl_agent_os.py
+++ b/cookbook/05_agent_os/22_studio/studio_hitl_agent_os.py
@@ -14,19 +14,24 @@ Try: run this file with --demo in another terminal
 import argparse
 import json
 import os
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
 import httpx
+import jwt
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.anthropic import Claude
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
+from agno.os.config import AuthorizationConfig
 from agno.registry import Registry
+from agno.run import RunContext
 from agno.tools.calculator import CalculatorTools
-from agno.tools.studio import StudioTools
+from agno.tools.studio import StudioAccess, StudioAction, StudioTools
+from agno.tools.studio_schema import ModelRef
 from agno.tools.user_control_flow import UserControlFlowTools
 from agno.tools.user_feedback import UserFeedbackTools
 
@@ -36,8 +41,40 @@ from agno.tools.user_feedback import UserFeedbackTools
 
 PORT = int(os.getenv("PORT", "7777"))
 BASE_URL = os.getenv("AGENT_OS_BASE_URL", f"http://127.0.0.1:{PORT}")
+OS_ID = "studio-hitl-os"
 AGENT_ID = "studio-hitl-agent"
 AUTO_INSTRUCTIONS = "Explain reliable research methods in concise steps."
+STUDIO_ADMIN_USER_ID = "studio-admin"
+JWT_SECRET = os.getenv(
+    "JWT_VERIFICATION_KEY",
+    "studio-hitl-development-secret-at-least-256-bits-long",
+)
+
+
+def authorize_studio_admin(
+    run_context: RunContext,
+    _access: StudioAccess,
+    _action: StudioAction,
+) -> bool:
+    """Limit the administrative Studio surface to the demo admin."""
+    return run_context.user_id == STUDIO_ADMIN_USER_ID
+
+
+def make_studio_admin_token() -> str:
+    """Mint a short-lived, audience-bound token for the local HTTP demo."""
+    now = datetime.now(UTC)
+    return jwt.encode(
+        {
+            "sub": STUDIO_ADMIN_USER_ID,
+            "aud": OS_ID,
+            "scopes": ["agent_os:admin"],
+            "iat": now,
+            "exp": now + timedelta(minutes=15),
+        },
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+
 
 DB_DIR = Path(__file__).parent / "tmp"
 DB_DIR.mkdir(exist_ok=True)
@@ -65,34 +102,44 @@ studio_agent = Agent(
         StudioTools(
             registry=registry,
             db=db,
-            default_model_id="gpt-5.5",
-            requires_confirmation_tools=["create_agent"],
+            authorize=authorize_studio_admin,
+            default_model=ModelRef(
+                id="gpt-5.5",
+                provider="OpenAI",
+                name="OpenAIResponses",
+            ),
         ),
         UserFeedbackTools(),
         UserControlFlowTools(),
     ],
     instructions=[
         "Help the user compose one Agent from registry primitives.",
-        "Call list_tools, list_models, and list_dbs first.",
+        "Call list_tools and list_models first; Studio already has one fixed catalog database.",
         "If tools are missing, call ask_user with one multi-select question whose "
         "options are exact names returned by list_tools.",
         "If instructions are missing, call get_user_input with one string field.",
         "Do not combine the missing tool and instruction questions in chat.",
-        "Use the exact database id returned by list_dbs when creating the Agent. "
-        "Never pass an empty string or the word 'default' as db_id.",
-        "Call create_agent only after both answers are available.",
+        "Translate each selected tool into the exact ToolRef returned by list_tools.",
+        "Call create_agent with one AgentCreate request only after both answers are available.",
+        "Keep the new component as a draft; publication is a separate admin decision.",
     ],
     db=db,
     markdown=True,
 )
 
 agent_os = AgentOS(
-    id="studio-hitl-os",
+    id=OS_ID,
     name="Studio HITL AgentOS",
     description="Studio composition with API-visible human-in-the-loop pauses.",
     agents=[studio_agent],
     registry=registry,
     db=db,
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+    ),
 )
 app = agent_os.get_app()
 
@@ -102,7 +149,10 @@ app = agent_os.get_app()
 # ---------------------------------------------------------------------------
 
 
-def resolve_paused_tools(tools: list[dict[str, Any]]) -> list[str]:
+def resolve_paused_tools(
+    tools: list[dict[str, Any]],
+    component_id: str,
+) -> list[str]:
     """Resolve every active feedback, input, or confirmation tool payload."""
     observed: list[str] = []
     for tool in tools:
@@ -129,6 +179,20 @@ def resolve_paused_tools(tools: list[dict[str, Any]]) -> list[str]:
             continue
 
         if tool.get("requires_confirmation") and tool.get("confirmed") is None:
+            tool_args = tool.get("tool_args")
+            request = tool_args.get("request") if isinstance(tool_args, dict) else None
+            requested_id = (
+                request.get("component_id") or request.get("name")
+                if isinstance(request, dict)
+                else None
+            )
+            if (
+                tool.get("tool_name") != "create_agent"
+                or requested_id != component_id
+                or not isinstance(tool_args, dict)
+                or tool_args.get("save_as", "draft") != "draft"
+            ):
+                raise RuntimeError(f"Unexpected Studio confirmation: {tool}")
             tool["confirmed"] = True
             observed.append("confirmation")
 
@@ -138,10 +202,14 @@ def resolve_paused_tools(tools: list[dict[str, Any]]) -> list[str]:
 
 
 def run_demo() -> None:
-    """Resolve all three pause types through the AgentOS continuation endpoint."""
+    """Resolve all three pause types as a verified Studio administrator."""
     component_id = f"os-research-buddy-{uuid4().hex[:8]}"
     session_id = f"studio-hitl-{component_id}"
-    with httpx.Client(base_url=BASE_URL, timeout=180.0) as client:
+    with httpx.Client(
+        base_url=BASE_URL,
+        timeout=180.0,
+        headers={"Authorization": f"Bearer {make_studio_admin_token()}"},
+    ) as client:
         response = client.post(
             f"/agents/{AGENT_ID}/runs",
             data={
@@ -157,7 +225,7 @@ def run_demo() -> None:
 
         while run["status"] == "PAUSED":
             tools = run.get("tools") or []
-            observed.extend(resolve_paused_tools(tools))
+            observed.extend(resolve_paused_tools(tools, component_id))
             response = client.post(
                 f"/agents/{AGENT_ID}/runs/{run['run_id']}/continue",
                 data={
@@ -185,10 +253,19 @@ def run_demo() -> None:
         component_response = client.get(f"/components/{component_id}")
         component_response.raise_for_status()
         component = component_response.json()
+        config_response = client.get(f"/components/{component_id}/configs/1")
+        config_response.raise_for_status()
+        config = config_response.json()
+        if component.get("current_version") is not None:
+            raise RuntimeError(
+                f"Expected a non-current draft component, got {component}"
+            )
+        if config.get("stage") != "draft":
+            raise RuntimeError(f"Expected draft version 1, got {config}")
 
     print(f"Pause sequence: {observed}")
     print(f"Final run: {run['run_id']} -> {run['status']}")
-    print(f"Created component: {component['component_id']}")
+    print(f"Created draft: {component['component_id']} v{config['version']}")
     print(run.get("content"))
 
 

--- a/cookbook/05_agent_os/22_studio/studio_runner_direct.py
+++ b/cookbook/05_agent_os/22_studio/studio_runner_direct.py
@@ -3,10 +3,11 @@ StudioRunnerTools called directly: list, run, and refusal semantics
 ===================================================================
 
 The runner's tools are plain methods, so a platform can call them without a
-wielding model. This example builds one component, lists it, runs it by id,
-and shows the registry guard: a runner constructed without the registry
-refuses to run a component whose stored config references registry-backed
-resources, because the rebuild would silently drop them.
+wielding model. This example builds typed Agent, Team, and Workflow components,
+lists them, runs an Agent by id, and shows the registry guard: a runner
+constructed without the registry refuses to run a component whose stored
+config references registry-backed resources, because the rebuild would
+silently drop them.
 
 Prerequisites: OPENAI_API_KEY
 Run: .venvs/demo/bin/python cookbook/05_agent_os/22_studio/studio_runner_direct.py
@@ -15,22 +16,46 @@ Try: pass registry=registry to the second runner and watch the refusal clear
 
 import json
 from pathlib import Path
+from typing import Any
 
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.registry import Registry
+from agno.run import RunContext
 from agno.tools.calculator import CalculatorTools
-from agno.tools.studio import StudioTools
+from agno.tools.studio import StudioAccess, StudioAction, StudioTools
 from agno.tools.studio_runner import StudioRunnerTools
+from agno.tools.studio_schema import (
+    AgentCreate,
+    ComponentRef,
+    ModelRef,
+    StudioResult,
+    TeamCreate,
+    TeamWorkflowStep,
+    ToolRef,
+    WorkflowCreate,
+)
 
 # ---------------------------------------------------------------------------
-# Create two components: one plain, one with registry-backed tools
+# Create typed, published components for runner-only discovery
 # ---------------------------------------------------------------------------
 
 DB_DIR = Path(__file__).parent / "tmp"
 DB_DIR.mkdir(exist_ok=True)
 DB_FILE = DB_DIR / "studio_runner_direct.db"
 DB_FILE.unlink(missing_ok=True)
+
+STUDIO_ADMIN_USER_ID = "studio-admin"
+
+
+def authorize_studio_admin(
+    run_context: RunContext,
+    _access: StudioAccess,
+    _action: StudioAction,
+) -> bool:
+    """Limit the administrative builder to the demo admin."""
+    return run_context.user_id == STUDIO_ADMIN_USER_ID
+
 
 db = SqliteDb(
     id="studio-runner-direct-db",
@@ -44,17 +69,94 @@ registry = Registry(
     dbs=[db],
 )
 
-builder = StudioTools(registry=registry, db=db, default_model_id="gpt-5.5")
-builder.create_agent(
-    name="Greeter",
-    instructions="Greet the user in one short sentence.",
-    model_id="gpt-5.5",
+builder = StudioTools(
+    registry=registry,
+    db=db,
+    authorize=authorize_studio_admin,
+    default_model=ModelRef(
+        id="gpt-5.5",
+        provider="OpenAI",
+        name="OpenAIResponses",
+    ),
+    teams=True,
+    workflows=True,
 )
-builder.create_agent(
-    name="Calculator Agent",
-    instructions="Solve arithmetic with the calculator tool.",
-    model_id="gpt-5.5",
-    tool_names=["calculator"],
+admin_context = RunContext(
+    run_id="seed-runner-components",
+    session_id="seed-components",
+    user_id=STUDIO_ADMIN_USER_ID,
+)
+
+
+def require_created(label: str, result: StudioResult[Any]) -> None:
+    """Stop immediately if a typed Studio seed operation failed."""
+    if not result.ok:
+        raise RuntimeError(f"Studio could not seed {label}: {result}")
+
+
+require_created(
+    "Greeter",
+    builder.create_agent(
+        AgentCreate(
+            component_id="greeter",
+            name="Greeter",
+            instructions="Greet the user in one short sentence.",
+        ),
+        save_as="published",
+        _agno_run_context=admin_context,
+    ),
+)
+require_created(
+    "Calculator Agent",
+    builder.create_agent(
+        AgentCreate(
+            component_id="calculator-agent",
+            name="Calculator Agent",
+            instructions="Solve arithmetic with the calculator tool.",
+            tools=[ToolRef(kind="toolkit", name="calculator")],
+        ),
+        save_as="published",
+        _agno_run_context=admin_context,
+    ),
+)
+require_created(
+    "Welcome Team",
+    builder.create_team(
+        TeamCreate(
+            component_id="welcome-team",
+            name="Welcome Team",
+            instructions="Delegate the greeting to the Greeter.",
+            members=[
+                ComponentRef(
+                    component_type="agent",
+                    component_id="greeter",
+                    version=1,
+                )
+            ],
+        ),
+        save_as="published",
+        _agno_run_context=admin_context,
+    ),
+)
+require_created(
+    "Welcome Workflow",
+    builder.create_workflow(
+        WorkflowCreate(
+            component_id="welcome-workflow",
+            name="Welcome Workflow",
+            steps=[
+                TeamWorkflowStep(
+                    kind="team",
+                    step_id="welcome",
+                    name="Welcome",
+                    component_id="welcome-team",
+                    version=1,
+                )
+            ],
+        ),
+        save_as="published",
+        _agno_run_context=admin_context,
+    ),
 )
 
 
@@ -70,8 +172,21 @@ def main() -> None:
     print("Agents in the platform database:")
     for row in listing["agents"]:
         print(" -", row["id"], "|", row["name"])
+    print("Teams:", [row["id"] for row in json.loads(runner.list_teams())["teams"]])
+    print(
+        "Workflows:",
+        [row["id"] for row in json.loads(runner.list_workflows())["workflows"]],
+    )
 
-    result = json.loads(runner.run_agent("greeter", "Hello there."))
+    result = json.loads(
+        runner.run_agent(
+            "greeter",
+            "Hello there.",
+            RunContext(
+                run_id="run-greeter", session_id="runner-demo", user_id="demo-user"
+            ),
+        )
+    )
     print("Run status:", result["status"])
     print("Run content:", result["content"])
 

--- a/cookbook/05_agent_os/22_studio/studio_runner_dispatcher.py
+++ b/cookbook/05_agent_os/22_studio/studio_runner_dispatcher.py
@@ -19,8 +19,10 @@ from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.registry import Registry
-from agno.tools.studio import StudioTools
+from agno.run import RunContext
+from agno.tools.studio import StudioAccess, StudioAction, StudioTools
 from agno.tools.studio_runner import StudioRunnerTools
+from agno.tools.studio_schema import AgentCreate, ModelRef
 
 # ---------------------------------------------------------------------------
 # Create a component with StudioTools
@@ -30,6 +32,18 @@ DB_DIR = Path(__file__).parent / "tmp"
 DB_DIR.mkdir(exist_ok=True)
 DB_FILE = DB_DIR / "studio_runner.db"
 DB_FILE.unlink(missing_ok=True)
+
+STUDIO_ADMIN_USER_ID = "studio-admin"
+
+
+def authorize_studio_admin(
+    run_context: RunContext,
+    _access: StudioAccess,
+    _action: StudioAction,
+) -> bool:
+    """Limit the administrative builder to the demo admin."""
+    return run_context.user_id == STUDIO_ADMIN_USER_ID
+
 
 db = SqliteDb(
     id="studio-runner-db",
@@ -42,12 +56,31 @@ registry = Registry(
     dbs=[db],
 )
 
-builder = StudioTools(registry=registry, db=db, default_model_id="gpt-5.5")
-builder.create_agent(
-    name="Haiku Writer",
-    instructions="Answer with a single haiku.",
-    model_id="gpt-5.5",
+builder = StudioTools(
+    registry=registry,
+    db=db,
+    authorize=authorize_studio_admin,
+    default_model=ModelRef(
+        id="gpt-5.5",
+        provider="OpenAI",
+        name="OpenAIResponses",
+    ),
 )
+created = builder.create_agent(
+    AgentCreate(
+        component_id="haiku-writer",
+        name="Haiku Writer",
+        instructions="Answer with a single haiku.",
+    ),
+    save_as="published",
+    _agno_run_context=RunContext(
+        run_id="seed-haiku-writer",
+        session_id="seed-components",
+        user_id=STUDIO_ADMIN_USER_ID,
+    ),
+)
+if not created.ok:
+    raise RuntimeError(f"Studio could not seed the Haiku Writer: {created}")
 
 # ---------------------------------------------------------------------------
 # Run it from a runner-only Agent

--- a/cookbook/05_agent_os/22_studio/studio_tools_agent.py
+++ b/cookbook/05_agent_os/22_studio/studio_tools_agent.py
@@ -12,19 +12,25 @@ Try: run this file with --demo in another terminal
 """
 
 import argparse
+import json
 import os
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from uuid import uuid4
 
 import httpx
+import jwt
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.anthropic import Claude
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
+from agno.os.config import AuthorizationConfig
 from agno.registry import Registry
+from agno.run import RunContext
 from agno.tools.calculator import CalculatorTools
-from agno.tools.studio import StudioTools
+from agno.tools.studio import StudioAccess, StudioAction, StudioTools
+from agno.tools.studio_schema import ModelRef
 
 # ---------------------------------------------------------------------------
 # Create Studio AgentOS
@@ -32,7 +38,39 @@ from agno.tools.studio import StudioTools
 
 PORT = int(os.getenv("PORT", "7777"))
 BASE_URL = os.getenv("AGENT_OS_BASE_URL", f"http://127.0.0.1:{PORT}")
+OS_ID = "studio-tools-os"
 STUDIO_AGENT_ID = "studio-agent"
+STUDIO_ADMIN_USER_ID = "studio-admin"
+JWT_SECRET = os.getenv(
+    "JWT_VERIFICATION_KEY",
+    "studio-tools-development-secret-at-least-256-bits-long",
+)
+
+
+def authorize_studio_admin(
+    run_context: RunContext,
+    _access: StudioAccess,
+    _action: StudioAction,
+) -> bool:
+    """Limit the administrative Studio surface to the demo admin."""
+    return run_context.user_id == STUDIO_ADMIN_USER_ID
+
+
+def make_studio_admin_token() -> str:
+    """Mint a short-lived, audience-bound token for the local HTTP demo."""
+    now = datetime.now(UTC)
+    return jwt.encode(
+        {
+            "sub": STUDIO_ADMIN_USER_ID,
+            "aud": OS_ID,
+            "scopes": ["agent_os:admin"],
+            "iat": now,
+            "exp": now + timedelta(minutes=15),
+        },
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+
 
 DB_DIR = Path(__file__).parent / "tmp"
 DB_DIR.mkdir(exist_ok=True)
@@ -71,9 +109,13 @@ reporter = Agent(
 studio_tools = StudioTools(
     registry=registry,
     db=db,
+    authorize=authorize_studio_admin,
     agents_list=[greeter, reporter],
-    default_model_id="gpt-5.5",
-    versions=True,
+    default_model=ModelRef(
+        id="gpt-5.5",
+        provider="OpenAI",
+        name="OpenAIResponses",
+    ),
 )
 
 studio_agent = Agent(
@@ -82,21 +124,29 @@ studio_agent = Agent(
     model=OpenAIResponses(id="gpt-5.5"),
     tools=[studio_tools],
     instructions=[
-        "Use StudioTools to compose persisted components from registry primitives.",
-        "Discover exact model and tool names before creating a component.",
-        "Report the component id, database version, and next versioning action.",
+        "Use StudioTools as an administrative control plane for persisted components.",
+        "Discover and copy exact typed model and tool references before creating a component.",
+        "Creates are drafts by default; publish only when the user explicitly asks.",
+        "Use expected_version and expected_current_version as compare-and-set guards.",
+        "Report result.status plus data.component_id, data.version, and data.stage.",
     ],
     db=db,
     markdown=True,
 )
 
 agent_os = AgentOS(
-    id="studio-tools-os",
+    id=OS_ID,
     name="Studio Tools AgentOS",
     description="AgentOS with code-defined and Studio-created components.",
     agents=[greeter, reporter, studio_agent],
     registry=registry,
     db=db,
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+    ),
 )
 app = agent_os.get_app()
 
@@ -106,10 +156,58 @@ app = agent_os.get_app()
 # ---------------------------------------------------------------------------
 
 
+def confirm_expected_actions(
+    tools: list[dict[str, object]],
+    component_id: str,
+    expected_actions: list[str],
+) -> list[str]:
+    """Confirm only the next exact Studio actions requested by the HTTP demo."""
+    pending = [
+        tool
+        for tool in tools
+        if tool.get("requires_confirmation") is True and tool.get("confirmed") is None
+    ]
+    if not pending or len(pending) > len(expected_actions):
+        raise RuntimeError(f"Unexpected Studio confirmations: {pending}")
+
+    confirmed: list[str] = []
+    for tool, expected_action in zip(pending, expected_actions):
+        tool_name = tool.get("tool_name")
+        tool_args = tool.get("tool_args")
+        if tool_name != expected_action or not isinstance(tool_args, dict):
+            raise RuntimeError(f"Unexpected confirmation request: {tool}")
+
+        if tool_name == "create_agent":
+            request = tool_args.get("request")
+            valid_args = (
+                isinstance(request, dict)
+                and request.get("component_id") == component_id
+                and tool_args.get("save_as", "draft") == "draft"
+            )
+        else:
+            valid_args = (
+                tool_name == "publish_component"
+                and tool_args.get("component_id") == component_id
+                and tool_args.get("version") == 1
+                and tool_args.get("expected_current_version") is None
+            )
+        if not valid_args:
+            raise RuntimeError(f"Unexpected {tool_name} arguments: {tool_args}")
+
+        print(f"Confirming {tool_name}: {tool_args}")
+        tool["confirmed"] = True
+        confirmed.append(tool_name)
+    return confirmed
+
+
 def run_demo() -> None:
-    """Use the live Studio Agent to create one persisted Agent."""
+    """Use a verified admin JWT to create one persisted Agent."""
     component_id = f"api-math-guide-{uuid4().hex[:8]}"
-    with httpx.Client(base_url=BASE_URL, timeout=180.0) as client:
+    with httpx.Client(
+        base_url=BASE_URL,
+        timeout=180.0,
+        headers={"Authorization": f"Bearer {make_studio_admin_token()}"},
+    ) as client:
         registry_response = client.get("/registry", params={"limit": 100})
         registry_response.raise_for_status()
         registry_names = {item["name"] for item in registry_response.json()["data"]}
@@ -120,10 +218,13 @@ def run_demo() -> None:
             f"/agents/{STUDIO_AGENT_ID}/runs",
             data={
                 "message": (
-                    "Call list_models and list_tools, then create an agent named "
-                    f"'{component_id}' with model 'gpt-5.5', exact tool name "
-                    "'calculator', and instructions 'Explain arithmetic clearly.' "
-                    "Do not edit or run it."
+                    "Call list_models and list_tools. Then call create_agent with an "
+                    f"AgentCreate request whose component_id is '{component_id}', "
+                    "name is 'API Math Guide', instructions are 'Explain arithmetic "
+                    "clearly.', model is the exact gpt-5.5 ModelRef, and tools contains "
+                    "the exact calculator toolkit ToolRef. Keep the default draft, "
+                    f"then publish '{component_id}' version 1 with "
+                    "expected_current_version=null. Do not edit or run it."
                 ),
                 "session_id": f"studio-tools-{component_id}",
                 "stream": "false",
@@ -131,6 +232,39 @@ def run_demo() -> None:
         )
         response.raise_for_status()
         run = response.json()
+        rounds = 0
+        expected_actions = ["create_agent", "publish_component"]
+        confirmed_actions: list[str] = []
+        while run["status"] == "PAUSED":
+            tools = run.get("tools") or []
+            if len(confirmed_actions) >= len(expected_actions):
+                raise RuntimeError(f"Unexpected extra Studio pause: {tools}")
+            confirmed_actions.extend(
+                confirm_expected_actions(
+                    tools,
+                    component_id,
+                    expected_actions[len(confirmed_actions) :],
+                )
+            )
+            response = client.post(
+                f"/agents/{STUDIO_AGENT_ID}/runs/{run['run_id']}/continue",
+                data={
+                    "tools": json.dumps(tools),
+                    "session_id": run["session_id"],
+                    "stream": "false",
+                },
+            )
+            response.raise_for_status()
+            run = response.json()
+            rounds += 1
+            if rounds > 4:
+                raise RuntimeError(
+                    "Studio Agent did not finish after four lifecycle continuations"
+                )
+        if confirmed_actions != expected_actions:
+            raise RuntimeError(
+                f"Expected confirmations {expected_actions}, got {confirmed_actions}"
+            )
         if run["status"] != "COMPLETED":
             raise RuntimeError(f"Expected COMPLETED, got {run['status']}")
 

--- a/cookbook/05_agent_os/TEST_PROMPT.md
+++ b/cookbook/05_agent_os/TEST_PROMPT.md
@@ -251,8 +251,9 @@ halves and record both observations.
 
 ### 22_studio
 
-- Run the standalone StudioTools create, edit, version, and publish lifecycle
-  against a synchronous SQLite database.
+- Run the standalone typed StudioTools create, edit, version, and publish
+  lifecycle against a synchronous SQLite database; verify the exact create,
+  publish, edit, and second-publish confirmations are continued in order.
 - Boot the AgentOS Studio servers and inspect registry primitives, code-defined
   components, and versioning tools.
 - Exercise user-feedback, user-input, and confirmation pauses both on the

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from agno.agent.agent import Agent
 
 from agno.db.base import BaseDb, ComponentType, SessionType
-from agno.db.utils import resolve_db_from_config
+from agno.db.utils import resolve_db_from_config, save_component_config
 from agno.exceptions import ComponentRehydrationError
 from agno.metrics import RunMetrics, SessionMetrics
 from agno.models.base import Model
@@ -1146,18 +1146,13 @@ def save(
         agent.id = generate_id_from_name(agent.name)
 
     try:
-        # Create or update component
-        db_.upsert_component(
+        config = save_component_config(
+            db_,
             component_id=agent.id,
             component_type=ComponentType.AGENT,
             name=getattr(agent, "name", agent.id),
             description=getattr(agent, "description", None),
             metadata=getattr(agent, "metadata", None),
-        )
-
-        # Create or update config
-        config = db_.upsert_config(
-            component_id=agent.id,
             config=to_dict(agent),
             label=label,
             stage=stage,
@@ -1224,6 +1219,7 @@ def delete(
     *,
     db: Optional[BaseDb] = None,
     hard_delete: bool = False,
+    require_no_dependents: bool = True,
 ) -> bool:
     """
     Delete the agent component.
@@ -1232,9 +1228,18 @@ def delete(
         agent: The Agent instance.
         db: The database to delete the component from.
         hard_delete: Whether to hard delete the component.
+        require_no_dependents: Refuse deletion while another active component
+            references this agent. Setting this to False bypasses dependency
+            validation and can leave active components with dangling links;
+            use it only for a deliberate repair or migration. Catalog-v1
+            adapters retain their historical unguarded deletion behavior.
 
     Returns:
         True if the component was deleted, False otherwise.
+
+    Raises:
+        ComponentDependencyError: If a dependent component references this
+            agent and require_no_dependents is True.
     """
     db_ = db or agent.db
     if not db_:
@@ -1244,4 +1249,12 @@ def delete(
     if agent.id is None:
         raise ValueError("Cannot delete agent without an id")
 
-    return db_.delete_component(component_id=agent.id, hard_delete=hard_delete)
+    if getattr(db_, "component_catalog_api_version", 1) < 2:
+        # Preserve the exact pre-2.9 adapter call shape. Third-party catalog-v1
+        # implementations cannot accept the v2-only keyword-only policy.
+        return db_.delete_component(component_id=agent.id, hard_delete=hard_delete)
+    return db_.delete_component(
+        component_id=agent.id,
+        hard_delete=hard_delete,
+        require_no_dependents=require_no_dependents,
+    )

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -983,8 +983,33 @@ class Agent:
         *,
         db: Optional["BaseDb"] = None,
         hard_delete: bool = False,
+        require_no_dependents: bool = True,
     ) -> bool:
-        return _storage.delete(self, db=db, hard_delete=hard_delete)
+        """Delete this agent's persisted component.
+
+        Args:
+            db: The database to delete the component from.
+            hard_delete: Permanently delete the component and its history.
+            require_no_dependents: Refuse deletion while another component
+                references this agent. Setting this to False bypasses
+                dependency validation and can leave active components with
+                dangling links; use it only for a deliberate repair or
+                migration. Catalog-v1 adapters retain their historical
+                unguarded deletion behavior.
+
+        Returns:
+            True if the component was deleted, False otherwise.
+
+        Raises:
+            ComponentDependencyError: If a dependent component references
+                this agent and require_no_dependents is True.
+        """
+        return _storage.delete(
+            self,
+            db=db,
+            hard_delete=hard_delete,
+            require_no_dependents=require_no_dependents,
+        )
 
     def get_run_output(
         self, run_id: str, session_id: Optional[str] = None, user_id: Optional[str] = None
@@ -1748,13 +1773,15 @@ def get_agent_by_id(
     label: Optional[str] = None,
     registry: Optional["Registry"] = None,
     strict: bool = False,
+    published_only: bool = False,
 ) -> Optional["Agent"]:
     """
     Get an Agent by id from the database (new entities/configs schema).
 
     Resolution order:
     - if label is provided: load that labeled version
-    - else: load component.current_version
+    - else: load the current published version, or the latest draft when the
+      component has never been published
 
     Args:
         db: Database handle.
@@ -1763,6 +1790,9 @@ def get_agent_by_id(
         registry: Optional Registry for reconstructing unserializable components.
         strict: If True, unresolvable registry references raise
             ComponentRehydrationError; None strictly means the agent was not found.
+        published_only: Resolve only the current published config when neither
+            an exact version nor label is supplied. Runtime dispatch uses this;
+            ordinary reads retain the draft-only fallback.
 
     Returns:
         Agent instance or None.
@@ -1774,7 +1804,11 @@ def get_agent_by_id(
     from agno.utils.log import log_error
 
     try:
-        row = db.get_config(component_id=id, label=label, version=version)
+        row = (
+            db.get_current_config(component_id=id)
+            if published_only and version is None and label is None
+            else db.get_config(component_id=id, label=label, version=version)
+        )
         if row is None:
             return None
 
@@ -1822,7 +1856,7 @@ def get_agents(
         )
         for component in components:
             try:
-                config = db.get_config(component_id=component["component_id"])
+                config = db.get_latest_config(component_id=component["component_id"])
                 if config is not None:
                     agent_config = config.get("config")
                     if agent_config is not None:
@@ -1833,7 +1867,7 @@ def get_agents(
                         # components so they stay visible and fixable.
                         agent = Agent.from_dict(agent_config, registry=registry, strict=False)
                         agent.id = component_id
-                        agent._version = component.get("current_version")
+                        agent._version = config.get("version")
                         agent._stage = config.get("stage")
                         agents.append(agent)
             except Exception as e:

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import date, datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Set, Tuple, TypedDict, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -27,11 +28,133 @@ class ComponentType(str, Enum):
     WORKFLOW = "workflow"
 
 
+DELETED_CONFIG_STAGE = "_deleted"
+
+
+@dataclass(frozen=True)
+class ComponentVersionGuard:
+    """Compare-and-set state for a component mutation."""
+
+    latest_version: Optional[int]
+    current_version: Optional[int]
+
+
+class ComponentProjection(TypedDict, total=False):
+    """Denormalized component fields synchronized with a config mutation."""
+
+    name: str
+    description: Optional[str]
+    metadata: Optional[Dict[str, Any]]
+
+
+class ComponentAlreadyExistsError(ValueError):
+    """Raised when an atomic component create finds an occupied id."""
+
+    def __init__(self, component_id: str):
+        super().__init__(f"Component {component_id} already exists")
+        self.component_id = component_id
+
+
+class ComponentVersionConflictError(ValueError):
+    """Raised when component state no longer matches a compare-and-set guard."""
+
+    def __init__(
+        self,
+        component_id: str,
+        *,
+        expected: ComponentVersionGuard,
+        actual: ComponentVersionGuard,
+    ):
+        super().__init__(
+            f"Component {component_id} version conflict: expected "
+            f"latest={expected.latest_version}, current={expected.current_version}; "
+            f"found latest={actual.latest_version}, current={actual.current_version}"
+        )
+        self.component_id = component_id
+        self.expected = expected
+        self.actual = actual
+
+
+class ComponentDependencyError(ValueError):
+    """Raised when a component or config is still referenced."""
+
+    def __init__(self, component_id: str, dependents: List[Dict[str, Any]], version: Optional[int] = None):
+        target = f"{component_id} v{version}" if version is not None else component_id
+        super().__init__(f"Cannot delete {target}: it is referenced by {len(dependents)} component link(s)")
+        self.component_id = component_id
+        self.version = version
+        self.dependents = dependents
+
+
+class ComponentDependencyUnavailableError(ValueError):
+    """Raised when restoring a published component would expose a broken dependency graph."""
+
+    def __init__(self, component_id: str, dependencies: List[Dict[str, Any]]):
+        super().__init__(
+            f"Cannot restore {component_id}: {len(dependencies)} pinned dependency version(s) are unavailable"
+        )
+        self.component_id = component_id
+        self.dependencies = dependencies
+
+
+class ComponentCycleError(ValueError):
+    """Raised when a component-link mutation would create a dependency cycle."""
+
+    def __init__(self, component_id: str, cycle_path: List[str]):
+        rendered_path = " -> ".join(cycle_path)
+        super().__init__(f"Component dependency cycle detected: {rendered_path}")
+        self.component_id = component_id
+        self.cycle_path = cycle_path
+
+
+class ComponentDraftRequiredError(ValueError):
+    """Raised when an operation only valid for drafts targets a published config."""
+
+    def __init__(self, component_id: str, version: int):
+        super().__init__(f"Cannot delete published config {component_id} v{version}; only draft configs can be deleted")
+        self.component_id = component_id
+        self.version = version
+
+
+class ComponentLastConfigError(ValueError):
+    """Raised when deleting a config would leave an active component unusable."""
+
+    def __init__(self, component_id: str, version: int):
+        super().__init__(f"Cannot delete the last config for {component_id}; archive the component instead")
+        self.component_id = component_id
+        self.version = version
+
+
 class BaseDb(ABC):
     """Base abstract class for all our Database implementations."""
 
     # We assume the database to be up to date with the 2.0.0 release
     default_schema_version = "2.0.0"
+    # Component persistence is an optional database capability. Catalog
+    # consumers must fail at construction time when a backend does not opt in,
+    # rather than surfacing a late NotImplementedError during a mutation.
+    supports_component_persistence = False
+    # Version 1 is the pre-2.9 component adapter contract. Direct component
+    # saves retain a deliberate v1 path; the guarded 2.9 control plane requires
+    # an adapter that explicitly advertises version 2.
+    component_catalog_api_version = 1
+    # Version 1 is the legacy scheduler adapter contract. Scheduler surfaces
+    # that rely on scoped names and durable manual triggers require an adapter
+    # that explicitly advertises version 2.
+    scheduler_api_version = 1
+
+    @staticmethod
+    def _projection_from_config(config: Dict[str, Any]) -> ComponentProjection:
+        """Extract denormalized component fields from one stored config payload."""
+        projection: ComponentProjection = {}
+        name = config.get("name")
+        if isinstance(name, str):
+            projection["name"] = name
+        if "description" in config and (config["description"] is None or isinstance(config["description"], str)):
+            projection["description"] = config["description"]
+        if "metadata" in config and (config["metadata"] is None or isinstance(config["metadata"], dict)):
+            projection["metadata"] = config["metadata"]
+        return projection
 
     def __init__(
         self,
@@ -665,17 +788,47 @@ class BaseDb(ABC):
         self,
         component_id: str,
         component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Get a component by ID.
 
         Args:
             component_id: The component ID.
             component_type: Optional filter by type (agent|team|workflow).
+            include_deleted: Include a soft-deleted component in the lookup.
 
         Returns:
             Component dictionary or None if not found.
         """
         raise NotImplementedError
+
+    def get_components(
+        self,
+        component_ids: Set[str],
+        component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Get a bounded set of components by ID.
+
+        The compatibility implementation uses scalar reads. Catalog adapters
+        should override this with one bulk query.
+        """
+        rows: List[Dict[str, Any]] = []
+        for component_id in sorted(component_ids):
+            row = (
+                self.get_component(
+                    component_id,
+                    component_type=component_type,
+                    include_deleted=True,
+                )
+                if include_deleted
+                else self.get_component(component_id, component_type)
+            )
+            if row is not None:
+                rows.append(row)
+        return rows
 
     def upsert_component(
         self,
@@ -693,14 +846,17 @@ class BaseDb(ABC):
             component_type: Type (agent|team|workflow). Required for create, optional for update.
             name: Display name.
             description: Optional description.
-            current_version: Optional current version.
+            current_version: Reserved for compatibility. Direct current-pointer
+                mutation is rejected; use set_current_version with a guard and
+                synchronized projection.
             metadata: Optional metadata dict.
 
         Returns:
             Created/updated component dictionary.
 
         Raises:
-            ValueError: If creating and component_type is not provided.
+            ValueError: If creating and component_type is not provided, or if
+                current_version is supplied.
         """
         raise NotImplementedError
 
@@ -708,15 +864,48 @@ class BaseDb(ABC):
         self,
         component_id: str,
         hard_delete: bool = False,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        require_no_dependents: bool = True,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Delete a component and all its configs/links.
 
         Args:
             component_id: The component ID.
             hard_delete: If True, permanently delete. Otherwise soft-delete.
+            guard: Optional expected latest/current version state.
+            require_no_dependents: Refuse deletion while referenced (the safe
+                default). Soft deletion considers active parents; hard deletion
+                considers every parent.
+            projection: Component fields to update atomically with a soft deletion.
 
         Returns:
             True if deleted, False if not found or already deleted.
+        """
+        raise NotImplementedError
+
+    def restore_component(
+        self,
+        component_id: str,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+    ) -> bool:
+        """Restore a soft-deleted component without replacing its identity or history.
+
+        A component with a current published version is restored only when its
+        complete pinned dependency graph is active and published. Draft-only
+        components have no runtime graph and may be restored independently.
+
+        Args:
+            component_id: The archived component ID.
+            guard: Optional expected latest/current version state.
+            projection: Optional component fields to restore atomically with
+                the archived row.
+
+        Returns:
+            True if restored, False if the component was not archived.
         """
         raise NotImplementedError
 
@@ -791,13 +980,66 @@ class BaseDb(ABC):
 
         Args:
             component_id: The component ID.
-            version: Specific version number. If None, uses current.
+            version: Specific version number. When both version and label are
+                omitted, returns the current published config or the latest
+                draft when the component has never been published.
             label: Config label to lookup. Ignored if version is provided.
 
         Returns:
             Config dictionary or None if not found.
         """
         raise NotImplementedError
+
+    def get_current_config(self, component_id: str) -> Optional[Dict[str, Any]]:
+        """Get only the component's current published config.
+
+        The default implementation uses v1-compatible calls so third-party
+        adapters can inherit it. Version-2 adapters should override it with a
+        single consistent read.
+        """
+        component = self.get_component(component_id)
+        if component is None:
+            return None
+        current_version = component.get("current_version")
+        if not isinstance(current_version, int):
+            return None
+        return self.get_config(component_id, version=current_version)
+
+    def get_latest_config(
+        self,
+        component_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Get the latest visible config, regardless of publication stage.
+
+        The default implementation retains compatibility with version-1
+        adapters. Version-2 adapters should override it with a direct query.
+        """
+        if include_deleted:
+            raise NotImplementedError("Catalog API v1 cannot read configs for archived components")
+        configs = self.list_configs(component_id, include_config=True)
+        return configs[0] if configs else None
+
+    def get_latest_configs(
+        self,
+        component_ids: Set[str],
+        *,
+        include_deleted: bool = False,
+    ) -> Dict[str, Optional[Dict[str, Any]]]:
+        """Get each requested component's latest visible config.
+
+        The compatibility implementation uses scalar reads. Catalog adapters
+        should override this with one bulk query.
+        """
+        rows: Dict[str, Optional[Dict[str, Any]]] = {}
+        for component_id in sorted(component_ids):
+            rows[component_id] = (
+                self.get_latest_config(component_id, include_deleted=True)
+                if include_deleted
+                else self.get_latest_config(component_id)
+            )
+        return rows
 
     def upsert_config(
         self,
@@ -808,22 +1050,40 @@ class BaseDb(ABC):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+        restore_if_deleted: bool = False,
+        expected_component_type: Optional[ComponentType] = None,
     ) -> Dict[str, Any]:
         """Create or update a config version for a component.
 
         Rules:
-            - Draft configs can be edited freely
+            - Stored config versions are immutable
+            - The latest draft may transition to published with a guard
             - Published configs are immutable
             - Publishing a config automatically sets it as current_version
 
         Args:
             component_id: The component ID.
-            config: The config data. Required for create, optional for update.
-            version: If None, creates new version. If provided, updates that version.
+            config: The config data. Required when appending a version.
+            version: If None, appends a version. If provided, publishes that draft.
             label: Optional human-readable label.
             stage: "draft" or "published". Defaults to "draft" for new configs.
             notes: Optional notes.
             links: Optional list of links. Each link must have child_version set.
+            guard: Optional expected latest/current version state. Required when
+                publishing an existing draft.
+            projection: Component fields to update atomically when publishing,
+                or while the component is draft-only. When omitted during a
+                pointer change, implementations derive it from the locked target
+                config. Once a published current version exists, a draft
+                projection is ignored.
+            restore_if_deleted: Restore an archived component in the same
+                transaction as the config mutation. Catalog API v2 adapters
+                must roll the restore back if the config mutation fails.
+            expected_component_type: Optional component identity invariant to
+                validate while holding the component write lock.
 
         Returns:
             Created/updated config dictionary.
@@ -838,21 +1098,30 @@ class BaseDb(ABC):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
-        """Delete a specific config version.
+        """Logically delete a specific config version.
 
         Only draft configs can be deleted. Published configs are immutable.
-        Cannot delete the current version.
+        Cannot delete the current version or the component's last visible
+        config. Implementations retain a hidden tombstone so version numbers
+        are never reused.
 
         Args:
             component_id: The component ID.
             version: The version to delete.
+            guard: Optional expected latest/current version state.
+            projection: Component fields to update atomically with deletion.
 
         Returns:
             True if deleted, False if not found.
 
         Raises:
-            ValueError: If attempting to delete a published or current config.
+            ComponentDraftRequiredError: If the config is published.
+            ComponentLastConfigError: If deleting the component's last visible config.
+            ValueError: If attempting to delete the current config.
         """
         raise NotImplementedError
 
@@ -877,6 +1146,9 @@ class BaseDb(ABC):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Set a specific published version as current.
 
@@ -887,6 +1159,9 @@ class BaseDb(ABC):
         Args:
             component_id: The component ID.
             version: The version to set as current (must be published).
+            guard: Optional expected latest/current version state.
+            projection: Component fields to update atomically with the current pointer.
+                When omitted, implementations derive them from the target config.
 
         Returns:
             True if successful, False if component or version not found.
@@ -919,12 +1194,15 @@ class BaseDb(ABC):
         self,
         component_id: str,
         version: Optional[int] = None,
+        *,
+        active_parents_only: bool = False,
     ) -> List[Dict[str, Any]]:
         """Find all components that reference this component.
 
         Args:
             component_id: The component ID to find dependents of.
             version: Optional specific version. If None, finds links to any version.
+            active_parents_only: Exclude links owned by soft-deleted parents.
 
         Returns:
             List of link dictionaries showing what depends on this component.
@@ -1226,8 +1504,15 @@ class BaseDb(ABC):
         """Get a schedule by ID."""
         raise NotImplementedError
 
-    def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
-        """Get a schedule by name."""
+    def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Get a schedule by name, optionally within one ownership namespace."""
         raise NotImplementedError
 
     def get_schedules(
@@ -1235,6 +1520,7 @@ class BaseDb(ABC):
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         """List schedules with optional filtering.
 
@@ -1255,12 +1541,43 @@ class BaseDb(ABC):
         """Delete a schedule and its associated runs."""
         raise NotImplementedError
 
+    def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue a manual trigger for a schedule."""
+        raise NotImplementedError
+
+    def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules in one managed target namespace."""
+        raise NotImplementedError
+
     def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
         """Atomically claim a due schedule for execution."""
         raise NotImplementedError
 
-    def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
-        """Release a claimed schedule and optionally update next_run_at."""
+    def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a fenced schedule claim and return its new lock timestamp."""
+        raise NotImplementedError
+
+    def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
+        """Release a claimed schedule, optionally fenced by its worker/timestamp lock pair."""
         raise NotImplementedError
 
     # --- Schedule Runs (Optional) ---
@@ -1488,6 +1805,10 @@ class BaseDb(ABC):
 
 class AsyncBaseDb(ABC):
     """Base abstract class for all our async database implementations."""
+
+    supports_component_persistence = False
+    component_catalog_api_version = 1
+    scheduler_api_version = 1
 
     def __init__(
         self,
@@ -2298,8 +2619,15 @@ class AsyncBaseDb(ABC):
         """Get a schedule by ID."""
         raise NotImplementedError
 
-    async def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
-        """Get a schedule by name."""
+    async def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Get a schedule by name, optionally within one ownership namespace."""
         raise NotImplementedError
 
     async def get_schedules(
@@ -2307,6 +2635,7 @@ class AsyncBaseDb(ABC):
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         """List schedules with optional filtering.
 
@@ -2327,12 +2656,43 @@ class AsyncBaseDb(ABC):
         """Delete a schedule and its associated runs."""
         raise NotImplementedError
 
+    async def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue a manual trigger for a schedule."""
+        raise NotImplementedError
+
+    async def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules in one managed target namespace."""
+        raise NotImplementedError
+
     async def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
         """Atomically claim a due schedule for execution."""
         raise NotImplementedError
 
-    async def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
-        """Release a claimed schedule and optionally update next_run_at."""
+    async def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a fenced schedule claim and return its new lock timestamp."""
+        raise NotImplementedError
+
+    async def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
+        """Release a claimed schedule, optionally fenced by its worker/timestamp lock pair."""
         raise NotImplementedError
 
     # --- Schedule Runs (Optional) ---

--- a/libs/agno/agno/db/clickhouse/clickhouse.py
+++ b/libs/agno/agno/db/clickhouse/clickhouse.py
@@ -786,6 +786,8 @@ class ClickhouseDb(BaseDb):
         self,
         component_id: str,
         component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         return None
 

--- a/libs/agno/agno/db/migrations/manager.py
+++ b/libs/agno/agno/db/migrations/manager.py
@@ -16,6 +16,7 @@ class MigrationManager:
         ("v2_3_0", packaging_version.parse("2.3.0")),
         ("v2_5_0", packaging_version.parse("2.5.0")),
         ("v2_5_6", packaging_version.parse("2.5.6")),
+        ("v2_9_0", packaging_version.parse("2.9.0")),
     ]
 
     def __init__(self, db: Union[AsyncBaseDb, BaseDb]):
@@ -51,6 +52,7 @@ class MigrationManager:
             "knowledge": "knowledge_table_name",
             "culture": "culture_table_name",
             "approvals": "approvals_table_name",
+            "schedules": "schedules_table_name",
         }
 
         # Select tables to migrate
@@ -122,8 +124,11 @@ class MigrationManager:
                 return await migration_module.async_up(self.db, table_type, table_name)
             else:
                 return migration_module.up(self.db, table_type, table_name)
-        except Exception as e:
-            log_error(f"Error running migration to version {version}: {str(e)}")
+        except Exception:
+            # Backend exception strings can contain connection URLs, credentials,
+            # or query parameters. The original exception is re-raised for the
+            # caller without duplicating those details into application logs.
+            log_error(f"Migration to version {version} failed")
             raise
 
     async def down(self, target_version: str, table_type: Optional[str] = None, force: bool = False):
@@ -144,6 +149,7 @@ class MigrationManager:
             "knowledge": "knowledge_table_name",
             "culture": "culture_table_name",
             "approvals": "approvals_table_name",
+            "schedules": "schedules_table_name",
         }
 
         # Select tables to migrate
@@ -200,6 +206,6 @@ class MigrationManager:
                 return await migration_module.async_down(self.db, table_type, table_name)
             else:
                 return migration_module.down(self.db, table_type, table_name)
-        except Exception as e:
-            log_error(f"Error running migration to version {version}: {str(e)}")
+        except Exception:
+            log_error(f"Migration rollback from version {version} failed")
             raise

--- a/libs/agno/agno/db/migrations/versions/v2_9_0.py
+++ b/libs/agno/agno/db/migrations/versions/v2_9_0.py
@@ -1,0 +1,1109 @@
+"""Migration v2.9.0: add Studio provenance and durable manual triggers.
+
+Generic schedule names stay globally unique within the generic surface. Studio
+names occupy a separate actor-scoped namespace, so a private Studio record is
+neither a name oracle nor a collision for an unrelated actor.
+"""
+
+import re
+from typing import Any
+
+from agno.db.base import AsyncBaseDb, BaseDb
+from agno.db.migrations.utils import quote_db_identifier
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY
+from agno.utils.log import log_info
+
+try:
+    from sqlalchemy import text
+except ImportError:
+    raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
+
+
+_PROVENANCE_COLUMNS = (
+    "managed_by",
+    "owner_actor_id",
+    "target_type",
+    "target_id",
+    "created_by_run_id",
+    "created_by_session_id",
+    "updated_by_run_id",
+    "updated_by_session_id",
+)
+_V2_9_COLUMNS = (*_PROVENANCE_COLUMNS, "pending_trigger_count", "manual_trigger_claimed")
+_LEGACY_SQLITE_COLUMNS = (
+    "id",
+    "name",
+    "description",
+    "method",
+    "endpoint",
+    "payload",
+    "cron_expr",
+    "timezone",
+    "timeout_seconds",
+    "max_retries",
+    "retry_delay_seconds",
+    "enabled",
+    "next_run_at",
+    "locked_by",
+    "locked_at",
+    "created_at",
+    "updated_at",
+)
+
+
+def _duplicate_error() -> ValueError:
+    return ValueError(
+        "Cannot enforce scoped unique schedule names because duplicates already exist; "
+        "remove or rename duplicate schedule rows, then retry the v2.9.0 migration."
+    )
+
+
+def _studio_data_error() -> ValueError:
+    return ValueError(
+        "Cannot remove Studio schedule provenance while Studio-managed schedules or their run history exist; "
+        "delete those schedules and runs, then retry the v2.9.0 downgrade."
+    )
+
+
+def _pending_trigger_error() -> ValueError:
+    return ValueError(
+        "Cannot remove durable schedule triggers while pending or claimed manual triggers exist; "
+        "allow the scheduler to consume them, then retry the v2.9.0 downgrade."
+    )
+
+
+def _sqlite_schema_error(schema_objects: list[str]) -> ValueError:
+    details = ", ".join(sorted(schema_objects))
+    return ValueError(
+        "Cannot safely rebuild the SQLite schedule table because it contains caller-owned or "
+        f"unrecognized schema: {details}. Remove or migrate that schema explicitly, then retry the v2.9.0 downgrade."
+    )
+
+
+def _studio_schedule_exists_query(db_type: str, table: str) -> Any:
+    managed_by = quote_db_identifier(db_type, "managed_by")
+    return text(f"SELECT 1 FROM {table} WHERE {managed_by} = :managed_by LIMIT 1")
+
+
+def _assert_no_studio_schedule_data(session: Any, db_type: str, table: str) -> None:
+    """Refuse to erase the only ownership boundary for Studio schedule data.
+
+    Schedule runs are owned through their parent schedule and are deleted with
+    it, so retaining a Studio schedule also retains every private run payload.
+    This check must run under the same write lock as the schema change.
+    """
+    studio_schedule = session.execute(
+        _studio_schedule_exists_query(db_type, table),
+        {"managed_by": STUDIO_SCHEDULE_MANAGED_BY},
+    ).scalar()
+    if studio_schedule is not None:
+        raise _studio_data_error()
+
+
+async def _assert_no_studio_schedule_data_async(session: Any, db_type: str, table: str) -> None:
+    studio_schedule = (
+        await session.execute(
+            _studio_schedule_exists_query(db_type, table),
+            {"managed_by": STUDIO_SCHEDULE_MANAGED_BY},
+        )
+    ).scalar()
+    if studio_schedule is not None:
+        raise _studio_data_error()
+
+
+def _assert_no_pending_triggers(
+    session: Any,
+    table: str,
+    *,
+    has_pending_count: bool,
+    has_claimed_marker: bool,
+) -> None:
+    predicates = []
+    if has_pending_count:
+        predicates.append("pending_trigger_count > 0")
+    if has_claimed_marker:
+        predicates.append("manual_trigger_claimed = TRUE")
+    if not predicates:
+        return
+    pending = session.execute(text(f"SELECT 1 FROM {table} WHERE {' OR '.join(predicates)} LIMIT 1")).scalar()
+    if pending is not None:
+        raise _pending_trigger_error()
+
+
+async def _assert_no_pending_triggers_async(
+    session: Any,
+    table: str,
+    *,
+    has_pending_count: bool,
+    has_claimed_marker: bool,
+) -> None:
+    predicates = []
+    if has_pending_count:
+        predicates.append("pending_trigger_count > 0")
+    if has_claimed_marker:
+        predicates.append("manual_trigger_claimed = TRUE")
+    if not predicates:
+        return
+    pending = (await session.execute(text(f"SELECT 1 FROM {table} WHERE {' OR '.join(predicates)} LIMIT 1"))).scalar()
+    if pending is not None:
+        raise _pending_trigger_error()
+
+
+def _is_sqlite(db: Any) -> bool:
+    from agno.db.sqlite.sqlite import SqliteDb
+
+    return isinstance(db, SqliteDb)
+
+
+def _is_postgres(db: Any) -> bool:
+    from agno.db.postgres.postgres import PostgresDb
+
+    return isinstance(db, PostgresDb)
+
+
+def _is_async_sqlite(db: Any) -> bool:
+    from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+
+    return isinstance(db, AsyncSqliteDb)
+
+
+def _is_async_postgres(db: Any) -> bool:
+    from agno.db.postgres.async_postgres import AsyncPostgresDb
+
+    return isinstance(db, AsyncPostgresDb)
+
+
+def up(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Apply the schedule migration for synchronous SQLite and PostgreSQL."""
+    if table_type != "schedules":
+        return False
+    db_type = type(db).__name__
+    if _is_sqlite(db):
+        return _migrate_sqlite(db, table_name)
+    if _is_postgres(db):
+        return _migrate_postgres(db, table_name)
+    log_info(f"{db_type} does not require the v2.9.0 schedule migration")
+    return False
+
+
+async def async_up(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Apply the schedule migration for asynchronous SQLite and PostgreSQL."""
+    if table_type != "schedules":
+        return False
+    db_type = type(db).__name__
+    if _is_async_sqlite(db):
+        return await _migrate_async_sqlite(db, table_name)
+    if _is_async_postgres(db):
+        return await _migrate_async_postgres(db, table_name)
+    log_info(f"{db_type} does not require the v2.9.0 schedule migration")
+    return False
+
+
+def down(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """Remove schedule provenance only after Studio-managed data is gone."""
+    if table_type != "schedules":
+        return False
+    if _is_sqlite(db):
+        return _revert_sqlite(db, table_name)
+    if _is_postgres(db):
+        return _revert_postgres(db, table_name)
+    return False
+
+
+async def async_down(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """Remove schedule provenance asynchronously only when no Studio data remains."""
+    if table_type != "schedules":
+        return False
+    if _is_async_sqlite(db):
+        return await _revert_async_sqlite(db, table_name)
+    if _is_async_postgres(db):
+        return await _revert_async_postgres(db, table_name)
+    return False
+
+
+def _index_names(db_type: str, table_name: str) -> dict[str, str]:
+    return {
+        "legacy": quote_db_identifier(db_type, f"{table_name}_uq_name"),
+        "generic": quote_db_identifier(db_type, f"{table_name}_uq_generic_name"),
+        "studio": quote_db_identifier(db_type, f"{table_name}_uq_studio_owner_name"),
+        "managed": quote_db_identifier(db_type, f"idx_{table_name}_managed_by"),
+        "owner": quote_db_identifier(db_type, f"idx_{table_name}_owner_actor_id"),
+    }
+
+
+def _sqlite_names(table_name: str) -> tuple[str, dict[str, str]]:
+    return quote_db_identifier("SqliteDb", table_name), _index_names("SqliteDb", table_name)
+
+
+def _sqlite_legacy_indexes(table_name: str) -> tuple[str, ...]:
+    return (
+        f"CREATE INDEX {quote_db_identifier('SqliteDb', f'idx_{table_name}_name')} "
+        f"ON {quote_db_identifier('SqliteDb', table_name)} (name)",
+        f"CREATE INDEX {quote_db_identifier('SqliteDb', f'idx_{table_name}_next_run_at')} "
+        f"ON {quote_db_identifier('SqliteDb', table_name)} (next_run_at)",
+        f"CREATE INDEX {quote_db_identifier('SqliteDb', f'idx_{table_name}_created_at')} "
+        f"ON {quote_db_identifier('SqliteDb', table_name)} (created_at)",
+        f"CREATE INDEX {quote_db_identifier('SqliteDb', f'idx_{table_name}_enabled_next_run_at')} "
+        f"ON {quote_db_identifier('SqliteDb', table_name)} (enabled, next_run_at)",
+    )
+
+
+def _sqlite_split_table_definitions(definitions: str) -> list[str]:
+    """Split a CREATE TABLE body without splitting nested expressions."""
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    quote: str | None = None
+    index = 0
+    while index < len(definitions):
+        char = definitions[index]
+        if quote is not None:
+            if quote == "[":
+                if char == "]":
+                    quote = None
+            elif char == quote:
+                if index + 1 < len(definitions) and definitions[index + 1] == quote:
+                    index += 1
+                else:
+                    quote = None
+        elif char in ("'", '"', "`", "["):
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        elif char == "," and depth == 0:
+            parts.append(definitions[start:index].strip())
+            start = index + 1
+        index += 1
+    parts.append(definitions[start:].strip())
+    return [part for part in parts if part]
+
+
+def _sqlite_definition_name(definition: str) -> str:
+    match = re.match(r'^\s*(?:"((?:""|[^"])*)"|`((?:``|[^`])*)`|\[([^]]+)\]|([^\s]+))', definition)
+    if match is None:
+        return ""
+    for value in match.groups():
+        if value is not None:
+            return value.replace('""', '"').replace("``", "`")
+    return ""
+
+
+def _sqlite_legacy_table_sql(source_sql: str, temporary_table_name: str) -> str:
+    """Remove only v2.9 columns while retaining the legacy table definition."""
+    open_paren = source_sql.find("(")
+    if open_paren < 0:
+        raise _sqlite_schema_error(["unreadable table definition"])
+
+    depth = 0
+    quote: str | None = None
+    close_paren = -1
+    index = open_paren
+    while index < len(source_sql):
+        char = source_sql[index]
+        if quote is not None:
+            if quote == "[":
+                if char == "]":
+                    quote = None
+            elif char == quote:
+                if index + 1 < len(source_sql) and source_sql[index + 1] == quote:
+                    index += 1
+                else:
+                    quote = None
+        elif char in ("'", '"', "`", "["):
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                close_paren = index
+                break
+        index += 1
+    if close_paren < 0:
+        raise _sqlite_schema_error(["unreadable table definition"])
+
+    definitions = _sqlite_split_table_definitions(source_sql[open_paren + 1 : close_paren])
+    legacy_definitions = [
+        definition for definition in definitions if _sqlite_definition_name(definition) not in _V2_9_COLUMNS
+    ]
+    if len(definitions) - len(legacy_definitions) != len(
+        {_sqlite_definition_name(definition) for definition in definitions}.intersection(_V2_9_COLUMNS)
+    ):
+        raise _sqlite_schema_error(["ambiguous v2.9 column definitions"])
+
+    temporary_table = quote_db_identifier("SqliteDb", temporary_table_name)
+    suffix = source_sql[close_paren + 1 :].strip()
+    suffix_sql = f" {suffix}" if suffix else ""
+    return f"CREATE TABLE {temporary_table} ({', '.join(legacy_definitions)}){suffix_sql}"
+
+
+def _sqlite_expected_index_specs(
+    table_name: str, indexes: dict[str, str]
+) -> dict[str, tuple[tuple[str, ...], bool, bool, str | None]]:
+    return {
+        f"idx_{table_name}_name": (("name",), False, False, None),
+        f"idx_{table_name}_next_run_at": (("next_run_at",), False, False, None),
+        f"idx_{table_name}_created_at": (("created_at",), False, False, None),
+        f"idx_{table_name}_enabled_next_run_at": (("enabled", "next_run_at"), False, False, None),
+        indexes["legacy"].strip('"'): (("name",), True, False, None),
+        indexes["managed"].strip('"'): (("managed_by",), False, False, None),
+        indexes["owner"].strip('"'): (("owner_actor_id",), False, False, None),
+        indexes["generic"].strip('"'): (
+            ("name",),
+            True,
+            True,
+            "managed_by is null or managed_by <> 'studio'",
+        ),
+        indexes["studio"].strip('"'): (
+            ("owner_actor_id", "name"),
+            True,
+            True,
+            "managed_by = 'studio'",
+        ),
+    }
+
+
+def _sqlite_normalize_predicate(index_sql: str | None) -> str | None:
+    if index_sql is None or re.search(r"\bwhere\b", index_sql, flags=re.IGNORECASE) is None:
+        return None
+    predicate = re.split(r"\bwhere\b", index_sql, maxsplit=1, flags=re.IGNORECASE)[1]
+    return " ".join(predicate.strip().lower().split())
+
+
+def _sqlite_schema_issues(
+    *,
+    table_name: str,
+    indexes: dict[str, str],
+    table_sql: str | None,
+    columns: list[Any],
+    index_rows: list[Any],
+    index_columns: dict[str, tuple[str, ...]],
+    index_sql: dict[str, str | None],
+    trigger_names: list[str],
+    foreign_keys: list[Any],
+    dependent_view_names: list[str],
+    temporary_object: str | None,
+) -> list[str]:
+    issues: list[str] = []
+    column_names = {row[1] for row in columns}
+    unknown_columns = column_names.difference((*_LEGACY_SQLITE_COLUMNS, *_V2_9_COLUMNS))
+    missing_columns = set(_LEGACY_SQLITE_COLUMNS).difference(column_names)
+    issues.extend(f"column {name!r}" for name in sorted(unknown_columns))
+    issues.extend(f"missing legacy column {name!r}" for name in sorted(missing_columns))
+    issues.extend(f"generated or hidden column {row[1]!r}" for row in columns if len(row) > 6 and row[6])
+
+    expected_indexes = _sqlite_expected_index_specs(table_name, indexes)
+    for row in index_rows:
+        name = row[1]
+        unique = bool(row[2])
+        origin = row[3] if len(row) > 3 else "c"
+        partial = bool(row[4]) if len(row) > 4 else False
+        columns_for_index = index_columns.get(name, ())
+        if origin == "pk" and columns_for_index == ("id",):
+            continue
+        expected = expected_indexes.get(name)
+        if expected is None:
+            issues.append(f"index {name!r}")
+            continue
+        expected_columns, expected_unique, expected_partial, expected_predicate = expected
+        if (
+            columns_for_index != expected_columns
+            or unique != expected_unique
+            or partial != expected_partial
+            or _sqlite_normalize_predicate(index_sql.get(name)) != expected_predicate
+        ):
+            issues.append(f"unrecognized definition for index {name!r}")
+
+    issues.extend(f"trigger {name!r}" for name in trigger_names)
+    if foreign_keys:
+        issues.append("outbound foreign key constraints")
+    issues.extend(f"dependent view {name!r}" for name in dependent_view_names)
+    if temporary_object is not None:
+        issues.append(f"existing downgrade temporary object {temporary_object!r}")
+
+    if table_sql is None:
+        issues.append("missing table definition")
+    else:
+        unsupported_features = re.findall(
+            r"\b(?:check|collate|generated|references|foreign\s+key|unique|without\s+rowid|strict|autoincrement)\b",
+            table_sql,
+            flags=re.IGNORECASE,
+        )
+        issues.extend(f"table feature {feature.lower()!r}" for feature in sorted(set(unsupported_features)))
+    return issues
+
+
+def _sqlite_rebuild_legacy_table(session: Any, table_name: str, table: str, source_sql: str) -> None:
+    temporary_table_name = f"{table_name}__v2_9_down"
+    temporary_table = quote_db_identifier("SqliteDb", temporary_table_name)
+    legacy_columns = ", ".join(quote_db_identifier("SqliteDb", column) for column in _LEGACY_SQLITE_COLUMNS)
+    session.execute(text(_sqlite_legacy_table_sql(source_sql, temporary_table_name)))
+    session.execute(text(f"INSERT INTO {temporary_table} ({legacy_columns}) SELECT {legacy_columns} FROM {table}"))
+    session.execute(text(f"DROP TABLE {table}"))
+    session.execute(text(f"ALTER TABLE {temporary_table} RENAME TO {quote_db_identifier('SqliteDb', table_name)}"))
+    for statement in _sqlite_legacy_indexes(table_name):
+        session.execute(text(statement))
+
+
+async def _sqlite_rebuild_legacy_table_async(session: Any, table_name: str, table: str, source_sql: str) -> None:
+    temporary_table_name = f"{table_name}__v2_9_down"
+    temporary_table = quote_db_identifier("AsyncSqliteDb", temporary_table_name)
+    legacy_columns = ", ".join(quote_db_identifier("AsyncSqliteDb", column) for column in _LEGACY_SQLITE_COLUMNS)
+    await session.execute(text(_sqlite_legacy_table_sql(source_sql, temporary_table_name)))
+    await session.execute(
+        text(f"INSERT INTO {temporary_table} ({legacy_columns}) SELECT {legacy_columns} FROM {table}")
+    )
+    await session.execute(text(f"DROP TABLE {table}"))
+    await session.execute(
+        text(f"ALTER TABLE {temporary_table} RENAME TO {quote_db_identifier('AsyncSqliteDb', table_name)}")
+    )
+    for statement in _sqlite_legacy_indexes(table_name):
+        await session.execute(text(statement))
+
+
+def _sqlite_table_exists(session: Any, table_name: str) -> bool:
+    return (
+        session.execute(
+            text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:table_name"),
+            {"table_name": table_name},
+        ).scalar()
+        is not None
+    )
+
+
+def _assert_sqlite_downgrade_schema_safe(session: Any, table_name: str, table: str, indexes: dict[str, str]) -> str:
+    table_sql = session.execute(
+        text("SELECT sql FROM sqlite_master WHERE type='table' AND name=:table_name"),
+        {"table_name": table_name},
+    ).scalar()
+    columns = list(session.execute(text(f"PRAGMA table_xinfo({table})")).fetchall())
+    index_rows = list(session.execute(text(f"PRAGMA index_list({table})")).fetchall())
+    index_columns: dict[str, tuple[str, ...]] = {}
+    index_sql: dict[str, str | None] = {}
+    for row in index_rows:
+        name = row[1]
+        quoted_name = quote_db_identifier("SqliteDb", name)
+        index_columns[name] = tuple(
+            index_row[2]
+            for index_row in session.execute(text(f"PRAGMA index_info({quoted_name})")).fetchall()
+            if index_row[2] is not None
+        )
+        index_sql[name] = session.execute(
+            text("SELECT sql FROM sqlite_master WHERE type='index' AND name=:name"), {"name": name}
+        ).scalar()
+    trigger_names = [
+        row[0]
+        for row in session.execute(
+            text("SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name=:table_name"),
+            {"table_name": table_name},
+        ).fetchall()
+    ]
+    foreign_keys = list(session.execute(text(f"PRAGMA foreign_key_list({table})")).fetchall())
+    dependent_view_names = [
+        row[0]
+        for row in session.execute(text("SELECT name, sql FROM sqlite_master WHERE type='view'")).fetchall()
+        if row[1] is not None and table_name.casefold() in row[1].casefold()
+    ]
+    temporary_table_name = f"{table_name}__v2_9_down"
+    temporary_object = session.execute(
+        text("SELECT type || ' ' || name FROM sqlite_master WHERE name=:name"),
+        {"name": temporary_table_name},
+    ).scalar()
+    issues = _sqlite_schema_issues(
+        table_name=table_name,
+        indexes=indexes,
+        table_sql=table_sql,
+        columns=columns,
+        index_rows=index_rows,
+        index_columns=index_columns,
+        index_sql=index_sql,
+        trigger_names=trigger_names,
+        foreign_keys=foreign_keys,
+        dependent_view_names=dependent_view_names,
+        temporary_object=temporary_object,
+    )
+    if issues:
+        raise _sqlite_schema_error(issues)
+    return table_sql
+
+
+async def _assert_sqlite_downgrade_schema_safe_async(
+    session: Any, table_name: str, table: str, indexes: dict[str, str]
+) -> str:
+    table_sql = (
+        await session.execute(
+            text("SELECT sql FROM sqlite_master WHERE type='table' AND name=:table_name"),
+            {"table_name": table_name},
+        )
+    ).scalar()
+    columns = list((await session.execute(text(f"PRAGMA table_xinfo({table})"))).fetchall())
+    index_rows = list((await session.execute(text(f"PRAGMA index_list({table})"))).fetchall())
+    index_columns: dict[str, tuple[str, ...]] = {}
+    index_sql: dict[str, str | None] = {}
+    for row in index_rows:
+        name = row[1]
+        quoted_name = quote_db_identifier("AsyncSqliteDb", name)
+        index_columns[name] = tuple(
+            index_row[2]
+            for index_row in (await session.execute(text(f"PRAGMA index_info({quoted_name})"))).fetchall()
+            if index_row[2] is not None
+        )
+        index_sql[name] = (
+            await session.execute(
+                text("SELECT sql FROM sqlite_master WHERE type='index' AND name=:name"), {"name": name}
+            )
+        ).scalar()
+    trigger_names = [
+        row[0]
+        for row in (
+            await session.execute(
+                text("SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name=:table_name"),
+                {"table_name": table_name},
+            )
+        ).fetchall()
+    ]
+    foreign_keys = list((await session.execute(text(f"PRAGMA foreign_key_list({table})"))).fetchall())
+    dependent_view_names = [
+        row[0]
+        for row in (await session.execute(text("SELECT name, sql FROM sqlite_master WHERE type='view'"))).fetchall()
+        if row[1] is not None and table_name.casefold() in row[1].casefold()
+    ]
+    temporary_table_name = f"{table_name}__v2_9_down"
+    temporary_object = (
+        await session.execute(
+            text("SELECT type || ' ' || name FROM sqlite_master WHERE name=:name"),
+            {"name": temporary_table_name},
+        )
+    ).scalar()
+    issues = _sqlite_schema_issues(
+        table_name=table_name,
+        indexes=indexes,
+        table_sql=table_sql,
+        columns=columns,
+        index_rows=index_rows,
+        index_columns=index_columns,
+        index_sql=index_sql,
+        trigger_names=trigger_names,
+        foreign_keys=foreign_keys,
+        dependent_view_names=dependent_view_names,
+        temporary_object=temporary_object,
+    )
+    if issues:
+        raise _sqlite_schema_error(issues)
+    return table_sql
+
+
+def _migrate_sqlite(db: BaseDb, table_name: str) -> bool:
+    table, indexes = _sqlite_names(table_name)
+    with db.Session() as session, session.begin():  # type: ignore[attr-defined]
+        session.connection().exec_driver_sql("BEGIN IMMEDIATE")
+        if not _sqlite_table_exists(session, table_name):
+            return False
+        columns = {row[1] for row in session.execute(text(f"PRAGMA table_info({table})")).fetchall()}
+        # SQLite may persist ALTER TABLE even when a surrounding ORM
+        # transaction later fails. Preflight legacy uniqueness before the
+        # first DDL statement so a rejected migration leaves no new columns.
+        if "managed_by" not in columns:
+            legacy_duplicate = session.execute(
+                text(f"SELECT 1 FROM {table} GROUP BY name HAVING COUNT(*) > 1 LIMIT 1")
+            ).scalar()
+            if legacy_duplicate is not None:
+                raise _duplicate_error()
+        else:
+            generic_duplicate = session.execute(
+                text(
+                    f"SELECT 1 FROM {table} WHERE managed_by IS NULL OR managed_by <> :studio "
+                    "GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"
+                ),
+                {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+            ).scalar()
+            studio_group = "owner_actor_id, name" if "owner_actor_id" in columns else "name"
+            studio_duplicate = session.execute(
+                text(
+                    f"SELECT 1 FROM {table} WHERE managed_by = :studio "
+                    f"GROUP BY {studio_group} HAVING COUNT(*) > 1 LIMIT 1"
+                ),
+                {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+            ).scalar()
+            if generic_duplicate is not None or studio_duplicate is not None:
+                raise _duplicate_error()
+        applied = False
+        for column in _PROVENANCE_COLUMNS:
+            if column not in columns:
+                quoted_column = quote_db_identifier("SqliteDb", column)
+                session.execute(text(f"ALTER TABLE {table} ADD COLUMN {quoted_column} TEXT"))
+                applied = True
+        if "pending_trigger_count" not in columns:
+            session.execute(text(f"ALTER TABLE {table} ADD COLUMN pending_trigger_count INTEGER NOT NULL DEFAULT 0"))
+            applied = True
+        if "manual_trigger_claimed" not in columns:
+            session.execute(text(f"ALTER TABLE {table} ADD COLUMN manual_trigger_claimed INTEGER NOT NULL DEFAULT 0"))
+            applied = True
+
+        generic_duplicate = session.execute(
+            text(
+                f"SELECT 1 FROM {table} WHERE managed_by IS NULL OR managed_by <> :studio "
+                "GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"
+            ),
+            {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+        ).scalar()
+        studio_duplicate = session.execute(
+            text(
+                f"SELECT 1 FROM {table} WHERE managed_by = :studio "
+                "GROUP BY owner_actor_id, name HAVING COUNT(*) > 1 LIMIT 1"
+            ),
+            {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+        ).scalar()
+        if generic_duplicate is not None or studio_duplicate is not None:
+            raise _duplicate_error()
+
+        index_names = {row[1] for row in session.execute(text(f"PRAGMA index_list({table})")).fetchall()}
+        if indexes["legacy"].strip('"') in index_names:
+            session.execute(text(f"DROP INDEX {indexes['legacy']}"))
+            applied = True
+        statements = {
+            "managed": f"CREATE INDEX {indexes['managed']} ON {table} (managed_by)",
+            "owner": f"CREATE INDEX {indexes['owner']} ON {table} (owner_actor_id)",
+            "generic": (
+                f"CREATE UNIQUE INDEX {indexes['generic']} ON {table} (name) "
+                "WHERE managed_by IS NULL OR managed_by <> 'studio'"
+            ),
+            "studio": (
+                f"CREATE UNIQUE INDEX {indexes['studio']} ON {table} (owner_actor_id, name) WHERE managed_by = 'studio'"
+            ),
+        }
+        for key, statement in statements.items():
+            if indexes[key].strip('"') not in index_names:
+                session.execute(text(statement))
+                applied = True
+        return applied
+
+
+async def _migrate_async_sqlite(db: AsyncBaseDb, table_name: str) -> bool:
+    table, indexes = _sqlite_names(table_name)
+    async with db.async_session_factory() as session, session.begin():  # type: ignore[attr-defined]
+        await session.execute(text("BEGIN IMMEDIATE"))
+        exists = (
+            await session.execute(
+                text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:table_name"),
+                {"table_name": table_name},
+            )
+        ).scalar()
+        if exists is None:
+            return False
+        columns = {row[1] for row in (await session.execute(text(f"PRAGMA table_info({table})"))).fetchall()}
+        if "managed_by" not in columns:
+            legacy_duplicate = (
+                await session.execute(text(f"SELECT 1 FROM {table} GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"))
+            ).scalar()
+            if legacy_duplicate is not None:
+                raise _duplicate_error()
+        else:
+            generic_duplicate = (
+                await session.execute(
+                    text(
+                        f"SELECT 1 FROM {table} WHERE managed_by IS NULL OR managed_by <> :studio "
+                        "GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"
+                    ),
+                    {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+                )
+            ).scalar()
+            studio_group = "owner_actor_id, name" if "owner_actor_id" in columns else "name"
+            studio_duplicate = (
+                await session.execute(
+                    text(
+                        f"SELECT 1 FROM {table} WHERE managed_by = :studio "
+                        f"GROUP BY {studio_group} HAVING COUNT(*) > 1 LIMIT 1"
+                    ),
+                    {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+                )
+            ).scalar()
+            if generic_duplicate is not None or studio_duplicate is not None:
+                raise _duplicate_error()
+        applied = False
+        for column in _PROVENANCE_COLUMNS:
+            if column not in columns:
+                quoted_column = quote_db_identifier("AsyncSqliteDb", column)
+                await session.execute(text(f"ALTER TABLE {table} ADD COLUMN {quoted_column} TEXT"))
+                applied = True
+        if "pending_trigger_count" not in columns:
+            await session.execute(
+                text(f"ALTER TABLE {table} ADD COLUMN pending_trigger_count INTEGER NOT NULL DEFAULT 0")
+            )
+            applied = True
+        if "manual_trigger_claimed" not in columns:
+            await session.execute(
+                text(f"ALTER TABLE {table} ADD COLUMN manual_trigger_claimed INTEGER NOT NULL DEFAULT 0")
+            )
+            applied = True
+
+        generic_duplicate = (
+            await session.execute(
+                text(
+                    f"SELECT 1 FROM {table} WHERE managed_by IS NULL OR managed_by <> :studio "
+                    "GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"
+                ),
+                {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+            )
+        ).scalar()
+        studio_duplicate = (
+            await session.execute(
+                text(
+                    f"SELECT 1 FROM {table} WHERE managed_by = :studio "
+                    "GROUP BY owner_actor_id, name HAVING COUNT(*) > 1 LIMIT 1"
+                ),
+                {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+            )
+        ).scalar()
+        if generic_duplicate is not None or studio_duplicate is not None:
+            raise _duplicate_error()
+
+        index_names = {row[1] for row in (await session.execute(text(f"PRAGMA index_list({table})"))).fetchall()}
+        if indexes["legacy"].strip('"') in index_names:
+            await session.execute(text(f"DROP INDEX {indexes['legacy']}"))
+            applied = True
+        statements = {
+            "managed": f"CREATE INDEX {indexes['managed']} ON {table} (managed_by)",
+            "owner": f"CREATE INDEX {indexes['owner']} ON {table} (owner_actor_id)",
+            "generic": (
+                f"CREATE UNIQUE INDEX {indexes['generic']} ON {table} (name) "
+                "WHERE managed_by IS NULL OR managed_by <> 'studio'"
+            ),
+            "studio": (
+                f"CREATE UNIQUE INDEX {indexes['studio']} ON {table} (owner_actor_id, name) WHERE managed_by = 'studio'"
+            ),
+        }
+        for key, statement in statements.items():
+            if indexes[key].strip('"') not in index_names:
+                await session.execute(text(statement))
+                applied = True
+        return applied
+
+
+def _postgres_names(db: Any, table_name: str) -> tuple[str, dict[str, str]]:
+    db_type = type(db).__name__
+    schema = quote_db_identifier(db_type, db.db_schema)
+    table = quote_db_identifier(db_type, table_name)
+    full_table = f"{schema}.{table}"
+    return full_table, _index_names(db_type, table_name)
+
+
+def _migrate_postgres(db: BaseDb, table_name: str) -> bool:
+    full_table, indexes = _postgres_names(db, table_name)
+    schema = full_table.rsplit(".", 1)[0]
+    with db.Session() as session, session.begin():  # type: ignore[attr-defined]
+        exists = session.execute(
+            text("SELECT 1 FROM information_schema.tables WHERE table_schema=:schema AND table_name=:table"),
+            {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+        ).scalar()
+        if exists is None:
+            return False
+        for column in _PROVENANCE_COLUMNS:
+            quoted_column = quote_db_identifier(type(db).__name__, column)
+            session.execute(text(f"ALTER TABLE {full_table} ADD COLUMN IF NOT EXISTS {quoted_column} VARCHAR"))
+        session.execute(
+            text(f"ALTER TABLE {full_table} ADD COLUMN IF NOT EXISTS pending_trigger_count BIGINT NOT NULL DEFAULT 0")
+        )
+        session.execute(
+            text(
+                f"ALTER TABLE {full_table} ADD COLUMN IF NOT EXISTS manual_trigger_claimed BOOLEAN NOT NULL DEFAULT FALSE"
+            )
+        )
+        generic_duplicate = session.execute(
+            text(
+                f"SELECT 1 FROM {full_table} WHERE managed_by IS DISTINCT FROM :studio "
+                "GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"
+            ),
+            {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+        ).scalar()
+        studio_duplicate = session.execute(
+            text(
+                f"SELECT 1 FROM {full_table} WHERE managed_by = :studio "
+                "GROUP BY owner_actor_id, name HAVING COUNT(*) > 1 LIMIT 1"
+            ),
+            {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+        ).scalar()
+        if generic_duplicate is not None or studio_duplicate is not None:
+            raise _duplicate_error()
+        session.execute(text(f"DROP INDEX IF EXISTS {schema}.{indexes['legacy']}"))
+        session.execute(text(f"CREATE INDEX IF NOT EXISTS {indexes['managed']} ON {full_table} (managed_by)"))
+        session.execute(text(f"CREATE INDEX IF NOT EXISTS {indexes['owner']} ON {full_table} (owner_actor_id)"))
+        session.execute(
+            text(
+                f"CREATE UNIQUE INDEX IF NOT EXISTS {indexes['generic']} ON {full_table} (name) "
+                "WHERE managed_by IS DISTINCT FROM 'studio'"
+            )
+        )
+        session.execute(
+            text(
+                f"CREATE UNIQUE INDEX IF NOT EXISTS {indexes['studio']} ON {full_table} (owner_actor_id, name) "
+                "WHERE managed_by = 'studio'"
+            )
+        )
+        return True
+
+
+async def _migrate_async_postgres(db: AsyncBaseDb, table_name: str) -> bool:
+    full_table, indexes = _postgres_names(db, table_name)
+    schema = full_table.rsplit(".", 1)[0]
+    async with db.async_session_factory() as session, session.begin():  # type: ignore[attr-defined]
+        exists = (
+            await session.execute(
+                text("SELECT 1 FROM information_schema.tables WHERE table_schema=:schema AND table_name=:table"),
+                {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+            )
+        ).scalar()
+        if exists is None:
+            return False
+        for column in _PROVENANCE_COLUMNS:
+            quoted_column = quote_db_identifier(type(db).__name__, column)
+            await session.execute(text(f"ALTER TABLE {full_table} ADD COLUMN IF NOT EXISTS {quoted_column} VARCHAR"))
+        await session.execute(
+            text(f"ALTER TABLE {full_table} ADD COLUMN IF NOT EXISTS pending_trigger_count BIGINT NOT NULL DEFAULT 0")
+        )
+        await session.execute(
+            text(
+                f"ALTER TABLE {full_table} ADD COLUMN IF NOT EXISTS manual_trigger_claimed BOOLEAN NOT NULL DEFAULT FALSE"
+            )
+        )
+        generic_duplicate = (
+            await session.execute(
+                text(
+                    f"SELECT 1 FROM {full_table} WHERE managed_by IS DISTINCT FROM :studio "
+                    "GROUP BY name HAVING COUNT(*) > 1 LIMIT 1"
+                ),
+                {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+            )
+        ).scalar()
+        studio_duplicate = (
+            await session.execute(
+                text(
+                    f"SELECT 1 FROM {full_table} WHERE managed_by = :studio "
+                    "GROUP BY owner_actor_id, name HAVING COUNT(*) > 1 LIMIT 1"
+                ),
+                {"studio": STUDIO_SCHEDULE_MANAGED_BY},
+            )
+        ).scalar()
+        if generic_duplicate is not None or studio_duplicate is not None:
+            raise _duplicate_error()
+        await session.execute(text(f"DROP INDEX IF EXISTS {schema}.{indexes['legacy']}"))
+        await session.execute(text(f"CREATE INDEX IF NOT EXISTS {indexes['managed']} ON {full_table} (managed_by)"))
+        await session.execute(text(f"CREATE INDEX IF NOT EXISTS {indexes['owner']} ON {full_table} (owner_actor_id)"))
+        await session.execute(
+            text(
+                f"CREATE UNIQUE INDEX IF NOT EXISTS {indexes['generic']} ON {full_table} (name) "
+                "WHERE managed_by IS DISTINCT FROM 'studio'"
+            )
+        )
+        await session.execute(
+            text(
+                f"CREATE UNIQUE INDEX IF NOT EXISTS {indexes['studio']} ON {full_table} (owner_actor_id, name) "
+                "WHERE managed_by = 'studio'"
+            )
+        )
+        return True
+
+
+def _revert_sqlite(db: BaseDb, table_name: str) -> bool:
+    table, indexes = _sqlite_names(table_name)
+    # SQLite's portable DROP COLUMN path is a table rebuild. Foreign keys must
+    # be disabled on this exact connection before the transaction begins so
+    # replacing the parent schedule table does not cascade-delete run history.
+    with db.db_engine.connect() as session:  # type: ignore[attr-defined]
+        foreign_keys_enabled = bool(session.exec_driver_sql("PRAGMA foreign_keys").scalar())
+        session.exec_driver_sql("PRAGMA foreign_keys=OFF")
+        session.commit()
+        try:
+            session.exec_driver_sql("BEGIN IMMEDIATE")
+            if not _sqlite_table_exists(session, table_name):
+                session.rollback()
+                return False
+            columns = {row[1] for row in session.execute(text(f"PRAGMA table_info({table})")).fetchall()}
+            v2_9_columns_present = set(_V2_9_COLUMNS).intersection(columns)
+            source_sql = None
+            if v2_9_columns_present:
+                source_sql = _assert_sqlite_downgrade_schema_safe(session, table_name, table, indexes)
+            if "managed_by" in columns:
+                _assert_no_studio_schedule_data(session, "SqliteDb", table)
+            if "pending_trigger_count" in columns or "manual_trigger_claimed" in columns:
+                _assert_no_pending_triggers(
+                    session,
+                    table,
+                    has_pending_count="pending_trigger_count" in columns,
+                    has_claimed_marker="manual_trigger_claimed" in columns,
+                )
+            index_names = {row[1] for row in session.execute(text(f"PRAGMA index_list({table})")).fetchall()}
+            applied = bool(v2_9_columns_present) or any(index.strip('"') in index_names for index in indexes.values())
+            if applied and v2_9_columns_present:
+                assert source_sql is not None
+                _sqlite_rebuild_legacy_table(session, table_name, table, source_sql)
+            else:
+                for index in indexes.values():
+                    if index.strip('"') in index_names:
+                        session.execute(text(f"DROP INDEX IF EXISTS {index}"))
+            session.commit()
+            return applied
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.exec_driver_sql(f"PRAGMA foreign_keys={1 if foreign_keys_enabled else 0}")
+            session.commit()
+
+
+async def _revert_async_sqlite(db: AsyncBaseDb, table_name: str) -> bool:
+    table, indexes = _sqlite_names(table_name)
+    async with db.db_engine.connect() as session:  # type: ignore[attr-defined]
+        foreign_keys_enabled = bool((await session.exec_driver_sql("PRAGMA foreign_keys")).scalar())
+        await session.exec_driver_sql("PRAGMA foreign_keys=OFF")
+        await session.commit()
+        try:
+            await session.exec_driver_sql("BEGIN IMMEDIATE")
+            exists = (
+                await session.execute(
+                    text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:table_name"),
+                    {"table_name": table_name},
+                )
+            ).scalar()
+            if exists is None:
+                await session.rollback()
+                return False
+            columns = {row[1] for row in (await session.execute(text(f"PRAGMA table_info({table})"))).fetchall()}
+            v2_9_columns_present = set(_V2_9_COLUMNS).intersection(columns)
+            source_sql = None
+            if v2_9_columns_present:
+                source_sql = await _assert_sqlite_downgrade_schema_safe_async(session, table_name, table, indexes)
+            if "managed_by" in columns:
+                await _assert_no_studio_schedule_data_async(session, "AsyncSqliteDb", table)
+            if "pending_trigger_count" in columns or "manual_trigger_claimed" in columns:
+                await _assert_no_pending_triggers_async(
+                    session,
+                    table,
+                    has_pending_count="pending_trigger_count" in columns,
+                    has_claimed_marker="manual_trigger_claimed" in columns,
+                )
+            index_names = {row[1] for row in (await session.execute(text(f"PRAGMA index_list({table})"))).fetchall()}
+            applied = bool(v2_9_columns_present) or any(index.strip('"') in index_names for index in indexes.values())
+            if applied and v2_9_columns_present:
+                assert source_sql is not None
+                await _sqlite_rebuild_legacy_table_async(session, table_name, table, source_sql)
+            else:
+                for index in indexes.values():
+                    if index.strip('"') in index_names:
+                        await session.execute(text(f"DROP INDEX IF EXISTS {index}"))
+            await session.commit()
+            return applied
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.exec_driver_sql(f"PRAGMA foreign_keys={1 if foreign_keys_enabled else 0}")
+            await session.commit()
+
+
+def _revert_postgres(db: BaseDb, table_name: str) -> bool:
+    full_table, indexes = _postgres_names(db, table_name)
+    schema = full_table.rsplit(".", 1)[0]
+    with db.Session() as session, session.begin():  # type: ignore[attr-defined]
+        exists = session.execute(
+            text("SELECT 1 FROM information_schema.tables WHERE table_schema=:schema AND table_name=:table"),
+            {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+        ).scalar()
+        if exists is None:
+            return False
+        session.execute(text(f"LOCK TABLE {full_table} IN ACCESS EXCLUSIVE MODE"))
+        managed_by_exists = session.execute(
+            text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema=:schema AND table_name=:table AND column_name='managed_by'"
+            ),
+            {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+        ).scalar()
+        if managed_by_exists is not None:
+            _assert_no_studio_schedule_data(session, type(db).__name__, full_table)
+        pending_trigger_exists = session.execute(
+            text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema=:schema AND table_name=:table AND column_name='pending_trigger_count'"
+            ),
+            {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+        ).scalar()
+        claimed_trigger_exists = session.execute(
+            text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema=:schema AND table_name=:table AND column_name='manual_trigger_claimed'"
+            ),
+            {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+        ).scalar()
+        if pending_trigger_exists is not None or claimed_trigger_exists is not None:
+            _assert_no_pending_triggers(
+                session,
+                full_table,
+                has_pending_count=pending_trigger_exists is not None,
+                has_claimed_marker=claimed_trigger_exists is not None,
+            )
+        for index in indexes.values():
+            session.execute(text(f"DROP INDEX IF EXISTS {schema}.{index}"))
+        for column in reversed(_V2_9_COLUMNS):
+            quoted_column = quote_db_identifier(type(db).__name__, column)
+            session.execute(text(f"ALTER TABLE {full_table} DROP COLUMN IF EXISTS {quoted_column}"))
+        return True
+
+
+async def _revert_async_postgres(db: AsyncBaseDb, table_name: str) -> bool:
+    full_table, indexes = _postgres_names(db, table_name)
+    schema = full_table.rsplit(".", 1)[0]
+    async with db.async_session_factory() as session, session.begin():  # type: ignore[attr-defined]
+        exists = (
+            await session.execute(
+                text("SELECT 1 FROM information_schema.tables WHERE table_schema=:schema AND table_name=:table"),
+                {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+            )
+        ).scalar()
+        if exists is None:
+            return False
+        await session.execute(text(f"LOCK TABLE {full_table} IN ACCESS EXCLUSIVE MODE"))
+        managed_by_exists = (
+            await session.execute(
+                text(
+                    "SELECT 1 FROM information_schema.columns "
+                    "WHERE table_schema=:schema AND table_name=:table AND column_name='managed_by'"
+                ),
+                {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+            )
+        ).scalar()
+        if managed_by_exists is not None:
+            await _assert_no_studio_schedule_data_async(session, type(db).__name__, full_table)
+        pending_trigger_exists = (
+            await session.execute(
+                text(
+                    "SELECT 1 FROM information_schema.columns "
+                    "WHERE table_schema=:schema AND table_name=:table AND column_name='pending_trigger_count'"
+                ),
+                {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+            )
+        ).scalar()
+        claimed_trigger_exists = (
+            await session.execute(
+                text(
+                    "SELECT 1 FROM information_schema.columns "
+                    "WHERE table_schema=:schema AND table_name=:table AND column_name='manual_trigger_claimed'"
+                ),
+                {"schema": db.db_schema, "table": table_name},  # type: ignore[attr-defined]
+            )
+        ).scalar()
+        if pending_trigger_exists is not None or claimed_trigger_exists is not None:
+            await _assert_no_pending_triggers_async(
+                session,
+                full_table,
+                has_pending_count=pending_trigger_exists is not None,
+                has_claimed_marker=claimed_trigger_exists is not None,
+            )
+        for index in indexes.values():
+            await session.execute(text(f"DROP INDEX IF EXISTS {schema}.{index}"))
+        for column in reversed(_V2_9_COLUMNS):
+            quoted_column = quote_db_identifier(type(db).__name__, column)
+            await session.execute(text(f"ALTER TABLE {full_table} DROP COLUMN IF EXISTS {quoted_column}"))
+        return True

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -28,6 +28,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import ScheduleNameConflictError
 from agno.db.utils import deserialize_session, deserialize_session_json_fields, deserialize_sessions
 from agno.session import AgentSession, Session, TeamSession, WorkflowSession
 from agno.utils.log import log_debug, log_error, log_info
@@ -97,6 +98,15 @@ _CLIENT_TYPE_PYMONGO_ASYNC = "pymongo_async"
 _CLIENT_TYPE_UNKNOWN = "unknown"
 
 
+def _is_schedule_name_conflict(error: DuplicateKeyError) -> bool:
+    """Match only MongoDB's generic or actor-scoped name indexes."""
+    details = error.details
+    return isinstance(details, dict) and details.get("keyPattern") in (
+        {"name": 1},
+        {"owner_actor_id": 1, "name": 1},
+    )
+
+
 def _detect_client_type(client: Any) -> str:
     """Detect whether a client is Motor or PyMongo async."""
     if client is None:
@@ -136,6 +146,8 @@ def _detect_client_type(client: Any) -> str:
 
 
 class AsyncMongoDb(AsyncBaseDb):
+    scheduler_api_version = 2
+
     # Client type constants (class-level access to module constants)
     CLIENT_TYPE_MOTOR = _CLIENT_TYPE_MOTOR
     CLIENT_TYPE_PYMONGO_ASYNC = _CLIENT_TYPE_PYMONGO_ASYNC
@@ -2880,31 +2892,46 @@ class AsyncMongoDb(AsyncBaseDb):
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error getting schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule")
+            raise
 
-    async def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
+    async def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         try:
             collection = await self._get_collection(table_type="schedules")
             if collection is None:
                 return None
 
-            result = await collection.find_one({"name": name})
+            query: Dict[str, Any] = {"name": name}
+            if managed_by is not None:
+                query["managed_by"] = managed_by
+            if owner_actor_id is not None:
+                query["owner_actor_id"] = owner_actor_id
+            if exclude_managed_by is not None:
+                query["managed_by"] = {"$ne": exclude_managed_by}
+            result = await collection.find_one(query)
             if result is None:
                 return None
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error getting schedule by name: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule by name")
+            raise
 
     async def get_schedules(
         self,
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             collection = await self._get_collection(table_type="schedules")
@@ -2914,6 +2941,8 @@ class AsyncMongoDb(AsyncBaseDb):
             query: Dict[str, Any] = {}
             if enabled is not None:
                 query["enabled"] = enabled
+            if exclude_managed_by is not None:
+                query["managed_by"] = {"$ne": exclude_managed_by}
 
             total_count = await collection.count_documents(query)
             offset = (page - 1) * limit
@@ -2922,12 +2951,14 @@ class AsyncMongoDb(AsyncBaseDb):
             for schedule in schedules:
                 schedule.pop("_id", None)
             return schedules, total_count
-        except Exception as e:
-            log_debug(f"Error listing schedules: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error listing schedules")
+            raise
 
     async def create_schedule(self, schedule_data: Dict[str, Any]) -> Dict[str, Any]:
         try:
+            schedule_data.setdefault("pending_trigger_count", 0)
+            schedule_data.setdefault("manual_trigger_claimed", False)
             collection = await self._get_collection(table_type="schedules", create_collection_if_not_found=True)
             if collection is None:
                 raise RuntimeError("Failed to get or create schedules collection")
@@ -2935,9 +2966,14 @@ class AsyncMongoDb(AsyncBaseDb):
             await collection.insert_one(schedule_data)
             schedule_data.pop("_id", None)
             return schedule_data
-        except Exception as e:
-            log_error(f"Error creating schedule: {e}")
-            raise e
+        except DuplicateKeyError as error:
+            if _is_schedule_name_conflict(error):
+                raise ScheduleNameConflictError(schedule_data["name"]) from None
+            log_error("Error creating schedule")
+            raise
+        except Exception:
+            log_error("Error creating schedule")
+            raise
 
     async def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
         try:
@@ -2950,9 +2986,55 @@ class AsyncMongoDb(AsyncBaseDb):
             if result.matched_count == 0:
                 return None
             return await self.get_schedule(schedule_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule: {e}")
+        except DuplicateKeyError as error:
+            name = kwargs.get("name")
+            if isinstance(name, str) and _is_schedule_name_conflict(error):
+                raise ScheduleNameConflictError(name) from None
+            log_debug("Error updating schedule")
+            raise
+        except Exception:
+            log_debug("Error updating schedule")
+            raise
+
+    async def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue one manual execution for a schedule."""
+        collection = await self._get_collection(table_type="schedules")
+        if collection is None:
             return None
+        result = await collection.find_one_and_update(
+            {"id": schedule_id},
+            {
+                "$inc": {"pending_trigger_count": 1},
+                "$set": {"updated_at": int(time.time())},
+            },
+            return_document=ReturnDocument.AFTER,
+        )
+        if result is None:
+            return None
+        result.pop("_id", None)
+        return result
+
+    async def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules for one managed target."""
+        collection = await self._get_collection(table_type="schedules")
+        if collection is None:
+            return 0
+        result = await collection.update_many(
+            {
+                "managed_by": managed_by,
+                "target_type": target_type,
+                "target_id": target_id,
+                "enabled": True,
+            },
+            {"$set": {"enabled": False, "updated_at": int(time.time())}},
+        )
+        return int(result.modified_count)
 
     async def delete_schedule(self, schedule_id: str) -> bool:
         try:
@@ -2966,8 +3048,8 @@ class AsyncMongoDb(AsyncBaseDb):
 
             result = await schedules_collection.delete_one({"id": schedule_id})
             return result.deleted_count > 0
-        except Exception as e:
-            log_debug(f"Error deleting schedule: {e}")
+        except Exception:
+            log_debug("Error deleting schedule")
             return False
 
     async def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
@@ -2979,42 +3061,121 @@ class AsyncMongoDb(AsyncBaseDb):
             now = int(time.time())
             stale_lock_threshold = now - lock_grace_seconds
 
+            lock_query = {
+                "$or": [
+                    {"locked_by": None},
+                    {"locked_at": {"$lte": stale_lock_threshold}},
+                ]
+            }
             result = await collection.find_one_and_update(
                 {
                     "enabled": True,
-                    "next_run_at": {"$lte": now},
-                    "$or": [
-                        {"locked_by": None},
-                        {"locked_at": {"$lte": stale_lock_threshold}},
-                    ],
+                    "manual_trigger_claimed": True,
+                    **lock_query,
                 },
                 {"$set": {"locked_by": worker_id, "locked_at": now}},
-                sort=[("next_run_at", 1)],
+                sort=[("locked_at", 1)],
                 return_document=ReturnDocument.AFTER,
             )
+            if result is None:
+                result = await collection.find_one_and_update(
+                    {
+                        "enabled": True,
+                        "manual_trigger_claimed": {"$ne": True},
+                        "pending_trigger_count": {"$gt": 0},
+                        "$nor": [{"next_run_at": {"$lte": now}}],
+                        **lock_query,
+                    },
+                    {
+                        "$inc": {"pending_trigger_count": -1},
+                        "$set": {
+                            "locked_by": worker_id,
+                            "locked_at": now,
+                            "manual_trigger_claimed": True,
+                        },
+                    },
+                    sort=[("created_at", 1)],
+                    return_document=ReturnDocument.AFTER,
+                )
+            if result is None:
+                result = await collection.find_one_and_update(
+                    {
+                        "enabled": True,
+                        "manual_trigger_claimed": {"$ne": True},
+                        "next_run_at": {"$lte": now},
+                        **lock_query,
+                    },
+                    {
+                        "$set": {
+                            "locked_by": worker_id,
+                            "locked_at": now,
+                            "manual_trigger_claimed": False,
+                        }
+                    },
+                    sort=[("next_run_at", 1)],
+                    return_document=ReturnDocument.AFTER,
+                )
             if result is None:
                 return None
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error claiming schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error claiming schedule")
+            raise
 
-    async def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
+    async def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a claim only while its worker/timestamp fence still matches."""
+        collection = await self._get_collection(table_type="schedules")
+        if collection is None:
+            return None
+        renewed_at = max(int(time.time()), locked_at + 1)
+        result = await collection.find_one_and_update(
+            {"id": schedule_id, "locked_by": worker_id, "locked_at": locked_at},
+            {"$set": {"locked_at": renewed_at}},
+            return_document=ReturnDocument.AFTER,
+        )
+        return renewed_at if result is not None else None
+
+    async def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
         try:
+            if (worker_id is None) != (locked_at is None):
+                return False
             collection = await self._get_collection(table_type="schedules")
             if collection is None:
                 return False
 
-            updates: Dict[str, Any] = {"locked_by": None, "locked_at": None, "updated_at": int(time.time())}
+            updates: Dict[str, Any] = {
+                "locked_by": None,
+                "locked_at": None,
+                "manual_trigger_claimed": False,
+                "updated_at": int(time.time()),
+            }
             if next_run_at is not None:
                 updates["next_run_at"] = next_run_at
 
-            result = await collection.update_one({"id": schedule_id}, {"$set": updates})
+            query: Dict[str, Any] = {"id": schedule_id}
+            if worker_id is None:
+                query["manual_trigger_claimed"] = {"$ne": True}
+            else:
+                query.update(locked_by=worker_id, locked_at=locked_at)
+            result = await collection.update_one(query, {"$set": updates})
             return result.matched_count > 0
-        except Exception as e:
-            log_debug(f"Error releasing schedule: {e}")
+        except Exception:
+            log_debug("Error releasing schedule")
             return False
 
     async def create_schedule_run(self, run_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -3026,9 +3187,9 @@ class AsyncMongoDb(AsyncBaseDb):
             await collection.insert_one(run_data)
             run_data.pop("_id", None)
             return run_data
-        except Exception as e:
-            log_error(f"Error creating schedule run: {e}")
-            raise e
+        except Exception:
+            log_error("Error creating schedule run")
+            raise
 
     async def update_schedule_run(self, schedule_run_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
         try:
@@ -3040,8 +3201,8 @@ class AsyncMongoDb(AsyncBaseDb):
             if result.matched_count == 0:
                 return None
             return await self.get_schedule_run(schedule_run_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule run: {e}")
+        except Exception:
+            log_debug("Error updating schedule run")
             return None
 
     async def get_schedule_run(self, run_id: str) -> Optional[Dict[str, Any]]:
@@ -3056,9 +3217,9 @@ class AsyncMongoDb(AsyncBaseDb):
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error getting schedule run: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule run")
+            raise
 
     async def get_schedule_runs(
         self,
@@ -3079,9 +3240,9 @@ class AsyncMongoDb(AsyncBaseDb):
             for run in runs:
                 run.pop("_id", None)
             return runs, total_count
-        except Exception as e:
-            log_debug(f"Error getting schedule runs: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error getting schedule runs")
+            raise
 
     # -- Learning methods --
     async def get_learning(

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -28,6 +28,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import ScheduleNameConflictError
 from agno.db.utils import deserialize_session, deserialize_session_json_fields, deserialize_sessions
 from agno.session import AgentSession, Session, TeamSession, WorkflowSession
 from agno.utils.log import log_debug, log_error, log_info
@@ -45,7 +46,18 @@ except ImportError:
 DRIVER_METADATA = DriverInfo(name="Agno", version=metadata.version("agno"))
 
 
+def _is_schedule_name_conflict(error: DuplicateKeyError) -> bool:
+    """Match only MongoDB's generic or actor-scoped name indexes."""
+    details = error.details
+    return isinstance(details, dict) and details.get("keyPattern") in (
+        {"name": 1},
+        {"owner_actor_id": 1, "name": 1},
+    )
+
+
 class MongoDb(BaseDb):
+    scheduler_api_version = 2
+
     def __init__(
         self,
         db_client: Optional[MongoClient] = None,
@@ -2718,31 +2730,46 @@ class MongoDb(BaseDb):
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error getting schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule")
+            raise
 
-    def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
+    def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         try:
             collection = self._get_collection(table_type="schedules")
             if collection is None:
                 return None
 
-            result = collection.find_one({"name": name})
+            query: Dict[str, Any] = {"name": name}
+            if managed_by is not None:
+                query["managed_by"] = managed_by
+            if owner_actor_id is not None:
+                query["owner_actor_id"] = owner_actor_id
+            if exclude_managed_by is not None:
+                query["managed_by"] = {"$ne": exclude_managed_by}
+            result = collection.find_one(query)
             if result is None:
                 return None
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error getting schedule by name: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule by name")
+            raise
 
     def get_schedules(
         self,
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             collection = self._get_collection(table_type="schedules")
@@ -2752,6 +2779,8 @@ class MongoDb(BaseDb):
             query: Dict[str, Any] = {}
             if enabled is not None:
                 query["enabled"] = enabled
+            if exclude_managed_by is not None:
+                query["managed_by"] = {"$ne": exclude_managed_by}
 
             total_count = collection.count_documents(query)
 
@@ -2761,12 +2790,14 @@ class MongoDb(BaseDb):
             for schedule in schedules:
                 schedule.pop("_id", None)
             return schedules, total_count
-        except Exception as e:
-            log_debug(f"Error listing schedules: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error listing schedules")
+            raise
 
     def create_schedule(self, schedule_data: Dict[str, Any]) -> Dict[str, Any]:
         try:
+            schedule_data.setdefault("pending_trigger_count", 0)
+            schedule_data.setdefault("manual_trigger_claimed", False)
             collection = self._get_collection(table_type="schedules", create_collection_if_not_found=True)
             if collection is None:
                 raise RuntimeError("Failed to get or create schedules collection")
@@ -2774,9 +2805,14 @@ class MongoDb(BaseDb):
             collection.insert_one(schedule_data)
             schedule_data.pop("_id", None)
             return schedule_data
-        except Exception as e:
-            log_error(f"Error creating schedule: {e}")
-            raise e
+        except DuplicateKeyError as error:
+            if _is_schedule_name_conflict(error):
+                raise ScheduleNameConflictError(schedule_data["name"]) from None
+            log_error("Error creating schedule")
+            raise
+        except Exception:
+            log_error("Error creating schedule")
+            raise
 
     def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
         try:
@@ -2789,9 +2825,55 @@ class MongoDb(BaseDb):
             if result.matched_count == 0:
                 return None
             return self.get_schedule(schedule_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule: {e}")
+        except DuplicateKeyError as error:
+            name = kwargs.get("name")
+            if isinstance(name, str) and _is_schedule_name_conflict(error):
+                raise ScheduleNameConflictError(name) from None
+            log_debug("Error updating schedule")
+            raise
+        except Exception:
+            log_debug("Error updating schedule")
+            raise
+
+    def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue one manual execution for a schedule."""
+        collection = self._get_collection(table_type="schedules")
+        if collection is None:
             return None
+        result = collection.find_one_and_update(
+            {"id": schedule_id},
+            {
+                "$inc": {"pending_trigger_count": 1},
+                "$set": {"updated_at": int(time.time())},
+            },
+            return_document=ReturnDocument.AFTER,
+        )
+        if result is None:
+            return None
+        result.pop("_id", None)
+        return result
+
+    def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules for one managed target."""
+        collection = self._get_collection(table_type="schedules")
+        if collection is None:
+            return 0
+        result = collection.update_many(
+            {
+                "managed_by": managed_by,
+                "target_type": target_type,
+                "target_id": target_id,
+                "enabled": True,
+            },
+            {"$set": {"enabled": False, "updated_at": int(time.time())}},
+        )
+        return int(result.modified_count)
 
     def delete_schedule(self, schedule_id: str) -> bool:
         try:
@@ -2805,8 +2887,8 @@ class MongoDb(BaseDb):
 
             result = schedules_collection.delete_one({"id": schedule_id})
             return result.deleted_count > 0
-        except Exception as e:
-            log_debug(f"Error deleting schedule: {e}")
+        except Exception:
+            log_debug("Error deleting schedule")
             return False
 
     def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
@@ -2818,42 +2900,126 @@ class MongoDb(BaseDb):
             now = int(time.time())
             stale_lock_threshold = now - lock_grace_seconds
 
+            lock_query = {
+                "$or": [
+                    {"locked_by": None},
+                    {"locked_at": {"$lte": stale_lock_threshold}},
+                ]
+            }
+            # Recover an already-claimed manual trigger first. The in-flight
+            # marker survives a dead worker, so stale-lock recovery must not
+            # consume another pending trigger.
             result = collection.find_one_and_update(
                 {
                     "enabled": True,
-                    "next_run_at": {"$lte": now},
-                    "$or": [
-                        {"locked_by": None},
-                        {"locked_at": {"$lte": stale_lock_threshold}},
-                    ],
+                    "manual_trigger_claimed": True,
+                    **lock_query,
                 },
                 {"$set": {"locked_by": worker_id, "locked_at": now}},
-                sort=[("next_run_at", 1)],
+                sort=[("locked_at", 1)],
                 return_document=ReturnDocument.AFTER,
             )
+            if result is None:
+                result = collection.find_one_and_update(
+                    {
+                        "enabled": True,
+                        "manual_trigger_claimed": {"$ne": True},
+                        "pending_trigger_count": {"$gt": 0},
+                        # A due cron occurrence is claimed first, leaving this
+                        # manual unit pending for the next claim.
+                        "$nor": [{"next_run_at": {"$lte": now}}],
+                        **lock_query,
+                    },
+                    {
+                        "$inc": {"pending_trigger_count": -1},
+                        "$set": {
+                            "locked_by": worker_id,
+                            "locked_at": now,
+                            "manual_trigger_claimed": True,
+                        },
+                    },
+                    sort=[("created_at", 1)],
+                    return_document=ReturnDocument.AFTER,
+                )
+            if result is None:
+                result = collection.find_one_and_update(
+                    {
+                        "enabled": True,
+                        "manual_trigger_claimed": {"$ne": True},
+                        "next_run_at": {"$lte": now},
+                        **lock_query,
+                    },
+                    {
+                        "$set": {
+                            "locked_by": worker_id,
+                            "locked_at": now,
+                            "manual_trigger_claimed": False,
+                        }
+                    },
+                    sort=[("next_run_at", 1)],
+                    return_document=ReturnDocument.AFTER,
+                )
             if result is None:
                 return None
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error claiming schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error claiming schedule")
+            raise
 
-    def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
+    def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a claim only while its worker/timestamp fence still matches."""
+        collection = self._get_collection(table_type="schedules")
+        if collection is None:
+            return None
+        renewed_at = max(int(time.time()), locked_at + 1)
+        result = collection.find_one_and_update(
+            {"id": schedule_id, "locked_by": worker_id, "locked_at": locked_at},
+            {"$set": {"locked_at": renewed_at}},
+            return_document=ReturnDocument.AFTER,
+        )
+        return renewed_at if result is not None else None
+
+    def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
         try:
+            if (worker_id is None) != (locked_at is None):
+                return False
             collection = self._get_collection(table_type="schedules")
             if collection is None:
                 return False
 
-            updates: Dict[str, Any] = {"locked_by": None, "locked_at": None, "updated_at": int(time.time())}
+            updates: Dict[str, Any] = {
+                "locked_by": None,
+                "locked_at": None,
+                "manual_trigger_claimed": False,
+                "updated_at": int(time.time()),
+            }
             if next_run_at is not None:
                 updates["next_run_at"] = next_run_at
 
-            result = collection.update_one({"id": schedule_id}, {"$set": updates})
+            query: Dict[str, Any] = {"id": schedule_id}
+            if worker_id is None:
+                query["manual_trigger_claimed"] = {"$ne": True}
+            else:
+                query.update(locked_by=worker_id, locked_at=locked_at)
+            result = collection.update_one(query, {"$set": updates})
             return result.matched_count > 0
-        except Exception as e:
-            log_debug(f"Error releasing schedule: {e}")
+        except Exception:
+            log_debug("Error releasing schedule")
             return False
 
     def create_schedule_run(self, run_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -2865,9 +3031,9 @@ class MongoDb(BaseDb):
             collection.insert_one(run_data)
             run_data.pop("_id", None)
             return run_data
-        except Exception as e:
-            log_error(f"Error creating schedule run: {e}")
-            raise e
+        except Exception:
+            log_error("Error creating schedule run")
+            raise
 
     def update_schedule_run(self, schedule_run_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
         try:
@@ -2879,8 +3045,8 @@ class MongoDb(BaseDb):
             if result.matched_count == 0:
                 return None
             return self.get_schedule_run(schedule_run_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule run: {e}")
+        except Exception:
+            log_debug("Error updating schedule run")
             return None
 
     def get_schedule_run(self, run_id: str) -> Optional[Dict[str, Any]]:
@@ -2894,9 +3060,9 @@ class MongoDb(BaseDb):
 
             result.pop("_id", None)
             return result
-        except Exception as e:
-            log_debug(f"Error getting schedule run: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule run")
+            raise
 
     def get_schedule_runs(
         self,
@@ -2918,9 +3084,9 @@ class MongoDb(BaseDb):
             for run in runs:
                 run.pop("_id", None)
             return runs, total_count
-        except Exception as e:
-            log_debug(f"Error getting schedule runs: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error getting schedule runs")
+            raise
 
     # -- Learning methods (stubs) --
     def get_learning(

--- a/libs/agno/agno/db/mongo/schemas.py
+++ b/libs/agno/agno/db/mongo/schemas.py
@@ -115,9 +115,28 @@ LEARNINGS_COLLECTION_SCHEMA = [
 
 SCHEDULES_COLLECTION_SCHEMA = [
     {"key": "id", "unique": True},
-    {"key": "name", "unique": True},
+    {
+        # Keep this key pattern distinct from the pre-2.9 global {name: 1}
+        # index. MongoDB cannot build the partial replacement alongside that
+        # legacy index when both use the same key pattern, which would make a
+        # fail-safe create-before-drop migration impossible.
+        "key": [("name", 1), ("managed_by", 1)],
+        "name": "uq_generic_name",
+        "unique": True,
+        "partialFilterExpression": {"managed_by": None},
+    },
+    {
+        "key": [("owner_actor_id", 1), ("name", 1)],
+        "name": "uq_studio_owner_name",
+        "unique": True,
+        "partialFilterExpression": {"managed_by": "studio"},
+    },
+    {"key": "managed_by"},
+    {"key": "owner_actor_id"},
     {"key": "enabled"},
     {"key": "next_run_at"},
+    {"key": "pending_trigger_count"},
+    {"key": "manual_trigger_claimed"},
     {"key": "locked_by"},
     {"key": "locked_at"},
     {"key": "created_at"},

--- a/libs/agno/agno/db/mongo/utils.py
+++ b/libs/agno/agno/db/mongo/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for the MongoDB database class."""
 
+import inspect
 import json
 import time
 from datetime import date, datetime, timedelta, timezone
@@ -20,35 +21,74 @@ except ImportError:
 def create_collection_indexes(collection: Collection, collection_type: str) -> None:
     """Create all required indexes for a collection"""
     try:
+        legacy_schedule_indexes: List[str] = []
+        if collection_type == "schedules":
+            # v2.9 replaces the legacy global unique name index with separate
+            # generic and actor-scoped Studio namespaces. Keep the legacy
+            # authority until both replacements have been created.
+            for existing in collection.list_indexes():
+                if (
+                    existing.get("name") != "uq_generic_name"
+                    and existing.get("unique") is True
+                    and dict(existing.get("key", {})) == {"name": 1}
+                ):
+                    legacy_schedule_indexes.append(existing["name"])
         indexes = get_collection_indexes(collection_type)
         for index_spec in indexes:
             key = index_spec["key"]
-            unique = index_spec.get("unique", False)
+            options = {option: value for option, value in index_spec.items() if option != "key"}
 
             if isinstance(key, list):
-                collection.create_index(key, unique=unique)
+                collection.create_index(key, **options)
             else:
-                collection.create_index([(key, 1)], unique=unique)
+                collection.create_index([(key, 1)], **options)
+        for index_name in legacy_schedule_indexes:
+            collection.drop_index(index_name)
 
     except Exception as e:
         log_warning(f"Error creating indexes for {collection_type} collection: {str(e)}")
+        # Schedule adapters advertise actor-scoped name isolation only after
+        # these indexes exist.  Continuing without them would turn a failed
+        # migration into a silent cross-actor uniqueness regression.
+        if collection_type == "schedules":
+            raise
 
 
 async def create_collection_indexes_async(collection: Any, collection_type: str) -> None:
     """Create all required indexes for a collection (async version for Motor)"""
     try:
+        legacy_schedule_indexes: List[str] = []
+        if collection_type == "schedules":
+            cursor = collection.list_indexes()
+            if inspect.isawaitable(cursor):
+                cursor = await cursor
+            if hasattr(cursor, "to_list"):
+                existing_indexes = await cursor.to_list(length=None)
+            else:
+                existing_indexes = [existing async for existing in cursor]
+            for existing in existing_indexes:
+                if (
+                    existing.get("name") != "uq_generic_name"
+                    and existing.get("unique") is True
+                    and dict(existing.get("key", {})) == {"name": 1}
+                ):
+                    legacy_schedule_indexes.append(existing["name"])
         indexes = get_collection_indexes(collection_type)
         for index_spec in indexes:
             key = index_spec["key"]
-            unique = index_spec.get("unique", False)
+            options = {option: value for option, value in index_spec.items() if option != "key"}
 
             if isinstance(key, list):
-                await collection.create_index(key, unique=unique)
+                await collection.create_index(key, **options)
             else:
-                await collection.create_index([(key, 1)], unique=unique)
+                await collection.create_index([(key, 1)], **options)
+        for index_name in legacy_schedule_indexes:
+            await collection.drop_index(index_name)
 
     except Exception as e:
         log_warning(f"Error creating indexes for {collection_type} collection: {str(e)}")
+        if collection_type == "schedules":
+            raise
 
 
 def apply_sorting(

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
 
-from agno.db.base import AsyncBaseDb, ComponentType, SessionType
+from agno.db.base import AsyncBaseDb, ComponentProjection, ComponentType, ComponentVersionGuard, SessionType
 from agno.db.migrations.manager import MigrationManager
 from agno.db.postgres.schemas import get_table_schema_definition
 from agno.db.postgres.utils import (
@@ -25,6 +25,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import ScheduleNameConflictError
 from agno.db.schemas.service_accounts import (
     resolve_service_account_sort_column,
     validate_service_account_update,
@@ -39,7 +40,7 @@ try:
     from sqlalchemy import ForeignKey, Index, String, Table, UniqueConstraint, and_, case, distinct, func, or_, update
     from sqlalchemy.dialects import postgresql
     from sqlalchemy.dialects.postgresql import TIMESTAMP
-    from sqlalchemy.exc import ProgrammingError
+    from sqlalchemy.exc import IntegrityError, ProgrammingError
     from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
     from sqlalchemy.schema import Column, MetaData
     from sqlalchemy.sql.expression import select, text
@@ -47,7 +48,32 @@ except ImportError:
     raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
 
 
+def _is_schedule_name_conflict(error: IntegrityError, table_name: str, schema_name: str) -> bool:
+    """Match only the generic or actor-scoped schedule-name indexes."""
+    original = error.orig
+    cause = getattr(original, "__cause__", None)
+    sqlstate = (
+        getattr(original, "sqlstate", None) or getattr(original, "pgcode", None) or getattr(cause, "sqlstate", None)
+    )
+    diagnostic = getattr(original, "diag", None)
+    constraint_name = getattr(diagnostic, "constraint_name", None) or getattr(cause, "constraint_name", None)
+    reported_table = getattr(diagnostic, "table_name", None) or getattr(cause, "table_name", None)
+    reported_schema = getattr(diagnostic, "schema_name", None) or getattr(cause, "schema_name", None)
+    return (
+        sqlstate == "23505"
+        and constraint_name
+        in {
+            f"{table_name}_uq_generic_name",
+            f"{table_name}_uq_studio_owner_name",
+        }
+        and reported_table == table_name
+        and reported_schema == schema_name
+    )
+
+
 class AsyncPostgresDb(AsyncBaseDb):
+    scheduler_api_version = 2
+
     def __init__(
         self,
         id: Optional[str] = None,
@@ -3608,6 +3634,8 @@ class AsyncPostgresDb(AsyncBaseDb):
         self,
         component_id: str,
         component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -3617,6 +3645,7 @@ class AsyncPostgresDb(AsyncBaseDb):
         component_type: Optional[ComponentType] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
+        current_version: Optional[int] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         raise NotImplementedError("Component methods not yet supported for async databases")
@@ -3625,6 +3654,10 @@ class AsyncPostgresDb(AsyncBaseDb):
         self,
         component_id: str,
         hard_delete: bool = False,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        require_no_dependents: bool = True,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -3671,6 +3704,9 @@ class AsyncPostgresDb(AsyncBaseDb):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> Dict[str, Any]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -3678,6 +3714,9 @@ class AsyncPostgresDb(AsyncBaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -3692,6 +3731,9 @@ class AsyncPostgresDb(AsyncBaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -3707,6 +3749,8 @@ class AsyncPostgresDb(AsyncBaseDb):
         self,
         component_id: str,
         version: Optional[int] = None,
+        *,
+        active_parents_only: bool = False,
     ) -> List[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -3728,28 +3772,43 @@ class AsyncPostgresDb(AsyncBaseDb):
                 result = await sess.execute(select(table).where(table.c.id == schedule_id))
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
-        except Exception as e:
-            log_debug(f"Error getting schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule")
+            raise
 
-    async def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
+    async def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         try:
             table = await self._get_table(table_type="schedules")
             if table is None:
                 return None
             async with self.async_session_factory() as sess:
-                result = await sess.execute(select(table).where(table.c.name == name))
+                query = select(table).where(table.c.name == name)
+                if managed_by is not None:
+                    query = query.where(table.c.managed_by == managed_by)
+                if owner_actor_id is not None:
+                    query = query.where(table.c.owner_actor_id == owner_actor_id)
+                if exclude_managed_by is not None:
+                    query = query.where(or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by))
+                result = await sess.execute(query)
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
-        except Exception as e:
-            log_debug(f"Error getting schedule by name: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule by name")
+            raise
 
     async def get_schedules(
         self,
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = await self._get_table(table_type="schedules")
@@ -3760,6 +3819,10 @@ class AsyncPostgresDb(AsyncBaseDb):
                 base_query = select(table)
                 if enabled is not None:
                     base_query = base_query.where(table.c.enabled == enabled)
+                if exclude_managed_by is not None:
+                    base_query = base_query.where(
+                        or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by)
+                    )
 
                 # Get total count
                 count_stmt = select(func.count()).select_from(base_query.alias())
@@ -3773,12 +3836,14 @@ class AsyncPostgresDb(AsyncBaseDb):
                 stmt = base_query.order_by(table.c.created_at.desc()).limit(limit).offset(offset)
                 result = await sess.execute(stmt)
                 return [dict(row._mapping) for row in result.fetchall()], total_count
-        except Exception as e:
-            log_debug(f"Error listing schedules: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error listing schedules")
+            raise
 
     async def create_schedule(self, schedule_data: Dict[str, Any]) -> Dict[str, Any]:
         try:
+            schedule_data.setdefault("pending_trigger_count", 0)
+            schedule_data.setdefault("manual_trigger_claimed", False)
             table = await self._get_table(table_type="schedules", create_table_if_not_found=True)
             if table is None:
                 raise RuntimeError("Failed to get or create schedules table")
@@ -3786,8 +3851,13 @@ class AsyncPostgresDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.insert().values(**schedule_data))
             return schedule_data
-        except Exception as e:
-            log_error(f"Error creating schedule: {str(e)}")
+        except IntegrityError as error:
+            if _is_schedule_name_conflict(error, self.schedules_table_name, self.db_schema):
+                raise ScheduleNameConflictError(schedule_data["name"]) from None
+            log_error("Error creating schedule")
+            raise
+        except Exception:
+            log_error("Error creating schedule")
             raise
 
     async def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -3800,9 +3870,59 @@ class AsyncPostgresDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.update().where(table.c.id == schedule_id).values(**kwargs))
             return await self.get_schedule(schedule_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule: {e}")
+        except IntegrityError as error:
+            name = kwargs.get("name")
+            if isinstance(name, str) and _is_schedule_name_conflict(error, self.schedules_table_name, self.db_schema):
+                raise ScheduleNameConflictError(name) from None
+            log_debug("Error updating schedule")
+            raise
+        except Exception:
+            log_debug("Error updating schedule")
+            raise
+
+    async def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue one manual execution for a schedule."""
+        table = await self._get_table(table_type="schedules")
+        if table is None:
             return None
+        async with self.async_session_factory() as sess:
+            async with sess.begin():
+                result = await sess.execute(
+                    update(table)
+                    .where(table.c.id == schedule_id)
+                    .values(
+                        pending_trigger_count=func.coalesce(table.c.pending_trigger_count, 0) + 1,
+                        updated_at=int(time.time()),
+                    )
+                    .returning(*table.c)
+                )
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+
+    async def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules for one managed target."""
+        table = await self._get_table(table_type="schedules")
+        if table is None:
+            return 0
+        async with self.async_session_factory() as sess:
+            async with sess.begin():
+                result = await sess.execute(
+                    table.update()
+                    .where(
+                        table.c.managed_by == managed_by,
+                        table.c.target_type == target_type,
+                        table.c.target_id == target_id,
+                        table.c.enabled == True,  # noqa: E712
+                    )
+                    .values(enabled=False, updated_at=int(time.time()))
+                )
+                return int(result.rowcount or 0)  # type: ignore[attr-defined]
 
     async def delete_schedule(self, schedule_id: str) -> bool:
         try:
@@ -3816,8 +3936,8 @@ class AsyncPostgresDb(AsyncBaseDb):
                         await sess.execute(runs_table.delete().where(runs_table.c.schedule_id == schedule_id))
                     result = await sess.execute(table.delete().where(table.c.id == schedule_id))
                     return result.rowcount > 0  # type: ignore[attr-defined]
-        except Exception as e:
-            log_debug(f"Error deleting schedule: {e}")
+        except Exception:
+            log_debug("Error deleting schedule")
             return False
 
     async def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
@@ -3834,13 +3954,30 @@ class AsyncPostgresDb(AsyncBaseDb):
                         select(table.c.id)
                         .where(
                             table.c.enabled == True,  # noqa: E712
-                            table.c.next_run_at <= now,
+                            or_(
+                                table.c.manual_trigger_claimed == True,  # noqa: E712
+                                table.c.pending_trigger_count > 0,
+                                table.c.next_run_at <= now,
+                            ),
                             or_(
                                 table.c.locked_by.is_(None),
                                 table.c.locked_at <= stale_lock_threshold,
                             ),
                         )
-                        .order_by(table.c.next_run_at.asc())
+                        .order_by(
+                            case(
+                                (table.c.manual_trigger_claimed == True, 0),  # noqa: E712
+                                (
+                                    and_(
+                                        table.c.pending_trigger_count > 0,
+                                        or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                    ),
+                                    1,
+                                ),
+                                else_=2,
+                            ),
+                            table.c.next_run_at.asc(),
+                        )
                         .limit(1)
                         .with_for_update(skip_locked=True)
                         .scalar_subquery()
@@ -3848,7 +3985,26 @@ class AsyncPostgresDb(AsyncBaseDb):
                     stmt = (
                         update(table)
                         .where(table.c.id == subq)
-                        .values(locked_by=worker_id, locked_at=now)
+                        .values(
+                            locked_by=worker_id,
+                            locked_at=now,
+                            pending_trigger_count=case(
+                                (
+                                    and_(
+                                        table.c.manual_trigger_claimed == False,  # noqa: E712
+                                        table.c.pending_trigger_count > 0,
+                                        or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                    ),
+                                    table.c.pending_trigger_count - 1,
+                                ),
+                                else_=table.c.pending_trigger_count,
+                            ),
+                            manual_trigger_claimed=case(
+                                (table.c.manual_trigger_claimed == True, True),  # noqa: E712
+                                (table.c.next_run_at <= now, False),
+                                else_=True,
+                            ),
+                        )
                         .returning(*table.c)
                     )
                     result = await sess.execute(stmt)
@@ -3856,24 +4012,68 @@ class AsyncPostgresDb(AsyncBaseDb):
                     if row is None:
                         return None
                     return dict(row._mapping)
-        except Exception as e:
-            log_debug(f"Error claiming schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error claiming schedule")
+            raise
 
-    async def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
+    async def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a claim only while its worker/timestamp fence still matches."""
+        table = await self._get_table(table_type="schedules")
+        if table is None:
+            return None
+        renewed_at = max(int(time.time()), locked_at + 1)
+        async with self.async_session_factory() as sess:
+            async with sess.begin():
+                result = await sess.execute(
+                    table.update()
+                    .where(
+                        table.c.id == schedule_id,
+                        table.c.locked_by == worker_id,
+                        table.c.locked_at == locked_at,
+                    )
+                    .values(locked_at=renewed_at)
+                )
+                return renewed_at if result.rowcount > 0 else None  # type: ignore[attr-defined]
+
+    async def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
         try:
+            if (worker_id is None) != (locked_at is None):
+                return False
             table = await self._get_table(table_type="schedules")
             if table is None:
                 return False
-            updates: Dict[str, Any] = {"locked_by": None, "locked_at": None, "updated_at": int(time.time())}
+            updates: Dict[str, Any] = {
+                "locked_by": None,
+                "locked_at": None,
+                "manual_trigger_claimed": False,
+                "updated_at": int(time.time()),
+            }
             if next_run_at is not None:
                 updates["next_run_at"] = next_run_at
             async with self.async_session_factory() as sess:
                 async with sess.begin():
-                    result = await sess.execute(table.update().where(table.c.id == schedule_id).values(**updates))
+                    stmt = table.update().where(table.c.id == schedule_id)
+                    if worker_id is None:
+                        stmt = stmt.where(table.c.manual_trigger_claimed == False)  # noqa: E712
+                    else:
+                        stmt = stmt.where(table.c.locked_by == worker_id, table.c.locked_at == locked_at)
+                    result = await sess.execute(stmt.values(**updates))
                     return result.rowcount > 0  # type: ignore[attr-defined]
-        except Exception as e:
-            log_debug(f"Error releasing schedule: {e}")
+        except Exception:
+            log_debug("Error releasing schedule")
             return False
 
     async def create_schedule_run(self, run_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -3885,8 +4085,8 @@ class AsyncPostgresDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.insert().values(**run_data))
             return run_data
-        except Exception as e:
-            log_error(f"Error creating schedule run: {str(e)}")
+        except Exception:
+            log_error("Error creating schedule run")
             raise
 
     async def update_schedule_run(self, schedule_run_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -3898,8 +4098,8 @@ class AsyncPostgresDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.update().where(table.c.id == schedule_run_id).values(**kwargs))
             return await self.get_schedule_run(schedule_run_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule run: {e}")
+        except Exception:
+            log_debug("Error updating schedule run")
             return None
 
     async def get_schedule_run(self, run_id: str) -> Optional[Dict[str, Any]]:
@@ -3911,9 +4111,9 @@ class AsyncPostgresDb(AsyncBaseDb):
                 result = await sess.execute(select(table).where(table.c.id == run_id))
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
-        except Exception as e:
-            log_debug(f"Error getting schedule run: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule run")
+            raise
 
     async def get_schedule_runs(
         self,
@@ -3944,9 +4144,9 @@ class AsyncPostgresDb(AsyncBaseDb):
                 )
                 result = await sess.execute(stmt)
                 return [dict(row._mapping) for row in result.fetchall()], total_count
-        except Exception as e:
-            log_debug(f"Error getting schedule runs: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error getting schedule runs")
+            raise
 
     # -- Approval methods --
 

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -1,5 +1,6 @@
 import time
 from datetime import date, datetime, timedelta, timezone
+from threading import RLock
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union, cast
 from uuid import uuid4
 
@@ -7,7 +8,21 @@ if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
 
 from agno.db import mcp_oauth_store
-from agno.db.base import BaseDb, ComponentType, SessionType
+from agno.db.base import (
+    DELETED_CONFIG_STAGE,
+    BaseDb,
+    ComponentAlreadyExistsError,
+    ComponentCycleError,
+    ComponentDependencyError,
+    ComponentDependencyUnavailableError,
+    ComponentDraftRequiredError,
+    ComponentLastConfigError,
+    ComponentProjection,
+    ComponentType,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+    SessionType,
+)
 from agno.db.migrations.manager import MigrationManager
 from agno.db.postgres.schemas import get_table_schema_definition
 from agno.db.postgres.utils import (
@@ -34,6 +49,7 @@ from agno.db.schemas.mcp_oauth import (
     MCP_OAUTH_TRANSACTIONS,
 )
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import ScheduleNameConflictError
 from agno.db.schemas.service_accounts import (
     resolve_service_account_sort_column,
     validate_service_account_update,
@@ -63,7 +79,7 @@ try:
     from sqlalchemy.dialects import postgresql
     from sqlalchemy.dialects.postgresql import TIMESTAMP
     from sqlalchemy.engine import Engine, create_engine
-    from sqlalchemy.exc import ProgrammingError
+    from sqlalchemy.exc import IntegrityError, ProgrammingError
     from sqlalchemy.orm import scoped_session, sessionmaker
     from sqlalchemy.schema import Column, MetaData, Table
     from sqlalchemy.sql.expression import text
@@ -71,7 +87,49 @@ except ImportError:
     raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
 
 
+_TABLE_INIT_LOCKS_GUARD = RLock()
+_TABLE_INIT_LOCKS: Dict[str, RLock] = {}
+# Graph writes can lock a parent and one or more children. A transaction-scoped
+# advisory lock gives those low-volume control-plane mutations one global lock
+# order, including across processes, while unrelated component metadata writes
+# remain concurrent.
+_COMPONENT_GRAPH_WRITE_LOCK_KEY = 0x41676E6F436F6D70
+
+
+def _shared_table_init_lock(database_key: str) -> RLock:
+    """Return one in-process lazy-DDL lock for every database schema."""
+    with _TABLE_INIT_LOCKS_GUARD:
+        return _TABLE_INIT_LOCKS.setdefault(database_key, RLock())
+
+
+def _is_schedule_name_conflict(error: IntegrityError, table_name: str, schema_name: str) -> bool:
+    """Match only the generic or actor-scoped schedule-name indexes."""
+    original = error.orig
+    cause = getattr(original, "__cause__", None)
+    sqlstate = (
+        getattr(original, "sqlstate", None) or getattr(original, "pgcode", None) or getattr(cause, "sqlstate", None)
+    )
+    diagnostic = getattr(original, "diag", None)
+    constraint_name = getattr(diagnostic, "constraint_name", None) or getattr(cause, "constraint_name", None)
+    reported_table = getattr(diagnostic, "table_name", None) or getattr(cause, "table_name", None)
+    reported_schema = getattr(diagnostic, "schema_name", None) or getattr(cause, "schema_name", None)
+    return (
+        sqlstate == "23505"
+        and constraint_name
+        in {
+            f"{table_name}_uq_generic_name",
+            f"{table_name}_uq_studio_owner_name",
+        }
+        and reported_table == table_name
+        and reported_schema == schema_name
+    )
+
+
 class PostgresDb(BaseDb):
+    supports_component_persistence = True
+    component_catalog_api_version = 2
+    scheduler_api_version = 2
+
     def __init__(
         self,
         db_url: Optional[str] = None,
@@ -157,10 +215,11 @@ class PostgresDb(BaseDb):
         self.db_url: Optional[str] = db_url
         self.db_engine: Engine = _engine
 
+        database_identity = db_url if db_url is not None else str(_engine.url)
+
         if id is None:
-            base_seed = db_url or str(db_engine.url)  # type: ignore
             schema_suffix = db_schema if db_schema is not None else "ai"
-            seed = f"{base_seed}#{schema_suffix}"
+            seed = f"{database_identity}#{schema_suffix}"
             id = generate_id(seed)
 
         super().__init__(
@@ -192,6 +251,8 @@ class PostgresDb(BaseDb):
 
         self.db_schema: str = db_schema if db_schema is not None else "ai"
         self.metadata: MetaData = MetaData(schema=self.db_schema)
+        database_key = generate_id(f"{database_identity}#{self.db_schema}")
+        self._table_init_lock = _shared_table_init_lock(database_key)
         self.create_schema: bool = create_schema
 
         # Initialize database session
@@ -428,9 +489,22 @@ class PostgresDb(BaseDb):
             # Create table
             table_created = False
             if not self.table_exists(table_name):
-                table.create(self.db_engine, checkfirst=True)
-                log_debug(f"Successfully created table '{self.db_schema}.{table_name}'")
-                table_created = True
+                try:
+                    table.create(self.db_engine, checkfirst=True)
+                    log_debug(f"Successfully created table '{self.db_schema}.{table_name}'")
+                    table_created = True
+                except Exception:
+                    # A separate process can win after the existence check.
+                    # Accept only a valid table created by that concurrent
+                    # initializer; every other DDL error still propagates.
+                    if not self.table_exists(table_name) or not is_valid_table(
+                        db_engine=self.db_engine,
+                        table_name=table_name,
+                        table_type=table_type,
+                        db_schema=self.db_schema,
+                    ):
+                        raise
+                    log_debug(f"Table '{self.db_schema}.{table_name}' was created concurrently")
             else:
                 log_debug(f"Table {self.db_schema}.{table_name} already exists, skipping creation")
 
@@ -660,6 +734,17 @@ class PostgresDb(BaseDb):
         raise ValueError(f"Unknown table type: {table_type}")
 
     def _get_or_create_table(
+        self, table_name: str, table_type: str, create_table_if_not_found: Optional[bool] = False
+    ) -> Optional[Table]:
+        # SQLAlchemy MetaData rejects two concurrent definitions of the same
+        # table before the database-level checkfirst guard can run. A single
+        # PostgresDb is intentionally shared across Studio worker threads, so
+        # serialize its lazy table reflection/creation. RLock is required
+        # because table creation can resolve another table through _get_table.
+        with self._table_init_lock:
+            return self._get_or_create_table_unlocked(table_name, table_type, create_table_if_not_found)
+
+    def _get_or_create_table_unlocked(
         self, table_name: str, table_type: str, create_table_if_not_found: Optional[bool] = False
     ) -> Optional[Table]:
         """
@@ -3623,21 +3708,310 @@ class PostgresDb(BaseDb):
             return [], 0
 
     # --- Components ---
+    @staticmethod
+    def _lock_component_graph_writes(sess: Any) -> None:
+        sess.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_key)"),
+            {"lock_key": _COMPONENT_GRAPH_WRITE_LOCK_KEY},
+        )
+
+    @staticmethod
+    def _component_version_state(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        component_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[ComponentVersionGuard]:
+        """Lock a component row and return the state used by guarded writes."""
+        stmt = select(components_table.c.current_version).where(components_table.c.component_id == component_id)
+        if not include_deleted:
+            stmt = stmt.where(components_table.c.deleted_at.is_(None))
+        component = sess.execute(stmt.with_for_update()).mappings().one_or_none()
+        if component is None:
+            return None
+
+        latest_version = sess.execute(
+            select(func.max(configs_table.c.version)).where(
+                configs_table.c.component_id == component_id,
+                configs_table.c.stage != DELETED_CONFIG_STAGE,
+            )
+        ).scalar()
+        return ComponentVersionGuard(
+            latest_version=latest_version,
+            current_version=component["current_version"],
+        )
+
+    @staticmethod
+    def _check_component_guard(
+        component_id: str,
+        expected: Optional[ComponentVersionGuard],
+        actual: ComponentVersionGuard,
+    ) -> None:
+        if expected is not None and expected != actual:
+            raise ComponentVersionConflictError(component_id, expected=expected, actual=actual)
+
+    @staticmethod
+    def _projection_values(projection: Optional[ComponentProjection]) -> Dict[str, Any]:
+        if projection is None:
+            return {}
+        allowed = {"name", "description", "metadata"}
+        unknown = set(projection) - allowed
+        if unknown:
+            raise ValueError(f"Invalid component projection fields: {sorted(unknown)}")
+        return dict(projection)
+
+    @staticmethod
+    def _validate_component_links(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        links: Optional[List[Dict[str, Any]]],
+        *,
+        require_published: bool,
+    ) -> None:
+        """Validate and lock every exact child version referenced by a write."""
+        sorted_links = sorted(
+            links or [],
+            key=lambda link: (str(link.get("child_component_id")), int(link.get("child_version") or 0)),
+        )
+        for link in sorted_links:
+            child_id = link.get("child_component_id")
+            child_version = link.get("child_version")
+            if not child_id or child_version is None:
+                raise ValueError("Each component link requires child_component_id and child_version")
+
+            child = (
+                sess.execute(
+                    select(components_table.c.component_type, configs_table.c.stage)
+                    .select_from(
+                        components_table.join(
+                            configs_table,
+                            (configs_table.c.component_id == components_table.c.component_id)
+                            & (configs_table.c.version == child_version),
+                        )
+                    )
+                    .where(
+                        components_table.c.component_id == child_id,
+                        components_table.c.deleted_at.is_(None),
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    )
+                    .with_for_update(of=components_table)
+                )
+                .mappings()
+                .one_or_none()
+            )
+            if child is None:
+                raise ValueError(f"Linked component version not found: {child_id} v{child_version}")
+            if require_published and child["stage"] != "published":
+                raise ValueError(f"Linked component version is not published: {child_id} v{child_version}")
+
+            expected_type = None
+            link_kind = link.get("link_kind")
+            if link_kind == "step_agent":
+                expected_type = ComponentType.AGENT.value
+            elif link_kind == "step_team":
+                expected_type = ComponentType.TEAM.value
+            elif link_kind == "step_workflow":
+                expected_type = ComponentType.WORKFLOW.value
+            elif link_kind == "member" and isinstance(link.get("meta"), dict):
+                expected_type = link["meta"].get("type")
+            if isinstance(expected_type, ComponentType):
+                expected_type = expected_type.value
+            if expected_type is not None and child["component_type"] != expected_type:
+                raise ValueError(
+                    f"Linked component {child_id} has type {child['component_type']}, expected {expected_type}"
+                )
+
+    @staticmethod
+    def _validate_restore_dependencies(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        links_table: Any,
+        component_id: str,
+        version: int,
+    ) -> None:
+        """Require every version reachable from a restored published root to remain runnable."""
+        unavailable: List[Dict[str, Any]] = []
+        unavailable_keys: Set[Tuple[str, int, str, int, str]] = set()
+        seen: Set[Tuple[str, int]] = {(component_id, version)}
+        pending: List[Tuple[str, int]] = [(component_id, version)]
+
+        while pending:
+            parent_id, parent_version = pending.pop()
+            links = (
+                sess.execute(
+                    select(
+                        links_table.c.child_component_id,
+                        links_table.c.child_version,
+                    )
+                    .where(
+                        links_table.c.parent_component_id == parent_id,
+                        links_table.c.parent_version == parent_version,
+                    )
+                    .order_by(links_table.c.child_component_id, links_table.c.child_version)
+                )
+                .mappings()
+                .all()
+            )
+
+            for link in reversed(links):
+                child_id = link["child_component_id"]
+                child_version = link["child_version"]
+                child = (
+                    sess.execute(
+                        select(components_table.c.deleted_at)
+                        .where(components_table.c.component_id == child_id)
+                        .with_for_update(of=components_table)
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+
+                reason: Optional[str] = None
+                if child is None:
+                    reason = "component_missing"
+                elif child["deleted_at"] is not None:
+                    reason = "component_archived"
+                else:
+                    child_stage = sess.execute(
+                        select(configs_table.c.stage)
+                        .where(
+                            configs_table.c.component_id == child_id,
+                            configs_table.c.version == child_version,
+                        )
+                        .with_for_update()
+                    ).scalar_one_or_none()
+                    if child_stage is None or child_stage == DELETED_CONFIG_STAGE:
+                        reason = "version_missing"
+                    elif child_stage != "published":
+                        reason = "version_not_published"
+
+                if reason is not None:
+                    unavailable_key = (parent_id, parent_version, child_id, child_version, reason)
+                    if unavailable_key not in unavailable_keys:
+                        unavailable_keys.add(unavailable_key)
+                        unavailable.append(
+                            {
+                                "component_id": child_id,
+                                "version": child_version,
+                                "referenced_by": {
+                                    "component_id": parent_id,
+                                    "version": parent_version,
+                                },
+                                "reason": reason,
+                            }
+                        )
+                    continue
+
+                child_key = (child_id, child_version)
+                if child_key not in seen:
+                    seen.add(child_key)
+                    pending.append(child_key)
+
+        if unavailable:
+            raise ComponentDependencyUnavailableError(component_id, unavailable)
+
+    @staticmethod
+    def _validate_component_acyclic(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        links_table: Any,
+        component_id: str,
+        version: int,
+        links: List[Dict[str, Any]],
+    ) -> None:
+        """Reject cycles while the caller holds the graph advisory lock."""
+        rows = (
+            sess.execute(
+                select(
+                    links_table.c.parent_component_id,
+                    links_table.c.parent_version,
+                    links_table.c.child_component_id,
+                )
+                .select_from(
+                    links_table.join(
+                        configs_table,
+                        (configs_table.c.component_id == links_table.c.parent_component_id)
+                        & (configs_table.c.version == links_table.c.parent_version),
+                    ).join(
+                        components_table,
+                        components_table.c.component_id == links_table.c.parent_component_id,
+                    )
+                )
+                .where(
+                    configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    components_table.c.deleted_at.is_(None),
+                )
+            )
+            .mappings()
+            .all()
+        )
+
+        adjacency: Dict[str, Set[str]] = {}
+        for row in rows:
+            if row["parent_component_id"] == component_id and row["parent_version"] == version:
+                continue
+            adjacency.setdefault(row["parent_component_id"], set()).add(row["child_component_id"])
+        for link in links:
+            child_id = link.get("child_component_id")
+            if child_id:
+                adjacency.setdefault(component_id, set()).add(child_id)
+
+        seen = {component_id}
+        pending: List[Tuple[str, List[str]]] = [(component_id, [component_id])]
+        while pending:
+            node, path = pending.pop()
+            for child_id in reversed(sorted(adjacency.get(node, set()))):
+                if child_id == component_id:
+                    raise ComponentCycleError(component_id, [*path, child_id])
+                if child_id in seen:
+                    continue
+                seen.add(child_id)
+                pending.append((child_id, [*path, child_id]))
+
+    @staticmethod
+    def _component_dependents(
+        sess: Any,
+        components_table: Any,
+        links_table: Any,
+        component_id: str,
+        *,
+        version: Optional[int] = None,
+        active_parents_only: bool = False,
+    ) -> List[Dict[str, Any]]:
+        stmt = select(links_table).where(links_table.c.child_component_id == component_id)
+        if version is not None:
+            stmt = stmt.where(links_table.c.child_version == version)
+        if active_parents_only:
+            stmt = stmt.select_from(
+                links_table.join(
+                    components_table,
+                    components_table.c.component_id == links_table.c.parent_component_id,
+                )
+            ).where(components_table.c.deleted_at.is_(None))
+        return [dict(row) for row in sess.execute(stmt).mappings().all()]
+
     def get_component(
         self,
         component_id: str,
         component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
+        """Get a component, excluding archived rows unless explicitly requested."""
         try:
             table = self._get_table(table_type="components")
             if table is None:
                 return None
 
             with self.Session() as sess:
-                stmt = select(table).where(
-                    table.c.component_id == component_id,
-                    table.c.deleted_at.is_(None),
-                )
+                stmt = select(table).where(table.c.component_id == component_id)
+                if not include_deleted:
+                    stmt = stmt.where(table.c.deleted_at.is_(None))
 
                 if component_type is not None:
                     stmt = stmt.where(table.c.component_type == component_type.value)
@@ -3647,6 +4021,36 @@ class PostgresDb(BaseDb):
 
         except Exception as e:
             log_error(f"Error getting component: {str(e)}")
+            raise
+
+    def get_components(
+        self,
+        component_ids: Set[str],
+        component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Get a bounded set of component rows in one query."""
+        if not component_ids:
+            return []
+        try:
+            table = getattr(self, "component_table", None)
+            if table is None:
+                table = self._get_table(table_type="components")
+            if table is None:
+                return []
+
+            with self.Session() as sess:
+                stmt = select(table).where(table.c.component_id.in_(component_ids))
+                if not include_deleted:
+                    stmt = stmt.where(table.c.deleted_at.is_(None))
+                if component_type is not None:
+                    stmt = stmt.where(table.c.component_type == component_type.value)
+                stmt = stmt.order_by(table.c.component_id)
+                return [dict(row) for row in sess.execute(stmt).mappings().all()]
+
+        except Exception as e:
+            log_error(f"Error getting components: {str(e)}")
             raise
 
     def upsert_component(
@@ -3665,27 +4069,33 @@ class PostgresDb(BaseDb):
             component_type: Type (agent|team|workflow). Required for create, optional for update.
             name: Display name.
             description: Optional description.
-            current_version: Optional current version.
+            current_version: Reserved. Use set_current_version for guarded,
+                projection-synchronized current-pointer changes.
             metadata: Optional metadata dict.
 
         Returns:
             Created/updated component dictionary.
 
         Raises:
-            ValueError: If creating and component_type is not provided.
+            ValueError: If creating and component_type is not provided, or if
+                current_version is supplied.
         """
+        if current_version is not None:
+            raise ValueError("current_version can only be changed with set_current_version")
+
         try:
             table = self._get_table(table_type="components", create_table_if_not_found=True)
             if table is None:
                 raise ValueError("Components table not found")
 
             with self.Session() as sess, sess.begin():
-                existing = sess.execute(select(table).where(table.c.component_id == component_id)).fetchone()
+                existing = sess.execute(
+                    select(table).where(table.c.component_id == component_id).with_for_update()
+                ).fetchone()
                 if existing is None:
                     # Create new component
                     if component_type is None:
                         raise ValueError("component_type is required when creating a new component")
-
                     sess.execute(
                         table.insert().values(
                             component_id=component_id,
@@ -3700,45 +4110,39 @@ class PostgresDb(BaseDb):
                     log_debug(f"Created component {component_id}")
 
                 elif existing.deleted_at is not None:
-                    # Reactivate soft-deleted
-                    if component_type is None:
-                        raise ValueError("component_type is required when reactivating a deleted component")
-
-                    sess.execute(
-                        table.update()
-                        .where(table.c.component_id == component_id)
-                        .values(
-                            component_type=component_type.value,
-                            name=name or component_id,
-                            description=description,
-                            current_version=None,
-                            metadata=metadata,
-                            updated_at=int(time.time()),
-                            deleted_at=None,
-                        )
-                    )
-                    log_debug(f"Reactivated component {component_id}")
+                    raise ValueError(f"Component {component_id} is archived and remains reserved")
 
                 else:
                     # Update existing
+                    if component_type is not None and component_type.value != existing.component_type:
+                        raise ValueError(
+                            f"Component {component_id} has type {existing.component_type}, not {component_type.value}"
+                        )
                     updates: Dict[str, Any] = {"updated_at": int(time.time())}
-                    if component_type is not None:
-                        updates["component_type"] = component_type.value
                     if name is not None:
                         updates["name"] = name
                     if description is not None:
                         updates["description"] = description
-                    if current_version is not None:
-                        updates["current_version"] = current_version
                     if metadata is not None:
                         updates["metadata"] = metadata
 
                     sess.execute(table.update().where(table.c.component_id == component_id).values(**updates))
                     log_debug(f"Updated component {component_id}")
 
-            result = self.get_component(component_id)
-            if result is None:
-                raise ValueError(f"Failed to get component {component_id} after upsert")
+                result_row = (
+                    sess.execute(
+                        select(table).where(
+                            table.c.component_id == component_id,
+                            table.c.deleted_at.is_(None),
+                        )
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                if result_row is None:
+                    raise ValueError(f"Failed to get component {component_id} during upsert")
+                result = dict(result_row)
+
             return result
 
         except Exception as e:
@@ -3749,12 +4153,19 @@ class PostgresDb(BaseDb):
         self,
         component_id: str,
         hard_delete: bool = False,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        require_no_dependents: bool = True,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Delete a component and all its configs/links.
 
         Args:
             component_id: The component ID.
             hard_delete: If True, permanently delete. Otherwise soft-delete.
+            guard: Expected latest/current version state for compare-and-set.
+            require_no_dependents: Refuse deletion while qualifying inbound links exist.
+            projection: Component fields to update atomically with a soft archive.
 
         Returns:
             True if deleted, False if not found or already deleted.
@@ -3766,47 +4177,141 @@ class PostgresDb(BaseDb):
 
             if components_table is None:
                 return False
+            if hard_delete and projection is not None:
+                raise ValueError("projection is not supported for hard delete")
 
             with self.Session() as sess, sess.begin():
-                # Verify component exists (and not already soft-deleted for soft-delete)
-                if hard_delete:
-                    exists = sess.execute(
-                        select(components_table.c.component_id).where(components_table.c.component_id == component_id)
-                    ).scalar_one_or_none()
+                self._lock_component_graph_writes(sess)
+                if configs_table is not None:
+                    actual = self._component_version_state(
+                        sess,
+                        components_table,
+                        configs_table,
+                        component_id,
+                        include_deleted=hard_delete,
+                    )
                 else:
-                    exists = sess.execute(
-                        select(components_table.c.component_id).where(
-                            components_table.c.component_id == component_id,
-                            components_table.c.deleted_at.is_(None),
-                        )
-                    ).scalar_one_or_none()
+                    component_stmt = select(components_table.c.current_version).where(
+                        components_table.c.component_id == component_id
+                    )
+                    if not hard_delete:
+                        component_stmt = component_stmt.where(components_table.c.deleted_at.is_(None))
+                    component = sess.execute(component_stmt.with_for_update()).mappings().one_or_none()
+                    actual = (
+                        ComponentVersionGuard(latest_version=None, current_version=component["current_version"])
+                        if component is not None
+                        else None
+                    )
 
-                if exists is None:
+                if actual is None:
                     log_error(f"Component {component_id} not found")
                     return False
+                self._check_component_guard(component_id, guard, actual)
+
+                if require_no_dependents and links_table is not None:
+                    dependents = self._component_dependents(
+                        sess,
+                        components_table,
+                        links_table,
+                        component_id,
+                        active_parents_only=not hard_delete,
+                    )
+                    if dependents:
+                        raise ComponentDependencyError(component_id, dependents)
 
                 if hard_delete:
-                    # Delete links where this component is parent or child
                     if links_table is not None:
                         sess.execute(links_table.delete().where(links_table.c.parent_component_id == component_id))
                         sess.execute(links_table.delete().where(links_table.c.child_component_id == component_id))
-                    # Delete configs
                     if configs_table is not None:
                         sess.execute(configs_table.delete().where(configs_table.c.component_id == component_id))
-                    # Delete component
-                    sess.execute(components_table.delete().where(components_table.c.component_id == component_id))
+                    result = sess.execute(
+                        components_table.delete().where(components_table.c.component_id == component_id)
+                    )
                 else:
-                    # Soft delete (preserve current_version for potential reactivation)
-                    sess.execute(
+                    now = int(time.time())
+                    updates: Dict[str, Any] = {"deleted_at": now, "updated_at": now}
+                    updates.update(self._projection_values(projection))
+                    result = sess.execute(
                         components_table.update()
-                        .where(components_table.c.component_id == component_id)
-                        .values(deleted_at=int(time.time()))
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                        .values(**updates)
                     )
 
-            return True
+            return result.rowcount > 0
 
         except Exception as e:
             log_error(f"Error deleting component: {str(e)}")
+            raise
+
+    def restore_component(
+        self,
+        component_id: str,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+    ) -> bool:
+        """Restore one archived component with an optional CAS guard."""
+        try:
+            components_table = self._get_table(table_type="components")
+            configs_table = self._get_table(table_type="component_configs")
+            links_table = self._get_table(table_type="component_links")
+            if components_table is None or configs_table is None:
+                return False
+
+            with self.Session() as sess, sess.begin():
+                self._lock_component_graph_writes(sess)
+                actual = self._component_version_state(
+                    sess,
+                    components_table,
+                    configs_table,
+                    component_id,
+                    include_deleted=True,
+                )
+                if actual is None:
+                    return False
+                archived = (
+                    sess.execute(
+                        select(components_table.c.deleted_at)
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_not(None),
+                        )
+                        .with_for_update()
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                if archived is None:
+                    return False
+                self._check_component_guard(component_id, guard, actual)
+                if actual.current_version is not None and links_table is not None:
+                    self._validate_restore_dependencies(
+                        sess,
+                        components_table,
+                        configs_table,
+                        links_table,
+                        component_id,
+                        actual.current_version,
+                    )
+
+                updates: Dict[str, Any] = {"deleted_at": None, "updated_at": int(time.time())}
+                updates.update(self._projection_values(projection))
+                result = sess.execute(
+                    components_table.update()
+                    .where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_not(None),
+                    )
+                    .values(**updates)
+                )
+                return result.rowcount > 0
+
+        except Exception as e:
+            log_error(f"Error restoring component: {str(e)}")
             raise
 
     def list_components(
@@ -3907,12 +4412,6 @@ class PostgresDb(BaseDb):
         if stage not in {"draft", "published"}:
             raise ValueError(f"Invalid stage: {stage}")
 
-        # Validate links have child_version
-        if links:
-            for link in links:
-                if link.get("child_version") is None:
-                    raise ValueError(f"child_version is required for link to {link['child_component_id']}")
-
         try:
             components_table = self._get_table(table_type="components", create_table_if_not_found=True)
             configs_table = self._get_table(table_type="component_configs", create_table_if_not_found=True)
@@ -3924,13 +4423,14 @@ class PostgresDb(BaseDb):
                 raise ValueError("Component configs table not found")
 
             with self.Session() as sess, sess.begin():
+                self._lock_component_graph_writes(sess)
                 # Check if component already exists
                 existing = sess.execute(
                     select(components_table.c.component_id).where(components_table.c.component_id == component_id)
                 ).scalar_one_or_none()
 
                 if existing is not None:
-                    raise ValueError(f"Component {component_id} already exists")
+                    raise ComponentAlreadyExistsError(component_id)
 
                 # Check label uniqueness
                 if label is not None:
@@ -3946,18 +4446,39 @@ class PostgresDb(BaseDb):
                 now = int(time.time())
                 version = 1
 
-                # Create component
-                sess.execute(
-                    components_table.insert().values(
-                        component_id=component_id,
-                        component_type=component_type.value,
-                        name=name,
-                        description=description,
-                        metadata=metadata,
-                        current_version=version if stage == "published" else None,
-                        created_at=now,
+                if links is not None and links_table is not None:
+                    self._validate_component_acyclic(
+                        sess,
+                        components_table,
+                        configs_table,
+                        links_table,
+                        component_id,
+                        version,
+                        links,
                     )
+
+                self._validate_component_links(
+                    sess,
+                    components_table,
+                    configs_table,
+                    links,
+                    require_published=stage == "published",
                 )
+
+                try:
+                    sess.execute(
+                        components_table.insert().values(
+                            component_id=component_id,
+                            component_type=component_type.value,
+                            name=name,
+                            description=description,
+                            metadata=metadata,
+                            current_version=version if stage == "published" else None,
+                            created_at=now,
+                        )
+                    )
+                except IntegrityError as exc:
+                    raise ComponentAlreadyExistsError(component_id) from exc
 
                 # Create initial config
                 sess.execute(
@@ -3989,14 +4510,33 @@ class PostgresDb(BaseDb):
                             )
                         )
 
-            # Fetch and return both
-            component = self.get_component(component_id)
-            config_result = self.get_config(component_id, version=version)
-
-            if component is None:
-                raise ValueError(f"Failed to get component {component_id} after creation")
-            if config_result is None:
-                raise ValueError(f"Failed to get config for {component_id} after creation")
+                component_row = (
+                    sess.execute(
+                        select(components_table).where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                config_row = (
+                    sess.execute(
+                        select(configs_table).where(
+                            configs_table.c.component_id == component_id,
+                            configs_table.c.version == version,
+                            configs_table.c.stage != DELETED_CONFIG_STAGE,
+                        )
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                if component_row is None:
+                    raise ValueError(f"Failed to get component {component_id} during creation")
+                if config_row is None:
+                    raise ValueError(f"Failed to get config for {component_id} during creation")
+                component = dict(component_row)
+                config_result = dict(config_row)
 
             return component, config_result
 
@@ -4015,7 +4555,9 @@ class PostgresDb(BaseDb):
 
         Args:
             component_id: The component ID.
-            version: Specific version number. If None, uses current or latest draft.
+            version: Specific version number. If omitted with no label, uses
+                the current published version or the latest draft when the
+                component has never been published.
             label: Config label to lookup. Ignored if version is provided.
 
         Returns:
@@ -4063,7 +4605,6 @@ class PostgresDb(BaseDb):
                         configs_table.c.version == current_version,
                     )
                 else:
-                    # No current_version set (draft only) - get the latest version
                     stmt = (
                         select(configs_table)
                         .where(configs_table.c.component_id == component_id)
@@ -4071,11 +4612,145 @@ class PostgresDb(BaseDb):
                         .limit(1)
                     )
 
+                stmt = stmt.where(configs_table.c.stage != DELETED_CONFIG_STAGE)
                 row = sess.execute(stmt).mappings().one_or_none()
                 return dict(row) if row else None
 
         except Exception as e:
             log_error(f"Error getting config: {str(e)}")
+            raise
+
+    def get_current_config(self, component_id: str) -> Optional[Dict[str, Any]]:
+        """Get only the current published config for an active component."""
+        try:
+            configs_table = self._get_table(table_type="component_configs")
+            components_table = self._get_table(table_type="components")
+            if configs_table is None or components_table is None:
+                return None
+
+            with self.Session() as sess:
+                row = (
+                    sess.execute(
+                        select(configs_table)
+                        .select_from(
+                            components_table.join(
+                                configs_table,
+                                (configs_table.c.component_id == components_table.c.component_id)
+                                & (configs_table.c.version == components_table.c.current_version),
+                            )
+                        )
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                            configs_table.c.stage == "published",
+                        )
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                return dict(row) if row else None
+
+        except Exception as e:
+            log_error(f"Error getting current config: {str(e)}")
+            raise
+
+    def get_latest_config(
+        self,
+        component_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Get the latest visible config, optionally for an archived component."""
+        try:
+            configs_table = self._get_table(table_type="component_configs")
+            components_table = self._get_table(table_type="components")
+            if configs_table is None or components_table is None:
+                return None
+
+            with self.Session() as sess:
+                component_stmt = select(components_table.c.component_id).where(
+                    components_table.c.component_id == component_id
+                )
+                if not include_deleted:
+                    component_stmt = component_stmt.where(components_table.c.deleted_at.is_(None))
+                if sess.execute(component_stmt).scalar_one_or_none() is None:
+                    return None
+
+                row = (
+                    sess.execute(
+                        select(configs_table)
+                        .where(
+                            configs_table.c.component_id == component_id,
+                            configs_table.c.stage != DELETED_CONFIG_STAGE,
+                        )
+                        .order_by(configs_table.c.version.desc())
+                        .limit(1)
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                return dict(row) if row else None
+
+        except Exception as e:
+            log_error(f"Error getting latest config: {str(e)}")
+            raise
+
+    def get_latest_configs(
+        self,
+        component_ids: Set[str],
+        *,
+        include_deleted: bool = False,
+    ) -> Dict[str, Optional[Dict[str, Any]]]:
+        """Get one latest visible config per requested component in one query."""
+        if not component_ids:
+            return {}
+        try:
+            configs_table = getattr(self, "component_configs_table", None)
+            if configs_table is None:
+                configs_table = self._get_table(table_type="component_configs")
+            components_table = getattr(self, "component_table", None)
+            if components_table is None:
+                components_table = self._get_table(table_type="components")
+            if configs_table is None or components_table is None:
+                return {component_id: None for component_id in component_ids}
+
+            latest_versions = (
+                select(
+                    configs_table.c.component_id,
+                    func.max(configs_table.c.version).label("latest_version"),
+                )
+                .where(
+                    configs_table.c.component_id.in_(component_ids),
+                    configs_table.c.stage != DELETED_CONFIG_STAGE,
+                )
+                .group_by(configs_table.c.component_id)
+                .subquery()
+            )
+            with self.Session() as sess:
+                stmt = (
+                    select(configs_table)
+                    .select_from(
+                        configs_table.join(
+                            latest_versions,
+                            (configs_table.c.component_id == latest_versions.c.component_id)
+                            & (configs_table.c.version == latest_versions.c.latest_version),
+                        ).join(
+                            components_table,
+                            components_table.c.component_id == configs_table.c.component_id,
+                        )
+                    )
+                    .where(components_table.c.component_id.in_(component_ids))
+                )
+                if not include_deleted:
+                    stmt = stmt.where(components_table.c.deleted_at.is_(None))
+                result: Dict[str, Optional[Dict[str, Any]]] = {component_id: None for component_id in component_ids}
+                for row in sess.execute(stmt).mappings().all():
+                    config_row = dict(row)
+                    result[config_row["component_id"]] = config_row
+                return result
+
+        except Exception as e:
+            log_error(f"Error getting latest configs: {str(e)}")
             raise
 
     def upsert_config(
@@ -4087,22 +4762,35 @@ class PostgresDb(BaseDb):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+        restore_if_deleted: bool = False,
+        expected_component_type: Optional[ComponentType] = None,
     ) -> Dict[str, Any]:
         """Create or update a config version for a component.
 
         Rules:
-            - Draft configs can be edited freely
+            - Stored config versions are immutable
+            - The latest draft may transition to published with a guard
             - Published configs are immutable
             - Publishing a config automatically sets it as current_version
 
         Args:
             component_id: The component ID.
-            config: The config data. Required for create, optional for update.
-            version: If None, creates new version. If provided, updates that version.
+            config: The config data. Required when appending a version.
+            version: If None, appends a version. If provided, publishes that draft.
             label: Optional human-readable label.
             stage: "draft" or "published". Defaults to "draft" for new configs.
             notes: Optional notes.
             links: Optional list of links. Each link must have child_version set.
+            guard: Expected latest/current version state for compare-and-set.
+            projection: Component fields synchronized atomically when publishing.
+                When omitted, they are derived from the target config.
+            restore_if_deleted: Restore an archived component in the same
+                transaction as this config mutation.
+            expected_component_type: Optional component type to validate under
+                the component row lock.
 
         Returns:
             Created/updated config dictionary.
@@ -4125,22 +4813,39 @@ class PostgresDb(BaseDb):
                 raise ValueError("Component configs table not found")
 
             with self.Session() as sess, sess.begin():
-                # Verify component exists and is not deleted
-                component = sess.execute(
-                    select(components_table.c.component_id).where(
-                        components_table.c.component_id == component_id,
-                        components_table.c.deleted_at.is_(None),
-                    )
-                ).scalar_one_or_none()
-
-                if component is None:
+                self._lock_component_graph_writes(sess)
+                actual = self._component_version_state(
+                    sess,
+                    components_table,
+                    configs_table,
+                    component_id,
+                    include_deleted=restore_if_deleted,
+                )
+                if actual is None:
                     raise ValueError(f"Component {component_id} not found")
+                self._check_component_guard(component_id, guard, actual)
+                is_archived = False
+                if restore_if_deleted:
+                    is_archived = (
+                        sess.execute(
+                            select(components_table.c.deleted_at).where(components_table.c.component_id == component_id)
+                        ).scalar_one()
+                        is not None
+                    )
+                if expected_component_type is not None:
+                    actual_type = sess.execute(
+                        select(components_table.c.component_type).where(components_table.c.component_id == component_id)
+                    ).scalar_one()
+                    if actual_type != expected_component_type.value:
+                        raise ValueError(
+                            f"Component {component_id} has type {actual_type}, not {expected_component_type.value}"
+                        )
 
-                # Label uniqueness check
                 if label is not None:
                     label_query = select(configs_table.c.version).where(
                         configs_table.c.component_id == component_id,
                         configs_table.c.label == label,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
                     )
                     if version is not None:
                         label_query = label_query.where(configs_table.c.version != version)
@@ -4148,79 +4853,105 @@ class PostgresDb(BaseDb):
                     if sess.execute(label_query).first():
                         raise ValueError(f"Label '{label}' already exists for {component_id}")
 
-                # Validate links have child_version
-                if links:
-                    for link in links:
-                        if link.get("child_version") is None:
-                            raise ValueError(f"child_version is required for link to {link['child_component_id']}")
-
+                existing: Optional[Dict[str, Any]] = None
                 if version is None:
                     if config is None:
                         raise ValueError("config is required when creating a new version")
-
-                    # Default to draft for new configs
-                    if stage is None:
-                        stage = "draft"
-
-                    max_version = sess.execute(
-                        select(configs_table.c.version)
-                        .where(configs_table.c.component_id == component_id)
-                        .order_by(configs_table.c.version.desc())
-                        .limit(1)
+                    final_stage = stage or "draft"
+                    target_config = config
+                    high_water = sess.execute(
+                        select(func.max(configs_table.c.version)).where(configs_table.c.component_id == component_id)
                     ).scalar()
+                    final_version = (high_water or 0) + 1
+                else:
+                    existing_row = (
+                        sess.execute(
+                            select(configs_table.c.version, configs_table.c.stage, configs_table.c.config)
+                            .where(
+                                configs_table.c.component_id == component_id,
+                                configs_table.c.version == version,
+                            )
+                            .with_for_update()
+                        )
+                        .mappings()
+                        .one_or_none()
+                    )
+                    if existing_row is None:
+                        raise ValueError(f"Config {component_id} v{version} not found")
+                    existing = dict(existing_row)
 
-                    final_version = (max_version or 0) + 1
+                    if existing["stage"] == DELETED_CONFIG_STAGE:
+                        raise ValueError(f"Config {component_id} v{version} not found")
+                    if existing["stage"] == "published":
+                        raise ValueError(f"Cannot update published config {component_id} v{version}")
 
+                    if guard is None:
+                        raise ValueError("Publishing an existing draft requires a component version guard")
+                    if stage != "published":
+                        raise ValueError("An existing config version is immutable; only guarded publication is allowed")
+                    if any(value is not None for value in (config, label, notes)):
+                        raise ValueError("A guarded publish cannot mutate config, label, or notes")
+                    if version != actual.latest_version:
+                        raise ValueError(f"Only the latest draft can be published; latest is v{actual.latest_version}")
+                    target_config = existing["config"]
+                    if not isinstance(target_config, dict):
+                        raise ValueError(f"Config {component_id} v{version} payload must be an object")
+                    final_version = version
+                    final_stage = "published"
+
+                links_to_validate = links
+                if final_stage == "published" and links_to_validate is None and links_table is not None:
+                    links_to_validate = [
+                        dict(row)
+                        for row in sess.execute(
+                            select(links_table).where(
+                                links_table.c.parent_component_id == component_id,
+                                links_table.c.parent_version == final_version,
+                            )
+                        )
+                        .mappings()
+                        .all()
+                    ]
+                if links_to_validate is not None and links_table is not None:
+                    self._validate_component_acyclic(
+                        sess,
+                        components_table,
+                        configs_table,
+                        links_table,
+                        component_id,
+                        final_version,
+                        links_to_validate,
+                    )
+                self._validate_component_links(
+                    sess,
+                    components_table,
+                    configs_table,
+                    links_to_validate,
+                    require_published=final_stage == "published",
+                )
+                now = int(time.time())
+
+                if version is None:
                     sess.execute(
                         configs_table.insert().values(
                             component_id=component_id,
                             version=final_version,
                             label=label,
-                            stage=stage,
+                            stage=final_stage,
                             config=config,
                             notes=notes,
-                            created_at=int(time.time()),
+                            created_at=now,
                         )
                     )
                 else:
-                    existing = (
-                        sess.execute(
-                            select(configs_table.c.version, configs_table.c.stage).where(
-                                configs_table.c.component_id == component_id,
-                                configs_table.c.version == version,
-                            )
-                        )
-                        .mappings()
-                        .one_or_none()
-                    )
-
-                    if existing is None:
-                        raise ValueError(f"Config {component_id} v{version} not found")
-
-                    # Published configs are immutable
-                    if existing["stage"] == "published":
-                        raise ValueError(f"Cannot update published config {component_id} v{version}")
-
-                    # Build update dict with only provided fields
-                    updates: Dict[str, Any] = {"updated_at": int(time.time())}
-                    if label is not None:
-                        updates["label"] = label
-                    if stage is not None:
-                        updates["stage"] = stage
-                    if config is not None:
-                        updates["config"] = config
-                    if notes is not None:
-                        updates["notes"] = notes
-
                     sess.execute(
                         configs_table.update()
                         .where(
                             configs_table.c.component_id == component_id,
                             configs_table.c.version == version,
                         )
-                        .values(**updates)
+                        .values(stage="published", updated_at=now)
                     )
-                    final_version = version
 
                 if links is not None and links_table is not None:
                     sess.execute(
@@ -4240,23 +4971,79 @@ class PostgresDb(BaseDb):
                                 child_version=link["child_version"],
                                 position=link["position"],
                                 meta=link.get("meta"),
-                                created_at=int(time.time()),
+                                created_at=now,
                             )
                         )
 
-                # Determine final stage (could be from update or create)
-                final_stage = stage if stage is not None else (existing["stage"] if version is not None else "draft")
-
-                if final_stage == "published":
+                if restore_if_deleted and is_archived:
+                    restored_version = final_version if final_stage == "published" else actual.current_version
+                    if restored_version is not None and links_table is not None:
+                        self._validate_restore_dependencies(
+                            sess,
+                            components_table,
+                            configs_table,
+                            links_table,
+                            component_id,
+                            restored_version,
+                        )
+                    # Reactivation is part of this write transaction. Any
+                    # label, graph, projection, or config failure rolls it back
+                    # together with the attempted config append.
                     sess.execute(
                         components_table.update()
                         .where(components_table.c.component_id == component_id)
-                        .values(current_version=final_version, updated_at=int(time.time()))
+                        .values(deleted_at=None, updated_at=now)
                     )
 
-            result = self.get_config(component_id, version=final_version)
-            if result is None:
-                raise ValueError(f"Failed to get config {component_id} v{final_version} after upsert")
+                if final_stage == "published":
+                    effective_projection = projection
+                    if effective_projection is None:
+                        effective_projection = self._projection_from_config(target_config)
+                    component_updates: Dict[str, Any] = {
+                        "current_version": final_version,
+                        "updated_at": now,
+                    }
+                    component_updates.update(self._projection_values(effective_projection))
+                    sess.execute(
+                        components_table.update()
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                        .values(**component_updates)
+                    )
+                elif projection is not None:
+                    # Draft-only components project their latest draft. The
+                    # conditional update safely ignores this projection when a
+                    # current published version already exists (including one
+                    # committed by a concurrent publisher).
+                    component_updates = {"updated_at": now}
+                    component_updates.update(self._projection_values(projection))
+                    sess.execute(
+                        components_table.update()
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                            components_table.c.current_version.is_(None),
+                        )
+                        .values(**component_updates)
+                    )
+
+                result_row = (
+                    sess.execute(
+                        select(configs_table).where(
+                            configs_table.c.component_id == component_id,
+                            configs_table.c.version == final_version,
+                            configs_table.c.stage != DELETED_CONFIG_STAGE,
+                        )
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                if result_row is None:
+                    raise ValueError(f"Failed to get config {component_id} v{final_version} during upsert")
+                result = dict(result_row)
+
             return result
 
         except Exception as e:
@@ -4267,6 +5054,9 @@ class PostgresDb(BaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Delete a specific config version.
 
@@ -4276,12 +5066,15 @@ class PostgresDb(BaseDb):
         Args:
             component_id: The component ID.
             version: The version to delete.
+            guard: Expected latest/current version state for compare-and-set.
+            projection: Component fields to update atomically with deletion.
 
         Returns:
             True if deleted, False if not found.
 
         Raises:
-            ValueError: If attempting to delete a published or current config.
+            ComponentDraftRequiredError: If attempting to delete a published config.
+            ValueError: If attempting to delete the current config.
         """
         try:
             configs_table = self._get_table(table_type="component_configs")
@@ -4292,26 +5085,50 @@ class PostgresDb(BaseDb):
                 return False
 
             with self.Session() as sess, sess.begin():
-                # Get config stage and check if it's current
-                config_row = sess.execute(
+                self._lock_component_graph_writes(sess)
+                actual = self._component_version_state(sess, components_table, configs_table, component_id)
+                if actual is None:
+                    return False
+                self._check_component_guard(component_id, guard, actual)
+
+                config_stage = sess.execute(
                     select(configs_table.c.stage).where(
                         configs_table.c.component_id == component_id,
                         configs_table.c.version == version,
                     )
                 ).scalar_one_or_none()
 
-                if config_row is None:
+                if config_stage is None:
                     return False
-
-                # Check if it's current version
-                current = sess.execute(
-                    select(components_table.c.current_version).where(components_table.c.component_id == component_id)
-                ).scalar_one_or_none()
-
-                if current == version:
+                if config_stage == DELETED_CONFIG_STAGE:
+                    return False
+                if config_stage == "published":
+                    raise ComponentDraftRequiredError(component_id, version)
+                if actual.current_version == version:
                     raise ValueError(f"Cannot delete current config {component_id} v{version}")
 
-                # Delete associated links
+                if links_table is not None:
+                    dependents = self._component_dependents(
+                        sess,
+                        components_table,
+                        links_table,
+                        component_id,
+                        version=version,
+                    )
+                    if dependents:
+                        raise ComponentDependencyError(component_id, dependents, version=version)
+
+                visible_count = sess.execute(
+                    select(func.count())
+                    .select_from(configs_table)
+                    .where(
+                        configs_table.c.component_id == component_id,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    )
+                ).scalar_one()
+                if visible_count <= 1:
+                    raise ComponentLastConfigError(component_id, version)
+
                 if links_table is not None:
                     sess.execute(
                         links_table.delete().where(
@@ -4320,15 +5137,35 @@ class PostgresDb(BaseDb):
                         )
                     )
 
-                # Delete the config
-                sess.execute(
-                    configs_table.delete().where(
+                result = sess.execute(
+                    configs_table.update()
+                    .where(
                         configs_table.c.component_id == component_id,
                         configs_table.c.version == version,
                     )
+                    .values(
+                        label=None,
+                        stage=DELETED_CONFIG_STAGE,
+                        config={},
+                        notes=None,
+                        updated_at=int(time.time()),
+                        deleted_at=int(time.time()),
+                    )
                 )
 
-            return True
+                component_updates = self._projection_values(projection)
+                if component_updates:
+                    component_updates["updated_at"] = int(time.time())
+                    sess.execute(
+                        components_table.update()
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                        .values(**component_updates)
+                    )
+
+            return result.rowcount > 0
 
         except Exception as e:
             log_error(f"Error deleting config: {str(e)}")
@@ -4382,7 +5219,10 @@ class PostgresDb(BaseDb):
                         configs_table.c.updated_at,
                     )
 
-                stmt = stmt.where(configs_table.c.component_id == component_id).order_by(configs_table.c.version.desc())
+                stmt = stmt.where(
+                    configs_table.c.component_id == component_id,
+                    configs_table.c.stage != DELETED_CONFIG_STAGE,
+                ).order_by(configs_table.c.version.desc())
 
                 results = sess.execute(stmt).mappings().all()
                 return [dict(row) for row in results]
@@ -4395,6 +5235,9 @@ class PostgresDb(BaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Set a specific published version as current.
 
@@ -4405,6 +5248,9 @@ class PostgresDb(BaseDb):
         Args:
             component_id: The component ID.
             version: The version to set as current (must be published).
+            guard: Expected latest/current version state for compare-and-set.
+            projection: Component fields synchronized atomically with the pointer.
+                When omitted, they are derived from the target config.
 
         Returns:
             True if successful, False if component or version not found.
@@ -4420,40 +5266,53 @@ class PostgresDb(BaseDb):
                 return False
 
             with self.Session() as sess, sess.begin():
-                # Verify component exists and is not deleted
-                component_exists = sess.execute(
-                    select(components_table.c.component_id).where(
-                        components_table.c.component_id == component_id,
-                        components_table.c.deleted_at.is_(None),
-                    )
-                ).scalar_one_or_none()
-
-                if component_exists is None:
+                actual = self._component_version_state(sess, components_table, configs_table, component_id)
+                if actual is None:
                     return False
+                self._check_component_guard(component_id, guard, actual)
 
-                # Verify version exists and get stage
-                stage = sess.execute(
-                    select(configs_table.c.stage).where(
-                        configs_table.c.component_id == component_id,
-                        configs_table.c.version == version,
+                target = (
+                    sess.execute(
+                        select(configs_table.c.stage, configs_table.c.config)
+                        .where(
+                            configs_table.c.component_id == component_id,
+                            configs_table.c.version == version,
+                        )
+                        .with_for_update()
                     )
-                ).scalar_one_or_none()
+                    .mappings()
+                    .one_or_none()
+                )
 
-                if stage is None:
+                if target is None:
                     return False
 
                 # Only published configs can be set as current
-                if stage != "published":
+                if target["stage"] != "published":
                     raise ValueError(
                         f"Cannot set draft config {component_id} v{version} as current. "
                         "Only published configs can be current."
                     )
 
-                # Update pointer
+                effective_projection = projection
+                if effective_projection is None:
+                    target_config = target["config"]
+                    if not isinstance(target_config, dict):
+                        raise ValueError(f"Config {component_id} v{version} payload must be an object")
+                    effective_projection = self._projection_from_config(target_config)
+
+                updates: Dict[str, Any] = {
+                    "current_version": version,
+                    "updated_at": int(time.time()),
+                }
+                updates.update(self._projection_values(effective_projection))
                 result = sess.execute(
                     components_table.update()
-                    .where(components_table.c.component_id == component_id)
-                    .values(current_version=version, updated_at=int(time.time()))
+                    .where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_(None),
+                    )
+                    .values(**updates)
                 )
 
                 if result.rowcount == 0:
@@ -4511,28 +5370,36 @@ class PostgresDb(BaseDb):
         self,
         component_id: str,
         version: Optional[int] = None,
+        *,
+        active_parents_only: bool = False,
     ) -> List[Dict[str, Any]]:
         """Find all components that reference this component.
 
         Args:
             component_id: The component ID to find dependents of.
             version: Optional specific version. If None, finds links to any version.
+            active_parents_only: Exclude links owned by archived parent components.
 
         Returns:
             List of link dictionaries showing what depends on this component.
         """
         try:
             table = self._get_table(table_type="component_links")
+            components_table = self._get_table(table_type="components")
             if table is None:
+                return []
+            if active_parents_only and components_table is None:
                 return []
 
             with self.Session() as sess:
-                stmt = select(table).where(table.c.child_component_id == component_id)
-                if version is not None:
-                    stmt = stmt.where(table.c.child_version == version)
-
-                rows = sess.execute(stmt).mappings().all()
-                return [dict(r) for r in rows]
+                return self._component_dependents(
+                    sess,
+                    components_table,
+                    table,
+                    component_id,
+                    version=version,
+                    active_parents_only=active_parents_only,
+                )
 
         except Exception as e:
             log_error(f"Error getting dependents: {str(e)}")
@@ -4543,11 +5410,11 @@ class PostgresDb(BaseDb):
         component_id: str,
         version: Optional[int],
     ) -> Optional[int]:
-        """Resolve a version number, handling None as 'current'.
+        """Resolve an explicit version or the component's generic readable head.
 
         Args:
             component_id: The component ID.
-            version: Version number or None for current.
+            version: Version number or None for current/latest-draft fallback.
 
         Returns:
             Resolved version number, or None if component missing/deleted or no current.
@@ -4556,17 +5423,9 @@ class PostgresDb(BaseDb):
             return version
 
         try:
-            components_table = self._get_table(table_type="components")
-            if components_table is None:
-                return None
-
-            with self.Session() as sess:
-                return sess.execute(
-                    select(components_table.c.current_version).where(
-                        components_table.c.component_id == component_id,
-                        components_table.c.deleted_at.is_(None),
-                    )
-                ).scalar_one_or_none()
+            config = self.get_config(component_id)
+            resolved = config.get("version") if config is not None else None
+            return resolved if isinstance(resolved, int) else None
 
         except Exception as e:
             log_error(f"Error resolving version: {str(e)}")
@@ -4605,7 +5464,12 @@ class PostgresDb(BaseDb):
             if component is None:
                 return None
 
-            resolved_version = self._resolve_version(component_id, version)
+            if version is None and label is not None:
+                labeled = self.get_config(component_id, label=label)
+                resolved = labeled.get("version") if labeled is not None else None
+                resolved_version = resolved if isinstance(resolved, int) else None
+            else:
+                resolved_version = self._resolve_version(component_id, version)
             if resolved_version is None:
                 return None
 
@@ -5131,27 +5995,42 @@ class PostgresDb(BaseDb):
             with self.Session() as sess:
                 result = sess.execute(select(table).where(table.c.id == schedule_id)).fetchone()
                 return dict(result._mapping) if result else None
-        except Exception as e:
-            log_debug(f"Error getting schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule")
+            raise
 
-    def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
+    def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         try:
             table = self._get_table(table_type="schedules")
             if table is None:
                 return None
             with self.Session() as sess:
-                result = sess.execute(select(table).where(table.c.name == name)).fetchone()
+                query = select(table).where(table.c.name == name)
+                if managed_by is not None:
+                    query = query.where(table.c.managed_by == managed_by)
+                if owner_actor_id is not None:
+                    query = query.where(table.c.owner_actor_id == owner_actor_id)
+                if exclude_managed_by is not None:
+                    query = query.where(or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by))
+                result = sess.execute(query).fetchone()
                 return dict(result._mapping) if result else None
-        except Exception as e:
-            log_debug(f"Error getting schedule by name: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule by name")
+            raise
 
     def get_schedules(
         self,
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = self._get_table(table_type="schedules")
@@ -5162,6 +6041,10 @@ class PostgresDb(BaseDb):
                 base_query = select(table)
                 if enabled is not None:
                     base_query = base_query.where(table.c.enabled == enabled)
+                if exclude_managed_by is not None:
+                    base_query = base_query.where(
+                        or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by)
+                    )
 
                 # Get total count
                 count_stmt = select(func.count()).select_from(base_query.alias())
@@ -5174,20 +6057,27 @@ class PostgresDb(BaseDb):
                 stmt = base_query.order_by(table.c.created_at.desc()).limit(limit).offset(offset)
                 results = sess.execute(stmt).fetchall()
                 return [dict(row._mapping) for row in results], total_count
-        except Exception as e:
-            log_debug(f"Error listing schedules: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error listing schedules")
+            raise
 
     def create_schedule(self, schedule_data: Dict[str, Any]) -> Dict[str, Any]:
         try:
+            schedule_data.setdefault("pending_trigger_count", 0)
+            schedule_data.setdefault("manual_trigger_claimed", False)
             table = self._get_table(table_type="schedules", create_table_if_not_found=True)
             if table is None:
                 raise RuntimeError("Failed to get or create schedules table")
             with self.Session() as sess, sess.begin():
                 sess.execute(table.insert().values(**schedule_data))
             return schedule_data
-        except Exception as e:
-            log_error(f"Error creating schedule: {str(e)}")
+        except IntegrityError as error:
+            if _is_schedule_name_conflict(error, self.schedules_table_name, self.db_schema):
+                raise ScheduleNameConflictError(schedule_data["name"]) from None
+            log_error("Error creating schedule")
+            raise
+        except Exception:
+            log_error("Error creating schedule")
             raise
 
     def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -5199,9 +6089,56 @@ class PostgresDb(BaseDb):
             with self.Session() as sess, sess.begin():
                 sess.execute(table.update().where(table.c.id == schedule_id).values(**kwargs))
             return self.get_schedule(schedule_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule: {e}")
+        except IntegrityError as error:
+            name = kwargs.get("name")
+            if isinstance(name, str) and _is_schedule_name_conflict(error, self.schedules_table_name, self.db_schema):
+                raise ScheduleNameConflictError(name) from None
+            log_debug("Error updating schedule")
+            raise
+        except Exception:
+            log_debug("Error updating schedule")
+            raise
+
+    def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue one manual execution for a schedule."""
+        table = self._get_table(table_type="schedules")
+        if table is None:
             return None
+        with self.Session() as sess, sess.begin():
+            result = sess.execute(
+                update(table)
+                .where(table.c.id == schedule_id)
+                .values(
+                    pending_trigger_count=func.coalesce(table.c.pending_trigger_count, 0) + 1,
+                    updated_at=int(time.time()),
+                )
+                .returning(*table.c)
+            ).fetchone()
+            return dict(result._mapping) if result else None
+
+    def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules for one managed target."""
+        table = self._get_table(table_type="schedules")
+        if table is None:
+            return 0
+        with self.Session() as sess, sess.begin():
+            result = sess.execute(
+                table.update()
+                .where(
+                    table.c.managed_by == managed_by,
+                    table.c.target_type == target_type,
+                    table.c.target_id == target_id,
+                    table.c.enabled == True,  # noqa: E712
+                )
+                .values(enabled=False, updated_at=int(time.time()))
+            )
+            return int(result.rowcount or 0)
 
     def delete_schedule(self, schedule_id: str) -> bool:
         try:
@@ -5214,8 +6151,8 @@ class PostgresDb(BaseDb):
                     sess.execute(runs_table.delete().where(runs_table.c.schedule_id == schedule_id))
                 result = sess.execute(table.delete().where(table.c.id == schedule_id))
                 return result.rowcount > 0
-        except Exception as e:
-            log_debug(f"Error deleting schedule: {e}")
+        except Exception:
+            log_debug("Error deleting schedule")
             return False
 
     def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
@@ -5232,13 +6169,30 @@ class PostgresDb(BaseDb):
                     select(table.c.id)
                     .where(
                         table.c.enabled == True,  # noqa: E712
-                        table.c.next_run_at <= now,
+                        or_(
+                            table.c.manual_trigger_claimed == True,  # noqa: E712
+                            table.c.pending_trigger_count > 0,
+                            table.c.next_run_at <= now,
+                        ),
                         or_(
                             table.c.locked_by.is_(None),
                             table.c.locked_at <= stale_lock_threshold,
                         ),
                     )
-                    .order_by(table.c.next_run_at.asc())
+                    .order_by(
+                        case(
+                            (table.c.manual_trigger_claimed == True, 0),  # noqa: E712
+                            (
+                                and_(
+                                    table.c.pending_trigger_count > 0,
+                                    or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                ),
+                                1,
+                            ),
+                            else_=2,
+                        ),
+                        table.c.next_run_at.asc(),
+                    )
                     .limit(1)
                     .with_for_update(skip_locked=True)
                     .scalar_subquery()
@@ -5246,30 +6200,92 @@ class PostgresDb(BaseDb):
                 stmt = (
                     update(table)
                     .where(table.c.id == subq)
-                    .values(locked_by=worker_id, locked_at=now)
+                    .values(
+                        locked_by=worker_id,
+                        locked_at=now,
+                        pending_trigger_count=case(
+                            (
+                                and_(
+                                    table.c.manual_trigger_claimed == False,  # noqa: E712
+                                    table.c.pending_trigger_count > 0,
+                                    or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                ),
+                                table.c.pending_trigger_count - 1,
+                            ),
+                            else_=table.c.pending_trigger_count,
+                        ),
+                        manual_trigger_claimed=case(
+                            (table.c.manual_trigger_claimed == True, True),  # noqa: E712
+                            (table.c.next_run_at <= now, False),
+                            else_=True,
+                        ),
+                    )
                     .returning(*table.c)
                 )
                 result = sess.execute(stmt).fetchone()
                 if result is None:
                     return None
                 return dict(result._mapping)
-        except Exception as e:
-            log_debug(f"Error claiming schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error claiming schedule")
+            raise
 
-    def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
+    def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a claim only while its worker/timestamp fence still matches."""
+        table = self._get_table(table_type="schedules")
+        if table is None:
+            return None
+        renewed_at = max(int(time.time()), locked_at + 1)
+        with self.Session() as sess, sess.begin():
+            result = sess.execute(
+                table.update()
+                .where(
+                    table.c.id == schedule_id,
+                    table.c.locked_by == worker_id,
+                    table.c.locked_at == locked_at,
+                )
+                .values(locked_at=renewed_at)
+            )
+            return renewed_at if result.rowcount > 0 else None
+
+    def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
         try:
+            if (worker_id is None) != (locked_at is None):
+                return False
             table = self._get_table(table_type="schedules")
             if table is None:
                 return False
-            updates: Dict[str, Any] = {"locked_by": None, "locked_at": None, "updated_at": int(time.time())}
+            updates: Dict[str, Any] = {
+                "locked_by": None,
+                "locked_at": None,
+                "manual_trigger_claimed": False,
+                "updated_at": int(time.time()),
+            }
             if next_run_at is not None:
                 updates["next_run_at"] = next_run_at
             with self.Session() as sess, sess.begin():
-                result = sess.execute(table.update().where(table.c.id == schedule_id).values(**updates))
+                stmt = table.update().where(table.c.id == schedule_id)
+                if worker_id is None:
+                    stmt = stmt.where(table.c.manual_trigger_claimed == False)  # noqa: E712
+                else:
+                    stmt = stmt.where(table.c.locked_by == worker_id, table.c.locked_at == locked_at)
+                result = sess.execute(stmt.values(**updates))
                 return result.rowcount > 0
-        except Exception as e:
-            log_debug(f"Error releasing schedule: {e}")
+        except Exception:
+            log_debug("Error releasing schedule")
             return False
 
     def create_schedule_run(self, run_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -5280,8 +6296,8 @@ class PostgresDb(BaseDb):
             with self.Session() as sess, sess.begin():
                 sess.execute(table.insert().values(**run_data))
             return run_data
-        except Exception as e:
-            log_error(f"Error creating schedule run: {str(e)}")
+        except Exception:
+            log_error("Error creating schedule run")
             raise
 
     def update_schedule_run(self, schedule_run_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -5292,8 +6308,8 @@ class PostgresDb(BaseDb):
             with self.Session() as sess, sess.begin():
                 sess.execute(table.update().where(table.c.id == schedule_run_id).values(**kwargs))
             return self.get_schedule_run(schedule_run_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule run: {e}")
+        except Exception:
+            log_debug("Error updating schedule run")
             return None
 
     def get_schedule_run(self, run_id: str) -> Optional[Dict[str, Any]]:
@@ -5304,9 +6320,9 @@ class PostgresDb(BaseDb):
             with self.Session() as sess:
                 result = sess.execute(select(table).where(table.c.id == run_id)).fetchone()
                 return dict(result._mapping) if result else None
-        except Exception as e:
-            log_debug(f"Error getting schedule run: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule run")
+            raise
 
     def get_schedule_runs(
         self,
@@ -5336,9 +6352,9 @@ class PostgresDb(BaseDb):
                 )
                 results = sess.execute(stmt).fetchall()
                 return [dict(row._mapping) for row in results], total_count
-        except Exception as e:
-            log_debug(f"Error getting schedule runs: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error getting schedule runs")
+            raise
 
     # -- Approval methods --
 

--- a/libs/agno/agno/db/postgres/schemas.py
+++ b/libs/agno/agno/db/postgres/schemas.py
@@ -239,6 +239,16 @@ SCHEDULE_TABLE_SCHEMA = {
     "timeout_seconds": {"type": BigInteger, "nullable": False},
     "max_retries": {"type": BigInteger, "nullable": False},
     "retry_delay_seconds": {"type": BigInteger, "nullable": False},
+    "managed_by": {"type": String, "nullable": True, "index": True},
+    "owner_actor_id": {"type": String, "nullable": True, "index": True},
+    "target_type": {"type": String, "nullable": True},
+    "target_id": {"type": String, "nullable": True},
+    "created_by_run_id": {"type": String, "nullable": True},
+    "created_by_session_id": {"type": String, "nullable": True},
+    "updated_by_run_id": {"type": String, "nullable": True},
+    "updated_by_session_id": {"type": String, "nullable": True},
+    "pending_trigger_count": {"type": BigInteger, "nullable": False, "default": 0},
+    "manual_trigger_claimed": {"type": Boolean, "nullable": False, "default": False},
     "enabled": {"type": Boolean, "nullable": False, "default": True},
     "next_run_at": {"type": BigInteger, "nullable": True, "index": True},
     "locked_by": {"type": String, "nullable": True},
@@ -247,6 +257,18 @@ SCHEDULE_TABLE_SCHEMA = {
     "updated_at": {"type": BigInteger, "nullable": True},
     "__composite_indexes__": [
         {"name": "enabled_next_run_at", "columns": ["enabled", "next_run_at"]},
+    ],
+    "_partial_unique_indexes": [
+        {
+            "name": "uq_generic_name",
+            "columns": ["name"],
+            "where": "managed_by IS DISTINCT FROM 'studio'",
+        },
+        {
+            "name": "uq_studio_owner_name",
+            "columns": ["owner_actor_id", "name"],
+            "where": "managed_by = 'studio'",
+        },
     ],
 }
 

--- a/libs/agno/agno/db/schemas/scheduler.py
+++ b/libs/agno/agno/db/schemas/scheduler.py
@@ -1,7 +1,23 @@
+import base64
+import re
+import unicodedata
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from agno.utils.dttm import now_epoch_s, to_epoch_s
+
+STUDIO_SCHEDULE_MANAGED_BY = "studio"
+STUDIO_SCHEDULE_ACTOR_HEADER = "X-Agno-Studio-Schedule-Actor"
+_STUDIO_SCHEDULE_ACTOR_ENCODING = "v1."
+_BASE64URL_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class ScheduleNameConflictError(ValueError):
+    """Raised when a schedule write violates the database-unique name constraint."""
+
+    def __init__(self, name: str):
+        self.name = name
+        super().__init__(f"Schedule with name '{name}' already exists")
 
 
 @dataclass
@@ -19,6 +35,22 @@ class Schedule:
     timeout_seconds: int = 3600
     max_retries: int = 0
     retry_delay_seconds: int = 60
+    # Server-owned control-plane provenance. Generic schedule APIs never accept
+    # or mutate these fields; Studio writes them through its trusted catalog DB.
+    managed_by: Optional[str] = None
+    owner_actor_id: Optional[str] = None
+    target_type: Optional[str] = None
+    target_id: Optional[str] = None
+    created_by_run_id: Optional[str] = None
+    created_by_session_id: Optional[str] = None
+    updated_by_run_id: Optional[str] = None
+    updated_by_session_id: Optional[str] = None
+    # Manual triggers are durable work, not a temporary rewrite of
+    # ``next_run_at``. A claim atomically moves one pending trigger into the
+    # in-flight marker so a stale lock can recover it without consuming a
+    # second trigger.
+    pending_trigger_count: int = 0
+    manual_trigger_claimed: bool = False
     enabled: bool = True
     next_run_at: Optional[int] = None
     locked_by: Optional[str] = None
@@ -34,6 +66,8 @@ class Schedule:
             self.next_run_at = int(self.next_run_at)
         if self.locked_at is not None:
             self.locked_at = int(self.locked_at)
+        self.pending_trigger_count = max(0, int(self.pending_trigger_count or 0))
+        self.manual_trigger_claimed = bool(self.manual_trigger_claimed)
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to dict. Preserves None values (important for DB updates)."""
@@ -49,6 +83,16 @@ class Schedule:
             "timeout_seconds": self.timeout_seconds,
             "max_retries": self.max_retries,
             "retry_delay_seconds": self.retry_delay_seconds,
+            "managed_by": self.managed_by,
+            "owner_actor_id": self.owner_actor_id,
+            "target_type": self.target_type,
+            "target_id": self.target_id,
+            "created_by_run_id": self.created_by_run_id,
+            "created_by_session_id": self.created_by_session_id,
+            "updated_by_run_id": self.updated_by_run_id,
+            "updated_by_session_id": self.updated_by_session_id,
+            "pending_trigger_count": self.pending_trigger_count,
+            "manual_trigger_claimed": self.manual_trigger_claimed,
             "enabled": self.enabled,
             "next_run_at": self.next_run_at,
             "locked_by": self.locked_by,
@@ -72,6 +116,16 @@ class Schedule:
             "timeout_seconds",
             "max_retries",
             "retry_delay_seconds",
+            "managed_by",
+            "owner_actor_id",
+            "target_type",
+            "target_id",
+            "created_by_run_id",
+            "created_by_session_id",
+            "updated_by_run_id",
+            "updated_by_session_id",
+            "pending_trigger_count",
+            "manual_trigger_claimed",
             "enabled",
             "next_run_at",
             "locked_by",
@@ -81,6 +135,56 @@ class Schedule:
         }
         filtered = {k: v for k, v in data.items() if k in valid_keys}
         return cls(**filtered)
+
+
+def is_studio_managed_schedule(schedule: Union[Schedule, Mapping[str, Any]]) -> bool:
+    """Return whether a record carries server-owned Studio provenance."""
+    managed_by = schedule.managed_by if isinstance(schedule, Schedule) else schedule.get("managed_by")
+    return managed_by == STUDIO_SCHEDULE_MANAGED_BY
+
+
+def is_valid_studio_schedule_actor_id(actor_id: Any) -> bool:
+    """Return whether an opaque actor ID is safe to delegate.
+
+    Actor IDs may contain Unicode. Header transport is handled separately by
+    :func:`encode_studio_schedule_actor_id`; raw control, formatting, surrogate,
+    and line-separator characters are rejected so control-like or
+    non-canonical header values never become principals.
+    """
+    if not isinstance(actor_id, str) or not actor_id or actor_id != actor_id.strip() or len(actor_id) > 255:
+        return False
+    try:
+        encoded_size = len(actor_id.encode("utf-8"))
+    except UnicodeEncodeError:
+        return False
+    if encoded_size > 1024:
+        return False
+    return not any(unicodedata.category(character) in {"Cc", "Cf", "Cs", "Zl", "Zp"} for character in actor_id)
+
+
+def encode_studio_schedule_actor_id(actor_id: str) -> str:
+    """Encode one validated opaque actor ID into an ASCII-only header value."""
+    if not is_valid_studio_schedule_actor_id(actor_id):
+        raise ValueError("Invalid delegated scheduler actor")
+    encoded = base64.urlsafe_b64encode(actor_id.encode("utf-8")).decode("ascii").rstrip("=")
+    return f"{_STUDIO_SCHEDULE_ACTOR_ENCODING}{encoded}"
+
+
+def decode_studio_schedule_actor_id(value: Any) -> str:
+    """Decode and validate the canonical internal scheduler actor header."""
+    if not isinstance(value, str) or not value.startswith(_STUDIO_SCHEDULE_ACTOR_ENCODING):
+        raise ValueError("Invalid delegated scheduler actor")
+    encoded = value[len(_STUDIO_SCHEDULE_ACTOR_ENCODING) :]
+    if not encoded or _BASE64URL_RE.fullmatch(encoded) is None:
+        raise ValueError("Invalid delegated scheduler actor")
+    try:
+        padding = "=" * (-len(encoded) % 4)
+        actor_id = base64.b64decode(encoded + padding, altchars=b"-_", validate=True).decode("utf-8")
+    except (UnicodeDecodeError, ValueError):
+        raise ValueError("Invalid delegated scheduler actor") from None
+    if not is_valid_studio_schedule_actor_id(actor_id) or encode_studio_schedule_actor_id(actor_id) != value:
+        raise ValueError("Invalid delegated scheduler actor")
+    return actor_id
 
 
 @dataclass

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -5,17 +5,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union, cast
 from uuid import uuid4
 
-from sqlalchemy import or_
-
 if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
 
-from agno.db.base import AsyncBaseDb, ComponentType, SessionType
+from agno.db.base import AsyncBaseDb, ComponentProjection, ComponentType, ComponentVersionGuard, SessionType
 from agno.db.migrations.manager import MigrationManager
 from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import ScheduleNameConflictError
 from agno.db.schemas.service_accounts import (
     resolve_service_account_sort_column,
     validate_service_account_update,
@@ -44,15 +43,26 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
 
 try:
-    from sqlalchemy import Column, ForeignKey, MetaData, String, Table, func, select, text
+    from sqlalchemy import Column, ForeignKey, MetaData, String, Table, and_, case, func, or_, select, text
     from sqlalchemy.dialects import sqlite
+    from sqlalchemy.exc import IntegrityError
     from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
     from sqlalchemy.schema import Index, UniqueConstraint
 except ImportError:
     raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
 
 
+def _is_schedule_name_conflict(error: IntegrityError, table_name: str) -> bool:
+    """Match only the generic or actor-scoped schedule-name indexes."""
+    return str(error.orig) in {
+        f"UNIQUE constraint failed: {table_name}.name",
+        f"UNIQUE constraint failed: {table_name}.owner_actor_id, {table_name}.name",
+    }
+
+
 class AsyncSqliteDb(AsyncBaseDb):
+    scheduler_api_version = 2
+
     def __init__(
         self,
         db_file: Optional[str] = None,
@@ -3718,6 +3728,8 @@ class AsyncSqliteDb(AsyncBaseDb):
         self,
         component_id: str,
         component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -3727,6 +3739,7 @@ class AsyncSqliteDb(AsyncBaseDb):
         component_type: Optional[ComponentType] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
+        current_version: Optional[int] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         raise NotImplementedError("Component methods not yet supported for async databases")
@@ -3735,6 +3748,10 @@ class AsyncSqliteDb(AsyncBaseDb):
         self,
         component_id: str,
         hard_delete: bool = False,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        require_no_dependents: bool = True,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -3781,6 +3798,9 @@ class AsyncSqliteDb(AsyncBaseDb):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> Dict[str, Any]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -3788,6 +3808,9 @@ class AsyncSqliteDb(AsyncBaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -3802,6 +3825,9 @@ class AsyncSqliteDb(AsyncBaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -3817,6 +3843,8 @@ class AsyncSqliteDb(AsyncBaseDb):
         self,
         component_id: str,
         version: Optional[int] = None,
+        *,
+        active_parents_only: bool = False,
     ) -> List[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 
@@ -3838,28 +3866,43 @@ class AsyncSqliteDb(AsyncBaseDb):
                 result = await sess.execute(select(table).where(table.c.id == schedule_id))
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
-        except Exception as e:
-            log_debug(f"Error getting schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule")
+            raise
 
-    async def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
+    async def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         try:
             table = await self._get_table(table_type="schedules")
             if table is None:
                 return None
             async with self.async_session_factory() as sess:
-                result = await sess.execute(select(table).where(table.c.name == name))
+                query = select(table).where(table.c.name == name)
+                if managed_by is not None:
+                    query = query.where(table.c.managed_by == managed_by)
+                if owner_actor_id is not None:
+                    query = query.where(table.c.owner_actor_id == owner_actor_id)
+                if exclude_managed_by is not None:
+                    query = query.where(or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by))
+                result = await sess.execute(query)
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
-        except Exception as e:
-            log_debug(f"Error getting schedule by name: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule by name")
+            raise
 
     async def get_schedules(
         self,
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = await self._get_table(table_type="schedules")
@@ -3870,6 +3913,10 @@ class AsyncSqliteDb(AsyncBaseDb):
                 base_query = select(table)
                 if enabled is not None:
                     base_query = base_query.where(table.c.enabled == enabled)
+                if exclude_managed_by is not None:
+                    base_query = base_query.where(
+                        or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by)
+                    )
 
                 # Get total count
                 count_stmt = select(func.count()).select_from(base_query.alias())
@@ -3883,12 +3930,14 @@ class AsyncSqliteDb(AsyncBaseDb):
                 stmt = base_query.order_by(table.c.created_at.desc()).limit(limit).offset(offset)
                 result = await sess.execute(stmt)
                 return [dict(row._mapping) for row in result.fetchall()], total_count
-        except Exception as e:
-            log_debug(f"Error listing schedules: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error listing schedules")
+            raise
 
     async def create_schedule(self, schedule_data: Dict[str, Any]) -> Dict[str, Any]:
         try:
+            schedule_data.setdefault("pending_trigger_count", 0)
+            schedule_data.setdefault("manual_trigger_claimed", False)
             table = await self._get_table(table_type="schedules", create_table_if_not_found=True)
             if table is None:
                 raise RuntimeError("Failed to get or create schedules table")
@@ -3896,8 +3945,13 @@ class AsyncSqliteDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.insert().values(**schedule_data))
             return schedule_data
-        except Exception as e:
-            log_error(f"Error creating schedule: {str(e)}")
+        except IntegrityError as error:
+            if _is_schedule_name_conflict(error, self.schedules_table_name):
+                raise ScheduleNameConflictError(schedule_data["name"]) from None
+            log_error("Error creating schedule")
+            raise
+        except Exception:
+            log_error("Error creating schedule")
             raise
 
     async def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -3910,9 +3964,59 @@ class AsyncSqliteDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.update().where(table.c.id == schedule_id).values(**kwargs))
             return await self.get_schedule(schedule_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule: {e}")
+        except IntegrityError as error:
+            name = kwargs.get("name")
+            if isinstance(name, str) and _is_schedule_name_conflict(error, self.schedules_table_name):
+                raise ScheduleNameConflictError(name) from None
+            log_debug("Error updating schedule")
+            raise
+        except Exception:
+            log_debug("Error updating schedule")
+            raise
+
+    async def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue one manual execution for a schedule."""
+        table = await self._get_table(table_type="schedules")
+        if table is None:
             return None
+        async with self.async_session_factory() as sess:
+            async with sess.begin():
+                result = await sess.execute(
+                    table.update()
+                    .where(table.c.id == schedule_id)
+                    .values(
+                        pending_trigger_count=func.coalesce(table.c.pending_trigger_count, 0) + 1,
+                        updated_at=int(time.time()),
+                    )
+                )
+                if result.rowcount == 0:  # type: ignore[attr-defined]
+                    return None
+        return await self.get_schedule(schedule_id)
+
+    async def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules for one managed target."""
+        table = await self._get_table(table_type="schedules")
+        if table is None:
+            return 0
+        async with self.async_session_factory() as sess:
+            async with sess.begin():
+                result = await sess.execute(
+                    table.update()
+                    .where(
+                        table.c.managed_by == managed_by,
+                        table.c.target_type == target_type,
+                        table.c.target_id == target_id,
+                        table.c.enabled == True,  # noqa: E712
+                    )
+                    .values(enabled=False, updated_at=int(time.time()))
+                )
+                return int(result.rowcount or 0)  # type: ignore[attr-defined]
 
     async def delete_schedule(self, schedule_id: str) -> bool:
         try:
@@ -3926,8 +4030,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                         await sess.execute(runs_table.delete().where(runs_table.c.schedule_id == schedule_id))
                     result = await sess.execute(table.delete().where(table.c.id == schedule_id))
                     return result.rowcount > 0  # type: ignore[attr-defined]
-        except Exception as e:
-            log_debug(f"Error deleting schedule: {e}")
+        except Exception:
+            log_debug("Error deleting schedule")
             return False
 
     async def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
@@ -3943,13 +4047,30 @@ class AsyncSqliteDb(AsyncBaseDb):
                         select(table)
                         .where(
                             table.c.enabled == True,  # noqa: E712
-                            table.c.next_run_at <= now,
+                            or_(
+                                table.c.manual_trigger_claimed == True,  # noqa: E712
+                                table.c.pending_trigger_count > 0,
+                                table.c.next_run_at <= now,
+                            ),
                             or_(
                                 table.c.locked_by.is_(None),
                                 table.c.locked_at <= stale_lock_threshold,
                             ),
                         )
-                        .order_by(table.c.next_run_at.asc())
+                        .order_by(
+                            case(
+                                (table.c.manual_trigger_claimed == True, 0),  # noqa: E712
+                                (
+                                    and_(
+                                        table.c.pending_trigger_count > 0,
+                                        or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                    ),
+                                    1,
+                                ),
+                                else_=2,
+                            ),
+                            table.c.next_run_at.asc(),
+                        )
                         .limit(1)
                     )
                     result = await sess.execute(stmt)
@@ -3961,36 +4082,105 @@ class AsyncSqliteDb(AsyncBaseDb):
                         table.update()
                         .where(
                             table.c.id == schedule["id"],
+                            table.c.enabled == True,  # noqa: E712
+                            or_(
+                                table.c.manual_trigger_claimed == True,  # noqa: E712
+                                table.c.pending_trigger_count > 0,
+                                table.c.next_run_at <= now,
+                            ),
                             or_(
                                 table.c.locked_by.is_(None),
                                 table.c.locked_at <= stale_lock_threshold,
                             ),
                         )
-                        .values(locked_by=worker_id, locked_at=now)
+                        .values(
+                            locked_by=worker_id,
+                            locked_at=now,
+                            pending_trigger_count=case(
+                                (
+                                    and_(
+                                        table.c.manual_trigger_claimed == False,  # noqa: E712
+                                        table.c.pending_trigger_count > 0,
+                                        or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                    ),
+                                    table.c.pending_trigger_count - 1,
+                                ),
+                                else_=table.c.pending_trigger_count,
+                            ),
+                            manual_trigger_claimed=case(
+                                (table.c.manual_trigger_claimed == True, True),  # noqa: E712
+                                (table.c.next_run_at <= now, False),
+                                else_=True,
+                            ),
+                        )
                     )
                     if claim_result.rowcount == 0:  # type: ignore[attr-defined]
                         return None
-                    schedule["locked_by"] = worker_id
-                    schedule["locked_at"] = now
-                    return schedule
-        except Exception as e:
-            log_debug(f"Error claiming schedule: {e}")
-            return None
+                    claimed_result = await sess.execute(select(table).where(table.c.id == schedule["id"]))
+                    claimed = claimed_result.fetchone()
+                    return dict(claimed._mapping) if claimed else None
+        except Exception:
+            log_debug("Error claiming schedule")
+            raise
 
-    async def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
+    async def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a claim only while its worker/timestamp fence still matches."""
+        table = await self._get_table(table_type="schedules")
+        if table is None:
+            return None
+        renewed_at = max(int(time.time()), locked_at + 1)
+        async with self.async_session_factory() as sess:
+            async with sess.begin():
+                result = await sess.execute(
+                    table.update()
+                    .where(
+                        table.c.id == schedule_id,
+                        table.c.locked_by == worker_id,
+                        table.c.locked_at == locked_at,
+                    )
+                    .values(locked_at=renewed_at)
+                )
+                return renewed_at if result.rowcount > 0 else None  # type: ignore[attr-defined]
+
+    async def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
         try:
+            if (worker_id is None) != (locked_at is None):
+                return False
             table = await self._get_table(table_type="schedules")
             if table is None:
                 return False
-            updates: Dict[str, Any] = {"locked_by": None, "locked_at": None, "updated_at": int(time.time())}
+            updates: Dict[str, Any] = {
+                "locked_by": None,
+                "locked_at": None,
+                "manual_trigger_claimed": False,
+                "updated_at": int(time.time()),
+            }
             if next_run_at is not None:
                 updates["next_run_at"] = next_run_at
             async with self.async_session_factory() as sess:
                 async with sess.begin():
-                    result = await sess.execute(table.update().where(table.c.id == schedule_id).values(**updates))
+                    stmt = table.update().where(table.c.id == schedule_id)
+                    if worker_id is None:
+                        stmt = stmt.where(table.c.manual_trigger_claimed == False)  # noqa: E712
+                    else:
+                        stmt = stmt.where(table.c.locked_by == worker_id, table.c.locked_at == locked_at)
+                    result = await sess.execute(stmt.values(**updates))
                     return result.rowcount > 0  # type: ignore[attr-defined]
-        except Exception as e:
-            log_debug(f"Error releasing schedule: {e}")
+        except Exception:
+            log_debug("Error releasing schedule")
             return False
 
     async def create_schedule_run(self, run_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -4002,8 +4192,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.insert().values(**run_data))
             return run_data
-        except Exception as e:
-            log_error(f"Error creating schedule run: {str(e)}")
+        except Exception:
+            log_error("Error creating schedule run")
             raise
 
     async def update_schedule_run(self, schedule_run_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -4015,8 +4205,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                 async with sess.begin():
                     await sess.execute(table.update().where(table.c.id == schedule_run_id).values(**kwargs))
             return await self.get_schedule_run(schedule_run_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule run: {e}")
+        except Exception:
+            log_debug("Error updating schedule run")
             return None
 
     async def get_schedule_run(self, run_id: str) -> Optional[Dict[str, Any]]:
@@ -4028,9 +4218,9 @@ class AsyncSqliteDb(AsyncBaseDb):
                 result = await sess.execute(select(table).where(table.c.id == run_id))
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
-        except Exception as e:
-            log_debug(f"Error getting schedule run: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule run")
+            raise
 
     async def get_schedule_runs(
         self,
@@ -4061,9 +4251,9 @@ class AsyncSqliteDb(AsyncBaseDb):
                 )
                 result = await sess.execute(stmt)
                 return [dict(row._mapping) for row in result.fetchall()], total_count
-        except Exception as e:
-            log_debug(f"Error getting schedule runs: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error getting schedule runs")
+            raise
 
     # -- Approval methods --
 

--- a/libs/agno/agno/db/sqlite/schemas.py
+++ b/libs/agno/agno/db/sqlite/schemas.py
@@ -230,6 +230,16 @@ SCHEDULE_TABLE_SCHEMA = {
     "timeout_seconds": {"type": BigInteger, "nullable": False},
     "max_retries": {"type": BigInteger, "nullable": False},
     "retry_delay_seconds": {"type": BigInteger, "nullable": False},
+    "managed_by": {"type": String, "nullable": True, "index": True},
+    "owner_actor_id": {"type": String, "nullable": True, "index": True},
+    "target_type": {"type": String, "nullable": True},
+    "target_id": {"type": String, "nullable": True},
+    "created_by_run_id": {"type": String, "nullable": True},
+    "created_by_session_id": {"type": String, "nullable": True},
+    "updated_by_run_id": {"type": String, "nullable": True},
+    "updated_by_session_id": {"type": String, "nullable": True},
+    "pending_trigger_count": {"type": BigInteger, "nullable": False, "default": 0},
+    "manual_trigger_claimed": {"type": Boolean, "nullable": False, "default": False},
     "enabled": {"type": Boolean, "nullable": False, "default": True},
     "next_run_at": {"type": BigInteger, "nullable": True, "index": True},
     "locked_by": {"type": String, "nullable": True},
@@ -238,6 +248,20 @@ SCHEDULE_TABLE_SCHEMA = {
     "updated_at": {"type": BigInteger, "nullable": True},
     "__composite_indexes__": [
         {"name": "enabled_next_run_at", "columns": ["enabled", "next_run_at"]},
+    ],
+    # Generic and Studio schedules occupy separate name namespaces. Studio
+    # names are unique only for one authenticated actor.
+    "_partial_unique_indexes": [
+        {
+            "name": "uq_generic_name",
+            "columns": ["name"],
+            "where": "managed_by IS NULL OR managed_by <> 'studio'",
+        },
+        {
+            "name": "uq_studio_owner_name",
+            "columns": ["owner_actor_id", "name"],
+            "where": "managed_by = 'studio'",
+        },
     ],
 }
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -1,15 +1,31 @@
 import json
 import time
+from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union, cast
+from threading import RLock
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Literal, Optional, Sequence, Set, Tuple, Union, cast
 from uuid import uuid4
 
 if TYPE_CHECKING:
     from agno.tracing.schemas import Span, Trace
 
 from agno.db import mcp_oauth_store
-from agno.db.base import BaseDb, ComponentType, SessionType
+from agno.db.base import (
+    DELETED_CONFIG_STAGE,
+    BaseDb,
+    ComponentAlreadyExistsError,
+    ComponentCycleError,
+    ComponentDependencyError,
+    ComponentDependencyUnavailableError,
+    ComponentDraftRequiredError,
+    ComponentLastConfigError,
+    ComponentProjection,
+    ComponentType,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+    SessionType,
+)
 from agno.db.migrations.manager import MigrationManager
 from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
@@ -23,6 +39,7 @@ from agno.db.schemas.mcp_oauth import (
     MCP_OAUTH_TRANSACTIONS,
 )
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import ScheduleNameConflictError
 from agno.db.schemas.service_accounts import (
     resolve_service_account_sort_column,
     validate_service_account_update,
@@ -52,16 +69,49 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
 
 try:
-    from sqlalchemy import Column, MetaData, String, Table, func, or_, select, text
+    from sqlalchemy import Column, MetaData, String, Table, and_, case, func, or_, select, text
     from sqlalchemy.dialects import sqlite
-    from sqlalchemy.engine import Engine, create_engine
+    from sqlalchemy.engine import Engine, create_engine, make_url
+    from sqlalchemy.exc import IntegrityError
     from sqlalchemy.orm import scoped_session, sessionmaker
+    from sqlalchemy.pool import StaticPool
     from sqlalchemy.schema import ForeignKey, Index, UniqueConstraint
 except ImportError:
     raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
 
 
+_TABLE_INIT_LOCKS_GUARD = RLock()
+_TABLE_INIT_LOCKS: Dict[str, RLock] = {}
+
+
+def _shared_table_init_lock(database_key: str) -> RLock:
+    """Return one in-process lazy-DDL lock for every physical database."""
+    with _TABLE_INIT_LOCKS_GUARD:
+        return _TABLE_INIT_LOCKS.setdefault(database_key, RLock())
+
+
+def _is_schedule_name_conflict(error: IntegrityError, table_name: str) -> bool:
+    """Match only the generic or actor-scoped schedule-name indexes."""
+    return str(error.orig) in {
+        f"UNIQUE constraint failed: {table_name}.name",
+        f"UNIQUE constraint failed: {table_name}.owner_actor_id, {table_name}.name",
+    }
+
+
+def _is_in_memory_sqlite_url(db_url: str) -> bool:
+    """Return whether a SQLite URL addresses an in-process memory database."""
+    try:
+        url = make_url(db_url)
+    except Exception:
+        return False
+    return url.get_backend_name() == "sqlite" and url.database in (None, "", ":memory:")
+
+
 class SqliteDb(BaseDb):
+    supports_component_persistence = True
+    component_catalog_api_version = 2
+    scheduler_api_version = 2
+
     def __init__(
         self,
         db_file: Optional[str] = None,
@@ -103,7 +153,8 @@ class SqliteDb(BaseDb):
 
         Args:
             db_file (Optional[str]): The database file to connect to.
-            db_engine (Optional[Engine]): The SQLAlchemy database engine to use.
+            db_engine (Optional[Engine]): The SQLAlchemy database engine to use. Caller-owned engines are used as-is;
+                in-memory engines need ``StaticPool`` and ``check_same_thread=False`` for worker-thread access.
             db_url (Optional[str]): The database URL to connect to.
             session_table (Optional[str]): Name of the table to store Agent, Team and Workflow sessions.
             culture_table (Optional[str]): Name of the table to store cultural notions.
@@ -164,7 +215,19 @@ class SqliteDb(BaseDb):
         _engine: Optional[Engine] = db_engine
         if _engine is None:
             if db_url is not None:
-                _engine = create_engine(db_url)
+                if _is_in_memory_sqlite_url(db_url):
+                    # Scheduler sync DB calls run in worker threads. A normal
+                    # in-memory SQLite engine creates one isolated database per
+                    # connection and enforces same-thread access, so configure
+                    # internally-created memory engines as a single shared
+                    # thread-safe connection.
+                    _engine = create_engine(
+                        db_url,
+                        connect_args={"check_same_thread": False},
+                        poolclass=StaticPool,
+                    )
+                else:
+                    _engine = create_engine(db_url)
             elif db_file is not None:
                 db_path = Path(db_file).resolve()
                 db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -181,6 +244,7 @@ class SqliteDb(BaseDb):
         self.db_url: Optional[str] = db_url
         self.db_file: Optional[str] = db_file
         self.metadata: MetaData = MetaData()
+        self._table_init_lock = _shared_table_init_lock(self.db_engine.url.render_as_string(hide_password=True))
 
         # Initialize database session
         self.Session: scoped_session = scoped_session(sessionmaker(bind=self.db_engine))
@@ -412,9 +476,22 @@ class SqliteDb(BaseDb):
             # Create table
             table_created = False
             if not self.table_exists(table_name):
-                table.create(self.db_engine, checkfirst=True)
-                log_debug(f"Successfully created table '{table_name}'")
-                table_created = True
+                try:
+                    table.create(self.db_engine, checkfirst=True)
+                    log_debug(f"Successfully created table '{table_name}'")
+                    table_created = True
+                except Exception:
+                    # The shared lock covers multiple SqliteDb objects in this
+                    # process. A second process can still win between the
+                    # existence check and CREATE, so accept only that exact
+                    # race and validate the table it created.
+                    if not self.table_exists(table_name) or not is_valid_table(
+                        db_engine=self.db_engine,
+                        table_name=table_name,
+                        table_type=table_type,
+                    ):
+                        raise
+                    log_debug(f"Table '{table_name}' was created concurrently")
             else:
                 log_debug(f"Table '{table_name}' already exists, skipping creation")
 
@@ -653,6 +730,18 @@ class SqliteDb(BaseDb):
             raise ValueError(f"Unknown table type: '{table_type}'")
 
     def _get_or_create_table(
+        self,
+        table_name: str,
+        table_type: str,
+        create_table_if_not_found: Optional[bool] = False,
+    ) -> Optional[Table]:
+        # A shared SqliteDb can receive simultaneous first writes from Studio
+        # worker threads. Serialize lazy SQLAlchemy metadata definitions so the
+        # database-level checkfirst path is reached instead of racing in-memory.
+        with self._table_init_lock:
+            return self._get_or_create_table_unlocked(table_name, table_type, create_table_if_not_found)
+
+    def _get_or_create_table_unlocked(
         self,
         table_name: str,
         table_type: str,
@@ -3517,16 +3606,284 @@ class SqliteDb(BaseDb):
             raise e
 
     # --- Components ---
+    @contextmanager
+    def _component_write_session(self) -> Iterator[Any]:
+        """Open a serialized SQLite write transaction for component state."""
+        with self.Session() as sess:
+            sess.connection().exec_driver_sql("BEGIN IMMEDIATE")
+            try:
+                yield sess
+                sess.commit()
+            except Exception:
+                sess.rollback()
+                raise
+
+    @staticmethod
+    def _component_version_state(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        component_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[ComponentVersionGuard]:
+        stmt = select(components_table.c.current_version).where(components_table.c.component_id == component_id)
+        if not include_deleted:
+            stmt = stmt.where(components_table.c.deleted_at.is_(None))
+        component = sess.execute(stmt).fetchone()
+        if component is None:
+            return None
+        latest_version = sess.execute(
+            select(func.max(configs_table.c.version)).where(
+                configs_table.c.component_id == component_id,
+                configs_table.c.stage != DELETED_CONFIG_STAGE,
+            )
+        ).scalar()
+        return ComponentVersionGuard(
+            latest_version=latest_version,
+            current_version=component.current_version,
+        )
+
+    @staticmethod
+    def _check_component_guard(
+        component_id: str,
+        expected: Optional[ComponentVersionGuard],
+        actual: ComponentVersionGuard,
+    ) -> None:
+        if expected is not None and expected != actual:
+            raise ComponentVersionConflictError(component_id, expected=expected, actual=actual)
+
+    @staticmethod
+    def _projection_values(projection: Optional[ComponentProjection]) -> Dict[str, Any]:
+        if projection is None:
+            return {}
+        allowed = {"name", "description", "metadata"}
+        unknown = set(projection) - allowed
+        if unknown:
+            raise ValueError(f"Invalid component projection fields: {sorted(unknown)}")
+        return dict(projection)
+
+    @staticmethod
+    def _validate_component_links(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        links: Optional[List[Dict[str, Any]]],
+        *,
+        require_published: bool,
+    ) -> None:
+        for link in links or []:
+            child_id = link.get("child_component_id")
+            child_version = link.get("child_version")
+            if not child_id or child_version is None:
+                raise ValueError("Each component link requires child_component_id and child_version")
+            child = sess.execute(
+                select(components_table.c.component_type, configs_table.c.stage)
+                .select_from(
+                    components_table.join(
+                        configs_table,
+                        (configs_table.c.component_id == components_table.c.component_id)
+                        & (configs_table.c.version == child_version),
+                    )
+                )
+                .where(
+                    components_table.c.component_id == child_id,
+                    components_table.c.deleted_at.is_(None),
+                    configs_table.c.stage != DELETED_CONFIG_STAGE,
+                )
+            ).fetchone()
+            if child is None:
+                raise ValueError(f"Linked component version not found: {child_id} v{child_version}")
+            if require_published and child.stage != "published":
+                raise ValueError(f"Linked component version is not published: {child_id} v{child_version}")
+
+            expected_type = None
+            link_kind = link.get("link_kind")
+            if link_kind == "step_agent":
+                expected_type = ComponentType.AGENT.value
+            elif link_kind == "step_team":
+                expected_type = ComponentType.TEAM.value
+            elif link_kind == "step_workflow":
+                expected_type = ComponentType.WORKFLOW.value
+            elif link_kind == "member" and isinstance(link.get("meta"), dict):
+                expected_type = link["meta"].get("type")
+            if expected_type is not None and child.component_type != expected_type:
+                raise ValueError(
+                    f"Linked component {child_id} has type {child.component_type}, expected {expected_type}"
+                )
+
+    @staticmethod
+    def _validate_restore_dependencies(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        links_table: Any,
+        component_id: str,
+        version: int,
+    ) -> None:
+        """Require every version reachable from a restored published root to remain runnable."""
+        unavailable: List[Dict[str, Any]] = []
+        unavailable_keys: Set[Tuple[str, int, str, int, str]] = set()
+        seen: Set[Tuple[str, int]] = {(component_id, version)}
+        pending: List[Tuple[str, int]] = [(component_id, version)]
+
+        while pending:
+            parent_id, parent_version = pending.pop()
+            links = sess.execute(
+                select(
+                    links_table.c.child_component_id,
+                    links_table.c.child_version,
+                )
+                .where(
+                    links_table.c.parent_component_id == parent_id,
+                    links_table.c.parent_version == parent_version,
+                )
+                .order_by(links_table.c.child_component_id, links_table.c.child_version)
+            ).fetchall()
+
+            for link in reversed(links):
+                child_id = link.child_component_id
+                child_version = link.child_version
+                child = sess.execute(
+                    select(components_table.c.deleted_at).where(components_table.c.component_id == child_id)
+                ).fetchone()
+
+                reason: Optional[str] = None
+                if child is None:
+                    reason = "component_missing"
+                elif child.deleted_at is not None:
+                    reason = "component_archived"
+                else:
+                    child_stage = sess.execute(
+                        select(configs_table.c.stage).where(
+                            configs_table.c.component_id == child_id,
+                            configs_table.c.version == child_version,
+                        )
+                    ).scalar_one_or_none()
+                    if child_stage is None or child_stage == DELETED_CONFIG_STAGE:
+                        reason = "version_missing"
+                    elif child_stage != "published":
+                        reason = "version_not_published"
+
+                if reason is not None:
+                    unavailable_key = (parent_id, parent_version, child_id, child_version, reason)
+                    if unavailable_key not in unavailable_keys:
+                        unavailable_keys.add(unavailable_key)
+                        unavailable.append(
+                            {
+                                "component_id": child_id,
+                                "version": child_version,
+                                "referenced_by": {
+                                    "component_id": parent_id,
+                                    "version": parent_version,
+                                },
+                                "reason": reason,
+                            }
+                        )
+                    continue
+
+                child_key = (child_id, child_version)
+                if child_key not in seen:
+                    seen.add(child_key)
+                    pending.append(child_key)
+
+        if unavailable:
+            raise ComponentDependencyUnavailableError(component_id, unavailable)
+
+    @staticmethod
+    def _validate_component_acyclic(
+        sess: Any,
+        components_table: Any,
+        configs_table: Any,
+        links_table: Any,
+        component_id: str,
+        version: int,
+        links: List[Dict[str, Any]],
+    ) -> None:
+        """Reject a proposed link set that closes a component-level cycle.
+
+        Every visible config of an active component contributes edges to the
+        dependency graph. Treating the graph as component-level prevents two
+        draft versions from creating reciprocal dependencies that would make
+        both components impossible to archive safely.
+        """
+        rows = sess.execute(
+            select(
+                links_table.c.parent_component_id,
+                links_table.c.parent_version,
+                links_table.c.child_component_id,
+            )
+            .select_from(
+                links_table.join(
+                    configs_table,
+                    (configs_table.c.component_id == links_table.c.parent_component_id)
+                    & (configs_table.c.version == links_table.c.parent_version),
+                ).join(
+                    components_table,
+                    components_table.c.component_id == links_table.c.parent_component_id,
+                )
+            )
+            .where(
+                configs_table.c.stage != DELETED_CONFIG_STAGE,
+                components_table.c.deleted_at.is_(None),
+            )
+        ).fetchall()
+
+        adjacency: Dict[str, Set[str]] = {}
+        for row in rows:
+            if row.parent_component_id == component_id and row.parent_version == version:
+                continue
+            adjacency.setdefault(row.parent_component_id, set()).add(row.child_component_id)
+        for link in links:
+            child_id = link.get("child_component_id")
+            if child_id:
+                adjacency.setdefault(component_id, set()).add(child_id)
+
+        seen = {component_id}
+        pending: List[Tuple[str, List[str]]] = [(component_id, [component_id])]
+        while pending:
+            node, path = pending.pop()
+            for child_id in reversed(sorted(adjacency.get(node, set()))):
+                if child_id == component_id:
+                    raise ComponentCycleError(component_id, [*path, child_id])
+                if child_id in seen:
+                    continue
+                seen.add(child_id)
+                pending.append((child_id, [*path, child_id]))
+
+    @staticmethod
+    def _component_dependents(
+        sess: Any,
+        components_table: Any,
+        links_table: Any,
+        component_id: str,
+        *,
+        version: Optional[int] = None,
+        active_parents_only: bool = False,
+    ) -> List[Dict[str, Any]]:
+        stmt = select(links_table).where(links_table.c.child_component_id == component_id)
+        if version is not None:
+            stmt = stmt.where(links_table.c.child_version == version)
+        if active_parents_only:
+            stmt = stmt.join(
+                components_table,
+                components_table.c.component_id == links_table.c.parent_component_id,
+            ).where(components_table.c.deleted_at.is_(None))
+        return [dict(row._mapping) for row in sess.execute(stmt).fetchall()]
+
     def get_component(
         self,
         component_id: str,
         component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """Get a component by ID.
 
         Args:
             component_id: The component ID.
             component_type: Optional type filter (agent|team|workflow).
+            include_deleted: Include a soft-deleted component in the lookup.
 
         Returns:
             Component dictionary or None if not found.
@@ -3537,10 +3894,9 @@ class SqliteDb(BaseDb):
                 return None
 
             with self.Session() as sess:
-                stmt = select(table).where(
-                    table.c.component_id == component_id,
-                    table.c.deleted_at.is_(None),
-                )
+                stmt = select(table).where(table.c.component_id == component_id)
+                if not include_deleted:
+                    stmt = stmt.where(table.c.deleted_at.is_(None))
                 if component_type is not None:
                     stmt = stmt.where(table.c.component_type == component_type.value)
 
@@ -3549,6 +3905,36 @@ class SqliteDb(BaseDb):
 
         except Exception as e:
             log_error(f"Error getting component: {str(e)}")
+            raise
+
+    def get_components(
+        self,
+        component_ids: Set[str],
+        component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Get a bounded set of component rows in one query."""
+        if not component_ids:
+            return []
+        try:
+            table = getattr(self, "components_table", None)
+            if table is None:
+                table = self._get_table(table_type="components")
+            if table is None:
+                return []
+
+            with self.Session() as sess:
+                stmt = select(table).where(table.c.component_id.in_(component_ids))
+                if not include_deleted:
+                    stmt = stmt.where(table.c.deleted_at.is_(None))
+                if component_type is not None:
+                    stmt = stmt.where(table.c.component_type == component_type.value)
+                stmt = stmt.order_by(table.c.component_id)
+                return [dict(row._mapping) for row in sess.execute(stmt).fetchall()]
+
+        except Exception as e:
+            log_error(f"Error getting components: {str(e)}")
             raise
 
     def upsert_component(
@@ -3567,32 +3953,41 @@ class SqliteDb(BaseDb):
             component_type: Type (agent|team|workflow). Required for create, optional for update.
             name: Display name.
             description: Optional description.
-            current_version: Optional current version.
+            current_version: Reserved. Use set_current_version for guarded,
+                projection-synchronized current-pointer changes.
             metadata: Optional metadata dict.
 
         Returns:
             Created/updated component dictionary.
 
         Raises:
-            ValueError: If creating and component_type is not provided.
+            ValueError: If creating and component_type is not provided, or if
+                current_version is supplied.
         """
+        if current_version is not None:
+            raise ValueError("current_version can only be changed with set_current_version")
+
         try:
             table = self._get_table(table_type="components", create_table_if_not_found=True)
             if table is None:
                 raise ValueError("Components table not found")
 
-            with self.Session() as sess, sess.begin():
+            with self._component_write_session() as sess:
+                requested_type = (
+                    component_type.value
+                    if component_type is not None and hasattr(component_type, "value")
+                    else component_type
+                )
                 existing = sess.execute(select(table).where(table.c.component_id == component_id)).fetchone()
 
                 if existing is None:
                     # Create new component
                     if component_type is None:
                         raise ValueError("component_type is required when creating a new component")
-
                     sess.execute(
                         table.insert().values(
                             component_id=component_id,
-                            component_type=component_type.value if hasattr(component_type, "value") else component_type,
+                            component_type=requested_type,
                             name=name or component_id,
                             description=description,
                             current_version=None,
@@ -3603,47 +3998,35 @@ class SqliteDb(BaseDb):
                     log_debug(f"Created component {component_id}")
 
                 elif existing.deleted_at is not None:
-                    # Reactivate soft-deleted
-                    if component_type is None:
-                        raise ValueError("component_type is required when reactivating a deleted component")
-
-                    sess.execute(
-                        table.update()
-                        .where(table.c.component_id == component_id)
-                        .values(
-                            component_type=component_type.value if hasattr(component_type, "value") else component_type,
-                            name=name or component_id,
-                            description=description,
-                            current_version=None,
-                            metadata=metadata,
-                            updated_at=int(time.time()),
-                            deleted_at=None,
-                        )
-                    )
-                    log_debug(f"Reactivated component {component_id}")
+                    raise ValueError(f"Component {component_id} is archived and remains reserved")
 
                 else:
                     # Update existing
-                    updates: Dict[str, Any] = {"updated_at": int(time.time())}
-                    if component_type is not None:
-                        updates["component_type"] = (
-                            component_type.value if hasattr(component_type, "value") else component_type
+                    if requested_type is not None and requested_type != existing.component_type:
+                        raise ValueError(
+                            f"Component {component_id} has type {existing.component_type}, not {requested_type}"
                         )
+                    updates: Dict[str, Any] = {"updated_at": int(time.time())}
                     if name is not None:
                         updates["name"] = name
                     if description is not None:
                         updates["description"] = description
-                    if current_version is not None:
-                        updates["current_version"] = current_version
                     if metadata is not None:
                         updates["metadata"] = metadata
 
                     sess.execute(table.update().where(table.c.component_id == component_id).values(**updates))
                     log_debug(f"Updated component {component_id}")
 
-            result = self.get_component(component_id)
-            if result is None:
-                raise ValueError(f"Failed to get component {component_id} after upsert")
+                result_row = sess.execute(
+                    select(table).where(
+                        table.c.component_id == component_id,
+                        table.c.deleted_at.is_(None),
+                    )
+                ).fetchone()
+                if result_row is None:
+                    raise ValueError(f"Failed to get component {component_id} during upsert")
+                result = dict(result_row._mapping)
+
             return result
 
         except Exception as e:
@@ -3654,12 +4037,21 @@ class SqliteDb(BaseDb):
         self,
         component_id: str,
         hard_delete: bool = False,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        require_no_dependents: bool = True,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Delete a component and all its configs/links.
 
         Args:
             component_id: The component ID.
             hard_delete: If True, permanently delete. Otherwise soft-delete.
+            guard: Optional expected latest/current version state.
+            require_no_dependents: Refuse deletion while referenced (the safe
+                default). Soft deletion considers active parents; hard deletion
+                considers every parent.
+            projection: Component fields to update atomically with a soft deletion.
 
         Returns:
             True if deleted, False if not found.
@@ -3672,7 +4064,42 @@ class SqliteDb(BaseDb):
             if components_table is None:
                 return False
 
-            with self.Session() as sess, sess.begin():
+            if hard_delete and projection is not None:
+                raise ValueError("projection is not supported for hard delete")
+
+            with self._component_write_session() as sess:
+                existing = sess.execute(
+                    select(components_table.c.component_id, components_table.c.current_version).where(
+                        components_table.c.component_id == component_id,
+                        *([] if hard_delete else [components_table.c.deleted_at.is_(None)]),
+                    )
+                ).fetchone()
+                if existing is None:
+                    return False
+
+                if configs_table is not None:
+                    actual = self._component_version_state(
+                        sess,
+                        components_table,
+                        configs_table,
+                        component_id,
+                        include_deleted=hard_delete,
+                    )
+                    if actual is None:
+                        return False
+                    self._check_component_guard(component_id, guard, actual)
+
+                if require_no_dependents and links_table is not None:
+                    dependents = self._component_dependents(
+                        sess,
+                        components_table,
+                        links_table,
+                        component_id,
+                        active_parents_only=not hard_delete,
+                    )
+                    if dependents:
+                        raise ComponentDependencyError(component_id, dependents)
+
                 if hard_delete:
                     # Delete links where this component is parent or child
                     if links_table is not None:
@@ -3686,18 +4113,82 @@ class SqliteDb(BaseDb):
                         components_table.delete().where(components_table.c.component_id == component_id)
                     )
                 else:
-                    # Soft delete
                     now = int(time.time())
+                    updates: Dict[str, Any] = {"deleted_at": now, "updated_at": now}
+                    updates.update(self._projection_values(projection))
                     result = sess.execute(
                         components_table.update()
-                        .where(components_table.c.component_id == component_id)
-                        .values(deleted_at=now)
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                        .values(**updates)
                     )
 
             return result.rowcount > 0
 
         except Exception as e:
             log_error(f"Error deleting component: {str(e)}")
+            raise
+
+    def restore_component(
+        self,
+        component_id: str,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+    ) -> bool:
+        """Restore one archived component with an optional CAS guard."""
+        try:
+            components_table = self._get_table(table_type="components")
+            configs_table = self._get_table(table_type="component_configs")
+            links_table = self._get_table(table_type="component_links")
+            if components_table is None or configs_table is None:
+                return False
+
+            with self._component_write_session() as sess:
+                actual = self._component_version_state(
+                    sess,
+                    components_table,
+                    configs_table,
+                    component_id,
+                    include_deleted=True,
+                )
+                if actual is None:
+                    return False
+                archived = sess.execute(
+                    select(components_table.c.deleted_at).where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_not(None),
+                    )
+                ).fetchone()
+                if archived is None:
+                    return False
+                self._check_component_guard(component_id, guard, actual)
+                if actual.current_version is not None and links_table is not None:
+                    self._validate_restore_dependencies(
+                        sess,
+                        components_table,
+                        configs_table,
+                        links_table,
+                        component_id,
+                        actual.current_version,
+                    )
+
+                updates: Dict[str, Any] = {"deleted_at": None, "updated_at": int(time.time())}
+                updates.update(self._projection_values(projection))
+                result = sess.execute(
+                    components_table.update()
+                    .where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_not(None),
+                    )
+                    .values(**updates)
+                )
+                return result.rowcount > 0
+
+        except Exception as e:
+            log_error(f"Error restoring component: {str(e)}")
             raise
 
     def list_components(
@@ -3814,14 +4305,14 @@ class SqliteDb(BaseDb):
             if configs_table is None:
                 raise ValueError("Component configs table not found")
 
-            with self.Session() as sess, sess.begin():
+            with self._component_write_session() as sess:
                 # Check if component already exists
                 existing = sess.execute(
                     select(components_table.c.component_id).where(components_table.c.component_id == component_id)
                 ).scalar_one_or_none()
 
                 if existing is not None:
-                    raise ValueError(f"Component {component_id} already exists")
+                    raise ComponentAlreadyExistsError(component_id)
 
                 # Check label uniqueness
                 if label is not None:
@@ -3836,6 +4327,25 @@ class SqliteDb(BaseDb):
 
                 now = int(time.time())
                 version = 1
+
+                if links is not None and links_table is not None:
+                    self._validate_component_acyclic(
+                        sess,
+                        components_table,
+                        configs_table,
+                        links_table,
+                        component_id,
+                        version,
+                        links,
+                    )
+
+                self._validate_component_links(
+                    sess,
+                    components_table,
+                    configs_table,
+                    links,
+                    require_published=stage == "published",
+                )
 
                 # Create component
                 sess.execute(
@@ -3880,14 +4390,25 @@ class SqliteDb(BaseDb):
                             )
                         )
 
-            # Fetch and return both
-            component = self.get_component(component_id)
-            config_result = self.get_config(component_id, version=version)
-
-            if component is None:
-                raise ValueError(f"Failed to get component {component_id} after creation")
-            if config_result is None:
-                raise ValueError(f"Failed to get config for {component_id} after creation")
+                component_row = sess.execute(
+                    select(components_table).where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_(None),
+                    )
+                ).fetchone()
+                config_row = sess.execute(
+                    select(configs_table).where(
+                        configs_table.c.component_id == component_id,
+                        configs_table.c.version == version,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    )
+                ).fetchone()
+                if component_row is None:
+                    raise ValueError(f"Failed to get component {component_id} during creation")
+                if config_row is None:
+                    raise ValueError(f"Failed to get config for {component_id} during creation")
+                component = dict(component_row._mapping)
+                config_result = dict(config_row._mapping)
 
             return component, config_result
 
@@ -3906,7 +4427,9 @@ class SqliteDb(BaseDb):
 
         Args:
             component_id: The component ID.
-            version: Specific version number. If None, uses current or latest draft.
+            version: Specific version number. If omitted with no label, uses
+                the current published version or the latest draft when the
+                component has never been published.
             label: Config label to lookup. Ignored if version is provided.
 
         Returns:
@@ -3954,7 +4477,6 @@ class SqliteDb(BaseDb):
                         configs_table.c.version == current_version,
                     )
                 else:
-                    # No current_version set (draft only) - get the latest version
                     stmt = (
                         select(configs_table)
                         .where(configs_table.c.component_id == component_id)
@@ -3962,11 +4484,137 @@ class SqliteDb(BaseDb):
                         .limit(1)
                     )
 
+                stmt = stmt.where(configs_table.c.stage != DELETED_CONFIG_STAGE)
                 result = sess.execute(stmt).fetchone()
                 return dict(result._mapping) if result else None
 
         except Exception as e:
             log_error(f"Error getting config: {str(e)}")
+            raise
+
+    def get_current_config(self, component_id: str) -> Optional[Dict[str, Any]]:
+        """Get only the current published config for an active component."""
+        try:
+            configs_table = self._get_table(table_type="component_configs")
+            components_table = self._get_table(table_type="components")
+            if configs_table is None or components_table is None:
+                return None
+
+            with self.Session() as sess:
+                row = sess.execute(
+                    select(configs_table)
+                    .select_from(
+                        components_table.join(
+                            configs_table,
+                            (configs_table.c.component_id == components_table.c.component_id)
+                            & (configs_table.c.version == components_table.c.current_version),
+                        )
+                    )
+                    .where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_(None),
+                        configs_table.c.stage == "published",
+                    )
+                ).fetchone()
+                return dict(row._mapping) if row else None
+
+        except Exception as e:
+            log_error(f"Error getting current config: {str(e)}")
+            raise
+
+    def get_latest_config(
+        self,
+        component_id: str,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Get the latest visible config, optionally for an archived component."""
+        try:
+            configs_table = self._get_table(table_type="component_configs")
+            components_table = self._get_table(table_type="components")
+            if configs_table is None or components_table is None:
+                return None
+
+            with self.Session() as sess:
+                component_stmt = select(components_table.c.component_id).where(
+                    components_table.c.component_id == component_id
+                )
+                if not include_deleted:
+                    component_stmt = component_stmt.where(components_table.c.deleted_at.is_(None))
+                if sess.execute(component_stmt).fetchone() is None:
+                    return None
+
+                row = sess.execute(
+                    select(configs_table)
+                    .where(
+                        configs_table.c.component_id == component_id,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    )
+                    .order_by(configs_table.c.version.desc())
+                    .limit(1)
+                ).fetchone()
+                return dict(row._mapping) if row else None
+
+        except Exception as e:
+            log_error(f"Error getting latest config: {str(e)}")
+            raise
+
+    def get_latest_configs(
+        self,
+        component_ids: Set[str],
+        *,
+        include_deleted: bool = False,
+    ) -> Dict[str, Optional[Dict[str, Any]]]:
+        """Get one latest visible config per requested component in one query."""
+        if not component_ids:
+            return {}
+        try:
+            configs_table = getattr(self, "component_configs_table", None)
+            if configs_table is None:
+                configs_table = self._get_table(table_type="component_configs")
+            components_table = getattr(self, "components_table", None)
+            if components_table is None:
+                components_table = self._get_table(table_type="components")
+            if configs_table is None or components_table is None:
+                return {component_id: None for component_id in component_ids}
+
+            latest_versions = (
+                select(
+                    configs_table.c.component_id,
+                    func.max(configs_table.c.version).label("latest_version"),
+                )
+                .where(
+                    configs_table.c.component_id.in_(component_ids),
+                    configs_table.c.stage != DELETED_CONFIG_STAGE,
+                )
+                .group_by(configs_table.c.component_id)
+                .subquery()
+            )
+            with self.Session() as sess:
+                stmt = (
+                    select(configs_table)
+                    .select_from(
+                        configs_table.join(
+                            latest_versions,
+                            (configs_table.c.component_id == latest_versions.c.component_id)
+                            & (configs_table.c.version == latest_versions.c.latest_version),
+                        ).join(
+                            components_table,
+                            components_table.c.component_id == configs_table.c.component_id,
+                        )
+                    )
+                    .where(components_table.c.component_id.in_(component_ids))
+                )
+                if not include_deleted:
+                    stmt = stmt.where(components_table.c.deleted_at.is_(None))
+                result: Dict[str, Optional[Dict[str, Any]]] = {component_id: None for component_id in component_ids}
+                for row in sess.execute(stmt).fetchall():
+                    config_row = dict(row._mapping)
+                    result[config_row["component_id"]] = config_row
+                return result
+
+        except Exception as e:
+            log_error(f"Error getting latest configs: {str(e)}")
             raise
 
     def upsert_config(
@@ -3978,22 +4626,36 @@ class SqliteDb(BaseDb):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
+        restore_if_deleted: bool = False,
+        expected_component_type: Optional[ComponentType] = None,
     ) -> Dict[str, Any]:
         """Create or update a config version for a component.
 
         Rules:
-            - Draft configs can be edited freely
+            - Stored config versions are immutable
+            - The latest draft may transition to published with a guard
             - Published configs are immutable
             - Publishing a config automatically sets it as current_version
 
         Args:
             component_id: The component ID.
-            config: The config data. Required for create, optional for update.
-            version: If None, creates new version. If provided, updates that version.
+            config: The config data. Required when appending a version.
+            version: If None, appends a version. If provided, publishes that draft.
             label: Optional human-readable label.
             stage: "draft" or "published". Defaults to "draft" for new configs.
             notes: Optional notes.
             links: Optional list of links. Each link must have child_version set.
+            guard: Optional expected latest/current version state. Guarded writes
+                append a version or publish the latest draft; they never edit a draft in place.
+            projection: Component fields to update atomically when publishing.
+                When omitted, they are derived from the target config.
+            restore_if_deleted: Restore an archived component in the same
+                transaction as this config mutation.
+            expected_component_type: Optional component type to validate under
+                the component write lock.
 
         Returns:
             Created/updated config dictionary.
@@ -4015,23 +4677,40 @@ class SqliteDb(BaseDb):
             if configs_table is None:
                 raise ValueError("Component configs table not found")
 
-            with self.Session() as sess, sess.begin():
-                # Verify component exists and is not deleted
-                component = sess.execute(
-                    select(components_table.c.component_id).where(
-                        components_table.c.component_id == component_id,
-                        components_table.c.deleted_at.is_(None),
-                    )
-                ).fetchone()
-
-                if component is None:
+            with self._component_write_session() as sess:
+                actual = self._component_version_state(
+                    sess,
+                    components_table,
+                    configs_table,
+                    component_id,
+                    include_deleted=restore_if_deleted,
+                )
+                if actual is None:
                     raise ValueError(f"Component {component_id} not found")
+                self._check_component_guard(component_id, guard, actual)
+                is_archived = False
+                if restore_if_deleted:
+                    is_archived = (
+                        sess.execute(
+                            select(components_table.c.deleted_at).where(components_table.c.component_id == component_id)
+                        ).scalar_one()
+                        is not None
+                    )
+                if expected_component_type is not None:
+                    actual_type = sess.execute(
+                        select(components_table.c.component_type).where(components_table.c.component_id == component_id)
+                    ).scalar_one()
+                    if actual_type != expected_component_type.value:
+                        raise ValueError(
+                            f"Component {component_id} has type {actual_type}, not {expected_component_type.value}"
+                        )
 
                 # Label uniqueness check
                 if label is not None:
                     label_query = select(configs_table.c.version).where(
                         configs_table.c.component_id == component_id,
                         configs_table.c.label == label,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
                     )
                     if version is not None:
                         label_query = label_query.where(configs_table.c.version != version)
@@ -4039,65 +4718,62 @@ class SqliteDb(BaseDb):
                     if sess.execute(label_query).first():
                         raise ValueError(f"Label '{label}' already exists for {component_id}")
 
-                # Validate links have child_version
-                if links:
-                    for link in links:
-                        if link.get("child_version") is None:
-                            raise ValueError(f"child_version is required for link to {link['child_component_id']}")
-
                 if version is None:
                     if config is None:
                         raise ValueError("config is required when creating a new version")
 
-                    # Default to draft for new configs
-                    if stage is None:
-                        stage = "draft"
-
-                    max_version = sess.execute(
-                        select(configs_table.c.version)
-                        .where(configs_table.c.component_id == component_id)
-                        .order_by(configs_table.c.version.desc())
-                        .limit(1)
+                    final_stage = stage or "draft"
+                    target_config = config
+                    high_water = sess.execute(
+                        select(func.max(configs_table.c.version)).where(configs_table.c.component_id == component_id)
                     ).scalar()
-
-                    final_version = (max_version or 0) + 1
+                    final_version = (high_water or 0) + 1
 
                     sess.execute(
                         configs_table.insert().values(
                             component_id=component_id,
                             version=final_version,
                             label=label,
-                            stage=stage,
+                            stage=final_stage,
                             config=config,
                             notes=notes,
                             created_at=int(time.time()),
                         )
                     )
                 else:
-                    existing = sess.execute(
-                        select(configs_table.c.version, configs_table.c.stage).where(
-                            configs_table.c.component_id == component_id,
-                            configs_table.c.version == version,
+                    existing = (
+                        sess.execute(
+                            select(configs_table.c.version, configs_table.c.stage, configs_table.c.config).where(
+                                configs_table.c.component_id == component_id,
+                                configs_table.c.version == version,
+                            )
                         )
-                    ).fetchone()
+                        .mappings()
+                        .one_or_none()
+                    )
 
                     if existing is None:
                         raise ValueError(f"Config {component_id} v{version} not found")
 
-                    # Published configs are immutable
-                    if existing.stage == "published":
+                    if existing["stage"] == DELETED_CONFIG_STAGE:
+                        raise ValueError(f"Config {component_id} v{version} not found")
+
+                    if existing["stage"] == "published":
                         raise ValueError(f"Cannot update published config {component_id} v{version}")
 
-                    # Build update dict with only provided fields
-                    updates: Dict[str, Any] = {"updated_at": int(time.time())}
-                    if label is not None:
-                        updates["label"] = label
-                    if stage is not None:
-                        updates["stage"] = stage
-                    if config is not None:
-                        updates["config"] = config
-                    if notes is not None:
-                        updates["notes"] = notes
+                    if guard is None:
+                        raise ValueError("Publishing an existing draft requires a component version guard")
+                    if version != actual.latest_version:
+                        raise ValueError("A guarded publish can only target the latest config version")
+                    if stage != "published":
+                        raise ValueError("An existing config version is immutable; only guarded publication is allowed")
+                    if any(value is not None for value in (config, label, notes)):
+                        raise ValueError("A guarded publish cannot mutate config, label, or notes")
+
+                    target_config = existing["config"]
+                    if not isinstance(target_config, dict):
+                        raise ValueError(f"Config {component_id} v{version} payload must be an object")
+                    final_stage = "published"
 
                     sess.execute(
                         configs_table.update()
@@ -4105,9 +4781,38 @@ class SqliteDb(BaseDb):
                             configs_table.c.component_id == component_id,
                             configs_table.c.version == version,
                         )
-                        .values(**updates)
+                        .values(stage="published", updated_at=int(time.time()))
                     )
                     final_version = version
+
+                links_to_validate = links
+                if final_stage == "published" and links_to_validate is None and links_table is not None:
+                    links_to_validate = [
+                        dict(row._mapping)
+                        for row in sess.execute(
+                            select(links_table).where(
+                                links_table.c.parent_component_id == component_id,
+                                links_table.c.parent_version == final_version,
+                            )
+                        ).fetchall()
+                    ]
+                if links_to_validate is not None and links_table is not None:
+                    self._validate_component_acyclic(
+                        sess,
+                        components_table,
+                        configs_table,
+                        links_table,
+                        component_id,
+                        final_version,
+                        links_to_validate,
+                    )
+                self._validate_component_links(
+                    sess,
+                    components_table,
+                    configs_table,
+                    links_to_validate,
+                    require_published=final_stage == "published",
+                )
 
                 if links is not None and links_table is not None:
                     sess.execute(
@@ -4131,19 +4836,72 @@ class SqliteDb(BaseDb):
                             )
                         )
 
-                # Determine final stage (could be from update or create)
-                final_stage = stage if stage is not None else (existing.stage if version is not None else "draft")
-
-                if final_stage == "published":
+                if restore_if_deleted and is_archived:
+                    restored_version = final_version if final_stage == "published" else actual.current_version
+                    if restored_version is not None and links_table is not None:
+                        self._validate_restore_dependencies(
+                            sess,
+                            components_table,
+                            configs_table,
+                            links_table,
+                            component_id,
+                            restored_version,
+                        )
+                    # Reactivation is part of this write transaction. Any
+                    # label, graph, projection, or config failure rolls it back
+                    # together with the attempted config append.
                     sess.execute(
                         components_table.update()
                         .where(components_table.c.component_id == component_id)
-                        .values(current_version=final_version, updated_at=int(time.time()))
+                        .values(deleted_at=None, updated_at=int(time.time()))
                     )
 
-            result = self.get_config(component_id, version=final_version)
-            if result is None:
-                raise ValueError(f"Failed to get config {component_id} v{final_version} after upsert")
+                if final_stage == "published":
+                    effective_projection = projection
+                    if effective_projection is None:
+                        effective_projection = self._projection_from_config(target_config)
+                    component_updates: Dict[str, Any] = {
+                        "current_version": final_version,
+                        "updated_at": int(time.time()),
+                    }
+                    component_updates.update(self._projection_values(effective_projection))
+                    sess.execute(
+                        components_table.update()
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                        .values(**component_updates)
+                    )
+                elif projection is not None:
+                    # Before the first publication the component row is a
+                    # projection of the latest draft. The conditional update
+                    # makes a projection based on a stale pre-write read safe:
+                    # a concurrent publication wins without rejecting the
+                    # otherwise valid draft append.
+                    component_updates = {"updated_at": int(time.time())}
+                    component_updates.update(self._projection_values(projection))
+                    sess.execute(
+                        components_table.update()
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                            components_table.c.current_version.is_(None),
+                        )
+                        .values(**component_updates)
+                    )
+
+                result_row = sess.execute(
+                    select(configs_table).where(
+                        configs_table.c.component_id == component_id,
+                        configs_table.c.version == final_version,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    )
+                ).fetchone()
+                if result_row is None:
+                    raise ValueError(f"Failed to get config {component_id} v{final_version} during upsert")
+                result = dict(result_row._mapping)
+
             return result
 
         except Exception as e:
@@ -4154,6 +4912,9 @@ class SqliteDb(BaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Delete a specific config version.
 
@@ -4163,12 +4924,15 @@ class SqliteDb(BaseDb):
         Args:
             component_id: The component ID.
             version: The version to delete.
+            guard: Optional expected latest/current version state.
+            projection: Component fields to update atomically with deletion.
 
         Returns:
             True if deleted, False if not found.
 
         Raises:
-            ValueError: If attempting to delete a published or current config.
+            ComponentDraftRequiredError: If attempting to delete a published config.
+            ValueError: If attempting to delete the current config.
         """
         try:
             configs_table = self._get_table(table_type="component_configs")
@@ -4178,8 +4942,12 @@ class SqliteDb(BaseDb):
             if configs_table is None or components_table is None:
                 return False
 
-            with self.Session() as sess, sess.begin():
-                # Get config stage and check if it's current
+            with self._component_write_session() as sess:
+                actual = self._component_version_state(sess, components_table, configs_table, component_id)
+                if actual is None:
+                    return False
+                self._check_component_guard(component_id, guard, actual)
+
                 config_row = sess.execute(
                     select(configs_table.c.stage).where(
                         configs_table.c.component_id == component_id,
@@ -4190,15 +4958,36 @@ class SqliteDb(BaseDb):
                 if config_row is None:
                     return False
 
-                # Check if it's current version
-                current = sess.execute(
-                    select(components_table.c.current_version).where(components_table.c.component_id == component_id)
-                ).fetchone()
+                if config_row.stage == DELETED_CONFIG_STAGE:
+                    return False
+                if config_row.stage == "published":
+                    raise ComponentDraftRequiredError(component_id, version)
 
-                if current and current.current_version == version:
+                if actual.current_version == version:
                     raise ValueError(f"Cannot delete current config {component_id} v{version}")
 
-                # Delete associated links
+                if links_table is not None:
+                    dependents = self._component_dependents(
+                        sess,
+                        components_table,
+                        links_table,
+                        component_id,
+                        version=version,
+                    )
+                    if dependents:
+                        raise ComponentDependencyError(component_id, dependents, version=version)
+
+                visible_count = sess.execute(
+                    select(func.count())
+                    .select_from(configs_table)
+                    .where(
+                        configs_table.c.component_id == component_id,
+                        configs_table.c.stage != DELETED_CONFIG_STAGE,
+                    )
+                ).scalar_one()
+                if visible_count <= 1:
+                    raise ComponentLastConfigError(component_id, version)
+
                 if links_table is not None:
                     sess.execute(
                         links_table.delete().where(
@@ -4207,13 +4996,35 @@ class SqliteDb(BaseDb):
                         )
                     )
 
-                # Delete the config
+                # Keep a hidden tombstone so this version number is never
+                # reused by a later draft (which would create an ABA hole for
+                # stale publish commands).
                 sess.execute(
-                    configs_table.delete().where(
+                    configs_table.update()
+                    .where(
                         configs_table.c.component_id == component_id,
                         configs_table.c.version == version,
                     )
+                    .values(
+                        label=None,
+                        stage=DELETED_CONFIG_STAGE,
+                        config={},
+                        notes=None,
+                        updated_at=int(time.time()),
+                    )
                 )
+
+                component_updates = self._projection_values(projection)
+                if component_updates:
+                    component_updates["updated_at"] = int(time.time())
+                    sess.execute(
+                        components_table.update()
+                        .where(
+                            components_table.c.component_id == component_id,
+                            components_table.c.deleted_at.is_(None),
+                        )
+                        .values(**component_updates)
+                    )
 
             return True
 
@@ -4269,7 +5080,10 @@ class SqliteDb(BaseDb):
                         configs_table.c.updated_at,
                     )
 
-                stmt = stmt.where(configs_table.c.component_id == component_id).order_by(configs_table.c.version.desc())
+                stmt = stmt.where(
+                    configs_table.c.component_id == component_id,
+                    configs_table.c.stage != DELETED_CONFIG_STAGE,
+                ).order_by(configs_table.c.version.desc())
 
                 results = sess.execute(stmt).fetchall()
                 return [dict(row._mapping) for row in results]
@@ -4282,6 +5096,9 @@ class SqliteDb(BaseDb):
         self,
         component_id: str,
         version: int,
+        *,
+        guard: Optional[ComponentVersionGuard] = None,
+        projection: Optional[ComponentProjection] = None,
     ) -> bool:
         """Set a specific published version as current.
 
@@ -4292,6 +5109,9 @@ class SqliteDb(BaseDb):
         Args:
             component_id: The component ID.
             version: The version to set as current (must be published).
+            guard: Optional expected latest/current version state.
+            projection: Component fields to update atomically with the current pointer.
+                When omitted, they are derived from the target config.
 
         Returns:
             True if successful, False if component or version not found.
@@ -4306,41 +5126,55 @@ class SqliteDb(BaseDb):
             if configs_table is None or components_table is None:
                 return False
 
-            with self.Session() as sess, sess.begin():
-                # Verify component exists and is not deleted
-                component_exists = sess.execute(
-                    select(components_table.c.component_id).where(
-                        components_table.c.component_id == component_id,
-                        components_table.c.deleted_at.is_(None),
-                    )
-                ).fetchone()
-
-                if component_exists is None:
+            with self._component_write_session() as sess:
+                actual = self._component_version_state(sess, components_table, configs_table, component_id)
+                if actual is None:
                     return False
+                self._check_component_guard(component_id, guard, actual)
 
-                # Verify version exists and get stage
-                stage = sess.execute(
-                    select(configs_table.c.stage).where(
-                        configs_table.c.component_id == component_id,
-                        configs_table.c.version == version,
+                # Read the target payload in the same serialized transaction as
+                # the pointer update so an omitted projection can be derived
+                # from the exact version becoming current.
+                target = (
+                    sess.execute(
+                        select(configs_table.c.stage, configs_table.c.config).where(
+                            configs_table.c.component_id == component_id,
+                            configs_table.c.version == version,
+                        )
                     )
-                ).fetchone()
+                    .mappings()
+                    .one_or_none()
+                )
 
-                if stage is None:
+                if target is None:
                     return False
 
                 # Only published configs can be set as current
-                if stage.stage != "published":
+                if target["stage"] != "published":
                     raise ValueError(
                         f"Cannot set draft config {component_id} v{version} as current. "
                         "Only published configs can be current."
                     )
 
-                # Update pointer
+                effective_projection = projection
+                if effective_projection is None:
+                    target_config = target["config"]
+                    if not isinstance(target_config, dict):
+                        raise ValueError(f"Config {component_id} v{version} payload must be an object")
+                    effective_projection = self._projection_from_config(target_config)
+
+                updates: Dict[str, Any] = {
+                    "current_version": version,
+                    "updated_at": int(time.time()),
+                }
+                updates.update(self._projection_values(effective_projection))
                 sess.execute(
                     components_table.update()
-                    .where(components_table.c.component_id == component_id)
-                    .values(current_version=version, updated_at=int(time.time()))
+                    .where(
+                        components_table.c.component_id == component_id,
+                        components_table.c.deleted_at.is_(None),
+                    )
+                    .values(**updates)
                 )
 
             log_debug(f"Set {component_id} current version to {version}")
@@ -4395,28 +5229,34 @@ class SqliteDb(BaseDb):
         self,
         component_id: str,
         version: Optional[int] = None,
+        *,
+        active_parents_only: bool = False,
     ) -> List[Dict[str, Any]]:
         """Find all components that reference this component.
 
         Args:
             component_id: The component ID to find dependents of.
             version: Optional specific version. If None, finds links to any version.
+            active_parents_only: Exclude links owned by soft-deleted parents.
 
         Returns:
             List of link dictionaries showing what depends on this component.
         """
         try:
-            table = self._get_table(table_type="component_links")
-            if table is None:
+            links_table = self._get_table(table_type="component_links")
+            components_table = self._get_table(table_type="components")
+            if links_table is None or components_table is None:
                 return []
 
             with self.Session() as sess:
-                stmt = select(table).where(table.c.child_component_id == component_id)
-                if version is not None:
-                    stmt = stmt.where(table.c.child_version == version)
-
-                results = sess.execute(stmt).fetchall()
-                return [dict(row._mapping) for row in results]
+                return self._component_dependents(
+                    sess,
+                    components_table,
+                    links_table,
+                    component_id,
+                    version=version,
+                    active_parents_only=active_parents_only,
+                )
 
         except Exception as e:
             log_error(f"Error getting dependents: {str(e)}")
@@ -4427,11 +5267,11 @@ class SqliteDb(BaseDb):
         component_id: str,
         version: Optional[int],
     ) -> Optional[int]:
-        """Resolve a version number, handling NULL (current) case.
+        """Resolve an explicit version or the component's generic readable head.
 
         Args:
             component_id: The component ID.
-            version: Version number or None for current.
+            version: Version number or None for current/latest-draft fallback.
 
         Returns:
             Resolved version number or None if component not found.
@@ -4440,15 +5280,9 @@ class SqliteDb(BaseDb):
             return version
 
         try:
-            components_table = self._get_table(table_type="components")
-            if components_table is None:
-                return None
-
-            with self.Session() as sess:
-                result = sess.execute(
-                    select(components_table.c.current_version).where(components_table.c.component_id == component_id)
-                ).scalar()
-                return result
+            config = self.get_config(component_id)
+            resolved = config.get("version") if config is not None else None
+            return resolved if isinstance(resolved, int) else None
 
         except Exception as e:
             log_error(f"Error resolving version: {str(e)}")
@@ -4476,8 +5310,14 @@ class SqliteDb(BaseDb):
             if component is None:
                 return None
 
-            # Resolve version
-            resolved_version = self.resolve_version(component_id, version)
+            # Resolve version. A label is an explicit catalog read; otherwise
+            # use the generic current/latest-draft semantics.
+            if version is None and label is not None:
+                labeled = self.get_config(component_id, label=label)
+                resolved = labeled.get("version") if labeled is not None else None
+                resolved_version = resolved if isinstance(resolved, int) else None
+            else:
+                resolved_version = self.resolve_version(component_id, version)
             if resolved_version is None:
                 return None
 
@@ -4982,27 +5822,42 @@ class SqliteDb(BaseDb):
             with self.Session() as sess:
                 result = sess.execute(select(table).where(table.c.id == schedule_id)).fetchone()
                 return dict(result._mapping) if result else None
-        except Exception as e:
-            log_debug(f"Error getting schedule: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule")
+            raise
 
-    def get_schedule_by_name(self, name: str) -> Optional[Dict[str, Any]]:
+    def get_schedule_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         try:
             table = self._get_table(table_type="schedules")
             if table is None:
                 return None
             with self.Session() as sess:
-                result = sess.execute(select(table).where(table.c.name == name)).fetchone()
+                query = select(table).where(table.c.name == name)
+                if managed_by is not None:
+                    query = query.where(table.c.managed_by == managed_by)
+                if owner_actor_id is not None:
+                    query = query.where(table.c.owner_actor_id == owner_actor_id)
+                if exclude_managed_by is not None:
+                    query = query.where(or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by))
+                result = sess.execute(query).fetchone()
                 return dict(result._mapping) if result else None
-        except Exception as e:
-            log_debug(f"Error getting schedule by name: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule by name")
+            raise
 
     def get_schedules(
         self,
         enabled: Optional[bool] = None,
         limit: int = 100,
         page: int = 1,
+        exclude_managed_by: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = self._get_table(table_type="schedules")
@@ -5013,6 +5868,10 @@ class SqliteDb(BaseDb):
                 base_query = select(table)
                 if enabled is not None:
                     base_query = base_query.where(table.c.enabled == enabled)
+                if exclude_managed_by is not None:
+                    base_query = base_query.where(
+                        or_(table.c.managed_by.is_(None), table.c.managed_by != exclude_managed_by)
+                    )
 
                 # Get total count
                 count_stmt = select(func.count()).select_from(base_query.alias())
@@ -5025,20 +5884,27 @@ class SqliteDb(BaseDb):
                 stmt = base_query.order_by(table.c.created_at.desc()).limit(limit).offset(offset)
                 results = sess.execute(stmt).fetchall()
                 return [dict(row._mapping) for row in results], total_count
-        except Exception as e:
-            log_debug(f"Error listing schedules: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error listing schedules")
+            raise
 
     def create_schedule(self, schedule_data: Dict[str, Any]) -> Dict[str, Any]:
         try:
+            schedule_data.setdefault("pending_trigger_count", 0)
+            schedule_data.setdefault("manual_trigger_claimed", False)
             table = self._get_table(table_type="schedules", create_table_if_not_found=True)
             if table is None:
                 raise RuntimeError("Failed to get or create schedules table")
             with self.Session() as sess, sess.begin():
                 sess.execute(table.insert().values(**schedule_data))
             return schedule_data
-        except Exception as e:
-            log_error(f"Error creating schedule: {str(e)}")
+        except IntegrityError as error:
+            if _is_schedule_name_conflict(error, self.schedules_table_name):
+                raise ScheduleNameConflictError(schedule_data["name"]) from None
+            log_error("Error creating schedule")
+            raise
+        except Exception:
+            log_error("Error creating schedule")
             raise
 
     def update_schedule(self, schedule_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -5050,9 +5916,57 @@ class SqliteDb(BaseDb):
             with self.Session() as sess, sess.begin():
                 sess.execute(table.update().where(table.c.id == schedule_id).values(**kwargs))
             return self.get_schedule(schedule_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule: {e}")
+        except IntegrityError as error:
+            name = kwargs.get("name")
+            if isinstance(name, str) and _is_schedule_name_conflict(error, self.schedules_table_name):
+                raise ScheduleNameConflictError(name) from None
+            log_debug("Error updating schedule")
+            raise
+        except Exception:
+            log_debug("Error updating schedule")
+            raise
+
+    def trigger_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
+        """Durably enqueue one manual execution for a schedule."""
+        table = self._get_table(table_type="schedules")
+        if table is None:
             return None
+        with self.Session() as sess, sess.begin():
+            result = sess.execute(
+                table.update()
+                .where(table.c.id == schedule_id)
+                .values(
+                    pending_trigger_count=func.coalesce(table.c.pending_trigger_count, 0) + 1,
+                    updated_at=int(time.time()),
+                )
+            )
+            if result.rowcount == 0:
+                return None
+        return self.get_schedule(schedule_id)
+
+    def disable_schedules_for_target(
+        self,
+        target_type: str,
+        target_id: str,
+        *,
+        managed_by: str,
+    ) -> int:
+        """Atomically disable enabled schedules for one managed target."""
+        table = self._get_table(table_type="schedules")
+        if table is None:
+            return 0
+        with self.Session() as sess, sess.begin():
+            result = sess.execute(
+                table.update()
+                .where(
+                    table.c.managed_by == managed_by,
+                    table.c.target_type == target_type,
+                    table.c.target_id == target_id,
+                    table.c.enabled == True,  # noqa: E712
+                )
+                .values(enabled=False, updated_at=int(time.time()))
+            )
+            return int(result.rowcount or 0)
 
     def delete_schedule(self, schedule_id: str) -> bool:
         try:
@@ -5065,8 +5979,8 @@ class SqliteDb(BaseDb):
                     sess.execute(runs_table.delete().where(runs_table.c.schedule_id == schedule_id))
                 result = sess.execute(table.delete().where(table.c.id == schedule_id))
                 return result.rowcount > 0
-        except Exception as e:
-            log_debug(f"Error deleting schedule: {e}")
+        except Exception:
+            log_debug("Error deleting schedule")
             return False
 
     def claim_due_schedule(self, worker_id: str, lock_grace_seconds: int = 300) -> Optional[Dict[str, Any]]:
@@ -5082,13 +5996,30 @@ class SqliteDb(BaseDb):
                     select(table)
                     .where(
                         table.c.enabled == True,  # noqa: E712
-                        table.c.next_run_at <= now,
+                        or_(
+                            table.c.manual_trigger_claimed == True,  # noqa: E712
+                            table.c.pending_trigger_count > 0,
+                            table.c.next_run_at <= now,
+                        ),
                         or_(
                             table.c.locked_by.is_(None),
                             table.c.locked_at <= stale_lock_threshold,
                         ),
                     )
-                    .order_by(table.c.next_run_at.asc())
+                    .order_by(
+                        case(
+                            (table.c.manual_trigger_claimed == True, 0),  # noqa: E712
+                            (
+                                and_(
+                                    table.c.pending_trigger_count > 0,
+                                    or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                ),
+                                1,
+                            ),
+                            else_=2,
+                        ),
+                        table.c.next_run_at.asc(),
+                    )
                     .limit(1)
                 )
                 row = sess.execute(stmt).fetchone()
@@ -5100,35 +6031,102 @@ class SqliteDb(BaseDb):
                     table.update()
                     .where(
                         table.c.id == schedule["id"],
+                        table.c.enabled == True,  # noqa: E712
+                        or_(
+                            table.c.manual_trigger_claimed == True,  # noqa: E712
+                            table.c.pending_trigger_count > 0,
+                            table.c.next_run_at <= now,
+                        ),
                         or_(
                             table.c.locked_by.is_(None),
                             table.c.locked_at <= stale_lock_threshold,
                         ),
                     )
-                    .values(locked_by=worker_id, locked_at=now)
+                    .values(
+                        locked_by=worker_id,
+                        locked_at=now,
+                        pending_trigger_count=case(
+                            (
+                                and_(
+                                    table.c.manual_trigger_claimed == False,  # noqa: E712
+                                    table.c.pending_trigger_count > 0,
+                                    or_(table.c.next_run_at.is_(None), table.c.next_run_at > now),
+                                ),
+                                table.c.pending_trigger_count - 1,
+                            ),
+                            else_=table.c.pending_trigger_count,
+                        ),
+                        manual_trigger_claimed=case(
+                            (table.c.manual_trigger_claimed == True, True),  # noqa: E712
+                            (table.c.next_run_at <= now, False),
+                            else_=True,
+                        ),
+                    )
                 )
                 if result.rowcount == 0:
                     return None
-                schedule["locked_by"] = worker_id
-                schedule["locked_at"] = now
-                return schedule
-        except Exception as e:
-            log_debug(f"Error claiming schedule: {e}")
-            return None
+                claimed = sess.execute(select(table).where(table.c.id == schedule["id"])).fetchone()
+                return dict(claimed._mapping) if claimed else None
+        except Exception:
+            log_debug("Error claiming schedule")
+            raise
 
-    def release_schedule(self, schedule_id: str, next_run_at: Optional[int] = None) -> bool:
+    def renew_schedule_claim(
+        self,
+        schedule_id: str,
+        *,
+        worker_id: str,
+        locked_at: int,
+    ) -> Optional[int]:
+        """Renew a claim only while its worker/timestamp fence still matches."""
+        table = self._get_table(table_type="schedules")
+        if table is None:
+            return None
+        renewed_at = max(int(time.time()), locked_at + 1)
+        with self.Session() as sess, sess.begin():
+            result = sess.execute(
+                table.update()
+                .where(
+                    table.c.id == schedule_id,
+                    table.c.locked_by == worker_id,
+                    table.c.locked_at == locked_at,
+                )
+                .values(locked_at=renewed_at)
+            )
+            return renewed_at if result.rowcount > 0 else None
+
+    def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: Optional[int] = None,
+        *,
+        worker_id: Optional[str] = None,
+        locked_at: Optional[int] = None,
+    ) -> bool:
         try:
+            if (worker_id is None) != (locked_at is None):
+                return False
             table = self._get_table(table_type="schedules")
             if table is None:
                 return False
-            updates: Dict[str, Any] = {"locked_by": None, "locked_at": None, "updated_at": int(time.time())}
+            updates: Dict[str, Any] = {
+                "locked_by": None,
+                "locked_at": None,
+                "manual_trigger_claimed": False,
+                "updated_at": int(time.time()),
+            }
             if next_run_at is not None:
                 updates["next_run_at"] = next_run_at
             with self.Session() as sess, sess.begin():
-                result = sess.execute(table.update().where(table.c.id == schedule_id).values(**updates))
+                stmt = table.update().where(table.c.id == schedule_id)
+                if worker_id is None:
+                    stmt = stmt.where(table.c.manual_trigger_claimed == False)  # noqa: E712
+                else:
+                    stmt = stmt.where(table.c.locked_by == worker_id, table.c.locked_at == locked_at)
+                result = sess.execute(stmt.values(**updates))
                 return result.rowcount > 0
-        except Exception as e:
-            log_debug(f"Error releasing schedule: {e}")
+        except Exception:
+            log_debug("Error releasing schedule")
             return False
 
     def create_schedule_run(self, run_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -5139,8 +6137,8 @@ class SqliteDb(BaseDb):
             with self.Session() as sess, sess.begin():
                 sess.execute(table.insert().values(**run_data))
             return run_data
-        except Exception as e:
-            log_error(f"Error creating schedule run: {str(e)}")
+        except Exception:
+            log_error("Error creating schedule run")
             raise
 
     def update_schedule_run(self, schedule_run_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
@@ -5151,8 +6149,8 @@ class SqliteDb(BaseDb):
             with self.Session() as sess, sess.begin():
                 sess.execute(table.update().where(table.c.id == schedule_run_id).values(**kwargs))
             return self.get_schedule_run(schedule_run_id)
-        except Exception as e:
-            log_debug(f"Error updating schedule run: {e}")
+        except Exception:
+            log_debug("Error updating schedule run")
             return None
 
     def get_schedule_run(self, run_id: str) -> Optional[Dict[str, Any]]:
@@ -5163,9 +6161,9 @@ class SqliteDb(BaseDb):
             with self.Session() as sess:
                 result = sess.execute(select(table).where(table.c.id == run_id)).fetchone()
                 return dict(result._mapping) if result else None
-        except Exception as e:
-            log_debug(f"Error getting schedule run: {e}")
-            return None
+        except Exception:
+            log_debug("Error getting schedule run")
+            raise
 
     def get_schedule_runs(
         self,
@@ -5195,9 +6193,9 @@ class SqliteDb(BaseDb):
                 )
                 results = sess.execute(stmt).fetchall()
                 return [dict(row._mapping) for row in results], total_count
-        except Exception as e:
-            log_debug(f"Error getting schedule runs: {e}")
-            return [], 0
+        except Exception:
+            log_debug("Error getting schedule runs")
+            raise
 
     # -- Approval methods --
 

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -1,6 +1,7 @@
 """Logic shared across different database implementations"""
 
 import json
+from copy import deepcopy
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from uuid import UUID
@@ -10,7 +11,7 @@ from agno.models.message import Message
 from agno.utils.log import log_error, log_warning
 
 if TYPE_CHECKING:
-    from agno.db.base import AsyncBaseDb, BaseDb, SessionType
+    from agno.db.base import AsyncBaseDb, BaseDb, ComponentProjection, ComponentType, SessionType
     from agno.registry.registry import Registry
     from agno.session import Session
 
@@ -44,6 +45,142 @@ DB_TABLE_NAME_KEYS: frozenset = frozenset(
         "mcp_oauth_keys_table",
     }
 )
+
+
+def save_component_config(
+    db: "BaseDb",
+    *,
+    component_id: str,
+    component_type: "ComponentType",
+    name: Optional[str],
+    description: Optional[str],
+    metadata: Optional[Dict[str, Any]],
+    config: Dict[str, Any],
+    stage: str,
+    label: Optional[str] = None,
+    notes: Optional[str] = None,
+    links: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Persist a component config through the adapter's declared catalog contract.
+
+    A component's first config is created in the same transaction as its
+    component row when the adapter supports the 2.9 atomic primitive. Legacy
+    custom adapters fall back to their pre-2.9 upsert sequence. Later published
+    configs atomically update the denormalized component fields with the
+    current-version pointer. A draft updates the projection only while the
+    component has never had a published version; once published, later drafts
+    cannot leak into the current projection.
+
+    A concurrent creator may occupy the ID between the initial lookup and the
+    insert. In that case, validate the winning row and continue through the
+    existing-component path, matching the append-on-save behavior of the
+    component APIs.
+    """
+    from agno.db.base import ComponentAlreadyExistsError, ComponentType
+
+    if stage not in {"draft", "published"}:
+        raise ValueError(f"Invalid stage: {stage}")
+
+    effective_name = name or component_id
+    # A config version owns the complete denormalized catalog projection. Keep
+    # explicit nulls in the immutable payload so a future rollback can clear a
+    # description or metadata introduced by a newer version. Serializers often
+    # omit None values, and mutating their dictionary here would leak storage
+    # concerns back into the live component.
+    config = deepcopy(config)
+    config.update(
+        {
+            "name": effective_name,
+            "description": description,
+            "metadata": deepcopy(metadata),
+        }
+    )
+
+    catalog_api_version = getattr(db, "component_catalog_api_version", 1)
+    if catalog_api_version < 2:
+        # The compatibility path must use the exact pre-2.9 call shapes. In
+        # particular, do not probe new keyword-only parameters and then catch
+        # TypeError: a third-party override rejects those arguments before any
+        # NotImplementedError fallback can run.
+        component = db.get_component(component_id)
+        if component is not None:
+            actual_type = component.get("component_type")
+            if isinstance(actual_type, ComponentType):
+                actual_type = actual_type.value
+            if actual_type is not None and actual_type != component_type.value:
+                raise ValueError(f"Component {component_id} has type {actual_type}, not {component_type.value}")
+
+        log_warning(
+            f"Database {type(db).__name__} uses component catalog API v1; component and config writes are not atomic"
+        )
+        db.upsert_component(
+            component_id=component_id,
+            component_type=component_type,
+            name=effective_name,
+            description=description,
+            metadata=metadata,
+        )
+        return db.upsert_config(
+            component_id=component_id,
+            config=config,
+            label=label,
+            stage=stage,
+            notes=notes,
+            links=links,
+        )
+
+    component = db.get_component(component_id, include_deleted=True)
+
+    if component is None:
+        try:
+            _, config_row = db.create_component_with_config(
+                component_id=component_id,
+                component_type=component_type,
+                name=effective_name,
+                description=description,
+                metadata=metadata,
+                config=config,
+                label=label,
+                stage=stage,
+                notes=notes,
+                links=links,
+            )
+            return config_row
+        except ComponentAlreadyExistsError:
+            component = db.get_component(component_id, include_deleted=True)
+            if component is None:
+                raise
+
+    actual_type = component.get("component_type")
+    if isinstance(actual_type, ComponentType):
+        actual_type = actual_type.value
+    expected_type = component_type.value
+    if actual_type != expected_type:
+        raise ValueError(f"Component {component_id} has type {actual_type}, not {expected_type}")
+
+    restore_if_deleted = component.get("deleted_at") is not None
+
+    # Always provide the complete desired projection. Version-2 adapters make
+    # the draft-only decision while holding the component write lock, so a
+    # concurrent publish between the read above and this append cannot turn a
+    # valid draft save into a false conflict or leak draft metadata.
+    projection: "ComponentProjection" = {
+        "name": effective_name,
+        "description": description,
+        "metadata": metadata,
+    }
+
+    return db.upsert_config(
+        component_id=component_id,
+        config=config,
+        label=label,
+        stage=stage,
+        notes=notes,
+        links=links,
+        projection=projection,
+        restore_if_deleted=restore_if_deleted,
+        expected_component_type=component_type,
+    )
 
 
 def detect_session_type(record: Dict[str, Any]) -> str:

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -46,7 +46,7 @@ from agno.os.interfaces.base import BaseInterface
 from agno.os.router import get_base_router, get_info_router, get_websocket_router
 from agno.os.routers.agents import get_agent_router
 from agno.os.routers.approvals import get_approval_router
-from agno.os.routers.components import get_components_router
+from agno.os.routers.components import get_components_router, supports_component_routes
 from agno.os.routers.database import get_database_router
 from agno.os.routers.evals import get_eval_router
 from agno.os.routers.health import get_health_router
@@ -224,6 +224,11 @@ def _get_disabled_feature_router(prefix: str, tag: str, requires: str) -> APIRou
         raise HTTPException(status_code=503, detail=detail)
 
     return router
+
+
+def _supports_component_routes(db: Union[BaseDb, AsyncBaseDb]) -> bool:
+    """Return whether this DB can safely back the synchronous Components API."""
+    return supports_component_routes(db)
 
 
 class AgentOS:
@@ -461,7 +466,7 @@ class AgentOS:
 
         # Track MCP tools declared on the registry so they connect in the same
         # lifespan as agent/team/workflow MCP tools (e.g. for components created
-        # from registry tools via StudioTool)
+        # from registry tools via StudioTools)
         collect_mcp_tools_from_registry(self.registry, self.mcp_tools)
 
         # Check for duplicate IDs
@@ -593,10 +598,14 @@ class AgentOS:
         ]
         # Routes that require a database
         if self.db is not None:
-            if isinstance(self.db, BaseDb):
+            if _supports_component_routes(self.db):
                 updated_routers.append(get_components_router(os_db=self.db, registry=self.registry))
             else:
-                updated_routers.append(_get_disabled_feature_router("/components", "Components", "sync db (BaseDb)"))
+                updated_routers.append(
+                    _get_disabled_feature_router(
+                        "/components", "Components", "sync db with component persistence support"
+                    )
+                )
             updated_routers.append(get_schedule_router(os_db=self.db, settings=self.settings))
             updated_routers.append(get_approval_router(os_db=self.db, settings=self.settings))
             updated_routers.append(get_service_accounts_router(os_db=self.db, settings=self.settings))
@@ -1115,10 +1124,14 @@ class AgentOS:
         ]
         # Routes that require a database
         if self.db is not None:
-            if isinstance(self.db, BaseDb):
+            if _supports_component_routes(self.db):
                 routers.append(get_components_router(os_db=self.db, registry=self.registry))
             else:
-                routers.append(_get_disabled_feature_router("/components", "Components", "sync db (BaseDb)"))
+                routers.append(
+                    _get_disabled_feature_router(
+                        "/components", "Components", "sync db with component persistence support"
+                    )
+                )
             routers.append(get_schedule_router(os_db=self.db, settings=self.settings))
             routers.append(get_approval_router(os_db=self.db, settings=self.settings))
             routers.append(get_service_accounts_router(os_db=self.db, settings=self.settings))

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -603,7 +603,10 @@ def get_agent_router(
         files: Optional[List[UploadFile]] = File(
             None, description="Files to upload (images, audio, video, or documents)"
         ),
-        version: Optional[str] = Form(None, description="Agent version to use for this run"),
+        version: Optional[str] = Form(
+            None,
+            description="Exact Agent version to use for this run, including a draft version for explicit preview",
+        ),
         background: bool = Form(
             False, description="Run in background and return immediately with run metadata (requires database)"
         ),
@@ -1380,7 +1383,12 @@ def get_agent_router(
 
         try:
             agent = get_agent_by_id(
-                agent_id=agent_id, agents=os.agents, db=os.db, registry=os.registry, create_fresh=True
+                agent_id=agent_id,
+                agents=os.agents,
+                db=os.db,
+                registry=os.registry,
+                create_fresh=True,
+                published_only=False,
             )  # type: ignore[assignment]
         except ComponentRehydrationError as rehydration_error:
             raise HTTPException(status_code=rehydration_error.status_code, detail=str(rehydration_error))

--- a/libs/agno/agno/os/routers/components/__init__.py
+++ b/libs/agno/agno/os/routers/components/__init__.py
@@ -1,3 +1,3 @@
-from agno.os.routers.components.components import get_components_router
+from agno.os.routers.components.components import get_components_router, supports_component_routes
 
-__all__ = ["get_components_router"]
+__all__ = ["get_components_router", "supports_component_routes"]

--- a/libs/agno/agno/os/routers/components/components.py
+++ b/libs/agno/agno/os/routers/components/components.py
@@ -1,10 +1,22 @@
 import logging
 import time
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
 
-from agno.db.base import AsyncBaseDb, BaseDb
+from agno.db.base import (
+    AsyncBaseDb,
+    BaseDb,
+    ComponentAlreadyExistsError,
+    ComponentCycleError,
+    ComponentDependencyError,
+    ComponentDraftRequiredError,
+    ComponentLastConfigError,
+    ComponentProjection,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+)
 from agno.db.base import ComponentType as DbComponentType
 from agno.db.utils import DB_TABLE_NAME_KEYS
 from agno.os.auth import get_authentication_dependency
@@ -12,15 +24,18 @@ from agno.os.schema import (
     BadRequestResponse,
     ComponentConfigResponse,
     ComponentCreate,
+    ComponentDelete,
     ComponentResponse,
     ComponentType,
     ComponentUpdate,
     ConfigCreate,
+    ConfigDelete,
     ConfigUpdate,
     InternalServerErrorResponse,
     NotFoundResponse,
     PaginatedResponse,
     PaginationInfo,
+    SetCurrentConfig,
     UnauthenticatedResponse,
     ValidationErrorResponse,
 )
@@ -30,6 +45,137 @@ from agno.utils.log import log_error, log_warning
 from agno.utils.string import generate_id_from_name
 
 logger = logging.getLogger(__name__)
+
+_STUDIO_CONFIG_KEY = "_agno_studio"
+_STUDIO_WRITE_CONFLICT = "Studio-owned components must be mutated through StudioTools."
+_LEGACY_COMPONENT_METHODS = (
+    "get_component",
+    "upsert_component",
+    "delete_component",
+    "list_components",
+    "get_config",
+    "upsert_config",
+    "delete_config",
+    "list_configs",
+    "set_current_version",
+)
+
+
+def supports_component_routes(db: Union[BaseDb, AsyncBaseDb]) -> bool:
+    """Return whether a DB implements a complete sync component catalog.
+
+    Catalog v2 is an explicit capability because its guarded, atomic contract
+    cannot be inferred from method names. Catalog v1 predates the capability
+    flag, so retain adapters that override the complete legacy method set even
+    when they inherit the old ``False`` default.
+    """
+    if not isinstance(db, BaseDb):
+        return False
+    if getattr(db, "component_catalog_api_version", 1) >= 2:
+        return bool(getattr(db, "supports_component_persistence", False))
+    if getattr(db, "supports_component_persistence", False):
+        return True
+
+    db_type = type(db)
+    return all(
+        getattr(db_type, method_name, None) is not getattr(BaseDb, method_name)
+        for method_name in _LEGACY_COMPONENT_METHODS
+    )
+
+
+def _version_guard(latest_version: Optional[int], current_version: Optional[int]) -> ComponentVersionGuard:
+    return ComponentVersionGuard(latest_version=latest_version, current_version=current_version)
+
+
+def _projection_from_config(
+    config: Dict[str, Any], *, fallback: Optional[Dict[str, Any]] = None
+) -> ComponentProjection:
+    """Build the complete component projection owned by one config version."""
+    fallback = fallback or {}
+    name = config.get("name")
+    if not isinstance(name, str):
+        name = fallback.get("name")
+    if not isinstance(name, str):
+        raise ValueError("Component config must resolve to a string name")
+
+    description = config.get("description") if "description" in config else fallback.get("description")
+    if description is not None and not isinstance(description, str):
+        description = fallback.get("description")
+    if description is not None and not isinstance(description, str):
+        description = None
+
+    metadata = config.get("metadata") if "metadata" in config else fallback.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        metadata = fallback.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        metadata = None
+
+    return ComponentProjection(
+        name=name,
+        description=description,
+        metadata=deepcopy(metadata),
+    )
+
+
+def _canonicalize_component_config(config: Dict[str, Any], *, fallback: Dict[str, Any]) -> Dict[str, Any]:
+    """Embed a complete immutable projection in a generic config payload."""
+    canonical = deepcopy(config)
+    canonical.update(_projection_from_config(canonical, fallback=fallback))
+    return canonical
+
+
+def _project_component_response(
+    component: Dict[str, Any], projection: ComponentProjection, *, current_version: int
+) -> Dict[str, Any]:
+    """Build the state committed by a pointer mutation without a post-commit read."""
+    projected = dict(component)
+    projected.update(projection)
+    projected["current_version"] = current_version
+    return projected
+
+
+def _append_component_metadata_patch(
+    config: Dict[str, Any],
+    *,
+    patch: ComponentUpdate,
+) -> Dict[str, Any]:
+    """Copy a generic config and apply the metadata-only edit contract."""
+    fields = patch.model_fields_set - {"guard"}
+    if not fields:
+        raise ValueError("Component update must contain at least one field in addition to guard")
+    if "name" in fields and (patch.name is None or not patch.name.strip()):
+        raise ValueError("Component name cannot be null or blank")
+
+    result = deepcopy(config)
+    if "name" in fields:
+        result["name"] = patch.name
+    if "description" in fields:
+        result["description"] = patch.description
+    if "metadata" in fields:
+        result["metadata"] = deepcopy(patch.metadata)
+    return result
+
+
+def _reject_reserved_studio_config(config: Dict[str, Any]) -> None:
+    """Keep the Studio manifest namespace exclusive to the typed control plane."""
+    if _STUDIO_CONFIG_KEY in config:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Config key '{_STUDIO_CONFIG_KEY}' is reserved for StudioTools.",
+        )
+
+
+def _reject_studio_owned_mutation(db: BaseDb, component_id: str) -> None:
+    """Prevent generic lifecycle routes from mutating any Studio-owned version.
+
+    Ownership is derived from immutable config history rather than only the
+    latest/current pointer. That keeps this boundary effective even if a raw
+    config was appended before the boundary existed.
+    """
+    for config_row in db.list_configs(component_id, include_config=True):
+        config = config_row.get("config")
+        if isinstance(config, dict) and _STUDIO_CONFIG_KEY in config:
+            raise HTTPException(status_code=409, detail=_STUDIO_WRITE_CONFLICT)
 
 
 def _resolve_db_in_config(
@@ -91,6 +237,8 @@ def _resolve_member_links(
     config: Dict[str, Any],
     db: BaseDb,
     registry: Optional[Registry] = None,
+    *,
+    require_published_pins: bool = False,
 ) -> Tuple[List[Dict[str, Any]], List[str]]:
     """Build ``component_links`` rows for a team config's ``members``.
 
@@ -103,7 +251,10 @@ def _resolve_member_links(
       current version) so the component graph reflects the team structure.
     - Members that are code-defined components (registered with the AgentOS
       instance but not persisted as DB components) are resolved from the
-      registry at load time and therefore do not get a link row.
+      registry at load time and therefore do not get a link row for drafts.
+      Published configs require durable exact-version pins, so code-defined
+      and draft-only members are rejected when ``require_published_pins`` is
+      true.
     - Members that resolve to neither are returned as unresolved so the caller
       can surface an error instead of silently creating a team with no members.
 
@@ -113,23 +264,31 @@ def _resolve_member_links(
     links: List[Dict[str, Any]] = []
     unresolved: List[str] = []
 
-    members = config.get("members") or []
+    members = config["members"] if "members" in config else []
+    if not isinstance(members, list):
+        raise ValueError("Team config.members must be a list")
+
     for position, member in enumerate(members):
         if not isinstance(member, dict):
-            continue
+            raise ValueError(f"Team config.members[{position}] must be an object")
 
         member_type = member.get("type")
         if member_type == "agent":
             child_id = member.get("agent_id")
+            if "team_id" in member:
+                raise ValueError(f"Team config.members[{position}] must declare exactly one of agent_id or team_id")
             in_registry = bool(registry and child_id and registry.get_agent(child_id) is not None)
         elif member_type == "team":
             child_id = member.get("team_id")
+            if "agent_id" in member:
+                raise ValueError(f"Team config.members[{position}] must declare exactly one of agent_id or team_id")
             in_registry = bool(registry and child_id and registry.get_team(child_id) is not None)
         else:
-            continue
+            raise ValueError(f"Team config.members[{position}].type must be 'agent' or 'team'")
 
-        if not child_id:
-            continue
+        if not isinstance(child_id, str) or not child_id:
+            reference_field = "agent_id" if member_type == "agent" else "team_id"
+            raise ValueError(f"Team config.members[{position}].{reference_field} must be a non-empty string")
 
         # Prefer a persisted DB component: create a link so the graph is complete.
         child_component = db.get_component(child_id)
@@ -146,16 +305,210 @@ def _resolve_member_links(
                         "meta": {"type": member_type},
                     }
                 )
-            # A draft-only component (no current_version) still exists; leave it
-            # to be resolved at load time rather than flagging it as unresolved.
+            elif require_published_pins:
+                unresolved.append(child_id)
+            # A draft-only component (no current_version) may still be used by
+            # a draft parent and resolved after it is published.
             continue
 
-        # Not a DB component. If it is a code-defined component it will be
-        # resolved from the registry at load time; otherwise it is unresolved.
-        if not in_registry:
+        # A code-defined component can be resolved only by the live registry,
+        # so it is valid for drafts but cannot satisfy a durable published pin.
+        if require_published_pins or not in_registry:
             unresolved.append(child_id)
 
     return links, unresolved
+
+
+def _published_member_pin_error(team_name: str, unresolved: List[str]) -> str:
+    return (
+        f"Cannot publish team '{team_name}': the following members do not have durable published versions: "
+        f"{', '.join(unresolved)}. Publish DB-backed members first; code-defined members are supported only in "
+        "drafts."
+    )
+
+
+def _unresolved_member_error(team_name: str, unresolved: List[str]) -> str:
+    return (
+        f"Cannot create team '{team_name}': the following members could not be resolved: {', '.join(unresolved)}. "
+        "Referenced agents/teams must exist as components or be registered with the AgentOS instance."
+    )
+
+
+def _component_type_value(component: Dict[str, Any]) -> Optional[str]:
+    component_type = component.get("component_type")
+    if isinstance(component_type, DbComponentType):
+        return component_type.value
+    return component_type if isinstance(component_type, str) else None
+
+
+_WORKFLOW_CONTAINER_FIELDS: Dict[str, Tuple[str, ...]] = {
+    "Parallel": ("steps",),
+    "Loop": ("steps",),
+    "Steps": ("steps",),
+    "Condition": ("steps", "else_steps"),
+    "Router": ("choices",),
+}
+_WORKFLOW_STEP_REFS: Dict[str, Tuple[str, str]] = {
+    "agent_id": ("step_agent", DbComponentType.AGENT.value),
+    "team_id": ("step_team", DbComponentType.TEAM.value),
+    "workflow_id": ("step_workflow", DbComponentType.WORKFLOW.value),
+}
+
+
+def _resolve_workflow_links(
+    config: Dict[str, Any],
+    db: BaseDb,
+    registry: Optional[Registry] = None,
+    *,
+    require_published_pins: bool = False,
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Validate a serialized workflow graph and derive its component links.
+
+    The generic components API accepts raw workflow dictionaries, so link rows
+    are a server-owned projection of ``config.steps``.  Drafts may reference a
+    draft-only DB component or a live registry component without a durable
+    link.  Published workflows require every component step to resolve to the
+    child's exact current published version.
+
+    Nested workflow containers are walked recursively.  Unknown container
+    types, malformed lists, ambiguous Step executors, unresolved functions,
+    and duplicate link keys fail closed before any database mutation.
+    """
+    if "steps" not in config:
+        steps: Any = []
+    else:
+        steps = config["steps"]
+    if not isinstance(steps, list):
+        raise ValueError("Workflow config.steps must be a list")
+
+    links: List[Dict[str, Any]] = []
+    unresolved: List[str] = []
+    seen_link_keys: set[Tuple[str, str]] = set()
+    position = 0
+
+    def _walk(step: Any, path: str) -> None:
+        nonlocal position
+        if not isinstance(step, dict):
+            raise ValueError(f"Workflow {path} must be an object")
+
+        step_type = step.get("type", "Step")
+        if not isinstance(step_type, str) or not step_type:
+            raise ValueError(f"Workflow {path}.type must be a non-empty string")
+
+        if step_type in _WORKFLOW_CONTAINER_FIELDS:
+            unexpected_refs = [key for key in (*_WORKFLOW_STEP_REFS, "executor_ref") if key in step]
+            if unexpected_refs:
+                raise ValueError(
+                    f"Workflow {path} is a {step_type} container and cannot declare executor references: "
+                    f"{', '.join(unexpected_refs)}"
+                )
+            for field in _WORKFLOW_CONTAINER_FIELDS[step_type]:
+                children = step.get(field)
+                if children is None and step_type == "Condition" and field == "else_steps":
+                    continue
+                if not isinstance(children, list):
+                    raise ValueError(f"Workflow {path}.{field} must be a list")
+                for child_position, child in enumerate(children):
+                    _walk(child, f"{path}.{field}[{child_position}]")
+            return
+
+        if step_type != "Step":
+            raise ValueError(f"Workflow {path} has unsupported step type '{step_type}'")
+
+        reference_fields = [key for key in (*_WORKFLOW_STEP_REFS, "executor_ref") if key in step]
+        if len(reference_fields) != 1:
+            raise ValueError(
+                f"Workflow {path} must declare exactly one of agent_id, team_id, workflow_id, or executor_ref"
+            )
+        reference_field = reference_fields[0]
+        reference = step[reference_field]
+        if not isinstance(reference, str) or not reference:
+            raise ValueError(f"Workflow {path}.{reference_field} must be a non-empty string")
+
+        leaf_position = position
+        position += 1
+
+        if reference_field == "executor_ref":
+            function_matches = (
+                [function for function in registry.functions if function.__name__ == reference]
+                if registry is not None
+                else []
+            )
+            if len(function_matches) > 1:
+                raise ValueError(
+                    f"Workflow {path}.executor_ref is ambiguous: multiple registered functions are named {reference!r}"
+                )
+            if len(function_matches) != 1:
+                unresolved.append(reference)
+            return
+
+        link_kind, expected_type = _WORKFLOW_STEP_REFS[reference_field]
+        child_component = db.get_component(reference)
+        if child_component is not None:
+            actual_type = _component_type_value(child_component)
+            if actual_type != expected_type:
+                raise ValueError(
+                    f"Workflow {path}.{reference_field} references {reference!r}, which is a "
+                    f"{actual_type or 'component of unknown type'} instead of a {expected_type}"
+                )
+            child_version = child_component.get("current_version")
+            if child_version is None:
+                if require_published_pins:
+                    unresolved.append(reference)
+                return
+            if not isinstance(child_version, int):
+                raise ValueError(f"Workflow child {reference!r} has an invalid current_version")
+
+            link_key = step.get("step_id") or step.get("name")
+            if not isinstance(link_key, str) or not link_key:
+                raise ValueError(
+                    f"Workflow {path} must have a non-empty step_id or name when it references a component"
+                )
+            key = (link_kind, link_key)
+            if key in seen_link_keys:
+                raise ValueError(f"Workflow contains duplicate {link_kind} link key {link_key!r}")
+            seen_link_keys.add(key)
+            links.append(
+                {
+                    "link_kind": link_kind,
+                    "link_key": link_key,
+                    "child_component_id": reference,
+                    "child_version": child_version,
+                    "position": leaf_position,
+                }
+            )
+            return
+
+        # Registry-backed agents and teams can be rehydrated only while the
+        # live registry is present, so they remain a draft-only convenience.
+        in_registry = False
+        if registry is not None and reference_field == "agent_id":
+            in_registry = registry.get_agent(reference) is not None
+        elif registry is not None and reference_field == "team_id":
+            in_registry = registry.get_team(reference) is not None
+        if require_published_pins or not in_registry:
+            unresolved.append(reference)
+
+    for step_position, step in enumerate(steps):
+        _walk(step, f"config.steps[{step_position}]")
+
+    return links, unresolved
+
+
+def _published_workflow_pin_error(workflow_name: str, unresolved: List[str]) -> str:
+    return (
+        f"Cannot publish workflow '{workflow_name}': the following step references do not have durable "
+        f"published versions: {', '.join(unresolved)}. Publish DB-backed agents, teams, and workflows first; "
+        "code-defined components are supported only in drafts."
+    )
+
+
+def _unresolved_workflow_ref_error(workflow_name: str, unresolved: List[str]) -> str:
+    return (
+        f"Cannot create workflow '{workflow_name}': the following step references could not be resolved: "
+        f"{', '.join(unresolved)}. Component steps must exist in the catalog or live registry, and function "
+        "steps must be registered with the AgentOS instance."
+    )
 
 
 def get_components_router(
@@ -184,6 +537,18 @@ def attach_routes(
     # Component routes require sync database
     if not isinstance(os_db, BaseDb):
         raise ValueError("Component routes require a sync database (BaseDb), not an async database.")
+    if not supports_component_routes(os_db):
+        raise ValueError("Component routes require a database with component persistence support.")
+    if getattr(os_db, "component_catalog_api_version", 1) < 2:
+        # Keep the old adapter calls and HTTP semantics isolated: accepting a
+        # v2 guard and then ignoring it would falsely advertise atomicity.
+        from agno.os.routers.components.legacy import attach_legacy_routes
+
+        log_warning(
+            f"Database {type(os_db).__name__} uses component catalog API v1; "
+            "serving the legacy unguarded Components API"
+        )
+        return attach_legacy_routes(router=router, db=os_db, registry=registry)
     db: BaseDb = os_db  # Type narrowed after isinstance check
 
     @router.get(
@@ -248,33 +613,65 @@ def attach_routes(
                 component_id = generate_id_from_name(body.name)
 
             # Prepare config - ensure it's a dict and resolve db reference
-            config = body.config or {}
+            config = deepcopy(body.config or {})
+            # ComponentCreate's top-level catalog fields are authoritative for
+            # version one. Persist them in the immutable config so a later
+            # rollback can restore null description/metadata as well as name.
+            config.update(
+                {
+                    "name": body.name,
+                    "description": body.description,
+                    "metadata": deepcopy(body.metadata),
+                }
+            )
+            _reject_reserved_studio_config(config)
             config = _resolve_db_in_config(config, db, registry)
 
             # Resolve member references into component links so the component
             # graph reflects the team structure (implements the members TODO).
             links: Optional[List[Dict[str, Any]]] = None
             if body.component_type == ComponentType.TEAM:
-                members = config.get("members")
-                if not members or len(members) == 0:
+                member_links, unresolved = _resolve_member_links(
+                    config,
+                    db,
+                    registry,
+                    require_published_pins=body.stage == "published",
+                )
+                members = config["members"] if "members" in config else []
+                if len(members) == 0:
                     log_warning(
                         f"Creating team '{body.name}' without members. "
                         "If this is unintended, add members to the config."
                     )
                 else:
-                    member_links, unresolved = _resolve_member_links(config, db, registry)
                     # Surface unresolved members instead of silently creating a
                     # team whose members render as "unknown" in the UI.
                     if unresolved:
+                        if body.stage == "published":
+                            detail = _published_member_pin_error(body.name, unresolved)
+                        else:
+                            detail = _unresolved_member_error(body.name, unresolved)
                         raise HTTPException(
                             status_code=400,
-                            detail=(
-                                f"Cannot create team '{body.name}': the following members could not be "
-                                f"resolved: {', '.join(unresolved)}. Referenced agents/teams must exist "
-                                "as components or be registered with the AgentOS instance."
-                            ),
+                            detail=detail,
                         )
                     links = member_links or None
+            elif body.component_type == ComponentType.WORKFLOW:
+                require_published_pins = body.stage == "published"
+                workflow_links, unresolved = _resolve_workflow_links(
+                    config,
+                    db,
+                    registry,
+                    require_published_pins=require_published_pins,
+                )
+                if unresolved:
+                    detail = (
+                        _published_workflow_pin_error(body.name, unresolved)
+                        if require_published_pins
+                        else _unresolved_workflow_ref_error(body.name, unresolved)
+                    )
+                    raise HTTPException(status_code=400, detail=detail)
+                links = workflow_links or None
 
             component, _config = db.create_component_with_config(
                 component_id=component_id,
@@ -292,6 +689,10 @@ def attach_routes(
             return ComponentResponse(**component)
         except HTTPException:
             raise
+        except ComponentAlreadyExistsError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except ComponentCycleError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
@@ -323,38 +724,81 @@ def attach_routes(
 
     @router.patch(
         "/components/{component_id}",
-        response_model=ComponentResponse,
+        response_model=ComponentConfigResponse,
         response_model_exclude_none=True,
         status_code=200,
         operation_id="update_component",
-        summary="Update Component",
-        description="Partially update a component by ID.",
+        summary="Append Component Metadata Draft",
+        description="Copy the latest config and append a guarded metadata-only draft edit.",
     )
     async def update_component(
         component_id: str = Path(description="Component ID"),
-        body: ComponentUpdate = Body(description="Component fields to update"),
-    ) -> ComponentResponse:
+        body: ComponentUpdate = Body(description="Guarded component metadata edit"),
+    ) -> ComponentConfigResponse:
         try:
             existing = db.get_component(component_id)
             if existing is None:
                 raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            _reject_studio_owned_mutation(db, component_id)
 
-            update_kwargs: Dict[str, Any] = {"component_id": component_id}
-            if body.name is not None:
-                update_kwargs["name"] = body.name
-            if body.description is not None:
-                update_kwargs["description"] = body.description
-            if body.metadata is not None:
-                update_kwargs["metadata"] = body.metadata
-            if body.current_version is not None:
-                update_kwargs["current_version"] = body.current_version
-            if body.component_type is not None:
-                update_kwargs["component_type"] = DbComponentType(body.component_type)
+            latest_version = body.guard.latest_version
+            if latest_version is None:
+                raise HTTPException(status_code=409, detail="Component update requires the latest config version")
+            latest = db.get_config(component_id, version=latest_version)
+            if latest is None:
+                raise HTTPException(status_code=409, detail=f"Latest config {component_id} v{latest_version} not found")
+            latest_config = latest.get("config")
+            if not isinstance(latest_config, dict):
+                raise HTTPException(status_code=400, detail=f"Config {component_id} v{latest_version} is invalid")
 
-            component = db.upsert_component(**update_kwargs)
-            return ComponentResponse(**component)
+            component_type = _component_type_value(existing)
+            if component_type is None:
+                raise HTTPException(status_code=400, detail=f"Component {component_id} has an invalid type")
+            config = _append_component_metadata_patch(
+                _canonicalize_component_config(latest_config, fallback=existing),
+                patch=body,
+            )
+
+            if component_type == DbComponentType.TEAM.value:
+                _, unresolved = _resolve_member_links(config, db, registry)
+                if unresolved:
+                    team_name = config.get("name") or existing.get("name") or component_id
+                    raise HTTPException(
+                        status_code=400,
+                        detail=_unresolved_member_error(str(team_name), unresolved),
+                    )
+            elif component_type == DbComponentType.WORKFLOW.value:
+                _, unresolved = _resolve_workflow_links(config, db, registry)
+                if unresolved:
+                    workflow_name = config.get("name") or existing.get("name") or component_id
+                    raise HTTPException(
+                        status_code=400,
+                        detail=_unresolved_workflow_ref_error(str(workflow_name), unresolved),
+                    )
+
+            # Metadata-only edits copy the exact graph owned by the guarded
+            # source version. Publication is the explicit point at which Team
+            # and Workflow references are re-resolved to current exact pins.
+            links = db.get_links(component_id, latest_version)
+
+            projection = (
+                _projection_from_config(config, fallback=existing) if existing.get("current_version") is None else None
+            )
+            appended = db.upsert_config(
+                component_id=component_id,
+                config=config,
+                stage="draft",
+                links=links,
+                guard=_version_guard(body.guard.latest_version, body.guard.current_version),
+                projection=projection,
+            )
+            return ComponentConfigResponse(**appended)
         except HTTPException:
             raise
+        except ComponentVersionConflictError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except ComponentCycleError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
@@ -370,13 +814,40 @@ def attach_routes(
     )
     async def delete_component(
         component_id: str = Path(description="Component ID"),
+        body: ComponentDelete = Body(description="Guarded soft-archive request"),
     ) -> None:
         try:
-            deleted = db.delete_component(component_id)
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            _reject_studio_owned_mutation(db, component_id)
+
+            projection_version = component.get("current_version")
+            if projection_version is None:
+                projection_version = body.guard.latest_version
+            if projection_version is None:
+                raise HTTPException(status_code=409, detail="Component archive requires the latest config version")
+            projection_config = db.get_config(component_id, version=projection_version)
+            if projection_config is None or not isinstance(projection_config.get("config"), dict):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Config {component_id} v{projection_version} cannot provide an archive projection",
+                )
+
+            deleted = db.delete_component(
+                component_id,
+                hard_delete=False,
+                guard=_version_guard(body.guard.latest_version, body.guard.current_version),
+                projection=_projection_from_config(projection_config["config"], fallback=component),
+            )
             if not deleted:
                 raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
         except HTTPException:
             raise
+        except (ComponentDependencyError, ComponentVersionConflictError) as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             log_error(f"Error deleting component: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
@@ -415,9 +886,71 @@ def attach_routes(
         body: ConfigCreate = Body(description="Config data"),
     ) -> ComponentConfigResponse:
         try:
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            _reject_studio_owned_mutation(db, component_id)
+
             # Resolve db from config if present
-            config_data = body.config or {}
+            config_data = _canonicalize_component_config(body.config or {}, fallback=component)
+            _reject_reserved_studio_config(config_data)
             config_data = _resolve_db_in_config(config_data, db, registry)
+
+            links = body.links
+            component_type = _component_type_value(component)
+            if component_type == DbComponentType.TEAM.value:
+                if body.links is not None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Team links are derived from config.members and must not be supplied by the caller.",
+                    )
+                require_published_pins = body.stage == "published"
+                member_links, unresolved = _resolve_member_links(
+                    config_data,
+                    db,
+                    registry,
+                    require_published_pins=require_published_pins,
+                )
+                if unresolved:
+                    team_name = config_data.get("name")
+                    if not isinstance(team_name, str) or not team_name:
+                        team_name = component.get("name") or component_id
+                    detail = (
+                        _published_member_pin_error(team_name, unresolved)
+                        if require_published_pins
+                        else _unresolved_member_error(team_name, unresolved)
+                    )
+                    raise HTTPException(status_code=400, detail=detail)
+                links = member_links or None
+            elif component_type == DbComponentType.WORKFLOW.value:
+                if body.links is not None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Workflow links are derived from config.steps and must not be supplied by the caller.",
+                    )
+                require_published_pins = body.stage == "published"
+                workflow_links, unresolved = _resolve_workflow_links(
+                    config_data,
+                    db,
+                    registry,
+                    require_published_pins=require_published_pins,
+                )
+                if unresolved:
+                    workflow_name = config_data.get("name")
+                    if not isinstance(workflow_name, str) or not workflow_name:
+                        workflow_name = component.get("name") or component_id
+                    detail = (
+                        _published_workflow_pin_error(workflow_name, unresolved)
+                        if require_published_pins
+                        else _unresolved_workflow_ref_error(workflow_name, unresolved)
+                    )
+                    raise HTTPException(status_code=400, detail=detail)
+                links = workflow_links or None
+            elif body.links is not None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Agent configs do not support component links; links are owned by Team and Workflow config.",
+                )
 
             config = db.upsert_config(
                 component_id=component_id,
@@ -426,9 +959,21 @@ def attach_routes(
                 label=body.label,
                 stage=body.stage,
                 notes=body.notes,
-                links=body.links,
+                links=links,
+                guard=_version_guard(body.guard.latest_version, body.guard.current_version),
+                projection=(
+                    _projection_from_config(config_data, fallback=component)
+                    if body.stage == "published" or component.get("current_version") is None
+                    else None
+                ),
             )
             return ComponentConfigResponse(**config)
+        except HTTPException:
+            raise
+        except ComponentVersionConflictError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except ComponentCycleError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
@@ -441,30 +986,88 @@ def attach_routes(
         response_model_exclude_none=True,
         status_code=200,
         operation_id="update_config",
-        summary="Update Draft Config",
-        description="Update an existing draft config. Cannot update published configs.",
+        summary="Publish Draft Config",
+        description="Publish the latest draft config without mutating its payload.",
     )
     async def update_config(
         component_id: str = Path(description="Component ID"),
         version: int = Path(description="Version number"),
-        body: ConfigUpdate = Body(description="Config fields to update"),
+        body: ConfigUpdate = Body(description="Guarded draft publication request"),
     ) -> ComponentConfigResponse:
         try:
-            # Resolve db from config if present
-            config_data = body.config
-            if config_data is not None:
-                config_data = _resolve_db_in_config(config_data, db, registry)
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            _reject_studio_owned_mutation(db, component_id)
+
+            target = db.get_config(component_id, version=version)
+            if target is None:
+                raise HTTPException(status_code=404, detail=f"Config {component_id} v{version} not found")
+
+            component_type = _component_type_value(component)
+            is_team = component_type == DbComponentType.TEAM.value
+            is_workflow = component_type == DbComponentType.WORKFLOW.value
+            links: List[Dict[str, Any]] = []
+            target_config: Dict[str, Any] = {}
+            if is_team or is_workflow:
+                target_config_data = target.get("config")
+                if not isinstance(target_config_data, dict):
+                    raise HTTPException(status_code=400, detail=f"Config {component_id} v{version} is invalid")
+                target_config = target_config_data
+
+            if is_team:
+                member_links, unresolved = _resolve_member_links(
+                    target_config,
+                    db,
+                    registry,
+                    require_published_pins=True,
+                )
+                if unresolved:
+                    team_name = target_config.get("name")
+                    if not isinstance(team_name, str) or not team_name:
+                        team_name = component.get("name") or component_id
+                    raise HTTPException(
+                        status_code=400,
+                        detail=_published_member_pin_error(team_name, unresolved),
+                    )
+                links = member_links
+            elif is_workflow:
+                workflow_links, unresolved = _resolve_workflow_links(
+                    target_config,
+                    db,
+                    registry,
+                    require_published_pins=True,
+                )
+                if unresolved:
+                    workflow_name = target_config.get("name")
+                    if not isinstance(workflow_name, str) or not workflow_name:
+                        workflow_name = component.get("name") or component_id
+                    raise HTTPException(
+                        status_code=400,
+                        detail=_published_workflow_pin_error(workflow_name, unresolved),
+                    )
+                links = workflow_links
+
+            upsert_kwargs: Dict[str, Any] = {
+                "component_id": component_id,
+                "version": version,
+                "stage": body.stage,
+                "guard": _version_guard(body.guard.latest_version, body.guard.current_version),
+                "projection": _projection_from_config(target["config"], fallback=component),
+            }
+            if is_team or is_workflow:
+                upsert_kwargs["links"] = links
 
             config = db.upsert_config(
-                component_id=component_id,
-                version=version,  # Always update existing
-                config=config_data,
-                label=body.label,
-                stage=body.stage,
-                notes=body.notes,
-                links=body.links,
+                **upsert_kwargs,
             )
             return ComponentConfigResponse(**config)
+        except HTTPException:
+            raise
+        except ComponentVersionConflictError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except ComponentCycleError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
@@ -484,7 +1087,7 @@ def attach_routes(
         component_id: str = Path(description="Component ID"),
     ) -> ComponentConfigResponse:
         try:
-            config = db.get_config(component_id)
+            config = db.get_current_config(component_id=component_id)
             if config is None:
                 raise HTTPException(status_code=404, detail=f"No current config for {component_id}")
             return ComponentConfigResponse(**config)
@@ -529,14 +1132,50 @@ def attach_routes(
     async def delete_config_version(
         component_id: str = Path(description="Component ID"),
         version: int = Path(description="Version number"),
+        body: ConfigDelete = Body(description="Guarded draft-version deletion request"),
     ) -> None:
         try:
-            # Resolve version number
-            deleted = db.delete_config(component_id, version=version)
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            _reject_studio_owned_mutation(db, component_id)
+
+            projection_config: Optional[Dict[str, Any]] = None
+            current_version = component.get("current_version")
+            if isinstance(current_version, int):
+                current = db.get_config(component_id, version=current_version)
+                if current is not None and isinstance(current.get("config"), dict):
+                    projection_config = current["config"]
+            else:
+                remaining = [
+                    row
+                    for row in db.list_configs(component_id, include_config=True)
+                    if row.get("version") != version and isinstance(row.get("config"), dict)
+                ]
+                if remaining:
+                    projection_config = remaining[0]["config"]
+
+            deleted = db.delete_config(
+                component_id,
+                version=version,
+                guard=_version_guard(body.guard.latest_version, body.guard.current_version),
+                projection=(
+                    _projection_from_config(projection_config, fallback=component)
+                    if projection_config is not None
+                    else None
+                ),
+            )
             if not deleted:
                 raise HTTPException(status_code=404, detail=f"Config {component_id} v{version} not found")
         except HTTPException:
             raise
+        except (
+            ComponentDependencyError,
+            ComponentDraftRequiredError,
+            ComponentLastConfigError,
+            ComponentVersionConflictError,
+        ) as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
@@ -555,22 +1194,35 @@ def attach_routes(
     async def set_current_config(
         component_id: str = Path(description="Component ID"),
         version: int = Path(description="Version number"),
+        body: SetCurrentConfig = Body(description="Guarded current-version update"),
     ) -> ComponentResponse:
         try:
-            success = db.set_current_version(component_id, version=version)
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            _reject_studio_owned_mutation(db, component_id)
+
+            target = db.get_config(component_id, version=version)
+            if target is None:
+                raise HTTPException(status_code=404, detail=f"Config {component_id} v{version} not found")
+            projection = _projection_from_config(target["config"], fallback=component)
+
+            success = db.set_current_version(
+                component_id,
+                version=version,
+                guard=_version_guard(body.guard.latest_version, body.guard.current_version),
+                projection=projection,
+            )
             if not success:
                 raise HTTPException(
                     status_code=404, detail=f"Component {component_id} or config version {version} not found"
                 )
 
-            # Fetch and return updated component
-            component = db.get_component(component_id)
-            if component is None:
-                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
-
-            return ComponentResponse(**component)
+            return ComponentResponse(**_project_component_response(component, projection, current_version=version))
         except HTTPException:
             raise
+        except ComponentVersionConflictError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:

--- a/libs/agno/agno/os/routers/components/legacy.py
+++ b/libs/agno/agno/os/routers/components/legacy.py
@@ -1,0 +1,439 @@
+"""Compatibility Components API for pre-2.9 database adapters.
+
+Catalog-v1 adapters expose independent, unguarded component/config writes.
+Keep those request and call shapes separate from the guarded catalog-v2 router
+so OpenAPI never promises compare-and-set or atomic lifecycle semantics that a
+legacy adapter cannot provide.
+"""
+
+import time
+from copy import deepcopy
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Body, HTTPException, Path, Query
+from pydantic import BaseModel, Field
+
+from agno.db.base import BaseDb
+from agno.db.base import ComponentType as DbComponentType
+from agno.os.schema import (
+    ComponentConfigResponse,
+    ComponentResponse,
+    ComponentType,
+    PaginatedResponse,
+    PaginationInfo,
+)
+from agno.registry import Registry
+from agno.utils.log import log_error, log_warning
+from agno.utils.string import generate_id_from_name
+
+
+class LegacyComponentCreate(BaseModel):
+    """Pre-2.9 component plus initial mutable config request."""
+
+    name: str = Field(..., description="Display name")
+    component_id: Optional[str] = None
+    component_type: ComponentType
+    description: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    config: Optional[Dict[str, Any]] = None
+    label: Optional[str] = None
+    stage: str = "draft"
+    notes: Optional[str] = None
+    set_current: bool = True
+
+
+class LegacyComponentUpdate(BaseModel):
+    """Unguarded catalog-v1 component-row patch."""
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    component_type: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    current_version: Optional[int] = None
+
+
+class LegacyConfigCreate(BaseModel):
+    """Unguarded catalog-v1 config append."""
+
+    config: Dict[str, Any] = Field(..., description="The configuration data")
+    version: Optional[int] = None
+    label: Optional[str] = None
+    stage: str = "draft"
+    notes: Optional[str] = None
+    links: Optional[List[Dict[str, Any]]] = None
+    set_current: bool = True
+
+
+class LegacyConfigUpdate(BaseModel):
+    """Mutable catalog-v1 draft config patch."""
+
+    config: Optional[Dict[str, Any]] = None
+    label: Optional[str] = None
+    stage: Optional[str] = None
+    notes: Optional[str] = None
+    links: Optional[List[Dict[str, Any]]] = None
+
+
+def attach_legacy_routes(router: APIRouter, db: BaseDb, registry: Optional[Registry] = None) -> APIRouter:
+    """Attach the exact unguarded API supported by catalog-v1 adapters."""
+    # Imported lazily by the v2 module after it has finished initialization,
+    # avoiding a module cycle while reusing its DB-reference resolver.
+    from agno.os.routers.components.components import _resolve_db_in_config, _resolve_member_links
+
+    @router.get(
+        "/components",
+        response_model=PaginatedResponse[ComponentResponse],
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="list_components",
+        summary="List Components (Legacy Catalog)",
+        description="Retrieve components from an unguarded catalog-v1 database adapter.",
+    )
+    async def list_components(
+        component_type: Optional[ComponentType] = Query(None, description="Filter by type"),
+        page: int = Query(1, ge=1, description="Page number"),
+        limit: int = Query(20, ge=1, le=100, description="Items per page"),
+    ) -> PaginatedResponse[ComponentResponse]:
+        try:
+            start_time_ms = time.time() * 1000
+            exclude_ids = registry.get_all_component_ids() if registry else None
+            components, total_count = db.list_components(
+                component_type=DbComponentType(component_type.value) if component_type else None,
+                limit=limit,
+                offset=(page - 1) * limit,
+                exclude_component_ids=exclude_ids or None,
+            )
+            return PaginatedResponse(
+                data=[ComponentResponse(**component) for component in components],
+                meta=PaginationInfo(
+                    page=page,
+                    limit=limit,
+                    total_pages=(total_count + limit - 1) // limit,
+                    total_count=total_count,
+                    search_time_ms=round(time.time() * 1000 - start_time_ms, 2),
+                ),
+            )
+        except Exception as error:
+            log_error(f"Error listing components through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.post(
+        "/components",
+        response_model=ComponentResponse,
+        response_model_exclude_none=True,
+        status_code=201,
+        operation_id="create_component",
+        summary="Create Component (Legacy Catalog)",
+        description="Create a component and config with two non-atomic catalog-v1 writes.",
+    )
+    async def create_component(body: LegacyComponentCreate) -> ComponentResponse:
+        try:
+            component_id = body.component_id or generate_id_from_name(body.name)
+            config = _resolve_db_in_config(deepcopy(body.config or {}), db, registry)
+
+            links: Optional[List[Dict[str, Any]]] = None
+            if body.component_type == ComponentType.TEAM:
+                members = config.get("members") or []
+                if not members:
+                    log_warning(
+                        f"Creating team '{body.name}' without members. If this is unintended, add members "
+                        "to the config."
+                    )
+                else:
+                    member_links, unresolved = _resolve_member_links(config, db, registry)
+                    if unresolved:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=(
+                                f"Cannot create team '{body.name}': the following members could not be "
+                                f"resolved: {', '.join(unresolved)}. Referenced agents/teams must exist "
+                                "as components or be registered with the AgentOS instance."
+                            ),
+                        )
+                    links = member_links or None
+
+            component = db.upsert_component(
+                component_id=component_id,
+                component_type=DbComponentType(body.component_type.value),
+                name=body.name,
+                description=body.description,
+                metadata=body.metadata,
+            )
+            db.upsert_config(
+                component_id=component_id,
+                config=config,
+                label=body.label,
+                stage=body.stage,
+                notes=body.notes,
+                links=links,
+            )
+            return ComponentResponse(**component)
+        except HTTPException:
+            raise
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error))
+        except Exception as error:
+            log_error(f"Error creating component through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.get(
+        "/components/{component_id}",
+        response_model=ComponentResponse,
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="get_component",
+        summary="Get Component (Legacy Catalog)",
+    )
+    async def get_component(component_id: str = Path(description="Component ID")) -> ComponentResponse:
+        try:
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            return ComponentResponse(**component)
+        except HTTPException:
+            raise
+        except Exception as error:
+            log_error(f"Error getting component through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.patch(
+        "/components/{component_id}",
+        response_model=ComponentResponse,
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="update_component",
+        summary="Update Component (Legacy Catalog)",
+        description="Apply an unguarded catalog-v1 component-row patch.",
+    )
+    async def update_component(
+        component_id: str = Path(description="Component ID"),
+        body: LegacyComponentUpdate = Body(description="Unguarded component fields"),
+    ) -> ComponentResponse:
+        try:
+            if db.get_component(component_id) is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+
+            update_kwargs: Dict[str, Any] = {"component_id": component_id}
+            if body.name is not None:
+                update_kwargs["name"] = body.name
+            if body.description is not None:
+                update_kwargs["description"] = body.description
+            if body.metadata is not None:
+                update_kwargs["metadata"] = body.metadata
+            if body.current_version is not None:
+                update_kwargs["current_version"] = body.current_version
+            if body.component_type is not None:
+                update_kwargs["component_type"] = DbComponentType(body.component_type)
+            return ComponentResponse(**db.upsert_component(**update_kwargs))
+        except HTTPException:
+            raise
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error))
+        except Exception as error:
+            log_error(f"Error updating component through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.delete(
+        "/components/{component_id}",
+        status_code=204,
+        operation_id="delete_component",
+        summary="Delete Component (Legacy Catalog)",
+        description="Delete a component without v2 dependency or version guards.",
+    )
+    async def delete_component(component_id: str = Path(description="Component ID")) -> None:
+        try:
+            if not db.delete_component(component_id):
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+        except HTTPException:
+            raise
+        except Exception as error:
+            log_error(f"Error deleting component through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.get(
+        "/components/{component_id}/configs",
+        response_model=List[ComponentConfigResponse],
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="list_configs",
+        summary="List Configs (Legacy Catalog)",
+    )
+    async def list_configs(
+        component_id: str = Path(description="Component ID"),
+        include_config: bool = Query(True, description="Include full config blob"),
+    ) -> List[ComponentConfigResponse]:
+        try:
+            return [
+                ComponentConfigResponse(**config)
+                for config in db.list_configs(component_id, include_config=include_config)
+            ]
+        except Exception as error:
+            log_error(f"Error listing configs through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.post(
+        "/components/{component_id}/configs",
+        response_model=ComponentConfigResponse,
+        response_model_exclude_none=True,
+        status_code=201,
+        operation_id="create_config",
+        summary="Create Config Version (Legacy Catalog)",
+        description="Append an unguarded catalog-v1 config version.",
+    )
+    async def create_config(
+        component_id: str = Path(description="Component ID"),
+        body: LegacyConfigCreate = Body(description="Unguarded config data"),
+    ) -> ComponentConfigResponse:
+        try:
+            config_data = _resolve_db_in_config(deepcopy(body.config), db, registry)
+            config = db.upsert_config(
+                component_id=component_id,
+                version=None,
+                config=config_data,
+                label=body.label,
+                stage=body.stage,
+                notes=body.notes,
+                links=body.links,
+            )
+            return ComponentConfigResponse(**config)
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error))
+        except Exception as error:
+            log_error(f"Error creating config through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.patch(
+        "/components/{component_id}/configs/{version}",
+        response_model=ComponentConfigResponse,
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="update_config",
+        summary="Update Draft Config (Legacy Catalog)",
+        description="Mutate a draft through the unguarded catalog-v1 contract.",
+    )
+    async def update_config(
+        component_id: str = Path(description="Component ID"),
+        version: int = Path(description="Version number"),
+        body: LegacyConfigUpdate = Body(description="Unguarded config fields"),
+    ) -> ComponentConfigResponse:
+        try:
+            config_data = deepcopy(body.config)
+            if config_data is not None:
+                config_data = _resolve_db_in_config(config_data, db, registry)
+            config = db.upsert_config(
+                component_id=component_id,
+                version=version,
+                config=config_data,
+                label=body.label,
+                stage=body.stage,
+                notes=body.notes,
+                links=body.links,
+            )
+            return ComponentConfigResponse(**config)
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error))
+        except Exception as error:
+            log_error(f"Error updating config through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.get(
+        "/components/{component_id}/configs/current",
+        response_model=ComponentConfigResponse,
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="get_current_config",
+        summary="Get Current Config (Legacy Catalog)",
+        description="Resolve the adapter's historical default config selection.",
+    )
+    async def get_current_config(component_id: str = Path(description="Component ID")) -> ComponentConfigResponse:
+        try:
+            config = db.get_config(component_id)
+            if config is None:
+                raise HTTPException(status_code=404, detail=f"No current config for {component_id}")
+            return ComponentConfigResponse(**config)
+        except HTTPException:
+            raise
+        except Exception as error:
+            log_error(f"Error getting current config through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.get(
+        "/components/{component_id}/configs/{version}",
+        response_model=ComponentConfigResponse,
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="get_config",
+        summary="Get Config Version (Legacy Catalog)",
+    )
+    async def get_config_version(
+        component_id: str = Path(description="Component ID"),
+        version: int = Path(description="Version number"),
+    ) -> ComponentConfigResponse:
+        try:
+            config = db.get_config(component_id, version=version)
+            if config is None:
+                raise HTTPException(status_code=404, detail=f"Config {component_id} v{version} not found")
+            return ComponentConfigResponse(**config)
+        except HTTPException:
+            raise
+        except Exception as error:
+            log_error(f"Error getting config through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.delete(
+        "/components/{component_id}/configs/{version}",
+        status_code=204,
+        operation_id="delete_config",
+        summary="Delete Config Version (Legacy Catalog)",
+        description="Delete a draft without a v2 compare-and-set guard.",
+    )
+    async def delete_config_version(
+        component_id: str = Path(description="Component ID"),
+        version: int = Path(description="Version number"),
+    ) -> None:
+        try:
+            if not db.delete_config(component_id, version=version):
+                raise HTTPException(status_code=404, detail=f"Config {component_id} v{version} not found")
+        except HTTPException:
+            raise
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error))
+        except Exception as error:
+            log_error(f"Error deleting config through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @router.post(
+        "/components/{component_id}/configs/{version}/set-current",
+        response_model=ComponentResponse,
+        response_model_exclude_none=True,
+        status_code=200,
+        operation_id="set_current_config",
+        summary="Set Current Config Version (Legacy Catalog)",
+        description="Move the current pointer without a v2 compare-and-set guard.",
+    )
+    async def set_current_config(
+        component_id: str = Path(description="Component ID"),
+        version: int = Path(description="Version number"),
+    ) -> ComponentResponse:
+        try:
+            if not db.set_current_version(component_id, version=version):
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Component {component_id} or config version {version} not found",
+                )
+            component = db.get_component(component_id)
+            if component is None:
+                raise HTTPException(status_code=404, detail=f"Component {component_id} not found")
+            return ComponentResponse(**component)
+        except HTTPException:
+            raise
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error))
+        except Exception as error:
+            log_error(f"Error setting current config through catalog v1: {error}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    return router
+
+
+__all__ = ["attach_legacy_routes"]

--- a/libs/agno/agno/os/routers/schedules/router.py
+++ b/libs/agno/agno/os/routers/schedules/router.py
@@ -7,6 +7,11 @@ from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from agno.db.schemas.scheduler import (
+    STUDIO_SCHEDULE_MANAGED_BY,
+    ScheduleNameConflictError,
+    is_studio_managed_schedule,
+)
 from agno.os.routers.schedules.schema import (
     ScheduleCreate,
     ScheduleResponse,
@@ -56,8 +61,8 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
 
             _require_croniter()
             _require_pytz()
-        except ImportError as exc:
-            raise HTTPException(status_code=503, detail=str(exc))
+        except ImportError:
+            raise HTTPException(status_code=503, detail="Scheduler dependencies are not installed")
 
     async def _db_call(method_name: _SchedulerDbMethod, *args: Any, **kwargs: Any) -> Any:
         fn = getattr(os_db, method_name, None)
@@ -70,6 +75,76 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         except NotImplementedError:
             raise HTTPException(status_code=503, detail="Scheduler not supported by the configured database")
 
+    async def _get_generic_schedule(schedule_id: str) -> Dict[str, Any]:
+        """Load an ordinary scheduler record without disclosing Studio rows."""
+        schedule = await _db_call("get_schedule", schedule_id)
+        if schedule is None or is_studio_managed_schedule(schedule):
+            raise HTTPException(status_code=404, detail="Schedule not found")
+        return schedule
+
+    def _name_conflict(name: str) -> HTTPException:
+        return HTTPException(status_code=409, detail=f"Schedule with name '{name}' already exists")
+
+    def _scheduler_api_version() -> int:
+        version = getattr(os_db, "scheduler_api_version", 1)
+        return version if isinstance(version, int) else 1
+
+    async def _schedule_name_is_taken(name: str, *, excluding_schedule_id: Optional[str] = None) -> bool:
+        if _scheduler_api_version() >= 2:
+            existing = await _db_call(
+                "get_schedule_by_name",
+                name,
+                exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            )
+        else:
+            # Legacy custom adapters do not accept the v2 scope keywords. A
+            # Studio row found through their global lookup remains invisible.
+            existing = await _db_call("get_schedule_by_name", name)
+        if existing is None or is_studio_managed_schedule(existing):
+            return False
+        existing_id = existing.get("id") if isinstance(existing, dict) else getattr(existing, "id", None)
+        return excluding_schedule_id is None or existing_id != excluding_schedule_id
+
+    def _unpack_schedule_page(result: Any) -> tuple[list[Any], Optional[int]]:
+        if isinstance(result, tuple):
+            rows = list(result[0])
+            total = result[1] if len(result) > 1 and isinstance(result[1], int) else None
+            return rows, total
+        return list(result or []), None
+
+    def _schedule_identity(schedule: Any) -> str:
+        schedule_id = schedule.get("id") if isinstance(schedule, dict) else getattr(schedule, "id", None)
+        return str(schedule_id) if schedule_id is not None else repr(schedule)
+
+    async def _scan_visible_schedules(enabled: Optional[bool], *, use_v2_filter: bool) -> list[Any]:
+        """Scan and locally filter adapters whose pagination cannot be trusted."""
+        batch_size = 1000
+        scan_page = 1
+        seen: set[str] = set()
+        visible: list[Any] = []
+        while True:
+            query: Dict[str, Any] = {"enabled": enabled, "limit": batch_size, "page": scan_page}
+            if use_v2_filter:
+                query["exclude_managed_by"] = STUDIO_SCHEDULE_MANAGED_BY
+            rows, reported_total = _unpack_schedule_page(await _db_call("get_schedules", **query))
+            new_rows = 0
+            for schedule in rows:
+                identity = _schedule_identity(schedule)
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                new_rows += 1
+                if not is_studio_managed_schedule(schedule):
+                    visible.append(schedule)
+            if not rows or new_rows == 0:
+                break
+            if reported_total is not None and len(seen) >= reported_total:
+                break
+            if reported_total is None and len(rows) < batch_size:
+                break
+            scan_page += 1
+        return visible
+
     # ------------------------------------------------------------------
     # Endpoints
     # ------------------------------------------------------------------
@@ -81,15 +156,39 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         page: int = Query(1, ge=1),
         _: bool = Depends(auth_dependency),
     ) -> PaginatedResponse[ScheduleResponse]:
-        schedules, total_count = await _db_call("get_schedules", enabled=enabled, limit=limit, page=page)
+        if _scheduler_api_version() >= 2:
+            result = await _db_call(
+                "get_schedules",
+                enabled=enabled,
+                limit=limit,
+                page=page,
+                exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            )
+            schedules, total_count = _unpack_schedule_page(result)
+            if any(is_studio_managed_schedule(schedule) for schedule in schedules):
+                all_visible = await _scan_visible_schedules(enabled, use_v2_filter=True)
+                total_count = len(all_visible)
+                offset = (page - 1) * limit
+                visible_schedules = all_visible[offset : offset + limit]
+            else:
+                visible_schedules = schedules
+                total_count = total_count if total_count is not None else len(visible_schedules)
+        else:
+            # v1 adapters receive only the historical call shape. Scan before
+            # filtering so hidden Studio rows cannot skew count or pagination.
+            all_visible = await _scan_visible_schedules(enabled, use_v2_filter=False)
+            total_count = len(all_visible)
+            offset = (page - 1) * limit
+            visible_schedules = all_visible[offset : offset + limit]
         total_pages = (total_count + limit - 1) // limit if total_count > 0 else 0
         return PaginatedResponse(
-            data=schedules,
+            data=visible_schedules,
             meta=PaginationInfo(
                 page=page,
                 limit=limit,
                 total_pages=total_pages,
                 total_count=total_count,
+                search_time_ms=0.0,
             ),
         )
 
@@ -107,9 +206,8 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
             raise HTTPException(status_code=422, detail=f"Invalid timezone: {body.timezone}")
 
         # Check name uniqueness
-        existing = await _db_call("get_schedule_by_name", body.name)
-        if existing is not None:
-            raise HTTPException(status_code=409, detail=f"Schedule with name '{body.name}' already exists")
+        if await _schedule_name_is_taken(body.name):
+            raise _name_conflict(body.name)
 
         next_run_at = compute_next_run(body.cron_expr, body.timezone)
         now = int(time.time())
@@ -134,8 +232,22 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
             "updated_at": None,
         }
 
-        result = await _db_call("create_schedule", schedule_dict)
+        try:
+            result = await _db_call("create_schedule", schedule_dict)
+        except ScheduleNameConflictError as error:
+            raise _name_conflict(error.name) from None
+        except HTTPException:
+            raise
+        except Exception:
+            # The database's unique name constraint is authoritative. Another
+            # request can win after the preflight lookup, so translate only a
+            # confirmed competing row into the stable API conflict response.
+            if await _schedule_name_is_taken(body.name, excluding_schedule_id=schedule_dict["id"]):
+                raise _name_conflict(body.name) from None
+            raise
         if result is None:
+            if await _schedule_name_is_taken(body.name, excluding_schedule_id=schedule_dict["id"]):
+                raise _name_conflict(body.name)
             raise HTTPException(status_code=500, detail="Failed to create schedule")
         return result
 
@@ -144,10 +256,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         schedule_id: str,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
-        schedule = await _db_call("get_schedule", schedule_id)
-        if schedule is None:
-            raise HTTPException(status_code=404, detail="Schedule not found")
-        return schedule
+        return await _get_generic_schedule(schedule_id)
 
     @router.patch("/schedules/{schedule_id}", response_model=ScheduleResponse)
     async def update_schedule(
@@ -155,9 +264,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         body: ScheduleUpdate,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
-        existing = await _db_call("get_schedule", schedule_id)
-        if existing is None:
-            raise HTTPException(status_code=404, detail="Schedule not found")
+        existing = await _get_generic_schedule(schedule_id)
 
         updates = body.model_dump(exclude_unset=True)
         if not updates:
@@ -180,12 +287,22 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
 
         # Validate name uniqueness if changing
         if "name" in updates and updates["name"] != existing["name"]:
-            dup = await _db_call("get_schedule_by_name", updates["name"])
-            if dup is not None:
-                raise HTTPException(status_code=409, detail=f"Schedule with name '{updates['name']}' already exists")
+            if await _schedule_name_is_taken(updates["name"]):
+                raise _name_conflict(updates["name"])
 
-        result = await _db_call("update_schedule", schedule_id, **updates)
+        try:
+            result = await _db_call("update_schedule", schedule_id, **updates)
+        except ScheduleNameConflictError as error:
+            raise _name_conflict(error.name) from None
+        except HTTPException:
+            raise
+        except Exception:
+            if "name" in updates and await _schedule_name_is_taken(updates["name"], excluding_schedule_id=schedule_id):
+                raise _name_conflict(updates["name"]) from None
+            raise
         if result is None:
+            if "name" in updates and await _schedule_name_is_taken(updates["name"], excluding_schedule_id=schedule_id):
+                raise _name_conflict(updates["name"])
             raise HTTPException(status_code=500, detail="Failed to update schedule")
         return result
 
@@ -194,9 +311,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         schedule_id: str,
         _: bool = Depends(auth_dependency),
     ) -> None:
-        existing = await _db_call("get_schedule", schedule_id)
-        if existing is None:
-            raise HTTPException(status_code=404, detail="Schedule not found")
+        await _get_generic_schedule(schedule_id)
         deleted = await _db_call("delete_schedule", schedule_id)
         if not deleted:
             raise HTTPException(status_code=500, detail="Failed to delete schedule")
@@ -206,9 +321,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         schedule_id: str,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
-        existing = await _db_call("get_schedule", schedule_id)
-        if existing is None:
-            raise HTTPException(status_code=404, detail="Schedule not found")
+        existing = await _get_generic_schedule(schedule_id)
 
         _check_scheduler_deps()
         from agno.scheduler.cron import compute_next_run
@@ -225,9 +338,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         schedule_id: str,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
-        existing = await _db_call("get_schedule", schedule_id)
-        if existing is None:
-            raise HTTPException(status_code=404, detail="Schedule not found")
+        existing = await _get_generic_schedule(schedule_id)
 
         result = await _db_call("update_schedule", schedule_id, enabled=False)
         if result is None:
@@ -241,9 +352,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         request: Request,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
-        existing = await _db_call("get_schedule", schedule_id)
-        if existing is None:
-            raise HTTPException(status_code=404, detail="Schedule not found")
+        existing = await _get_generic_schedule(schedule_id)
 
         if not existing.get("enabled", True):
             raise HTTPException(status_code=409, detail="Schedule is disabled")
@@ -262,9 +371,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         page: int = Query(1, ge=1),
         _: bool = Depends(auth_dependency),
     ) -> PaginatedResponse[ScheduleRunResponse]:
-        existing = await _db_call("get_schedule", schedule_id)
-        if existing is None:
-            raise HTTPException(status_code=404, detail="Schedule not found")
+        await _get_generic_schedule(schedule_id)
         runs, total_count = await _db_call("get_schedule_runs", schedule_id, limit=limit, page=page)
         total_pages = (total_count + limit - 1) // limit if total_count > 0 else 0
         return PaginatedResponse(
@@ -274,6 +381,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
                 limit=limit,
                 total_pages=total_pages,
                 total_count=total_count,
+                search_time_ms=0.0,
             ),
         )
 
@@ -283,6 +391,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         run_id: str,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
+        await _get_generic_schedule(schedule_id)
         run = await _db_call("get_schedule_run", run_id)
         if run is None or run.get("schedule_id") != schedule_id:
             raise HTTPException(status_code=404, detail="Schedule run not found")

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -586,7 +586,10 @@ def get_team_router(
         files: Optional[List[UploadFile]] = File(
             None, description="Files to upload (images, audio, video, or documents)"
         ),
-        version: Optional[int] = Form(None, description="Team version to use for this run"),
+        version: Optional[int] = Form(
+            None,
+            description="Exact Team version to use for this run, including a draft version for explicit preview",
+        ),
         background: bool = Form(
             False, description="Run in background and return immediately with run metadata (requires database)"
         ),
@@ -1455,7 +1458,14 @@ def get_team_router(
             return TeamResponse.from_factory(factory)
 
         try:
-            team = get_team_by_id(team_id=team_id, teams=os.teams, db=os.db, registry=registry, create_fresh=True)  # type: ignore[assignment]
+            team = get_team_by_id(
+                team_id=team_id,
+                teams=os.teams,
+                db=os.db,
+                registry=registry,
+                create_fresh=True,
+                published_only=False,
+            )  # type: ignore[assignment]
         except ComponentRehydrationError as rehydration_error:
             raise HTTPException(status_code=rehydration_error.status_code, detail=str(rehydration_error))
         except Exception as e:

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -75,6 +75,7 @@ async def handle_workflow_via_websocket(
         session_id = message.get("session_id")
         user_message = message.get("message", "")
         user_id = message.get("user_id")
+        version = message.get("version")
         factory_input = message.get("factory_input")
 
         # Defense-in-depth: if the caller authenticated via JWT, ensure user_id
@@ -125,6 +126,7 @@ async def handle_workflow_via_websocket(
                     workflow_id=workflow_id,
                     workflows=os.workflows,
                     db=os.db,
+                    version=version,
                     registry=os.registry,
                     create_fresh=True,
                     ctx=ctx,
@@ -135,7 +137,12 @@ async def handle_workflow_via_websocket(
         else:
             try:
                 workflow = get_workflow_by_id(
-                    workflow_id=workflow_id, workflows=os.workflows, db=os.db, registry=os.registry, create_fresh=True
+                    workflow_id=workflow_id,
+                    workflows=os.workflows,
+                    db=os.db,
+                    version=version,
+                    registry=os.registry,
+                    create_fresh=True,
                 )
             except Exception as e:
                 await websocket.send_text(json.dumps({"event": "error", "error": f"Error resolving workflow: {e}"}))

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1113,6 +1113,7 @@ def get_workflow_router(
                 registry=os.registry,
                 create_fresh=True,
                 version=version,
+                published_only=False,
             )  # type: ignore[assignment]
         except ComponentRehydrationError as rehydration_error:
             raise HTTPException(status_code=rehydration_error.status_code, detail=str(rehydration_error))
@@ -1176,7 +1177,10 @@ def get_workflow_router(
             None, description="Session ID for conversation continuity. If not provided, a new session is created"
         ),
         user_id: Optional[str] = Form(None, description="User identifier for tracking and personalization"),
-        version: Optional[int] = Form(None, description="Workflow version to use for this run"),
+        version: Optional[int] = Form(
+            None,
+            description="Exact Workflow version to use for this run, including a draft version for explicit preview",
+        ),
         factory_input: Optional[str] = Form(
             None,
             description="JSON object with factory-specific parameters for dynamic workflow construction",

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -807,6 +807,8 @@ class ComponentType(str, Enum):
 
 
 class ComponentCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: str = Field(..., description="Display name")
     component_id: Optional[str] = Field(
         None, description="Unique identifier for the entity. Auto-generated from name if not provided."
@@ -817,9 +819,8 @@ class ComponentCreate(BaseModel):
     # Config parameters are optional, but if provided, they will be used to create the initial config
     config: Optional[Dict[str, Any]] = Field(None, description="Optional configuration")
     label: Optional[str] = Field(None, description="Optional label (e.g., 'stable')")
-    stage: str = Field("draft", description="Stage: 'draft' or 'published'")
+    stage: Literal["draft", "published"] = Field("draft", description="Stage: 'draft' or 'published'")
     notes: Optional[str] = Field(None, description="Optional notes")
-    set_current: bool = Field(True, description="Set as current version")
 
 
 class ComponentResponse(BaseModel):
@@ -833,14 +834,24 @@ class ComponentResponse(BaseModel):
     updated_at: Optional[int] = None
 
 
+class ComponentVersionGuardRequest(BaseModel):
+    """Required compare-and-set state for a component config mutation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    latest_version: int = Field(..., ge=1, description="Expected latest visible config version")
+    current_version: Optional[int] = Field(..., ge=1, description="Expected current published config version")
+
+
 class ConfigCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     config: Dict[str, Any] = Field(..., description="The configuration data")
-    version: Optional[int] = Field(None, description="Optional version number")
     label: Optional[str] = Field(None, description="Optional label (e.g., 'stable')")
-    stage: str = Field("draft", description="Stage: 'draft' or 'published'")
+    stage: Literal["draft", "published"] = Field("draft", description="Stage: 'draft' or 'published'")
     notes: Optional[str] = Field(None, description="Optional notes")
     links: Optional[List[Dict[str, Any]]] = Field(None, description="Optional links to child components")
-    set_current: bool = Field(True, description="Set as current version")
+    guard: ComponentVersionGuardRequest = Field(..., description="Expected component version state")
 
 
 class ComponentConfigResponse(BaseModel):
@@ -848,26 +859,52 @@ class ComponentConfigResponse(BaseModel):
     version: int
     label: Optional[str] = None
     stage: str
-    config: Dict[str, Any]
+    config: Optional[Dict[str, Any]] = None
     notes: Optional[str] = None
     created_at: int
     updated_at: Optional[int] = None
 
 
 class ComponentUpdate(BaseModel):
-    name: Optional[str] = None
+    """Guarded metadata edit that appends a new draft config version."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: Optional[str] = Field(None, min_length=1)
     description: Optional[str] = None
-    component_type: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
-    current_version: Optional[int] = None
+    guard: ComponentVersionGuardRequest = Field(..., description="Expected component version state")
 
 
 class ConfigUpdate(BaseModel):
-    config: Optional[Dict[str, Any]] = None
-    label: Optional[str] = None
-    stage: Optional[str] = None
-    notes: Optional[str] = None
-    links: Optional[List[Dict[str, Any]]] = None
+    """Publish an existing latest draft without mutating its immutable payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    stage: Literal["published"]
+    guard: ComponentVersionGuardRequest = Field(..., description="Expected component version state")
+
+
+class SetCurrentConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    guard: ComponentVersionGuardRequest = Field(..., description="Expected component version state")
+
+
+class ComponentDelete(BaseModel):
+    """Guarded soft-archive request."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    guard: ComponentVersionGuardRequest = Field(..., description="Expected component version state")
+
+
+class ConfigDelete(BaseModel):
+    """Guarded draft-version deletion request."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    guard: ComponentVersionGuardRequest = Field(..., description="Expected component version state")
 
 
 class RegistryResourceType(str, Enum):

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -851,6 +851,7 @@ def get_agent_by_id(
     create_fresh: bool = False,
     ctx: Optional[RequestContext] = None,
     strict: bool = True,
+    published_only: bool = True,
 ) -> Optional[Union[Agent, RemoteAgent, AgentProtocol]]:
     """Get an agent by ID, optionally creating a fresh instance for request isolation.
 
@@ -869,6 +870,9 @@ def get_agent_by_id(
         strict: If True (the default here, unlike the from_dict/load APIs), a
             db-backed agent whose references cannot be rehydrated raises
             instead of loading degraded
+        published_only: If True (the runtime-safe default), an unversioned DB
+            lookup resolves only the current published config. Detail reads
+            explicitly disable this to expose a draft-only component.
 
     Returns:
         The agent instance (shared or fresh copy based on create_fresh)
@@ -905,7 +909,14 @@ def get_agent_by_id(
         from agno.agent.agent import get_agent_by_id as get_agent_by_id_db
 
         try:
-            db_agent = get_agent_by_id_db(db=db, id=agent_id, version=version, registry=registry, strict=strict)
+            db_agent = get_agent_by_id_db(
+                db=db,
+                id=agent_id,
+                version=version,
+                registry=registry,
+                strict=strict,
+                published_only=published_only,
+            )
             return db_agent
         except ComponentRehydrationError:
             # Broken is not "not found": propagate so the caller can refuse loudly.
@@ -926,8 +937,9 @@ async def get_agent_by_id_async(
     create_fresh: bool = False,
     ctx: Optional[RequestContext] = None,
     strict: bool = True,
+    published_only: bool = True,
 ) -> Optional[Union[Agent, RemoteAgent, AgentProtocol]]:
-    """Async variant of get_agent_by_id that supports async factories."""
+    """Async resolver; DB lookups default to current published runtime state."""
     if agent_id is None:
         return None
 
@@ -955,7 +967,14 @@ async def get_agent_by_id_async(
         from agno.agent.agent import get_agent_by_id as get_agent_by_id_db
 
         try:
-            db_agent = get_agent_by_id_db(db=db, id=agent_id, version=version, registry=registry, strict=strict)
+            db_agent = get_agent_by_id_db(
+                db=db,
+                id=agent_id,
+                version=version,
+                registry=registry,
+                strict=strict,
+                published_only=published_only,
+            )
             return db_agent
         except ComponentRehydrationError:
             # Broken is not "not found": propagate so the caller can refuse loudly.
@@ -976,6 +995,7 @@ def get_team_by_id(
     registry: Optional[Registry] = None,
     ctx: Optional[RequestContext] = None,
     strict: bool = True,
+    published_only: bool = True,
 ) -> Optional[Union[Team, RemoteTeam]]:
     """Get a team by ID, optionally creating a fresh instance for request isolation.
 
@@ -993,6 +1013,9 @@ def get_team_by_id(
         strict: If True (the default here, unlike the from_dict/load APIs), a
             db-backed team whose members or references cannot be rehydrated
             raises instead of loading degraded
+        published_only: If True (the runtime-safe default), an unversioned DB
+            lookup resolves only the current published config. Detail reads
+            explicitly disable this to expose a draft-only component.
 
     Returns:
         The team instance (shared or fresh copy based on create_fresh)
@@ -1022,7 +1045,14 @@ def get_team_by_id(
         from agno.team.team import get_team_by_id as get_team_by_id_db
 
         try:
-            db_team = get_team_by_id_db(db=db, id=team_id, version=version, registry=registry, strict=strict)
+            db_team = get_team_by_id_db(
+                db=db,
+                id=team_id,
+                version=version,
+                registry=registry,
+                strict=strict,
+                published_only=published_only,
+            )
             return db_team
         except ComponentRehydrationError:
             # Broken is not "not found": propagate so the caller can refuse loudly.
@@ -1043,8 +1073,9 @@ async def get_team_by_id_async(
     registry: Optional[Registry] = None,
     ctx: Optional[RequestContext] = None,
     strict: bool = True,
+    published_only: bool = True,
 ) -> Optional[Union[Team, RemoteTeam]]:
-    """Async variant of get_team_by_id that supports async factories."""
+    """Async resolver; DB lookups default to current published runtime state."""
     if team_id is None:
         return None
 
@@ -1066,7 +1097,14 @@ async def get_team_by_id_async(
         from agno.team.team import get_team_by_id as get_team_by_id_db
 
         try:
-            db_team = get_team_by_id_db(db=db, id=team_id, version=version, registry=registry, strict=strict)
+            db_team = get_team_by_id_db(
+                db=db,
+                id=team_id,
+                version=version,
+                registry=registry,
+                strict=strict,
+                published_only=published_only,
+            )
             return db_team
         except ComponentRehydrationError:
             # Broken is not "not found": propagate so the caller can refuse loudly.
@@ -1087,6 +1125,7 @@ def get_workflow_by_id(
     registry: Optional[Registry] = None,
     ctx: Optional[RequestContext] = None,
     strict: bool = True,
+    published_only: bool = True,
 ) -> Optional[Union[Workflow, RemoteWorkflow]]:
     """Get a workflow by ID, optionally creating a fresh instance for request isolation.
 
@@ -1107,6 +1146,9 @@ def get_workflow_by_id(
         strict: If True (the default here, unlike the from_dict/load APIs), a
             db-backed workflow whose references cannot be rehydrated raises
             instead of loading degraded
+        published_only: If True (the runtime-safe default), an unversioned DB
+            lookup resolves only the current published config. Detail reads
+            explicitly disable this to expose a draft-only component.
 
     Returns:
         The workflow instance (shared or fresh copy based on create_fresh)
@@ -1139,7 +1181,12 @@ def get_workflow_by_id(
 
         try:
             db_workflow = get_workflow_by_id_db(
-                db=db, id=workflow_id, version=version, registry=registry, strict=strict
+                db=db,
+                id=workflow_id,
+                version=version,
+                registry=registry,
+                strict=strict,
+                published_only=published_only,
             )
             return db_workflow
         except ComponentRehydrationError:
@@ -1161,8 +1208,9 @@ async def get_workflow_by_id_async(
     registry: Optional[Registry] = None,
     ctx: Optional[RequestContext] = None,
     strict: bool = True,
+    published_only: bool = True,
 ) -> Optional[Union[Workflow, RemoteWorkflow]]:
-    """Async variant of get_workflow_by_id that supports async factories."""
+    """Async resolver; DB lookups default to current published runtime state."""
     if workflow_id is None:
         return None
 
@@ -1187,7 +1235,12 @@ async def get_workflow_by_id_async(
 
         try:
             db_workflow = get_workflow_by_id_db(
-                db=db, id=workflow_id, version=version, registry=registry, strict=strict
+                db=db,
+                id=workflow_id,
+                version=version,
+                registry=registry,
+                strict=strict,
+                published_only=published_only,
             )
             return db_workflow
         except ComponentRehydrationError:
@@ -1492,7 +1545,7 @@ def collect_mcp_tools_from_registry(registry: Optional[Registry], mcp_tools: Lis
     Registry tools are not attached to any agent, team or workflow, so the
     other collectors never see them. They still must be connected in the
     AgentOS lifespan: components created from registry tools (e.g. via
-    StudioTool) serialize a toolkit's functions at persist time, and an
+    StudioTools) serialize a toolkit's functions at persist time, and an
     unconnected MCP toolkit has none -- its tools would be silently dropped.
     """
     if registry is None or not registry.tools:

--- a/libs/agno/agno/scheduler/manager.py
+++ b/libs/agno/agno/scheduler/manager.py
@@ -6,8 +6,8 @@ import time
 from typing import Any, Dict, List, Literal, Optional
 from uuid import uuid4
 
-from agno.db.schemas.scheduler import Schedule, ScheduleRun
-from agno.utils.log import log_debug, log_warning
+from agno.db.schemas.scheduler import Schedule, ScheduleNameConflictError, ScheduleRun, is_studio_managed_schedule
+from agno.utils.log import log_debug
 
 # Valid DB method names for the scheduler
 SchedulerDbMethod = Literal[
@@ -17,6 +17,7 @@ SchedulerDbMethod = Literal[
     "create_schedule",
     "update_schedule",
     "delete_schedule",
+    "trigger_schedule",
     "release_schedule",
     "claim_due_schedule",
     "create_schedule_run",
@@ -24,6 +25,19 @@ SchedulerDbMethod = Literal[
     "get_schedule_run",
     "get_schedule_runs",
 ]
+
+_STUDIO_PROVENANCE_FIELDS = frozenset(
+    {
+        "managed_by",
+        "owner_actor_id",
+        "target_type",
+        "target_id",
+        "created_by_run_id",
+        "created_by_session_id",
+        "updated_by_run_id",
+        "updated_by_session_id",
+    }
+)
 
 
 class ScheduleManager:
@@ -76,6 +90,10 @@ class ScheduleManager:
         # whole query, so it runs on a worker thread.
         return await asyncio.to_thread(fn, *args, **kwargs)
 
+    def _scheduler_api_version(self) -> int:
+        version = getattr(self.db, "scheduler_api_version", 1)
+        return version if isinstance(version, int) else 1
+
     @staticmethod
     def _to_schedule(data: Any) -> Optional[Schedule]:
         """Convert a DB result to a Schedule object."""
@@ -93,11 +111,189 @@ class ScheduleManager:
         return [Schedule.from_dict(d) if isinstance(d, dict) else d for d in data]
 
     @staticmethod
+    def _unpack_schedule_page(data: Any) -> tuple[List[Any], Optional[int]]:
+        """Normalize legacy adapters that may omit a total count."""
+        if isinstance(data, tuple):
+            rows = list(data[0])
+            total = data[1] if len(data) > 1 and isinstance(data[1], int) else None
+            return rows, total
+        return list(data or []), None
+
+    def _list_v1_filtered(
+        self,
+        *,
+        enabled: Optional[bool],
+        limit: int,
+        page: int,
+        exclude_managed_by: str,
+    ) -> List[Schedule]:
+        """Filter a v1 adapter before applying the caller's page.
+
+        V1 adapters accept only the historical ``enabled/limit/page`` shape.
+        Scanning first prevents hidden Studio rows from under-filling or shifting
+        the requested page while never sending a v2 keyword to the adapter.
+        """
+        batch_size = 1000
+        scan_page = 1
+        seen_ids: set[str] = set()
+        visible: List[Schedule] = []
+        while True:
+            data = self._call("get_schedules", enabled=enabled, limit=batch_size, page=scan_page)
+            rows, reported_total = self._unpack_schedule_page(data)
+            schedules = self._to_schedule_list(rows)
+            fresh = [schedule for schedule in schedules if schedule.id not in seen_ids]
+            if not fresh:
+                break
+            seen_ids.update(schedule.id for schedule in fresh)
+            visible.extend(schedule for schedule in fresh if schedule.managed_by != exclude_managed_by)
+            if reported_total is not None and len(seen_ids) >= reported_total:
+                break
+            if reported_total is None and len(rows) < batch_size:
+                break
+            scan_page += 1
+        offset = (page - 1) * limit
+        return visible[offset : offset + limit]
+
+    async def _alist_v1_filtered(
+        self,
+        *,
+        enabled: Optional[bool],
+        limit: int,
+        page: int,
+        exclude_managed_by: str,
+    ) -> List[Schedule]:
+        """Async counterpart to :meth:`_list_v1_filtered`."""
+        batch_size = 1000
+        scan_page = 1
+        seen_ids: set[str] = set()
+        visible: List[Schedule] = []
+        while True:
+            data = await self._acall("get_schedules", enabled=enabled, limit=batch_size, page=scan_page)
+            rows, reported_total = self._unpack_schedule_page(data)
+            schedules = self._to_schedule_list(rows)
+            fresh = [schedule for schedule in schedules if schedule.id not in seen_ids]
+            if not fresh:
+                break
+            seen_ids.update(schedule.id for schedule in fresh)
+            visible.extend(schedule for schedule in fresh if schedule.managed_by != exclude_managed_by)
+            if reported_total is not None and len(seen_ids) >= reported_total:
+                break
+            if reported_total is None and len(rows) < batch_size:
+                break
+            scan_page += 1
+        offset = (page - 1) * limit
+        return visible[offset : offset + limit]
+
+    @staticmethod
     def _to_run_list(data: Any) -> List[ScheduleRun]:
         """Convert a list of DB results to ScheduleRun objects."""
         if not data:
             return []
         return [ScheduleRun.from_dict(d) if isinstance(d, dict) else d for d in data]
+
+    @staticmethod
+    def _matches_name_scope(
+        schedule: Schedule,
+        *,
+        managed_by: Optional[str],
+        owner_actor_id: Optional[str],
+        exclude_managed_by: Optional[str],
+    ) -> bool:
+        if managed_by is not None and schedule.managed_by != managed_by:
+            return False
+        if owner_actor_id is not None and schedule.owner_actor_id != owner_actor_id:
+            return False
+        if exclude_managed_by is not None and schedule.managed_by == exclude_managed_by:
+            return False
+        return True
+
+    def get_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Schedule]:
+        """Get a schedule by name within an explicit namespace."""
+        scopes = {
+            "managed_by": managed_by,
+            "owner_actor_id": owner_actor_id,
+            "exclude_managed_by": exclude_managed_by,
+        }
+        if self._scheduler_api_version() >= 2:
+            data = self._call("get_schedule_by_name", name, **scopes)
+        else:
+            data = self._call("get_schedule_by_name", name)
+        schedule = self._to_schedule(data)
+        if schedule is None or not self._matches_name_scope(schedule, **scopes):
+            return None
+        return schedule
+
+    async def aget_by_name(
+        self,
+        name: str,
+        *,
+        managed_by: Optional[str] = None,
+        owner_actor_id: Optional[str] = None,
+        exclude_managed_by: Optional[str] = None,
+    ) -> Optional[Schedule]:
+        """Async get a schedule by name within an explicit namespace."""
+        scopes = {
+            "managed_by": managed_by,
+            "owner_actor_id": owner_actor_id,
+            "exclude_managed_by": exclude_managed_by,
+        }
+        if self._scheduler_api_version() >= 2:
+            data = await self._acall("get_schedule_by_name", name, **scopes)
+        else:
+            data = await self._acall("get_schedule_by_name", name)
+        schedule = self._to_schedule(data)
+        if schedule is None or not self._matches_name_scope(schedule, **scopes):
+            return None
+        return schedule
+
+    def _resolve_existing_create(
+        self,
+        existing: Schedule,
+        name: str,
+        if_exists: str,
+        update_values: Dict[str, Any],
+    ) -> Schedule:
+        """Apply create's name-collision policy to an already stored schedule."""
+        if is_studio_managed_schedule(existing):
+            raise ValueError(f"Schedule name '{name}' is reserved by Studio") from None
+        if if_exists == "skip":
+            log_debug(f"Schedule '{name}' already exists, skipping")
+            return existing
+        if if_exists == "update":
+            log_debug(f"Schedule '{name}' already exists, updating")
+            updated = self._to_schedule(self._call("update_schedule", existing.id, **update_values))
+            if updated is None:
+                raise RuntimeError(f"Failed to update existing schedule '{name}'") from None
+            return updated
+        raise ValueError(f"Schedule with name '{name}' already exists") from None
+
+    async def _aresolve_existing_create(
+        self,
+        existing: Schedule,
+        name: str,
+        if_exists: str,
+        update_values: Dict[str, Any],
+    ) -> Schedule:
+        """Async counterpart to :meth:`_resolve_existing_create`."""
+        if is_studio_managed_schedule(existing):
+            raise ValueError(f"Schedule name '{name}' is reserved by Studio") from None
+        if if_exists == "skip":
+            log_debug(f"Schedule '{name}' already exists, skipping")
+            return existing
+        if if_exists == "update":
+            log_debug(f"Schedule '{name}' already exists, updating")
+            updated = self._to_schedule(await self._acall("update_schedule", existing.id, **update_values))
+            if updated is None:
+                raise RuntimeError(f"Failed to update existing schedule '{name}'") from None
+            return updated
+        raise ValueError(f"Schedule with name '{name}' already exists") from None
 
     # --- Sync API ---
 
@@ -134,34 +330,23 @@ class ScheduleManager:
         if not validate_timezone(timezone):
             raise ValueError(f"Invalid timezone: {timezone}")
 
-        existing = self._to_schedule(self._call("get_schedule_by_name", name))
-        if existing is not None:
-            if if_exists == "skip":
-                log_debug(f"Schedule '{name}' already exists, skipping")
-                return existing
-            if if_exists == "update":
-                log_debug(f"Schedule '{name}' already exists, updating")
-                next_run_at = compute_next_run(cron, timezone)
-                updated = self._to_schedule(
-                    self._call(
-                        "update_schedule",
-                        existing.id,
-                        cron_expr=cron,
-                        endpoint=endpoint,
-                        method=method.upper(),
-                        description=description,
-                        payload=payload,
-                        timezone=timezone,
-                        timeout_seconds=timeout_seconds,
-                        max_retries=max_retries,
-                        retry_delay_seconds=retry_delay_seconds,
-                        next_run_at=next_run_at,
-                    )
-                )
-                return updated or existing
-            raise ValueError(f"Schedule with name '{name}' already exists")
-
         next_run_at = compute_next_run(cron, timezone)
+        update_values = {
+            "cron_expr": cron,
+            "endpoint": endpoint,
+            "method": method.upper(),
+            "description": description,
+            "payload": payload,
+            "timezone": timezone,
+            "timeout_seconds": timeout_seconds,
+            "max_retries": max_retries,
+            "retry_delay_seconds": retry_delay_seconds,
+            "next_run_at": next_run_at,
+        }
+        existing = self.get_by_name(name, exclude_managed_by="studio")
+        if existing is not None:
+            return self._resolve_existing_create(existing, name, if_exists, update_values)
+
         now = int(time.time())
 
         schedule = Schedule(
@@ -184,15 +369,44 @@ class ScheduleManager:
             updated_at=None,
         )
 
-        result = self._to_schedule(self._call("create_schedule", schedule.to_dict()))
-        if result is None:
-            raise RuntimeError("Failed to create schedule")
-        log_debug(f"Schedule '{name}' created (id={result.id}, cron={cron})")
-        return result
+        try:
+            result = self._to_schedule(self._call("create_schedule", schedule.to_dict()))
+        except ScheduleNameConflictError:
+            # The unique name index is the concurrency authority. Another
+            # creator can win after our initial lookup; re-read that committed
+            # row and apply the caller's collision policy instead of exposing a
+            # backend-specific uniqueness exception.
+            winner = self.get_by_name(name, exclude_managed_by="studio")
+            if winner is None:
+                raise
+        else:
+            if result is None:
+                raise RuntimeError("Failed to create schedule")
+            log_debug(f"Schedule '{name}' created (id={result.id}, cron={cron})")
+            return result
+        # Resolve outside the exception handler so a deliberate collision
+        # result has no backend exception attached as implicit context.
+        return self._resolve_existing_create(winner, name, if_exists, update_values)
 
-    def list(self, enabled: Optional[bool] = None, limit: int = 100, page: int = 1) -> List[Schedule]:
+    def list(
+        self,
+        enabled: Optional[bool] = None,
+        limit: int = 100,
+        page: int = 1,
+        exclude_managed_by: Optional[str] = None,
+    ) -> List[Schedule]:
         """List all schedules."""
-        result = self._call("get_schedules", enabled=enabled, limit=limit, page=page)
+        if self._scheduler_api_version() < 2 and exclude_managed_by is not None:
+            return self._list_v1_filtered(
+                enabled=enabled,
+                limit=limit,
+                page=page,
+                exclude_managed_by=exclude_managed_by,
+            )
+        query: Dict[str, Any] = {"enabled": enabled, "limit": limit, "page": page}
+        if exclude_managed_by is not None:
+            query["exclude_managed_by"] = exclude_managed_by
+        result = self._call("get_schedules", **query)
         # get_schedules returns (schedules_list, total_count) tuple
         schedules_data = result[0] if isinstance(result, tuple) else result
         return self._to_schedule_list(schedules_data)
@@ -203,6 +417,12 @@ class ScheduleManager:
 
     def update(self, schedule_id: str, **kwargs: Any) -> Optional[Schedule]:
         """Update a schedule."""
+        if _STUDIO_PROVENANCE_FIELDS.intersection(kwargs):
+            raise ValueError("Studio schedule provenance cannot be changed through ScheduleManager.update")
+        return self._to_schedule(self._call("update_schedule", schedule_id, **kwargs))
+
+    def _update_studio(self, schedule_id: str, **kwargs: Any) -> Optional[Schedule]:
+        """Trusted Studio-only update path for server-owned provenance."""
         return self._to_schedule(self._call("update_schedule", schedule_id, **kwargs))
 
     def delete(self, schedule_id: str) -> bool:
@@ -223,18 +443,13 @@ class ScheduleManager:
         """Disable a schedule."""
         return self._to_schedule(self._call("update_schedule", schedule_id, enabled=False))
 
-    def trigger(self, schedule_id: str) -> None:
-        """Manually trigger a schedule.
-
-        Note: Direct triggering is not supported through the manager.
-        Use the REST API ``POST /schedules/{id}/trigger`` endpoint,
-        or the ``SchedulePoller.trigger()`` method with a running executor.
-        """
-        log_warning(
-            "ScheduleManager.trigger() is not supported for direct DB access. "
-            "Use the REST API POST /schedules/{id}/trigger endpoint, or "
-            "SchedulePoller.trigger() with a running executor."
-        )
+    def trigger(self, schedule_id: str) -> Optional[Schedule]:
+        """Durably queue one manual execution for a schedule."""
+        if self._scheduler_api_version() >= 2:
+            return self._to_schedule(self._call("trigger_schedule", schedule_id))
+        # Scheduler API v1 has no durable pending-trigger counter. Preserve its
+        # historical trigger contract by making the cron row due immediately.
+        return self._to_schedule(self._call("update_schedule", schedule_id, next_run_at=int(time.time())))
 
     def get_runs(self, schedule_id: str, limit: int = 20, page: int = 1) -> List[ScheduleRun]:
         """Get run history for a schedule."""
@@ -278,34 +493,23 @@ class ScheduleManager:
         if not validate_timezone(timezone):
             raise ValueError(f"Invalid timezone: {timezone}")
 
-        existing = self._to_schedule(await self._acall("get_schedule_by_name", name))
-        if existing is not None:
-            if if_exists == "skip":
-                log_debug(f"Schedule '{name}' already exists, skipping")
-                return existing
-            if if_exists == "update":
-                log_debug(f"Schedule '{name}' already exists, updating")
-                next_run_at = compute_next_run(cron, timezone)
-                updated = self._to_schedule(
-                    await self._acall(
-                        "update_schedule",
-                        existing.id,
-                        cron_expr=cron,
-                        endpoint=endpoint,
-                        method=method.upper(),
-                        description=description,
-                        payload=payload,
-                        timezone=timezone,
-                        timeout_seconds=timeout_seconds,
-                        max_retries=max_retries,
-                        retry_delay_seconds=retry_delay_seconds,
-                        next_run_at=next_run_at,
-                    )
-                )
-                return updated or existing
-            raise ValueError(f"Schedule with name '{name}' already exists")
-
         next_run_at = compute_next_run(cron, timezone)
+        update_values = {
+            "cron_expr": cron,
+            "endpoint": endpoint,
+            "method": method.upper(),
+            "description": description,
+            "payload": payload,
+            "timezone": timezone,
+            "timeout_seconds": timeout_seconds,
+            "max_retries": max_retries,
+            "retry_delay_seconds": retry_delay_seconds,
+            "next_run_at": next_run_at,
+        }
+        existing = await self.aget_by_name(name, exclude_managed_by="studio")
+        if existing is not None:
+            return await self._aresolve_existing_create(existing, name, if_exists, update_values)
+
         now = int(time.time())
 
         schedule = Schedule(
@@ -328,15 +532,38 @@ class ScheduleManager:
             updated_at=None,
         )
 
-        result = self._to_schedule(await self._acall("create_schedule", schedule.to_dict()))
-        if result is None:
-            raise RuntimeError("Failed to create schedule")
-        log_debug(f"Schedule '{name}' created (id={result.id}, cron={cron})")
-        return result
+        try:
+            result = self._to_schedule(await self._acall("create_schedule", schedule.to_dict()))
+        except ScheduleNameConflictError:
+            winner = await self.aget_by_name(name, exclude_managed_by="studio")
+            if winner is None:
+                raise
+        else:
+            if result is None:
+                raise RuntimeError("Failed to create schedule")
+            log_debug(f"Schedule '{name}' created (id={result.id}, cron={cron})")
+            return result
+        return await self._aresolve_existing_create(winner, name, if_exists, update_values)
 
-    async def alist(self, enabled: Optional[bool] = None, limit: int = 100, page: int = 1) -> List[Schedule]:
+    async def alist(
+        self,
+        enabled: Optional[bool] = None,
+        limit: int = 100,
+        page: int = 1,
+        exclude_managed_by: Optional[str] = None,
+    ) -> List[Schedule]:
         """Async list all schedules."""
-        result = await self._acall("get_schedules", enabled=enabled, limit=limit, page=page)
+        if self._scheduler_api_version() < 2 and exclude_managed_by is not None:
+            return await self._alist_v1_filtered(
+                enabled=enabled,
+                limit=limit,
+                page=page,
+                exclude_managed_by=exclude_managed_by,
+            )
+        query: Dict[str, Any] = {"enabled": enabled, "limit": limit, "page": page}
+        if exclude_managed_by is not None:
+            query["exclude_managed_by"] = exclude_managed_by
+        result = await self._acall("get_schedules", **query)
         # get_schedules returns (schedules_list, total_count) tuple
         schedules_data = result[0] if isinstance(result, tuple) else result
         return self._to_schedule_list(schedules_data)
@@ -347,6 +574,12 @@ class ScheduleManager:
 
     async def aupdate(self, schedule_id: str, **kwargs: Any) -> Optional[Schedule]:
         """Async update a schedule."""
+        if _STUDIO_PROVENANCE_FIELDS.intersection(kwargs):
+            raise ValueError("Studio schedule provenance cannot be changed through ScheduleManager.aupdate")
+        return self._to_schedule(await self._acall("update_schedule", schedule_id, **kwargs))
+
+    async def _aupdate_studio(self, schedule_id: str, **kwargs: Any) -> Optional[Schedule]:
+        """Trusted Studio-only async update path for server-owned provenance."""
         return self._to_schedule(await self._acall("update_schedule", schedule_id, **kwargs))
 
     async def adelete(self, schedule_id: str) -> bool:
@@ -368,6 +601,12 @@ class ScheduleManager:
     async def adisable(self, schedule_id: str) -> Optional[Schedule]:
         """Async disable a schedule."""
         return self._to_schedule(await self._acall("update_schedule", schedule_id, enabled=False))
+
+    async def atrigger(self, schedule_id: str) -> Optional[Schedule]:
+        """Durably queue one manual execution for a schedule."""
+        if self._scheduler_api_version() >= 2:
+            return self._to_schedule(await self._acall("trigger_schedule", schedule_id))
+        return self._to_schedule(await self._acall("update_schedule", schedule_id, next_run_at=int(time.time())))
 
     async def aget_runs(self, schedule_id: str, limit: int = 20, page: int = 1) -> List[ScheduleRun]:
         """Async get run history for a schedule."""

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel
 
 from agno.agent import Agent
 from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, SessionType
-from agno.db.utils import resolve_db_from_config
+from agno.db.utils import resolve_db_from_config, save_component_config
 from agno.exceptions import ComponentPinError, ComponentRehydrationError
 from agno.metrics import RunMetrics, SessionMetrics
 from agno.models.base import Model
@@ -1332,18 +1332,13 @@ def save(
                 }
             )
 
-        # Create or update component
-        db_.upsert_component(
+        config = save_component_config(
+            db_,
             component_id=team.id,
             component_type=ComponentType.TEAM,
             name=getattr(team, "name", team.id),
             description=getattr(team, "description", None),
             metadata=getattr(team, "metadata", None),
-        )
-
-        # Create or update config with links
-        config = db_.upsert_config(
-            component_id=team.id,
             config=team.to_dict(),
             links=all_links if all_links else None,
             label=label,
@@ -1486,6 +1481,7 @@ def delete(
     *,
     db: Optional["BaseDb"] = None,
     hard_delete: bool = False,
+    require_no_dependents: bool = True,
 ) -> bool:
     """
     Delete the team component.
@@ -1493,9 +1489,18 @@ def delete(
     Args:
         db: The database to delete the component from.
         hard_delete: Whether to hard delete the component.
+        require_no_dependents: Refuse deletion while another active component
+            references this team. Setting this to False bypasses dependency
+            validation and can leave active components with dangling links;
+            use it only for a deliberate repair or migration. Catalog-v1
+            adapters retain their historical unguarded deletion behavior.
 
     Returns:
         True if the component was deleted, False otherwise.
+
+    Raises:
+        ComponentDependencyError: If a dependent component references this
+            team and require_no_dependents is True.
     """
     db_ = db or team.db
     if not db_:
@@ -1505,7 +1510,15 @@ def delete(
     if team.id is None:
         raise ValueError("Cannot delete team without an id")
 
-    return db_.delete_component(component_id=team.id, hard_delete=hard_delete)
+    if getattr(db_, "component_catalog_api_version", 1) < 2:
+        # Preserve the exact pre-2.9 adapter call shape. Third-party catalog-v1
+        # implementations cannot accept the v2-only keyword-only policy.
+        return db_.delete_component(component_id=team.id, hard_delete=hard_delete)
+    return db_.delete_component(
+        component_id=team.id,
+        hard_delete=hard_delete,
+        require_no_dependents=require_no_dependents,
+    )
 
 
 def get_session_metrics(team: "Team", session_id: Optional[str] = None):

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -1590,8 +1590,33 @@ class Team:
         *,
         db: Optional["BaseDb"] = None,
         hard_delete: bool = False,
+        require_no_dependents: bool = True,
     ) -> bool:
-        return _storage.delete(self, db=db, hard_delete=hard_delete)
+        """Delete this team's persisted component.
+
+        Args:
+            db: The database to delete the component from.
+            hard_delete: Permanently delete the component and its history.
+            require_no_dependents: Refuse deletion while another component
+                references this team. Setting this to False bypasses
+                dependency validation and can leave active components with
+                dangling links; use it only for a deliberate repair or
+                migration. Catalog-v1 adapters retain their historical
+                unguarded deletion behavior.
+
+        Returns:
+            True if the component was deleted, False otherwise.
+
+        Raises:
+            ComponentDependencyError: If a dependent component references
+                this team and require_no_dependents is True.
+        """
+        return _storage.delete(
+            self,
+            db=db,
+            hard_delete=hard_delete,
+            require_no_dependents=require_no_dependents,
+        )
 
     # -*- Public convenience functions
     def get_run_output(
@@ -1793,6 +1818,7 @@ def get_team_by_id(
     label: Optional[str] = None,
     registry: Optional["Registry"] = None,
     strict: bool = False,
+    published_only: bool = False,
 ) -> Optional["Team"]:
     """
     Get a Team by id from the database.
@@ -1800,7 +1826,8 @@ def get_team_by_id(
     Resolution order:
     - if version is provided: load that version
     - elif label is provided: load that labeled version
-    - else: load component.current_version
+    - else: load the current published version, or the latest draft when the
+      component has never been published
 
     Args:
         db: Database handle.
@@ -1810,6 +1837,9 @@ def get_team_by_id(
         registry: Optional Registry for reconstructing unserializable components.
         strict: If True, unresolvable members and registry references
             raise ComponentRehydrationError; None strictly means the team was not found.
+        published_only: Resolve only the current published config when neither
+            an exact version nor label is supplied. Runtime dispatch uses this;
+            ordinary reads retain the draft-only fallback.
 
     Returns:
         Team instance or None.
@@ -1820,7 +1850,11 @@ def get_team_by_id(
     from agno.exceptions import ComponentRehydrationError
 
     try:
-        row = db.get_config(component_id=id, version=version, label=label)
+        row = (
+            db.get_current_config(component_id=id)
+            if published_only and version is None and label is None
+            else db.get_config(component_id=id, version=version, label=label)
+        )
         if row is None:
             return None
 
@@ -1883,7 +1917,7 @@ def get_teams(
         for component in components:
             component_id = component["component_id"]
             try:
-                config = db.get_config(component_id=component_id)
+                config = db.get_latest_config(component_id=component_id)
                 if config is not None:
                     team_config = config.get("config")
                     if team_config is not None:
@@ -1895,7 +1929,7 @@ def get_teams(
                         # per-version pin links are a detail-read concern.
                         team = Team.from_dict(team_config, db=db, registry=registry, strict=False)
                         team.id = component_id
-                        team._version = component.get("current_version")
+                        team._version = config.get("version")
                         team._stage = config.get("stage")
                         teams.append(team)
             except Exception as e:

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -1,74 +1,72 @@
-"""StudioTools -- give agents the ability to compose agents, teams, and workflows.
+"""Typed, authorization-gated Studio control-plane tools.
 
-Uses the AgentOS Registry (tools, models, dbs, functions) and the core
-component APIs (Agent, Team, Workflow, Step) to dynamically create, edit,
-version, and execute components described in natural language.
+``StudioTools`` lets an administrator compose versioned agents, teams, and
+workflows from the live AgentOS registry.  The 2.9 API is intentionally
+breaking: requests and responses are typed, one catalog database is fixed at
+construction time, creates are draft-first, edits use optimistic concurrency,
+and destructive lifecycle operations archive rather than hard-delete.
 
-Typical use:
-    from agno.tools.studio import StudioTools
-
-    studio_agent = Agent(
-        model=Claude(id="claude-sonnet-4-5"),
-        tools=[StudioTools(registry=registry, db=db)],
-    )
-
-    studio_agent.print_response(
-        "Create an agent named 'math-tutor' that uses claude-sonnet-4-5 and "
-        "the calculator toolkit."
-    )
-
-Semantics:
-    * create_* persists a new component with a single published config.
-    * edit_* loads the component, applies the patch, and saves it:
-      - with versions=True the edit is saved as a new immutable draft. Use
-        publish_component() to promote the draft to published+current.
-      - with versions=False (default) the edit is published immediately as a
-        new current version. Each edit creates a new published version; prior
-        versions remain in history (they are immutable).
-    * run_* execute a component as the current user, with one sub-session per
-      calling conversation and PAUSED results that carry their unresolved
-      requirements. The implementation is StudioRunnerTools
-      (agno.tools.studio_runner), which platforms can also mount standalone
-      as a dispatch-only surface -- discovery and execution without the
-      Studio's mutation tools.
-
-Enable flags:
-    * Default: only agent operations are exposed (agents=True, teams=False,
-      workflows=False). Discovery functions are always available.
-    * Pass teams=True / workflows=True to also expose those operations.
-    * Passing agents=False without enabling teams or workflows leaves only
-      discovery tools registered.
-    * Passing agents_list auto-enables teams and workflows (you can build them
-      from those agents). Passing teams_list auto-enables workflows. Explicit
-      False overrides the auto-enable.
-    * Versioning tools (list_versions, get_version, publish_component,
-      set_current_version, delete_version) are exposed only when versions=True.
-    * Schedule tools (create_schedule, list_schedules, get_schedule,
-      get_schedule_runs, trigger_schedule, enable_schedule, disable_schedule,
-      delete_schedule) are exposed only when schedules=True. create_schedule is
-      Studio's own (component-aware targets); the management tools are shared
-      with SchedulerTools.
-
-Persistence:
-    * Studio saves ONLY the component it creates/edits. It does NOT cascade to
-      member agents or step agents -- those are assumed to be code-defined
-      (registry / passed-in lists) or separately persisted by a prior create_*.
+The data-plane ``run_*`` behavior remains owned by :class:`StudioRunnerTools`.
+Studio wraps that runner so authorization is applied consistently without
+duplicating its resolution, rehydration, identity, or pause/resume semantics.
 """
 
 from __future__ import annotations
 
-import json
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Union
+import asyncio
+import inspect
+from collections import Counter
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Sequence, Union, cast
 
+from agno.db.schemas.scheduler import (
+    STUDIO_SCHEDULE_MANAGED_BY,
+    Schedule,
+    ScheduleNameConflictError,
+    is_valid_studio_schedule_actor_id,
+)
 from agno.run import RunContext
 from agno.tools.function import Function
-from agno.tools.studio_runner import AmbiguousComponentNameError, StudioRunnerError, StudioRunnerTools, _slugify
+from agno.tools.studio_runner import StudioRunnerError, StudioRunnerTools, _slugify
+from agno.tools.studio_schema import (
+    AgentCreate,
+    AgentPatch,
+    AgentView,
+    AgentWorkflowStep,
+    ComponentActionView,
+    ComponentRef,
+    ComponentSummary,
+    ComponentView,
+    ContextPolicy,
+    FunctionRef,
+    FunctionWorkflowStep,
+    ModelRef,
+    ScheduleActionView,
+    ScheduleCreate,
+    ScheduleRunView,
+    ScheduleView,
+    StudioError,
+    StudioResult,
+    TeamCreate,
+    TeamPatch,
+    TeamView,
+    TeamWorkflowStep,
+    ToolRef,
+    VersionSummary,
+    WorkflowCreate,
+    WorkflowPatch,
+    WorkflowStep,
+    WorkflowView,
+)
 from agno.tools.toolkit import Toolkit
 from agno.utils.log import log_debug, logger
+from agno.utils.string import generate_id_from_name
 
 if TYPE_CHECKING:
     from agno.agent.agent import Agent
-    from agno.db.base import BaseDb, ComponentVersionGuard
+    from agno.db.base import BaseDb, ComponentProjection, ComponentType
+    from agno.db.schemas.scheduler import ScheduleRun
     from agno.models.base import Model
     from agno.registry.registry import Registry
     from agno.scheduler.manager import ScheduleManager
@@ -78,114 +76,153 @@ if TYPE_CHECKING:
 
 Component = Union["Agent", "Team", "Workflow"]
 TeamMember = Union["Agent", "Team"]
+SaveStage = Literal["draft", "published"]
+IfExists = Literal["error", "return_existing"]
+StudioAccess = Literal["read", "mutate"]
+StudioAction = Literal[
+    "list_models",
+    "list_tools",
+    "list_functions",
+    "list_agents",
+    "list_teams",
+    "list_workflows",
+    "get_agent",
+    "get_team",
+    "get_workflow",
+    "list_versions",
+    "get_version",
+    "create_agent",
+    "create_team",
+    "create_workflow",
+    "edit_agent",
+    "edit_team",
+    "edit_workflow",
+    "publish_component",
+    "set_current_version",
+    "delete_version",
+    "archive_agent",
+    "archive_team",
+    "archive_workflow",
+    "restore_agent",
+    "restore_team",
+    "restore_workflow",
+    "run_agent",
+    "run_team",
+    "run_workflow",
+    "create_schedule",
+    "list_schedules",
+    "get_schedule",
+    "get_schedule_runs",
+    "trigger_schedule",
+    "enable_schedule",
+    "disable_schedule",
+    "delete_schedule",
+]
+StudioAuthorizer = Callable[[RunContext, StudioAccess, StudioAction], bool]
 
+_STUDIO_CONFIG_KEY = "_agno_studio"
+_STUDIO_SCHEMA_VERSION = 2
 _SCHEDULE_TARGET_TYPES = ("agent", "team", "workflow")
 
 
+@dataclass(frozen=True)
+class _ResolvedRef:
+    component: Component
+    ref: ComponentRef
+    link: Optional[Dict[str, Any]]
+    code_defined: bool
+
+
+class _StudioRequestError(ValueError):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        details: Optional[Dict[str, Any]] = None,
+        retryable: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details or {}
+        self.retryable = retryable
+
+
 class StudioTools(Toolkit):
-    """Toolkit that lets an agent compose agents, teams, and workflows.
+    """Administrative tools for composing and versioning Studio components.
 
     Args:
-        registry: Registry holding models, tools, databases, and code-defined
-            agents/teams available for composition.
-        db: Database for persisting components. Falls back to ``registry.dbs[0]``.
-        agents_list: Optional live list (e.g. ``agent_os.agents``) used only for
-            discovery in ``list_agents()``. Studio-created components are NOT
-            appended to this list -- they are DB components, so appending would
-            duplicate them in AgentOS's ``/agents`` response.
-        teams_list: Same as ``agents_list`` but for teams.
-        workflows_list: Same as ``agents_list`` but for workflows.
-        default_model_id: Model id to use when a caller omits one.
-        default_num_history_runs: History depth for created agents and teams
-            when a caller omits ``num_history_runs``. None lets the
-            component's own default apply.
-        agents: Expose agent operations. Defaults to True.
-        teams: Expose team operations. Defaults to False (see module docstring
-            for auto-enable rules).
-        workflows: Expose workflow operations. Defaults to False.
-        versions: Expose versioning tools (list_versions, get_version,
-            publish_component, set_current_version, delete_version). Defaults
-            to False; without versioning, edits publish immediately instead of
-            producing drafts.
-        list_limit: Cap on DB components returned by each list tool (default
-            100). The list payloads report 'db_total' so a capped list is
-            visible as capped.
-        schedules: Expose schedule tools: Studio's own create_schedule
-            (component-aware targets) plus the SchedulerTools management tools
-            (list_schedules, get_schedule, get_schedule_runs, trigger_schedule,
-            enable_schedule, disable_schedule, delete_schedule). Defaults to
-            False. Requires the optional scheduler dependencies (croniter and
-            pytz -- ``pip install agno[scheduler]``); when they are missing,
-            the first schedule tool call that needs them returns an error JSON.
+        registry: Live registry that supplies exact models, tools, functions,
+            and code-defined component references.
+        db: The single catalog database used for every Studio lifecycle call.
+        authorize: Required synchronous policy callback. It receives the
+            framework-injected ``RunContext``, access kind, and exact action.
+            Returning false rejects the call before any registry or DB access.
+        agents_list: Optional live code-defined agents used for discovery and
+            draft composition.
+        teams_list: Optional live code-defined teams used for discovery and
+            draft composition.
+        workflows_list: Optional live code-defined workflows used for discovery.
+        default_model: Exact registry reference used when a create/patch model
+            is null. No implicit first-registry-model fallback is used.
+        default_context: Resolved context policy used when a create request's
+            context is null.
+        agents: Expose agent operations (default true).
+        teams: Expose team operations. Supplying ``agents_list`` or
+            ``teams_list`` auto-enables this unless explicitly overridden.
+        workflows: Expose workflow operations. Supplying an agents, teams, or
+            workflows list auto-enables this unless explicitly overridden.
+        schedules: Expose authorization-wrapped schedule operations.
+        list_limit: Maximum DB rows returned per component list.
     """
 
     def __init__(
         self,
         registry: "Registry",
-        db: Optional["BaseDb"] = None,
+        db: "BaseDb",
+        authorize: StudioAuthorizer,
+        *,
         agents_list: Optional[List["Agent"]] = None,
         teams_list: Optional[List["Team"]] = None,
         workflows_list: Optional[List["Workflow"]] = None,
-        default_model_id: Optional[str] = None,
-        default_num_history_runs: Optional[int] = None,
+        default_model: Optional[ModelRef] = None,
+        default_context: Optional[ContextPolicy] = None,
         agents: Optional[bool] = None,
         teams: Optional[bool] = None,
         workflows: Optional[bool] = None,
-        versions: bool = False,
         schedules: bool = False,
         list_limit: int = 100,
         **kwargs: Any,
-    ):
+    ) -> None:
+        if db is None:
+            raise ValueError("StudioTools requires one fixed catalog db")
+        if not getattr(db, "supports_component_persistence", False):
+            raise ValueError(
+                "StudioTools requires a synchronous catalog db with atomic component persistence; "
+                "use SqliteDb or PostgresDb."
+            )
+        if getattr(db, "component_catalog_api_version", 1) < 2:
+            raise ValueError("StudioTools requires component catalog API version 2")
+        if schedules and getattr(db, "scheduler_api_version", 1) < 2:
+            raise ValueError("StudioTools schedules require scheduler API version 2")
+        if not callable(authorize):
+            raise TypeError("StudioTools authorize must be callable")
+        if inspect.iscoroutinefunction(authorize):
+            raise TypeError("StudioTools authorize must be synchronous")
+        if list_limit < 1:
+            raise ValueError("list_limit must be at least 1")
+
         self.registry = registry
-        self.db: Optional["BaseDb"] = db if db is not None else (registry.dbs[0] if registry.dbs else None)
+        self.db = db
+        self.authorize = authorize
         self.agents_list = agents_list
         self.teams_list = teams_list
         self.workflows_list = workflows_list
-        # Rehydration resolves code-defined references through the registry
-        # only; a component reachable solely via these live lists could be
-        # referenced at create time but never reload. Make the lists visible.
-        pending_mirrors: List[tuple] = []
-        for source, bucket, source_name in (
-            (agents_list, registry.agents, "agents_list"),
-            (teams_list, registry.teams, "teams_list"),
-        ):
-            for component in source or []:
-                component_id = getattr(component, "id", None)
-                if not component_id:
-                    continue
-                existing = next((entry for entry in bucket if getattr(entry, "id", None) == component_id), None)
-                if existing is None:
-                    pending_mirrors.append((bucket, component))
-                elif existing is not component:
-                    # Studio lookup prefers the explicit list; rehydration
-                    # resolves through the registry. Two distinct objects under
-                    # one id would build with one and reload as the other.
-                    raise ValueError(
-                        f"{source_name} and the registry define distinct components with id "
-                        f"'{component_id}'; pass the same object to both, or remove one."
-                    )
-        for bucket, component in pending_mirrors:
-            bucket.append(component)
-        self.default_model_id = default_model_id
-        self.default_num_history_runs = default_num_history_runs
-
-        # Execution and component resolution live on StudioRunnerTools -- the
-        # standalone dispatch toolkit. Studio registers its run tools from this
-        # embedded instance and delegates its own lookups to it, so the builder
-        # and a dispatcher resolve and run components one way.
-        self._runner_tools = StudioRunnerTools(
-            registry=registry,
-            db=self.db,
-            agents_list=agents_list,
-            teams_list=teams_list,
-            workflows_list=workflows_list,
-            # The Studio holds the registry as its build palette and its run_* are
-            # the smoke test for what it just composed, so its reach over registry
-            # components is the point rather than an accident. A standalone runner
-            # mounted on a router gets the narrower default.
-            include_all_components=True,
-            list_limit=list_limit,
-        )
+        self._mirror_reference_lists_into_registry()
+        self.default_model = default_model
+        self.default_context = default_context or ContextPolicy()
+        self.list_limit = list_limit
 
         self.enable_agents, self.enable_teams, self.enable_workflows = _resolve_flags(
             agents=agents,
@@ -193,61 +230,41 @@ class StudioTools(Toolkit):
             workflows=workflows,
             has_agents_list=agents_list is not None,
             has_teams_list=teams_list is not None,
+            has_workflows_list=workflows_list is not None,
         )
-        self.enable_versions: bool = versions
-        self.enable_schedules: bool = schedules
-        # Schedule management is shared with SchedulerTools; Studio owns only
-        # create_schedule (component targets, internally built endpoint).
+        self.enable_schedules = schedules
+
+        if self.enable_workflows:
+            self._validate_workflow_function_catalog()
+
+        self._runner_tools = StudioRunnerTools(
+            registry=registry,
+            db=db,
+            agents_list=agents_list,
+            teams_list=teams_list,
+            workflows_list=workflows_list,
+            include_all_components=True,
+            list_limit=list_limit,
+        )
+
         self._scheduler_tools: Optional["SchedulerTools"] = None
-        if self.enable_schedules:
+        if schedules:
             from agno.tools.scheduler import SchedulerTools
 
-            self._scheduler_tools = SchedulerTools(db=self.db)
+            self._scheduler_tools = SchedulerTools(db=db)
 
-        tools: List[Callable] = [
-            # Discovery -- always available regardless of flags.
+        tools: List[Callable[..., Any]] = [
             self.list_models,
             self.list_tools,
             self.list_functions,
-            self.list_dbs,
-            self.list_agents,
-            self.list_teams,
-            self.list_workflows,
+        ]
+        async_tools: List[tuple[Callable[..., Any], str]] = [
+            (self.alist_models, "list_models"),
+            (self.alist_tools, "list_tools"),
+            (self.alist_functions, "list_functions"),
         ]
 
-        if self.enable_agents:
-            tools.extend(
-                [
-                    self.get_agent,
-                    self.create_agent,
-                    self.edit_agent,
-                    self.delete_agent,
-                    self.run_agent,
-                ]
-            )
-        if self.enable_teams:
-            tools.extend(
-                [
-                    self.get_team,
-                    self.create_team,
-                    self.edit_team,
-                    self.delete_team,
-                    self.run_team,
-                ]
-            )
-        if self.enable_workflows:
-            tools.extend(
-                [
-                    self.get_workflow,
-                    self.create_workflow,
-                    self.edit_workflow,
-                    self.delete_workflow,
-                    self.run_workflow,
-                ]
-            )
-
-        # Versioning works on any component type, but is opt-in.
-        if self.enable_versions:
+        if self.enable_agents or self.enable_teams or self.enable_workflows:
             tools.extend(
                 [
                     self.list_versions,
@@ -257,62 +274,6 @@ class StudioTools(Toolkit):
                     self.delete_version,
                 ]
             )
-
-        # Schedules target an existing component by id; opt-in.
-        if self._scheduler_tools is not None:
-            tools.extend(
-                [
-                    self.create_schedule,
-                    self._scheduler_tools.list_schedules,
-                    self._scheduler_tools.get_schedule,
-                    self._scheduler_tools.get_schedule_runs,
-                    self._scheduler_tools.trigger_schedule,
-                    self._scheduler_tools.enable_schedule,
-                    self._scheduler_tools.disable_schedule,
-                    self._scheduler_tools.delete_schedule,
-                ]
-            )
-
-        async_tools: List[tuple[Callable[..., Any], str]] = [
-            (self.alist_models, "list_models"),
-            (self.alist_tools, "list_tools"),
-            (self.alist_functions, "list_functions"),
-            (self.alist_dbs, "list_dbs"),
-            (self.alist_agents, "list_agents"),
-            (self.alist_teams, "list_teams"),
-            (self.alist_workflows, "list_workflows"),
-        ]
-        if self.enable_agents:
-            async_tools.extend(
-                [
-                    (self.aget_agent, "get_agent"),
-                    (self.acreate_agent, "create_agent"),
-                    (self.aedit_agent, "edit_agent"),
-                    (self.adelete_agent, "delete_agent"),
-                    (self.arun_agent, "run_agent"),
-                ]
-            )
-        if self.enable_teams:
-            async_tools.extend(
-                [
-                    (self.aget_team, "get_team"),
-                    (self.acreate_team, "create_team"),
-                    (self.aedit_team, "edit_team"),
-                    (self.adelete_team, "delete_team"),
-                    (self.arun_team, "run_team"),
-                ]
-            )
-        if self.enable_workflows:
-            async_tools.extend(
-                [
-                    (self.aget_workflow, "get_workflow"),
-                    (self.acreate_workflow, "create_workflow"),
-                    (self.aedit_workflow, "edit_workflow"),
-                    (self.adelete_workflow, "delete_workflow"),
-                    (self.arun_workflow, "run_workflow"),
-                ]
-            )
-        if self.enable_versions:
             async_tools.extend(
                 [
                     (self.alist_versions, "list_versions"),
@@ -322,66 +283,153 @@ class StudioTools(Toolkit):
                     (self.adelete_version, "delete_version"),
                 ]
             )
-        if self._scheduler_tools is not None:
+
+        if self.enable_agents:
+            tools.extend(
+                [
+                    self.list_agents,
+                    self.get_agent,
+                    self.create_agent,
+                    self.edit_agent,
+                    self.archive_agent,
+                    self.restore_agent,
+                    self.run_agent,
+                ]
+            )
+            async_tools.extend(
+                [
+                    (self.alist_agents, "list_agents"),
+                    (self.aget_agent, "get_agent"),
+                    (self.acreate_agent, "create_agent"),
+                    (self.aedit_agent, "edit_agent"),
+                    (self.aarchive_agent, "archive_agent"),
+                    (self.arestore_agent, "restore_agent"),
+                    (self.arun_agent, "run_agent"),
+                ]
+            )
+        if self.enable_teams:
+            tools.extend(
+                [
+                    self.list_teams,
+                    self.get_team,
+                    self.create_team,
+                    self.edit_team,
+                    self.archive_team,
+                    self.restore_team,
+                    self.run_team,
+                ]
+            )
+            async_tools.extend(
+                [
+                    (self.alist_teams, "list_teams"),
+                    (self.aget_team, "get_team"),
+                    (self.acreate_team, "create_team"),
+                    (self.aedit_team, "edit_team"),
+                    (self.aarchive_team, "archive_team"),
+                    (self.arestore_team, "restore_team"),
+                    (self.arun_team, "run_team"),
+                ]
+            )
+        if self.enable_workflows:
+            tools.extend(
+                [
+                    self.list_workflows,
+                    self.get_workflow,
+                    self.create_workflow,
+                    self.edit_workflow,
+                    self.archive_workflow,
+                    self.restore_workflow,
+                    self.run_workflow,
+                ]
+            )
+            async_tools.extend(
+                [
+                    (self.alist_workflows, "list_workflows"),
+                    (self.aget_workflow, "get_workflow"),
+                    (self.acreate_workflow, "create_workflow"),
+                    (self.aedit_workflow, "edit_workflow"),
+                    (self.aarchive_workflow, "archive_workflow"),
+                    (self.arestore_workflow, "restore_workflow"),
+                    (self.arun_workflow, "run_workflow"),
+                ]
+            )
+        if schedules:
+            tools.extend(
+                [
+                    self.create_schedule,
+                    self.list_schedules,
+                    self.get_schedule,
+                    self.get_schedule_runs,
+                    self.trigger_schedule,
+                    self.enable_schedule,
+                    self.disable_schedule,
+                    self.delete_schedule,
+                ]
+            )
             async_tools.extend(
                 [
                     (self.acreate_schedule, "create_schedule"),
-                    (self._scheduler_tools.alist_schedules, "list_schedules"),
-                    (self._scheduler_tools.aget_schedule, "get_schedule"),
-                    (self._scheduler_tools.aget_schedule_runs, "get_schedule_runs"),
-                    (self._scheduler_tools.atrigger_schedule, "trigger_schedule"),
-                    (self._scheduler_tools.aenable_schedule, "enable_schedule"),
-                    (self._scheduler_tools.adisable_schedule, "disable_schedule"),
-                    (self._scheduler_tools.adelete_schedule, "delete_schedule"),
+                    (self.alist_schedules, "list_schedules"),
+                    (self.aget_schedule, "get_schedule"),
+                    (self.aget_schedule_runs, "get_schedule_runs"),
+                    (self.atrigger_schedule, "trigger_schedule"),
+                    (self.aenable_schedule, "enable_schedule"),
+                    (self.adisable_schedule, "disable_schedule"),
+                    (self.adelete_schedule, "delete_schedule"),
                 ]
             )
 
         instruction_lines = [
-            "Compose agents, teams, and workflows from registry primitives.",
-            "Discovery: call list_tools/list_functions/list_models/list_dbs first. Tool and function names "
-            "are exact and case-sensitive -- do NOT guess.",
-            "Create: create_agent/create_team/create_workflow. When the user mentions specific "
-            "tools, you MUST include ALL of those names in tool_names; do not silently drop any.",
-            "Created agents and teams remember the session by default; pass "
-            "add_history_to_context=False only for stateless components.",
-            "Edit: ALWAYS call get_agent/get_team/get_workflow first to read the current state, "
-            "then call edit_agent/edit_team/edit_workflow with only the fields that change.",
-            "Run tools execute a component as the current user; a PAUSED result is waiting on human "
-            "approval -- relay its requirements and keep the run_id/session_id for the resume.",
-            "Component lookups accept an exact id or a display name; an ambiguous display name returns "
-            "an error listing the matching ids -- retry with the exact id. Deletes require the exact id.",
-            "Call a given component sequentially within a turn: parallel runs of the same component "
-            "share one session and can overwrite each other.",
+            "Use Studio as an administrative control plane for versioned agents, teams, and workflows.",
+            "Call list_models/list_tools/list_functions and copy their exact typed references; never guess names.",
+            "Create calls take one typed request object and save a draft by default. Component ids are stable; an omitted id is the deterministic slug of the name.",
+            "A component id conflict never creates a suffixed id. Set request.if_exists='return_existing' only to retry an identical request.",
+            "Edits take one typed patch plus expected_version. A version conflict means you must read the latest version and intentionally retry.",
+            "Publish is explicit. Code-defined composite references may be explored in drafts but must be persisted and pinned before publication.",
+            "Create and edit calls require confirmation even for drafts because either call can publish via save_as.",
+            "get_version returns a safe typed view, never the raw persisted configuration.",
+            "Archive requires an exact component id and refuses components or versions that active configs depend on.",
+            "Archived ids remain reserved. Use the matching restore tool with the current-version value observed before archive.",
+            "Run calls use the current published version; a draft is never dispatched as current.",
         ]
-        if self.enable_versions:
-            instruction_lines.extend(
-                [
-                    "Edits produce a draft. Call publish_component to promote the draft to published+current.",
-                    "Versioning: list_versions shows all config versions; set_current_version rolls "
-                    "back to a prior published version; delete_version removes a draft.",
-                ]
-            )
-        else:
-            instruction_lines.append("Edits are published immediately as the new current version.")
         if self.enable_teams:
-            instruction_lines.append(
-                "Team rules: member_ids must be ids returned by create_agent or present in list_agents."
-            )
+            instruction_lines.append("Team members are typed ComponentRef values, including their component type.")
         if self.enable_workflows:
-            instruction_lines.append(
-                "Workflow rules: each step_spec is a dict with 'name' and exactly one of "
-                "'agent_id', 'team_id', or 'function_name'. Use function_name values from list_functions."
-            )
-        if self.enable_schedules:
-            instruction_lines.append(
-                "Schedules: create_schedule targets an existing component by target_type "
-                "('agent'/'team'/'workflow') + target_id (ids from list_agents/list_teams/list_workflows) "
-                "and requires a message. Cron is 5-field; timezone is an IANA name. trigger_schedule "
-                "queues an enabled schedule to run now via the platform poller."
-            )
+            instruction_lines.append("Workflow steps are discriminated by kind: agent, team, or function.")
+        if schedules:
+            instruction_lines.append("Every schedule operation is authorization-gated like component operations.")
 
-        # Toolkit instructions are only injected into the system message when
-        # add_instructions is set, so default it on.
+        # Confirmation is currently configured per tool, not per invocation.
+        # Since every create/edit tool accepts save_as="published", the only
+        # truthful way to guarantee confirmation for all publication paths is
+        # to confirm draft calls too.
+        confirmation_actions = {
+            "create_agent",
+            "create_team",
+            "create_workflow",
+            "edit_agent",
+            "edit_team",
+            "edit_workflow",
+            "publish_component",
+            "set_current_version",
+            "delete_version",
+            "archive_agent",
+            "archive_team",
+            "archive_workflow",
+            "restore_agent",
+            "restore_team",
+            "restore_workflow",
+            "create_schedule",
+            "trigger_schedule",
+            "enable_schedule",
+            "disable_schedule",
+            "delete_schedule",
+        }
+        available_tool_names = {tool.__name__ for tool in tools}
+        configured_confirmations = set(kwargs.pop("requires_confirmation_tools", []) or [])
+        kwargs["requires_confirmation_tools"] = sorted(
+            configured_confirmations | (confirmation_actions & available_tool_names)
+        )
         kwargs.setdefault("add_instructions", True)
         super().__init__(
             name="studio",
@@ -392,109 +440,457 @@ class StudioTools(Toolkit):
         )
 
     # ------------------------------------------------------------------
-    # Registry lookups
+    # Result and authorization helpers
     # ------------------------------------------------------------------
 
-    def _find_model(self, model_id: Optional[str]) -> Optional["Model"]:
-        target = model_id or self.default_model_id
-        if target is None:
-            return self.registry.models[0] if self.registry.models else None
-        for model in self.registry.models:
-            if getattr(model, "id", None) == target:
-                return model
+    @staticmethod
+    def _success(status: str, data: Any, warnings: Optional[List[str]] = None) -> StudioResult[Any]:
+        return StudioResult[Any](ok=True, status=status, data=data, warnings=warnings or [])
+
+    @staticmethod
+    def _failure(
+        code: str,
+        message: str,
+        *,
+        details: Optional[Dict[str, Any]] = None,
+        retryable: bool = False,
+    ) -> StudioResult[Any]:
+        return StudioResult[Any](
+            ok=False,
+            status="error",
+            error=StudioError(code=code, message=message, details=details or {}, retryable=retryable),
+        )
+
+    def _authorize(
+        self,
+        action: StudioAction,
+        access: StudioAccess,
+        run_context: Optional[RunContext],
+    ) -> Optional[StudioResult[Any]]:
+        if not isinstance(run_context, RunContext):
+            return self._failure(
+                "auth_context_required",
+                "Studio requires a framework-injected RunContext.",
+            )
+        if not run_context.user_id:
+            return self._failure("unauthenticated", "Studio requires an authenticated actor.")
+        try:
+            allowed = self.authorize(run_context, access, action)
+        except Exception:
+            logger.error("Studio authorization callback failed for action=%s", action)
+            return self._failure("authorization_failed", "Studio authorization failed.")
+        if not isinstance(allowed, bool):
+            logger.error("Studio authorization callback returned a non-boolean value for action=%s", action)
+            return self._failure("authorization_failed", "Studio authorization failed.")
+        if not allowed:
+            return self._failure("forbidden", "The actor is not allowed to perform this Studio action.")
         return None
 
-    def _find_db(self, db_id: Optional[str]) -> Optional["BaseDb"]:
-        if db_id is None:
-            return self.db
-        return self.registry.get_db(db_id)
+    @staticmethod
+    def _request_failure(error: _StudioRequestError) -> StudioResult[Any]:
+        return StudioTools._failure(
+            error.code,
+            error.message,
+            details=error.details,
+            retryable=error.retryable,
+        )
 
-    def _find_tool(self, name: str) -> Optional[Any]:
-        """Match by Toolkit.name, Function.name, callable __name__, or toolkit function key.
+    @staticmethod
+    def _internal_failure(action: str) -> StudioResult[Any]:
+        # Backend exceptions can contain DSNs, credentials, or private payloads.
+        # Keep the operator signal while leaving exception details to the caller's
+        # explicit diagnostics boundary.
+        logger.error("Studio %s failed", action)
+        return StudioTools._failure("internal_error", f"Studio could not {action}.", retryable=True)
 
-        Top-level name matches take precedence over functions found inside a
-        toolkit. When a name matches more than one distinct registry entry
-        (e.g. two toolkits sharing a name), a ValueError is raised instead of
-        silently returning the first match -- resolving to whichever entry was
-        registered first would wire the agent to the wrong tool.
+    @staticmethod
+    def _validate_save_as(save_as: Any) -> SaveStage:
+        if save_as not in ("draft", "published"):
+            raise _StudioRequestError(
+                "invalid_save_stage",
+                "save_as must be either 'draft' or 'published'.",
+                details={"allowed": ["draft", "published"]},
+            )
+        return cast(SaveStage, save_as)
+
+    @staticmethod
+    def _validate_if_exists(if_exists: Any) -> IfExists:
+        if if_exists not in ("error", "return_existing"):
+            raise _StudioRequestError(
+                "invalid_if_exists",
+                "if_exists must be either 'error' or 'return_existing'.",
+                details={"allowed": ["error", "return_existing"]},
+            )
+        return cast(IfExists, if_exists)
+
+    @staticmethod
+    def _validate_component_id(component_id: Any) -> str:
+        if (
+            not isinstance(component_id, str)
+            or not component_id
+            or not component_id[0].isascii()
+            or not component_id[0].isalnum()
+            or any(
+                not character.isascii() or not (character.isalnum() or character in "._-") for character in component_id
+            )
+        ):
+            raise _StudioRequestError(
+                "invalid_component_id",
+                "component_id must start with an ASCII letter or number and contain only letters, numbers, '.', '_', or '-'.",
+            )
+        return component_id
+
+    def _ensure_component_type_enabled(self, component_type: str) -> None:
+        enabled = {
+            "agent": self.enable_agents,
+            "team": self.enable_teams,
+            "workflow": self.enable_workflows,
+        }.get(component_type)
+        if enabled is None:
+            raise _StudioRequestError("invalid_component_type", "The component type is invalid.")
+        if not enabled:
+            raise _StudioRequestError(
+                "component_type_disabled",
+                f"StudioTools was created with {component_type}s=False.",
+                details={"component_type": component_type},
+            )
+
+    def _validate_workflow_function_catalog(self) -> None:
+        names = [
+            name
+            for function in self.registry.functions
+            if isinstance((name := getattr(function, "__name__", None)), str) and name
+        ]
+        duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
+        if duplicates:
+            raise ValueError(
+                "StudioTools workflows require unique registered function names; duplicates: " + ", ".join(duplicates)
+            )
+
+    def _mirror_reference_lists_into_registry(self) -> None:
+        """Make code-defined composition references reload through the registry.
+
+        Agent and Team rehydration resolves code-defined children through the
+        registry, while Studio discovery can be narrowed with explicit live
+        lists.  A child selected from one of those lists must therefore be the
+        exact object the registry will return for its id.  Mirror valid entries
+        before the runner is constructed and reject split-brain identities
+        without partially mutating the registry.
+
+        Invalid list entries are deliberately ignored here.  Discovery owns
+        their count-only warning and must remain able to isolate a broken or
+        volatile ``id`` property instead of failing Studio construction.
         """
-        matches: List[Any] = []
-        function_matches: List[Any] = []
-        for tool in self.registry.tools:
-            if isinstance(tool, Toolkit):
-                if tool.name == name:
-                    matches.append(tool)
-                elif name in tool.functions:
-                    member = tool.functions[name]
-                    # Stamp the attribution so a component saved with this bare
-                    # Function keeps its "toolkit" key (see Registry.rehydrate_function).
-                    if isinstance(tool.name, str) and tool.name:
-                        member.owning_toolkit = tool.name
-                    function_matches.append(member)
-            elif isinstance(tool, Function):
-                if tool.name == name:
-                    matches.append(tool)
-            elif callable(tool) and getattr(tool, "__name__", None) == name:
-                matches.append(tool)
+        from agno.agent.agent import Agent
+        from agno.team.team import Team
 
-        candidates = matches or function_matches
-        if not candidates:
+        sources: List[tuple[Optional[List[Any]], List[Any], type, str]] = [
+            (cast(Optional[List[Any]], self.agents_list), cast(List[Any], self.registry.agents), Agent, "agents_list"),
+            (cast(Optional[List[Any]], self.teams_list), cast(List[Any], self.registry.teams), Team, "teams_list"),
+        ]
+        pending: Dict[tuple[int, str], tuple[List[Any], Any, str]] = {}
+        for source, bucket, expected_type, source_name in sources:
+            for component in source or []:
+                if not isinstance(component, expected_type):
+                    continue
+                try:
+                    component_id = getattr(component, "id", None)
+                except Exception:
+                    continue
+                if not component_id:
+                    continue
+                matches = [entry for entry in bucket if getattr(entry, "id", None) == component_id]
+                pending_match = pending.get((id(bucket), component_id))
+                distinct = [entry for entry in matches if entry is not component]
+                if pending_match is not None and pending_match[1] is not component:
+                    distinct.append(pending_match[1])
+                if distinct:
+                    raise ValueError(
+                        f"{source_name} and the registry define distinct components with id "
+                        f"'{component_id}'; pass the same object to both, or remove one."
+                    )
+                if not matches and pending_match is None:
+                    pending[(id(bucket), component_id)] = (bucket, component, source_name)
+
+        for bucket, component, _source_name in pending.values():
+            bucket.append(component)
+
+    def _ensure_registry_reference_identity(self, component_type: str, component: Component) -> None:
+        """Keep a live-list child aligned with the registry at selection time.
+
+        Lists are live and may be appended to or replaced after Studio is
+        constructed.  Reconcile again when a reference is persisted so a
+        later strict reload cannot silently bind a different object.
+        """
+        component_id = getattr(component, "id", None)
+        bucket = cast(
+            List[Any],
+            self.registry.agents if component_type == "agent" else self.registry.teams,
+        )
+        matches = [entry for entry in bucket if getattr(entry, "id", None) == component_id]
+        if any(entry is not component for entry in matches):
+            raise _StudioRequestError(
+                "component_identity_mismatch",
+                f"Code-defined {component_type} '{component_id}' is not the registry's object for that id; "
+                "align the live list and registry before persisting the reference.",
+                details={"component_id": component_id, "component_type": component_type},
+            )
+        if not matches:
+            bucket.append(component)
+
+    def _ensure_no_source_collision(self, component_id: str, _component_type: Optional[str] = None) -> None:
+        self._validate_component_id(component_id)
+        stored = self.db.get_component(component_id, include_deleted=True)
+        if stored is None:
+            return
+        code_types = [
+            candidate_type
+            for candidate_type, candidates in (
+                ("agent", self._iter_agents()),
+                ("team", self._iter_teams()),
+                ("workflow", self._iter_workflows()),
+            )
+            if self._contains_component_id(candidates, component_id)
+        ]
+        self._raise_source_collision(component_id, stored, code_types)
+
+    @staticmethod
+    def _raise_source_collision(
+        component_id: str,
+        stored: Dict[str, Any],
+        code_types: Sequence[str],
+    ) -> None:
+        if code_types:
+            raise _StudioRequestError(
+                "component_source_collision",
+                f"Component id '{component_id}' exists in both code and Studio; rename one source before continuing.",
+                details={
+                    "component_id": component_id,
+                    "studio_component_type": stored.get("component_type"),
+                    "code_component_types": code_types,
+                },
+            )
+
+    @staticmethod
+    def _contains_component_id(candidates: Sequence[Component], component_id: str) -> bool:
+        for candidate in candidates:
+            try:
+                if getattr(candidate, "id", None) == component_id:
+                    return True
+            except Exception:
+                # Discovery reports malformed code-defined components via a
+                # count-only warning; collision diagnostics must not re-read a
+                # broken property and turn that safe skip into a list failure.
+                continue
+        return False
+
+    @staticmethod
+    def _safe_dependents(dependents: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        safe: List[Dict[str, Any]] = []
+        for dependent in dependents:
+            parent_id = dependent.get("parent_component_id")
+            parent_version = dependent.get("parent_version")
+            if not isinstance(parent_id, str) or not isinstance(parent_version, int):
+                continue
+            item = {"component_id": parent_id, "version": parent_version}
+            if item not in safe:
+                safe.append(item)
+        return safe
+
+    @staticmethod
+    def _safe_unavailable_dependencies(dependencies: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        safe: List[Dict[str, Any]] = []
+        allowed_reasons = {
+            "component_missing",
+            "component_archived",
+            "version_missing",
+            "version_not_published",
+        }
+        for dependency in dependencies:
+            component_id = dependency.get("component_id")
+            version = dependency.get("version")
+            referenced_by = dependency.get("referenced_by")
+            reason = dependency.get("reason")
+            if (
+                not isinstance(component_id, str)
+                or not isinstance(version, int)
+                or not isinstance(referenced_by, dict)
+                or reason not in allowed_reasons
+            ):
+                continue
+            parent_id = referenced_by.get("component_id")
+            parent_version = referenced_by.get("version")
+            if not isinstance(parent_id, str) or not isinstance(parent_version, int):
+                continue
+            safe.append(
+                {
+                    "component_id": component_id,
+                    "version": version,
+                    "referenced_by": {"component_id": parent_id, "version": parent_version},
+                    "reason": reason,
+                }
+            )
+        return safe
+
+    # ------------------------------------------------------------------
+    # Registry and default resolution
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _model_ref(model: Optional["Model"]) -> Optional[ModelRef]:
+        if model is None or not getattr(model, "id", None):
             return None
-        if len(candidates) > 1:
-            raise ValueError(
-                f"Tool name '{name}' is ambiguous: it matches {len(candidates)} registry entries. "
-                "Give each tool a distinct name (e.g. MCPTools(name=...)) so it can be selected unambiguously."
-            )
-        return candidates[0]
+        return ModelRef(
+            id=cast(str, model.id),
+            provider=getattr(model, "provider", None),
+            name=getattr(model, "name", None),
+        )
 
-    def _resolve_tools(self, names: Optional[List[str]]) -> List[Any]:
-        if not names:
-            return []
-        resolved: List[Any] = []
-        missing: List[str] = []
-        for name in names:
-            found = self._find_tool(name)
-            if found is None:
-                missing.append(name)
-            else:
-                resolved.append(found)
-        if missing:
-            raise ValueError(f"Tools not found in registry: {missing}")
-        # Persisting a component serializes each toolkit's functions; a toolkit
-        # with none (e.g. an MCP toolkit that never connected) would be silently
-        # dropped from the config, permanently. Refuse instead.
-        empty_toolkits = [t.name for t in resolved if isinstance(t, Toolkit) and not t.functions]
-        if empty_toolkits:
-            raise ValueError(
-                f"Toolkits have no functions and cannot be persisted: {empty_toolkits}. "
-                "An MCP toolkit has no functions until it is connected. Connect it before "
-                "creating or editing components with it (AgentOS connects MCP tools found in "
-                "the registry and on agents/teams/workflows at startup)."
+    def _resolve_model(self, model_ref: Optional[ModelRef]) -> tuple["Model", ModelRef]:
+        requested = model_ref or self.default_model
+        if requested is None:
+            raise _StudioRequestError(
+                "model_required",
+                "No model was supplied and Studio has no default_model configured.",
             )
-        return resolved
+        matches = [
+            model
+            for model in self.registry.models
+            if getattr(model, "id", None) == requested.id
+            and (requested.provider is None or getattr(model, "provider", None) == requested.provider)
+            and (requested.name is None or getattr(model, "name", None) == requested.name)
+        ]
+        if not matches:
+            raise _StudioRequestError(
+                "model_not_found",
+                "The exact model reference is not registered.",
+                details={"model": requested.model_dump(exclude_none=True)},
+            )
+        if len(matches) > 1:
+            raise _StudioRequestError(
+                "ambiguous_model",
+                "The model reference matches multiple registry entries; include provider and name.",
+                details={
+                    "model": requested.model_dump(exclude_none=True),
+                    "matches": [
+                        ref.model_dump(exclude_none=True)
+                        for model in matches
+                        if (ref := self._model_ref(model)) is not None
+                    ],
+                },
+            )
+        model = matches[0]
+        resolved = self._model_ref(model)
+        if resolved is None:
+            raise _StudioRequestError("invalid_model", "The registered model has no id.")
+        return model, resolved
 
-    def _normalize_tool_names(self, names: List[str]) -> List[str]:
-        """Collapse toolkit function names back to their toolkit name."""
-        func_to_toolkit: Dict[str, str] = {}
+    def _resolve_context(self, context: Optional[ContextPolicy]) -> ContextPolicy:
+        requested = context or self.default_context
+        history_runs = requested.history_runs
+        if history_runs is None and requested.include_history:
+            history_runs = self.default_context.history_runs
+        return ContextPolicy(
+            include_history=requested.include_history,
+            history_runs=history_runs if requested.include_history else None,
+            include_datetime=requested.include_datetime,
+        )
+
+    def _tool_catalog(self) -> List[tuple[ToolRef, Any]]:
+        catalog: List[tuple[ToolRef, Any]] = []
         for tool in self.registry.tools:
             if isinstance(tool, Toolkit):
-                for fn_name in tool.functions:
-                    func_to_toolkit[fn_name] = tool.name
+                catalog.append((ToolRef(kind="toolkit", name=tool.name), tool))
+                for function_name, function in tool.get_functions().items():
+                    catalog.append((ToolRef(kind="function", name=function_name, toolkit=tool.name), function))
+            elif isinstance(tool, Function):
+                catalog.append((ToolRef(kind="function", name=tool.name), tool))
+            elif callable(tool):
+                name = getattr(tool, "__name__", None)
+                if isinstance(name, str) and name:
+                    catalog.append((ToolRef(kind="function", name=name), tool))
+        return catalog
 
-        normalized: List[str] = []
-        for name in names:
-            mapped = func_to_toolkit.get(name, name)
-            if mapped not in normalized:
-                normalized.append(mapped)
-        return normalized
-
-    # ------------------------------------------------------------------
-    # Component lookup -- delegated to the embedded StudioRunnerTools so the
-    # builder and a standalone dispatcher resolve components one way: exact
-    # ids first (code-defined, then DB), then display names (code-defined,
-    # then DB, where an ambiguous name raises AmbiguousComponentNameError),
-    # then the identifier's slug as an id.
-    # ------------------------------------------------------------------
+    def _resolve_tools(self, refs: Sequence[ToolRef]) -> List[Any]:
+        catalog = self._tool_catalog()
+        resolved: List[Any] = []
+        claimed_names: Dict[str, ToolRef] = {}
+        for ref in refs:
+            matches = [tool for candidate, tool in catalog if candidate == ref]
+            if not matches:
+                raise _StudioRequestError(
+                    "tool_not_found",
+                    "The exact tool reference is not registered.",
+                    details={"tool": ref.model_dump(exclude_none=True)},
+                )
+            if len(matches) > 1:
+                raise _StudioRequestError(
+                    "ambiguous_tool",
+                    "The tool reference matches multiple registry entries.",
+                    details={"tool": ref.model_dump(exclude_none=True)},
+                )
+            tool = matches[0]
+            if ref.kind == "function" and ref.toolkit is None:
+                flat_sources: List[Any] = []
+                for registered in self.registry.tools:
+                    if isinstance(registered, Toolkit):
+                        source = registered.get_functions().get(ref.name)
+                        if source is not None:
+                            flat_sources.append(source)
+                    elif isinstance(registered, Function) and registered.name == ref.name:
+                        flat_sources.append(registered)
+                    elif callable(registered) and getattr(registered, "__name__", None) == ref.name:
+                        flat_sources.append(registered)
+                entrypoint_ids = {
+                    id(source.entrypoint if isinstance(source, Function) and source.entrypoint is not None else source)
+                    for source in flat_sources
+                }
+                if len(entrypoint_ids) > 1:
+                    raise _StudioRequestError(
+                        "ambiguous_tool_binding",
+                        f"Unqualified function '{ref.name}' has multiple live registry entrypoints; qualify the "
+                        "toolkit or give the functions distinct names.",
+                        details={"tool": ref.model_dump(exclude_none=True)},
+                    )
+            if isinstance(tool, Toolkit) and not tool.functions:
+                raise _StudioRequestError(
+                    "toolkit_not_ready",
+                    f"Toolkit '{tool.name}' has no connected functions and cannot be persisted.",
+                )
+            functions = list(tool.get_functions().values()) if isinstance(tool, Toolkit) else [tool]
+            unavailable_functions = sorted(
+                function.name
+                for function in functions
+                if isinstance(function, Function) and function.entrypoint is None and not function.external_execution
+            )
+            if unavailable_functions:
+                raise _StudioRequestError(
+                    "tool_not_ready",
+                    "The selected tool reference contains functions without live entrypoints.",
+                    details={
+                        "tool": ref.model_dump(exclude_none=True),
+                        "functions": unavailable_functions,
+                    },
+                )
+            if isinstance(tool, Function) and ref.toolkit:
+                tool.owning_toolkit = ref.toolkit
+            exposed_names = list(tool.get_functions()) if isinstance(tool, Toolkit) else [ref.name]
+            for function_name in exposed_names:
+                previous = claimed_names.get(function_name)
+                if previous is not None:
+                    raise _StudioRequestError(
+                        "duplicate_tool_name",
+                        f"Selected tool references both expose function name '{function_name}', which Agent would "
+                        "otherwise resolve by registration order.",
+                        details={
+                            "function_name": function_name,
+                            "first": previous.model_dump(exclude_none=True),
+                            "second": ref.model_dump(exclude_none=True),
+                        },
+                    )
+                claimed_names[function_name] = ref
+            resolved.append(tool)
+        return resolved
 
     def _iter_agents(self) -> List["Agent"]:
         return self._runner_tools._iter_agents()
@@ -505,2367 +901,3657 @@ class StudioTools(Toolkit):
     def _iter_workflows(self) -> List["Workflow"]:
         return self._runner_tools._iter_workflows()
 
-    def _find_agent(self, agent_id: str) -> Optional["Agent"]:
-        return self._runner_tools._find_agent(agent_id)
+    def _code_component(self, component_type: str, component_id: str) -> Optional[Component]:
+        candidates: Sequence[Component]
+        if component_type == "agent":
+            candidates = self._iter_agents()
+        elif component_type == "team":
+            candidates = self._iter_teams()
+        else:
+            candidates = self._iter_workflows()
+        matches = [candidate for candidate in candidates if getattr(candidate, "id", None) == component_id]
+        if len(matches) > 1:
+            raise _StudioRequestError(
+                "ambiguous_component",
+                f"Multiple code-defined {component_type}s use component_id '{component_id}'.",
+            )
+        return matches[0] if matches else None
 
-    def _find_team(self, team_id: str) -> Optional["Team"]:
-        return self._runner_tools._find_team(team_id)
+    def _db_component(self, component_type: str, component_id: str) -> Optional[Dict[str, Any]]:
+        from agno.db.base import ComponentType
 
-    def _find_workflow(self, workflow_id: str) -> Optional["Workflow"]:
-        return self._runner_tools._find_workflow(workflow_id)
+        return self.db.get_component(component_id, component_type=ComponentType(component_type))
 
-    # Edit-base lookups: like _find_*, but DB components load from the latest
-    # draft when versioning is enabled, so successive partial edits accumulate
-    # instead of each resetting to the published config.
-
-    def _edit_version_snapshot(self, component_id: str) -> tuple[Optional[int], Optional["ComponentVersionGuard"]]:
-        """Capture the exact config loaded by an edit and its catalog-v2 CAS state."""
-        if self.db is None:
-            return None, None
-        if not self.enable_versions or getattr(self.db, "component_catalog_api_version", 1) < 2:
-            return self._edit_base_version(component_id), None
-
-        from agno.db.base import ComponentVersionGuard
-
-        component = self.db.get_component(component_id)
-        if component is None:
-            return None, None
-        configs = self.db.list_configs(component_id, include_config=False)
-        versions = [row["version"] for row in configs if isinstance(row.get("version"), int)]
-        drafts = [
-            row["version"] for row in configs if row.get("stage") == "draft" and isinstance(row.get("version"), int)
-        ]
-        current_version = component.get("current_version")
-        base_version = max(drafts) if drafts else current_version
-        return base_version, ComponentVersionGuard(
-            latest_version=max(versions) if versions else None,
-            current_version=current_version,
+    def _load_db_component(
+        self,
+        component_type: str,
+        component_id: str,
+        version: Optional[int],
+        *,
+        for_dispatch: bool = False,
+    ) -> Optional[Component]:
+        if component_type == "agent":
+            return self._runner_tools._load_agent_from_db(
+                component_id,
+                version=version,
+                for_dispatch=for_dispatch,
+            )
+        if component_type == "team":
+            return self._runner_tools._load_team_from_db(
+                component_id,
+                version=version,
+                for_dispatch=for_dispatch,
+            )
+        return self._runner_tools._load_workflow_from_db(
+            component_id,
+            version=version,
+            for_dispatch=for_dispatch,
         )
 
-    def _find_agent_for_edit(
-        self, agent_id: str
-    ) -> tuple[Optional["Agent"], Optional[int], Optional["ComponentVersionGuard"]]:
-        for a in self._iter_agents():
-            if getattr(a, "id", None) == agent_id:
-                return a, None, None
-        if self._runner_tools._db_component_exists("agent", agent_id):
-            base_version, guard = self._edit_version_snapshot(agent_id)
-            return self._load_agent_from_db(agent_id, version=base_version), base_version, guard
-        resolved = self._runner_tools._resolve_db_id_by_name_or_slug("agent", agent_id)
-        if resolved is None:
-            return None, None, None
-        base_version, guard = self._edit_version_snapshot(resolved)
-        return self._load_agent_from_db(resolved, version=base_version), base_version, guard
-
-    def _find_team_for_edit(
-        self, team_id: str
-    ) -> tuple[Optional["Team"], Optional[int], Optional["ComponentVersionGuard"]]:
-        for t in self._iter_teams():
-            if getattr(t, "id", None) == team_id:
-                return t, None, None
-        if self._runner_tools._db_component_exists("team", team_id):
-            base_version, guard = self._edit_version_snapshot(team_id)
-            return self._load_team_from_db(team_id, version=base_version), base_version, guard
-        resolved = self._runner_tools._resolve_db_id_by_name_or_slug("team", team_id)
-        if resolved is None:
-            return None, None, None
-        base_version, guard = self._edit_version_snapshot(resolved)
-        return self._load_team_from_db(resolved, version=base_version), base_version, guard
-
-    def _find_workflow_for_edit(
-        self, workflow_id: str
-    ) -> tuple[Optional["Workflow"], Optional[int], Optional["ComponentVersionGuard"]]:
-        for w in self._iter_workflows():
-            if getattr(w, "id", None) == workflow_id:
-                return w, None, None
-        if self._runner_tools._db_component_exists("workflow", workflow_id):
-            base_version, guard = self._edit_version_snapshot(workflow_id)
-            return self._load_workflow_from_db(workflow_id, version=base_version), base_version, guard
-        resolved = self._runner_tools._resolve_db_id_by_name_or_slug("workflow", workflow_id)
-        if resolved is None:
-            return None, None, None
-        base_version, guard = self._edit_version_snapshot(resolved)
-        return self._load_workflow_from_db(resolved, version=base_version), base_version, guard
-
-    def _is_code_defined(self, component_id: str, candidates: List[Any], component_type: str) -> bool:
-        """True if the identifier refers to a code-defined (registry/list) component.
-
-        Code-defined components are not DB-backed, so editing them would write an
-        unreachable DB row that the live object always shadows. edit_* rejects
-        these instead of silently persisting a draft no one can load.
-
-        A display-name match only counts when the identifier is not an exact DB
-        id: exact ids resolve to the DB component on every other path (id-first
-        order), so the edit guard must agree.
-        """
-        for c in candidates:
-            if getattr(c, "id", None) == component_id:
-                return True
-        for c in candidates:
-            if getattr(c, "name", None) == component_id:
-                return not self._runner_tools._db_component_exists(component_type, component_id)
-        return False
-
-    def _edit_base_version(self, component_id: str) -> Optional[int]:
-        """Version to base an edit on: the latest draft when versioning is
-        enabled, else None (the current published version)."""
-        if not self.enable_versions:
-            return None
-        return self._latest_draft_version(component_id)
-
-    def _latest_draft_version(self, component_id: str) -> Optional[int]:
-        if self.db is None:
-            return None
-        configs = self.db.list_configs(component_id, include_config=False)
-        drafts: List[int] = [
-            c["version"] for c in configs if c.get("stage") == "draft" and isinstance(c.get("version"), int)
-        ]
-        return max(drafts) if drafts else None
-
-    def _load_agent_from_db(self, agent_id: str, version: Optional[int] = None) -> Optional["Agent"]:
-        return self._runner_tools._load_agent_from_db(agent_id, version=version)
-
-    def _load_team_from_db(self, team_id: str, version: Optional[int] = None) -> Optional["Team"]:
-        return self._runner_tools._load_team_from_db(team_id, version=version)
-
-    def _load_workflow_from_db(self, workflow_id: str, version: Optional[int] = None) -> Optional["Workflow"]:
-        return self._runner_tools._load_workflow_from_db(workflow_id, version=version)
-
-    # ------------------------------------------------------------------
-    # Discovery tools
-    # ------------------------------------------------------------------
-
-    def list_models(self) -> str:
-        """List models available in the registry.
-
-        Returns:
-            str: JSON object with 'models' (each {id, provider}) and 'count'.
-        """
-        try:
-            models = [{"id": getattr(m, "id", None), "provider": type(m).__name__} for m in self.registry.models]
-            return json.dumps({"models": models, "count": len(models)})
-        except Exception as e:
-            logger.exception("Failed to list models")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def list_tools(self) -> str:
-        """List toolkits and functions available in the registry.
-
-        Returns:
-            str: JSON object with 'tools' (each {name, kind, functions?}) and 'count'.
-                'kind' is 'toolkit', 'function', or 'callable'.
-        """
-        try:
-            result: List[Dict[str, Any]] = []
-            for tool in self.registry.tools:
-                if isinstance(tool, Toolkit):
-                    result.append({"name": tool.name, "kind": "toolkit", "functions": list(tool.functions.keys())})
-                elif isinstance(tool, Function):
-                    result.append({"name": tool.name, "kind": "function"})
-                elif callable(tool):
-                    result.append({"name": getattr(tool, "__name__", repr(tool)), "kind": "callable"})
-            return json.dumps({"tools": result, "count": len(result)})
-        except Exception as e:
-            logger.exception("Failed to list tools")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def list_functions(self) -> str:
-        """List raw functions available in the registry for workflow steps.
-
-        Returns:
-            str: JSON object with 'functions' (each {name, description, signature}) and 'count'.
-        """
-        try:
-            import inspect
-
-            result: List[Dict[str, Any]] = []
-            for func in self.registry.functions:
-                name = getattr(func, "__name__", None) or "anonymous"
-                signature = None
-                try:
-                    signature = str(inspect.signature(func))
-                except (TypeError, ValueError):
-                    pass
-                result.append(
-                    {
-                        "name": name,
-                        "description": inspect.getdoc(func),
-                        "signature": signature,
-                    }
-                )
-            return json.dumps({"functions": result, "count": len(result)})
-        except Exception as e:
-            logger.exception("Failed to list functions")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def list_dbs(self) -> str:
-        """List databases available in the registry.
-
-        Returns:
-            str: JSON object with 'dbs' (each {id, class}) and 'count'.
-        """
-        try:
-            dbs = [{"id": getattr(d, "id", None), "class": type(d).__name__} for d in self.registry.dbs]
-            return json.dumps({"dbs": dbs, "count": len(dbs)})
-        except Exception as e:
-            logger.exception("Failed to list dbs")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def list_agents(self) -> str:
-        """List all known agents: code-defined (registry / agents_list) plus DB components.
-
-        Returns:
-            str: JSON object with 'agents' (each {id, name, model_id, tools, source}), 'count', and
-                'db_total' (DB components in storage; more than the db rows shown means the list
-                is capped -- capped components still resolve by exact id). 'source' is 'code' for
-                registry/list-defined agents, 'db' for DB components.
-        """
-        try:
-            result: List[Dict[str, Any]] = []
-            seen_ids: set[str] = set()
-            idless_names: set[str] = set()  # code ids, plus the names of code components that have no id
-            for a in self._iter_agents():
-                aid = getattr(a, "id", None)
-                name = getattr(a, "name", None)
-                if aid is not None:
-                    seen_ids.add(aid)
-                elif name is not None:
-                    idless_names.add(name)
-                result.append(
-                    {
-                        "id": aid,
-                        "name": name,
-                        "model_id": getattr(getattr(a, "model", None), "id", None),
-                        "tools": _summarize_tools(getattr(a, "tools", None)),
-                        "source": "code",
-                    }
-                )
-            db_rows, db_total = self._list_db_components("agent")
-            # A DB component duplicates a code one when they share an id, or -- for a
-            # code component with no id -- when they share a name. A name collision with
-            # a code component that HAS its own id is a genuinely distinct component and
-            # must stay listed (it is what get_/run_/edit_ resolve to).
-            for row in db_rows:
-                if row["id"] in seen_ids or row["name"] in idless_names:
-                    continue
-                result.append({**row, "source": "db"})
-            return json.dumps({"agents": result, "count": len(result), "db_total": db_total})
-        except Exception as e:
-            logger.exception("Failed to list agents")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def list_teams(self) -> str:
-        """List all known teams: code-defined plus DB components.
-
-        Returns:
-            str: JSON object with 'teams' (each {id, name, model_id, member_ids?, source}), 'count',
-                and 'db_total' (DB components in storage; a capped list is visible as capped).
-        """
-        try:
-            result: List[Dict[str, Any]] = []
-            seen_ids: set[str] = set()
-            idless_names: set[str] = set()  # code ids, plus the names of code components that have no id
-            for team in self._iter_teams():
-                tid = getattr(team, "id", None)
-                name = getattr(team, "name", None)
-                if tid is not None:
-                    seen_ids.add(tid)
-                elif name is not None:
-                    idless_names.add(name)
-                members = getattr(team, "members", None) or []
-                member_ids = [getattr(m, "id", None) for m in members] if not callable(members) else []
-                result.append(
-                    {
-                        "id": tid,
-                        "name": name,
-                        "model_id": getattr(getattr(team, "model", None), "id", None),
-                        "member_ids": member_ids,
-                        "source": "code",
-                    }
-                )
-            db_rows, db_total = self._list_db_components("team")
-            # A DB component duplicates a code one when they share an id, or -- for a
-            # code component with no id -- when they share a name. A name collision with
-            # a code component that HAS its own id is a genuinely distinct component and
-            # must stay listed (it is what get_/run_/edit_ resolve to).
-            for row in db_rows:
-                if row["id"] in seen_ids or row["name"] in idless_names:
-                    continue
-                result.append({**row, "source": "db"})
-            return json.dumps({"teams": result, "count": len(result), "db_total": db_total})
-        except Exception as e:
-            logger.exception("Failed to list teams")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def list_workflows(self) -> str:
-        """List all known workflows: code-defined plus DB components.
-
-        Returns:
-            str: JSON object with 'workflows' (each {id, name, description, steps?, source}), 'count',
-                and 'db_total' (DB components in storage; a capped list is visible as capped).
-        """
-        try:
-            result: List[Dict[str, Any]] = []
-            seen_ids: set[str] = set()
-            idless_names: set[str] = set()  # code ids, plus the names of code components that have no id
-            for wf in self._iter_workflows():
-                wid = getattr(wf, "id", None)
-                name = getattr(wf, "name", None)
-                if wid is not None:
-                    seen_ids.add(wid)
-                elif name is not None:
-                    idless_names.add(name)
-                steps = getattr(wf, "steps", None) or []
-                result.append(
-                    {
-                        "id": wid,
-                        "name": name,
-                        "description": getattr(wf, "description", None),
-                        "steps": [getattr(s, "name", None) for s in steps] if isinstance(steps, list) else [],
-                        "source": "code",
-                    }
-                )
-            db_rows, db_total = self._list_db_components("workflow")
-            # A DB component duplicates a code one when they share an id, or -- for a
-            # code component with no id -- when they share a name. A name collision with
-            # a code component that HAS its own id is a genuinely distinct component and
-            # must stay listed (it is what get_/run_/edit_ resolve to).
-            for row in db_rows:
-                if row["id"] in seen_ids or row["name"] in idless_names:
-                    continue
-                result.append({**row, "source": "db"})
-            return json.dumps({"workflows": result, "count": len(result), "db_total": db_total})
-        except Exception as e:
-            logger.exception("Failed to list workflows")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def _list_db_components(self, component_type: str) -> tuple[List[Dict[str, Any]], int]:
-        """Thin summaries of DB components of a given type plus the total DB count.
-
-        The total makes a capped list visible as capped: components beyond the
-        cap still resolve by exact id."""
-        return self._runner_tools._list_db_component_rows(component_type)
-
-    # ------------------------------------------------------------------
-    # Read one
-    # ------------------------------------------------------------------
-
-    def get_agent(self, agent_id: str) -> str:
-        """Read an agent's current published config. Call this before edit_agent.
-
-        Returns the published version; pending draft edits are not reflected here.
-
-        Args:
-            agent_id (str): The id or name of the agent.
-        """
-        try:
-            agent = self._find_agent(agent_id)
-        except StudioRunnerError as e:
-            return json.dumps({"error": str(e) or type(e).__name__})
-        except Exception as e:
-            logger.exception("Failed to resolve agent")
-            return json.dumps({"error": f"Failed to resolve agent '{agent_id}': {str(e) or type(e).__name__}"})
-        if agent is None:
-            return json.dumps({"error": f"Agent not found: {agent_id}"})
-        return json.dumps(
-            {
-                "id": getattr(agent, "id", None),
-                "name": getattr(agent, "name", None),
-                "model_id": getattr(getattr(agent, "model", None), "id", None),
-                "instructions": getattr(agent, "instructions", None),
-                "description": getattr(agent, "description", None),
-                "tools": self._normalize_tool_names(_summarize_tools(getattr(agent, "tools", None))),
-                "add_history_to_context": getattr(agent, "add_history_to_context", None),
-                "num_history_runs": getattr(agent, "num_history_runs", None),
-                "add_datetime_to_context": getattr(agent, "add_datetime_to_context", None),
-            },
-            default=str,
-        )
-
-    def get_team(self, team_id: str) -> str:
-        """Read a team's current published config. Call this before edit_team.
-
-        Returns the published version; pending draft edits are not reflected here.
-
-        Args:
-            team_id (str): The id or name of the team.
-        """
-        try:
-            team = self._find_team(team_id)
-        except StudioRunnerError as e:
-            return json.dumps({"error": str(e) or type(e).__name__})
-        except Exception as e:
-            logger.exception("Failed to resolve team")
-            return json.dumps({"error": f"Failed to resolve team '{team_id}': {str(e) or type(e).__name__}"})
-        if team is None:
-            return json.dumps({"error": f"Team not found: {team_id}"})
-        members = getattr(team, "members", None) or []
-        return json.dumps(
-            {
-                "id": getattr(team, "id", None),
-                "name": getattr(team, "name", None),
-                "model_id": getattr(getattr(team, "model", None), "id", None),
-                "instructions": getattr(team, "instructions", None),
-                "description": getattr(team, "description", None),
-                "member_ids": [getattr(m, "id", None) for m in members] if not callable(members) else [],
-                "add_history_to_context": getattr(team, "add_history_to_context", None),
-                "num_history_runs": getattr(team, "num_history_runs", None),
-                "add_datetime_to_context": getattr(team, "add_datetime_to_context", None),
-            },
-            default=str,
-        )
-
-    def get_workflow(self, workflow_id: str) -> str:
-        """Read a workflow's current published config. Call this before edit_workflow.
-
-        Returns the published version; pending draft edits are not reflected here.
-
-        Args:
-            workflow_id (str): The id or name of the workflow.
-        """
-        try:
-            wf = self._find_workflow(workflow_id)
-        except StudioRunnerError as e:
-            return json.dumps({"error": str(e) or type(e).__name__})
-        except Exception as e:
-            logger.exception("Failed to resolve workflow")
-            return json.dumps({"error": f"Failed to resolve workflow '{workflow_id}': {str(e) or type(e).__name__}"})
-        if wf is None:
-            return json.dumps({"error": f"Workflow not found: {workflow_id}"})
-        steps = getattr(wf, "steps", None) or []
-        step_summaries: List[Dict[str, Any]] = []
-        for step in steps if isinstance(steps, list) else []:
-            executor = getattr(step, "executor", None)
-            function_name = None
-            if executor is not None:
-                function_name = getattr(executor, "name", None) or getattr(executor, "__name__", None)
-            step_summaries.append(
-                {
-                    "name": getattr(step, "name", None),
-                    "agent_id": getattr(getattr(step, "agent", None), "id", None),
-                    "team_id": getattr(getattr(step, "team", None), "id", None),
-                    "function_name": function_name,
-                }
-            )
-        return json.dumps(
-            {
-                "id": getattr(wf, "id", None),
-                "name": getattr(wf, "name", None),
-                "description": getattr(wf, "description", None),
-                "steps": step_summaries,
-            },
-            default=str,
-        )
-
-    # ------------------------------------------------------------------
-    # Create (published v1)
-    # ------------------------------------------------------------------
-
-    def create_agent(
+    def _resolve_component_ref(
         self,
-        name: str,
-        instructions: str,
-        model_id: Optional[str] = None,
-        tool_names: Optional[List[str]] = None,
-        db_id: Optional[str] = None,
-        description: Optional[str] = None,
-        add_history_to_context: bool = True,
-        num_history_runs: Optional[int] = None,
-        add_datetime_to_context: bool = True,
-    ) -> str:
-        """Create a new agent and persist it as a published component.
-
-        Args:
-            name (str): Display name; also used as the id.
-            instructions (str): System instructions for the agent.
-            model_id (Optional[str]): Model id from the registry (see list_models).
-            tool_names (Optional[List[str]]): Toolkit or function names from the registry
-                (see list_tools). Include EVERY tool the user mentioned.
-            db_id (Optional[str]): Database id from the registry. Uses the default if omitted.
-            description (Optional[str]): Optional human-readable description.
-            add_history_to_context (bool): Include prior turns of the session so the
-                agent remembers the conversation. Defaults to True; pass False for a
-                stateless agent.
-            num_history_runs (Optional[int]): How many prior runs to include when
-                history is on. Omit for the default.
-            add_datetime_to_context (bool): Add the current date and time to the
-                agent's context so it can date and time-reference reliably.
-                Defaults to True; pass False to omit.
-
-        Returns:
-            str: JSON with {status, id, name, model_id, tools, add_history_to_context,
-            add_datetime_to_context, db_version}.
-        """
-        from agno.agent.agent import Agent
-
-        try:
-            model = self._find_model(model_id)
-            if model is None:
-                return json.dumps({"error": f"Model not found: {model_id or 'default'}"})
-            tools = self._resolve_tools(tool_names)
-            db = self._find_db(db_id)
-            if db is None:
-                message = f"Db not found: {db_id}" if db_id is not None else "StudioTools has no db configured."
-                return json.dumps({"error": message})
-
-            agent_id = self._unique_component_id(name, db)
-            agent = Agent(
-                id=agent_id,
-                name=name,
-                model=model,
-                tools=tools or None,
-                instructions=instructions,
-                db=db,
-                description=description,
-                add_history_to_context=add_history_to_context,
-                num_history_runs=num_history_runs if num_history_runs is not None else self.default_num_history_runs,
-                add_datetime_to_context=add_datetime_to_context,
+        ref: ComponentRef,
+        *,
+        link_kind: str,
+        link_key: str,
+        position: int,
+    ) -> _ResolvedRef:
+        self._ensure_no_source_collision(ref.component_id, ref.component_type)
+        row = self.db.get_component(ref.component_id)
+        if row is not None and row.get("component_type") != ref.component_type:
+            raise _StudioRequestError(
+                "component_type_mismatch",
+                f"Component '{ref.component_id}' is not a {ref.component_type}.",
             )
-
-            version = _persist_only(agent, db)
-            log_debug(f"StudioTools created agent id={agent_id} version={version}")
-            return json.dumps(
-                {
-                    "status": "created",
-                    "id": agent_id,
-                    "name": name,
-                    "model_id": getattr(model, "id", None),
-                    "tools": _summarize_tools(tools),
-                    "add_history_to_context": add_history_to_context,
-                    "add_datetime_to_context": add_datetime_to_context,
-                    "db_version": version,
-                }
-            )
-        except Exception as e:
-            logger.exception("Failed to create agent")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def create_team(
-        self,
-        name: str,
-        instructions: str,
-        member_ids: List[str],
-        model_id: Optional[str] = None,
-        db_id: Optional[str] = None,
-        description: Optional[str] = None,
-        add_history_to_context: bool = True,
-        num_history_runs: Optional[int] = None,
-        add_datetime_to_context: bool = True,
-    ) -> str:
-        """Create a new team and persist it as a published component.
-
-        Args:
-            name (str): Display name; also used as the id.
-            instructions (str): Instructions that steer the team leader.
-            member_ids (List[str]): Ids of existing agents or teams (see list_agents/list_teams).
-            model_id (Optional[str]): Model id for the team leader.
-            db_id (Optional[str]): Database id from the registry.
-            description (Optional[str]): Optional description.
-            add_history_to_context (bool): Include prior turns of the session so the
-                team remembers the conversation. Defaults to True; pass False for a
-                stateless team.
-            num_history_runs (Optional[int]): How many prior runs to include when
-                history is on. Omit for the default.
-            add_datetime_to_context (bool): Add the current date and time to the
-                team's context so it can date and time-reference reliably.
-                Defaults to True; pass False to omit.
-
-        Returns:
-            str: JSON with {status, id, name, model_id, member_ids, add_history_to_context,
-            add_datetime_to_context, db_version}.
-        """
-        from agno.team.team import Team
-
-        try:
-            model = self._find_model(model_id)
-            if model is None:
-                return json.dumps({"error": f"Model not found: {model_id or 'default'}"})
-
-            db = self._find_db(db_id)
-            if db is None:
-                message = f"Db not found: {db_id}" if db_id is not None else "StudioTools has no db configured."
-                return json.dumps({"error": message})
-            try:
-                members, missing = self._resolve_members(member_ids, target_db=db)
-            except ValueError as e:
-                # Ambiguity and id-less refusals are validation of model input,
-                # not system failures: no traceback in the operator log.
-                return json.dumps({"error": str(e)})
-            if missing:
-                return json.dumps({"error": f"Members not found: {missing}"})
-            if not members:
-                return json.dumps({"error": "A team must have at least one member"})
-
-            try:
-                members, member_pins = self._bind_members_to_target_db(members, db)
-            except ValueError as e:
-                return json.dumps({"error": str(e)})
-            team_id = self._unique_component_id(name, db)
-            team = Team(
-                id=team_id,
-                name=name,
-                model=model,
-                members=members,
-                instructions=instructions,
-                db=db,
-                description=description,
-                add_history_to_context=add_history_to_context,
-                num_history_runs=num_history_runs if num_history_runs is not None else self.default_num_history_runs,
-                add_datetime_to_context=add_datetime_to_context,
-            )
-
-            version = _persist_only(team, db, links=self._links_for_component(team, db=db, pinned_versions=member_pins))
-            log_debug(f"StudioTools created team id={team_id} members={member_ids} version={version}")
-            return json.dumps(
-                {
-                    "status": "created",
-                    "id": team_id,
-                    "name": name,
-                    "model_id": getattr(model, "id", None),
-                    "member_ids": [getattr(m, "id", None) for m in members],
-                    "add_history_to_context": add_history_to_context,
-                    "add_datetime_to_context": add_datetime_to_context,
-                    "db_version": version,
-                }
-            )
-        except Exception as e:
-            logger.exception("Failed to create team")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def create_workflow(
-        self,
-        name: str,
-        description: str,
-        step_specs: List[Dict[str, Any]],
-        db_id: Optional[str] = None,
-    ) -> str:
-        """Create a new workflow and persist it as a published component.
-
-        Args:
-            name (str): Display name; also used as the id.
-            description (str): What the workflow does.
-            step_specs (List[dict]): Ordered steps. Each dict has 'name' and exactly
-                one of 'agent_id', 'team_id', or 'function_name'. Optional: 'description'.
-            db_id (Optional[str]): Database id from the registry.
-
-        Returns:
-            str: JSON with {status, id, name, description, steps, db_version}.
-        """
-        from agno.workflow.workflow import Workflow
-
-        try:
-            db = self._find_db(db_id)
-            if db is None:
-                message = f"Db not found: {db_id}" if db_id is not None else "StudioTools has no db configured."
-                return json.dumps({"error": message})
-            steps, err = self._build_steps(step_specs, fallback_db=db)
-            if err is not None:
-                return json.dumps({"error": err})
-
-            try:
-                step_pins = self._bind_steps_to_target_db(steps, db)
-            except ValueError as e:
-                return json.dumps({"error": str(e)})
-            workflow_id = self._unique_component_id(name, db)
-            workflow = Workflow(
-                id=workflow_id,
-                name=name,
-                description=description,
-                steps=steps,
-                db=db,
-            )
-
-            version = _persist_only(
-                workflow, db, links=self._links_for_component(workflow, db=db, pinned_versions=step_pins)
-            )
-            log_debug(f"StudioTools created workflow id={workflow_id} steps={len(steps)} version={version}")
-            return json.dumps(
-                {
-                    "status": "created",
-                    "id": workflow_id,
-                    "name": name,
-                    "description": description,
-                    "steps": [s.name for s in steps],
-                    "db_version": version,
-                }
-            )
-        except Exception as e:
-            logger.exception("Failed to create workflow")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    # ------------------------------------------------------------------
-    # Edit (produces a draft version)
-    # ------------------------------------------------------------------
-
-    def edit_agent(
-        self,
-        agent_id: str,
-        instructions: Optional[str] = None,
-        model_id: Optional[str] = None,
-        tool_names: Optional[List[str]] = None,
-        description: Optional[str] = None,
-        add_history_to_context: Optional[bool] = None,
-        num_history_runs: Optional[int] = None,
-        add_datetime_to_context: Optional[bool] = None,
-    ) -> str:
-        """Edit an agent.
-
-        Always call get_agent(agent_id) first to read the current state, then
-        pass only the fields that should change. With versioning enabled the
-        edit is saved as a draft (use publish_component to promote it);
-        otherwise it is published immediately as the new current version.
-
-        Args:
-            agent_id (str): The id or display name of the agent to edit.
-            instructions (Optional[str]): New instructions. Omit to keep.
-            model_id (Optional[str]): New model id from the registry. Omit to keep.
-            tool_names (Optional[List[str]]): New tool list (replaces existing). Omit to keep.
-            description (Optional[str]): New description. Omit to keep.
-            add_history_to_context (Optional[bool]): Whether the agent sees prior turns
-                of the session. Omit to keep.
-            num_history_runs (Optional[int]): New history depth. Omit to keep.
-            add_datetime_to_context (Optional[bool]): Whether the agent sees the
-                current date and time. Omit to keep.
-        """
-        if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured; cannot edit components."})
-        try:
-            # _is_code_defined does DB I/O; keep it inside the try so a db failure here
-            # returns a structured error like every other resolve path, not an unhandled raise.
-            if self._is_code_defined(agent_id, self._iter_agents(), "agent"):
-                hint = ""
-                try:
-                    shadowed = self._runner_tools._resolve_db_id_by_name_or_slug("agent", agent_id)
-                    if shadowed is not None:
-                        hint = f" A Studio-created agent with this name exists: use its exact id '{shadowed}'."
-                except AmbiguousComponentNameError:
-                    pass
-                return json.dumps(
-                    {
-                        "error": f"Cannot edit code-defined agent: {agent_id}. "
-                        f"Only Studio-created components are editable.{hint}"
-                    }
+        if row is not None:
+            version = ref.version if ref.version is not None else row.get("current_version")
+            if version is None:
+                raise _StudioRequestError(
+                    "published_version_required",
+                    f"Component '{ref.component_id}' has no current published version; publish it first.",
                 )
-            agent, edit_base_version, edit_guard = self._find_agent_for_edit(agent_id)
-        except StudioRunnerError as e:
-            return json.dumps({"error": str(e) or type(e).__name__})
-        except Exception as e:
-            logger.exception("Failed to resolve agent")
-            return json.dumps({"error": f"Failed to resolve agent '{agent_id}': {str(e) or type(e).__name__}"})
-        if agent is None:
-            return json.dumps({"error": f"Agent not found: {agent_id}"})
-
-        try:
-            agent = agent.deep_copy()
-            if getattr(agent, "id", None) is None:
-                agent.id = agent_id
-            agent.db = self.db
-            if instructions is not None:
-                agent.instructions = instructions
-            if description is not None:
-                agent.description = description
-            if model_id is not None:
-                model = self._find_model(model_id)
-                if model is None:
-                    return json.dumps({"error": f"Model not found: {model_id}"})
-                agent.model = model
-            if tool_names is not None:
-                agent.tools = self._resolve_tools(tool_names) or None
-            if add_history_to_context is not None:
-                agent.add_history_to_context = add_history_to_context
-            if num_history_runs is not None:
-                agent.num_history_runs = num_history_runs
-                # Mirror Agent.__init__'s resolution: num_history_runs wins
-                # over num_history_messages.
-                agent.num_history_messages = None
-            if add_datetime_to_context is not None:
-                agent.add_datetime_to_context = add_datetime_to_context
-
-            replaced_keys = set()
-            if tool_names is not None:
-                replaced_keys.add("tools")
-            if model_id is not None:
-                replaced_keys.add("model")
-            result = self._save_edit(
-                agent,
-                replaced_keys=replaced_keys,
-                base_version=edit_base_version,
-                guard=edit_guard,
-            )
-            log_debug(f"StudioTools edited agent id={agent.id} result={result}")
-            return json.dumps({"status": "edited", "id": getattr(agent, "id", None) or agent_id, **result})
-        except Exception as e:
-            logger.exception("Failed to edit agent")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def edit_team(
-        self,
-        team_id: str,
-        instructions: Optional[str] = None,
-        model_id: Optional[str] = None,
-        member_ids: Optional[List[str]] = None,
-        description: Optional[str] = None,
-        add_history_to_context: Optional[bool] = None,
-        num_history_runs: Optional[int] = None,
-        add_datetime_to_context: Optional[bool] = None,
-    ) -> str:
-        """Edit a team.
-
-        Always call get_team(team_id) first to read the current state, then
-        pass only the fields that should change. With versioning enabled the
-        edit is saved as a draft (use publish_component to promote it);
-        otherwise it is published immediately as the new current version.
-
-        Args:
-            team_id (str): The id or display name of the team to edit.
-            instructions (Optional[str]): New instructions. Omit to keep.
-            model_id (Optional[str]): New model id. Omit to keep.
-            member_ids (Optional[List[str]]): New member ids (replaces existing). Omit to keep.
-            description (Optional[str]): New description. Omit to keep.
-            add_history_to_context (Optional[bool]): Whether the team sees prior turns
-                of the session. Omit to keep.
-            num_history_runs (Optional[int]): New history depth. Omit to keep.
-            add_datetime_to_context (Optional[bool]): Whether the team sees the
-                current date and time. Omit to keep.
-        """
-        if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured; cannot edit components."})
-        try:
-            # _is_code_defined does DB I/O; keep it inside the try so a db failure here
-            # returns a structured error like every other resolve path, not an unhandled raise.
-            if self._is_code_defined(team_id, self._iter_teams(), "team"):
-                hint = ""
-                try:
-                    shadowed = self._runner_tools._resolve_db_id_by_name_or_slug("team", team_id)
-                    if shadowed is not None:
-                        hint = f" A Studio-created team with this name exists: use its exact id '{shadowed}'."
-                except AmbiguousComponentNameError:
-                    pass
-                return json.dumps(
-                    {
-                        "error": f"Cannot edit code-defined team: {team_id}. "
-                        f"Only Studio-created components are editable.{hint}"
-                    }
-                )
-            team, edit_base_version, edit_guard = self._find_team_for_edit(team_id)
-        except StudioRunnerError as e:
-            return json.dumps({"error": str(e) or type(e).__name__})
-        except Exception as e:
-            logger.exception("Failed to resolve team")
-            return json.dumps({"error": f"Failed to resolve team '{team_id}': {str(e) or type(e).__name__}"})
-        if team is None:
-            return json.dumps({"error": f"Team not found: {team_id}"})
-
-        try:
-            replaced_pins: Optional[Dict[str, int]] = None
-            team = team.deep_copy()
-            if getattr(team, "id", None) is None:
-                team.id = team_id
-            team.db = self.db
-            if instructions is not None:
-                team.instructions = instructions
-            if description is not None:
-                team.description = description
-            if model_id is not None:
-                model = self._find_model(model_id)
-                if model is None:
-                    return json.dumps({"error": f"Model not found: {model_id}"})
-                team.model = model
-            if member_ids is not None:
-                try:
-                    members, missing = self._resolve_members(member_ids)
-                    if self.db is not None:
-                        members, replaced_pins = self._bind_members_to_target_db(
-                            members, self.db, require_published=not self.enable_versions
-                        )
-                except ValueError as e:
-                    return json.dumps({"error": str(e)})
-                if missing:
-                    return json.dumps({"error": f"Members not found: {missing}"})
-                if not members:
-                    return json.dumps({"error": "A team must have at least one member"})
-                team.members = members
-            else:
-                # Team.from_dict resolves members through the registry and db only,
-                # dropping (with a warning) any it cannot supply -- a code-defined
-                # agents_list entry, for one. Re-serializing that rebuild would
-                # publish a roster silently shrunk by an unrelated edit.
-                resolved_id = getattr(team, "id", None) or team_id
-                row = self.db.get_config(component_id=resolved_id, version=edit_base_version)
-                stored_config = row.get("config") if isinstance(row, dict) else None
-                stored_members = (stored_config or {}).get("members") or []
-                rebuilt_members = team.members if isinstance(team.members, list) else []
-                if len(rebuilt_members) < len(stored_members):
-                    return json.dumps(
-                        {
-                            "error": f"Editing '{resolved_id}' would drop members its rebuild cannot resolve "
-                            f"({len(rebuilt_members)} of {len(stored_members)} resolved). Register the "
-                            "missing members in the registry or database, then retry."
-                        }
-                    )
-            if add_history_to_context is not None:
-                team.add_history_to_context = add_history_to_context
-            if num_history_runs is not None:
-                team.num_history_runs = num_history_runs
-                # Mirror Team.__init__'s resolution: num_history_runs wins
-                # over num_history_messages.
-                team.num_history_messages = None
-            if add_datetime_to_context is not None:
-                team.add_datetime_to_context = add_datetime_to_context
-
-            replaced_keys = set()
-            if member_ids is not None:
-                replaced_keys.add("members")
-            if model_id is not None:
-                replaced_keys.add("model")
-            result = self._save_edit(
-                team,
-                replaced_keys=replaced_keys,
-                pinned_children=replaced_pins,
-                base_version=edit_base_version,
-                guard=edit_guard,
-            )
-            log_debug(f"StudioTools edited team id={team.id} result={result}")
-            return json.dumps({"status": "edited", "id": getattr(team, "id", None) or team_id, **result})
-        except Exception as e:
-            logger.exception("Failed to edit team")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def edit_workflow(
-        self,
-        workflow_id: str,
-        description: Optional[str] = None,
-        step_specs: Optional[List[Dict[str, Any]]] = None,
-    ) -> str:
-        """Edit a workflow.
-
-        Always call get_workflow(workflow_id) first to read the current state,
-        then pass only the fields that should change. With versioning enabled
-        the edit is saved as a draft (use publish_component to promote it);
-        otherwise it is published immediately as the new current version.
-
-        Args:
-            workflow_id (str): The id or display name of the workflow to edit.
-            description (Optional[str]): New description. Omit to keep.
-            step_specs (Optional[List[dict]]): New ordered steps (replaces existing). Omit to keep.
-                Same shape as create_workflow.step_specs.
-        """
-        if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured; cannot edit components."})
-        try:
-            # _is_code_defined does DB I/O; keep it inside the try so a db failure here
-            # returns a structured error like every other resolve path, not an unhandled raise.
-            if self._is_code_defined(workflow_id, self._iter_workflows(), "workflow"):
-                hint = ""
-                try:
-                    shadowed = self._runner_tools._resolve_db_id_by_name_or_slug("workflow", workflow_id)
-                    if shadowed is not None:
-                        hint = f" A Studio-created workflow with this name exists: use its exact id '{shadowed}'."
-                except AmbiguousComponentNameError:
-                    pass
-                return json.dumps(
-                    {
-                        "error": f"Cannot edit code-defined workflow: {workflow_id}. "
-                        f"Only Studio-created components are editable.{hint}"
-                    }
-                )
-            wf, edit_base_version, edit_guard = self._find_workflow_for_edit(workflow_id)
-        except StudioRunnerError as e:
-            return json.dumps({"error": str(e) or type(e).__name__})
-        except Exception as e:
-            logger.exception("Failed to resolve workflow")
-            return json.dumps({"error": f"Failed to resolve workflow '{workflow_id}': {str(e) or type(e).__name__}"})
-        if wf is None:
-            return json.dumps({"error": f"Workflow not found: {workflow_id}"})
-
-        try:
-            wf = wf.deep_copy()
-            if getattr(wf, "id", None) is None:
-                wf.id = workflow_id
-            wf.db = self.db
-            if description is not None:
-                wf.description = description
-            replaced_pins: Optional[Dict[str, int]] = None
-            if step_specs is not None:
-                steps, err = self._build_steps(step_specs)
-                if err is not None:
-                    return json.dumps({"error": err})
-                if self.db is not None:
-                    try:
-                        replaced_pins = self._bind_steps_to_target_db(
-                            steps, self.db, require_published=not self.enable_versions
-                        )
-                    except ValueError as e:
-                        return json.dumps({"error": str(e)})
-                wf.steps = steps
-
-            result = self._save_edit(
-                wf,
-                replaced_keys={"steps"} if step_specs is not None else None,
-                pinned_children=replaced_pins,
-                base_version=edit_base_version,
-                guard=edit_guard,
-            )
-            log_debug(f"StudioTools edited workflow id={wf.id} result={result}")
-            return json.dumps({"status": "edited", "id": getattr(wf, "id", None) or workflow_id, **result})
-        except Exception as e:
-            logger.exception("Failed to edit workflow")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    # ------------------------------------------------------------------
-    # Versioning / configs
-    # ------------------------------------------------------------------
-
-    def list_versions(self, component_id: str) -> str:
-        """List all config versions for a component.
-
-        Args:
-            component_id (str): The component id.
-        """
-        if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured."})
-        try:
-            component = self.db.get_component(component_id) or {}
-            current_version = component.get("current_version")
-            configs = self.db.list_configs(component_id, include_config=False)
-            versions = [
-                {
-                    "version": c.get("version"),
-                    "stage": c.get("stage"),
-                    "label": c.get("label"),
-                    "created_at": c.get("created_at"),
-                    "is_current": current_version is not None and c.get("version") == current_version,
-                }
-                for c in configs
-            ]
-            return json.dumps({"component_id": component_id, "versions": versions, "count": len(versions)})
-        except Exception as e:
-            logger.exception("Failed to list versions")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def get_version(self, component_id: str, version: Optional[int] = None) -> str:
-        """Get a specific config version. If version is omitted, returns the current version.
-
-        Args:
-            component_id (str): The component id.
-            version (Optional[int]): Version number, or omit for the current version.
-        """
-        if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured."})
-        try:
-            config = self.db.get_config(component_id=component_id, version=version)
+            config = self.db.get_config(ref.component_id, version=version)
             if config is None:
-                return json.dumps({"error": f"Version not found: component_id={component_id} version={version}"})
-            return json.dumps(config, default=str)
-        except Exception as e:
-            logger.exception("Failed to get version")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def publish_component(self, component_id: str, version: Optional[int] = None) -> str:
-        """Promote a draft to published (and make it the current version).
-
-        Args:
-            component_id (str): The component id.
-            version (Optional[int]): The draft version to publish. If omitted, publishes the
-                latest draft. Re-publishing an already-published version is a no-op and
-                returns status "already_published".
-        """
-        if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured."})
-        try:
-            from agno.db.base import ComponentVersionGuard
-
-            component = self.db.get_component(component_id)
-            if component is None:
-                return json.dumps({"error": f"Component not found: {component_id}"})
-            catalog_v2 = getattr(self.db, "component_catalog_api_version", 1) >= 2
-            configs = self.db.list_configs(component_id, include_config=False)
-            latest_version = max(
-                (c["version"] for c in configs if isinstance(c.get("version"), int)),
-                default=None,
-            )
-            target = version
-            if target is None:
-                drafts = [c for c in configs if c.get("stage") == "draft"]
-                if not drafts:
-                    return json.dumps({"error": "No draft version to publish."})
-                target = max(d.get("version", 0) for d in drafts)
-            else:
-                # Explicit version: validate it exists and is not already published.
-                match = next((c for c in configs if c.get("version") == target), None)
-                if match is None:
-                    return json.dumps({"error": f"Version not found: {component_id} v{target}"})
-                if match.get("stage") == "published":
-                    if not catalog_v2:
-                        self._sync_component_row(component_id, target)
-                    return json.dumps({"status": "already_published", "id": component_id, "version": target})
-
-            if catalog_v2:
-                result = self.db.upsert_config(
-                    component_id=component_id,
-                    version=target,
-                    stage="published",
-                    guard=ComponentVersionGuard(
-                        latest_version=latest_version,
-                        current_version=component.get("current_version"),
-                    ),
+                raise _StudioRequestError(
+                    "version_not_found",
+                    f"Version {version} was not found for component '{ref.component_id}'.",
                 )
-            else:
-                result = self.db.upsert_config(component_id=component_id, version=target, stage="published")
-            published_version = result.get("version", target)
-            if not catalog_v2:
-                self._sync_component_row(component_id, published_version)
-            return json.dumps(
-                {
-                    "status": "published",
-                    "id": component_id,
-                    "version": published_version,
-                }
+            if config.get("stage") != "published":
+                raise _StudioRequestError(
+                    "published_version_required",
+                    f"Component '{ref.component_id}' v{version} is a draft; publish it before referencing it.",
+                )
+            component = self._load_db_component(ref.component_type, ref.component_id, version)
+            if component is None:
+                raise _StudioRequestError(
+                    "component_rehydration_failed",
+                    f"Component '{ref.component_id}' v{version} could not be faithfully rehydrated.",
+                )
+            pinned_ref = ComponentRef(
+                component_type=ref.component_type,
+                component_id=ref.component_id,
+                version=version,
             )
-        except Exception as e:
-            logger.exception("Failed to publish component")
-            return json.dumps({"error": str(e) or type(e).__name__})
+            return _ResolvedRef(
+                component=component,
+                ref=pinned_ref,
+                link={
+                    "link_kind": link_kind,
+                    "link_key": link_key,
+                    "child_component_id": ref.component_id,
+                    "child_version": version,
+                    "position": position,
+                    "meta": {"type": ref.component_type},
+                },
+                code_defined=False,
+            )
 
-    def set_current_version(self, component_id: str, version: int) -> str:
-        """Roll back to a previously published version (make it current).
+        if ref.version is not None:
+            raise _StudioRequestError(
+                "component_not_found",
+                f"Stored {ref.component_type} '{ref.component_id}' was not found for pinned version {ref.version}.",
+            )
+        component = self._code_component(ref.component_type, ref.component_id)
+        if component is None:
+            raise _StudioRequestError(
+                "component_not_found",
+                f"{ref.component_type.capitalize()} '{ref.component_id}' was not found.",
+            )
+        self._ensure_registry_reference_identity(ref.component_type, component)
+        return _ResolvedRef(component=component, ref=ref, link=None, code_defined=True)
 
-        Args:
-            component_id (str): The component id.
-            version (int): A published version to set as current.
-        """
-        if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured."})
-        try:
-            ok = self.db.set_current_version(component_id, version=version)
-            if not ok:
-                return json.dumps({"error": f"Component or version not found: {component_id} v{version}"})
-            return json.dumps({"status": "set_current", "id": component_id, "version": version})
-        except Exception as e:
-            logger.exception("Failed to set current version")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def delete_version(self, component_id: str, version: int) -> str:
-        """Delete a draft config version. Published and current versions cannot be deleted.
-
-        Args:
-            component_id (str): The component id.
-            version (int): The draft version to delete.
-        """
-        if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured."})
-        try:
-            deleted = self.db.delete_config(component_id, version=version)
-            if not deleted:
-                return json.dumps({"error": f"Version not found: {component_id} v{version}"})
-            return json.dumps({"status": "deleted", "id": component_id, "version": version})
-        except Exception as e:
-            logger.exception("Failed to delete version")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    # ------------------------------------------------------------------
-    # Delete
-    # ------------------------------------------------------------------
-
-    def delete_agent(self, agent_id: str) -> str:
-        """Hard-delete an agent DB component.
-
-        Args:
-            agent_id (str): The exact id of the agent to delete. Display names
-                do not resolve for destructive operations.
-        """
-        if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured; cannot delete components."})
-        try:
-            from agno.db.base import ComponentType
-
-            component = self.db.get_component(agent_id, component_type=ComponentType.AGENT)
-            if component is None:
-                resolved = self._runner_tools._resolve_db_id_by_name_or_slug("agent", agent_id)
-                if resolved is not None:
-                    return json.dumps(
-                        {"error": f"Delete requires the exact id: '{agent_id}' resolves to '{resolved}'."}
-                    )
-                return json.dumps({"error": f"Agent not found: {agent_id}"})
-            deleted = self.db.delete_component(agent_id, hard_delete=True)
-            if not deleted:
-                return json.dumps({"error": f"Agent not found: {agent_id}"})
-            return json.dumps({"status": "deleted", "id": agent_id})
-        except Exception as e:
-            logger.exception("Failed to delete agent")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def delete_team(self, team_id: str) -> str:
-        """Hard-delete a team component.
-
-        Args:
-            team_id (str): The exact id of the team to delete. Display names
-                do not resolve for destructive operations.
-        """
-        if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured; cannot delete components."})
-        try:
-            from agno.db.base import ComponentType
-
-            component = self.db.get_component(team_id, component_type=ComponentType.TEAM)
-            if component is None:
-                resolved = self._runner_tools._resolve_db_id_by_name_or_slug("team", team_id)
-                if resolved is not None:
-                    return json.dumps({"error": f"Delete requires the exact id: '{team_id}' resolves to '{resolved}'."})
-                return json.dumps({"error": f"Team not found: {team_id}"})
-            deleted = self.db.delete_component(team_id, hard_delete=True)
-            if not deleted:
-                return json.dumps({"error": f"Team not found: {team_id}"})
-            return json.dumps({"status": "deleted", "id": team_id})
-        except Exception as e:
-            logger.exception("Failed to delete team")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    def delete_workflow(self, workflow_id: str) -> str:
-        """Hard-delete a workflow component.
-
-        Args:
-            workflow_id (str): The exact id of the workflow to delete. Display
-                names do not resolve for destructive operations.
-        """
-        if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured; cannot delete components."})
-        try:
-            from agno.db.base import ComponentType
-
-            component = self.db.get_component(workflow_id, component_type=ComponentType.WORKFLOW)
-            if component is None:
-                resolved = self._runner_tools._resolve_db_id_by_name_or_slug("workflow", workflow_id)
-                if resolved is not None:
-                    return json.dumps(
-                        {"error": f"Delete requires the exact id: '{workflow_id}' resolves to '{resolved}'."}
-                    )
-                return json.dumps({"error": f"Workflow not found: {workflow_id}"})
-            deleted = self.db.delete_component(workflow_id, hard_delete=True)
-            if not deleted:
-                return json.dumps({"error": f"Workflow not found: {workflow_id}"})
-            return json.dumps({"status": "deleted", "id": workflow_id})
-        except Exception as e:
-            logger.exception("Failed to delete workflow")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    # ------------------------------------------------------------------
-    # Public run methods. StudioRunnerTools owns the run semantics
-    # (current-user identity, per-conversation sub-sessions, PAUSED results
-    # that carry their unresolved requirements); these forward to it and add
-    # an 'id' key beside the runner's typed key. __init__ registers THESE
-    # methods for the model, so the model-facing payload carries both keys
-    # and a subclass override sits on the model's path. The paths are
-    # separate methods: a policy gate must override run_agent AND arun_agent
-    # (async_mode picks one), or it guards only half the surface. Only a
-    # standalone StudioRunnerTools serves the typed key alone.
-    # ------------------------------------------------------------------
+    def _assert_no_cycle(self, parent_component_id: str, links: Sequence[Dict[str, Any]]) -> None:
+        pending = [
+            (link.get("child_component_id"), link.get("child_version"))
+            for link in links
+            if link.get("child_component_id")
+        ]
+        seen: set[tuple[str, Optional[int]]] = set()
+        while pending:
+            child_id, child_version = pending.pop()
+            key = (cast(str, child_id), cast(Optional[int], child_version))
+            if key in seen:
+                continue
+            seen.add(key)
+            if child_id == parent_component_id:
+                raise _StudioRequestError(
+                    "component_cycle",
+                    f"Saving '{parent_component_id}' would create a component dependency cycle.",
+                )
+            if child_version is None:
+                continue
+            for child_link in self.db.get_links(cast(str, child_id), cast(int, child_version)):
+                nested_id = child_link.get("child_component_id")
+                if nested_id:
+                    pending.append((nested_id, child_link.get("child_version")))
 
     @staticmethod
-    def _alias_runner_result(result: str) -> str:
-        """The runner payload plus an 'id' key holding the resolved component id.
+    def _ensure_publishable_refs(refs: Sequence[_ResolvedRef]) -> None:
+        code_refs = [resolved.ref.component_id for resolved in refs if resolved.code_defined]
+        if code_refs:
+            raise _StudioRequestError(
+                "code_reference_not_publishable",
+                "Published composites require stored, version-pinned child components.",
+                details={"code_defined_component_ids": code_refs},
+            )
 
-        Error payloads carry no id and pass through unchanged."""
-        try:
-            payload = json.loads(result)
-        except Exception:
-            return result
-        if isinstance(payload, dict) and "error" not in payload:
-            for key in ("agent_id", "team_id", "workflow_id"):
-                if key in payload:
-                    payload.setdefault("id", payload[key])
-                    return json.dumps(payload, default=str)
+    @staticmethod
+    def _actor_metadata(
+        existing: Optional[Dict[str, Any]],
+        run_context: RunContext,
+        action: StudioAction,
+    ) -> Dict[str, Any]:
+        metadata = dict(existing or {})
+        agno_metadata = dict(metadata.get("_agno") or {})
+        studio_metadata = dict(agno_metadata.get("studio") or {})
+        studio_metadata.setdefault("created_by", run_context.user_id)
+        studio_metadata.setdefault("created_run_id", run_context.run_id)
+        studio_metadata.setdefault("created_session_id", run_context.session_id)
+        studio_metadata.update(
+            {
+                "last_actor_id": run_context.user_id,
+                "last_action": action,
+                "last_run_id": run_context.run_id,
+                "last_session_id": run_context.session_id,
+            }
+        )
+        agno_metadata["studio"] = studio_metadata
+        metadata["_agno"] = agno_metadata
+        return metadata
+
+    @staticmethod
+    def _manifest(request: Any) -> Dict[str, Any]:
+        return {
+            "schema_version": _STUDIO_SCHEMA_VERSION,
+            # ``if_exists`` controls only this create attempt. Persisting it
+            # would turn an idempotent retry into component behavior and make
+            # the retry compare unequal to the original create.
+            "request": request.model_dump(mode="json", exclude={"if_exists"}),
+        }
+
+    @staticmethod
+    def _attach_manifest(config: Dict[str, Any], request: Any) -> Dict[str, Any]:
+        result = dict(config)
+        result[_STUDIO_CONFIG_KEY] = StudioTools._manifest(request)
         return result
 
-    # These are what the model calls, not the embedded runner's bound methods, so a
-    # subclass override sits on the path -- the sync and async halves separately,
-    # as everywhere else in agno. They carry the `_agno_run_context` channel for
-    # the same reason the runner does: the framework fills it, it is kept out of
-    # the model-facing schema, and a model-supplied value for it is dropped.
+    @staticmethod
+    def _serialize_component(component: Component, request: Any) -> Dict[str, Any]:
+        """Serialize only the top-level component and remove its catalog DB.
 
-    def run_agent(self, agent_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
-        """Run an agent by id or display name. Forwards to StudioRunnerTools.
-
-        Args:
-            agent_id (str): Id of the agent to run (a display name or its slug also resolves).
-            message (str): The message to send.
-
-        Returns:
-            str: JSON object with 'agent_id', 'id', 'run_id', 'session_id', 'status',
-                'content' and, when paused, 'requirements'.
+        Persisting ``db`` leaks connection configuration and can make a later
+        runner reconstruct a second catalog.  The fixed runner DB is the only
+        fallback Studio components need.
         """
-        return self._alias_runner_result(self._runner_tools.run_agent(agent_id, message, _agno_run_context))
-
-    def run_team(self, team_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
-        """Run a team by id or display name. Forwards to StudioRunnerTools.
-
-        Args:
-            team_id (str): Id of the team to run (a display name or its slug also resolves).
-            message (str): The message to send.
-
-        Returns:
-            str: JSON object with 'team_id', 'id', 'run_id', 'session_id', 'status',
-                'content' and, when paused, 'requirements'.
-        """
-        return self._alias_runner_result(self._runner_tools.run_team(team_id, message, _agno_run_context))
-
-    def run_workflow(self, workflow_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
-        """Run a workflow by id or display name. Forwards to StudioRunnerTools.
-
-        Args:
-            workflow_id (str): Id of the workflow to run (a display name or its slug also resolves).
-            message (str): Input to pass to the first step.
-
-        Returns:
-            str: JSON object with 'workflow_id', 'id', 'run_id', 'session_id', 'status',
-                'content' and, when paused, 'requirements'.
-        """
-        return self._alias_runner_result(self._runner_tools.run_workflow(workflow_id, message, _agno_run_context))
-
-    async def arun_agent(self, agent_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
-        """Async variant of run_agent.
-
-        Args:
-            agent_id (str): Id of the agent to run (a display name or its slug also resolves).
-            message (str): The message to send.
-        """
-        return self._alias_runner_result(await self._runner_tools.arun_agent(agent_id, message, _agno_run_context))
-
-    async def arun_team(self, team_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
-        """Async variant of run_team.
-
-        Args:
-            team_id (str): Id of the team to run (a display name or its slug also resolves).
-            message (str): The message to send.
-        """
-        return self._alias_runner_result(await self._runner_tools.arun_team(team_id, message, _agno_run_context))
-
-    async def arun_workflow(
-        self, workflow_id: str, message: str, _agno_run_context: Optional[RunContext] = None
-    ) -> str:
-        """Async variant of run_workflow.
-
-        Args:
-            workflow_id (str): Id of the workflow to run (a display name or its slug also resolves).
-            message (str): Input to pass to the first step.
-        """
-        return self._alias_runner_result(
-            await self._runner_tools.arun_workflow(workflow_id, message, _agno_run_context)
-        )
-
-    # ------------------------------------------------------------------
-    # Schedules (component-aware)
-    # ------------------------------------------------------------------
-
-    def create_schedule(
-        self,
-        name: str,
-        cron: str,
-        target_type: str,
-        target_id: str,
-        message: str,
-        timezone: str = "UTC",
-        description: Optional[str] = None,
-    ) -> str:
-        """Create (or update) a schedule that runs an existing component on a cron cadence.
-
-        Args:
-            name (str): Unique schedule name (e.g. "daily-news-digest"). Re-using an
-                existing name updates that schedule in place.
-            cron (str): 5-field cron expression (e.g. "0 9 * * *" for daily at 9am).
-            target_type (str): One of 'agent', 'team', or 'workflow'.
-            target_id (str): Id (or name) of an existing component -- use ids from
-                list_agents/list_teams/list_workflows.
-            message (str): The message sent to the component on every scheduled run.
-            timezone (str): IANA timezone name for the cron expression
-                (e.g. "America/New_York"). Defaults to "UTC".
-            description (Optional[str]): Human-readable description of the schedule.
-
-        Returns:
-            str: JSON with {status, id, name, cron, target_type, target_id, endpoint,
-                timezone, enabled, next_run_at}.
-        """
-        try:
-            component_id, target_error = self._resolve_schedule_target(target_type, target_id)
-            if target_error is not None:
-                return json.dumps({"error": target_error})
-            if not message or not message.strip():
-                return json.dumps(
-                    {
-                        "error": "message must be a non-empty string; it is the prompt "
-                        "sent to the component on every scheduled run."
-                    }
-                )
-            manager = self._get_schedule_manager()
-            schedule = manager.create(
-                name=name,
-                cron=cron,
-                endpoint=f"/{target_type}s/{component_id}/runs",
-                method="POST",
-                description=description,
-                payload={"message": message},
-                timezone=timezone,
-                if_exists="update",
-            )
-            log_debug(f"StudioTools created schedule name={name} target={target_type}:{component_id}")
-            return json.dumps(
-                {
-                    "status": "created",
-                    "id": schedule.id,
-                    "name": schedule.name,
-                    "cron": schedule.cron_expr,
-                    "target_type": target_type,
-                    "target_id": component_id,
-                    "endpoint": schedule.endpoint,
-                    "timezone": schedule.timezone,
-                    "enabled": schedule.enabled,
-                    "next_run_at": schedule.next_run_at,
-                }
-            )
-        except Exception as e:
-            logger.exception("Failed to create schedule")
-            return json.dumps({"error": str(e) or type(e).__name__})
-
-    # ------------------------------------------------------------------
-    # Async tools
-    # ------------------------------------------------------------------
-
-    async def alist_models(self) -> str:
-        """Async variant of list_models."""
-        return await self._run_sync_tool(self.list_models)
-
-    async def alist_tools(self) -> str:
-        """Async variant of list_tools."""
-        return await self._run_sync_tool(self.list_tools)
-
-    async def alist_functions(self) -> str:
-        """Async variant of list_functions."""
-        return await self._run_sync_tool(self.list_functions)
-
-    async def alist_dbs(self) -> str:
-        """Async variant of list_dbs."""
-        return await self._run_sync_tool(self.list_dbs)
-
-    async def alist_agents(self) -> str:
-        """Async variant of list_agents."""
-        return await self._run_sync_tool(self.list_agents)
-
-    async def alist_teams(self) -> str:
-        """Async variant of list_teams."""
-        return await self._run_sync_tool(self.list_teams)
-
-    async def alist_workflows(self) -> str:
-        """Async variant of list_workflows."""
-        return await self._run_sync_tool(self.list_workflows)
-
-    async def aget_agent(self, agent_id: str) -> str:
-        """Async variant of get_agent."""
-        return await self._run_sync_tool(self.get_agent, agent_id)
-
-    async def aget_team(self, team_id: str) -> str:
-        """Async variant of get_team."""
-        return await self._run_sync_tool(self.get_team, team_id)
-
-    async def aget_workflow(self, workflow_id: str) -> str:
-        """Async variant of get_workflow."""
-        return await self._run_sync_tool(self.get_workflow, workflow_id)
-
-    async def acreate_agent(
-        self,
-        name: str,
-        instructions: str,
-        model_id: Optional[str] = None,
-        tool_names: Optional[List[str]] = None,
-        db_id: Optional[str] = None,
-        description: Optional[str] = None,
-        add_history_to_context: bool = True,
-        num_history_runs: Optional[int] = None,
-        add_datetime_to_context: bool = True,
-    ) -> str:
-        """Async variant of create_agent."""
-        return await self._run_sync_tool(
-            self.create_agent,
-            name,
-            instructions,
-            model_id=model_id,
-            tool_names=tool_names,
-            db_id=db_id,
-            description=description,
-            add_history_to_context=add_history_to_context,
-            num_history_runs=num_history_runs,
-            add_datetime_to_context=add_datetime_to_context,
-        )
-
-    async def acreate_team(
-        self,
-        name: str,
-        instructions: str,
-        member_ids: List[str],
-        model_id: Optional[str] = None,
-        db_id: Optional[str] = None,
-        description: Optional[str] = None,
-        add_history_to_context: bool = True,
-        num_history_runs: Optional[int] = None,
-        add_datetime_to_context: bool = True,
-    ) -> str:
-        """Async variant of create_team."""
-        return await self._run_sync_tool(
-            self.create_team,
-            name,
-            instructions,
-            member_ids,
-            model_id=model_id,
-            db_id=db_id,
-            description=description,
-            add_history_to_context=add_history_to_context,
-            num_history_runs=num_history_runs,
-            add_datetime_to_context=add_datetime_to_context,
-        )
-
-    async def acreate_workflow(
-        self,
-        name: str,
-        description: str,
-        step_specs: List[Dict[str, Any]],
-        db_id: Optional[str] = None,
-    ) -> str:
-        """Async variant of create_workflow."""
-        return await self._run_sync_tool(
-            self.create_workflow,
-            name,
-            description,
-            step_specs,
-            db_id=db_id,
-        )
-
-    async def aedit_agent(
-        self,
-        agent_id: str,
-        instructions: Optional[str] = None,
-        model_id: Optional[str] = None,
-        tool_names: Optional[List[str]] = None,
-        description: Optional[str] = None,
-        add_history_to_context: Optional[bool] = None,
-        num_history_runs: Optional[int] = None,
-        add_datetime_to_context: Optional[bool] = None,
-    ) -> str:
-        """Async variant of edit_agent."""
-        return await self._run_sync_tool(
-            self.edit_agent,
-            agent_id,
-            instructions=instructions,
-            model_id=model_id,
-            tool_names=tool_names,
-            description=description,
-            add_history_to_context=add_history_to_context,
-            num_history_runs=num_history_runs,
-            add_datetime_to_context=add_datetime_to_context,
-        )
-
-    async def aedit_team(
-        self,
-        team_id: str,
-        instructions: Optional[str] = None,
-        model_id: Optional[str] = None,
-        member_ids: Optional[List[str]] = None,
-        description: Optional[str] = None,
-        add_history_to_context: Optional[bool] = None,
-        num_history_runs: Optional[int] = None,
-        add_datetime_to_context: Optional[bool] = None,
-    ) -> str:
-        """Async variant of edit_team."""
-        return await self._run_sync_tool(
-            self.edit_team,
-            team_id,
-            instructions=instructions,
-            model_id=model_id,
-            member_ids=member_ids,
-            description=description,
-            add_history_to_context=add_history_to_context,
-            num_history_runs=num_history_runs,
-            add_datetime_to_context=add_datetime_to_context,
-        )
-
-    async def aedit_workflow(
-        self,
-        workflow_id: str,
-        description: Optional[str] = None,
-        step_specs: Optional[List[Dict[str, Any]]] = None,
-    ) -> str:
-        """Async variant of edit_workflow."""
-        return await self._run_sync_tool(
-            self.edit_workflow,
-            workflow_id,
-            description=description,
-            step_specs=step_specs,
-        )
-
-    async def alist_versions(self, component_id: str) -> str:
-        """Async variant of list_versions."""
-        return await self._run_sync_tool(self.list_versions, component_id)
-
-    async def aget_version(self, component_id: str, version: Optional[int] = None) -> str:
-        """Async variant of get_version."""
-        return await self._run_sync_tool(self.get_version, component_id, version=version)
-
-    async def apublish_component(self, component_id: str, version: Optional[int] = None) -> str:
-        """Async variant of publish_component."""
-        return await self._run_sync_tool(self.publish_component, component_id, version=version)
-
-    async def aset_current_version(self, component_id: str, version: int) -> str:
-        """Async variant of set_current_version."""
-        return await self._run_sync_tool(self.set_current_version, component_id, version)
-
-    async def adelete_version(self, component_id: str, version: int) -> str:
-        """Async variant of delete_version."""
-        return await self._run_sync_tool(self.delete_version, component_id, version)
-
-    async def adelete_agent(self, agent_id: str) -> str:
-        """Async variant of delete_agent."""
-        return await self._run_sync_tool(self.delete_agent, agent_id)
-
-    async def adelete_team(self, team_id: str) -> str:
-        """Async variant of delete_team."""
-        return await self._run_sync_tool(self.delete_team, team_id)
-
-    async def adelete_workflow(self, workflow_id: str) -> str:
-        """Async variant of delete_workflow."""
-        return await self._run_sync_tool(self.delete_workflow, workflow_id)
-
-    async def acreate_schedule(
-        self,
-        name: str,
-        cron: str,
-        target_type: str,
-        target_id: str,
-        message: str,
-        timezone: str = "UTC",
-        description: Optional[str] = None,
-    ) -> str:
-        """Async variant of create_schedule."""
-        return await self._run_sync_tool(
-            self.create_schedule,
-            name,
-            cron,
-            target_type,
-            target_id,
-            message,
-            timezone=timezone,
-            description=description,
-        )
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    async def _run_sync_tool(self, function: Callable[..., str], *args: Any, **kwargs: Any) -> str:
-        import asyncio
-
-        return await asyncio.to_thread(function, *args, **kwargs)
-
-    def _unique_component_id(self, name: str, db: "BaseDb") -> str:
-        """Return a unique id in the DB component namespace.
-
-        Components use ``component_id`` as the primary key, so agents, teams,
-        and workflows intentionally share one id namespace.
-        """
-        base = _slugify(name)
-        candidate = base
-        suffix = 2
-        while self._component_id_exists(candidate, db):
-            candidate = f"{base}-{suffix}"
-            suffix += 1
-        return candidate
-
-    def _get_schedule_manager(self) -> "ScheduleManager":
-        """The shared SchedulerTools instance's manager."""
-        if self.db is None:
-            raise ValueError("StudioTools has no db configured; cannot manage schedules.")
-        if self._scheduler_tools is None:
-            raise ValueError("StudioTools was built with schedules=False; cannot manage schedules.")
-        return self._scheduler_tools.manager
-
-    def _resolve_schedule_target(self, target_type: str, target_id: str) -> tuple[Optional[str], Optional[str]]:
-        """Resolve a schedule target to a real component id.
-
-        Returns ``(component_id, error)``: exactly one side is set. Targets
-        resolve through the Studio lookup path (code-defined lists, then DB;
-        matched by id or name), so schedules always point at a component's
-        real id even when the caller passed its display name.
-        """
-        if target_type not in _SCHEDULE_TARGET_TYPES:
-            return None, f"Invalid target_type: {target_type}. Must be one of {list(_SCHEDULE_TARGET_TYPES)}."
-        finders: Dict[str, Callable[[str], Optional[Any]]] = {
-            "agent": self._find_agent,
-            "team": self._find_team,
-            "workflow": self._find_workflow,
-        }
-        component = finders[target_type](target_id)
-        if component is None:
-            return None, f"{target_type.capitalize()} not found: {target_id}"
-        component_id = getattr(component, "id", None)
-        if component_id is None:
-            return None, f"{target_type.capitalize()} has no id: {target_id}"
-        return component_id, None
-
-    def _component_id_exists(self, component_id: str, db: "BaseDb") -> bool:
-        for component in [*self._iter_agents(), *self._iter_teams(), *self._iter_workflows()]:
-            component_name = getattr(component, "name", None)
-            if (
-                getattr(component, "id", None) == component_id
-                or component_name == component_id
-                or (component_name is not None and _slugify(component_name) == component_id)
-            ):
-                return True
-        return db.get_component(component_id) is not None
-
-    def _bind_child_to_target_db(
-        self, child: Any, target_db: "BaseDb", noun: str, require_published: bool = True
-    ) -> tuple[Any, Optional[int]]:
-        """The object a stored reference will actually reload from ``target_db``,
-        with the version to pin it at.
-
-        Reload resolution is db-first in the target db, then registry, so a
-        child resolved from the catalog must match that outcome: an id claimed
-        by both a code-defined component and a target-db row is a coin flip
-        and refuses; a db-backed child absent from the target db (or stored
-        there as a different component type) can never reload as itself and
-        refuses; a db-backed child present there is strictly re-resolved from
-        that exact db AND version, so the reference, the pin, and the reload
-        name one row - and a row too degraded to rebuild refuses at create
-        instead of persisting a parent guaranteed not to dispatch. A published
-        parent additionally refuses a draft child, whose config can change in
-        place under the pin.
-
-        The db offers no transactions, so the typed-metadata and config reads
-        are re-verified once; a pair that still disagrees (a concurrent
-        replace or delete) refuses rather than persisting a torn snapshot.
-        """
-        from agno.agent.agent import get_agent_by_id
-        from agno.db.base import ComponentType
-        from agno.exceptions import ComponentRehydrationError
-        from agno.team.team import Team, get_team_by_id
-
-        child_id = getattr(child, "id", None)
-        if not isinstance(child_id, str):
-            raise ValueError(f"{noun} has no id and cannot be stored as a reference.")
-        is_team = isinstance(child, Team)
-        expected_type = ComponentType.TEAM if is_team else ComponentType.AGENT
-        candidates = self._iter_teams() if is_team else self._iter_agents()
-        code_defined = any(getattr(candidate, "id", None) == child_id for candidate in candidates)
-        db_label = getattr(target_db, "id", None) or type(target_db).__name__
-
-        def read_snapshot() -> tuple:
-            try:
-                typed_row = target_db.get_component(child_id, component_type=expected_type)
-                untyped = target_db.get_component(child_id) if typed_row is None else typed_row
-                config_row = target_db.get_config(component_id=child_id) if typed_row is not None else None
-            except NotImplementedError:
-                return None, None, None
-            return typed_row, untyped, config_row
-
-        component_row, untyped_row, row = read_snapshot()
-        verify_component_row, verify_untyped_row, verify_row = read_snapshot()
-        torn = (
-            (component_row is None) != (verify_component_row is None)
-            or (row is None) != (verify_row is None)
-            or (
-                isinstance(row, dict)
-                and isinstance(verify_row, dict)
-                and row.get("version") != verify_row.get("version")
-            )
-        )
-        if torn:
-            raise ValueError(
-                f"{noun} '{child_id}' in db '{db_label}' changed while it was being referenced; retry the operation."
-            )
-        untyped_row = verify_untyped_row if untyped_row is None else untyped_row
-
-        if code_defined and row is not None:
-            raise ValueError(
-                f"{noun} id '{child_id}' is claimed by both a code-defined component and a stored "
-                f"row in db '{db_label}'; reloading would bind whichever wins that db's precedence. "
-                "Give them distinct ids."
-            )
-        if code_defined:
-            # Reconcile the live lists with the registry at selection time:
-            # rehydration resolves the registry, so the object being written
-            # about must be the object the registry will answer with.
-            bucket = self.registry.teams if is_team else self.registry.agents
-            registered = next((entry for entry in bucket if getattr(entry, "id", None) == child_id), None)
-            if registered is None:
-                bucket.append(child)
-            elif registered is not child:
-                raise ValueError(
-                    f"{noun} '{child_id}' from the live list is not the registry's object for that "
-                    "id; a reload would bind the registry's. Align the list and the registry."
-                )
-            return child, None
-        if component_row is None and untyped_row is not None:
-            raise ValueError(
-                f"{noun} '{child_id}' is stored in db '{db_label}' as a "
-                f"{untyped_row.get('component_type')}, not the referenced type. Give the "
-                "components distinct ids."
-            )
-        if row is None:
-            raise ValueError(
-                f"{noun} '{child_id}' is not stored in db '{db_label}'. Create it there first, or "
-                "reference a code-defined component."
-            )
-        if require_published and row.get("stage") != "published":
-            raise ValueError(
-                f"{noun} '{child_id}' in db '{db_label}' has only a {row.get('stage')} config, "
-                "which can change in place under a published parent's pin. Publish the child first."
-            )
-        resolved_version = row.get("version") if isinstance(row, dict) else None
-        loader = get_team_by_id if is_team else get_agent_by_id
-        try:
-            rebound = loader(db=target_db, id=child_id, version=resolved_version, registry=self.registry, strict=True)
-        except ComponentRehydrationError as e:
-            raise ValueError(f"{noun} '{child_id}' in db '{db_label}' cannot be rebuilt: {e}") from e
-        if rebound is None:
-            raise ValueError(f"{noun} '{child_id}' could not be loaded from db '{db_label}'.")
-        return rebound, (resolved_version if isinstance(resolved_version, int) else None)
-
-    def _bind_members_to_target_db(
-        self, members: List[Any], target_db: "BaseDb", require_published: bool = True
-    ) -> tuple[List[Any], Dict[str, int]]:
-        bound: List[Any] = []
-        pins: Dict[str, int] = {}
-        for member in members:
-            rebound, version = self._bind_child_to_target_db(
-                member, target_db, "Member", require_published=require_published
-            )
-            bound.append(rebound)
-            if version is not None and getattr(rebound, "id", None):
-                pins[rebound.id] = version
-        return bound, pins
-
-    def _bind_steps_to_target_db(
-        self, steps: List[Any], target_db: "BaseDb", require_published: bool = True
-    ) -> Dict[str, int]:
-        pins: Dict[str, int] = {}
-        for step in steps:
-            for attr, noun in (("agent", "Step agent"), ("team", "Step team")):
-                child = getattr(step, attr, None)
-                if child is None:
-                    continue
-                rebound, version = self._bind_child_to_target_db(
-                    child, target_db, noun, require_published=require_published
-                )
-                setattr(step, attr, rebound)
-                if version is not None and getattr(rebound, "id", None):
-                    pins[rebound.id] = version
-        return pins
-
-    def _target_db_exact(self, identifier: str, target_db: "BaseDb") -> Optional[Any]:
-        """The component ``identifier`` names by exact id in the target db.
-
-        Checked across both types; a target db claiming the id as both an
-        agent and a team is undecidable from the identifier alone.
-        """
-        from agno.agent.agent import get_agent_by_id
-        from agno.db.base import ComponentType
-        from agno.exceptions import ComponentRehydrationError
-        from agno.team.team import get_team_by_id
-
-        try:
-            agent_row = target_db.get_component(identifier, component_type=ComponentType.AGENT)
-            team_row = target_db.get_component(identifier, component_type=ComponentType.TEAM)
-        except NotImplementedError:
-            return None
-        if agent_row is not None and team_row is not None:
-            raise ValueError(
-                f"Ambiguous member id: '{identifier}' is stored in the target db as both an agent "
-                "and a team. Give the components distinct ids."
-            )
-        if agent_row is None and team_row is None:
-            return None
-        loader = get_agent_by_id if agent_row is not None else get_team_by_id
-        try:
-            return loader(db=target_db, id=identifier, registry=self.registry, strict=True)
-        except ComponentRehydrationError as e:
-            raise ValueError(f"Member '{identifier}' in the target db cannot be rebuilt: {e}") from e
-
-    def _resolve_members(
-        self, member_ids: List[str], target_db: Optional["BaseDb"] = None
-    ) -> tuple[List[TeamMember], List[str]]:
-        """Resolve member identifiers to agents or teams, in request order.
-
-        Exact ids resolve before any name matching - across code-defined
-        components, the catalog db, AND the selected target db - so a live
-        component merely named like a stored id can never steal that member
-        slot. An identifier naming a stored component that fails to load
-        counts as missing rather than falling through to name matching.
-        """
-        runner = self._runner_tools
-        members: List[TeamMember] = []
-        missing: List[str] = []
-        for mid in member_ids:
-            agent_match = runner._find_agent_by_exact_id(mid)
-            team_match = runner._find_team_by_exact_id(mid)
-            if agent_match is None and team_match is None and target_db is not None and target_db is not self.db:
-                # Exact ids in the selected target db outrank every name tier.
-                target_match = self._target_db_exact(mid, target_db)
-                if target_match is not None:
-                    members.append(target_match)
-                    continue
-            if agent_match is not None and team_match is not None:
-                # Ids are only unique per type, so an agent and a team may
-                # legally share one; member_ids cannot disambiguate.
-                raise ValueError(
-                    f"Ambiguous member id: '{mid}' matches both an agent and a team. "
-                    "Give the components distinct ids to reference them as members."
-                )
-            member: Optional[TeamMember] = agent_match or team_match
-            if member is None and not (
-                runner._db_component_exists("agent", mid) or runner._db_component_exists("team", mid)
-            ):
-                agent_named = runner._find_agent_by_name(mid)
-                team_named = runner._find_team_by_name(mid)
-                if agent_named is not None and team_named is not None:
-                    raise ValueError(
-                        f"Ambiguous member name: '{mid}' matches both an agent and a team. Use an exact id."
-                    )
-                member = agent_named or team_named
-            if member is None:
-                missing.append(mid)
-            else:
-                if not getattr(member, "id", None):
-                    # Persisting the reference would store a null id; on reload the
-                    # registry lookup by id=None binds whichever id-less component
-                    # it sees first -- silently the wrong one. Falsy, not None:
-                    # the load-side guard refuses an empty-string id the same way.
-                    raise ValueError(
-                        f"Member '{mid}' is code-defined with no id, so a stored reference "
-                        "cannot name it. Set an explicit id on the component."
-                    )
-                members.append(member)
-        return members, missing
-
-    def _build_steps(
-        self, step_specs: List[Dict[str, Any]], fallback_db: Optional["BaseDb"] = None
-    ) -> tuple[List[Any], Optional[str]]:
-        from agno.workflow.step import Step
-
-        if not step_specs:
-            return [], "step_specs must contain at least one step"
-
-        def find_agent(identifier: str) -> Optional[Any]:
-            found = self._runner_tools._find_agent_by_exact_id(identifier)
-            if found is None and fallback_db is not None and fallback_db is not self.db:
-                from agno.agent.agent import get_agent_by_id
-
-                # Exact ids in the selected target db outrank catalog name tiers.
-                found = get_agent_by_id(db=fallback_db, id=identifier, registry=self.registry)
-            return found if found is not None else self._find_agent(identifier)
-
-        def find_team(identifier: str) -> Optional[Any]:
-            found = self._runner_tools._find_team_by_exact_id(identifier)
-            if found is None and fallback_db is not None and fallback_db is not self.db:
-                from agno.team.team import get_team_by_id
-
-                found = get_team_by_id(db=fallback_db, id=identifier, registry=self.registry)
-            return found if found is not None else self._find_team(identifier)
-
-        steps: List[Step] = []
-        for i, spec in enumerate(step_specs):
-            step_name = spec.get("name") or f"step_{i + 1}"
-            step_desc = spec.get("description")
-            if "agent_id" in spec:
-                agent = find_agent(spec["agent_id"])
-                if agent is None:
-                    return [], f"Agent not found for step '{step_name}': {spec['agent_id']}"
-                if not getattr(agent, "id", None):
-                    # A null (or empty) id in the stored step config makes the
-                    # workflow unreconstructable: created and listed, never loadable.
-                    return [], (
-                        f"Agent for step '{step_name}' ('{spec['agent_id']}') is code-defined with no id, "
-                        "so a stored step cannot name it. Set an explicit id on the agent."
-                    )
-                steps.append(Step(name=step_name, agent=agent, description=step_desc))
-            elif "team_id" in spec:
-                team = find_team(spec["team_id"])
-                if team is None:
-                    return [], f"Team not found for step '{step_name}': {spec['team_id']}"
-                if not getattr(team, "id", None):
-                    return [], (
-                        f"Team for step '{step_name}' ('{spec['team_id']}') is code-defined with no id, "
-                        "so a stored step cannot name it. Set an explicit id on the team."
-                    )
-                steps.append(Step(name=step_name, team=team, description=step_desc))
-            elif "function_name" in spec:
-                func = self.registry.get_function(spec["function_name"])
-                if func is None:
-                    return [], f"Function not found for step '{step_name}': {spec['function_name']}"
-                steps.append(Step(name=step_name, executor=func, description=step_desc))
-            else:
-                return [], f"Step '{step_name}' must specify agent_id, team_id, or function_name"
-        return steps, None
-
-    # Reference keys a lenient load drops when they cannot resolve (the three
-    # model keys are serialized but not yet consumed by from_dict); an edit
-    # that did not replace them must not persist the loss.
-    _LENIENT_DROPPABLE_KEYS = (
-        "tools",
-        "input_schema",
-        "output_schema",
-        "knowledge",
-        "reasoning_model",
-        "parser_model",
-        "output_model",
-    )
-
-    def _save_edit(
-        self,
-        component: Component,
-        replaced_keys: Optional[Set[str]] = None,
-        pinned_children: Optional[Dict[str, int]] = None,
-        base_version: Optional[int] = None,
-        guard: Optional["ComponentVersionGuard"] = None,
-    ) -> Dict[str, Any]:
-        """Persist an edited component.
-
-        With versioning enabled the edit is saved as a draft awaiting
-        publish_component; otherwise it is published immediately as the new
-        current version.
-
-        The edit round-trips through a leniently loaded object, so the config
-        written here keeps the stored value for any unresolvable reference the
-        load dropped (unless this edit replaced that key), and re-emits the
-        member/step links so the new version stays pinned.
-        """
-        config = _component_to_dict(component)
-        replaced = replaced_keys or set()
-        component_id = getattr(component, "id", None)
-        self._preserve_unresolved_keys(component_id, config, replaced, base_version)
-        if replaced & {"members", "steps"}:
-            # The edit replaced the composition: pin the new children at the
-            # exact versions the binder rebuilt them from.
-            links = self._links_for_component(component, pinned_versions=pinned_children)
+        from agno.agent.agent import Agent
+        from agno.team.team import Team
+        from agno.workflow.workflow import Workflow
+
+        if isinstance(component, Agent):
+            from agno.agent._storage import to_dict as agent_to_dict
+
+            config = agent_to_dict(component)
+        elif isinstance(component, Team):
+            from agno.team._storage import to_dict as team_to_dict
+
+            config = team_to_dict(component)
+        elif isinstance(component, Workflow):
+            config = component.to_dict()
         else:
-            # Untouched composition keeps the base version's pins verbatim,
-            # including link kinds this walk does not reconstruct.
-            links = self._base_links(component_id, base_version)
-        if self.enable_versions:
-            version = self._upsert_draft(component, config=config, links=links, guard=guard)
-            return {"draft_version": version, "stage": "draft"}
-        version = _persist_only(component, self.db, config=config, links=links)
-        return {"version": version, "stage": "published"}
+            raise TypeError(f"Unsupported component type: {type(component).__name__}")
+        config.pop("db", None)
+        return StudioTools._attach_manifest(config, request)
 
-    def _preserve_unresolved_keys(
-        self,
-        component_id: Optional[str],
-        config: Dict[str, Any],
-        replaced_keys: Set[str],
-        base_version: Optional[int],
-    ) -> None:
-        """Copy stored reference keys the lenient load dropped back into ``config``."""
-        if self.db is None or component_id is None:
-            return
-        base = self._runner_tools._load_config_from_db(component_id, version=base_version)
-        if not isinstance(base, dict):
-            raise ValueError(
-                f"Cannot edit '{component_id}': its stored config could not be read, so an edit would drop "
-                "whatever the rebuild does not carry back."
+    @staticmethod
+    def _component_type(component: Component) -> "ComponentType":
+        from agno.agent.agent import Agent
+        from agno.db.base import ComponentType
+        from agno.team.team import Team
+        from agno.workflow.workflow import Workflow
+
+        if isinstance(component, Agent):
+            return ComponentType.AGENT
+        if isinstance(component, Team):
+            return ComponentType.TEAM
+        if isinstance(component, Workflow):
+            return ComponentType.WORKFLOW
+        raise TypeError(f"Unsupported component type: {type(component).__name__}")
+
+    @staticmethod
+    def _manifest_request(config: Dict[str, Any]) -> Dict[str, Any]:
+        manifest = config.get(_STUDIO_CONFIG_KEY)
+        if not isinstance(manifest, dict) or manifest.get("schema_version") != _STUDIO_SCHEMA_VERSION:
+            raise _StudioRequestError(
+                "unsupported_component_config",
+                "This component is not owned by the typed Studio 2.9 contract and cannot be mutated safely.",
             )
-        # The db reference and untouched composition subtrees are
-        # base-authoritative: no edit surface changes them, the runtime object
-        # cannot improve on them, and re-serializing them churns identity
-        # (fresh step_ids would orphan every carried-forward pin).
-        for key in ("db", "model", "steps", "members"):
-            if key in replaced_keys:
-                continue
-            config.pop(key, None)
-            if key in base:
-                config[key] = base[key]
-        for key in self._LENIENT_DROPPABLE_KEYS:
-            if key in replaced_keys:
-                continue
-            if key in base and base.get(key) is not None and config.get(key) is None:
-                config[key] = base[key]
-                log_debug(f"StudioTools: preserving stored '{key}' the lenient load could not resolve.")
+        request = manifest.get("request")
+        if not isinstance(request, dict):
+            raise _StudioRequestError("invalid_component_config", "The Studio request manifest is invalid.")
+        return request
 
-    def _base_links(self, component_id: Optional[str], base_version: Optional[int]) -> Optional[List[Dict[str, Any]]]:
-        """The base version's links, carried forward verbatim on an edit that
-        did not replace the component's composition."""
-        if self.db is None or component_id is None:
-            return None
-        return self._runner_tools._load_links_from_db(component_id, version=base_version)
+    @staticmethod
+    def _projection(request: Any, metadata: Dict[str, Any]) -> "ComponentProjection":
+        return cast(
+            "ComponentProjection",
+            {
+                "name": request.name,
+                "description": request.description,
+                "metadata": metadata,
+            },
+        )
 
-    def _links_for_component(
+    @staticmethod
+    def _projected_component_state(
+        component: Dict[str, Any],
+        request: Any,
+        metadata: Dict[str, Any],
+        *,
+        current_version: int,
+    ) -> Dict[str, Any]:
+        """Return the component row state committed with a pointer mutation.
+
+        The database mutation already applied these projection values in one
+        transaction. Building the response from that committed input avoids a
+        public re-read that could observe a later archive and falsely report
+        that the successful mutation failed.
+        """
+        projected = dict(component)
+        projected.update(
+            {
+                "name": request.name,
+                "description": request.description,
+                "metadata": metadata,
+                "current_version": current_version,
+            }
+        )
+        return projected
+
+    def _build_agent(
+        self,
+        request: AgentCreate,
+        metadata: Dict[str, Any],
+    ) -> tuple["Agent", AgentCreate]:
+        from agno.agent.agent import Agent
+
+        if request.component_id is None:
+            raise _StudioRequestError("component_id_required", "The effective agent request has no component_id.")
+        model, model_ref = self._resolve_model(request.model)
+        context = self._resolve_context(request.context)
+        tools = self._resolve_tools(request.tools)
+        effective = request.model_copy(
+            update={
+                "component_id": request.component_id,
+                "model": model_ref,
+                "context": context,
+            }
+        )
+        agent = Agent(
+            id=request.component_id,
+            name=request.name,
+            instructions=request.instructions,
+            description=request.description,
+            model=model,
+            tools=tools or None,
+            db=self.db,
+            metadata=metadata,
+            add_history_to_context=context.include_history,
+            num_history_runs=context.history_runs,
+            add_datetime_to_context=context.include_datetime,
+        )
+        return agent, effective
+
+    def _build_team(
+        self,
+        request: TeamCreate,
+        metadata: Dict[str, Any],
+    ) -> tuple["Team", TeamCreate, List[Dict[str, Any]], List[str], List[_ResolvedRef]]:
+        from agno.team.team import Team
+
+        if request.component_id is None:
+            raise _StudioRequestError("component_id_required", "The effective team request has no component_id.")
+        model, model_ref = self._resolve_model(request.model)
+        context = self._resolve_context(request.context)
+        resolved_refs = [
+            self._resolve_component_ref(
+                ref,
+                link_kind="member",
+                link_key=f"member_{position}",
+                position=position,
+            )
+            for position, ref in enumerate(request.members)
+        ]
+        links = [cast(Dict[str, Any], resolved.link) for resolved in resolved_refs if resolved.link is not None]
+        self._assert_no_cycle(request.component_id, links)
+        warnings = [
+            f"Draft references code-defined component '{resolved.ref.component_id}'; persist and pin it before publication."
+            for resolved in resolved_refs
+            if resolved.code_defined
+        ]
+        effective = request.model_copy(
+            update={
+                "component_id": request.component_id,
+                "model": model_ref,
+                "context": context,
+                "members": [resolved.ref for resolved in resolved_refs],
+            }
+        )
+        team = Team(
+            id=request.component_id,
+            name=request.name,
+            instructions=request.instructions,
+            description=request.description,
+            model=model,
+            members=[cast(TeamMember, resolved.component) for resolved in resolved_refs],
+            db=self.db,
+            metadata=metadata,
+            add_history_to_context=context.include_history,
+            num_history_runs=context.history_runs,
+            add_datetime_to_context=context.include_datetime,
+        )
+        return team, effective, links, warnings, resolved_refs
+
+    def _build_workflow(
+        self,
+        request: WorkflowCreate,
+        metadata: Dict[str, Any],
+    ) -> tuple["Workflow", WorkflowCreate, List[Dict[str, Any]], List[str], List[_ResolvedRef]]:
+        from agno.workflow.step import Step
+        from agno.workflow.workflow import Workflow
+
+        if request.component_id is None:
+            raise _StudioRequestError("component_id_required", "The effective workflow request has no component_id.")
+        steps: List[Step] = []
+        effective_steps: List[WorkflowStep] = []
+        links: List[Dict[str, Any]] = []
+        warnings: List[str] = []
+        component_refs: List[_ResolvedRef] = []
+        seen_step_ids: set[str] = set()
+
+        for position, spec in enumerate(request.steps):
+            step_id = spec.step_id or f"{_slugify(spec.name)}-{position + 1}"
+            if step_id in seen_step_ids:
+                raise _StudioRequestError("duplicate_step_id", f"Workflow step_id '{step_id}' is duplicated.")
+            seen_step_ids.add(step_id)
+
+            if isinstance(spec, AgentWorkflowStep):
+                resolved = self._resolve_component_ref(
+                    ComponentRef(component_type="agent", component_id=spec.component_id, version=spec.version),
+                    link_kind="step_agent",
+                    link_key=step_id,
+                    position=position,
+                )
+                step = Step(
+                    name=spec.name,
+                    step_id=step_id,
+                    agent=cast("Agent", resolved.component),
+                    description=spec.description,
+                )
+                effective_spec: WorkflowStep = spec.model_copy(
+                    update={"step_id": step_id, "version": resolved.ref.version}
+                )
+                component_refs.append(resolved)
+            elif isinstance(spec, TeamWorkflowStep):
+                resolved = self._resolve_component_ref(
+                    ComponentRef(component_type="team", component_id=spec.component_id, version=spec.version),
+                    link_kind="step_team",
+                    link_key=step_id,
+                    position=position,
+                )
+                step = Step(
+                    name=spec.name,
+                    step_id=step_id,
+                    team=cast("Team", resolved.component),
+                    description=spec.description,
+                )
+                effective_spec = spec.model_copy(update={"step_id": step_id, "version": resolved.ref.version})
+                component_refs.append(resolved)
+            elif isinstance(spec, FunctionWorkflowStep):
+                matches = [
+                    function
+                    for function in self.registry.functions
+                    if getattr(function, "__name__", None) == spec.function_name
+                ]
+                if not matches:
+                    raise _StudioRequestError(
+                        "function_not_found",
+                        f"Workflow function '{spec.function_name}' is not registered.",
+                    )
+                if len(matches) > 1:
+                    raise _StudioRequestError(
+                        "ambiguous_function",
+                        f"Multiple workflow functions are named '{spec.function_name}'.",
+                    )
+                step = Step(
+                    name=spec.name,
+                    step_id=step_id,
+                    executor=matches[0],
+                    description=spec.description,
+                )
+                effective_spec = spec.model_copy(update={"step_id": step_id})
+            else:  # pragma: no cover - Pydantic's discriminator makes this unreachable
+                raise _StudioRequestError("invalid_workflow_step", "Unsupported workflow step kind.")
+
+            if (
+                component_refs
+                and component_refs[-1].link is not None
+                and isinstance(spec, (AgentWorkflowStep, TeamWorkflowStep))
+            ):
+                links.append(cast(Dict[str, Any], component_refs[-1].link))
+            if (
+                component_refs
+                and component_refs[-1].code_defined
+                and isinstance(spec, (AgentWorkflowStep, TeamWorkflowStep))
+            ):
+                warnings.append(
+                    f"Draft references code-defined component '{component_refs[-1].ref.component_id}'; persist and pin it before publication."
+                )
+            steps.append(step)
+            effective_steps.append(effective_spec)
+
+        self._assert_no_cycle(request.component_id, links)
+        effective = request.model_copy(update={"component_id": request.component_id, "steps": effective_steps})
+        workflow = Workflow(
+            id=request.component_id,
+            name=request.name,
+            description=request.description,
+            steps=cast(Any, steps),
+            db=self.db,
+            metadata=metadata,
+        )
+        return workflow, effective, links, warnings, component_refs
+
+    @staticmethod
+    def _normalized_request(request: Any) -> Dict[str, Any]:
+        return request.model_dump(mode="json", exclude={"if_exists"})
+
+    def _latest_config(self, component_id: str) -> Optional[Dict[str, Any]]:
+        return self.db.get_latest_config(component_id)
+
+    def _existing_create_result(
+        self,
+        component_type: str,
+        request: Any,
+        save_as: SaveStage,
+        if_exists: IfExists,
+    ) -> Optional[StudioResult[Any]]:
+        from agno.db.base import ComponentType
+
+        code_component_types = [
+            candidate_type
+            for candidate_type, candidates in (
+                ("agent", self._iter_agents()),
+                ("team", self._iter_teams()),
+                ("workflow", self._iter_workflows()),
+            )
+            if any(getattr(candidate, "id", None) == request.component_id for candidate in candidates)
+        ]
+        if code_component_types:
+            raise _StudioRequestError(
+                "component_conflict",
+                f"Component id '{request.component_id}' is reserved by a code-defined component.",
+                details={"code_component_types": code_component_types},
+            )
+
+        row = self.db.get_component(
+            request.component_id,
+            component_type=ComponentType(component_type),
+            include_deleted=True,
+        )
+        if row is None:
+            # An id occupied by another type must still conflict because the DB
+            # component namespace is global.
+            other = self.db.get_component(request.component_id, include_deleted=True)
+            if other is None:
+                return None
+            raise _StudioRequestError(
+                "component_conflict",
+                f"Component id '{request.component_id}' is already used by a {other.get('component_type')}.",
+            )
+        if row.get("deleted_at") is not None:
+            raise _StudioRequestError(
+                "component_archived",
+                f"Component id '{request.component_id}' is archived and remains reserved.",
+            )
+        if if_exists == "error":
+            raise _StudioRequestError(
+                "component_conflict",
+                f"Component id '{request.component_id}' already exists.",
+            )
+        latest = self._latest_config(request.component_id)
+        if latest is None or latest.get("stage") != save_as:
+            raise _StudioRequestError(
+                "component_conflict",
+                "The existing component does not have the requested lifecycle stage.",
+            )
+        config = latest.get("config")
+        if not isinstance(config, dict):
+            raise _StudioRequestError("invalid_component_config", "The existing component config is invalid.")
+        stored = self._manifest_request(config)
+        if stored != self._normalized_request(request):
+            raise _StudioRequestError(
+                "component_conflict",
+                "The existing component has a different effective configuration.",
+            )
+        if save_as == "published":
+            if row.get("current_version") != latest.get("version"):
+                raise _StudioRequestError(
+                    "component_conflict",
+                    "The identical published configuration exists but is not the current version.",
+                )
+            existing_request = self._request_from_config_row(component_type, latest)
+            self._validate_publishability(
+                component_type,
+                cast(str, request.component_id),
+                cast(int, latest["version"]),
+                existing_request,
+            )
+        return self._success("existing", self._view_from_record(row, latest))
+
+    def _create_component(
         self,
         component: Component,
-        db: Optional["BaseDb"] = None,
-        pinned_versions: Optional[Dict[str, int]] = None,
-    ) -> Optional[List[Dict[str, Any]]]:
-        """Member/step links for a component snapshot, pinned at each child's
-        current stored version in the SAME db the snapshot is written to.
+        request: Any,
+        save_as: SaveStage,
+        links: Sequence[Dict[str, Any]],
+        warnings: List[str],
+        resolved_refs: Sequence[_ResolvedRef],
+        if_exists: IfExists,
+    ) -> StudioResult[Any]:
+        from agno.db.base import ComponentAlreadyExistsError
 
-        The persist paths do not cascade-save, so children are not re-saved. A
-        child gets no link when it has no stored version in that db, or when a
-        code-defined component claims its exact id: resolution prefers the live
-        object there, and pinning the same-id db row would bind an unrelated
-        shadow.
-        """
+        config = self._serialize_component(component, request)
+        if save_as == "published":
+            self._validate_immediate_publishability(
+                component,
+                self._component_type(component).value,
+                request,
+                resolved_refs,
+            )
+        existing = self._existing_create_result(
+            self._component_type(component).value,
+            request,
+            save_as,
+            if_exists,
+        )
+        if existing is not None:
+            return existing
+
+        try:
+            row, config_row = self.db.create_component_with_config(
+                component_id=request.component_id,
+                component_type=self._component_type(component),
+                name=request.name,
+                description=request.description,
+                metadata=getattr(component, "metadata", None),
+                config=config,
+                stage=save_as,
+                links=list(links) or None,
+            )
+        except ComponentAlreadyExistsError:
+            # The losing side of a concurrent retry re-runs the exact same
+            # typed comparison; a different request remains a conflict.
+            existing = self._existing_create_result(
+                self._component_type(component).value,
+                request,
+                save_as,
+                if_exists,
+            )
+            if existing is not None:
+                return existing
+            raise
+        return self._success("created", self._view_from_record(row, config_row), warnings)
+
+    # ------------------------------------------------------------------
+    # Safe typed projections
+    # ------------------------------------------------------------------
+
+    def _view_from_record(self, component: Dict[str, Any], config_row: Dict[str, Any]) -> ComponentView:
+        config = config_row.get("config")
+        if not isinstance(config, dict):
+            raise _StudioRequestError("invalid_component_config", "The stored component config is invalid.")
+        request_data = self._manifest_request(config)
+        component_type = component.get("component_type")
+        version = config_row.get("version")
+        stage = cast(Literal["draft", "published"], config_row.get("stage"))
+        is_current = component.get("current_version") == version
+
+        if component_type == "agent":
+            agent_request = AgentCreate.model_validate(request_data)
+            if agent_request.model is None or agent_request.context is None:
+                raise _StudioRequestError("invalid_component_config", "The stored agent manifest is unresolved.")
+            return AgentView(
+                component_id=cast(str, agent_request.component_id),
+                name=agent_request.name,
+                instructions=agent_request.instructions,
+                description=agent_request.description,
+                model=agent_request.model,
+                tools=agent_request.tools,
+                context=agent_request.context,
+                version=version,
+                stage=stage,
+                is_current=is_current,
+                source="studio",
+            )
+        if component_type == "team":
+            team_request = TeamCreate.model_validate(request_data)
+            if team_request.model is None or team_request.context is None:
+                raise _StudioRequestError("invalid_component_config", "The stored team manifest is unresolved.")
+            return TeamView(
+                component_id=cast(str, team_request.component_id),
+                name=team_request.name,
+                instructions=team_request.instructions,
+                description=team_request.description,
+                model=team_request.model,
+                members=team_request.members,
+                context=team_request.context,
+                version=version,
+                stage=stage,
+                is_current=is_current,
+                source="studio",
+            )
+        if component_type == "workflow":
+            workflow_request = WorkflowCreate.model_validate(request_data)
+            return WorkflowView(
+                component_id=cast(str, workflow_request.component_id),
+                name=workflow_request.name,
+                description=workflow_request.description,
+                steps=workflow_request.steps,
+                version=version,
+                stage=stage,
+                is_current=is_current,
+                source="studio",
+            )
+        raise _StudioRequestError("invalid_component_type", "The stored component type is invalid.")
+
+    def _view_for_version(self, component_id: str, version: Optional[int]) -> ComponentView:
+        component = self.db.get_component(component_id)
+        if component is None:
+            raise _StudioRequestError("component_not_found", f"Component '{component_id}' was not found.")
+        self._ensure_component_type_enabled(cast(str, component.get("component_type")))
+        config = (
+            self.db.get_current_config(component_id)
+            if version is None
+            else self.db.get_config(component_id, version=version)
+        )
+        if config is None:
+            if version is None:
+                raise _StudioRequestError(
+                    "published_version_not_found",
+                    f"Component '{component_id}' has no current published version.",
+                )
+            raise _StudioRequestError(
+                "version_not_found",
+                f"Version {version} was not found for component '{component_id}'.",
+            )
+        return self._view_from_record(component, config)
+
+    def _summary_from_db_row(self, row: Dict[str, Any], latest: Optional[Dict[str, Any]]) -> ComponentSummary:
+        component_id = cast(str, row["component_id"])
+        component_type = cast(Literal["agent", "team", "workflow"], row.get("component_type"))
+        if latest is None:
+            raise _StudioRequestError(
+                "invalid_component_config",
+                f"Component '{component_id}' has no stored configuration.",
+            )
+        latest_version = latest.get("version")
+        latest_stage = latest.get("stage")
+        if not isinstance(latest_version, int) or latest_stage not in ("draft", "published"):
+            raise _StudioRequestError(
+                "invalid_component_config",
+                f"Component '{component_id}' has invalid latest-version metadata.",
+            )
+        latest_request = self._request_from_config_row(component_type, latest)
+        return ComponentSummary(
+            component_id=component_id,
+            component_type=component_type,
+            # Discovery follows the editable head. ``current_version`` is
+            # reported separately, so a draft rename must not be hidden behind
+            # the older published projection stored on the catalog row.
+            name=latest_request.name,
+            source="studio",
+            latest_version=latest_version,
+            latest_stage=cast(Literal["draft", "published"], latest_stage),
+            current_version=cast(Optional[int], row.get("current_version")),
+        )
+
+    @staticmethod
+    def _summary_from_code(component_type: str, component: Component, component_id: str) -> ComponentSummary:
+        return ComponentSummary(
+            component_id=component_id,
+            component_type=cast(Literal["agent", "team", "workflow"], component_type),
+            name=getattr(component, "name", None) or component_id,
+            source="code",
+            latest_version=None,
+            latest_stage="code",
+            current_version=None,
+        )
+
+    @staticmethod
+    def _tool_refs_from_component(tools: Any) -> List[ToolRef]:
+        if not tools or callable(tools):
+            return []
+        refs: List[ToolRef] = []
+        for tool in tools:
+            if isinstance(tool, Toolkit):
+                refs.append(ToolRef(kind="toolkit", name=tool.name))
+            elif isinstance(tool, Function):
+                toolkit = getattr(tool, "owning_toolkit", None)
+                refs.append(ToolRef(kind="function", name=tool.name, toolkit=toolkit))
+            elif callable(tool):
+                name = getattr(tool, "__name__", None)
+                if isinstance(name, str) and name:
+                    refs.append(ToolRef(kind="function", name=name))
+        return refs
+
+    @staticmethod
+    def _static_instructions(value: Any) -> str:
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list) and all(isinstance(item, str) for item in value):
+            return "\n".join(value)
+        return "Instructions are resolved dynamically at runtime."
+
+    def _code_agent_view(self, agent: "Agent") -> AgentView:
+        model = self._model_ref(getattr(agent, "model", None))
+        if model is None:
+            raise _StudioRequestError("model_not_found", "The code-defined agent has no inspectable model.")
+        return AgentView(
+            component_id=cast(str, agent.id),
+            name=agent.name or cast(str, agent.id),
+            instructions=self._static_instructions(agent.instructions),
+            description=agent.description,
+            model=model,
+            tools=self._tool_refs_from_component(agent.tools),
+            context=ContextPolicy(
+                include_history=bool(agent.add_history_to_context),
+                history_runs=agent.num_history_runs if agent.add_history_to_context else None,
+                include_datetime=bool(agent.add_datetime_to_context),
+            ),
+            version=None,
+            stage="code",
+            is_current=True,
+            source="code",
+        )
+
+    def _code_team_view(self, team: "Team") -> TeamView:
+        model = self._model_ref(getattr(team, "model", None))
+        if model is None:
+            raise _StudioRequestError("model_not_found", "The code-defined team has no inspectable model.")
+        members = team.members if isinstance(team.members, list) else []
+        refs: List[ComponentRef] = []
+        from agno.agent.agent import Agent
+
+        for member in members:
+            member_id = getattr(member, "id", None)
+            if not member_id:
+                continue
+            refs.append(
+                ComponentRef(
+                    component_type="agent" if isinstance(member, Agent) else "team",
+                    component_id=member_id,
+                )
+            )
+        return TeamView(
+            component_id=cast(str, team.id),
+            name=team.name or cast(str, team.id),
+            instructions=self._static_instructions(team.instructions),
+            description=team.description,
+            model=model,
+            members=refs,
+            context=ContextPolicy(
+                include_history=bool(team.add_history_to_context),
+                history_runs=team.num_history_runs if team.add_history_to_context else None,
+                include_datetime=bool(team.add_datetime_to_context),
+            ),
+            version=None,
+            stage="code",
+            is_current=True,
+            source="code",
+        )
+
+    def _code_workflow_view(self, workflow: "Workflow") -> WorkflowView:
+        from agno.agent.agent import Agent
         from agno.team.team import Team
         from agno.workflow.condition import Condition
         from agno.workflow.loop import Loop
         from agno.workflow.parallel import Parallel
         from agno.workflow.router import Router
-        from agno.workflow.step import Step
         from agno.workflow.steps import Steps
         from agno.workflow.workflow import Workflow
 
-        target_db = db if db is not None else self.db
-        if target_db is None:
-            return None
-
-        def code_defined(child_id: Optional[str], candidates: List[Any]) -> bool:
-            return any(getattr(candidate, "id", None) == child_id for candidate in candidates)
-
-        def current_version(child_id: Optional[str], expected_type: Optional[str] = None) -> Optional[int]:
-            if not child_id:
-                return None
-            if pinned_versions is not None and child_id in pinned_versions:
-                # The binder already selected this exact version; a fresh read
-                # could see a publish that happened since.
-                return pinned_versions[child_id]
-            if expected_type is not None:
-                from agno.db.base import ComponentType
-
-                try:
-                    if target_db.get_component(child_id, component_type=ComponentType(expected_type)) is None:
-                        # A same-id row of a different type is not this child.
-                        return None
-                except NotImplementedError:
-                    return None
-            try:
-                row = target_db.get_config(component_id=child_id)
-            except NotImplementedError:
-                return None
-            version = row.get("version") if isinstance(row, dict) else None
-            return version if isinstance(version, int) else None
-
-        links: List[Dict[str, Any]] = []
-        if isinstance(component, Team):
-            from agno.agent.agent import Agent
-
-            code_agents = list(self._iter_agents())
-            code_teams = list(self._iter_teams())
-            members = component.members if isinstance(component.members, list) else []
-            for position, member in enumerate(members):
-                member_id = getattr(member, "id", None)
-                is_member_team = isinstance(member, Team)
-                candidates = code_teams if is_member_team else code_agents
-                if code_defined(member_id, candidates):
-                    continue
-                child_version = current_version(member_id, "team" if is_member_team else "agent")
-                if child_version is None:
-                    continue
-                links.append(
-                    {
-                        "link_kind": "member",
-                        "link_key": f"member_{position}",
-                        "child_component_id": member.id,
-                        "child_version": child_version,
-                        "position": position,
-                        "meta": {"type": "agent" if isinstance(member, Agent) else "team"},
-                    }
-                )
-        elif isinstance(component, Workflow):
-            code_agents = list(self._iter_agents())
-            code_teams = list(self._iter_teams())
-
-            def walk(step: Any, position: int, key_suffix: str = "") -> None:
-                if isinstance(step, Step):
-                    for link in step.get_links(position=position):
-                        child_id = link.get("child_component_id")
-                        link_kind = link.get("link_kind")
-                        candidates: List[Any]
-                        if link_kind == "step_team":
-                            candidates = code_teams
-                            child_type = "team"
-                        elif link_kind == "step_workflow":
-                            candidates = list(self._iter_workflows())
-                            child_type = "workflow"
-                        else:
-                            candidates = code_agents
-                            child_type = "agent"
-                        if code_defined(child_id, candidates):
-                            continue
-                        child_version = current_version(child_id, child_type)
-                        if child_version is None:
-                            continue
-                        link["child_version"] = child_version
-                        if key_suffix:
-                            link["link_key"] = f"{link.get('link_key')}{key_suffix}"
-                        links.append(link)
-                elif isinstance(step, (Parallel, Loop, Steps, Condition)):
-                    for nested_position, nested in enumerate(getattr(step, "steps", None) or []):
-                        walk(nested, nested_position, key_suffix)
-                    for nested_position, nested in enumerate(getattr(step, "else_steps", None) or []):
-                        walk(nested, nested_position, key_suffix + "#else")
-                elif isinstance(step, Router):
-                    for nested_position, nested in enumerate(getattr(step, "choices", None) or []):
-                        walk(nested, nested_position, key_suffix)
-
-            steps = component.steps if isinstance(component.steps, list) else []
-            for position, step in enumerate(steps):
-                walk(step, position)
-            seen_links: Dict[tuple, Dict[str, Any]] = {}
-            deduped: List[Dict[str, Any]] = []
-            for link in links:
-                dedupe_key = (link.get("link_kind"), link.get("link_key"))
-                existing = seen_links.get(dedupe_key)
-                if existing is not None:
-                    if existing.get("child_component_id") == link.get("child_component_id"):
-                        continue
-                    raise ValueError(
-                        f"Workflow '{getattr(component, 'id', None)}' produces two different links "
-                        f"for key '{link.get('link_key')}' ('{existing.get('child_component_id')}' "
-                        f"and '{link.get('child_component_id')}'); give steps distinct names so "
-                        "every pin is kept."
-                    )
-                seen_links[dedupe_key] = link
-                deduped.append(link)
-            links = deduped
+        raw_steps = workflow.steps
+        if raw_steps is None:
+            workflow_steps: List[Any] = []
+        elif isinstance(raw_steps, list):
+            workflow_steps = raw_steps
         else:
-            return None
-        return links
-
-    def _upsert_draft(
-        self,
-        component: Component,
-        config: Optional[Dict[str, Any]] = None,
-        links: Optional[List[Dict[str, Any]]] = None,
-        guard: Optional["ComponentVersionGuard"] = None,
-    ) -> Optional[int]:
-        """Append an immutable draft using the component version observed by this edit.
-
-        The component row's name/description/metadata are NOT updated here --
-        draft-only changes must not leak into listings until the draft is
-        published.
-        """
-        if self.db is None:
-            raise ValueError("db is required for draft persistence")
-
-        component_id = getattr(component, "id", None)
-        if component_id is None:
-            raise ValueError("Component has no id")
-
-        catalog_v2 = getattr(self.db, "component_catalog_api_version", 1) >= 2
-        component_row = self.db.get_component(component_id)
-        if component_row is None:
-            if catalog_v2:
-                raise ValueError(f"Component not found: {component_id}")
-            self.db.upsert_component(
-                component_id=component_id,
-                component_type=_component_type(component),
-                name=getattr(component, "name", component_id),
-                description=getattr(component, "description", None),
-                metadata=getattr(component, "metadata", None),
+            raise _StudioRequestError(
+                "unsupported_workflow_shape",
+                f"Code-defined workflow '{workflow.id}' uses an unrepresentable {type(raw_steps).__name__} "
+                "steps container; Studio refuses to return a lossy view.",
             )
 
-        if not catalog_v2:
-            result = self.db.upsert_config(
-                component_id=component_id,
-                version=self._latest_draft_version(component_id),
-                config=config if config is not None else _component_to_dict(component),
-                stage="draft",
-                links=links,
+        steps: List[WorkflowStep] = []
+        composite_types = (Parallel, Loop, Condition, Router, Steps)
+        for position, step in enumerate(workflow_steps):
+            if isinstance(step, composite_types):
+                raise _StudioRequestError(
+                    "unsupported_workflow_shape",
+                    f"Code-defined workflow '{workflow.id}' contains {type(step).__name__} at position "
+                    f"{position + 1}; Studio refuses to return a view that drops composite branches.",
+                )
+            step_name = getattr(step, "name", None) or f"Step {position + 1}"
+            step_id = getattr(step, "step_id", None)
+            description = getattr(step, "description", None)
+            agent = step if isinstance(step, Agent) else getattr(step, "agent", None)
+            team = step if isinstance(step, Team) else getattr(step, "team", None)
+            agent_id = getattr(agent, "id", None)
+            team_id = getattr(team, "id", None)
+            executor = (
+                step
+                if callable(step) and not isinstance(step, (Agent, Team, Workflow))
+                else getattr(step, "executor", None)
             )
-            return result.get("version")
-
-        if guard is None:
-            raise ValueError("A catalog-v2 draft append requires a component version guard")
-
-        result = self.db.upsert_config(
-            component_id=component_id,
-            config=config if config is not None else _component_to_dict(component),
-            stage="draft",
-            links=links,
-            guard=guard,
+            if isinstance(agent_id, str) and agent_id:
+                steps.append(
+                    AgentWorkflowStep(
+                        kind="agent",
+                        name=step_name,
+                        step_id=step_id,
+                        component_id=agent_id,
+                        description=description,
+                    )
+                )
+            elif isinstance(team_id, str) and team_id:
+                steps.append(
+                    TeamWorkflowStep(
+                        kind="team",
+                        name=step_name,
+                        step_id=step_id,
+                        component_id=team_id,
+                        description=description,
+                    )
+                )
+            elif executor is not None and (getattr(executor, "__name__", None) or getattr(executor, "name", None)):
+                steps.append(
+                    FunctionWorkflowStep(
+                        kind="function",
+                        name=step_name,
+                        step_id=step_id,
+                        function_name=getattr(executor, "__name__", None) or executor.name,
+                        description=description,
+                    )
+                )
+            else:
+                raise _StudioRequestError(
+                    "unsupported_workflow_shape",
+                    f"Code-defined workflow '{workflow.id}' has an unrepresentable {type(step).__name__} at "
+                    f"position {position + 1}; Studio refuses to return a lossy view.",
+                )
+        return WorkflowView(
+            component_id=cast(str, workflow.id),
+            name=workflow.name or cast(str, workflow.id),
+            description=workflow.description,
+            steps=steps,
+            version=None,
+            stage="code",
+            is_current=True,
+            source="code",
         )
-        return result.get("version")
 
-    def _sync_component_row(self, component_id: str, version: Optional[int]) -> None:
-        """Sync legacy catalog-v1 projections after a publication."""
-        if self.db is None:
-            return
+    @staticmethod
+    def _storage_failure(error: Exception) -> Optional[StudioResult[Any]]:
+        from agno.db.base import (
+            ComponentAlreadyExistsError,
+            ComponentCycleError,
+            ComponentDependencyError,
+            ComponentDependencyUnavailableError,
+            ComponentDraftRequiredError,
+            ComponentLastConfigError,
+            ComponentVersionConflictError,
+        )
+
+        if isinstance(error, ComponentAlreadyExistsError):
+            return StudioTools._failure("component_conflict", str(error))
+        if isinstance(error, ComponentCycleError):
+            return StudioTools._failure(
+                "component_cycle",
+                str(error),
+                details={"component_id": error.component_id, "cycle_path": error.cycle_path},
+            )
+        if isinstance(error, ComponentVersionConflictError):
+            return StudioTools._failure(
+                "version_conflict",
+                str(error),
+                details={"expected": error.expected, "actual": error.actual},
+                retryable=True,
+            )
+        if isinstance(error, ComponentDependencyError):
+            return StudioTools._failure(
+                "component_has_dependents",
+                str(error),
+                details={"dependents": StudioTools._safe_dependents(error.dependents)},
+            )
+        if isinstance(error, ComponentDependencyUnavailableError):
+            return StudioTools._failure(
+                "component_dependency_unavailable",
+                str(error),
+                details={
+                    "component_id": error.component_id,
+                    "dependencies": StudioTools._safe_unavailable_dependencies(error.dependencies),
+                },
+            )
+        if isinstance(error, ComponentDraftRequiredError):
+            return StudioTools._failure(
+                "draft_required",
+                str(error),
+                details={"component_id": error.component_id, "version": error.version},
+            )
+        if isinstance(error, ComponentLastConfigError):
+            return StudioTools._failure(
+                "last_config_required",
+                str(error),
+                details={"component_id": error.component_id, "version": error.version},
+            )
+        return None
+
+    # ------------------------------------------------------------------
+    # Typed discovery and reads
+    # ------------------------------------------------------------------
+
+    def list_models(self, _agno_run_context: Optional[RunContext] = None) -> StudioResult[List[ModelRef]]:
+        """List exact model references available for Studio requests."""
+        denied = self._authorize("list_models", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[List[ModelRef]], denied)
+        try:
+            refs = [ref for model in self.registry.models if (ref := self._model_ref(model)) is not None]
+            return StudioResult[List[ModelRef]](ok=True, status="listed", data=refs)
+        except Exception:
+            return cast(StudioResult[List[ModelRef]], self._internal_failure("list models"))
+
+    def list_tools(self, _agno_run_context: Optional[RunContext] = None) -> StudioResult[List[ToolRef]]:
+        """List copyable toolkit and function references available for agents."""
+        denied = self._authorize("list_tools", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[List[ToolRef]], denied)
+        try:
+            return StudioResult[List[ToolRef]](
+                ok=True,
+                status="listed",
+                data=[ref for ref, _ in self._tool_catalog()],
+            )
+        except Exception:
+            return cast(StudioResult[List[ToolRef]], self._internal_failure("list tools"))
+
+    def list_functions(self, _agno_run_context: Optional[RunContext] = None) -> StudioResult[List[FunctionRef]]:
+        """List exact registered functions available for workflow steps."""
+        denied = self._authorize("list_functions", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[List[FunctionRef]], denied)
+        try:
+            refs = [
+                FunctionRef(
+                    name=getattr(function, "__name__", "anonymous"),
+                    description=inspect.getdoc(function),
+                )
+                for function in self.registry.functions
+            ]
+            return StudioResult[List[FunctionRef]](ok=True, status="listed", data=refs)
+        except Exception:
+            return cast(StudioResult[List[FunctionRef]], self._internal_failure("list functions"))
+
+    def _list_components(
+        self,
+        component_type: Literal["agent", "team", "workflow"],
+        code_components: Sequence[Component],
+    ) -> tuple[List[ComponentSummary], List[str]]:
         from agno.db.base import ComponentType
 
-        component = self.db.get_component(component_id)
-        row = self.db.get_config(component_id=component_id, version=version)
-        config = row.get("config") if isinstance(row, dict) else None
-        if component is None or not isinstance(config, dict):
-            return
-        self.db.upsert_component(
+        result: List[ComponentSummary] = []
+        code_ids: set[str] = set()
+        skipped_code = 0
+        for component in code_components:
+            try:
+                component_id = self._validate_component_id(getattr(component, "id", None))
+                summary = self._summary_from_code(component_type, component, component_id)
+            except Exception:
+                skipped_code += 1
+                logger.warning("Studio skipped an invalid code-defined %s during discovery", component_type)
+                continue
+            code_ids.add(component_id)
+            result.append(summary)
+
+        if code_ids:
+            stored_code_rows = self.db.get_components(
+                component_ids=code_ids,
+                include_deleted=True,
+            )
+            if not isinstance(stored_code_rows, list):
+                raise TypeError("Component catalog returned an invalid bulk component result")
+            for stored in stored_code_rows:
+                if not isinstance(stored, dict):
+                    raise TypeError("Component catalog returned an invalid bulk component row")
+                stored_component_id = stored.get("component_id")
+                if not isinstance(stored_component_id, str) or stored_component_id not in code_ids:
+                    raise TypeError("Component catalog returned an unexpected bulk component row")
+                self._raise_source_collision(stored_component_id, stored, [component_type])
+
+        rows, _ = self.db.list_components(
+            component_type=ComponentType(component_type),
+            limit=self.list_limit,
+        )
+        valid_rows: List[tuple[str, Dict[str, Any]]] = []
+        skipped_stored = 0
+        for row in rows:
+            try:
+                if not isinstance(row, dict):
+                    raise TypeError("component row is not an object")
+                component_id = row["component_id"]
+                if not isinstance(component_id, str):
+                    raise TypeError("component_id is not a string")
+            except (KeyError, TypeError):
+                skipped_stored += 1
+                logger.warning("Studio skipped an invalid stored %s row during discovery", component_type)
+                continue
+            valid_rows.append((component_id, row))
+
+        requested_config_ids = {component_id for component_id, _ in valid_rows}
+        latest_by_component = self.db.get_latest_configs(
+            component_ids=requested_config_ids,
+            include_deleted=False,
+        )
+        if not isinstance(latest_by_component, dict):
+            raise TypeError("Component catalog returned an invalid bulk latest-config result")
+        if set(latest_by_component) != requested_config_ids:
+            raise TypeError("Component catalog returned an incomplete bulk latest-config result")
+
+        for component_id, row in valid_rows:
+            try:
+                latest = latest_by_component.get(component_id)
+                if latest is not None and not isinstance(latest, dict):
+                    raise TypeError("latest config row is not an object")
+                result.append(self._summary_from_db_row(row, latest))
+            except (_StudioRequestError, KeyError, TypeError, ValueError):
+                skipped_stored += 1
+                logger.warning("Studio skipped an invalid stored %s row during discovery", component_type)
+
+        warnings = []
+        if skipped_code:
+            warnings.append(f"Skipped {skipped_code} invalid code-defined {component_type}(s) during discovery.")
+        if skipped_stored:
+            warnings.append(f"Skipped {skipped_stored} invalid stored {component_type} row(s) during discovery.")
+        return result, warnings
+
+    def list_agents(self, _agno_run_context: Optional[RunContext] = None) -> StudioResult[List[ComponentSummary]]:
+        """List code-defined and Studio-created agent summaries."""
+        denied = self._authorize("list_agents", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[List[ComponentSummary]], denied)
+        try:
+            self._ensure_component_type_enabled("agent")
+            data, warnings = self._list_components("agent", self._iter_agents())
+            return StudioResult[List[ComponentSummary]](
+                ok=True,
+                status="listed",
+                data=data,
+                warnings=warnings,
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[List[ComponentSummary]], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[List[ComponentSummary]], self._internal_failure("list agents"))
+
+    def list_teams(self, _agno_run_context: Optional[RunContext] = None) -> StudioResult[List[ComponentSummary]]:
+        """List code-defined and Studio-created team summaries."""
+        denied = self._authorize("list_teams", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[List[ComponentSummary]], denied)
+        try:
+            self._ensure_component_type_enabled("team")
+            data, warnings = self._list_components("team", self._iter_teams())
+            return StudioResult[List[ComponentSummary]](
+                ok=True,
+                status="listed",
+                data=data,
+                warnings=warnings,
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[List[ComponentSummary]], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[List[ComponentSummary]], self._internal_failure("list teams"))
+
+    def list_workflows(self, _agno_run_context: Optional[RunContext] = None) -> StudioResult[List[ComponentSummary]]:
+        """List code-defined and Studio-created workflow summaries."""
+        denied = self._authorize("list_workflows", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[List[ComponentSummary]], denied)
+        try:
+            self._ensure_component_type_enabled("workflow")
+            data, warnings = self._list_components("workflow", self._iter_workflows())
+            return StudioResult[List[ComponentSummary]](
+                ok=True,
+                status="listed",
+                data=data,
+                warnings=warnings,
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[List[ComponentSummary]], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[List[ComponentSummary]], self._internal_failure("list workflows"))
+
+    def get_agent(
+        self,
+        component_id: str,
+        version: Optional[int] = None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[AgentView]:
+        """Get an agent by exact component id and optional config version.
+
+        Args:
+            component_id: Exact agent id returned by Studio discovery.
+            version: Exact stored version, or omit to read the current
+                published version (or the live code-defined agent).
+        """
+        denied = self._authorize("get_agent", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[AgentView], denied)
+        try:
+            self._ensure_component_type_enabled("agent")
+            self._ensure_no_source_collision(component_id, "agent")
+            if self._db_component("agent", component_id) is not None:
+                view = self._view_for_version(component_id, version)
+                if not isinstance(view, AgentView):
+                    raise _StudioRequestError("component_type_mismatch", "The component is not an agent.")
+                return StudioResult[AgentView](ok=True, status="found", data=view)
+            if version is not None:
+                raise _StudioRequestError("component_not_found", f"Agent '{component_id}' was not found.")
+            code = self._code_component("agent", component_id)
+            if code is None:
+                raise _StudioRequestError("component_not_found", f"Agent '{component_id}' was not found.")
+            return StudioResult[AgentView](ok=True, status="found", data=self._code_agent_view(cast("Agent", code)))
+        except _StudioRequestError as error:
+            return cast(StudioResult[AgentView], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[AgentView], self._internal_failure("get agent"))
+
+    def get_team(
+        self,
+        component_id: str,
+        version: Optional[int] = None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[TeamView]:
+        """Get a team by exact component id and optional config version.
+
+        Args:
+            component_id: Exact team id returned by Studio discovery.
+            version: Exact stored version, or omit to read the current
+                published version (or the live code-defined team).
+        """
+        denied = self._authorize("get_team", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[TeamView], denied)
+        try:
+            self._ensure_component_type_enabled("team")
+            self._ensure_no_source_collision(component_id, "team")
+            if self._db_component("team", component_id) is not None:
+                view = self._view_for_version(component_id, version)
+                if not isinstance(view, TeamView):
+                    raise _StudioRequestError("component_type_mismatch", "The component is not a team.")
+                return StudioResult[TeamView](ok=True, status="found", data=view)
+            if version is not None:
+                raise _StudioRequestError("component_not_found", f"Team '{component_id}' was not found.")
+            code = self._code_component("team", component_id)
+            if code is None:
+                raise _StudioRequestError("component_not_found", f"Team '{component_id}' was not found.")
+            return StudioResult[TeamView](ok=True, status="found", data=self._code_team_view(cast("Team", code)))
+        except _StudioRequestError as error:
+            return cast(StudioResult[TeamView], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[TeamView], self._internal_failure("get team"))
+
+    def get_workflow(
+        self,
+        component_id: str,
+        version: Optional[int] = None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[WorkflowView]:
+        """Get a workflow by exact component id and optional config version.
+
+        Args:
+            component_id: Exact workflow id returned by Studio discovery.
+            version: Exact stored version, or omit to read the current
+                published version (or the live code-defined workflow).
+        """
+        denied = self._authorize("get_workflow", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[WorkflowView], denied)
+        try:
+            self._ensure_component_type_enabled("workflow")
+            self._ensure_no_source_collision(component_id, "workflow")
+            if self._db_component("workflow", component_id) is not None:
+                view = self._view_for_version(component_id, version)
+                if not isinstance(view, WorkflowView):
+                    raise _StudioRequestError("component_type_mismatch", "The component is not a workflow.")
+                return StudioResult[WorkflowView](ok=True, status="found", data=view)
+            if version is not None:
+                raise _StudioRequestError("component_not_found", f"Workflow '{component_id}' was not found.")
+            code = self._code_component("workflow", component_id)
+            if code is None:
+                raise _StudioRequestError("component_not_found", f"Workflow '{component_id}' was not found.")
+            return StudioResult[WorkflowView](
+                ok=True,
+                status="found",
+                data=self._code_workflow_view(cast("Workflow", code)),
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[WorkflowView], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[WorkflowView], self._internal_failure("get workflow"))
+
+    def list_versions(
+        self,
+        component_id: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[List[VersionSummary]]:
+        """List safe lifecycle metadata for every config version.
+
+        Args:
+            component_id: Exact Studio component id.
+        """
+        denied = self._authorize("list_versions", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[List[VersionSummary]], denied)
+        try:
+            self._ensure_no_source_collision(component_id)
+            component = self.db.get_component(component_id)
+            if component is None:
+                raise _StudioRequestError("component_not_found", f"Component '{component_id}' was not found.")
+            self._ensure_component_type_enabled(cast(str, component.get("component_type")))
+            current = component.get("current_version")
+            versions = [
+                VersionSummary(
+                    version=config["version"],
+                    stage=config["stage"],
+                    label=config.get("label"),
+                    is_current=config.get("version") == current,
+                    created_at=config.get("created_at"),
+                    updated_at=config.get("updated_at"),
+                )
+                for config in self.db.list_configs(component_id, include_config=False)
+            ]
+            return StudioResult[List[VersionSummary]](ok=True, status="listed", data=versions)
+        except _StudioRequestError as error:
+            return cast(StudioResult[List[VersionSummary]], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[List[VersionSummary]], self._internal_failure("list versions"))
+
+    def get_version(
+        self,
+        component_id: str,
+        version: int,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentView]:
+        """Get a safe typed component view for one exact version.
+
+        Persisted config blobs are never returned by this API.
+
+        Args:
+            component_id: Exact Studio component id.
+            version: Exact stored version to inspect.
+        """
+        denied = self._authorize("get_version", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ComponentView], denied)
+        try:
+            self._ensure_no_source_collision(component_id)
+            return StudioResult[ComponentView](
+                ok=True,
+                status="found",
+                data=self._view_for_version(component_id, version),
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ComponentView], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[ComponentView], self._internal_failure("get version"))
+
+    # ------------------------------------------------------------------
+    # Atomic, deterministic creates
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _effective_component_id(component_id: Optional[str], name: str) -> str:
+        if component_id is not None:
+            return StudioTools._validate_component_id(component_id)
+        return StudioTools._validate_component_id(generate_id_from_name(name))
+
+    def create_agent(
+        self,
+        request: AgentCreate,
+        save_as: SaveStage = "draft",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[AgentView]:
+        """Create an agent from one typed request.
+
+        Args:
+            request: Complete declarative agent configuration, including the
+                create-only ``if_exists`` retry policy.
+            save_as: Save as a draft by default or publish immediately.
+        """
+        denied = self._authorize("create_agent", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[AgentView], denied)
+        try:
+            assert _agno_run_context is not None
+            self._ensure_component_type_enabled("agent")
+            save_as = self._validate_save_as(save_as)
+            if_exists = self._validate_if_exists(request.if_exists)
+            effective_id = self._effective_component_id(request.component_id, request.name)
+            request = request.model_copy(update={"component_id": effective_id})
+            metadata = self._actor_metadata(None, _agno_run_context, "create_agent")
+            agent, effective = self._build_agent(request, metadata)
+            result = self._create_component(agent, effective, save_as, [], [], [], if_exists)
+            log_debug(f"Studio created agent component_id={effective_id} stage={save_as}")
+            return cast(StudioResult[AgentView], result)
+        except _StudioRequestError as error:
+            return cast(StudioResult[AgentView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[AgentView], known)
+            return cast(StudioResult[AgentView], self._internal_failure("create agent"))
+
+    def create_team(
+        self,
+        request: TeamCreate,
+        save_as: SaveStage = "draft",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[TeamView]:
+        """Create a team from typed, version-aware member references.
+
+        Args:
+            request: Complete declarative team configuration, including the
+                create-only ``if_exists`` retry policy.
+            save_as: Save as a draft by default or publish immediately.
+        """
+        denied = self._authorize("create_team", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[TeamView], denied)
+        try:
+            assert _agno_run_context is not None
+            self._ensure_component_type_enabled("team")
+            save_as = self._validate_save_as(save_as)
+            if_exists = self._validate_if_exists(request.if_exists)
+            effective_id = self._effective_component_id(request.component_id, request.name)
+            request = request.model_copy(update={"component_id": effective_id})
+            metadata = self._actor_metadata(None, _agno_run_context, "create_team")
+            team, effective, links, warnings, resolved = self._build_team(request, metadata)
+            result = self._create_component(team, effective, save_as, links, warnings, resolved, if_exists)
+            log_debug(f"Studio created team component_id={effective_id} stage={save_as}")
+            return cast(StudioResult[TeamView], result)
+        except _StudioRequestError as error:
+            return cast(StudioResult[TeamView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[TeamView], known)
+            return cast(StudioResult[TeamView], self._internal_failure("create team"))
+
+    def create_workflow(
+        self,
+        request: WorkflowCreate,
+        save_as: SaveStage = "draft",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[WorkflowView]:
+        """Create a workflow from discriminated typed steps.
+
+        Args:
+            request: Complete declarative workflow configuration, including the
+                create-only ``if_exists`` retry policy.
+            save_as: Save as a draft by default or publish immediately.
+        """
+        denied = self._authorize("create_workflow", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[WorkflowView], denied)
+        try:
+            assert _agno_run_context is not None
+            self._ensure_component_type_enabled("workflow")
+            save_as = self._validate_save_as(save_as)
+            if_exists = self._validate_if_exists(request.if_exists)
+            effective_id = self._effective_component_id(request.component_id, request.name)
+            request = request.model_copy(update={"component_id": effective_id})
+            metadata = self._actor_metadata(None, _agno_run_context, "create_workflow")
+            workflow, effective, links, warnings, resolved = self._build_workflow(request, metadata)
+            result = self._create_component(workflow, effective, save_as, links, warnings, resolved, if_exists)
+            log_debug(f"Studio created workflow component_id={effective_id} stage={save_as}")
+            return cast(StudioResult[WorkflowView], result)
+        except _StudioRequestError as error:
+            return cast(StudioResult[WorkflowView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[WorkflowView], known)
+            return cast(StudioResult[WorkflowView], self._internal_failure("create workflow"))
+
+    # ------------------------------------------------------------------
+    # Omission-aware CAS edits
+    # ------------------------------------------------------------------
+
+    def _edit_base(
+        self,
+        component_type: str,
+        component_id: str,
+        expected_version: int,
+    ) -> tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any]]:
+        from agno.db.base import ComponentType
+
+        self._ensure_no_source_collision(component_id, component_type)
+        component = self.db.get_component(component_id, component_type=ComponentType(component_type))
+        if component is None:
+            if self._code_component(component_type, component_id) is not None:
+                raise _StudioRequestError(
+                    "code_component_read_only",
+                    "Code-defined components cannot be edited by Studio.",
+                )
+            raise _StudioRequestError(
+                "component_not_found",
+                f"{component_type.capitalize()} '{component_id}' was not found.",
+            )
+        config_row = self.db.get_config(component_id, version=expected_version)
+        if config_row is None:
+            raise _StudioRequestError(
+                "version_not_found",
+                f"Version {expected_version} was not found for component '{component_id}'.",
+            )
+        config = config_row.get("config")
+        if not isinstance(config, dict):
+            raise _StudioRequestError("invalid_component_config", "The stored component config is invalid.")
+        return component, config_row, self._manifest_request(config)
+
+    def _patched_context(self, current: Optional[ContextPolicy], patch: Any) -> Optional[ContextPolicy]:
+        if patch is None:
+            return current
+        base = current or self.default_context
+        values = base.model_dump()
+        for field, value in patch.model_dump(exclude_unset=True).items():
+            if field == "history_runs" and value is None:
+                values[field] = self.default_context.history_runs
+            else:
+                values[field] = value
+        if (
+            values.get("include_history") is False
+            and "history_runs" in patch.model_fields_set
+            and patch.history_runs is not None
+        ):
+            raise _StudioRequestError(
+                "invalid_context_policy",
+                "history_runs cannot be set while history context is disabled; enable include_history in the same patch.",
+            )
+        if values.get("include_history") is False:
+            values["history_runs"] = None
+        elif values.get("history_runs") is None:
+            values["history_runs"] = self.default_context.history_runs
+        return ContextPolicy.model_validate(values)
+
+    def _apply_agent_patch(self, current: AgentCreate, patch: AgentPatch) -> AgentCreate:
+        updates = {field: getattr(patch, field) for field in patch.model_fields_set}
+        if "context" in patch.model_fields_set:
+            updates["context"] = self._patched_context(current.context, patch.context)
+        return current.model_copy(update=updates)
+
+    def _apply_team_patch(self, current: TeamCreate, patch: TeamPatch) -> TeamCreate:
+        updates = {field: getattr(patch, field) for field in patch.model_fields_set}
+        if "context" in patch.model_fields_set:
+            updates["context"] = self._patched_context(current.context, patch.context)
+        return current.model_copy(update=updates)
+
+    @staticmethod
+    def _apply_workflow_patch(current: WorkflowCreate, patch: WorkflowPatch) -> WorkflowCreate:
+        return current.model_copy(update={field: getattr(patch, field) for field in patch.model_fields_set})
+
+    def _append_edit(
+        self,
+        catalog_row: Dict[str, Any],
+        base_config: Dict[str, Any],
+        component: Component,
+        request: Any,
+        expected_version: int,
+        save_as: SaveStage,
+        links: Sequence[Dict[str, Any]],
+        warnings: List[str],
+        resolved_refs: Sequence[_ResolvedRef],
+        preserve_model: bool = False,
+    ) -> StudioResult[Any]:
+        from agno.db.base import ComponentVersionGuard
+
+        config = self._serialize_component(component, request)
+        if preserve_model:
+            config.pop("model", None)
+            if "model" in base_config:
+                config["model"] = deepcopy(base_config["model"])
+        if save_as == "published":
+            self._validate_immediate_publishability(
+                component,
+                self._component_type(component).value,
+                request,
+                resolved_refs,
+            )
+        component_id = cast(str, request.component_id)
+        guard = ComponentVersionGuard(
+            latest_version=expected_version,
+            current_version=catalog_row.get("current_version"),
+        )
+        config_row = self.db.upsert_config(
             component_id=component_id,
-            component_type=ComponentType(component["component_type"]),
-            name=config.get("name") or component.get("name"),
-            description=config.get("description"),
-            metadata=config.get("metadata"),
+            config=config,
+            stage=save_as,
+            links=list(links),
+            guard=guard,
+            projection=(
+                self._projection(request, cast(Dict[str, Any], getattr(component, "metadata", None) or {}))
+                if save_as == "published"
+                else None
+            ),
+        )
+        response_component = catalog_row
+        if save_as == "published":
+            response_component = self._projected_component_state(
+                catalog_row,
+                request,
+                cast(Dict[str, Any], getattr(component, "metadata", None) or {}),
+                current_version=cast(int, config_row["version"]),
+            )
+        return self._success("edited", self._view_from_record(response_component, config_row), warnings)
+
+    def edit_agent(
+        self,
+        component_id: str,
+        patch: AgentPatch,
+        expected_version: int,
+        save_as: SaveStage = "draft",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[AgentView]:
+        """Append an omission-aware agent version with optimistic concurrency.
+
+        Args:
+            component_id: Exact Studio agent id.
+            patch: Typed changes to apply; omitted fields stay unchanged.
+            expected_version: Latest version observed by the caller.
+            save_as: Save the new version as a draft by default or publish it
+                immediately.
+        """
+        denied = self._authorize("edit_agent", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[AgentView], denied)
+        try:
+            assert _agno_run_context is not None
+            self._ensure_component_type_enabled("agent")
+            save_as = self._validate_save_as(save_as)
+            row, config_row, request_data = self._edit_base("agent", component_id, expected_version)
+            current = AgentCreate.model_validate(request_data)
+            requested = self._apply_agent_patch(current, patch)
+            metadata = self._actor_metadata(row.get("metadata"), _agno_run_context, "edit_agent")
+            agent, effective = self._build_agent(requested, metadata)
+            return cast(
+                StudioResult[AgentView],
+                self._append_edit(
+                    row,
+                    cast(Dict[str, Any], config_row["config"]),
+                    agent,
+                    effective,
+                    expected_version,
+                    save_as,
+                    [],
+                    [],
+                    [],
+                    preserve_model="model" not in patch.model_fields_set,
+                ),
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[AgentView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[AgentView], known)
+            return cast(StudioResult[AgentView], self._internal_failure("edit agent"))
+
+    def edit_team(
+        self,
+        component_id: str,
+        patch: TeamPatch,
+        expected_version: int,
+        save_as: SaveStage = "draft",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[TeamView]:
+        """Append an omission-aware team version with optimistic concurrency.
+
+        Args:
+            component_id: Exact Studio team id.
+            patch: Typed changes to apply; omitted fields stay unchanged.
+            expected_version: Latest version observed by the caller.
+            save_as: Save the new version as a draft by default or publish it
+                immediately.
+        """
+        denied = self._authorize("edit_team", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[TeamView], denied)
+        try:
+            assert _agno_run_context is not None
+            self._ensure_component_type_enabled("team")
+            save_as = self._validate_save_as(save_as)
+            row, config_row, request_data = self._edit_base("team", component_id, expected_version)
+            current = TeamCreate.model_validate(request_data)
+            requested = self._apply_team_patch(current, patch)
+            metadata = self._actor_metadata(row.get("metadata"), _agno_run_context, "edit_team")
+            team, effective, links, warnings, resolved = self._build_team(requested, metadata)
+            return cast(
+                StudioResult[TeamView],
+                self._append_edit(
+                    row,
+                    cast(Dict[str, Any], config_row["config"]),
+                    team,
+                    effective,
+                    expected_version,
+                    save_as,
+                    links,
+                    warnings,
+                    resolved,
+                    preserve_model="model" not in patch.model_fields_set,
+                ),
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[TeamView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[TeamView], known)
+            return cast(StudioResult[TeamView], self._internal_failure("edit team"))
+
+    def edit_workflow(
+        self,
+        component_id: str,
+        patch: WorkflowPatch,
+        expected_version: int,
+        save_as: SaveStage = "draft",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[WorkflowView]:
+        """Append an omission-aware workflow version with optimistic concurrency.
+
+        Args:
+            component_id: Exact Studio workflow id.
+            patch: Typed changes to apply; omitted fields stay unchanged.
+            expected_version: Latest version observed by the caller.
+            save_as: Save the new version as a draft by default or publish it
+                immediately.
+        """
+        denied = self._authorize("edit_workflow", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[WorkflowView], denied)
+        try:
+            assert _agno_run_context is not None
+            self._ensure_component_type_enabled("workflow")
+            save_as = self._validate_save_as(save_as)
+            row, config_row, request_data = self._edit_base("workflow", component_id, expected_version)
+            current = WorkflowCreate.model_validate(request_data)
+            requested = self._apply_workflow_patch(current, patch)
+            metadata = self._actor_metadata(row.get("metadata"), _agno_run_context, "edit_workflow")
+            workflow, effective, links, warnings, resolved = self._build_workflow(requested, metadata)
+            return cast(
+                StudioResult[WorkflowView],
+                self._append_edit(
+                    row,
+                    cast(Dict[str, Any], config_row["config"]),
+                    workflow,
+                    effective,
+                    expected_version,
+                    save_as,
+                    links,
+                    warnings,
+                    resolved,
+                ),
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[WorkflowView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[WorkflowView], known)
+            return cast(StudioResult[WorkflowView], self._internal_failure("edit workflow"))
+
+    # ------------------------------------------------------------------
+    # Atomic publish, rollback, draft deletion, and archive
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _request_for_component_type(component_type: str, request_data: Dict[str, Any]) -> Any:
+        if component_type == "agent":
+            return AgentCreate.model_validate(request_data)
+        if component_type == "team":
+            return TeamCreate.model_validate(request_data)
+        if component_type == "workflow":
+            return WorkflowCreate.model_validate(request_data)
+        raise _StudioRequestError("invalid_component_type", "The stored component type is invalid.")
+
+    def _owned_request_from_config(
+        self,
+        component_type: Literal["agent", "team", "workflow"],
+        component_id: str,
+        config: Dict[str, Any],
+    ) -> Any:
+        """Validate that a config is a complete typed Studio manifest for this row."""
+        request_data = self._manifest_request(config)
+        try:
+            request = self._request_for_component_type(component_type, request_data)
+        except (TypeError, ValueError):
+            raise _StudioRequestError(
+                "invalid_component_config",
+                "The stored Studio request manifest is invalid for this component type.",
+            ) from None
+        canonical_request = request.model_dump(mode="json", exclude={"if_exists"})
+        if request_data != canonical_request:
+            raise _StudioRequestError(
+                "invalid_component_config",
+                "The stored Studio request manifest is not a canonical effective request.",
+            )
+        if request.component_id != component_id:
+            raise _StudioRequestError(
+                "invalid_component_config",
+                "The stored Studio request manifest does not match the catalog component id.",
+            )
+        if isinstance(request, (AgentCreate, TeamCreate)) and (request.model is None or request.context is None):
+            raise _StudioRequestError(
+                "invalid_component_config",
+                "The stored Studio request manifest contains unresolved model or context defaults.",
+            )
+        return request
+
+    def _request_from_config_row(self, component_type: str, config_row: Dict[str, Any]) -> Any:
+        config = config_row.get("config")
+        if not isinstance(config, dict):
+            raise _StudioRequestError("invalid_component_config", "The stored component config is invalid.")
+        return self._request_for_component_type(component_type, self._manifest_request(config))
+
+    def _require_published_pins(
+        self,
+        component_type: str,
+        component_id: str,
+        version: int,
+        request: Any,
+    ) -> None:
+        expected: List[tuple[str, int, str, str]] = []
+        if component_type == "team":
+            for position, ref in enumerate(cast(TeamCreate, request).members):
+                if ref.version is None:
+                    raise _StudioRequestError(
+                        "code_reference_not_publishable",
+                        "Published teams require version-pinned stored members.",
+                        details={"component_id": ref.component_id},
+                    )
+                expected.append((ref.component_id, ref.version, "member", f"member_{position}"))
+        elif component_type == "workflow":
+            for spec in cast(WorkflowCreate, request).steps:
+                if isinstance(spec, AgentWorkflowStep):
+                    if spec.version is None:
+                        raise _StudioRequestError(
+                            "code_reference_not_publishable",
+                            "Published workflows require version-pinned stored step components.",
+                            details={"component_id": spec.component_id},
+                        )
+                    expected.append((spec.component_id, spec.version, "step_agent", cast(str, spec.step_id)))
+                elif isinstance(spec, TeamWorkflowStep):
+                    if spec.version is None:
+                        raise _StudioRequestError(
+                            "code_reference_not_publishable",
+                            "Published workflows require version-pinned stored step components.",
+                            details={"component_id": spec.component_id},
+                        )
+                    expected.append((spec.component_id, spec.version, "step_team", cast(str, spec.step_id)))
+
+        actual = {
+            (
+                link.get("child_component_id"),
+                link.get("child_version"),
+                link.get("link_kind"),
+                link.get("link_key"),
+            )
+            for link in self.db.get_links(component_id, version)
+        }
+        missing_links: List[Dict[str, Any]] = []
+        for child_id, child_version, link_kind, link_key in expected:
+            if (child_id, child_version, link_kind, link_key) not in actual:
+                missing_links.append(
+                    {
+                        "component_id": child_id,
+                        "version": child_version,
+                        "link_kind": link_kind,
+                        "link_key": link_key,
+                    }
+                )
+                continue
+            child = self.db.get_component(child_id)
+            child_config = self.db.get_config(child_id, version=child_version) if child is not None else None
+            if child is None or child_config is None or child_config.get("stage") != "published":
+                raise _StudioRequestError(
+                    "unpublished_dependency",
+                    f"Dependency '{child_id}' v{child_version} is not an active published component.",
+                )
+        if missing_links:
+            raise _StudioRequestError(
+                "missing_component_links",
+                "The draft is missing durable links for one or more component references.",
+                details={"missing": missing_links},
+            )
+
+    def _validate_published_ref_tree(
+        self,
+        resolved_refs: Sequence[_ResolvedRef],
+        seen: set[tuple[str, str, int]],
+    ) -> None:
+        """Revalidate every durable child before a parent can become current."""
+        self._ensure_publishable_refs(resolved_refs)
+        for resolved in resolved_refs:
+            ref = resolved.ref
+            if resolved.code_defined or ref.version is None:
+                raise _StudioRequestError(
+                    "code_reference_not_publishable",
+                    "Published composites require stored, version-pinned child components.",
+                    details={"component_id": ref.component_id},
+                )
+            child = self._db_component(ref.component_type, ref.component_id)
+            child_config = self.db.get_config(ref.component_id, version=ref.version) if child is not None else None
+            if child is None or child_config is None or child_config.get("stage") != "published":
+                raise _StudioRequestError(
+                    "unpublished_dependency",
+                    f"Dependency '{ref.component_id}' v{ref.version} is not an active published component.",
+                )
+            child_request = self._request_from_config_row(ref.component_type, child_config)
+            self._validate_publishability(
+                ref.component_type,
+                ref.component_id,
+                ref.version,
+                child_request,
+                seen,
+            )
+
+    def _validate_immediate_publishability(
+        self,
+        component: Component,
+        component_type: str,
+        request: Any,
+        resolved_refs: Sequence[_ResolvedRef],
+    ) -> None:
+        """Bound a freshly built graph before atomically storing it live.
+
+        The top-level runtime was just built from exact registry objects. Its
+        durable children, however, may have become non-dispatchable since they
+        were published, so validate their complete pinned trees as strictly as
+        the explicit publish and rollback paths do. The root itself does not
+        exist in the catalog yet, so only apply the runner's in-memory graph
+        bound here; stored-runtime fidelity is checked when dispatch loads the
+        committed version.
+        """
+        if request.component_id is None:
+            raise _StudioRequestError("component_id_required", "Published components require a component_id.")
+        if component_type not in ("agent", "team", "workflow"):
+            raise _StudioRequestError("invalid_component_type", "The component type is invalid.")
+        self._validate_published_ref_tree(resolved_refs, set())
+        try:
+            self._runner_tools._require_inspectable_depth(component, component_type, request.component_id)
+        except StudioRunnerError as error:
+            raise _StudioRequestError(
+                "component_not_publishable",
+                str(error),
+                details={
+                    "component_id": request.component_id,
+                    "component_type": component_type,
+                    "reason": type(error).__name__,
+                },
+            ) from error
+
+    @staticmethod
+    def _normalize_runtime_fidelity_config(config: Dict[str, Any]) -> Dict[str, Any]:
+        """Ignore deterministic strict-schema decoration in fidelity checks.
+
+        Rehydration processes Function entrypoints and adds
+        ``additionalProperties: false`` recursively. A freshly registered
+        Toolkit may not have been processed yet, so that generated decoration
+        can differ even though both runtimes hold the same exact registry
+        functions. Typed ToolRefs make the registry identity authoritative;
+        normalize only this generated false marker while retaining every tool,
+        parameter, description, and runtime field.
+        """
+
+        def strip_generated_strictness(value: Any) -> None:
+            if isinstance(value, list):
+                for item in value:
+                    strip_generated_strictness(item)
+                return
+            if not isinstance(value, dict):
+                return
+            if value.get("additionalProperties") is False:
+                value.pop("additionalProperties")
+            for item in value.values():
+                strip_generated_strictness(item)
+
+        tools = config.get("tools")
+        if isinstance(tools, list):
+            for tool in tools:
+                if isinstance(tool, dict):
+                    strip_generated_strictness(tool.get("parameters"))
+        return config
+
+    def _validate_publishability(
+        self,
+        component_type: str,
+        component_id: str,
+        version: int,
+        request: Any,
+        seen: Optional[set[tuple[str, str, int]]] = None,
+    ) -> None:
+        if seen is None:
+            seen = set()
+        identity = (component_type, component_id, version)
+        if identity in seen:
+            return
+        seen.add(identity)
+        if request.component_id != component_id:
+            raise _StudioRequestError(
+                "invalid_component_config",
+                "The stored request component_id does not match its catalog id.",
+            )
+
+        metadata: Dict[str, Any] = {}
+        resolved_refs: Sequence[_ResolvedRef] = []
+        built: Component
+        effective: Union[AgentCreate, TeamCreate, WorkflowCreate]
+        if component_type == "agent":
+            built, effective = self._build_agent(cast(AgentCreate, request), metadata)
+        elif component_type == "team":
+            built, effective, _, _, resolved_refs = self._build_team(cast(TeamCreate, request), metadata)
+        elif component_type == "workflow":
+            built, effective, _, _, resolved_refs = self._build_workflow(cast(WorkflowCreate, request), metadata)
+        else:
+            raise _StudioRequestError("invalid_component_type", "The stored component type is invalid.")
+
+        if self._normalized_request(effective) != self._normalized_request(request):
+            raise _StudioRequestError(
+                "component_not_publishable",
+                "The stored request contains unresolved defaults or references; edit and save a fresh draft first.",
+            )
+        self._ensure_publishable_refs(resolved_refs)
+        self._validate_published_ref_tree(resolved_refs, seen)
+        self._require_published_pins(component_type, component_id, version, request)
+
+        try:
+            rebuilt = self._load_db_component(
+                component_type,
+                component_id,
+                version,
+                for_dispatch=True,
+            )
+        except Exception as error:
+            raise _StudioRequestError(
+                "component_not_publishable",
+                "The component cannot be faithfully rehydrated for dispatch; repair its registry dependencies first.",
+                details={
+                    "component_id": component_id,
+                    "component_type": component_type,
+                    "version": version,
+                    "reason": type(error).__name__,
+                },
+            ) from error
+        if rebuilt is None:
+            raise _StudioRequestError(
+                "component_not_publishable",
+                "The component cannot be faithfully rehydrated for dispatch.",
+                details={
+                    "component_id": component_id,
+                    "component_type": component_type,
+                    "version": version,
+                },
+            )
+
+        expected_config = self._normalize_runtime_fidelity_config(self._serialize_component(built, request))
+        rebuilt_config = self._normalize_runtime_fidelity_config(self._serialize_component(rebuilt, request))
+        # Actor metadata is a component projection and can legitimately be
+        # newer than an immutable config version. Everything else must match
+        # the typed request's fresh rebuild before that version can go live.
+        expected_config.pop("metadata", None)
+        rebuilt_config.pop("metadata", None)
+        if expected_config != rebuilt_config:
+            raise _StudioRequestError(
+                "component_not_publishable",
+                "The persisted runtime config diverges from its typed Studio request; save a fresh draft first.",
+                details={
+                    "component_id": component_id,
+                    "component_type": component_type,
+                    "version": version,
+                },
+            )
+
+    def publish_component(
+        self,
+        component_id: str,
+        version: int,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentView]:
+        """Publish the latest draft using a current-version CAS guard.
+
+        Args:
+            component_id: Exact Studio component id.
+            version: Latest draft version to publish.
+            expected_current_version: Current published version observed by
+                the caller, or null when the component has never been
+                published.
+        """
+        denied = self._authorize("publish_component", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ComponentView], denied)
+        try:
+            assert _agno_run_context is not None
+            from agno.db.base import ComponentVersionGuard
+
+            self._ensure_no_source_collision(component_id)
+            component = self.db.get_component(component_id)
+            if component is None:
+                raise _StudioRequestError("component_not_found", f"Component '{component_id}' was not found.")
+            self._ensure_component_type_enabled(cast(str, component.get("component_type")))
+            config_row = self.db.get_config(component_id, version=version)
+            if config_row is None:
+                raise _StudioRequestError("version_not_found", f"Version {version} was not found.")
+            component_type = cast(str, component["component_type"])
+            request = self._request_from_config_row(component_type, config_row)
+            if config_row.get("stage") == "published" and component.get("current_version") == version:
+                self._validate_publishability(component_type, component_id, version, request)
+                return StudioResult[ComponentView](
+                    ok=True,
+                    status="already_published",
+                    data=self._view_from_record(component, config_row),
+                )
+            if config_row.get("stage") != "draft":
+                raise _StudioRequestError(
+                    "draft_required",
+                    "Only a draft can be published; use set_current_version for an older published version.",
+                )
+            self._validate_publishability(component_type, component_id, version, request)
+            metadata = self._actor_metadata(component.get("metadata"), _agno_run_context, "publish_component")
+            result = self.db.upsert_config(
+                component_id=component_id,
+                version=version,
+                stage="published",
+                guard=ComponentVersionGuard(
+                    latest_version=version,
+                    current_version=expected_current_version,
+                ),
+                projection=self._projection(request, metadata),
+            )
+            response_component = self._projected_component_state(
+                component,
+                request,
+                metadata,
+                current_version=version,
+            )
+            return StudioResult[ComponentView](
+                ok=True,
+                status="published",
+                data=self._view_from_record(response_component, result),
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ComponentView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[ComponentView], known)
+            return cast(StudioResult[ComponentView], self._internal_failure("publish component"))
+
+    def set_current_version(
+        self,
+        component_id: str,
+        version: int,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentView]:
+        """Make an immutable published version current using CAS.
+
+        Args:
+            component_id: Exact Studio component id.
+            version: Published version to make current.
+            expected_current_version: Current published version observed by
+                the caller, or null when no version is currently published.
+        """
+        denied = self._authorize("set_current_version", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ComponentView], denied)
+        try:
+            assert _agno_run_context is not None
+            from agno.db.base import ComponentVersionGuard
+
+            self._ensure_no_source_collision(component_id)
+            component = self.db.get_component(component_id)
+            if component is None:
+                raise _StudioRequestError("component_not_found", f"Component '{component_id}' was not found.")
+            self._ensure_component_type_enabled(cast(str, component.get("component_type")))
+            config_row = self.db.get_config(component_id, version=version)
+            if config_row is None:
+                raise _StudioRequestError("version_not_found", f"Version {version} was not found.")
+            if config_row.get("stage") != "published":
+                raise _StudioRequestError("published_version_required", "Only a published version can be current.")
+            component_type = cast(str, component["component_type"])
+            request = self._request_from_config_row(component_type, config_row)
+            self._validate_publishability(component_type, component_id, version, request)
+            if component.get("current_version") == version:
+                return StudioResult[ComponentView](
+                    ok=True,
+                    status="already_current",
+                    data=self._view_from_record(component, config_row),
+                )
+            metadata = self._actor_metadata(component.get("metadata"), _agno_run_context, "set_current_version")
+            configs = self.db.list_configs(component_id, include_config=False)
+            latest = max((config["version"] for config in configs), default=None)
+            ok = self.db.set_current_version(
+                component_id,
+                version,
+                guard=ComponentVersionGuard(
+                    latest_version=latest,
+                    current_version=expected_current_version,
+                ),
+                projection=self._projection(request, metadata),
+            )
+            if not ok:
+                raise _StudioRequestError("version_not_found", f"Version {version} was not found.")
+            response_component = self._projected_component_state(
+                component,
+                request,
+                metadata,
+                current_version=version,
+            )
+            return StudioResult[ComponentView](
+                ok=True,
+                status="current_version_set",
+                data=self._view_from_record(response_component, config_row),
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ComponentView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[ComponentView], known)
+            return cast(StudioResult[ComponentView], self._internal_failure("set current version"))
+
+    def delete_version(
+        self,
+        component_id: str,
+        version: int,
+        expected_latest_version: int,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        """Delete one unreferenced draft version using a latest-version guard.
+
+        Args:
+            component_id: Exact Studio component id.
+            version: Draft version to delete.
+            expected_latest_version: Latest version observed by the caller.
+        """
+        denied = self._authorize("delete_version", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ComponentActionView], denied)
+        try:
+            assert _agno_run_context is not None
+            from agno.db.base import ComponentVersionGuard
+
+            self._ensure_no_source_collision(component_id)
+            component = self.db.get_component(component_id)
+            if component is None:
+                raise _StudioRequestError("component_not_found", f"Component '{component_id}' was not found.")
+            self._ensure_component_type_enabled(cast(str, component.get("component_type")))
+            metadata = self._actor_metadata(component.get("metadata"), _agno_run_context, "delete_version")
+            deleted = self.db.delete_config(
+                component_id,
+                version,
+                guard=ComponentVersionGuard(
+                    latest_version=expected_latest_version,
+                    current_version=component.get("current_version"),
+                ),
+                projection=cast("ComponentProjection", {"metadata": metadata}),
+            )
+            if not deleted:
+                raise _StudioRequestError("version_not_found", f"Version {version} was not found.")
+            return StudioResult[ComponentActionView](
+                ok=True,
+                status="draft_deleted",
+                data=ComponentActionView(
+                    component_id=component_id,
+                    component_type=component["component_type"],
+                    version=version,
+                ),
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ComponentActionView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[ComponentActionView], known)
+            return cast(StudioResult[ComponentActionView], self._internal_failure("delete draft version"))
+
+    def _archive_component(
+        self,
+        component_type: Literal["agent", "team", "workflow"],
+        component_id: str,
+        expected_current_version: int | None,
+        run_context: RunContext,
+        action: StudioAction,
+    ) -> StudioResult[ComponentActionView]:
+        from agno.db.base import ComponentType, ComponentVersionGuard
+
+        self._ensure_component_type_enabled(component_type)
+        self._ensure_no_source_collision(component_id, component_type)
+        component = self.db.get_component(
+            component_id,
+            component_type=ComponentType(component_type),
+            include_deleted=True,
+        )
+        if component is None:
+            raise _StudioRequestError(
+                "component_not_found",
+                f"{component_type.capitalize()} '{component_id}' was not found.",
+            )
+        latest_config = self.db.get_latest_config(component_id, include_deleted=True)
+        if not isinstance(latest_config, dict):
+            raise _StudioRequestError(
+                "invalid_component_config",
+                f"Component '{component_id}' has no stored configuration.",
+            )
+        stored_config = latest_config.get("config")
+        if not isinstance(stored_config, dict):
+            raise _StudioRequestError("invalid_component_config", "The stored component config is invalid.")
+        self._owned_request_from_config(component_type, component_id, stored_config)
+        latest = latest_config.get("version")
+        if not isinstance(latest, int):
+            raise _StudioRequestError(
+                "invalid_component_config",
+                f"Component '{component_id}' has invalid latest-version metadata.",
+            )
+        if component.get("deleted_at") is not None:
+            return StudioResult[ComponentActionView](
+                ok=True,
+                status="already_archived",
+                data=ComponentActionView(
+                    component_id=component_id,
+                    component_type=component_type,
+                    version=component.get("current_version"),
+                ),
+                warnings=self._schedule_cleanup_warnings(component_type, component_id),
+            )
+        metadata = self._actor_metadata(component.get("metadata"), run_context, action)
+        archive_projection = cast(
+            "ComponentProjection",
+            {
+                "name": component.get("name"),
+                "description": component.get("description"),
+                "metadata": metadata,
+            },
+        )
+        archived = self.db.delete_component(
+            component_id,
+            hard_delete=False,
+            guard=ComponentVersionGuard(
+                latest_version=latest,
+                current_version=expected_current_version,
+            ),
+            require_no_dependents=True,
+            projection=archive_projection,
+        )
+        if not archived:
+            raise _StudioRequestError("component_not_found", f"Component '{component_id}' was not found.")
+        return StudioResult[ComponentActionView](
+            ok=True,
+            status="archived",
+            data=ComponentActionView(
+                component_id=component_id,
+                component_type=component_type,
+                version=component.get("current_version"),
+            ),
+            warnings=self._schedule_cleanup_warnings(component_type, component_id),
         )
 
+    def archive_agent(
+        self,
+        component_id: str,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        """Archive an agent if no active component depends on it.
 
-# ----------------------------------------------------------------------
-# Module-level helpers
-# ----------------------------------------------------------------------
+        Args:
+            component_id: Exact Studio agent id.
+            expected_current_version: Current published version observed by
+                the caller, or null when the agent is draft-only.
+        """
+        denied = self._authorize("archive_agent", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ComponentActionView], denied)
+        try:
+            assert _agno_run_context is not None
+            return self._archive_component(
+                "agent", component_id, expected_current_version, _agno_run_context, "archive_agent"
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ComponentActionView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[ComponentActionView], known)
+            return cast(StudioResult[ComponentActionView], self._internal_failure("archive agent"))
 
+    def archive_team(
+        self,
+        component_id: str,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        """Archive a team if no active component depends on it.
 
-def _summarize_tools(tools: Any) -> List[str]:
-    if not tools or callable(tools):
+        Args:
+            component_id: Exact Studio team id.
+            expected_current_version: Current published version observed by
+                the caller, or null when the team is draft-only.
+        """
+        denied = self._authorize("archive_team", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ComponentActionView], denied)
+        try:
+            assert _agno_run_context is not None
+            return self._archive_component(
+                "team", component_id, expected_current_version, _agno_run_context, "archive_team"
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ComponentActionView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[ComponentActionView], known)
+            return cast(StudioResult[ComponentActionView], self._internal_failure("archive team"))
+
+    def archive_workflow(
+        self,
+        component_id: str,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        """Archive a workflow if no active component depends on it.
+
+        Args:
+            component_id: Exact Studio workflow id.
+            expected_current_version: Current published version observed by
+                the caller, or null when the workflow is draft-only.
+        """
+        denied = self._authorize("archive_workflow", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ComponentActionView], denied)
+        try:
+            assert _agno_run_context is not None
+            return self._archive_component(
+                "workflow", component_id, expected_current_version, _agno_run_context, "archive_workflow"
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ComponentActionView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[ComponentActionView], known)
+            return cast(StudioResult[ComponentActionView], self._internal_failure("archive workflow"))
+
+    def _restore_component(
+        self,
+        component_type: Literal["agent", "team", "workflow"],
+        component_id: str,
+        expected_current_version: int | None,
+        run_context: RunContext,
+        action: StudioAction,
+    ) -> StudioResult[ComponentActionView]:
+        from agno.db.base import ComponentType, ComponentVersionGuard
+
+        self._ensure_component_type_enabled(component_type)
+        self._ensure_no_source_collision(component_id, component_type)
+        component = self.db.get_component(
+            component_id,
+            component_type=ComponentType(component_type),
+            include_deleted=True,
+        )
+        if component is None:
+            other = self.db.get_component(component_id, include_deleted=True)
+            if other is not None:
+                raise _StudioRequestError(
+                    "component_type_mismatch",
+                    f"Component '{component_id}' is not a {component_type}.",
+                )
+            if self._code_component(component_type, component_id) is not None:
+                raise _StudioRequestError(
+                    "code_component_read_only",
+                    "Code-defined components cannot be restored by Studio.",
+                )
+            raise _StudioRequestError(
+                "component_not_found",
+                f"{component_type.capitalize()} '{component_id}' was not found.",
+            )
+        if component.get("deleted_at") is None:
+            raise _StudioRequestError(
+                "component_not_archived",
+                f"{component_type.capitalize()} '{component_id}' is not archived.",
+            )
+
+        latest = self.db.get_latest_config(component_id, include_deleted=True)
+        if not isinstance(latest, dict):
+            raise _StudioRequestError(
+                "invalid_component_config",
+                f"Archived {component_type} '{component_id}' has no stored configuration.",
+            )
+        latest_version = latest.get("version")
+        if not isinstance(latest_version, int):
+            raise _StudioRequestError(
+                "invalid_component_config",
+                f"Archived {component_type} '{component_id}' has no valid latest version.",
+            )
+        stored_config = latest.get("config")
+        if not isinstance(stored_config, dict):
+            raise _StudioRequestError("invalid_component_config", "The stored component config is invalid.")
+        self._owned_request_from_config(component_type, component_id, stored_config)
+
+        metadata = self._actor_metadata(component.get("metadata"), run_context, action)
+        restored = self.db.restore_component(
+            component_id,
+            guard=ComponentVersionGuard(
+                latest_version=latest_version,
+                current_version=expected_current_version,
+            ),
+            projection=cast(
+                "ComponentProjection",
+                {
+                    "name": component.get("name"),
+                    "description": component.get("description"),
+                    "metadata": metadata,
+                },
+            ),
+        )
+        if not restored:
+            raise _StudioRequestError(
+                "component_not_archived",
+                f"{component_type.capitalize()} '{component_id}' is not archived.",
+            )
+        # Restore changes only catalog visibility. It deliberately does not
+        # re-enable schedules that were disabled while the component was
+        # archived; schedule policy remains an explicit separate operation.
+        return StudioResult[ComponentActionView](
+            ok=True,
+            status="restored",
+            data=ComponentActionView(
+                component_id=component_id,
+                component_type=component_type,
+                version=component.get("current_version"),
+            ),
+        )
+
+    def restore_agent(
+        self,
+        component_id: str,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        """Restore an archived Studio agent after an exact current-version check.
+
+        Args:
+            component_id: Exact archived Studio agent id.
+            expected_current_version: Current published version observed by
+                the caller before archive, or null for a draft-only agent.
+        """
+        denied = self._authorize("restore_agent", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ComponentActionView], denied)
+        try:
+            assert _agno_run_context is not None
+            return self._restore_component(
+                "agent", component_id, expected_current_version, _agno_run_context, "restore_agent"
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ComponentActionView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[ComponentActionView], known)
+            return cast(StudioResult[ComponentActionView], self._internal_failure("restore agent"))
+
+    def restore_team(
+        self,
+        component_id: str,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        """Restore an archived Studio team after an exact current-version check.
+
+        Args:
+            component_id: Exact archived Studio team id.
+            expected_current_version: Current published version observed by
+                the caller before archive, or null for a draft-only team.
+        """
+        denied = self._authorize("restore_team", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ComponentActionView], denied)
+        try:
+            assert _agno_run_context is not None
+            return self._restore_component(
+                "team", component_id, expected_current_version, _agno_run_context, "restore_team"
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ComponentActionView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[ComponentActionView], known)
+            return cast(StudioResult[ComponentActionView], self._internal_failure("restore team"))
+
+    def restore_workflow(
+        self,
+        component_id: str,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        """Restore an archived Studio workflow after an exact current-version check.
+
+        Args:
+            component_id: Exact archived Studio workflow id.
+            expected_current_version: Current published version observed by
+                the caller before archive, or null for a draft-only workflow.
+        """
+        denied = self._authorize("restore_workflow", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ComponentActionView], denied)
+        try:
+            assert _agno_run_context is not None
+            return self._restore_component(
+                "workflow", component_id, expected_current_version, _agno_run_context, "restore_workflow"
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ComponentActionView], self._request_failure(error))
+        except Exception as error:
+            known = self._storage_failure(error)
+            if known is not None:
+                return cast(StudioResult[ComponentActionView], known)
+            return cast(StudioResult[ComponentActionView], self._internal_failure("restore workflow"))
+
+    # ------------------------------------------------------------------
+    # Authorization-wrapped data-plane dispatch
+    # ------------------------------------------------------------------
+
+    def run_agent(
+        self,
+        agent_id: str,
+        message: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> str:
+        """Run an agent through StudioRunnerTools as the authenticated actor.
+
+        Args:
+            agent_id: Exact agent id whose current published version should run.
+            message: Input message sent to the agent.
+        """
+        denied = self._authorize("run_agent", "mutate", _agno_run_context)
+        if denied is not None:
+            return str(denied)
+        try:
+            self._ensure_component_type_enabled("agent")
+            self._ensure_no_source_collision(agent_id, "agent")
+            return self._runner_tools.run_agent(agent_id, message, _agno_run_context)
+        except _StudioRequestError as error:
+            return str(self._request_failure(error))
+        except Exception:
+            return str(self._internal_failure("run agent"))
+
+    def run_team(
+        self,
+        team_id: str,
+        message: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> str:
+        """Run a team through StudioRunnerTools as the authenticated actor.
+
+        Args:
+            team_id: Exact team id whose current published version should run.
+            message: Input message sent to the team.
+        """
+        denied = self._authorize("run_team", "mutate", _agno_run_context)
+        if denied is not None:
+            return str(denied)
+        try:
+            self._ensure_component_type_enabled("team")
+            self._ensure_no_source_collision(team_id, "team")
+            return self._runner_tools.run_team(team_id, message, _agno_run_context)
+        except _StudioRequestError as error:
+            return str(self._request_failure(error))
+        except Exception:
+            return str(self._internal_failure("run team"))
+
+    def run_workflow(
+        self,
+        workflow_id: str,
+        message: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> str:
+        """Run a workflow through StudioRunnerTools as the authenticated actor.
+
+        Args:
+            workflow_id: Exact workflow id whose current published version should run.
+            message: Input message sent to the workflow.
+        """
+        denied = self._authorize("run_workflow", "mutate", _agno_run_context)
+        if denied is not None:
+            return str(denied)
+        try:
+            self._ensure_component_type_enabled("workflow")
+            self._ensure_no_source_collision(workflow_id, "workflow")
+            return self._runner_tools.run_workflow(workflow_id, message, _agno_run_context)
+        except _StudioRequestError as error:
+            return str(self._request_failure(error))
+        except Exception:
+            return str(self._internal_failure("run workflow"))
+
+    # ------------------------------------------------------------------
+    # Authorization-wrapped schedules
+    # ------------------------------------------------------------------
+
+    def _schedule_manager(self) -> "ScheduleManager":
+        if self._scheduler_tools is None:
+            raise _StudioRequestError("schedules_disabled", "StudioTools was created with schedules=False.")
+        return self._scheduler_tools.manager
+
+    def _catalog_schedule_manager(self) -> "ScheduleManager":
+        """Return a manager for lifecycle cleanup even when schedule tools are hidden."""
+        if self._scheduler_tools is not None:
+            return self._scheduler_tools.manager
+        from agno.scheduler.manager import ScheduleManager
+
+        return ScheduleManager(db=self.db)
+
+    @staticmethod
+    def _scan_schedules(
+        manager: "ScheduleManager",
+        *,
+        enabled: Optional[bool] = None,
+    ) -> List["Schedule"]:
+        """Read every schedule page without looping forever on a broken adapter."""
+        page_size = 100
+        page = 1
+        seen_ids: set[str] = set()
+        schedules: List["Schedule"] = []
+        while True:
+            batch = manager.list(enabled=enabled, limit=page_size, page=page)
+            fresh = [schedule for schedule in batch if schedule.id not in seen_ids]
+            if not fresh:
+                break
+            schedules.extend(fresh)
+            seen_ids.update(schedule.id for schedule in fresh)
+            if len(batch) < page_size:
+                break
+            page += 1
+        return schedules
+
+    @staticmethod
+    def _studio_schedule_metadata(schedule: "Schedule") -> Optional[Dict[str, Any]]:
+        """Return server-owned Studio provenance only when the record is coherent."""
+        if schedule.managed_by != STUDIO_SCHEDULE_MANAGED_BY:
+            return None
+        owner_actor_id = schedule.owner_actor_id
+        target_type = schedule.target_type
+        target_id = schedule.target_id
+        if not is_valid_studio_schedule_actor_id(owner_actor_id):
+            return None
+        assert isinstance(owner_actor_id, str)
+        if target_type not in _SCHEDULE_TARGET_TYPES:
+            return None
+        try:
+            target_id = StudioTools._validate_component_id(target_id)
+        except _StudioRequestError:
+            return None
+        if schedule.method.upper() != "POST" or schedule.endpoint != f"/{target_type}s/{target_id}/runs":
+            return None
+        return {
+            "owner_actor_id": owner_actor_id,
+            "target_type": target_type,
+            "target_id": target_id,
+            "created_by_run_id": schedule.created_by_run_id,
+            "created_by_session_id": schedule.created_by_session_id,
+            "updated_by_run_id": schedule.updated_by_run_id,
+            "updated_by_session_id": schedule.updated_by_session_id,
+        }
+
+    @staticmethod
+    def _schedule_payload(request: ScheduleCreate) -> Dict[str, Any]:
+        """Build the private dispatch payload without ownership metadata."""
+        return {"message": request.message}
+
+    def _create_studio_schedule_record(
+        self,
+        request: ScheduleCreate,
+        target_id: str,
+        run_context: RunContext,
+    ) -> "Schedule":
+        """Atomically insert a schedule carrying server-owned Studio provenance."""
+        import time
+        from uuid import uuid4
+
+        from agno.scheduler.cron import compute_next_run
+
+        assert run_context.user_id is not None
+        schedule = Schedule(
+            id=str(uuid4()),
+            name=request.name,
+            cron_expr=request.cron,
+            endpoint=f"/{request.target_type}s/{target_id}/runs",
+            method="POST",
+            description=request.description,
+            payload=self._schedule_payload(request),
+            timezone=request.timezone,
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            owner_actor_id=run_context.user_id,
+            target_type=request.target_type,
+            target_id=target_id,
+            created_by_run_id=run_context.run_id,
+            created_by_session_id=run_context.session_id,
+            updated_by_run_id=run_context.run_id,
+            updated_by_session_id=run_context.session_id,
+            enabled=True,
+            next_run_at=compute_next_run(request.cron, request.timezone),
+            created_at=int(time.time()),
+        )
+        stored = self.db.create_schedule(schedule.to_dict())
+        return Schedule.from_dict(stored)
+
+    @staticmethod
+    def _schedule_view(schedule: "Schedule", metadata: Dict[str, Any]) -> ScheduleView:
+        return ScheduleView(
+            schedule_id=schedule.id,
+            name=schedule.name,
+            description=schedule.description,
+            cron=schedule.cron_expr,
+            target_type=cast(Literal["agent", "team", "workflow"], metadata["target_type"]),
+            target_id=metadata["target_id"],
+            timezone=schedule.timezone,
+            enabled=schedule.enabled,
+            next_run_at=schedule.next_run_at,
+            owner_actor_id=metadata["owner_actor_id"],
+            created_at=schedule.created_at,
+            updated_at=schedule.updated_at,
+        )
+
+    @staticmethod
+    def _schedule_action_view(schedule: "Schedule", metadata: Dict[str, Any]) -> ScheduleActionView:
+        return ScheduleActionView(
+            schedule_id=schedule.id,
+            name=schedule.name,
+            target_type=cast(Literal["agent", "team", "workflow"], metadata["target_type"]),
+            target_id=metadata["target_id"],
+            enabled=schedule.enabled,
+        )
+
+    @staticmethod
+    def _schedule_run_view(run: "ScheduleRun") -> ScheduleRunView:
+        return ScheduleRunView(
+            schedule_run_id=run.id,
+            schedule_id=run.schedule_id,
+            attempt=run.attempt,
+            status=run.status,
+            triggered_at=run.triggered_at,
+            completed_at=run.completed_at,
+            status_code=run.status_code,
+            component_run_id=run.run_id,
+            session_id=run.session_id,
+            has_error=run.error is not None,
+            has_requirements=bool(run.requirements),
+            created_at=run.created_at,
+        )
+
+    def _owned_schedule(self, schedule_id: str, run_context: RunContext) -> tuple["Schedule", Dict[str, Any]]:
+        schedule = self._schedule_manager().get(schedule_id)
+        if schedule is None:
+            raise _StudioRequestError("schedule_not_found", f"Schedule '{schedule_id}' was not found.")
+        metadata = self._studio_schedule_metadata(schedule)
+        if metadata is None or metadata["owner_actor_id"] != run_context.user_id:
+            # Do not disclose whether the id belongs to another actor or to a
+            # non-Studio scheduler record in the shared table.
+            raise _StudioRequestError("schedule_not_found", f"Schedule '{schedule_id}' was not found.")
+        return schedule, metadata
+
+    @staticmethod
+    def _validate_schedule_cadence(request: ScheduleCreate) -> None:
+        from agno.scheduler.cron import validate_cron_expr, validate_timezone
+
+        if not validate_cron_expr(request.cron):
+            raise _StudioRequestError("invalid_cron", "Schedule cron must be a valid five-field expression.")
+        if not validate_timezone(request.timezone):
+            raise _StudioRequestError("invalid_timezone", "Schedule timezone must be a valid IANA timezone.")
+
+    def _disable_studio_schedules_for_target(self, component_type: str, component_id: str) -> int:
+        """Atomically disable every Studio-owned schedule for an archived target."""
+        if getattr(self.db, "scheduler_api_version", 1) < 2:
+            raise RuntimeError("Studio schedule cleanup requires scheduler API version 2")
+        return self.db.disable_schedules_for_target(
+            component_type,
+            component_id,
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        )
+
+    def _schedule_cleanup_warnings(self, component_type: str, component_id: str) -> List[str]:
+        """Disable archived-target schedules and project any backend failure safely."""
+        try:
+            self._disable_studio_schedules_for_target(component_type, component_id)
+        except Exception:
+            # Archival is already committed (or was committed by an earlier
+            # attempt). Report it truthfully rather than returning a failure
+            # for a mutation that happened. A retry gets another cleanup pass.
+            logger.error(
+                "Studio archived %s '%s' but could not disable all of its schedules",
+                component_type,
+                component_id,
+            )
+            return [
+                "The component was archived, but one or more schedules could not be disabled; inspect the scheduler."
+            ]
         return []
-    names: List[str] = []
-    for t in tools:
-        if isinstance(t, Toolkit):
-            names.append(t.name)
-        elif isinstance(t, Function):
-            names.append(t.name)
-        elif callable(t):
-            names.append(getattr(t, "__name__", repr(t)))
-    return names
 
+    def _resolve_schedule_target(self, target_type: str, target_id: str) -> str:
+        if target_type not in _SCHEDULE_TARGET_TYPES:
+            raise _StudioRequestError(
+                "invalid_target_type",
+                f"target_type must be one of {list(_SCHEDULE_TARGET_TYPES)}.",
+            )
+        self._ensure_component_type_enabled(target_type)
+        self._ensure_no_source_collision(target_id, target_type)
+        code = self._code_component(target_type, target_id)
+        if code is not None:
+            return target_id
+        row = self._db_component(target_type, target_id)
+        if row is None or row.get("current_version") is None:
+            raise _StudioRequestError(
+                "published_target_not_found",
+                f"Published {target_type} '{target_id}' was not found.",
+            )
+        return target_id
 
-def _persist_only(
-    component: Component,
-    db: Optional["BaseDb"],
-    stage: str = "published",
-    config: Optional[Dict[str, Any]] = None,
-    links: Optional[List[Dict[str, Any]]] = None,
-) -> Optional[int]:
-    """Save a component WITHOUT cascading to members or step agents.
+    def _revalidate_schedule_target_after_write(
+        self,
+        schedule: "Schedule",
+        target_type: str,
+        target_id: str,
+        *,
+        delete_on_failure: bool = False,
+    ) -> "Schedule":
+        """Close the monotonic archive race around schedule writes.
 
-    Agno's built-in ``component.save()`` recursively persists every member of
-    a team and every agent/team referenced by a workflow step. That pulls
-    code-defined agents (ones you passed via ``agents_list`` or the registry)
-    into the DB as components, which is not what studio should do.
+        Archive commits and then disables every schedule it can see. A create or
+        enable that lands after that scan must perform the other half of the
+        protocol: re-read the target and synchronously disable its own record
+        before returning an error. If the write lands first, archive's scan sees
+        it; if archive lands first, this check sees the archived target.
+        """
+        try:
+            self._resolve_schedule_target(target_type, target_id)
+        except _StudioRequestError as target_error:
+            manager = self._catalog_schedule_manager()
+            if delete_on_failure:
+                cleaned_up = manager.delete(schedule.id) is True
+            else:
+                disabled = manager.disable(schedule.id)
+                cleaned_up = disabled is not None and not disabled.enabled
+            if not cleaned_up:
+                raise RuntimeError(
+                    f"Schedule '{schedule.id}' targeted an archived component and could not be cleaned up"
+                ) from target_error
+            raise
+        return schedule
 
-    This helper saves only the top-level component row and its config. Member
-    / step references travel in the config dict by id; rehydration resolves
-    them via ``get_agent_by_id`` / ``get_team_by_id``, which check the DB.
-    Code-defined members won't be found on a cold reload -- that's the
-    trade-off for keeping them out of DB.
-    """
-    if db is None:
-        raise ValueError("db is required for persistence")
-    component_id = getattr(component, "id", None)
-    if component_id is None:
-        raise ValueError("Component has no id")
-    db.upsert_component(
-        component_id=component_id,
-        component_type=_component_type(component),
-        name=getattr(component, "name", component_id),
-        description=getattr(component, "description", None),
-        metadata=getattr(component, "metadata", None),
-    )
-    result = db.upsert_config(
-        component_id=component_id,
-        config=config if config is not None else _component_to_dict(component),
-        stage=stage,
-        links=links,
-    )
-    return result.get("version")
+    def create_schedule(
+        self,
+        request: ScheduleCreate,
+        if_exists: Literal["error", "update"] = "error",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ScheduleView]:
+        """Create an actor-owned schedule from one typed request.
+
+        Args:
+            request: Typed cadence, target, and prompt for the component schedule.
+            if_exists: Refuse a name conflict by default, or update a schedule
+                with the same name owned by the authenticated actor.
+        """
+        denied = self._authorize("create_schedule", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ScheduleView], denied)
+        try:
+            assert _agno_run_context is not None
+            if not is_valid_studio_schedule_actor_id(_agno_run_context.user_id):
+                raise _StudioRequestError(
+                    "invalid_schedule_actor",
+                    "The authenticated actor identifier cannot be delegated to a scheduled run.",
+                )
+            if if_exists not in ("error", "update"):
+                raise _StudioRequestError(
+                    "invalid_if_exists",
+                    "if_exists must be either 'error' or 'update'.",
+                    details={"allowed": ["error", "update"]},
+                )
+            self._validate_schedule_cadence(request)
+            component_id = self._resolve_schedule_target(request.target_type, request.target_id)
+            manager = self._schedule_manager()
+            existing = manager.get_by_name(
+                request.name,
+                managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+                owner_actor_id=_agno_run_context.user_id,
+            )
+            schedule: Optional[Schedule] = None
+            status: Optional[Literal["created", "updated"]] = None
+
+            if existing is None:
+                try:
+                    schedule = self._create_studio_schedule_record(request, component_id, _agno_run_context)
+                except ScheduleNameConflictError:
+                    # The database uniqueness constraint is the concurrency
+                    # authority. Only a same-actor Studio winner is observable
+                    # here; names in other actors' or generic namespaces stay
+                    # independent and undisclosed.
+                    if if_exists == "error":
+                        raise _StudioRequestError(
+                            "schedule_conflict",
+                            "A Studio schedule with that name already exists in this actor's scope.",
+                        ) from None
+                    existing = manager.get_by_name(
+                        request.name,
+                        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+                        owner_actor_id=_agno_run_context.user_id,
+                    )
+                    if existing is None:
+                        raise _StudioRequestError(
+                            "schedule_conflict",
+                            "The Studio schedule changed concurrently; read this actor's schedules and retry.",
+                            retryable=True,
+                        ) from None
+                else:
+                    status = "created"
+
+            if existing is not None:
+                existing_metadata = self._studio_schedule_metadata(existing)
+                if existing_metadata is None:
+                    raise _StudioRequestError(
+                        "schedule_name_conflict",
+                        "A malformed Studio schedule already occupies that name in this actor's scope.",
+                    )
+                if if_exists == "error":
+                    raise _StudioRequestError("schedule_conflict", "A Studio schedule with that name already exists.")
+                from agno.scheduler.cron import compute_next_run
+
+                updated = manager._update_studio(
+                    existing.id,
+                    cron_expr=request.cron,
+                    endpoint=f"/{request.target_type}s/{component_id}/runs",
+                    method="POST",
+                    description=request.description,
+                    payload=self._schedule_payload(request),
+                    timezone=request.timezone,
+                    next_run_at=compute_next_run(request.cron, request.timezone),
+                    target_type=request.target_type,
+                    target_id=component_id,
+                    updated_by_run_id=_agno_run_context.run_id,
+                    updated_by_session_id=_agno_run_context.session_id,
+                )
+                if updated is None:
+                    raise _StudioRequestError("schedule_not_found", "The schedule no longer exists.", retryable=True)
+                schedule = updated
+                status = "updated"
+
+            if schedule is None or status is None:
+                raise RuntimeError("Studio schedule write did not produce a record")
+            schedule = self._revalidate_schedule_target_after_write(
+                schedule,
+                request.target_type,
+                component_id,
+                delete_on_failure=status == "created",
+            )
+
+            metadata = self._studio_schedule_metadata(schedule)
+            if metadata is None:
+                raise RuntimeError("Studio schedule provenance was not persisted faithfully")
+            return StudioResult[ScheduleView](ok=True, status=status, data=self._schedule_view(schedule, metadata))
+        except _StudioRequestError as error:
+            return cast(StudioResult[ScheduleView], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[ScheduleView], self._internal_failure("create schedule"))
+
+    def list_schedules(
+        self,
+        enabled_only: bool = False,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[List[ScheduleView]]:
+        """List schedules owned by the authenticated actor.
+
+        Args:
+            enabled_only: Return only schedules currently enabled for execution.
+        """
+        denied = self._authorize("list_schedules", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[List[ScheduleView]], denied)
+        try:
+            assert _agno_run_context is not None
+            if not isinstance(enabled_only, bool):
+                raise _StudioRequestError("invalid_enabled_filter", "enabled_only must be a boolean.")
+            views: List[ScheduleView] = []
+            for schedule in self._scan_schedules(self._schedule_manager(), enabled=True if enabled_only else None):
+                metadata = self._studio_schedule_metadata(schedule)
+                if metadata is not None and metadata["owner_actor_id"] == _agno_run_context.user_id:
+                    views.append(self._schedule_view(schedule, metadata))
+                    if len(views) >= self.list_limit:
+                        break
+            return StudioResult[List[ScheduleView]](ok=True, status="listed", data=views)
+        except _StudioRequestError as error:
+            return cast(StudioResult[List[ScheduleView]], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[List[ScheduleView]], self._internal_failure("list schedules"))
+
+    def get_schedule(
+        self,
+        schedule_id: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ScheduleView]:
+        """Get one schedule owned by the authenticated actor.
+
+        Args:
+            schedule_id: Exact schedule id returned by list_schedules.
+        """
+        denied = self._authorize("get_schedule", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ScheduleView], denied)
+        try:
+            assert _agno_run_context is not None
+            schedule, metadata = self._owned_schedule(schedule_id, _agno_run_context)
+            return StudioResult[ScheduleView](ok=True, status="found", data=self._schedule_view(schedule, metadata))
+        except _StudioRequestError as error:
+            return cast(StudioResult[ScheduleView], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[ScheduleView], self._internal_failure("get schedule"))
+
+    def get_schedule_runs(
+        self,
+        schedule_id: str,
+        limit: int = 10,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[List[ScheduleRunView]]:
+        """List safe run summaries for an actor-owned schedule.
+
+        Args:
+            schedule_id: Exact schedule id returned by list_schedules.
+            limit: Maximum run summaries to return, from 1 through 100.
+        """
+        denied = self._authorize("get_schedule_runs", "read", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[List[ScheduleRunView]], denied)
+        try:
+            assert _agno_run_context is not None
+            if not isinstance(limit, int) or isinstance(limit, bool) or not 1 <= limit <= 100:
+                raise _StudioRequestError("invalid_schedule_run_limit", "limit must be an integer from 1 through 100.")
+            self._owned_schedule(schedule_id, _agno_run_context)
+            runs = self._schedule_manager().get_runs(schedule_id, limit=limit)
+            return StudioResult[List[ScheduleRunView]](
+                ok=True,
+                status="listed",
+                data=[self._schedule_run_view(run) for run in runs],
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[List[ScheduleRunView]], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[List[ScheduleRunView]], self._internal_failure("list schedule runs"))
+
+    def trigger_schedule(
+        self,
+        schedule_id: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ScheduleActionView]:
+        """Durably queue one run of an enabled actor-owned schedule.
+
+        Args:
+            schedule_id: Exact schedule id returned by list_schedules.
+        """
+        denied = self._authorize("trigger_schedule", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ScheduleActionView], denied)
+        try:
+            assert _agno_run_context is not None
+            schedule, metadata = self._owned_schedule(schedule_id, _agno_run_context)
+            if not schedule.enabled:
+                raise _StudioRequestError(
+                    "schedule_disabled",
+                    "The schedule is disabled; enable it before triggering.",
+                )
+            self._resolve_schedule_target(metadata["target_type"], metadata["target_id"])
+            updated = self._schedule_manager().trigger(schedule_id)
+            if updated is None:
+                raise _StudioRequestError("schedule_not_found", "The schedule no longer exists.", retryable=True)
+            return StudioResult[ScheduleActionView](
+                ok=True,
+                status="triggered",
+                data=self._schedule_action_view(updated, metadata),
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ScheduleActionView], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[ScheduleActionView], self._internal_failure("trigger schedule"))
+
+    def enable_schedule(
+        self,
+        schedule_id: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ScheduleActionView]:
+        """Enable an actor-owned schedule whose target remains publishable.
+
+        Args:
+            schedule_id: Exact schedule id returned by list_schedules.
+        """
+        denied = self._authorize("enable_schedule", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ScheduleActionView], denied)
+        try:
+            assert _agno_run_context is not None
+            schedule, metadata = self._owned_schedule(schedule_id, _agno_run_context)
+            self._resolve_schedule_target(metadata["target_type"], metadata["target_id"])
+            if schedule.enabled:
+                schedule = self._revalidate_schedule_target_after_write(
+                    schedule,
+                    metadata["target_type"],
+                    metadata["target_id"],
+                )
+                return StudioResult[ScheduleActionView](
+                    ok=True,
+                    status="already_enabled",
+                    data=self._schedule_action_view(schedule, metadata),
+                )
+            updated = self._schedule_manager().enable(schedule_id)
+            if updated is None:
+                raise _StudioRequestError("schedule_not_found", "The schedule no longer exists.", retryable=True)
+            updated = self._revalidate_schedule_target_after_write(
+                updated,
+                metadata["target_type"],
+                metadata["target_id"],
+            )
+            return StudioResult[ScheduleActionView](
+                ok=True,
+                status="enabled",
+                data=self._schedule_action_view(updated, metadata),
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ScheduleActionView], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[ScheduleActionView], self._internal_failure("enable schedule"))
+
+    def disable_schedule(
+        self,
+        schedule_id: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ScheduleActionView]:
+        """Disable an actor-owned schedule without dispatching it.
+
+        Args:
+            schedule_id: Exact schedule id returned by list_schedules.
+        """
+        denied = self._authorize("disable_schedule", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ScheduleActionView], denied)
+        try:
+            assert _agno_run_context is not None
+            schedule, metadata = self._owned_schedule(schedule_id, _agno_run_context)
+            if not schedule.enabled:
+                return StudioResult[ScheduleActionView](
+                    ok=True,
+                    status="already_disabled",
+                    data=self._schedule_action_view(schedule, metadata),
+                )
+            updated = self._schedule_manager().disable(schedule_id)
+            if updated is None:
+                raise _StudioRequestError("schedule_not_found", "The schedule no longer exists.", retryable=True)
+            return StudioResult[ScheduleActionView](
+                ok=True,
+                status="disabled",
+                data=self._schedule_action_view(updated, metadata),
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ScheduleActionView], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[ScheduleActionView], self._internal_failure("disable schedule"))
+
+    def delete_schedule(
+        self,
+        schedule_id: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ScheduleActionView]:
+        """Delete an actor-owned schedule and its scheduler run history.
+
+        Args:
+            schedule_id: Exact schedule id returned by list_schedules.
+        """
+        denied = self._authorize("delete_schedule", "mutate", _agno_run_context)
+        if denied is not None:
+            return cast(StudioResult[ScheduleActionView], denied)
+        try:
+            assert _agno_run_context is not None
+            schedule, metadata = self._owned_schedule(schedule_id, _agno_run_context)
+            if not self._schedule_manager().delete(schedule_id):
+                raise _StudioRequestError("schedule_not_found", "The schedule no longer exists.", retryable=True)
+            return StudioResult[ScheduleActionView](
+                ok=True,
+                status="deleted",
+                data=self._schedule_action_view(schedule, metadata),
+            )
+        except _StudioRequestError as error:
+            return cast(StudioResult[ScheduleActionView], self._request_failure(error))
+        except Exception:
+            return cast(StudioResult[ScheduleActionView], self._internal_failure("delete schedule"))
+
+    # ------------------------------------------------------------------
+    # Async parity. Sync DB control-plane work runs in a worker thread;
+    # runner dispatch uses its native async methods.
+    # ------------------------------------------------------------------
+
+    async def alist_models(self, _agno_run_context: Optional[RunContext] = None) -> StudioResult[List[ModelRef]]:
+        return await asyncio.to_thread(self.list_models, _agno_run_context)
+
+    async def alist_tools(self, _agno_run_context: Optional[RunContext] = None) -> StudioResult[List[ToolRef]]:
+        return await asyncio.to_thread(self.list_tools, _agno_run_context)
+
+    async def alist_functions(self, _agno_run_context: Optional[RunContext] = None) -> StudioResult[List[FunctionRef]]:
+        return await asyncio.to_thread(self.list_functions, _agno_run_context)
+
+    async def alist_agents(
+        self, _agno_run_context: Optional[RunContext] = None
+    ) -> StudioResult[List[ComponentSummary]]:
+        return await asyncio.to_thread(self.list_agents, _agno_run_context)
+
+    async def alist_teams(self, _agno_run_context: Optional[RunContext] = None) -> StudioResult[List[ComponentSummary]]:
+        return await asyncio.to_thread(self.list_teams, _agno_run_context)
+
+    async def alist_workflows(
+        self, _agno_run_context: Optional[RunContext] = None
+    ) -> StudioResult[List[ComponentSummary]]:
+        return await asyncio.to_thread(self.list_workflows, _agno_run_context)
+
+    async def aget_agent(
+        self,
+        component_id: str,
+        version: Optional[int] = None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[AgentView]:
+        return await asyncio.to_thread(self.get_agent, component_id, version, _agno_run_context)
+
+    async def aget_team(
+        self,
+        component_id: str,
+        version: Optional[int] = None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[TeamView]:
+        return await asyncio.to_thread(self.get_team, component_id, version, _agno_run_context)
+
+    async def aget_workflow(
+        self,
+        component_id: str,
+        version: Optional[int] = None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[WorkflowView]:
+        return await asyncio.to_thread(self.get_workflow, component_id, version, _agno_run_context)
+
+    async def alist_versions(
+        self,
+        component_id: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[List[VersionSummary]]:
+        return await asyncio.to_thread(self.list_versions, component_id, _agno_run_context)
+
+    async def aget_version(
+        self,
+        component_id: str,
+        version: int,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentView]:
+        return await asyncio.to_thread(self.get_version, component_id, version, _agno_run_context)
+
+    async def acreate_agent(
+        self,
+        request: AgentCreate,
+        save_as: SaveStage = "draft",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[AgentView]:
+        return await asyncio.to_thread(self.create_agent, request, save_as, _agno_run_context)
+
+    async def acreate_team(
+        self,
+        request: TeamCreate,
+        save_as: SaveStage = "draft",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[TeamView]:
+        return await asyncio.to_thread(self.create_team, request, save_as, _agno_run_context)
+
+    async def acreate_workflow(
+        self,
+        request: WorkflowCreate,
+        save_as: SaveStage = "draft",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[WorkflowView]:
+        return await asyncio.to_thread(self.create_workflow, request, save_as, _agno_run_context)
+
+    async def aedit_agent(
+        self,
+        component_id: str,
+        patch: AgentPatch,
+        expected_version: int,
+        save_as: SaveStage = "draft",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[AgentView]:
+        return await asyncio.to_thread(
+            self.edit_agent,
+            component_id,
+            patch,
+            expected_version,
+            save_as,
+            _agno_run_context,
+        )
+
+    async def aedit_team(
+        self,
+        component_id: str,
+        patch: TeamPatch,
+        expected_version: int,
+        save_as: SaveStage = "draft",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[TeamView]:
+        return await asyncio.to_thread(
+            self.edit_team,
+            component_id,
+            patch,
+            expected_version,
+            save_as,
+            _agno_run_context,
+        )
+
+    async def aedit_workflow(
+        self,
+        component_id: str,
+        patch: WorkflowPatch,
+        expected_version: int,
+        save_as: SaveStage = "draft",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[WorkflowView]:
+        return await asyncio.to_thread(
+            self.edit_workflow,
+            component_id,
+            patch,
+            expected_version,
+            save_as,
+            _agno_run_context,
+        )
+
+    async def apublish_component(
+        self,
+        component_id: str,
+        version: int,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentView]:
+        return await asyncio.to_thread(
+            self.publish_component,
+            component_id,
+            version,
+            expected_current_version,
+            _agno_run_context,
+        )
+
+    async def aset_current_version(
+        self,
+        component_id: str,
+        version: int,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentView]:
+        return await asyncio.to_thread(
+            self.set_current_version,
+            component_id,
+            version,
+            expected_current_version,
+            _agno_run_context,
+        )
+
+    async def adelete_version(
+        self,
+        component_id: str,
+        version: int,
+        expected_latest_version: int,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        return await asyncio.to_thread(
+            self.delete_version,
+            component_id,
+            version,
+            expected_latest_version,
+            _agno_run_context,
+        )
+
+    async def aarchive_agent(
+        self,
+        component_id: str,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        return await asyncio.to_thread(
+            self.archive_agent,
+            component_id,
+            expected_current_version,
+            _agno_run_context,
+        )
+
+    async def aarchive_team(
+        self,
+        component_id: str,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        return await asyncio.to_thread(
+            self.archive_team,
+            component_id,
+            expected_current_version,
+            _agno_run_context,
+        )
+
+    async def aarchive_workflow(
+        self,
+        component_id: str,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        return await asyncio.to_thread(
+            self.archive_workflow,
+            component_id,
+            expected_current_version,
+            _agno_run_context,
+        )
+
+    async def arestore_agent(
+        self,
+        component_id: str,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        return await asyncio.to_thread(
+            self.restore_agent,
+            component_id,
+            expected_current_version,
+            _agno_run_context,
+        )
+
+    async def arestore_team(
+        self,
+        component_id: str,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        return await asyncio.to_thread(
+            self.restore_team,
+            component_id,
+            expected_current_version,
+            _agno_run_context,
+        )
+
+    async def arestore_workflow(
+        self,
+        component_id: str,
+        expected_current_version: int | None,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ComponentActionView]:
+        return await asyncio.to_thread(
+            self.restore_workflow,
+            component_id,
+            expected_current_version,
+            _agno_run_context,
+        )
+
+    async def arun_agent(
+        self,
+        agent_id: str,
+        message: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> str:
+        denied = await asyncio.to_thread(self._authorize, "run_agent", "mutate", _agno_run_context)
+        if denied is not None:
+            return str(denied)
+        try:
+            self._ensure_component_type_enabled("agent")
+            await asyncio.to_thread(self._ensure_no_source_collision, agent_id, "agent")
+            return await self._runner_tools.arun_agent(agent_id, message, _agno_run_context)
+        except _StudioRequestError as error:
+            return str(self._request_failure(error))
+        except Exception:
+            return str(self._internal_failure("run agent"))
+
+    async def arun_team(
+        self,
+        team_id: str,
+        message: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> str:
+        denied = await asyncio.to_thread(self._authorize, "run_team", "mutate", _agno_run_context)
+        if denied is not None:
+            return str(denied)
+        try:
+            self._ensure_component_type_enabled("team")
+            await asyncio.to_thread(self._ensure_no_source_collision, team_id, "team")
+            return await self._runner_tools.arun_team(team_id, message, _agno_run_context)
+        except _StudioRequestError as error:
+            return str(self._request_failure(error))
+        except Exception:
+            return str(self._internal_failure("run team"))
+
+    async def arun_workflow(
+        self,
+        workflow_id: str,
+        message: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> str:
+        denied = await asyncio.to_thread(self._authorize, "run_workflow", "mutate", _agno_run_context)
+        if denied is not None:
+            return str(denied)
+        try:
+            self._ensure_component_type_enabled("workflow")
+            await asyncio.to_thread(self._ensure_no_source_collision, workflow_id, "workflow")
+            return await self._runner_tools.arun_workflow(workflow_id, message, _agno_run_context)
+        except _StudioRequestError as error:
+            return str(self._request_failure(error))
+        except Exception:
+            return str(self._internal_failure("run workflow"))
+
+    async def acreate_schedule(
+        self,
+        request: ScheduleCreate,
+        if_exists: Literal["error", "update"] = "error",
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ScheduleView]:
+        return await asyncio.to_thread(
+            self.create_schedule,
+            request,
+            if_exists,
+            _agno_run_context,
+        )
+
+    async def alist_schedules(
+        self,
+        enabled_only: bool = False,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[List[ScheduleView]]:
+        return await asyncio.to_thread(self.list_schedules, enabled_only, _agno_run_context)
+
+    async def aget_schedule(
+        self,
+        schedule_id: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ScheduleView]:
+        return await asyncio.to_thread(self.get_schedule, schedule_id, _agno_run_context)
+
+    async def aget_schedule_runs(
+        self,
+        schedule_id: str,
+        limit: int = 10,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[List[ScheduleRunView]]:
+        return await asyncio.to_thread(self.get_schedule_runs, schedule_id, limit, _agno_run_context)
+
+    async def atrigger_schedule(
+        self,
+        schedule_id: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ScheduleActionView]:
+        return await asyncio.to_thread(self.trigger_schedule, schedule_id, _agno_run_context)
+
+    async def aenable_schedule(
+        self,
+        schedule_id: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ScheduleActionView]:
+        return await asyncio.to_thread(self.enable_schedule, schedule_id, _agno_run_context)
+
+    async def adisable_schedule(
+        self,
+        schedule_id: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ScheduleActionView]:
+        return await asyncio.to_thread(self.disable_schedule, schedule_id, _agno_run_context)
+
+    async def adelete_schedule(
+        self,
+        schedule_id: str,
+        _agno_run_context: Optional[RunContext] = None,
+    ) -> StudioResult[ScheduleActionView]:
+        return await asyncio.to_thread(self.delete_schedule, schedule_id, _agno_run_context)
 
 
 def _resolve_flags(
@@ -2874,78 +4560,65 @@ def _resolve_flags(
     workflows: Optional[bool],
     has_agents_list: bool,
     has_teams_list: bool,
+    has_workflows_list: bool,
 ) -> tuple[bool, bool, bool]:
-    """Resolve the enable flags for the three capability groups.
-
-    * Agents are enabled by default unless ``agents=False`` is explicit.
-    * Teams and workflows are disabled by default unless explicitly enabled
-      or auto-enabled by live component lists.
-    * Passing ``agents=False`` without enabling another component type leaves
-      only discovery tools registered.
-    * Passing ``agents_list`` auto-enables teams and workflows (you can build
-      them from those agents). Passing ``teams_list`` auto-enables workflows.
-      Explicit flags take precedence over these auto-enables.
-    """
-    a = bool(agents) if agents is not None else True
-    t = bool(teams) if teams is not None else False
-    w = bool(workflows) if workflows is not None else False
-
-    if has_agents_list and teams is None:
-        t = True
-    if has_agents_list and workflows is None:
-        w = True
-    if has_teams_list and workflows is None:
-        w = True
-
-    return a, t, w
+    agent_enabled = bool(agents) if agents is not None else True
+    team_enabled = bool(teams) if teams is not None else has_agents_list or has_teams_list
+    workflow_enabled = (
+        bool(workflows) if workflows is not None else has_agents_list or has_teams_list or has_workflows_list
+    )
+    return agent_enabled, team_enabled, workflow_enabled
 
 
-def _component_type(component: Component) -> Any:
-    from agno.agent.agent import Agent
-    from agno.db.base import ComponentType
-    from agno.team.team import Team
-    from agno.workflow.workflow import Workflow
+# Async aliases must expose the canonical sync documentation. Toolkit schema
+# processing reads each callable independently, so this keeps descriptions as
+# well as signatures in lockstep instead of letting thin wrappers overwrite the
+# model-facing contract.
+for _sync_name, _async_name in (
+    ("list_models", "alist_models"),
+    ("list_tools", "alist_tools"),
+    ("list_functions", "alist_functions"),
+    ("list_agents", "alist_agents"),
+    ("list_teams", "alist_teams"),
+    ("list_workflows", "alist_workflows"),
+    ("get_agent", "aget_agent"),
+    ("get_team", "aget_team"),
+    ("get_workflow", "aget_workflow"),
+    ("list_versions", "alist_versions"),
+    ("get_version", "aget_version"),
+    ("create_agent", "acreate_agent"),
+    ("create_team", "acreate_team"),
+    ("create_workflow", "acreate_workflow"),
+    ("edit_agent", "aedit_agent"),
+    ("edit_team", "aedit_team"),
+    ("edit_workflow", "aedit_workflow"),
+    ("publish_component", "apublish_component"),
+    ("set_current_version", "aset_current_version"),
+    ("delete_version", "adelete_version"),
+    ("archive_agent", "aarchive_agent"),
+    ("archive_team", "aarchive_team"),
+    ("archive_workflow", "aarchive_workflow"),
+    ("restore_agent", "arestore_agent"),
+    ("restore_team", "arestore_team"),
+    ("restore_workflow", "arestore_workflow"),
+    ("run_agent", "arun_agent"),
+    ("run_team", "arun_team"),
+    ("run_workflow", "arun_workflow"),
+    ("create_schedule", "acreate_schedule"),
+    ("list_schedules", "alist_schedules"),
+    ("get_schedule", "aget_schedule"),
+    ("get_schedule_runs", "aget_schedule_runs"),
+    ("trigger_schedule", "atrigger_schedule"),
+    ("enable_schedule", "aenable_schedule"),
+    ("disable_schedule", "adisable_schedule"),
+    ("delete_schedule", "adelete_schedule"),
+):
+    getattr(StudioTools, _async_name).__doc__ = getattr(StudioTools, _sync_name).__doc__
 
-    if isinstance(component, Agent):
-        return ComponentType.AGENT
-    if isinstance(component, Team):
-        return ComponentType.TEAM
-    if isinstance(component, Workflow):
-        return ComponentType.WORKFLOW
-    raise TypeError(f"Unsupported component type: {type(component).__name__}")
 
-
-# Serialized by to_dict and never read back by from_dict (#9452), so a rebuild
-# drops them. An edit that resaves a rebuild would therefore delete a
-# declaration it never touched -- and quietly lift the dispatch refusal that
-# declaration causes -- so edits carry them forward verbatim.
-_UNRECONSTRUCTED_KEYS = ("reasoning_model", "parser_model", "output_model")
-
-
-def _component_to_dict(component: Component, carry: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    from agno.agent.agent import Agent
-    from agno.team.team import Team
-    from agno.workflow.workflow import Workflow
-
-    if isinstance(component, Agent):
-        from agno.agent._storage import to_dict as agent_to_dict
-
-        config = agent_to_dict(component)
-    elif isinstance(component, Team):
-        from agno.team._storage import to_dict as team_to_dict
-
-        config = team_to_dict(component)
-    elif isinstance(component, Workflow):
-        config = component.to_dict()
-    else:
-        raise TypeError(f"Unsupported component type: {type(component).__name__}")
-    for key, value in (carry or {}).items():
-        # Only what the rebuild lost: a value the component still carries is
-        # the edited one and wins.
-        config.setdefault(key, value)
-    return config
-
-
-# Backward-compatible alias. The toolkit was originally released as ``StudioTool``
-# (singular); ``StudioTools`` is the canonical name. Both refer to the same class.
-StudioTool = StudioTools
+__all__ = [
+    "StudioAccess",
+    "StudioAction",
+    "StudioAuthorizer",
+    "StudioTools",
+]

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -20,8 +20,7 @@ Typical use:
 Semantics:
     * create_* persists a new component with a single published config.
     * edit_* loads the component, applies the patch, and saves it:
-      - with versions=True the edit is saved as a draft (an existing draft is
-        updated in place; otherwise a new draft version is created). Use
+      - with versions=True the edit is saved as a new immutable draft. Use
         publish_component() to promote the draft to published+current.
       - with versions=False (default) the edit is published immediately as a
         new current version. Each edit creates a new published version; prior
@@ -69,7 +68,7 @@ from agno.utils.log import log_debug, logger
 
 if TYPE_CHECKING:
     from agno.agent.agent import Agent
-    from agno.db.base import BaseDb
+    from agno.db.base import BaseDb, ComponentVersionGuard
     from agno.models.base import Model
     from agno.registry.registry import Registry
     from agno.scheduler.manager import ScheduleManager
@@ -519,38 +518,74 @@ class StudioTools(Toolkit):
     # draft when versioning is enabled, so successive partial edits accumulate
     # instead of each resetting to the published config.
 
-    def _find_agent_for_edit(self, agent_id: str) -> Optional["Agent"]:
+    def _edit_version_snapshot(self, component_id: str) -> tuple[Optional[int], Optional["ComponentVersionGuard"]]:
+        """Capture the exact config loaded by an edit and its catalog-v2 CAS state."""
+        if self.db is None:
+            return None, None
+        if not self.enable_versions or getattr(self.db, "component_catalog_api_version", 1) < 2:
+            return self._edit_base_version(component_id), None
+
+        from agno.db.base import ComponentVersionGuard
+
+        component = self.db.get_component(component_id)
+        if component is None:
+            return None, None
+        configs = self.db.list_configs(component_id, include_config=False)
+        versions = [row["version"] for row in configs if isinstance(row.get("version"), int)]
+        drafts = [
+            row["version"] for row in configs if row.get("stage") == "draft" and isinstance(row.get("version"), int)
+        ]
+        current_version = component.get("current_version")
+        base_version = max(drafts) if drafts else current_version
+        return base_version, ComponentVersionGuard(
+            latest_version=max(versions) if versions else None,
+            current_version=current_version,
+        )
+
+    def _find_agent_for_edit(
+        self, agent_id: str
+    ) -> tuple[Optional["Agent"], Optional[int], Optional["ComponentVersionGuard"]]:
         for a in self._iter_agents():
             if getattr(a, "id", None) == agent_id:
-                return a
+                return a, None, None
         if self._runner_tools._db_component_exists("agent", agent_id):
-            return self._load_agent_from_db(agent_id, version=self._edit_base_version(agent_id))
+            base_version, guard = self._edit_version_snapshot(agent_id)
+            return self._load_agent_from_db(agent_id, version=base_version), base_version, guard
         resolved = self._runner_tools._resolve_db_id_by_name_or_slug("agent", agent_id)
         if resolved is None:
-            return None
-        return self._load_agent_from_db(resolved, version=self._edit_base_version(resolved))
+            return None, None, None
+        base_version, guard = self._edit_version_snapshot(resolved)
+        return self._load_agent_from_db(resolved, version=base_version), base_version, guard
 
-    def _find_team_for_edit(self, team_id: str) -> Optional["Team"]:
+    def _find_team_for_edit(
+        self, team_id: str
+    ) -> tuple[Optional["Team"], Optional[int], Optional["ComponentVersionGuard"]]:
         for t in self._iter_teams():
             if getattr(t, "id", None) == team_id:
-                return t
+                return t, None, None
         if self._runner_tools._db_component_exists("team", team_id):
-            return self._load_team_from_db(team_id, version=self._edit_base_version(team_id))
+            base_version, guard = self._edit_version_snapshot(team_id)
+            return self._load_team_from_db(team_id, version=base_version), base_version, guard
         resolved = self._runner_tools._resolve_db_id_by_name_or_slug("team", team_id)
         if resolved is None:
-            return None
-        return self._load_team_from_db(resolved, version=self._edit_base_version(resolved))
+            return None, None, None
+        base_version, guard = self._edit_version_snapshot(resolved)
+        return self._load_team_from_db(resolved, version=base_version), base_version, guard
 
-    def _find_workflow_for_edit(self, workflow_id: str) -> Optional["Workflow"]:
+    def _find_workflow_for_edit(
+        self, workflow_id: str
+    ) -> tuple[Optional["Workflow"], Optional[int], Optional["ComponentVersionGuard"]]:
         for w in self._iter_workflows():
             if getattr(w, "id", None) == workflow_id:
-                return w
+                return w, None, None
         if self._runner_tools._db_component_exists("workflow", workflow_id):
-            return self._load_workflow_from_db(workflow_id, version=self._edit_base_version(workflow_id))
+            base_version, guard = self._edit_version_snapshot(workflow_id)
+            return self._load_workflow_from_db(workflow_id, version=base_version), base_version, guard
         resolved = self._runner_tools._resolve_db_id_by_name_or_slug("workflow", workflow_id)
         if resolved is None:
-            return None
-        return self._load_workflow_from_db(resolved, version=self._edit_base_version(resolved))
+            return None, None, None
+        base_version, guard = self._edit_version_snapshot(resolved)
+        return self._load_workflow_from_db(resolved, version=base_version), base_version, guard
 
     def _is_code_defined(self, component_id: str, candidates: List[Any], component_type: str) -> bool:
         """True if the identifier refers to a code-defined (registry/list) component.
@@ -1211,7 +1246,7 @@ class StudioTools(Toolkit):
                         f"Only Studio-created components are editable.{hint}"
                     }
                 )
-            agent = self._find_agent_for_edit(agent_id)
+            agent, edit_base_version, edit_guard = self._find_agent_for_edit(agent_id)
         except StudioRunnerError as e:
             return json.dumps({"error": str(e) or type(e).__name__})
         except Exception as e:
@@ -1251,7 +1286,12 @@ class StudioTools(Toolkit):
                 replaced_keys.add("tools")
             if model_id is not None:
                 replaced_keys.add("model")
-            result = self._save_edit(agent, replaced_keys=replaced_keys)
+            result = self._save_edit(
+                agent,
+                replaced_keys=replaced_keys,
+                base_version=edit_base_version,
+                guard=edit_guard,
+            )
             log_debug(f"StudioTools edited agent id={agent.id} result={result}")
             return json.dumps({"status": "edited", "id": getattr(agent, "id", None) or agent_id, **result})
         except Exception as e:
@@ -1307,7 +1347,7 @@ class StudioTools(Toolkit):
                         f"Only Studio-created components are editable.{hint}"
                     }
                 )
-            team = self._find_team_for_edit(team_id)
+            team, edit_base_version, edit_guard = self._find_team_for_edit(team_id)
         except StudioRunnerError as e:
             return json.dumps({"error": str(e) or type(e).__name__})
         except Exception as e:
@@ -1351,7 +1391,7 @@ class StudioTools(Toolkit):
                 # agents_list entry, for one. Re-serializing that rebuild would
                 # publish a roster silently shrunk by an unrelated edit.
                 resolved_id = getattr(team, "id", None) or team_id
-                row = self.db.get_config(component_id=resolved_id, version=self._edit_base_version(resolved_id))
+                row = self.db.get_config(component_id=resolved_id, version=edit_base_version)
                 stored_config = row.get("config") if isinstance(row, dict) else None
                 stored_members = (stored_config or {}).get("members") or []
                 rebuilt_members = team.members if isinstance(team.members, list) else []
@@ -1378,7 +1418,13 @@ class StudioTools(Toolkit):
                 replaced_keys.add("members")
             if model_id is not None:
                 replaced_keys.add("model")
-            result = self._save_edit(team, replaced_keys=replaced_keys, pinned_children=replaced_pins)
+            result = self._save_edit(
+                team,
+                replaced_keys=replaced_keys,
+                pinned_children=replaced_pins,
+                base_version=edit_base_version,
+                guard=edit_guard,
+            )
             log_debug(f"StudioTools edited team id={team.id} result={result}")
             return json.dumps({"status": "edited", "id": getattr(team, "id", None) or team_id, **result})
         except Exception as e:
@@ -1423,7 +1469,7 @@ class StudioTools(Toolkit):
                         f"Only Studio-created components are editable.{hint}"
                     }
                 )
-            wf = self._find_workflow_for_edit(workflow_id)
+            wf, edit_base_version, edit_guard = self._find_workflow_for_edit(workflow_id)
         except StudioRunnerError as e:
             return json.dumps({"error": str(e) or type(e).__name__})
         except Exception as e:
@@ -1457,6 +1503,8 @@ class StudioTools(Toolkit):
                 wf,
                 replaced_keys={"steps"} if step_specs is not None else None,
                 pinned_children=replaced_pins,
+                base_version=edit_base_version,
+                guard=edit_guard,
             )
             log_debug(f"StudioTools edited workflow id={wf.id} result={result}")
             return json.dumps({"status": "edited", "id": getattr(wf, "id", None) or workflow_id, **result})
@@ -1525,7 +1573,17 @@ class StudioTools(Toolkit):
         if self.db is None:
             return json.dumps({"error": "StudioTools has no db configured."})
         try:
+            from agno.db.base import ComponentVersionGuard
+
+            component = self.db.get_component(component_id)
+            if component is None:
+                return json.dumps({"error": f"Component not found: {component_id}"})
+            catalog_v2 = getattr(self.db, "component_catalog_api_version", 1) >= 2
             configs = self.db.list_configs(component_id, include_config=False)
+            latest_version = max(
+                (c["version"] for c in configs if isinstance(c.get("version"), int)),
+                default=None,
+            )
             target = version
             if target is None:
                 drafts = [c for c in configs if c.get("stage") == "draft"]
@@ -1538,12 +1596,25 @@ class StudioTools(Toolkit):
                 if match is None:
                     return json.dumps({"error": f"Version not found: {component_id} v{target}"})
                 if match.get("stage") == "published":
-                    self._sync_component_row(component_id, target)
+                    if not catalog_v2:
+                        self._sync_component_row(component_id, target)
                     return json.dumps({"status": "already_published", "id": component_id, "version": target})
 
-            result = self.db.upsert_config(component_id=component_id, version=target, stage="published")
+            if catalog_v2:
+                result = self.db.upsert_config(
+                    component_id=component_id,
+                    version=target,
+                    stage="published",
+                    guard=ComponentVersionGuard(
+                        latest_version=latest_version,
+                        current_version=component.get("current_version"),
+                    ),
+                )
+            else:
+                result = self.db.upsert_config(component_id=component_id, version=target, stage="published")
             published_version = result.get("version", target)
-            self._sync_component_row(component_id, published_version)
+            if not catalog_v2:
+                self._sync_component_row(component_id, published_version)
             return json.dumps(
                 {
                     "status": "published",
@@ -2449,6 +2520,8 @@ class StudioTools(Toolkit):
         component: Component,
         replaced_keys: Optional[Set[str]] = None,
         pinned_children: Optional[Dict[str, int]] = None,
+        base_version: Optional[int] = None,
+        guard: Optional["ComponentVersionGuard"] = None,
     ) -> Dict[str, Any]:
         """Persist an edited component.
 
@@ -2464,7 +2537,7 @@ class StudioTools(Toolkit):
         config = _component_to_dict(component)
         replaced = replaced_keys or set()
         component_id = getattr(component, "id", None)
-        self._preserve_unresolved_keys(component_id, config, replaced)
+        self._preserve_unresolved_keys(component_id, config, replaced, base_version)
         if replaced & {"members", "steps"}:
             # The edit replaced the composition: pin the new children at the
             # exact versions the binder rebuilt them from.
@@ -2472,20 +2545,24 @@ class StudioTools(Toolkit):
         else:
             # Untouched composition keeps the base version's pins verbatim,
             # including link kinds this walk does not reconstruct.
-            links = self._base_links(component_id)
+            links = self._base_links(component_id, base_version)
         if self.enable_versions:
-            version = self._upsert_draft(component, config=config, links=links)
+            version = self._upsert_draft(component, config=config, links=links, guard=guard)
             return {"draft_version": version, "stage": "draft"}
         version = _persist_only(component, self.db, config=config, links=links)
         return {"version": version, "stage": "published"}
 
     def _preserve_unresolved_keys(
-        self, component_id: Optional[str], config: Dict[str, Any], replaced_keys: Set[str]
+        self,
+        component_id: Optional[str],
+        config: Dict[str, Any],
+        replaced_keys: Set[str],
+        base_version: Optional[int],
     ) -> None:
         """Copy stored reference keys the lenient load dropped back into ``config``."""
         if self.db is None or component_id is None:
             return
-        base = self._runner_tools._load_config_from_db(component_id, version=self._edit_base_version(component_id))
+        base = self._runner_tools._load_config_from_db(component_id, version=base_version)
         if not isinstance(base, dict):
             raise ValueError(
                 f"Cannot edit '{component_id}': its stored config could not be read, so an edit would drop "
@@ -2508,12 +2585,12 @@ class StudioTools(Toolkit):
                 config[key] = base[key]
                 log_debug(f"StudioTools: preserving stored '{key}' the lenient load could not resolve.")
 
-    def _base_links(self, component_id: Optional[str]) -> Optional[List[Dict[str, Any]]]:
+    def _base_links(self, component_id: Optional[str], base_version: Optional[int]) -> Optional[List[Dict[str, Any]]]:
         """The base version's links, carried forward verbatim on an edit that
         did not replace the component's composition."""
         if self.db is None or component_id is None:
             return None
-        return self._runner_tools._load_links_from_db(component_id, version=self._edit_base_version(component_id))
+        return self._runner_tools._load_links_from_db(component_id, version=base_version)
 
     def _links_for_component(
         self,
@@ -2661,12 +2738,13 @@ class StudioTools(Toolkit):
         component: Component,
         config: Optional[Dict[str, Any]] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        guard: Optional["ComponentVersionGuard"] = None,
     ) -> Optional[int]:
-        """Save a component as a draft. Updates the latest draft in place, else creates one.
+        """Append an immutable draft using the component version observed by this edit.
 
         The component row's name/description/metadata are NOT updated here --
         draft-only changes must not leak into listings until the draft is
-        published (publish_component syncs the row).
+        published.
         """
         if self.db is None:
             raise ValueError("db is required for draft persistence")
@@ -2675,7 +2753,11 @@ class StudioTools(Toolkit):
         if component_id is None:
             raise ValueError("Component has no id")
 
-        if self.db.get_component(component_id) is None:
+        catalog_v2 = getattr(self.db, "component_catalog_api_version", 1) >= 2
+        component_row = self.db.get_component(component_id)
+        if component_row is None:
+            if catalog_v2:
+                raise ValueError(f"Component not found: {component_id}")
             self.db.upsert_component(
                 component_id=component_id,
                 component_type=_component_type(component),
@@ -2684,19 +2766,30 @@ class StudioTools(Toolkit):
                 metadata=getattr(component, "metadata", None),
             )
 
-        # Reuse an existing draft if there is one; otherwise create a new draft version.
+        if not catalog_v2:
+            result = self.db.upsert_config(
+                component_id=component_id,
+                version=self._latest_draft_version(component_id),
+                config=config if config is not None else _component_to_dict(component),
+                stage="draft",
+                links=links,
+            )
+            return result.get("version")
+
+        if guard is None:
+            raise ValueError("A catalog-v2 draft append requires a component version guard")
+
         result = self.db.upsert_config(
             component_id=component_id,
-            version=self._latest_draft_version(component_id),
             config=config if config is not None else _component_to_dict(component),
             stage="draft",
             links=links,
+            guard=guard,
         )
         return result.get("version")
 
     def _sync_component_row(self, component_id: str, version: Optional[int]) -> None:
-        """Bring the component row's name/description/metadata in line with a
-        newly published config version."""
+        """Sync legacy catalog-v1 projections after a publication."""
         if self.db is None:
             return
         from agno.db.base import ComponentType

--- a/libs/agno/agno/tools/studio_runner.py
+++ b/libs/agno/agno/tools/studio_runner.py
@@ -3,7 +3,7 @@
 The runner is the dispatch half of the Studio: list the agents, teams, and
 workflows this runner can run -- those in the platform database, plus any
 code-defined components it admits -- and run one by id. It carries no
-create/edit/delete surface, so it is safe to mount on any component that should
+create/edit/archive surface, so it is safe to mount on any component that should
 hand work to built components -- a team lead, a router -- without granting the
 Studio's mutation tools.
 
@@ -63,11 +63,11 @@ Semantics:
       stream=True still hands back its final run output, never an unconsumed
       event iterator.
     * run_* resolve in a fixed order: code-defined exact id, DB exact id,
-      code-defined display name, DB display name, then the identifier's slug
-      as an id (covers renamed components, whose ids keep the original
-      name's slug). Exact ids always win over display names. A display name
-      matching several components of the type returns an error listing the
-      matching ids.
+      code-defined display name, then DB display name. Exact ids always win
+      over display names; fuzzy or slug aliases are not inferred.
+      A display name matching several components of the type returns an error
+      listing the matching ids. An explicit component id is never inferred
+      from a normalized version of a different display name.
     * Persisted components rebuild from their stored config. Registry-backed
       references (tools, knowledge, function steps, schemas, code-defined
       members) require the registry: without it the runner refuses to run a
@@ -76,23 +76,35 @@ Semantics:
       is checked against its own config before dispatch, so an unresolved tool
       or a dropped schema stops the run rather than quietly changing what it
       does. Reads and edits load it either way, so it stays repairable.
-      Member references resolve at their current
-      published version. Model connection settings, credentials and a
-      declared db are not fully persisted, so a rebuild can fall back to
-      provider defaults and to the catalog db; the runner logs a warning for
-      the dispatched agent's or team's own model and for a dropped db.
-    * list_* read the database only (id, name, description, newest first), and
-      run_* dispatch that same set: a component you cannot list is a component
-      you cannot run. Code-defined components arrive through the registry,
-      which is passed so persisted components can rehydrate rather than to
-      grant the runner the run of the application, so dispatching them is
-      opt-in via include_all_components. An explicit agents_list/teams_list/
-      workflows_list is itself the allowlist and always runs. 'total' reports
-      the full DB count, so a capped list is visible as capped.
+      Stored member references resolve at the exact published versions pinned
+      by the parent config; legacy unpinned references use the current version.
+      Typed Studio components always require the registry for dispatch, even
+      when they have no tools: their top-level and nested models must be the
+      exact live instances in ``registry.models``. Model connection settings
+      and credentials are not persisted, so a config rebuild is refused rather
+      than allowed to fall back to provider defaults. Legacy stored configs
+      retain the warning for a rebuilt top-level model. A declared db is also
+      not always reconstructable, so the runner warns when it falls back to the
+      catalog db.
+      The component database itself is the trusted durable boundary. Typed
+      manifests preserve live registry identity and public Studio mutations
+      keep published versions immutable; they are not checksums for detecting
+      privileged, out-of-band edits to component rows. Protect the catalog
+      with database access controls and use the Studio lifecycle APIs to edit
+      it.
+    * list_* report everything this runner can dispatch: stored components plus
+      admitted code-defined components. Code-defined components arrive through
+      the registry, which is passed so persisted components can rehydrate rather
+      than to grant the runner the run of the application, so dispatching them
+      is opt-in via include_all_components. An explicit agents_list/teams_list/
+      workflows_list is itself the allowlist and always runs, even without a
+      database. 'total' counts distinct runnable components, so a capped list is
+      visible as capped and a stored row shadowed by a code-defined id is counted
+      only once.
 
-StudioTools embeds this toolkit for its own run_* tools and delegates its
-component lookups here, so a builder's smoke-test runs and a dispatcher's
-production runs share one implementation.
+StudioTools embeds this toolkit for its own run_* tools and reuses its persisted
+component loaders, so a builder's smoke-test runs and a dispatcher's production
+runs share one implementation.
 """
 
 from __future__ import annotations
@@ -106,6 +118,7 @@ from agno.run import RunContext
 from agno.run.utils import run_status_string, serialized_paused_requirements
 from agno.tools.toolkit import Toolkit
 from agno.utils.log import logger
+from agno.utils.string import generate_id_from_name
 
 if TYPE_CHECKING:
     from agno.agent.agent import Agent
@@ -119,17 +132,31 @@ if TYPE_CHECKING:
 _NAME_LOOKUP_PAGE = 100
 
 
-# How deep the dispatch checks walk a component graph. A graph deeper than this
-# is refused rather than half-inspected, so a cap can never read as a pass.
-_GRAPH_DEPTH_CAP = 32
+# Dispatch checks bound recursion depth and total graph size independently.
+# Exceeding either bound is a refusal rather than a partial inspection, so a
+# safety cap can never read as a pass.
+_GRAPH_MAX_DEPTH = 32
+_GRAPH_MAX_NODES = 1024
+
+
+# Typed Studio configs carry this private manifest. Keep the runner's trust
+# decision local rather than importing StudioTools, which embeds this toolkit.
+_STUDIO_CONFIG_KEY = "_agno_studio"
+_STUDIO_SCHEMA_VERSION = 2
 
 
 def _slugify(name: str) -> str:
-    """Component ids are slugified names (shared with StudioTools' create path)."""
-    slug = "".join(c.lower() if c.isalnum() else "-" for c in name.strip())
-    while "--" in slug:
-        slug = slug.replace("--", "-")
-    return slug.strip("-") or "component"
+    """Normalize through the catalog-wide component ID policy."""
+    return generate_id_from_name(name)
+
+
+def _is_typed_studio_config(config: Dict[str, Any]) -> bool:
+    """Whether this config was written through the typed Studio contract.
+
+    Presence is enough: a corrupt manifest must not downgrade a typed config
+    into the legacy, warning-only model path.
+    """
+    return _STUDIO_CONFIG_KEY in config
 
 
 class StudioRunnerError(Exception):
@@ -213,25 +240,106 @@ def _references_executors(component_type: str, config: Dict[str, Any]) -> bool:
 
 
 def _references_idless_components(component_type: str, config: Dict[str, Any]) -> bool:
-    """True when a stored config carries an agent/team reference whose id is
+    """True when a stored config carries a component reference whose id is
     null. Serialization writes the referenced component's id even when it is
     None, and a code-defined component that never ran has no id, so a null id
     marks a component only the registry can supply."""
     return any(
-        ("agent_id" in ref and not ref["agent_id"]) or ("team_id" in ref and not ref["team_id"])
+        ("agent_id" in ref and not ref["agent_id"])
+        or ("team_id" in ref and not ref["team_id"])
+        or ("workflow_id" in ref and not ref["workflow_id"])
         for ref in _reference_configs(component_type, config)
     )
 
 
+def _component_reference_entries(component_type: str, config: Dict[str, Any]) -> List[Tuple[str, str, Optional[str]]]:
+    """(type, id, link key) entries in serialized reference order.
+
+    The link key matters when two workflow steps pin different versions of the
+    same component. Keying pins only by child id silently makes the last link
+    win and compares one step's runtime object with another step's config.
+    """
+    refs: List[Tuple[str, str, Optional[str]]] = []
+
+    def append_reference(ref: Dict[str, Any], link_key: Optional[str]) -> None:
+        if ref.get("team_id"):
+            refs.append(("team", str(ref["team_id"]), link_key))
+        elif ref.get("agent_id"):
+            refs.append(("agent", str(ref["agent_id"]), link_key))
+        elif ref.get("workflow_id"):
+            refs.append(("workflow", str(ref["workflow_id"]), link_key))
+
+    if component_type == "team":
+        members = config.get("members") or []
+        if isinstance(members, list):
+            for position, member in enumerate(members):
+                if isinstance(member, dict):
+                    append_reference(member, f"member_{position}")
+        return refs
+    if component_type != "workflow":
+        return refs
+
+    def walk(steps: Any, suffix: str = "") -> None:
+        if not isinstance(steps, list):
+            return
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            raw_key = step.get("step_id") or step.get("name")
+            link_key = f"{raw_key}{suffix}" if raw_key is not None else None
+            append_reference(step, link_key)
+            walk(step.get("steps"), suffix)
+            walk(step.get("else_steps"), f"{suffix}#else")
+            walk(step.get("choices"), suffix)
+
+    walk(config.get("steps"))
+    return refs
+
+
 def _component_references(component_type: str, config: Dict[str, Any]) -> List[tuple]:
     """(type, id) pairs for the components a stored config references by id."""
-    refs: List[tuple] = []
-    for ref in _reference_configs(component_type, config):
-        if ref.get("team_id"):
-            refs.append(("team", str(ref["team_id"])))
-        elif ref.get("agent_id"):
-            refs.append(("agent", str(ref["agent_id"])))
-    return refs
+    return [(ref_type, ref_id) for ref_type, ref_id, _link_key in _component_reference_entries(component_type, config)]
+
+
+def _pinned_reference_version(
+    links: List[Dict[str, Any]],
+    ref_type: str,
+    ref_id: str,
+    link_key: Optional[str],
+) -> Optional[int]:
+    """Resolve the pin for one exact serialized reference.
+
+    Step.from_dict prefers the matching link key and otherwise accepts a child
+    fallback only when every matching link pins the same version. Mirror that
+    rule so the fidelity check judges the same config version that
+    reconstruction used and never chooses one side of an ambiguous pin.
+    """
+    candidates: List[Tuple[Optional[str], Optional[int]]] = []
+    for link in links:
+        if link.get("child_component_id") != ref_id:
+            continue
+        link_kind = link.get("link_kind")
+        meta = link.get("meta")
+        linked_type = meta.get("type") if isinstance(meta, dict) else None
+        if linked_type is None and isinstance(link_kind, str) and link_kind.startswith("step_"):
+            linked_type = link_kind.removeprefix("step_")
+        if linked_type is not None and linked_type != ref_type:
+            continue
+        raw_version = link.get("child_version")
+        child_version = raw_version if isinstance(raw_version, int) else None
+        candidate_key = link.get("link_key")
+        if link_key is not None and candidate_key == link_key:
+            return child_version
+        candidates.append((candidate_key if isinstance(candidate_key, str) else None, child_version))
+    if not candidates:
+        return None
+    versions = {version for _, version in candidates}
+    if len(versions) == 1:
+        return candidates[0][1]
+    raise ComponentNotDispatchableError(
+        f"Reference '{ref_id}' matches no link for key '{link_key}', and the parent pins that child "
+        "at multiple versions. Re-save the parent so every reference pin is keyed to its occurrence."
+    )
 
 
 class StudioRunnerTools(Toolkit):
@@ -284,8 +392,8 @@ class StudioRunnerTools(Toolkit):
                 "Run components built in the Studio: discover what exists, then run by id.",
                 f"{list_names}: id, name, and description of every component this toolkit can run, newest first.",
                 f"{run_names}: send one message; the result carries run_id, session_id, status, and content. "
-                "Use the exact id from a list tool; a display name or its slug also resolves. An ambiguous "
-                "display name returns an error listing the matching ids -- retry with the exact id.",
+                "Use the exact id from a list tool; an exact display name also resolves. An ambiguous display "
+                "name returns an error listing the matching ids -- retry with the exact id.",
                 "A PAUSED status means the run awaits human approval: relay the requirements to the user and "
                 "include the run_id and session_id -- the run is resumed through the platform, never by "
                 "running it again.",
@@ -306,8 +414,7 @@ class StudioRunnerTools(Toolkit):
         )
 
     # ------------------------------------------------------------------
-    # Component resolution -- StudioTools delegates its lookups here so the
-    # builder and the runner resolve components one way.
+    # Runner component resolution.
     # ------------------------------------------------------------------
 
     def _iter_agents(self, for_dispatch: bool = False) -> List["Agent"]:
@@ -341,12 +448,11 @@ class StudioRunnerTools(Toolkit):
 
     def _find_agent(self, agent_id: str, for_dispatch: bool = False) -> Optional["Agent"]:
         """Lookup order: code-defined exact id, DB exact id, code-defined display
-        name, DB display name (ambiguous -> AmbiguousComponentNameError), then
-        the identifier's slug as an id. Exact ids always win over names.
+        name, then DB display name (ambiguous -> AmbiguousComponentNameError).
+        Exact ids always win over names.
 
-        Split into an exact tier and a name tier so cross-type callers
-        (StudioTools._resolve_members) can try exact ids across both types
-        before any name matching."""
+        Split into an exact tier and a name tier so cross-type member lookup
+        can try exact ids across both types before any name matching."""
         agent = self._find_agent_by_exact_id(agent_id, for_dispatch=for_dispatch)
         if agent is not None:
             return agent
@@ -368,7 +474,7 @@ class StudioRunnerTools(Toolkit):
             raise AmbiguousComponentNameError("agent", agent_id, [str(getattr(a, "id", "")) for a in named_agents])
         if named_agents:
             return named_agents[0]
-        resolved = self._resolve_db_id_by_name_or_slug("agent", agent_id)
+        resolved = self._resolve_db_id_by_name("agent", agent_id)
         if resolved is None:
             return None
         if for_dispatch:
@@ -395,7 +501,7 @@ class StudioRunnerTools(Toolkit):
             raise AmbiguousComponentNameError("team", team_id, [str(getattr(t, "id", "")) for t in named_teams])
         if named_teams:
             return named_teams[0]
-        resolved = self._resolve_db_id_by_name_or_slug("team", team_id)
+        resolved = self._resolve_db_id_by_name("team", team_id)
         if resolved is None:
             return None
         if for_dispatch:
@@ -426,7 +532,7 @@ class StudioRunnerTools(Toolkit):
             )
         if named_workflows:
             return named_workflows[0]
-        resolved = self._resolve_db_id_by_name_or_slug("workflow", workflow_id)
+        resolved = self._resolve_db_id_by_name("workflow", workflow_id)
         if resolved is None:
             return None
         if for_dispatch:
@@ -458,11 +564,11 @@ class StudioRunnerTools(Toolkit):
             )
         try:
             fresh = copier()
-        except Exception as e:
+        except Exception:
             raise DispatchCopyError(
-                f"deep_copy failed for '{label}': {str(e) or type(e).__name__}. "
+                f"deep_copy failed for '{label}'. "
                 "Give the class a deep_copy that rebuilds it, or store the component in the database."
-            ) from e
+            ) from None
         if fresh is component:
             raise DispatchCopyError(
                 f"deep_copy of '{label}' returned the shared instance; the runner does not dispatch it. "
@@ -641,7 +747,7 @@ class StudioRunnerTools(Toolkit):
 
     @staticmethod
     def _step_list_divergence(original_steps: Any, fresh_steps: Any, depth: int = 0) -> Optional[str]:
-        if depth > _GRAPH_DEPTH_CAP:
+        if depth > _GRAPH_MAX_DEPTH:
             # _require_inspectable_depth refuses before a real graph gets here,
             # so this is only the cycle guard.
             return None
@@ -688,7 +794,7 @@ class StudioRunnerTools(Toolkit):
         whether the copy holds the same members at all. A copier that drops a
         member or rebuilds it as a different component has not produced the
         component that was asked for, and neither shows up as sharing."""
-        if depth > _GRAPH_DEPTH_CAP:
+        if depth > _GRAPH_MAX_DEPTH:
             # _require_inspectable_depth refuses before a real graph gets
             # here, so this is only the cycle guard.
             return None
@@ -870,16 +976,6 @@ class StudioRunnerTools(Toolkit):
             raise AmbiguousComponentNameError(component_type, name, matches)
         return matches[0] if matches else None
 
-    def _resolve_db_id_by_name_or_slug(self, component_type: str, identifier: str) -> Optional[str]:
-        """DB id for a non-id identifier: display name first, then its slug."""
-        resolved = self._resolve_db_id_by_name(component_type, identifier)
-        if resolved is not None:
-            return resolved
-        slug = _slugify(identifier)
-        if slug != identifier and self._db_component_exists(component_type, slug):
-            return slug
-        return None
-
     @staticmethod
     def _require_resolvable_member_ids(component_type: str, component_id: str, config: Dict[str, Any]) -> None:
         """Refuse a config that references a member or step executor by a null id.
@@ -905,6 +1001,7 @@ class StudioRunnerTools(Toolkit):
         config: Dict[str, Any],
         _seen: Optional[set] = None,
         version: Optional[int] = None,
+        require_typed_registry: bool = False,
     ) -> None:
         """Refuse to rebuild a component whose config needs the absent registry.
 
@@ -917,12 +1014,16 @@ class StudioRunnerTools(Toolkit):
             return
         if _seen is None:
             _seen = set()
-        # Versions of one id are distinct nodes: two branches can pin the same
-        # child at different versions, and each version's config is its own.
-        key = f"{component_type}:{component_id}:{version}"
+        key = (component_type, component_id, version)
         if key in _seen:
             return
         _seen.add(key)
+        if require_typed_registry and _is_typed_studio_config(config):
+            raise ComponentNeedsRegistryError(
+                f"{component_type.capitalize()} '{component_id}' was persisted by the typed Studio contract and "
+                "cannot be dispatched from the database alone. Construct StudioRunnerTools with the registry so "
+                "its exact live model instances, connection settings, and credentials can be restored."
+            )
         needs: List[str] = []
         # Tools are deliberately NOT pre-guarded on "the config declares some".
         # Not every serialized tool needs the registry -- a provider-native tool
@@ -944,28 +1045,30 @@ class StudioRunnerTools(Toolkit):
             )
         from agno.db.base import ComponentType
 
-        # Every pinned version of a child is checked, not one per id: two
-        # branches can pin the same child id at different versions, and either
-        # version's config may need the registry.
-        pinned_versions: Dict[str, set] = {}
-        for link in self._load_links_from_db(component_id, version=version):
-            child_id = link.get("child_component_id")
-            if child_id:
-                pinned_versions.setdefault(child_id, set()).add(link.get("child_version"))
-        for ref_type, ref_id in _component_references(component_type, config):
-            versions = pinned_versions.get(ref_id) or {None}
-            for ref_version in sorted(versions, key=lambda v: (v is None, v)):
-                ref_loaded = self._load_config_row_from_db(
-                    ref_id, version=ref_version, component_type=ComponentType(ref_type)
+        links = self._load_links_from_db(component_id, version=version)
+        for ref_type, ref_id, link_key in _component_reference_entries(component_type, config):
+            ref_version = _pinned_reference_version(links, ref_type, ref_id, link_key)
+            ref_loaded = self._load_config_row_from_db(
+                ref_id,
+                version=ref_version,
+                component_type=ComponentType(ref_type),
+                current_only=ref_version is None,
+            )
+            if ref_loaded is None:
+                raise ComponentNeedsRegistryError(
+                    f"{component_type.capitalize()} '{component_id}' references {ref_type} '{ref_id}', "
+                    "which is not stored in the database (a code-defined component); "
+                    "construct StudioRunnerTools with the registry to run it."
                 )
-                if ref_loaded is None:
-                    raise ComponentNeedsRegistryError(
-                        f"{component_type.capitalize()} '{component_id}' references {ref_type} '{ref_id}', "
-                        "which is not stored in the database (a code-defined component); "
-                        "construct StudioRunnerTools with the registry to run it."
-                    )
-                ref_config, ref_resolved_version = ref_loaded
-                self._require_registry_for(ref_type, ref_id, ref_config, _seen, version=ref_resolved_version)
+            ref_config, ref_resolved_version = ref_loaded
+            self._require_registry_for(
+                ref_type,
+                ref_id,
+                ref_config,
+                _seen,
+                version=ref_resolved_version,
+                require_typed_registry=require_typed_registry,
+            )
 
     def _dispatch_refusal(
         self,
@@ -1016,6 +1119,157 @@ class StudioRunnerTools(Toolkit):
             self._require_faithful_registry_copies(component, component_type, component_id)
             self._require_faithful_references(component, config, component_type, component_id, version=version)
 
+    def _require_unambiguous_typed_registry(
+        self,
+        component: Any,
+        config: Dict[str, Any],
+        component_type: str,
+        component_id: str,
+    ) -> None:
+        """Require every persisted typed reference to resolve exactly once.
+
+        Registry resolution historically picks one matching model, tool, or
+        function. That is unsafe for a typed Studio config: a later ambiguous
+        registry can bind different credentials, endpoints, or executable code
+        while retaining the same serialized name. Refuse before dispatch.
+        """
+        if not _is_typed_studio_config(config):
+            return
+        if self.registry is None:
+            raise ComponentNeedsRegistryError(
+                f"{component_type.capitalize()} '{component_id}' requires the registry used by typed Studio."
+            )
+        manifest = config.get(_STUDIO_CONFIG_KEY)
+        request = manifest.get("request") if isinstance(manifest, dict) else None
+        if (
+            not isinstance(manifest, dict)
+            or manifest.get("schema_version") != _STUDIO_SCHEMA_VERSION
+            or not isinstance(request, dict)
+        ):
+            raise ComponentNotDispatchableError(
+                f"{component_type.capitalize()} '{component_id}' has an invalid typed Studio manifest."
+            )
+
+        def require_one(resource: str, reference: str, matches: List[Any]) -> None:
+            if len(matches) == 1:
+                return
+            if not matches:
+                location = "registry.models" if resource == "model" else "the registry"
+                state = f"is not present in {location}"
+            else:
+                state = f"is ambiguous because the registry has {len(matches)} matches"
+            model_warning = " Serialized models do not preserve base_url or credentials." if resource == "model" else ""
+            raise ComponentNeedsRegistryError(
+                f"{component_type.capitalize()} '{component_id}' {resource} reference {reference} {state}; "
+                f"register exactly one live match before dispatch.{model_warning}"
+            )
+
+        if component_type in ("agent", "team"):
+            model_ref = request.get("model")
+            if not isinstance(model_ref, dict) or not isinstance(model_ref.get("id"), str):
+                raise ComponentNotDispatchableError(
+                    f"{component_type.capitalize()} '{component_id}' has no exact model reference in its typed manifest."
+                )
+            model_matches = [
+                model
+                for model in self.registry.models or []
+                if getattr(model, "id", None) == model_ref["id"]
+                and (model_ref.get("provider") is None or getattr(model, "provider", None) == model_ref["provider"])
+                and (model_ref.get("name") is None or getattr(model, "name", None) == model_ref["name"])
+            ]
+            model_label = {key: model_ref[key] for key in ("id", "provider", "name") if model_ref.get(key) is not None}
+            require_one("model", repr(model_label), model_matches)
+            if getattr(component, "model", None) is not model_matches[0]:
+                raise ComponentNotDispatchableError(
+                    f"{component_type.capitalize()} '{component_id}' runtime model diverges from its typed manifest."
+                )
+
+        if component_type == "agent":
+            from agno.tools.function import Function
+
+            catalog: List[Tuple[Tuple[str, str, Optional[str]], Any]] = []
+            for tool in self.registry.tools or []:
+                if isinstance(tool, Toolkit):
+                    catalog.append((("toolkit", tool.name, None), tool))
+                    catalog.extend(
+                        (("function", function_name, tool.name), function)
+                        for function_name, function in tool.get_functions().items()
+                    )
+                elif isinstance(tool, Function):
+                    catalog.append((("function", tool.name, None), tool))
+                elif callable(tool):
+                    name = getattr(tool, "__name__", None)
+                    if isinstance(name, str) and name:
+                        catalog.append((("function", name, None), tool))
+
+            tool_refs = request.get("tools", [])
+            if not isinstance(tool_refs, list):
+                raise ComponentNotDispatchableError(
+                    f"Agent '{component_id}' has an invalid tool list in its typed manifest."
+                )
+            runtime_tools = [tool for tool in (getattr(component, "tools", None) or []) if isinstance(tool, Function)]
+            for tool_ref in tool_refs:
+                if not isinstance(tool_ref, dict):
+                    raise ComponentNotDispatchableError(
+                        f"Agent '{component_id}' has an invalid tool reference in its typed manifest."
+                    )
+                key = (tool_ref.get("kind"), tool_ref.get("name"), tool_ref.get("toolkit"))
+                matches = [tool for candidate, tool in catalog if candidate == key]
+                label = {name: tool_ref[name] for name in ("kind", "name", "toolkit") if tool_ref.get(name) is not None}
+                require_one("tool", repr(label), matches)
+                matched = matches[0]
+                if tool_ref.get("kind") == "toolkit" and isinstance(matched, Toolkit):
+                    expected_sources = list(matched.get_functions().items())
+                else:
+                    expected_sources = [(str(tool_ref.get("name")), matched)]
+                for function_name, source in expected_sources:
+                    owning_toolkit = (
+                        tool_ref.get("name") if tool_ref.get("kind") == "toolkit" else tool_ref.get("toolkit")
+                    )
+                    runtime_matches = [
+                        tool
+                        for tool in runtime_tools
+                        if tool.name == function_name and tool.owning_toolkit == owning_toolkit
+                    ]
+                    expected_entrypoint = source.entrypoint if isinstance(source, Function) else source
+                    if len(runtime_matches) != 1 or runtime_matches[0].entrypoint is not expected_entrypoint:
+                        raise ComponentNeedsRegistryError(
+                            f"Agent '{component_id}' runtime binding for tool '{function_name}' diverges from "
+                            "the unique registry match."
+                        )
+
+        if component_type == "workflow":
+            steps = request.get("steps", [])
+            if not isinstance(steps, list):
+                raise ComponentNotDispatchableError(
+                    f"Workflow '{component_id}' has an invalid step list in its typed manifest."
+                )
+            runtime_steps = {
+                getattr(step, "step_id", None) or getattr(step, "name", None): step
+                for step in self._branch_items(getattr(component, "steps", None))
+            }
+            for step in steps:
+                if not isinstance(step, dict) or step.get("kind") != "function":
+                    continue
+                workflow_function_name = step.get("function_name")
+                if not isinstance(workflow_function_name, str):
+                    raise ComponentNotDispatchableError(
+                        f"Workflow '{component_id}' has an invalid function reference in its typed manifest."
+                    )
+                matches = [
+                    function
+                    for function in self.registry.functions or []
+                    if getattr(function, "__name__", None) == workflow_function_name
+                ]
+                require_one("function", repr({"name": workflow_function_name}), matches)
+                step_key = step.get("step_id") or step.get("name")
+                runtime_step = runtime_steps.get(step_key)
+                if runtime_step is None or getattr(runtime_step, "executor", None) is not matches[0]:
+                    raise ComponentNeedsRegistryError(
+                        f"Workflow '{component_id}' runtime binding for function '{workflow_function_name}' diverges from "
+                        "the unique registry match."
+                    )
+
     def _require_faithful_rebuild(
         self, component: Any, config: Dict[str, Any], component_type: str, component_id: str
     ) -> None:
@@ -1033,6 +1287,9 @@ class StudioRunnerTools(Toolkit):
         Reads and edits skip this, so a component missing a tool stays loadable
         and repairable."""
         from agno.tools.function import Function
+
+        self._require_unambiguous_typed_registry(component, config, component_type, component_id)
+        self._require_registered_models_for_typed_config(component, config, component_type, component_id)
 
         missing: List[str] = []
 
@@ -1081,26 +1338,85 @@ class StudioRunnerTools(Toolkit):
                 "edits still load the component."
             )
 
-    def _require_inspectable_depth(self, component: Any, component_type: str, component_id: str) -> None:
-        """Refuse a graph deeper than the dispatch checks walk.
+    def _require_registered_models_for_typed_config(
+        self,
+        component: Any,
+        config: Dict[str, Any],
+        component_type: str,
+        component_id: str,
+    ) -> None:
+        """Require live registry model identity throughout a typed Studio graph.
 
-        Every check here is depth-capped so a cycle cannot hang it, and a cap
-        reached mid-walk returns "nothing wrong" -- a pass for a graph that was
-        never fully inspected. Refusing past the cap stops a cap reading as an
-        approval."""
+        Model serialization intentionally carries only identity fields. A model
+        rebuilt from that dict can have the right id/provider/name while losing
+        its base URL, credentials, client, and other connection settings. For a
+        typed Studio component, equality is therefore insufficient: every model
+        that can execute in the materialized root/member/step graph must be one
+        of the exact objects registered for this AgentOS process.
+
+        This guard is keyed only by the persisted Studio manifest. Explicit and
+        registry/code-defined runner targets keep their existing copy behavior.
+        """
+        if not _is_typed_studio_config(config):
+            return
+        if self.registry is None:
+            raise ComponentNeedsRegistryError(
+                f"{component_type.capitalize()} '{component_id}' was persisted by the typed Studio contract and "
+                "requires the registry for dispatch."
+            )
+
+        registered_models = list(self.registry.models or [])
+        missing: List[str] = []
+        seen_models: set[int] = set()
+
+        declared_model = config.get("model")
+        if declared_model is not None and getattr(component, "model", None) is None:
+            declared_id = declared_model.get("id") if isinstance(declared_model, dict) else declared_model
+            missing.append(f"{component_type} '{component_id}' model '{declared_id or '?'}' was dropped")
+
+        for node in [component, *self._descendants(component)]:
+            model = getattr(node, "model", None)
+            if model is None or id(model) in seen_models:
+                continue
+            seen_models.add(id(model))
+            if any(model is registered for registered in registered_models):
+                continue
+            node_id = getattr(node, "id", None) or getattr(node, "name", None) or type(node).__name__
+            model_id = getattr(model, "id", None) or type(model).__name__
+            missing.append(f"'{node_id}' uses model '{model_id}' rebuilt outside registry.models")
+
+        if missing:
+            raise ComponentNeedsRegistryError(
+                f"{component_type.capitalize()} '{component_id}' cannot be dispatched faithfully: "
+                f"{'; '.join(missing)}. Register the exact live model instance before running it; serialized "
+                "models do not preserve connection settings such as base_url or credentials."
+            )
+
+    def _require_inspectable_depth(self, component: Any, component_type: str, component_id: str) -> None:
+        """Refuse a graph deeper or larger than the dispatch checks walk.
+
+        Every downstream check is bounded so a cycle cannot hang it. This gate
+        establishes that the entire runtime graph is within those bounds before
+        any bounded helper may return "nothing wrong."""
         seen: set = set()
         frontier = [(component, 0)]
         while frontier:
             node, depth = frontier.pop()
             if node is None or id(node) in seen:
                 continue
-            seen.add(id(node))
-            if depth > _GRAPH_DEPTH_CAP:
+            if depth > _GRAPH_MAX_DEPTH:
                 raise ComponentNotDispatchableError(
                     f"{component_type.capitalize()} '{component_id}' nests deeper than "
-                    f"{_GRAPH_DEPTH_CAP} levels, past what the runner inspects before dispatch; "
+                    f"{_GRAPH_MAX_DEPTH} levels, past what the runner inspects before dispatch; "
                     "flatten it, or dispatch the nested component directly."
                 )
+            if len(seen) >= _GRAPH_MAX_NODES:
+                raise ComponentNotDispatchableError(
+                    f"{component_type.capitalize()} '{component_id}' contains more than "
+                    f"{_GRAPH_MAX_NODES} inspectable graph nodes, past what the runner checks before dispatch; "
+                    "split it into smaller components before dispatch."
+                )
+            seen.add(id(node))
             frontier.extend((child, depth + 1) for child in self._child_nodes(node))
 
     def _require_faithful_registry_copies(self, component: Any, component_type: str, component_id: str) -> None:
@@ -1161,7 +1477,7 @@ class StudioRunnerTools(Toolkit):
         """Every member and step executor below a component, once each."""
         seen = set() if seen is None else seen
         found: List[Any] = []
-        if node is None or depth > _GRAPH_DEPTH_CAP:
+        if node is None or depth > _GRAPH_MAX_DEPTH:
             return found
         for child in StudioRunnerTools._child_nodes(node):
             if id(child) in seen:
@@ -1256,48 +1572,37 @@ class StudioRunnerTools(Toolkit):
         from agno.db.base import ComponentType
 
         key = (component_type, component_id, version)
-        # `seen` is the cycle guard and nothing else: counting it bounded how
-        # WIDE a graph could be rather than how deep, so a team with more
-        # members than the cap stopped checking the rest of them. Versions of
-        # one id are distinct nodes; the depth cap bounds any version chain.
-        if key in seen or depth > _GRAPH_DEPTH_CAP:
+        if key in seen:
             return
+        if depth > _GRAPH_MAX_DEPTH:
+            raise ComponentNotDispatchableError(
+                f"{component_type.capitalize()} '{component_id}' nests deeper than "
+                f"{_GRAPH_MAX_DEPTH} stored-reference levels, past what the runner inspects before dispatch."
+            )
+        if len(seen) >= _GRAPH_MAX_NODES:
+            raise ComponentNotDispatchableError(
+                f"{component_type.capitalize()} '{component_id}' reaches more than "
+                f"{_GRAPH_MAX_NODES} stored-reference nodes, past what the runner inspects before dispatch."
+            )
         seen.add(key)
         links = self._load_links_from_db(component_id, version=version)
+        rebuilt = self._components_by_reference(component_type, component)
+        used_occurrences: Dict[tuple, int] = {}
         registered = {
             (self._component_kind(instance), instance_id)
-            for instance, instance_id in (
-                (instance, getattr(instance, "id", None)) for instance in self._registry_instances()
-            )
-            if isinstance(instance_id, str)
+            for instance in self._registry_instances()
+            if isinstance((instance_id := getattr(instance, "id", None)), str)
         }
-        if component_type == "workflow":
-            checks = []
-            checked_occurrences = set()
-            for link_kind, link_key, ref_type, ref_id, target in self._step_occurrences(component):
-                if not isinstance(ref_id, str) or target is None:
-                    continue
-                ref_version = self._occurrence_pin(links, link_kind, link_key, ref_id)
-                occurrence = (ref_type, ref_id, ref_version, id(target))
-                if occurrence in checked_occurrences:
-                    continue
-                checked_occurrences.add(occurrence)
-                checks.append((ref_type, ref_id, ref_version, target))
-        else:
-            pins: Dict[str, Optional[int]] = {}
-            for link in links:
-                child_id = link.get("child_component_id")
-                if child_id:
-                    pins[child_id] = link.get("child_version")
-            rebuilt = self._components_by_id(component)
-            checks = [
-                (ref_type, ref_id, pins.get(ref_id), rebuilt.get((ref_type, ref_id)))
-                for ref_type, ref_id in _component_references(component_type, config)
-            ]
-        for ref_type, ref_id, ref_version, target in checks:
-            if target is None:
+        for ref_type, ref_id, link_key in _component_reference_entries(component_type, config):
+            ref_key = (ref_type, ref_id)
+            occurrence = used_occurrences.get(ref_key, 0)
+            targets = rebuilt.get(ref_key, [])
+            if occurrence >= len(targets):
                 continue
-            if (ref_type, ref_id) in registered:
+            target = targets[occurrence]
+            used_occurrences[ref_key] = occurrence + 1
+            ref_version = _pinned_reference_version(links, ref_type, ref_id, link_key)
+            if ref_key in registered and ref_version is None:
                 # from_dict resolves a member or step executor from the registry
                 # before the database, so this object was never built from the
                 # stored config and does not have to match it: a live toolkit is
@@ -1316,7 +1621,12 @@ class StudioRunnerTools(Toolkit):
             if cache_key in configs:
                 ref_config, ref_resolved_version = configs[cache_key]
             else:
-                ref_loaded = self._load_config_row_from_db(ref_id, version=ref_version, component_type=stored_type)
+                ref_loaded = self._load_config_row_from_db(
+                    ref_id,
+                    version=ref_version,
+                    component_type=stored_type,
+                    current_only=ref_version is None,
+                )
                 ref_config, ref_resolved_version = ref_loaded if ref_loaded is not None else (None, None)
                 configs[cache_key] = (ref_config, ref_resolved_version)
             if ref_config is None:
@@ -1338,86 +1648,6 @@ class StudioRunnerTools(Toolkit):
             )
 
     @staticmethod
-    def _step_occurrences(workflow: Any) -> List[tuple]:
-        """Each step-family reference below a workflow, with the branch-qualified
-        link key it was pinned under: (link_kind, link_key, ref_type, ref_id, object).
-
-        Mirrors the save traversal and Step.from_dict's key rule: a step's key
-        is its step_id (or name) plus one ``#else`` per enclosing else branch.
-        The same child id can appear on several branches at different pinned
-        versions, so each occurrence carries its own key instead of collapsing
-        by id."""
-        from agno.workflow.condition import Condition
-        from agno.workflow.loop import Loop
-        from agno.workflow.parallel import Parallel
-        from agno.workflow.router import Router
-        from agno.workflow.step import Step
-        from agno.workflow.steps import Steps
-
-        found: List[tuple] = []
-
-        def walk(step: Any, suffix: str) -> None:
-            if isinstance(step, Step):
-                key_base = getattr(step, "step_id", None) or getattr(step, "name", None)
-                qualified = f"{key_base}{suffix}" if key_base else None
-                agent = getattr(step, "agent", None)
-                if agent is not None:
-                    found.append(("step_agent", qualified, "agent", getattr(agent, "id", None), agent))
-                team = getattr(step, "team", None)
-                if team is not None:
-                    found.append(("step_team", qualified, "team", getattr(team, "id", None), team))
-                nested_workflow = getattr(step, "workflow", None)
-                if nested_workflow is not None:
-                    found.append(
-                        ("step_workflow", qualified, "workflow", getattr(nested_workflow, "id", None), nested_workflow)
-                    )
-                return
-            if isinstance(step, (Parallel, Loop, Steps, Condition)):
-                for nested in getattr(step, "steps", None) or []:
-                    walk(nested, suffix)
-                for nested in getattr(step, "else_steps", None) or []:
-                    walk(nested, f"{suffix}#else")
-                return
-            if isinstance(step, Router):
-                for nested in getattr(step, "choices", None) or []:
-                    walk(nested, suffix)
-                return
-            # A bare component used directly as a step has no Step wrapper and
-            # no link key; it still has to be checked, under the id-level rule.
-            kind = StudioRunnerTools._component_kind(step)
-            if kind in ("agent", "team", "workflow") and isinstance(getattr(step, "id", None), str):
-                link_kind = {"agent": "step_agent", "team": "step_team", "workflow": "step_workflow"}[kind]
-                found.append((link_kind, None, kind, step.id, step))
-
-        steps = getattr(workflow, "steps", None)
-        for step in steps if isinstance(steps, list) else []:
-            walk(step, "")
-        return found
-
-    @staticmethod
-    def _occurrence_pin(
-        links: List[Dict[str, Any]], link_kind: str, link_key: Optional[str], child_id: str
-    ) -> Optional[int]:
-        """The version pinned for one step occurrence.
-
-        The exact branch-qualified key wins; without an exact match the
-        id-level pin applies only when every pin for the child agrees - the
-        same resolution rule Step.from_dict rebuilds with, so the version
-        checked is the version the object was built from."""
-        child_links = [
-            link for link in links if link.get("link_kind") == link_kind and link.get("child_component_id") == child_id
-        ]
-        if not child_links:
-            return None
-        for link in child_links:
-            if link_key is not None and link.get("link_key") == link_key:
-                return link.get("child_version")
-        versions = {link.get("child_version") for link in child_links}
-        if len(versions) == 1:
-            return child_links[0].get("child_version")
-        return None
-
-    @staticmethod
     def _components_by_id(node: Any) -> Dict[tuple, Any]:
         """The rebuilt members and step executors below a component, by (type, id).
 
@@ -1432,6 +1662,51 @@ class StudioRunnerTools(Toolkit):
         return found
 
     @staticmethod
+    def _components_by_reference(component_type: str, node: Any) -> Dict[tuple, List[Any]]:
+        """Direct serialized references grouped by typed id and occurrence.
+
+        A workflow may reference two different versions of the same component.
+        Keep every occurrence so each serialized reference can be compared with
+        the runtime object reconstructed for that occurrence. Do not descend
+        into an executor's own graph here: recursion validates that graph against
+        the executor's config, and mixing its descendants into the parent's
+        occurrence list pairs unrelated references.
+        """
+        found: Dict[tuple, List[Any]] = {}
+
+        def add(component: Any) -> None:
+            if not StudioRunnerTools._is_executor(component):
+                return
+            component_id = getattr(component, "id", None)
+            if not isinstance(component_id, str):
+                return
+            found.setdefault((StudioRunnerTools._component_kind(component), component_id), []).append(component)
+
+        if component_type == "team":
+            members = getattr(node, "members", None)
+            for member in members if isinstance(members, list) else []:
+                add(member)
+            return found
+        if component_type != "workflow":
+            return found
+
+        def walk(steps: Any) -> None:
+            for step in StudioRunnerTools._branch_items(steps):
+                if StudioRunnerTools._is_executor(step):
+                    add(step)
+                    continue
+                for attribute in ("agent", "team", "workflow"):
+                    executor = getattr(step, attribute, None)
+                    if executor is not None:
+                        add(executor)
+                        break
+                for attribute in ("steps", "else_steps", "choices"):
+                    walk(getattr(step, attribute, None))
+
+        walk(getattr(node, "steps", None))
+        return found
+
+    @staticmethod
     def _unresolved_below(node: Any, depth: int = 0, seen: Optional[set] = None) -> Optional[str]:
         """The first nested member or step executor holding a tool with no
         entrypoint, or None when the graph below is intact.
@@ -1443,7 +1718,7 @@ class StudioRunnerTools(Toolkit):
         tools. Depth- and cycle-capped, over objects already in memory."""
         from agno.tools.function import Function
 
-        if node is None or depth > _GRAPH_DEPTH_CAP:
+        if node is None or depth > _GRAPH_MAX_DEPTH:
             return None
         seen = set() if seen is None else seen
         if id(node) in seen:
@@ -1677,7 +1952,7 @@ class StudioRunnerTools(Toolkit):
         _shared_member applies: a member with no deep_copy is shared by design,
         because a remote proxy holds no per-run state to isolate. The node the
         search starts from is judged without that exemption."""
-        if node is None or depth > _GRAPH_DEPTH_CAP:
+        if node is None or depth > _GRAPH_MAX_DEPTH:
             return None
         is_shared = any(node is instance for instance in shared)
         if is_shared and (depth == 0 or callable(getattr(node, "deep_copy", None))):
@@ -1764,14 +2039,26 @@ class StudioRunnerTools(Toolkit):
     ) -> Optional["Agent"]:
         """Load an agent from DB via config + from_dict.
 
-        Registry-backed references resolve at their current published version."""
+        Registry-backed resources resolve through the live Registry; dispatch
+        refuses the component when a required resource cannot be restored."""
         from agno.db.base import ComponentType
 
-        loaded = self._load_config_row_from_db(agent_id, version=version, component_type=ComponentType.AGENT)
+        loaded = self._load_config_row_from_db(
+            agent_id,
+            version=version,
+            component_type=ComponentType.AGENT,
+            current_only=for_dispatch and version is None,
+        )
         if loaded is None:
             return None
         config, resolved_version = loaded
-        self._require_registry_for("agent", agent_id, config, version=resolved_version)
+        self._require_registry_for(
+            "agent",
+            agent_id,
+            config,
+            version=resolved_version,
+            require_typed_registry=for_dispatch,
+        )
         from agno.agent.agent import Agent
 
         try:
@@ -1802,7 +2089,7 @@ class StudioRunnerTools(Toolkit):
                 version=resolved_version,
             ) from rehydration_error
         except Exception:
-            logger.warning("StudioRunnerTools: Agent.from_dict failed for %s", agent_id, exc_info=True)
+            logger.warning("StudioRunnerTools: Agent.from_dict failed for %s", agent_id)
             return None
         if for_dispatch:
             self._require_dispatchable(agent, config, "agent", agent_id, version=resolved_version)
@@ -1813,7 +2100,12 @@ class StudioRunnerTools(Toolkit):
     ) -> Optional["Team"]:
         from agno.db.base import ComponentType
 
-        loaded = self._load_config_row_from_db(team_id, version=version, component_type=ComponentType.TEAM)
+        loaded = self._load_config_row_from_db(
+            team_id,
+            version=version,
+            component_type=ComponentType.TEAM,
+            current_only=for_dispatch and version is None,
+        )
         if loaded is None:
             return None
         config, resolved_version = loaded
@@ -1821,7 +2113,13 @@ class StudioRunnerTools(Toolkit):
             # Dispatch only: a null reference cannot be resolved, but the component
             # still has to load so the bad reference can be seen and repaired.
             self._require_resolvable_member_ids("team", team_id, config)
-        self._require_registry_for("team", team_id, config, version=resolved_version)
+        self._require_registry_for(
+            "team",
+            team_id,
+            config,
+            version=resolved_version,
+            require_typed_registry=for_dispatch,
+        )
         from agno.team.team import Team
 
         links = self._load_links_from_db(team_id, version=resolved_version)
@@ -1852,7 +2150,7 @@ class StudioRunnerTools(Toolkit):
                 version=resolved_version,
             ) from rehydration_error
         except Exception:
-            logger.warning("StudioRunnerTools: Team.from_dict failed for %s", team_id, exc_info=True)
+            logger.warning("StudioRunnerTools: Team.from_dict failed for %s", team_id)
             return None
         if for_dispatch:
             self._require_dispatchable(team, config, "team", team_id, version=resolved_version)
@@ -1863,7 +2161,12 @@ class StudioRunnerTools(Toolkit):
     ) -> Optional["Workflow"]:
         from agno.db.base import ComponentType
 
-        loaded = self._load_config_row_from_db(workflow_id, version=version, component_type=ComponentType.WORKFLOW)
+        loaded = self._load_config_row_from_db(
+            workflow_id,
+            version=version,
+            component_type=ComponentType.WORKFLOW,
+            current_only=for_dispatch and version is None,
+        )
         if loaded is None:
             return None
         config, resolved_version = loaded
@@ -1871,7 +2174,13 @@ class StudioRunnerTools(Toolkit):
             # Dispatch only: a null reference cannot be resolved, but the component
             # still has to load so the bad reference can be seen and repaired.
             self._require_resolvable_member_ids("workflow", workflow_id, config)
-        self._require_registry_for("workflow", workflow_id, config, version=resolved_version)
+        self._require_registry_for(
+            "workflow",
+            workflow_id,
+            config,
+            version=resolved_version,
+            require_typed_registry=for_dispatch,
+        )
         from agno.workflow.workflow import Workflow
 
         links = self._load_links_from_db(workflow_id, version=resolved_version)
@@ -1902,7 +2211,7 @@ class StudioRunnerTools(Toolkit):
                 version=resolved_version,
             ) from rehydration_error
         except Exception:
-            logger.warning("StudioRunnerTools: Workflow.from_dict failed for %s", workflow_id, exc_info=True)
+            logger.warning("StudioRunnerTools: Workflow.from_dict failed for %s", workflow_id)
             return None
         if for_dispatch:
             self._require_dispatchable(wf, config, "workflow", workflow_id, version=resolved_version)
@@ -1923,6 +2232,8 @@ class StudioRunnerTools(Toolkit):
         component_id: str,
         version: Optional[int] = None,
         component_type: Optional["ComponentType"] = None,
+        *,
+        current_only: bool = False,
     ) -> Optional[Tuple[Dict[str, Any], Optional[int]]]:
         """Load a component's config and its resolved version in one read.
 
@@ -1942,7 +2253,10 @@ class StudioRunnerTools(Toolkit):
                 and self.db.get_component(component_id, component_type=component_type) is None
             ):
                 return None
-            row = self.db.get_config(component_id=component_id, version=version)
+            if version is None and current_only:
+                row = self.db.get_current_config(component_id)
+            else:
+                row = self.db.get_config(component_id=component_id, version=version)
         except NotImplementedError:
             # Not every db adapter implements component storage; treat the
             # component as absent so code-defined resolution still works.
@@ -1966,7 +2280,7 @@ class StudioRunnerTools(Toolkit):
             return []
         try:
             if version is None:
-                row = self.db.get_config(component_id=component_id)
+                row = self.db.get_current_config(component_id)
                 version = row.get("version") if isinstance(row, dict) else None
             if not version:
                 return []
@@ -2045,6 +2359,18 @@ class StudioRunnerTools(Toolkit):
         """
         return self._list_payload("workflow", "workflows")
 
+    @staticmethod
+    def _unexpected_failure(action: str) -> str:
+        """Return a stable failure without exposing backend exception text.
+
+        Database drivers and component runtimes may include DSNs, credentials,
+        private payloads, or provider responses in exception messages. Keep the
+        operation-level signal in logs and reserve detailed, caller-facing
+        messages for deliberate ``StudioRunnerError`` refusals.
+        """
+        logger.error("StudioRunnerTools could not %s", action)
+        return json.dumps({"error": f"StudioRunnerTools could not {action}."})
+
     def _list_payload(self, component_type: str, key: str) -> str:
         admitted = self._admitted_code_components(component_type)
         if self.db is None:
@@ -2068,9 +2394,8 @@ class StudioRunnerTools(Toolkit):
             # A code component shadows the stored one it shares an id with, so
             # the pair is one component to run, not two to count.
             return json.dumps({key: items, "count": len(items), "total": total + len(admitted) - shadowed})
-        except Exception as e:
-            logger.exception("Failed to list %s", key)
-            return json.dumps({"error": str(e) or type(e).__name__})
+        except Exception:
+            return self._unexpected_failure(f"list {key}")
 
     def _admitted_code_components(self, component_type: str) -> List[Dict[str, Any]]:
         """The code-defined components this runner will dispatch, as list rows.
@@ -2114,7 +2439,7 @@ class StudioRunnerTools(Toolkit):
         plus the run_id and session_id a continue call must address.
 
         Args:
-            agent_id (str): Id of the agent to run (a display name or its slug also resolves).
+            agent_id (str): Exact agent id, or an exact display name.
             message (str): The message to send.
 
         Returns:
@@ -2126,23 +2451,26 @@ class StudioRunnerTools(Toolkit):
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
-        except Exception as e:
-            logger.exception("Failed to resolve agent")
-            return json.dumps({"error": f"Failed to resolve agent '{agent_id}': {str(e) or type(e).__name__}"})
+        except Exception:
+            return self._unexpected_failure("resolve agent")
         if agent is None:
             return json.dumps({"error": f"Agent not found: {agent_id}"})
         component_id = getattr(agent, "id", None) or agent_id
         try:
+            user_id = self._caller_user_id(_agno_run_context, agent)
+            session_id = self._sub_session_id(_agno_run_context, "agent", component_id)
+        except StudioRunnerError as e:
+            return json.dumps({"error": str(e)})
+        try:
             response = agent.run(
                 message,
                 stream=False,
-                user_id=self._caller_user_id(_agno_run_context, agent),
-                session_id=self._sub_session_id(_agno_run_context, "agent", component_id),
+                user_id=user_id,
+                session_id=session_id,
             )
             return self._run_payload("agent_id", component_id, response)
-        except Exception as e:
-            logger.exception("Failed to run agent")
-            return json.dumps({"error": str(e) or type(e).__name__})
+        except Exception:
+            return self._unexpected_failure("run agent")
 
     def run_team(self, team_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
         """Run a team and return its result.
@@ -2153,7 +2481,7 @@ class StudioRunnerTools(Toolkit):
         plus the run_id and session_id a continue call must address.
 
         Args:
-            team_id (str): Id of the team to run (a display name or its slug also resolves).
+            team_id (str): Exact team id, or an exact display name.
             message (str): The message to send.
 
         Returns:
@@ -2165,23 +2493,26 @@ class StudioRunnerTools(Toolkit):
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
-        except Exception as e:
-            logger.exception("Failed to resolve team")
-            return json.dumps({"error": f"Failed to resolve team '{team_id}': {str(e) or type(e).__name__}"})
+        except Exception:
+            return self._unexpected_failure("resolve team")
         if team is None:
             return json.dumps({"error": f"Team not found: {team_id}"})
         component_id = getattr(team, "id", None) or team_id
         try:
+            user_id = self._caller_user_id(_agno_run_context, team)
+            session_id = self._sub_session_id(_agno_run_context, "team", component_id)
+        except StudioRunnerError as e:
+            return json.dumps({"error": str(e)})
+        try:
             response = team.run(
                 message,
                 stream=False,
-                user_id=self._caller_user_id(_agno_run_context, team),
-                session_id=self._sub_session_id(_agno_run_context, "team", component_id),
+                user_id=user_id,
+                session_id=session_id,
             )
             return self._run_payload("team_id", component_id, response)
-        except Exception as e:
-            logger.exception("Failed to run team")
-            return json.dumps({"error": str(e) or type(e).__name__})
+        except Exception:
+            return self._unexpected_failure("run team")
 
     def run_workflow(self, workflow_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
         """Run a workflow and return its final result.
@@ -2192,7 +2523,7 @@ class StudioRunnerTools(Toolkit):
         requirements plus the run_id and session_id a continue call must address.
 
         Args:
-            workflow_id (str): Id of the workflow to run (a display name or its slug also resolves).
+            workflow_id (str): Exact workflow id, or an exact display name.
             message (str): Input to pass to the first step.
 
         Returns:
@@ -2204,29 +2535,32 @@ class StudioRunnerTools(Toolkit):
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
-        except Exception as e:
-            logger.exception("Failed to resolve workflow")
-            return json.dumps({"error": f"Failed to resolve workflow '{workflow_id}': {str(e) or type(e).__name__}"})
+        except Exception:
+            return self._unexpected_failure("resolve workflow")
         if wf is None:
             return json.dumps({"error": f"Workflow not found: {workflow_id}"})
         component_id = getattr(wf, "id", None) or workflow_id
         try:
+            user_id = self._caller_user_id(_agno_run_context, wf)
+            session_id = self._sub_session_id(_agno_run_context, "workflow", component_id)
+        except StudioRunnerError as e:
+            return json.dumps({"error": str(e)})
+        try:
             response = wf.run(
                 input=message,
                 stream=False,
-                user_id=self._caller_user_id(_agno_run_context, wf),
-                session_id=self._sub_session_id(_agno_run_context, "workflow", component_id),
+                user_id=user_id,
+                session_id=session_id,
             )
             return self._run_payload("workflow_id", component_id, response)
-        except Exception as e:
-            logger.exception("Failed to run workflow")
-            return json.dumps({"error": str(e) or type(e).__name__})
+        except Exception:
+            return self._unexpected_failure("run workflow")
 
     async def arun_agent(self, agent_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
         """Async variant of run_agent.
 
         Args:
-            agent_id (str): Id of the agent to run (a display name or its slug also resolves).
+            agent_id (str): Exact agent id, or an exact display name.
             message (str): The message to send.
         """
         # Resolution hits the DB synchronously; keep it off the event loop.
@@ -2235,29 +2569,32 @@ class StudioRunnerTools(Toolkit):
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
-        except Exception as e:
-            logger.exception("Failed to resolve agent")
-            return json.dumps({"error": f"Failed to resolve agent '{agent_id}': {str(e) or type(e).__name__}"})
+        except Exception:
+            return self._unexpected_failure("resolve agent")
         if agent is None:
             return json.dumps({"error": f"Agent not found: {agent_id}"})
         component_id = getattr(agent, "id", None) or agent_id
         try:
+            user_id = self._caller_user_id(_agno_run_context, agent)
+            session_id = self._sub_session_id(_agno_run_context, "agent", component_id)
+        except StudioRunnerError as e:
+            return json.dumps({"error": str(e)})
+        try:
             response = await agent.arun(
                 message,
                 stream=False,
-                user_id=self._caller_user_id(_agno_run_context, agent),
-                session_id=self._sub_session_id(_agno_run_context, "agent", component_id),
+                user_id=user_id,
+                session_id=session_id,
             )
             return self._run_payload("agent_id", component_id, response)
-        except Exception as e:
-            logger.exception("Failed to run agent")
-            return json.dumps({"error": str(e) or type(e).__name__})
+        except Exception:
+            return self._unexpected_failure("run agent")
 
     async def arun_team(self, team_id: str, message: str, _agno_run_context: Optional[RunContext] = None) -> str:
         """Async variant of run_team.
 
         Args:
-            team_id (str): Id of the team to run (a display name or its slug also resolves).
+            team_id (str): Exact team id, or an exact display name.
             message (str): The message to send.
         """
         try:
@@ -2265,23 +2602,26 @@ class StudioRunnerTools(Toolkit):
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
-        except Exception as e:
-            logger.exception("Failed to resolve team")
-            return json.dumps({"error": f"Failed to resolve team '{team_id}': {str(e) or type(e).__name__}"})
+        except Exception:
+            return self._unexpected_failure("resolve team")
         if team is None:
             return json.dumps({"error": f"Team not found: {team_id}"})
         component_id = getattr(team, "id", None) or team_id
         try:
+            user_id = self._caller_user_id(_agno_run_context, team)
+            session_id = self._sub_session_id(_agno_run_context, "team", component_id)
+        except StudioRunnerError as e:
+            return json.dumps({"error": str(e)})
+        try:
             response = await team.arun(
                 message,
                 stream=False,
-                user_id=self._caller_user_id(_agno_run_context, team),
-                session_id=self._sub_session_id(_agno_run_context, "team", component_id),
+                user_id=user_id,
+                session_id=session_id,
             )
             return self._run_payload("team_id", component_id, response)
-        except Exception as e:
-            logger.exception("Failed to run team")
-            return json.dumps({"error": str(e) or type(e).__name__})
+        except Exception:
+            return self._unexpected_failure("run team")
 
     async def arun_workflow(
         self, workflow_id: str, message: str, _agno_run_context: Optional[RunContext] = None
@@ -2289,7 +2629,7 @@ class StudioRunnerTools(Toolkit):
         """Async variant of run_workflow.
 
         Args:
-            workflow_id (str): Id of the workflow to run (a display name or its slug also resolves).
+            workflow_id (str): Exact workflow id, or an exact display name.
             message (str): Input to pass to the first step.
         """
         try:
@@ -2297,23 +2637,26 @@ class StudioRunnerTools(Toolkit):
         except StudioRunnerError as e:
             # Deliberate refusals with an actionable message; not failures to log.
             return json.dumps({"error": str(e)})
-        except Exception as e:
-            logger.exception("Failed to resolve workflow")
-            return json.dumps({"error": f"Failed to resolve workflow '{workflow_id}': {str(e) or type(e).__name__}"})
+        except Exception:
+            return self._unexpected_failure("resolve workflow")
         if wf is None:
             return json.dumps({"error": f"Workflow not found: {workflow_id}"})
         component_id = getattr(wf, "id", None) or workflow_id
         try:
+            user_id = self._caller_user_id(_agno_run_context, wf)
+            session_id = self._sub_session_id(_agno_run_context, "workflow", component_id)
+        except StudioRunnerError as e:
+            return json.dumps({"error": str(e)})
+        try:
             response = await wf.arun(
                 input=message,
                 stream=False,
-                user_id=self._caller_user_id(_agno_run_context, wf),
-                session_id=self._sub_session_id(_agno_run_context, "workflow", component_id),
+                user_id=user_id,
+                session_id=session_id,
             )
             return self._run_payload("workflow_id", component_id, response)
-        except Exception as e:
-            logger.exception("Failed to run workflow")
-            return json.dumps({"error": str(e) or type(e).__name__})
+        except Exception:
+            return self._unexpected_failure("run workflow")
 
     async def alist_agents(self) -> str:
         """Async variant of list_agents."""
@@ -2383,7 +2726,7 @@ class StudioRunnerTools(Toolkit):
             try:
                 content = run_output.get_content_as_string()
             except Exception:
-                logger.warning("StudioRunnerTools: get_content_as_string failed; returning raw content", exc_info=True)
+                logger.warning("StudioRunnerTools: get_content_as_string failed; returning raw content")
         payload: Dict[str, Any] = {
             id_key: component_id,
             "run_id": getattr(run_output, "run_id", None),

--- a/libs/agno/agno/tools/studio_schema.py
+++ b/libs/agno/agno/tools/studio_schema.py
@@ -1,0 +1,598 @@
+"""Typed public request and response models for Studio tools."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Generic, Literal, TypeVar, Union
+
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, StringConstraints, model_validator
+
+
+def _require_nonblank(value: str) -> str:
+    if not value.strip():
+        raise ValueError("Value must contain at least one non-whitespace character")
+    return value
+
+
+NonBlankString = Annotated[
+    str,
+    StringConstraints(min_length=1),
+    AfterValidator(_require_nonblank),
+]
+ComponentId = Annotated[
+    str,
+    StringConstraints(min_length=1, pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$"),
+]
+
+
+class StudioSchema(BaseModel):
+    """Base model for the public Studio contract."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, validate_default=True)
+
+
+class ModelRef(StudioSchema):
+    """Reference to a model registered with AgentOS."""
+
+    id: NonBlankString = Field(description="Exact model id returned by list_models.")
+    provider: NonBlankString | None = Field(
+        default=None,
+        description="Registered provider used to disambiguate models that share an id.",
+    )
+    name: NonBlankString | None = Field(
+        default=None,
+        description="Registered model name used for final disambiguation.",
+    )
+
+
+class ToolRef(StudioSchema):
+    """Reference to a whole toolkit or one registered function."""
+
+    kind: Literal["toolkit", "function"] = Field(description="Kind of registry entry to attach.")
+    name: NonBlankString = Field(description="Exact toolkit or function name returned by list_tools.")
+    toolkit: NonBlankString | None = Field(
+        default=None,
+        description="Owning toolkit when selecting one function from a toolkit.",
+    )
+
+    @model_validator(mode="after")
+    def validate_toolkit_qualifier(self) -> "ToolRef":
+        if self.kind == "toolkit" and self.toolkit is not None:
+            raise ValueError("'toolkit' is only valid when kind='function'")
+        return self
+
+
+class FunctionRef(StudioSchema):
+    """Summary of a registered function available to workflow steps."""
+
+    name: NonBlankString = Field(description="Exact registered function name used by a function workflow step.")
+    description: str | None = Field(default=None, description="Registered function documentation, when available.")
+
+
+class ContextPolicy(StudioSchema):
+    """Context behavior for a Studio-created agent or team."""
+
+    include_history: bool = Field(default=True, description="Include prior runs from the current session.")
+    history_runs: int | None = Field(
+        default=None,
+        ge=1,
+        description="Number of prior runs to include, or null to use the Studio default.",
+    )
+    include_datetime: bool = Field(default=True, description="Include the current date and time in context.")
+
+    @model_validator(mode="after")
+    def validate_history_policy(self) -> "ContextPolicy":
+        if not self.include_history and self.history_runs is not None:
+            raise ValueError("'history_runs' cannot be set when history is disabled")
+        return self
+
+
+class ContextPolicyPatch(StudioSchema):
+    """Omission-aware patch for context behavior."""
+
+    include_history: bool | None = Field(
+        default=None,
+        description="Set whether prior runs are included; omit to preserve the current value.",
+    )
+    history_runs: int | None = Field(
+        default=None,
+        ge=1,
+        description="Set history depth, use null to reset to the Studio default, or omit to preserve it.",
+    )
+    include_datetime: bool | None = Field(
+        default=None,
+        description="Set whether current date and time are included; omit to preserve the current value.",
+    )
+
+    @model_validator(mode="after")
+    def validate_patch(self) -> "ContextPolicyPatch":
+        if not self.model_fields_set:
+            raise ValueError("Context patch must contain at least one field")
+        for field_name in ("include_history", "include_datetime"):
+            if field_name in self.model_fields_set and getattr(self, field_name) is None:
+                raise ValueError(f"'{field_name}' cannot be set to null")
+        if self.include_history is False and "history_runs" in self.model_fields_set and self.history_runs is not None:
+            raise ValueError("'history_runs' cannot be set when history is disabled")
+        return self
+
+
+class ComponentRef(StudioSchema):
+    """Reference to a versioned agent or team component."""
+
+    component_type: Literal["agent", "team"] = Field(description="Exact type of the referenced component.")
+    component_id: ComponentId = Field(description="Exact path-safe component id returned by Studio discovery.")
+    version: int | None = Field(
+        default=None,
+        ge=1,
+        description="Pinned component version, or null to resolve the current published version.",
+    )
+
+
+def _validate_unique_member_ids(members: list[ComponentRef]) -> None:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for member in members:
+        if member.component_id in seen:
+            duplicates.add(member.component_id)
+        seen.add(member.component_id)
+    if duplicates:
+        duplicate_list = ", ".join(sorted(duplicates))
+        raise ValueError(f"Team members must have unique component_id values; duplicates: {duplicate_list}")
+
+
+class AgentCreate(StudioSchema):
+    """Declarative request for creating an agent component."""
+
+    component_id: ComponentId | None = Field(
+        default=None,
+        description="Stable path-safe component id; deterministically derived from name when omitted.",
+    )
+    name: NonBlankString = Field(description="Human-readable agent name.")
+    instructions: NonBlankString = Field(description="Instructions that define the agent's behavior.")
+    description: str | None = Field(default=None, description="Optional concise purpose shown in Studio discovery.")
+    model: ModelRef | None = Field(default=None, description="Model reference, or null to use the Studio default.")
+    tools: list[ToolRef] = Field(default_factory=list, description="Exact registered tools available to the agent.")
+    context: ContextPolicy | None = Field(default=None, description="Context policy, or null to use Studio defaults.")
+    if_exists: Literal["error", "return_existing"] = Field(
+        default="error",
+        description="Create policy: reject an occupied id, or return an identical existing component.",
+    )
+
+
+class AgentPatch(StudioSchema):
+    """Omission-aware patch for an agent component.
+
+    Explicit null clears ``description`` and resets ``model`` to the Studio
+    default. An empty list clears ``tools``. Other fields reject explicit null.
+    """
+
+    name: NonBlankString | None = Field(default=None, description="Replacement agent name; omit to preserve it.")
+    instructions: NonBlankString | None = Field(
+        default=None,
+        description="Replacement agent instructions; omit to preserve them.",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Replacement description, explicit null to clear, or omit to preserve it.",
+    )
+    model: ModelRef | None = Field(
+        default=None,
+        description="Replacement model, explicit null to reset to the Studio default, or omit to preserve it.",
+    )
+    tools: list[ToolRef] | None = Field(
+        default=None,
+        description="Replacement tool list, an empty list to clear, or omit to preserve it.",
+    )
+    context: ContextPolicyPatch | None = Field(
+        default=None,
+        description="Context changes to apply; omit to preserve the current policy.",
+    )
+
+    @model_validator(mode="after")
+    def validate_patch(self) -> "AgentPatch":
+        if not self.model_fields_set:
+            raise ValueError("Agent patch must contain at least one field")
+        for field_name in ("name", "instructions", "tools", "context"):
+            if field_name in self.model_fields_set and getattr(self, field_name) is None:
+                raise ValueError(f"'{field_name}' cannot be set to null")
+        return self
+
+
+class TeamCreate(StudioSchema):
+    """Declarative request for creating a team component."""
+
+    component_id: ComponentId | None = Field(
+        default=None,
+        description="Stable path-safe component id; deterministically derived from name when omitted.",
+    )
+    name: NonBlankString = Field(description="Human-readable team name.")
+    instructions: NonBlankString = Field(description="Instructions that define how the team collaborates.")
+    members: list[ComponentRef] = Field(
+        min_length=1,
+        description="Ordered agent or team references; stored references resolve to exact published versions.",
+    )
+    description: str | None = Field(default=None, description="Optional concise purpose shown in Studio discovery.")
+    model: ModelRef | None = Field(default=None, description="Model reference, or null to use the Studio default.")
+    context: ContextPolicy | None = Field(default=None, description="Context policy, or null to use Studio defaults.")
+    if_exists: Literal["error", "return_existing"] = Field(
+        default="error",
+        description="Create policy: reject an occupied id, or return an identical existing component.",
+    )
+
+    @model_validator(mode="after")
+    def validate_unique_members(self) -> "TeamCreate":
+        _validate_unique_member_ids(self.members)
+        return self
+
+
+class TeamPatch(StudioSchema):
+    """Omission-aware patch for a team component."""
+
+    name: NonBlankString | None = Field(default=None, description="Replacement team name; omit to preserve it.")
+    instructions: NonBlankString | None = Field(
+        default=None,
+        description="Replacement team instructions; omit to preserve them.",
+    )
+    members: list[ComponentRef] | None = Field(
+        default=None,
+        min_length=1,
+        description="Replacement ordered member list; omit to preserve current members.",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Replacement description, explicit null to clear, or omit to preserve it.",
+    )
+    model: ModelRef | None = Field(
+        default=None,
+        description="Replacement model, explicit null to reset to the Studio default, or omit to preserve it.",
+    )
+    context: ContextPolicyPatch | None = Field(
+        default=None,
+        description="Context changes to apply; omit to preserve the current policy.",
+    )
+
+    @model_validator(mode="after")
+    def validate_patch(self) -> "TeamPatch":
+        if not self.model_fields_set:
+            raise ValueError("Team patch must contain at least one field")
+        for field_name in ("name", "instructions", "members", "context"):
+            if field_name in self.model_fields_set and getattr(self, field_name) is None:
+                raise ValueError(f"'{field_name}' cannot be set to null")
+        if self.members is not None:
+            _validate_unique_member_ids(self.members)
+        return self
+
+
+class AgentWorkflowStep(StudioSchema):
+    """Workflow step executed by an agent component."""
+
+    kind: Literal["agent"] = Field(description="Discriminator selecting an agent-backed step.")
+    step_id: NonBlankString | None = Field(
+        default=None,
+        description="Stable step id; deterministically derived from name and position when omitted.",
+    )
+    name: NonBlankString = Field(description="Human-readable name for this workflow step.")
+    component_id: ComponentId = Field(description="Exact agent component id returned by Studio discovery.")
+    version: int | None = Field(
+        default=None,
+        ge=1,
+        description="Exact published agent version, or null to resolve the current published version.",
+    )
+    description: str | None = Field(default=None, description="Optional explanation of this step's purpose.")
+
+
+class TeamWorkflowStep(StudioSchema):
+    """Workflow step executed by a team component."""
+
+    kind: Literal["team"] = Field(description="Discriminator selecting a team-backed step.")
+    step_id: NonBlankString | None = Field(
+        default=None,
+        description="Stable step id; deterministically derived from name and position when omitted.",
+    )
+    name: NonBlankString = Field(description="Human-readable name for this workflow step.")
+    component_id: ComponentId = Field(description="Exact team component id returned by Studio discovery.")
+    version: int | None = Field(
+        default=None,
+        ge=1,
+        description="Exact published team version, or null to resolve the current published version.",
+    )
+    description: str | None = Field(default=None, description="Optional explanation of this step's purpose.")
+
+
+class FunctionWorkflowStep(StudioSchema):
+    """Workflow step executed by a registered function."""
+
+    kind: Literal["function"] = Field(description="Discriminator selecting a registered-function step.")
+    step_id: NonBlankString | None = Field(
+        default=None,
+        description="Stable step id; deterministically derived from name and position when omitted.",
+    )
+    name: NonBlankString = Field(description="Human-readable name for this workflow step.")
+    function_name: NonBlankString = Field(description="Exact unique function name returned by list_functions.")
+    description: str | None = Field(default=None, description="Optional explanation of this step's purpose.")
+
+
+WorkflowStep = Annotated[
+    Union[AgentWorkflowStep, TeamWorkflowStep, FunctionWorkflowStep],
+    Field(discriminator="kind"),
+]
+
+
+class WorkflowCreate(StudioSchema):
+    """Declarative request for creating a workflow component."""
+
+    component_id: ComponentId | None = Field(
+        default=None,
+        description="Stable path-safe component id; deterministically derived from name when omitted.",
+    )
+    name: NonBlankString = Field(description="Human-readable workflow name.")
+    description: str | None = Field(default=None, description="Optional concise purpose shown in Studio discovery.")
+    steps: list[WorkflowStep] = Field(
+        min_length=1,
+        description="Ordered discriminated steps executed by the workflow.",
+    )
+    if_exists: Literal["error", "return_existing"] = Field(
+        default="error",
+        description="Create policy: reject an occupied id, or return an identical existing component.",
+    )
+
+
+class WorkflowPatch(StudioSchema):
+    """Omission-aware patch for a workflow component."""
+
+    name: NonBlankString | None = Field(default=None, description="Replacement workflow name; omit to preserve it.")
+    description: str | None = Field(
+        default=None,
+        description="Replacement description, explicit null to clear, or omit to preserve it.",
+    )
+    steps: list[WorkflowStep] | None = Field(
+        default=None,
+        min_length=1,
+        description="Replacement ordered steps; omit to preserve the current workflow.",
+    )
+
+    @model_validator(mode="after")
+    def validate_patch(self) -> "WorkflowPatch":
+        if not self.model_fields_set:
+            raise ValueError("Workflow patch must contain at least one field")
+        for field_name in ("name", "steps"):
+            if field_name in self.model_fields_set and getattr(self, field_name) is None:
+                raise ValueError(f"'{field_name}' cannot be set to null")
+        return self
+
+
+ComponentStage = Literal["draft", "published", "code"]
+ComponentSource = Literal["studio", "code"]
+
+
+class ComponentSummary(StudioSchema):
+    """Compact component projection used by Studio discovery tools."""
+
+    component_id: ComponentId | None = Field(
+        default=None,
+        description="Exact component id, or null when a code-defined component has no stable id.",
+    )
+    component_type: Literal["agent", "team", "workflow"] = Field(description="Component runtime type.")
+    name: NonBlankString = Field(description="Human-readable component name.")
+    source: ComponentSource = Field(description="Whether the component is stored by Studio or defined in code.")
+    latest_version: int | None = Field(
+        default=None,
+        ge=1,
+        description="Latest edit-head version used for optimistic concurrency, or null for code source.",
+    )
+    latest_stage: ComponentStage = Field(description="Lifecycle stage of the latest stored version.")
+    current_version: int | None = Field(
+        default=None,
+        ge=1,
+        description="Published dispatch version, or null when no stored version is current.",
+    )
+
+
+class VersionSummary(StudioSchema):
+    """Compact metadata for one stored component version."""
+
+    version: int = Field(ge=1, description="Immutable component version number.")
+    stage: Literal["draft", "published"] = Field(description="Lifecycle stage of this version.")
+    label: NonBlankString | None = Field(default=None, description="Optional stored version label.")
+    is_current: bool = Field(description="Whether this published version is the current dispatch target.")
+    created_at: int | None = Field(default=None, description="Creation timestamp, when recorded by the database.")
+    updated_at: int | None = Field(default=None, description="Last update timestamp, when recorded by the database.")
+
+
+class ComponentActionView(StudioSchema):
+    """Minimal result for a successful component lifecycle action."""
+
+    component_id: ComponentId = Field(description="Exact affected component id.")
+    component_type: Literal["agent", "team", "workflow"] = Field(description="Affected component type.")
+    version: int | None = Field(default=None, ge=1, description="Affected version, when applicable.")
+
+
+class AgentView(StudioSchema):
+    """Safe, model-facing projection of an agent configuration."""
+
+    component_id: ComponentId = Field(description="Exact path-safe agent component id.")
+    component_type: Literal["agent"] = Field(default="agent", description="Agent view discriminator.")
+    name: NonBlankString = Field(description="Human-readable agent name.")
+    instructions: NonBlankString = Field(description="Instructions defining the agent's behavior.")
+    description: str | None = Field(default=None, description="Optional concise purpose.")
+    model: ModelRef = Field(description="Exact resolved model reference.")
+    tools: list[ToolRef] = Field(default_factory=list, description="Exact resolved tool references.")
+    context: ContextPolicy = Field(description="Resolved context policy.")
+    version: int | None = Field(default=None, ge=1, description="Stored version, or null for code source.")
+    stage: ComponentStage = Field(description="Lifecycle stage.")
+    is_current: bool = Field(description="Whether this version is the current dispatch target.")
+    source: ComponentSource = Field(description="Whether this agent is stored by Studio or defined in code.")
+
+
+class TeamView(StudioSchema):
+    """Safe, model-facing projection of a team configuration."""
+
+    component_id: ComponentId = Field(description="Exact path-safe team component id.")
+    component_type: Literal["team"] = Field(default="team", description="Team view discriminator.")
+    name: NonBlankString = Field(description="Human-readable team name.")
+    instructions: NonBlankString = Field(description="Instructions defining team collaboration.")
+    members: list[ComponentRef] = Field(default_factory=list, description="Ordered exact member references.")
+    description: str | None = Field(default=None, description="Optional concise purpose.")
+    model: ModelRef = Field(description="Exact resolved model reference.")
+    context: ContextPolicy = Field(description="Resolved context policy.")
+    version: int | None = Field(default=None, ge=1, description="Stored version, or null for code source.")
+    stage: ComponentStage = Field(description="Lifecycle stage.")
+    is_current: bool = Field(description="Whether this version is the current dispatch target.")
+    source: ComponentSource = Field(description="Whether this team is stored by Studio or defined in code.")
+
+
+class WorkflowView(StudioSchema):
+    """Safe, model-facing projection of a workflow configuration."""
+
+    component_id: ComponentId = Field(description="Exact path-safe workflow component id.")
+    component_type: Literal["workflow"] = Field(default="workflow", description="Workflow view discriminator.")
+    name: NonBlankString = Field(description="Human-readable workflow name.")
+    description: str | None = Field(default=None, description="Optional concise purpose.")
+    steps: list[WorkflowStep] = Field(default_factory=list, description="Ordered discriminated workflow steps.")
+    version: int | None = Field(default=None, ge=1, description="Stored version, or null for code source.")
+    stage: ComponentStage = Field(description="Lifecycle stage.")
+    is_current: bool = Field(description="Whether this version is the current dispatch target.")
+    source: ComponentSource = Field(description="Whether this workflow is stored by Studio or defined in code.")
+
+
+ComponentView = Annotated[
+    Union[AgentView, TeamView, WorkflowView],
+    Field(discriminator="component_type"),
+]
+
+
+ScheduleTargetType = Literal["agent", "team", "workflow"]
+
+
+class ScheduleCreate(StudioSchema):
+    """Declarative request for a Studio-owned component schedule."""
+
+    name: NonBlankString = Field(
+        description="Human-readable schedule name, unique within the authenticated actor's Studio namespace."
+    )
+    cron: NonBlankString = Field(description="Five-field cron expression controlling the recurring cadence.")
+    target_type: ScheduleTargetType = Field(description="Type of published component the schedule dispatches.")
+    target_id: ComponentId = Field(description="Exact published component id the schedule dispatches.")
+    message: NonBlankString = Field(description="Prompt sent to the component whenever the schedule runs.")
+    timezone: NonBlankString = Field(default="UTC", description="IANA timezone used to interpret the cron expression.")
+    description: str | None = Field(default=None, description="Optional concise purpose shown in schedule discovery.")
+
+
+class ScheduleView(StudioSchema):
+    """Safe projection of a Studio-owned schedule without its raw payload."""
+
+    schedule_id: NonBlankString = Field(description="Exact scheduler record id.")
+    name: NonBlankString = Field(description="Human-readable schedule name.")
+    description: str | None = Field(default=None, description="Optional concise purpose.")
+    cron: NonBlankString = Field(description="Five-field cron expression controlling the recurring cadence.")
+    target_type: ScheduleTargetType = Field(description="Type of component dispatched by the schedule.")
+    target_id: ComponentId = Field(description="Exact component id dispatched by the schedule.")
+    timezone: NonBlankString = Field(description="IANA timezone used to interpret the cron expression.")
+    enabled: bool = Field(description="Whether the scheduler may claim this schedule.")
+    next_run_at: int | None = Field(default=None, description="Next planned execution timestamp, when available.")
+    owner_actor_id: NonBlankString = Field(description="Authenticated actor that owns this Studio schedule.")
+    created_at: int | None = Field(default=None, description="Creation timestamp, when recorded by the database.")
+    updated_at: int | None = Field(default=None, description="Last update timestamp, when recorded by the database.")
+
+
+class ScheduleRunView(StudioSchema):
+    """Safe schedule-run projection without raw input, output, errors, or requirements."""
+
+    schedule_run_id: NonBlankString = Field(description="Exact schedule-run record id.")
+    schedule_id: NonBlankString = Field(description="Owning schedule record id.")
+    attempt: int = Field(ge=1, description="One-based execution attempt number.")
+    status: NonBlankString = Field(description="Recorded scheduler execution status.")
+    triggered_at: int | None = Field(default=None, description="Timestamp at which execution started.")
+    completed_at: int | None = Field(default=None, description="Timestamp at which execution completed.")
+    status_code: int | None = Field(default=None, description="Endpoint response status code, when recorded.")
+    component_run_id: NonBlankString | None = Field(
+        default=None, description="Dispatched component run id, when recorded."
+    )
+    session_id: NonBlankString | None = Field(
+        default=None, description="Dispatched component session id, when recorded."
+    )
+    has_error: bool = Field(description="Whether the scheduler recorded an error without exposing its contents.")
+    has_requirements: bool = Field(description="Whether the run recorded pending requirements without exposing them.")
+    created_at: int | None = Field(default=None, description="Creation timestamp, when recorded by the database.")
+
+
+class ScheduleActionView(StudioSchema):
+    """Minimal safe result for a successful schedule lifecycle action."""
+
+    schedule_id: NonBlankString = Field(description="Exact affected schedule id.")
+    name: NonBlankString = Field(description="Human-readable affected schedule name.")
+    target_type: ScheduleTargetType = Field(description="Type of component dispatched by the schedule.")
+    target_id: ComponentId = Field(description="Exact component id dispatched by the schedule.")
+    enabled: bool = Field(description="Schedule enabled state immediately before or after the action.")
+
+
+class StudioError(StudioSchema):
+    """Stable structured error returned by Studio operations."""
+
+    code: NonBlankString = Field(description="Stable machine-readable error code.")
+    message: NonBlankString = Field(description="Safe actionable error message.")
+    details: dict[str, Any] = Field(default_factory=dict, description="Safe structured diagnostic details.")
+    retryable: bool = Field(default=False, description="Whether retrying after refreshing state may succeed.")
+
+
+ResultT = TypeVar("ResultT")
+
+
+class StudioResult(StudioSchema, Generic[ResultT]):
+    """Result envelope containing exactly one typed value or structured error."""
+
+    ok: bool = Field(description="True exactly when data is present and error is absent.")
+    status: NonBlankString = Field(description="Stable operation status.")
+    data: ResultT | None = Field(default=None, description="Typed successful result.")
+    error: StudioError | None = Field(default=None, description="Structured failure result.")
+    warnings: list[str] = Field(default_factory=list, description="Non-fatal follow-up guidance.")
+
+    @model_validator(mode="after")
+    def validate_result(self) -> "StudioResult[ResultT]":
+        has_data = self.data is not None
+        has_error = self.error is not None
+        if has_data == has_error:
+            raise ValueError("StudioResult must contain exactly one of 'data' or 'error'")
+        if self.ok != has_data:
+            raise ValueError("'ok' must be true for data results and false for error results")
+        return self
+
+    def __str__(self) -> str:
+        """Serialize tool results as JSON while keeping typed Python returns."""
+        return self.model_dump_json(exclude_none=True)
+
+
+__all__ = [
+    "AgentCreate",
+    "AgentPatch",
+    "AgentView",
+    "AgentWorkflowStep",
+    "ComponentActionView",
+    "ComponentId",
+    "ComponentRef",
+    "ComponentSource",
+    "ComponentStage",
+    "ComponentSummary",
+    "ComponentView",
+    "ContextPolicy",
+    "ContextPolicyPatch",
+    "FunctionRef",
+    "FunctionWorkflowStep",
+    "ModelRef",
+    "ScheduleActionView",
+    "ScheduleCreate",
+    "ScheduleRunView",
+    "ScheduleTargetType",
+    "ScheduleView",
+    "StudioError",
+    "StudioResult",
+    "TeamCreate",
+    "TeamPatch",
+    "TeamView",
+    "TeamWorkflowStep",
+    "ToolRef",
+    "VersionSummary",
+    "WorkflowCreate",
+    "WorkflowPatch",
+    "WorkflowStep",
+    "WorkflowView",
+]

--- a/libs/agno/agno/utils/json_schema.py
+++ b/libs/agno/agno/utils/json_schema.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from enum import Enum
 from typing import Any, Dict, Literal, Optional, Union, get_args, get_origin
 
@@ -44,77 +45,120 @@ def get_json_type_for_py_type(arg: str) -> str:
 
 
 def inline_pydantic_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Recursively inline Pydantic model schemas by replacing $ref with actual schema.
+    """Inline local Pydantic ``$defs`` references throughout a JSON schema.
+
+    Pydantic emits discriminated unions as ``oneOf`` branches plus a
+    ``discriminator.mapping`` whose values point at ``$defs``. Once those
+    definitions are inlined the mapping is both redundant (each branch keeps
+    its discriminator ``const``) and invalid, because its targets no longer
+    exist. Keep ``propertyName`` and discard only that stale mapping.
     """
     if not isinstance(schema, dict):
         return schema
 
-    def resolve_ref(ref: str, defs: Dict[str, Any]) -> Dict[str, Any]:
+    definitions = schema.get("$defs", {})
+    if not isinstance(definitions, dict):
+        definitions = {}
+
+    schema_value_keys = {
+        "additionalProperties",
+        "contains",
+        "contentSchema",
+        "else",
+        "if",
+        "items",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    }
+    schema_list_keys = {"allOf", "anyOf", "oneOf", "prefixItems"}
+    schema_map_keys = {"dependentSchemas", "patternProperties", "properties"}
+
+    def resolve_ref(ref: str, resolving: frozenset[str]) -> Dict[str, Any]:
         """Resolve a $ref to its actual schema."""
         if not ref.startswith("#/$defs/"):
             return {"type": "object"}  # Fallback for external refs
 
         def_name = ref.split("/")[-1]
-        if def_name in defs:
-            return defs[def_name]
-        return {"type": "object"}  # Fallback if definition not found
+        definition = definitions.get(def_name)
+        if not isinstance(definition, dict):
+            return {"type": "object"}
+        # A recursive model cannot be fully inlined into finite JSON. Match the
+        # existing fallback behavior instead of retaining a dangling local ref.
+        if def_name in resolving:
+            return {"type": "object"}
+        return process_schema(definition, resolving | {def_name})
 
-    def process_schema(s: Dict[str, Any], defs: Dict[str, Any]) -> Dict[str, Any]:
-        """Process a schema dictionary, resolving all references."""
-        if not isinstance(s, dict):
-            return s
+    def process_discriminator(discriminator: Dict[str, Any]) -> Dict[str, Any]:
+        """Keep discriminator metadata that remains valid after inlining."""
+        result: Dict[str, Any] = {}
+        for key, value in discriminator.items():
+            if key != "mapping" or not isinstance(value, dict):
+                result[key] = deepcopy(value)
+                continue
 
-        # Handle $ref
-        if "$ref" in s:
-            return resolve_ref(s["$ref"], defs)
-
-        # Create a new dict to avoid modifying the input
-        result = s.copy()
-
-        # Handle arrays
-        if "items" in result:
-            result["items"] = process_schema(result["items"], defs)
-
-        # Handle object properties
-        if "properties" in result:
-            for prop_name, prop_schema in result["properties"].items():
-                result["properties"][prop_name] = process_schema(prop_schema, defs)
-
-        # Handle anyOf (for Union types)
-        if "anyOf" in result:
-            result["anyOf"] = [process_schema(sub_schema, defs) for sub_schema in result["anyOf"]]
-
-        # Handle allOf (for inheritance)
-        if "allOf" in result:
-            result["allOf"] = [process_schema(sub_schema, defs) for sub_schema in result["allOf"]]
-
-        # Handle additionalProperties
-        if "additionalProperties" in result:
-            result["additionalProperties"] = process_schema(result["additionalProperties"], defs)
-
-        # Handle propertyNames
-        if "propertyNames" in result:
-            result["propertyNames"] = process_schema(result["propertyNames"], defs)
-
+            # Local mapping targets disappear with $defs. Preserve any external
+            # mappings rather than discarding unrelated discriminator metadata.
+            external_mapping = {
+                tag: target
+                for tag, target in value.items()
+                if not (isinstance(target, str) and target.startswith("#/$defs/"))
+            }
+            if external_mapping:
+                result[key] = external_mapping
         return result
 
-    # Store definitions for later use
-    definitions = schema.pop("$defs", {})
+    def process_keyword(key: str, value: Any, resolving: frozenset[str]) -> Any:
+        """Process only values JSON Schema defines as nested schemas.
 
-    # First, resolve any nested references in definitions
-    resolved_definitions = {}
-    for def_name, def_schema in definitions.items():
-        resolved_definitions[def_name] = process_schema(def_schema, definitions)
+        Values under ``default``, ``examples``, ``const``, ``enum`` and
+        extension keywords are arbitrary JSON payloads. Recursing through
+        those values would mistake payload keys such as ``$defs`` or
+        ``discriminator`` for schema syntax and silently corrupt them.
+        """
+        if key == "discriminator" and isinstance(value, dict):
+            return process_discriminator(value)
+        if key in schema_value_keys:
+            if isinstance(value, list):
+                return [process_schema(item, resolving) for item in value]
+            if isinstance(value, dict):
+                return process_schema(value, resolving)
+            return deepcopy(value)
+        if key in schema_list_keys and isinstance(value, list):
+            return [process_schema(item, resolving) for item in value]
+        if key in schema_map_keys and isinstance(value, dict):
+            return {name: process_schema(item, resolving) for name, item in value.items()}
+        if key == "dependencies" and isinstance(value, dict):
+            return {
+                name: process_schema(item, resolving) if isinstance(item, dict) else deepcopy(item)
+                for name, item in value.items()
+            }
+        return deepcopy(value)
 
-    # Process the main schema with resolved definitions
-    result = process_schema(schema, resolved_definitions)
+    def process_schema(value: Any, resolving: frozenset[str] = frozenset()) -> Any:
+        """Recursively resolve refs in every dict/list schema position."""
+        if isinstance(value, list):
+            return [process_schema(item, resolving) for item in value]
+        if not isinstance(value, dict):
+            return value
 
-    # Remove any remaining definitions
-    if "$defs" in result:
-        del result["$defs"]
+        if "$ref" in value:
+            resolved = resolve_ref(value["$ref"], resolving)
+            # JSON Schema permits siblings beside $ref. Preserve them after the
+            # referenced schema so an explicit sibling can refine metadata.
+            siblings = {key: process_keyword(key, item, resolving) for key, item in value.items() if key != "$ref"}
+            return {**resolved, **siblings}
 
-    return result
+        result: Dict[str, Any] = {}
+        for key, item in value.items():
+            if key == "$defs":
+                continue
+            result[key] = process_keyword(key, item, resolving)
+        return result
+
+    return process_schema(schema)
 
 
 def get_json_schema_for_arg(type_hint: Any) -> Optional[Dict[str, Any]]:

--- a/libs/agno/agno/utils/string.py
+++ b/libs/agno/agno/utils/string.py
@@ -304,6 +304,10 @@ def generate_id_from_name(name: Optional[str] = None) -> str:
         name (str): The name string to generate the ID from.
     """
     if name:
+        # This exact transformation is a persisted identity contract. Agents,
+        # teams, workflows, Studio, and the Components API have historically
+        # derived IDs with it, so tightening the slug shape here would silently
+        # point an existing name at a different catalog row.
         return name.lower().replace(" ", "-").replace("_", "-")
     else:
         from agno.utils.names import generate_human_readable_id

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 from agno.agent.agent import Agent
 from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, SessionType
-from agno.db.utils import resolve_db_from_config
+from agno.db.utils import resolve_db_from_config, save_component_config
 from agno.exceptions import InputCheckError, OutputCheckError, RunCancelledException
 from agno.media import Audio, File, Image, Video
 from agno.models.message import Message
@@ -1151,6 +1151,13 @@ class Workflow:
                         link.get("child_component_id"),
                         link.get("child_version"),
                     ):
+                        # Preserve the historical warn-and-keep-first behavior
+                        # when dropping this row cannot discard a distinct pin.
+                        log_warning(
+                            f"Workflow '{self.id}': dropping duplicate {link.get('link_kind')} link for "
+                            f"key '{link.get('link_key')}' (child '{link.get('child_component_id')}'); "
+                            "give steps distinct names so each pin is kept."
+                        )
                         continue
                     # A save that silently drops one of two different pins
                     # would float that child to its latest version forever.
@@ -1165,15 +1172,13 @@ class Workflow:
                 deduped_links.append(link)
             all_links = deduped_links
 
-            db_.upsert_component(
+            config = save_component_config(
+                db_,
                 component_id=self.id,
                 component_type=ComponentType.WORKFLOW,
                 name=self.name,
                 description=self.description,
                 metadata=self.metadata,
-            )
-            config = db_.upsert_config(
-                component_id=self.id,
                 config=self.to_dict(),
                 links=all_links,
                 label=label,
@@ -1253,6 +1258,7 @@ class Workflow:
         *,
         db: Optional["BaseDb"] = None,
         hard_delete: bool = False,
+        require_no_dependents: bool = True,
     ) -> bool:
         """
         Delete the workflow component.
@@ -1260,9 +1266,19 @@ class Workflow:
         Args:
             db: The database to delete the workflow from.
             hard_delete: Whether to hard delete the workflow.
+            require_no_dependents: Refuse deletion while another active
+                component references this workflow. Setting this to False
+                bypasses dependency validation and can leave active components
+                with dangling links; use it only for a deliberate repair or
+                migration. Catalog-v1 adapters retain their historical
+                unguarded deletion behavior.
 
         Returns:
             True if the workflow was deleted, False otherwise.
+
+        Raises:
+            ComponentDependencyError: If a dependent component references
+                this workflow and require_no_dependents is True.
         """
         db_ = db or self.db
         if not db_:
@@ -1272,7 +1288,15 @@ class Workflow:
         if self.id is None:
             raise ValueError("Cannot delete workflow without an id")
 
-        return db_.delete_component(component_id=self.id, hard_delete=hard_delete)
+        if getattr(db_, "component_catalog_api_version", 1) < 2:
+            # Preserve the exact pre-2.9 adapter call shape. Third-party
+            # catalog-v1 implementations cannot accept the v2-only policy.
+            return db_.delete_component(component_id=self.id, hard_delete=hard_delete)
+        return db_.delete_component(
+            component_id=self.id,
+            hard_delete=hard_delete,
+            require_no_dependents=require_no_dependents,
+        )
 
     async def aget_run_output(
         self, run_id: str, session_id: Optional[str] = None, user_id: Optional[str] = None
@@ -10885,6 +10909,7 @@ def get_workflow_by_id(
     label: Optional[str] = None,
     registry: Optional["Registry"] = None,
     strict: bool = False,
+    published_only: bool = False,
 ) -> Optional["Workflow"]:
     """
     Get a Workflow by id from the database (new entities/configs schema).
@@ -10892,7 +10917,8 @@ def get_workflow_by_id(
     Resolution order:
     - if version is provided: load that version
     - elif label is provided: load that labeled version
-    - else: load entity.current_version
+    - else: load the current published version, or the latest draft when the
+      component has never been published
 
     Args:
         db: Database handle.
@@ -10902,6 +10928,9 @@ def get_workflow_by_id(
         registry: Optional Registry for reconstructing unserializable components.
         strict: If True, unresolvable registry references raise
             ComponentRehydrationError; None strictly means the workflow was not found.
+        published_only: Resolve only the current published config when neither
+            an exact version nor label is supplied. Runtime dispatch uses this;
+            ordinary reads retain the draft-only fallback.
 
     Returns:
         Workflow instance or None.
@@ -10912,7 +10941,11 @@ def get_workflow_by_id(
     from agno.exceptions import ComponentRehydrationError
 
     try:
-        row = db.get_config(component_id=id, version=version, label=label)
+        row = (
+            db.get_current_config(component_id=id)
+            if published_only and version is None and label is None
+            else db.get_config(component_id=id, version=version, label=label)
+        )
         if row is None:
             return None
 
@@ -10965,7 +10998,7 @@ def get_workflows(
         components, _ = db.list_components(component_type=ComponentType.WORKFLOW)
         for component in components:
             try:
-                config = db.get_config(component_id=component["component_id"])
+                config = db.get_latest_config(component_id=component["component_id"])
                 if config is not None:
                     workflow_config = config.get("config")
                     if workflow_config is not None:
@@ -10976,7 +11009,7 @@ def get_workflows(
                         # components so they stay visible and fixable.
                         workflow = Workflow.from_dict(workflow_config, db=db, registry=registry, strict=False)
                         workflow.id = component_id
-                        workflow._version = component.get("current_version")
+                        workflow._version = config.get("version")
                         workflow._stage = config.get("stage")
                         workflows.append(workflow)
             except Exception as e:

--- a/libs/agno/tests/integration/db/postgres/test_component_lifecycle.py
+++ b/libs/agno/tests/integration/db/postgres/test_component_lifecycle.py
@@ -1,0 +1,975 @@
+"""PostgreSQL integration tests for guarded component lifecycle operations."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+from typing import Any, Dict, List, Optional, cast
+
+import pytest
+from sqlalchemy import event
+
+from agno.db.base import (
+    DELETED_CONFIG_STAGE,
+    ComponentAlreadyExistsError,
+    ComponentCycleError,
+    ComponentDependencyError,
+    ComponentDependencyUnavailableError,
+    ComponentDraftRequiredError,
+    ComponentProjection,
+    ComponentType,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+)
+from agno.db.postgres.postgres import PostgresDb
+
+
+def _guard(latest_version: Optional[int], current_version: Optional[int]) -> ComponentVersionGuard:
+    return ComponentVersionGuard(latest_version=latest_version, current_version=current_version)
+
+
+def _component_link(child_id: str, *, link_key: str = "step_0") -> Dict[str, Any]:
+    return {
+        "link_kind": "step_agent",
+        "link_key": link_key,
+        "child_component_id": child_id,
+        "child_version": 1,
+        "position": 0,
+    }
+
+
+def _create_component(
+    db: PostgresDb,
+    component_id: str,
+    *,
+    component_type: ComponentType = ComponentType.AGENT,
+    stage: str = "published",
+    name: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
+    links: Optional[List[Dict[str, Any]]] = None,
+) -> None:
+    db.create_component_with_config(
+        component_id=component_id,
+        component_type=component_type,
+        name=name or component_id,
+        config=config or {"name": name or component_id},
+        stage=stage,
+        links=links,
+    )
+
+
+def test_postgres_generic_read_falls_back_to_latest_draft_and_guarded_append_conflicts(
+    postgres_db_real: PostgresDb,
+) -> None:
+    _create_component(postgres_db_real, "draft-only-agent", stage="draft")
+    assert postgres_db_real.get_current_config("draft-only-agent") is None
+    draft = postgres_db_real.get_config("draft-only-agent")
+    assert draft is not None
+    assert draft["version"] == 1
+    assert postgres_db_real.get_latest_config("draft-only-agent") == draft
+
+    _create_component(postgres_db_real, "guarded-agent", config={"instructions": "published"})
+    created = postgres_db_real.upsert_config(
+        "guarded-agent",
+        config={"instructions": "writer one"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    assert created["version"] == 2
+
+    with pytest.raises(ComponentVersionConflictError):
+        postgres_db_real.upsert_config(
+            "guarded-agent",
+            config={"instructions": "stale writer"},
+            stage="draft",
+            guard=_guard(1, 1),
+        )
+
+
+def test_postgres_bulk_component_reads_are_complete_bounded_and_single_query(
+    postgres_db_real: PostgresDb,
+) -> None:
+    _create_component(postgres_db_real, "bulk-active", name="Published", config={"name": "Published"})
+    postgres_db_real.upsert_config(
+        "bulk-active",
+        config={"name": "Draft"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    _create_component(
+        postgres_db_real,
+        "bulk-team",
+        component_type=ComponentType.TEAM,
+    )
+    _create_component(postgres_db_real, "bulk-archived")
+    assert postgres_db_real.delete_component("bulk-archived")
+
+    statements: List[str] = []
+
+    def record_statement(_conn: Any, _cursor: Any, statement: str, _parameters: Any, _context: Any, _many: bool):
+        statements.append(statement)
+
+    event.listen(postgres_db_real.db_engine, "before_cursor_execute", record_statement)
+    try:
+        rows = postgres_db_real.get_components(
+            {"bulk-active", "bulk-team", "bulk-archived", "bulk-missing"},
+            include_deleted=True,
+        )
+    finally:
+        event.remove(postgres_db_real.db_engine, "before_cursor_execute", record_statement)
+
+    assert [row["component_id"] for row in rows] == ["bulk-active", "bulk-archived", "bulk-team"]
+    assert len(statements) == 1
+    assert statements[0].lstrip().upper().startswith("SELECT")
+    assert [
+        row["component_id"]
+        for row in postgres_db_real.get_components(
+            {"bulk-active", "bulk-team", "bulk-archived"},
+            component_type=ComponentType.AGENT,
+        )
+    ] == ["bulk-active"]
+    assert postgres_db_real.get_components(set()) == []
+
+    statements.clear()
+    event.listen(postgres_db_real.db_engine, "before_cursor_execute", record_statement)
+    try:
+        latest = postgres_db_real.get_latest_configs(
+            {"bulk-active", "bulk-archived", "bulk-missing"},
+        )
+    finally:
+        event.remove(postgres_db_real.db_engine, "before_cursor_execute", record_statement)
+
+    assert set(latest) == {"bulk-active", "bulk-archived", "bulk-missing"}
+    assert latest["bulk-active"] is not None
+    assert latest["bulk-active"]["version"] == 2
+    assert latest["bulk-active"]["stage"] == "draft"
+    assert latest["bulk-archived"] is None
+    assert latest["bulk-missing"] is None
+    assert len(statements) == 1
+    assert statements[0].lstrip().upper().startswith("SELECT")
+
+    archived_latest = postgres_db_real.get_latest_configs({"bulk-archived"}, include_deleted=True)
+    assert archived_latest["bulk-archived"] is not None
+    assert archived_latest["bulk-archived"]["version"] == 1
+    assert postgres_db_real.get_latest_configs(set()) == {}
+
+
+def test_postgres_draft_projection_tracks_latest_only_until_first_publish(postgres_db_real: PostgresDb) -> None:
+    _create_component(
+        postgres_db_real,
+        "draft-projection",
+        stage="draft",
+        name="Draft one",
+        config={"name": "Draft one"},
+    )
+
+    postgres_db_real.upsert_config(
+        "draft-projection",
+        config={"name": "Draft two"},
+        stage="draft",
+        projection={"name": "Draft two"},
+    )
+    component = postgres_db_real.get_component("draft-projection")
+    assert component is not None
+    assert component["current_version"] is None
+    assert component["name"] == "Draft two"
+
+    postgres_db_real.upsert_config(
+        "draft-projection",
+        config={"name": "Published"},
+        stage="published",
+        projection={"name": "Published"},
+    )
+    latest_draft = postgres_db_real.upsert_config(
+        "draft-projection",
+        config={"name": "Must not leak"},
+        stage="draft",
+        projection={"name": "Must not leak"},
+    )
+
+    component = postgres_db_real.get_component("draft-projection")
+    assert component is not None
+    assert component["current_version"] == 3
+    assert component["name"] == "Published"
+    assert latest_draft["version"] == 4
+    assert postgres_db_real.get_latest_config("draft-projection") == latest_draft
+    assert postgres_db_real.get_current_config("draft-projection")["version"] == 3  # type: ignore[index]
+
+
+def test_postgres_only_draft_cannot_be_deleted_into_a_zombie(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "sole-draft", stage="draft")
+
+    with pytest.raises(ValueError, match="last config.*archive"):
+        postgres_db_real.delete_config("sole-draft", 1, guard=_guard(1, None))
+
+    assert [row["version"] for row in postgres_db_real.list_configs("sole-draft")] == [1]
+    assert postgres_db_real.get_config("sole-draft", version=1) is not None
+    assert postgres_db_real.delete_component("sole-draft", guard=_guard(1, None)) is True
+
+
+def test_postgres_generic_update_cannot_move_current_pointer(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "pointer-agent", name="Version one")
+    postgres_db_real.upsert_config(
+        "pointer-agent",
+        config={"name": "Version two"},
+        stage="published",
+        projection={"name": "Version two"},
+    )
+
+    with pytest.raises(ValueError, match="set_current_version"):
+        postgres_db_real.upsert_component("pointer-agent", current_version=1)
+
+    component = postgres_db_real.get_component("pointer-agent")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Version two"
+
+
+def test_postgres_mutation_results_are_captured_before_commit(
+    postgres_db_real: PostgresDb,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_public_read(*args: object, **kwargs: object) -> None:
+        raise AssertionError("mutation must not perform a post-commit public read")
+
+    monkeypatch.setattr(postgres_db_real, "get_component", fail_public_read)
+    monkeypatch.setattr(postgres_db_real, "get_config", fail_public_read)
+
+    component, initial = postgres_db_real.create_component_with_config(
+        component_id="atomic-response",
+        component_type=ComponentType.AGENT,
+        name="Initial",
+        config={"name": "Initial"},
+        stage="published",
+    )
+    updated = postgres_db_real.upsert_component("atomic-response", name="Updated")
+    draft = postgres_db_real.upsert_config(
+        "atomic-response",
+        config={"name": "Draft"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    assert component["component_id"] == "atomic-response"
+    assert initial["version"] == 1
+    assert updated["name"] == "Updated"
+    assert draft["version"] == 2
+    assert draft["stage"] == "draft"
+
+
+def test_postgres_publish_and_rollback_update_pointer_and_projection(postgres_db_real: PostgresDb) -> None:
+    _create_component(
+        postgres_db_real,
+        "release-agent",
+        name="Version one",
+        config={"instructions": "v1"},
+    )
+    draft = postgres_db_real.upsert_config(
+        "release-agent",
+        config={"instructions": "v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    published = postgres_db_real.upsert_config(
+        "release-agent",
+        version=draft["version"],
+        stage="published",
+        guard=_guard(2, 1),
+        projection={"name": "Version two", "metadata": {"release": 2}},
+    )
+    assert published["stage"] == "published"
+
+    component = postgres_db_real.get_component("release-agent")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Version two"
+    assert component["metadata"] == {"release": 2}
+
+    assert postgres_db_real.set_current_version(
+        "release-agent",
+        1,
+        guard=_guard(2, 2),
+        projection={"name": "Version one", "metadata": {"release": 1}},
+    )
+    component = postgres_db_real.get_component("release-agent")
+    assert component is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Version one"
+
+    with pytest.raises(ComponentDraftRequiredError, match="only draft configs") as exc:
+        postgres_db_real.delete_config("release-agent", 2, guard=_guard(2, 1))
+
+    assert exc.value.component_id == "release-agent"
+    assert exc.value.version == 2
+
+
+def test_postgres_existing_draft_is_immutable_and_publish_derives_projection(postgres_db_real: PostgresDb) -> None:
+    postgres_db_real.create_component_with_config(
+        component_id="immutable-draft",
+        component_type=ComponentType.AGENT,
+        name="Catalog placeholder",
+        config={
+            "name": "Locked draft",
+            "description": "Derived from the stored payload",
+            "metadata": {"release": 1},
+            "instructions": "original",
+        },
+        description="Catalog placeholder",
+        metadata={"release": 0},
+        stage="draft",
+    )
+
+    with pytest.raises(ValueError, match="requires a component version guard"):
+        postgres_db_real.upsert_config(
+            "immutable-draft",
+            version=1,
+            config={"name": "mutated"},
+            stage="draft",
+        )
+    with pytest.raises(ValueError, match="cannot mutate config"):
+        postgres_db_real.upsert_config(
+            "immutable-draft",
+            version=1,
+            config={"name": "mutated"},
+            stage="published",
+            guard=_guard(1, None),
+        )
+
+    published = postgres_db_real.upsert_config(
+        "immutable-draft",
+        version=1,
+        stage="published",
+        guard=_guard(1, None),
+    )
+    component = postgres_db_real.get_component("immutable-draft")
+
+    assert published["config"]["instructions"] == "original"
+    assert component is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Locked draft"
+    assert component["description"] == "Derived from the stored payload"
+    assert component["metadata"] == {"release": 1}
+
+
+def test_postgres_publish_and_set_current_derive_projection_from_target_config(
+    postgres_db_real: PostgresDb,
+) -> None:
+    postgres_db_real.create_component_with_config(
+        component_id="derived-pointer",
+        component_type=ComponentType.AGENT,
+        name="Version one",
+        config={"name": "Version one", "description": "First", "metadata": {"release": 1}},
+        description="First",
+        metadata={"release": 1},
+        stage="published",
+    )
+
+    postgres_db_real.upsert_config(
+        "derived-pointer",
+        config={"name": "Version two", "description": "Second", "metadata": {"release": 2}},
+        stage="published",
+    )
+    component = postgres_db_real.get_component("derived-pointer")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Version two"
+    assert component["description"] == "Second"
+    assert component["metadata"] == {"release": 2}
+
+    assert postgres_db_real.set_current_version("derived-pointer", 1, guard=_guard(2, 2))
+    component = postgres_db_real.get_component("derived-pointer")
+    assert component is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Version one"
+    assert component["description"] == "First"
+    assert component["metadata"] == {"release": 1}
+
+
+def test_postgres_draft_delete_and_projection_are_one_transaction(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "audited-delete", config={"instructions": "v1"})
+    postgres_db_real.upsert_config(
+        "audited-delete",
+        config={"instructions": "discard me"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    invalid_projection = cast(ComponentProjection, {"unknown_field": "must fail"})
+    with pytest.raises(ValueError, match="projection"):
+        postgres_db_real.delete_config(
+            "audited-delete",
+            2,
+            guard=_guard(2, 1),
+            projection=invalid_projection,
+        )
+
+    assert postgres_db_real.get_config("audited-delete", version=2) is not None
+    assert postgres_db_real.delete_config(
+        "audited-delete",
+        2,
+        guard=_guard(2, 1),
+        projection={"metadata": {"last_action": "delete_version"}},
+    )
+    component = postgres_db_real.get_component("audited-delete")
+    assert component is not None
+    assert component["metadata"] == {"last_action": "delete_version"}
+    assert postgres_db_real.get_config("audited-delete", version=2) is None
+
+
+def test_postgres_deleted_draft_tombstone_allows_visible_state_cas_without_version_reuse(
+    postgres_db_real: PostgresDb,
+) -> None:
+    """Deleting v2 restores visible latest=v1, but its audit tombstone reserves v2 forever."""
+    _create_component(postgres_db_real, "aba-agent")
+    postgres_db_real.upsert_config(
+        "aba-agent",
+        config={"instructions": "discarded v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    assert postgres_db_real.delete_config("aba-agent", 2, guard=_guard(2, 1))
+
+    configs_table = postgres_db_real._get_table(table_type="component_configs")
+    assert configs_table is not None
+    with postgres_db_real.Session() as session:
+        tombstone = (
+            session.execute(
+                configs_table.select().where(
+                    configs_table.c.component_id == "aba-agent",
+                    configs_table.c.version == 2,
+                )
+            )
+            .mappings()
+            .one()
+        )
+    assert tombstone["stage"] == DELETED_CONFIG_STAGE
+    assert tombstone["config"] == {}
+    assert tombstone["updated_at"] is not None
+
+    # Guards intentionally compare visible lifecycle state. After deleting the
+    # only draft, latest=v1/current=v1 is fresh again; the high-water mark still
+    # makes this append v3 rather than overwriting or reusing the audited v2.
+    replacement = postgres_db_real.upsert_config(
+        "aba-agent",
+        config={"instructions": "replacement"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    assert replacement["version"] == 3
+    assert postgres_db_real.get_config("aba-agent", version=2) is None
+    with postgres_db_real.Session() as session:
+        history = session.execute(
+            configs_table.select().where(configs_table.c.component_id == "aba-agent").order_by(configs_table.c.version)
+        ).fetchall()
+    assert [(row.version, row.stage) for row in history] == [
+        (1, "published"),
+        (2, DELETED_CONFIG_STAGE),
+        (3, "draft"),
+    ]
+    with pytest.raises(ValueError, match="not found"):
+        postgres_db_real.upsert_config(
+            "aba-agent",
+            version=2,
+            stage="published",
+            guard=_guard(3, 1),
+            projection={"name": "Must not publish"},
+        )
+
+
+def test_postgres_publish_revalidates_stored_links(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "draft-child-for-publish", stage="draft")
+    _create_component(postgres_db_real, "parent-for-publish", component_type=ComponentType.TEAM)
+    postgres_db_real.upsert_config(
+        "parent-for-publish",
+        config={"members": ["draft-child-for-publish"]},
+        stage="draft",
+        guard=_guard(1, 1),
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "draft-child-for-publish",
+                "child_version": 1,
+                "position": 0,
+                "meta": {"type": "agent"},
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="not published"):
+        postgres_db_real.upsert_config(
+            "parent-for-publish",
+            version=2,
+            stage="published",
+            guard=_guard(2, 1),
+            projection={"name": "Must remain draft"},
+        )
+
+    parent = postgres_db_real.get_component("parent-for-publish")
+    draft = postgres_db_real.get_config("parent-for-publish", version=2)
+    assert parent is not None
+    assert draft is not None
+    assert parent["current_version"] == 1
+    assert draft["stage"] == "draft"
+
+
+def test_postgres_guarded_publish_atomically_derives_and_persists_links(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "published-child-for-derived-link")
+    _create_component(
+        postgres_db_real,
+        "draft-parent-for-derived-link",
+        component_type=ComponentType.TEAM,
+        stage="draft",
+    )
+
+    published = postgres_db_real.upsert_config(
+        "draft-parent-for-derived-link",
+        version=1,
+        stage="published",
+        guard=_guard(1, None),
+        projection={"name": "Published parent"},
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "published-child-for-derived-link",
+                "child_version": 1,
+                "position": 0,
+                "meta": {"type": "agent"},
+            }
+        ],
+    )
+
+    assert published["stage"] == "published"
+    component = postgres_db_real.get_component("draft-parent-for-derived-link")
+    assert component is not None and component["current_version"] == 1
+    links = postgres_db_real.get_links("draft-parent-for-derived-link", 1)
+    assert [(link["child_component_id"], link["child_version"]) for link in links] == [
+        ("published-child-for-derived-link", 1)
+    ]
+
+
+def test_postgres_rejects_unpublished_child_pin_atomically(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "draft-child", stage="draft")
+
+    with pytest.raises(ValueError, match="not published"):
+        _create_component(
+            postgres_db_real,
+            "invalid-parent",
+            component_type=ComponentType.TEAM,
+            links=[
+                {
+                    "link_kind": "member",
+                    "link_key": "member_0",
+                    "child_component_id": "draft-child",
+                    "child_version": 1,
+                    "position": 0,
+                    "meta": {"type": "agent"},
+                }
+            ],
+        )
+
+    assert postgres_db_real.get_component("invalid-parent", include_deleted=True) is None
+    assert postgres_db_real.get_config("invalid-parent", version=1) is None
+
+
+def test_postgres_archive_is_dependency_safe_and_archived_ids_remain_occupied(
+    postgres_db_real: PostgresDb,
+) -> None:
+    _create_component(postgres_db_real, "child-agent")
+    _create_component(
+        postgres_db_real,
+        "parent-team",
+        component_type=ComponentType.TEAM,
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "child-agent",
+                "child_version": 1,
+                "position": 0,
+                "meta": {"type": "agent"},
+            }
+        ],
+    )
+
+    with pytest.raises(ComponentDependencyError):
+        postgres_db_real.delete_component(
+            "child-agent",
+            guard=_guard(1, 1),
+            require_no_dependents=True,
+        )
+
+    assert postgres_db_real.delete_component(
+        "parent-team",
+        guard=_guard(1, 1),
+        require_no_dependents=True,
+    )
+    assert postgres_db_real.get_dependents("child-agent", active_parents_only=True) == []
+    assert postgres_db_real.delete_component(
+        "child-agent",
+        guard=_guard(1, 1),
+        require_no_dependents=True,
+        projection={"name": "Archived child", "metadata": {"release": 1}},
+    )
+    archived = postgres_db_real.get_component("child-agent", include_deleted=True)
+    assert archived is not None
+    assert archived["name"] == "Archived child"
+    assert archived["metadata"] == {"release": 1}
+
+    with pytest.raises(ComponentAlreadyExistsError):
+        _create_component(postgres_db_real, "child-agent", name="Replacement")
+
+
+def test_postgres_restore_component_is_guarded_and_preserves_history(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "restored-agent", name="Published")
+    assert postgres_db_real.delete_component("restored-agent", guard=_guard(1, 1))
+
+    assert postgres_db_real.get_config("restored-agent") is None
+    archived_latest = postgres_db_real.get_latest_config("restored-agent", include_deleted=True)
+    assert archived_latest is not None
+    assert archived_latest["version"] == 1
+
+    with pytest.raises(ComponentVersionConflictError):
+        postgres_db_real.restore_component("restored-agent", guard=_guard(0, 1))
+    assert postgres_db_real.get_component("restored-agent") is None
+
+    assert postgres_db_real.restore_component(
+        "restored-agent",
+        guard=_guard(1, 1),
+        projection={"name": "Restored", "description": "Same identity", "metadata": {"restored": True}},
+    )
+    restored = postgres_db_real.get_component("restored-agent")
+    assert restored is not None
+    assert restored["name"] == "Restored"
+    assert restored["description"] == "Same identity"
+    assert restored["metadata"] == {"restored": True}
+    assert postgres_db_real.get_current_config("restored-agent")["version"] == 1  # type: ignore[index]
+    assert [row["version"] for row in postgres_db_real.list_configs("restored-agent")] == [1]
+
+
+def test_postgres_restore_rejects_an_archived_pinned_dependency_but_allows_draft_only_components(
+    postgres_db_real: PostgresDb,
+) -> None:
+    _create_component(postgres_db_real, "restore-child")
+    _create_component(
+        postgres_db_real,
+        "restore-parent",
+        component_type=ComponentType.WORKFLOW,
+        links=[_component_link("restore-child")],
+    )
+    assert postgres_db_real.delete_component("restore-parent", guard=_guard(1, 1))
+    assert postgres_db_real.delete_component("restore-child", guard=_guard(1, 1))
+
+    with pytest.raises(ComponentDependencyUnavailableError) as unavailable:
+        postgres_db_real.restore_component("restore-parent", guard=_guard(1, 1))
+
+    assert unavailable.value.component_id == "restore-parent"
+    assert unavailable.value.dependencies == [
+        {
+            "component_id": "restore-child",
+            "version": 1,
+            "referenced_by": {"component_id": "restore-parent", "version": 1},
+            "reason": "component_archived",
+        }
+    ]
+    parent = postgres_db_real.get_component("restore-parent", include_deleted=True)
+    assert parent is not None and parent["deleted_at"] is not None
+
+    assert postgres_db_real.restore_component("restore-child", guard=_guard(1, 1))
+    assert postgres_db_real.restore_component("restore-parent", guard=_guard(1, 1))
+
+    _create_component(postgres_db_real, "restore-draft", stage="draft")
+    assert postgres_db_real.delete_component("restore-draft", guard=_guard(1, None))
+    assert postgres_db_real.restore_component("restore-draft", guard=_guard(1, None))
+    restored_draft = postgres_db_real.get_component("restore-draft")
+    assert restored_draft is not None and restored_draft["current_version"] is None
+
+
+def test_postgres_restore_and_dependency_archive_race_never_exposes_a_broken_graph(
+    postgres_db_real: PostgresDb,
+) -> None:
+    _create_component(postgres_db_real, "restore-race-child")
+    _create_component(
+        postgres_db_real,
+        "restore-race-parent",
+        component_type=ComponentType.WORKFLOW,
+        links=[_component_link("restore-race-child")],
+    )
+    assert postgres_db_real.delete_component("restore-race-parent", guard=_guard(1, 1))
+    ready = Barrier(2)
+
+    def restore_parent() -> str:
+        ready.wait()
+        try:
+            postgres_db_real.restore_component("restore-race-parent", guard=_guard(1, 1))
+        except ComponentDependencyUnavailableError:
+            return "restore_blocked"
+        return "restored"
+
+    def archive_child() -> str:
+        ready.wait()
+        try:
+            postgres_db_real.delete_component("restore-race-child", guard=_guard(1, 1))
+        except ComponentDependencyError:
+            return "archive_blocked"
+        return "archived"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        restore_future = executor.submit(restore_parent)
+        archive_future = executor.submit(archive_child)
+        outcomes = {restore_future.result(timeout=10), archive_future.result(timeout=10)}
+
+    assert outcomes in ({"restored", "archive_blocked"}, {"restore_blocked", "archived"})
+    parent_is_active = postgres_db_real.get_component("restore-race-parent") is not None
+    child_is_active = postgres_db_real.get_component("restore-race-child") is not None
+    if outcomes == {"restored", "archive_blocked"}:
+        assert parent_is_active and child_is_active
+    else:
+        assert not parent_is_active and not child_is_active
+
+
+def test_postgres_atomic_restore_and_draft_append_roll_back_when_the_current_graph_is_unavailable(
+    postgres_db_real: PostgresDb,
+) -> None:
+    _create_component(postgres_db_real, "restore-append-child")
+    _create_component(
+        postgres_db_real,
+        "restore-append-parent",
+        component_type=ComponentType.WORKFLOW,
+        links=[_component_link("restore-append-child")],
+    )
+    assert postgres_db_real.delete_component("restore-append-parent", guard=_guard(1, 1))
+    assert postgres_db_real.delete_component("restore-append-child", guard=_guard(1, 1))
+
+    with pytest.raises(ComponentDependencyUnavailableError):
+        postgres_db_real.upsert_config(
+            "restore-append-parent",
+            config={"name": "Draft edit"},
+            stage="draft",
+            guard=_guard(1, 1),
+            restore_if_deleted=True,
+            expected_component_type=ComponentType.WORKFLOW,
+        )
+
+    parent = postgres_db_real.get_component("restore-append-parent", include_deleted=True)
+    assert parent is not None and parent["deleted_at"] is not None
+    latest = postgres_db_real.get_latest_config("restore-append-parent", include_deleted=True)
+    assert latest is not None and latest["version"] == 1
+
+    _create_component(postgres_db_real, "restore-repair-child")
+    repaired = postgres_db_real.upsert_config(
+        "restore-append-parent",
+        config={"name": "Published repair"},
+        stage="published",
+        guard=_guard(1, 1),
+        links=[_component_link("restore-repair-child")],
+        restore_if_deleted=True,
+        expected_component_type=ComponentType.WORKFLOW,
+    )
+    assert repaired["version"] == 2
+    parent = postgres_db_real.get_component("restore-append-parent")
+    assert parent is not None and parent["current_version"] == 2
+    assert postgres_db_real.get_component("restore-append-child") is None
+
+
+def test_postgres_atomic_restore_and_append_rolls_back_on_duplicate_label(
+    postgres_db_real: PostgresDb,
+) -> None:
+    postgres_db_real.create_component_with_config(
+        component_id="restore-append-agent",
+        component_type=ComponentType.AGENT,
+        name="Version one",
+        config={"name": "Version one"},
+        stage="published",
+        label="stable",
+    )
+    assert postgres_db_real.delete_component("restore-append-agent", guard=_guard(1, 1))
+
+    with pytest.raises(ValueError, match="Label 'stable' already exists"):
+        postgres_db_real.upsert_config(
+            "restore-append-agent",
+            config={"name": "Rejected version"},
+            stage="published",
+            label="stable",
+            projection={"name": "Rejected version"},
+            restore_if_deleted=True,
+        )
+
+    assert postgres_db_real.get_component("restore-append-agent") is None
+    archived = postgres_db_real.get_component("restore-append-agent", include_deleted=True)
+    assert archived is not None and archived["deleted_at"] is not None
+    assert postgres_db_real.get_latest_config("restore-append-agent", include_deleted=True)["version"] == 1  # type: ignore[index]
+
+    appended = postgres_db_real.upsert_config(
+        "restore-append-agent",
+        config={"name": "Version two"},
+        stage="published",
+        label="next",
+        projection={"name": "Version two"},
+        restore_if_deleted=True,
+    )
+    assert appended["version"] == 2
+    restored = postgres_db_real.get_component("restore-append-agent")
+    assert restored is not None
+    assert restored["current_version"] == 2
+    assert restored["name"] == "Version two"
+
+
+def test_postgres_expected_component_type_rejects_replaced_identity(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "replaced-identity", component_type=ComponentType.AGENT)
+    assert postgres_db_real.delete_component(
+        "replaced-identity",
+        hard_delete=True,
+        require_no_dependents=False,
+    )
+    _create_component(postgres_db_real, "replaced-identity", component_type=ComponentType.TEAM)
+
+    with pytest.raises(ValueError, match="has type team, not agent"):
+        postgres_db_real.upsert_config(
+            "replaced-identity",
+            config={"name": "Agent payload"},
+            stage="published",
+            projection={"name": "Agent payload"},
+            expected_component_type=ComponentType.AGENT,
+        )
+
+    component = postgres_db_real.get_component("replaced-identity")
+    assert component is not None
+    assert component["component_type"] == ComponentType.TEAM.value
+    assert component["current_version"] == 1
+    assert [row["version"] for row in postgres_db_real.list_configs("replaced-identity")] == [1]
+
+
+def test_postgres_draft_with_inbound_pin_cannot_be_deleted(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "pinned-draft", stage="draft")
+    _create_component(postgres_db_real, "legacy-parent", component_type=ComponentType.TEAM)
+
+    links_table = postgres_db_real._get_table(table_type="component_links", create_table_if_not_found=True)
+    assert links_table is not None
+    with postgres_db_real.Session() as sess, sess.begin():
+        sess.execute(
+            links_table.insert().values(
+                parent_component_id="legacy-parent",
+                parent_version=1,
+                link_kind="member",
+                link_key="member_0",
+                child_component_id="pinned-draft",
+                child_version=1,
+                position=0,
+            )
+        )
+
+    with pytest.raises(ComponentDependencyError):
+        postgres_db_real.delete_config("pinned-draft", 1, guard=_guard(1, None))
+
+
+def test_postgres_concurrent_guarded_appends_yield_one_conflict(postgres_db_real: PostgresDb) -> None:
+    _create_component(postgres_db_real, "concurrent-agent")
+    ready = Barrier(2)
+
+    def append_draft(instructions: str) -> str:
+        ready.wait()
+        try:
+            postgres_db_real.upsert_config(
+                "concurrent-agent",
+                config={"instructions": instructions},
+                stage="draft",
+                guard=_guard(1, 1),
+            )
+        except ComponentVersionConflictError:
+            return "conflict"
+        return "created"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(append_draft, ["writer one", "writer two"]))
+
+    assert sorted(outcomes) == ["conflict", "created"]
+    assert [config["version"] for config in postgres_db_real.list_configs("concurrent-agent")] == [2, 1]
+
+
+def test_postgres_atomic_create_rejects_self_cycle_without_rows(postgres_db_real: PostgresDb) -> None:
+    with pytest.raises(ComponentCycleError) as exc:
+        _create_component(
+            postgres_db_real,
+            "self-cycle",
+            component_type=ComponentType.WORKFLOW,
+            stage="draft",
+            links=[_component_link("self-cycle")],
+        )
+
+    assert exc.value.cycle_path == ["self-cycle", "self-cycle"]
+    assert postgres_db_real.get_component("self-cycle", include_deleted=True) is None
+    assert postgres_db_real.get_config("self-cycle", version=1) is None
+
+
+def test_postgres_two_node_and_multi_node_cycles_fail_transactionally(postgres_db_real: PostgresDb) -> None:
+    for component_id in ("cycle-a", "cycle-b", "cycle-c"):
+        _create_component(postgres_db_real, component_id)
+
+    postgres_db_real.upsert_config(
+        "cycle-a",
+        config={"child": "cycle-b"},
+        stage="draft",
+        guard=_guard(1, 1),
+        links=[_component_link("cycle-b")],
+    )
+    with pytest.raises(ComponentCycleError) as two_node:
+        postgres_db_real.upsert_config(
+            "cycle-b",
+            config={"child": "cycle-a"},
+            stage="draft",
+            guard=_guard(1, 1),
+            links=[_component_link("cycle-a")],
+        )
+    assert two_node.value.cycle_path == ["cycle-b", "cycle-a", "cycle-b"]
+    assert [row["version"] for row in postgres_db_real.list_configs("cycle-b")] == [1]
+
+    postgres_db_real.upsert_config(
+        "cycle-b",
+        config={"child": "cycle-c"},
+        stage="draft",
+        guard=_guard(1, 1),
+        links=[_component_link("cycle-c")],
+    )
+    with pytest.raises(ComponentCycleError) as multi_node:
+        postgres_db_real.upsert_config(
+            "cycle-c",
+            config={"child": "cycle-a"},
+            stage="draft",
+            guard=_guard(1, 1),
+            links=[_component_link("cycle-a")],
+        )
+    assert multi_node.value.cycle_path == ["cycle-c", "cycle-a", "cycle-b", "cycle-c"]
+    assert [row["version"] for row in postgres_db_real.list_configs("cycle-c")] == [1]
+
+
+def test_postgres_cross_parent_link_writes_commit_at_most_one_edge(postgres_db_real: PostgresDb) -> None:
+    """A->B and B->A writes serialize, and the second edge fails as a cycle."""
+    _create_component(postgres_db_real, "graph-a")
+    _create_component(postgres_db_real, "graph-b")
+    ready = Barrier(2)
+
+    def append_link(parent_id: str, child_id: str) -> str:
+        ready.wait()
+        try:
+            postgres_db_real.upsert_config(
+                parent_id,
+                config={"child": child_id},
+                stage="draft",
+                guard=_guard(1, 1),
+                links=[_component_link(child_id)],
+            )
+        except ComponentCycleError:
+            return "cycle"
+        return "created"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        a_to_b = executor.submit(append_link, "graph-a", "graph-b")
+        b_to_a = executor.submit(append_link, "graph-b", "graph-a")
+        outcomes = [a_to_b.result(timeout=10), b_to_a.result(timeout=10)]
+
+    assert sorted(outcomes) == ["created", "cycle"]
+    created_versions = sum(
+        len(postgres_db_real.list_configs(component_id)) - 1 for component_id in ("graph-a", "graph-b")
+    )
+    assert created_versions == 1

--- a/libs/agno/tests/integration/db/postgres/test_schedule_migration_v2_9.py
+++ b/libs/agno/tests/integration/db/postgres/test_schedule_migration_v2_9.py
@@ -1,0 +1,412 @@
+"""Live PostgreSQL coverage for the v2.9 schedule migration."""
+
+import time
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from agno.db.migrations.versions import v2_9_0
+from agno.db.postgres import AsyncPostgresDb, PostgresDb
+from agno.db.schemas.scheduler import ScheduleNameConflictError
+
+
+def _manual_claim_schedule(schedule_id: str) -> dict:
+    return {
+        "id": schedule_id,
+        "name": schedule_id,
+        "method": "POST",
+        "endpoint": "/external",
+        "cron_expr": "0 9 * * *",
+        "timezone": "UTC",
+        "timeout_seconds": 3600,
+        "max_retries": 0,
+        "retry_delay_seconds": 60,
+        "enabled": True,
+        "next_run_at": int(time.time()) + 9999,
+        "created_at": int(time.time()),
+    }
+
+
+def _assert_sync_stale_manual_recovery(db: PostgresDb) -> None:
+    schedule = _manual_claim_schedule(f"manual-{uuid.uuid4().hex}")
+    now = int(time.time())
+    future = now + 9999
+    db.create_schedule(schedule)
+    try:
+        db.trigger_schedule(schedule["id"])
+        abandoned = db.claim_due_schedule("dead-worker")
+        assert abandoned is not None and abandoned["manual_trigger_claimed"] is True
+
+        stale_fence = now - 600
+        db.update_schedule(schedule["id"], locked_at=stale_fence)
+        with patch("agno.db.postgres.postgres.time.time", return_value=stale_fence):
+            renewed_at = db.renew_schedule_claim(
+                schedule["id"],
+                worker_id="dead-worker",
+                locked_at=stale_fence,
+            )
+        assert renewed_at == stale_fence + 1
+        assert not db.release_schedule(schedule["id"], worker_id="dead-worker", locked_at=stale_fence)
+
+        db.update_schedule(schedule["id"], locked_at=now - 600, next_run_at=now - 1)
+        recovered = db.claim_due_schedule("recovery-worker")
+        assert recovered is not None
+        assert recovered["pending_trigger_count"] == 0
+        assert recovered["manual_trigger_claimed"] is True
+        assert not db.release_schedule(
+            schedule["id"],
+            worker_id=abandoned["locked_by"],
+            locked_at=abandoned["locked_at"],
+        )
+        assert db.release_schedule(
+            schedule["id"],
+            worker_id=recovered["locked_by"],
+            locked_at=recovered["locked_at"],
+        )
+
+        cron_claim = db.claim_due_schedule("cron-worker")
+        assert cron_claim is not None and cron_claim["manual_trigger_claimed"] is False
+        assert db.release_schedule(
+            schedule["id"],
+            next_run_at=future,
+            worker_id=cron_claim["locked_by"],
+            locked_at=cron_claim["locked_at"],
+        )
+        assert db.claim_due_schedule("extra-worker") is None
+    finally:
+        db.delete_schedule(schedule["id"])
+
+
+def test_postgres_schedule_migration_is_reversible_and_preserves_legacy_rows(
+    postgres_db_real: PostgresDb,
+) -> None:
+    schema = postgres_db_real.db_schema
+    table_name = postgres_db_real.schedules_table_name
+    runs_table_name = postgres_db_real.schedule_runs_table_name
+    qualified_table = f'"{schema}"."{table_name}"'
+    qualified_runs_table = f'"{schema}"."{runs_table_name}"'
+
+    with postgres_db_real.Session() as session, session.begin():
+        session.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
+        session.execute(text(f"DROP TABLE IF EXISTS {qualified_runs_table} CASCADE"))
+        session.execute(text(f"DROP TABLE IF EXISTS {qualified_table} CASCADE"))
+        session.execute(
+            text(
+                f"""
+                CREATE TABLE {qualified_table} (
+                    id VARCHAR PRIMARY KEY NOT NULL,
+                    name VARCHAR NOT NULL,
+                    description VARCHAR,
+                    method VARCHAR NOT NULL,
+                    endpoint VARCHAR NOT NULL,
+                    payload JSON,
+                    cron_expr VARCHAR NOT NULL,
+                    timezone VARCHAR NOT NULL,
+                    timeout_seconds BIGINT NOT NULL,
+                    max_retries BIGINT NOT NULL,
+                    retry_delay_seconds BIGINT NOT NULL,
+                    enabled BOOLEAN NOT NULL,
+                    next_run_at BIGINT,
+                    locked_by VARCHAR,
+                    locked_at BIGINT,
+                    created_at BIGINT NOT NULL,
+                    updated_at BIGINT
+                )
+                """
+            )
+        )
+        session.execute(
+            text(
+                f"""
+                INSERT INTO {qualified_table} (
+                    id, name, method, endpoint, cron_expr, timezone,
+                    timeout_seconds, max_retries, retry_delay_seconds,
+                    enabled, created_at
+                ) VALUES
+                    ('legacy-1', 'legacy-one', 'POST', '/external', '0 9 * * *', 'UTC', 3600, 0, 60, true, 1),
+                    ('legacy-2', 'legacy-two', 'POST', '/external', '0 10 * * *', 'UTC', 3600, 0, 60, true, 1)
+                """
+            )
+        )
+
+    assert v2_9_0.up(postgres_db_real, "schedules", table_name) is True
+
+    with postgres_db_real.Session() as session:
+        columns = {
+            row.column_name
+            for row in session.execute(
+                text(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = :schema AND table_name = :table_name
+                    """
+                ),
+                {"schema": schema, "table_name": table_name},
+            )
+        }
+        legacy_row = session.execute(
+            text(
+                f"""
+                SELECT managed_by, owner_actor_id, target_type, target_id
+                FROM {qualified_table}
+                WHERE id = 'legacy-1'
+                """
+            )
+        ).one()
+        indexes = {
+            row.indexname
+            for row in session.execute(
+                text(
+                    """
+                    SELECT indexname
+                    FROM pg_indexes
+                    WHERE schemaname = :schema AND tablename = :table_name
+                    """
+                ),
+                {"schema": schema, "table_name": table_name},
+            )
+        }
+
+    assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+    assert tuple(legacy_row) == (None, None, None, None)
+    assert {
+        f"{table_name}_uq_generic_name",
+        f"{table_name}_uq_studio_owner_name",
+    }.issubset(indexes)
+
+    with pytest.raises(IntegrityError):
+        with postgres_db_real.Session() as session, session.begin():
+            session.execute(
+                text(
+                    f"""
+                    INSERT INTO {qualified_table} (
+                        id, name, method, endpoint, cron_expr, timezone,
+                        timeout_seconds, max_retries, retry_delay_seconds,
+                        enabled, created_at
+                    ) VALUES (
+                        'duplicate-name', 'legacy-one', 'POST', '/external',
+                        '0 11 * * *', 'UTC', 3600, 0, 60, true, 1
+                    )
+                    """
+                )
+            )
+
+    duplicate_schedule = {
+        "id": "adapter-duplicate-name",
+        "name": "legacy-one",
+        "method": "POST",
+        "endpoint": "/external",
+        "cron_expr": "0 11 * * *",
+        "timezone": "UTC",
+        "timeout_seconds": 3600,
+        "max_retries": 0,
+        "retry_delay_seconds": 60,
+        "enabled": True,
+        "created_at": 1,
+    }
+    with pytest.raises(ScheduleNameConflictError, match="legacy-one"):
+        postgres_db_real.create_schedule(duplicate_schedule)
+    with pytest.raises(ScheduleNameConflictError, match="legacy-one"):
+        postgres_db_real.update_schedule("legacy-2", name="legacy-one")
+
+    with postgres_db_real.Session() as session, session.begin():
+        session.execute(
+            text(
+                f"""
+                UPDATE {qualified_table}
+                SET managed_by = 'studio',
+                    owner_actor_id = 'actor-1',
+                    target_type = 'agent',
+                    target_id = 'private-agent',
+                    payload = '{{"message": "private prompt"}}'
+                WHERE id = 'legacy-2'
+                """
+            )
+        )
+        session.execute(
+            text(
+                f"""
+                CREATE TABLE {qualified_runs_table} (
+                    id VARCHAR PRIMARY KEY NOT NULL,
+                    schedule_id VARCHAR NOT NULL REFERENCES {qualified_table}(id) ON DELETE CASCADE,
+                    input JSON,
+                    output JSON
+                )
+                """
+            )
+        )
+        session.execute(
+            text(
+                f"""
+                INSERT INTO {qualified_runs_table} (id, schedule_id, input, output)
+                VALUES (
+                    'studio-run',
+                    'legacy-2',
+                    '{{"message": "private prompt"}}',
+                    '{{"content": "private response"}}'
+                )
+                """
+            )
+        )
+
+    with pytest.raises(ValueError, match="Cannot remove Studio schedule provenance"):
+        v2_9_0.down(postgres_db_real, "schedules", table_name)
+
+    with postgres_db_real.Session() as session, session.begin():
+        protected_schedule = session.execute(
+            text(f"SELECT managed_by, owner_actor_id, payload FROM {qualified_table} WHERE id = 'legacy-2'")
+        ).one()
+        protected_run = session.execute(
+            text(f"SELECT input, output FROM {qualified_runs_table} WHERE id = 'studio-run'")
+        ).one()
+        columns_after_refusal = {
+            row.column_name
+            for row in session.execute(
+                text(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = :schema AND table_name = :table_name
+                    """
+                ),
+                {"schema": schema, "table_name": table_name},
+            )
+        }
+        indexes_after_refusal = {
+            row.indexname
+            for row in session.execute(
+                text(
+                    """
+                    SELECT indexname
+                    FROM pg_indexes
+                    WHERE schemaname = :schema AND tablename = :table_name
+                    """
+                ),
+                {"schema": schema, "table_name": table_name},
+            )
+        }
+        session.execute(text(f"DELETE FROM {qualified_table} WHERE id = 'legacy-2'"))
+
+    assert tuple(protected_schedule[:2]) == ("studio", "actor-1")
+    assert protected_schedule.payload == {"message": "private prompt"}
+    assert protected_run.input == {"message": "private prompt"}
+    assert protected_run.output == {"content": "private response"}
+    assert set(v2_9_0._V2_9_COLUMNS).issubset(columns_after_refusal)
+    assert {
+        f"{table_name}_uq_generic_name",
+        f"{table_name}_uq_studio_owner_name",
+    }.issubset(indexes_after_refusal)
+
+    assert v2_9_0.down(postgres_db_real, "schedules", table_name) is True
+
+    with postgres_db_real.Session() as session, session.begin():
+        columns_after = {
+            row.column_name
+            for row in session.execute(
+                text(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = :schema AND table_name = :table_name
+                    """
+                ),
+                {"schema": schema, "table_name": table_name},
+            )
+        }
+        indexes_after = {
+            row.indexname
+            for row in session.execute(
+                text(
+                    """
+                    SELECT indexname
+                    FROM pg_indexes
+                    WHERE schemaname = :schema AND tablename = :table_name
+                    """
+                ),
+                {"schema": schema, "table_name": table_name},
+            )
+        }
+        session.execute(
+            text(
+                f"""
+                INSERT INTO {qualified_table} (
+                    id, name, method, endpoint, cron_expr, timezone,
+                    timeout_seconds, max_retries, retry_delay_seconds,
+                    enabled, created_at
+                ) VALUES (
+                    'duplicate-after-down', 'legacy-one', 'POST', '/external',
+                    '0 12 * * *', 'UTC', 3600, 0, 60, true, 1
+                )
+                """
+            )
+        )
+
+    assert set(v2_9_0._V2_9_COLUMNS).isdisjoint(columns_after)
+    assert f"{table_name}_uq_generic_name" not in indexes_after
+    assert f"{table_name}_uq_studio_owner_name" not in indexes_after
+
+
+def test_postgres_stale_manual_claim_is_recovered_exactly_once(postgres_db_real: PostgresDb) -> None:
+    _assert_sync_stale_manual_recovery(postgres_db_real)
+
+
+@pytest.mark.asyncio
+async def test_async_postgres_stale_manual_claim_is_recovered_exactly_once() -> None:
+    schema = f"test_schedule_async_{uuid.uuid4().hex[:8]}"
+    db = AsyncPostgresDb(
+        db_url="postgresql+psycopg_async://ai:ai@localhost:5532/ai",
+        db_schema=schema,
+    )
+    schedule = _manual_claim_schedule(f"manual-{uuid.uuid4().hex}")
+    now = int(time.time())
+    future = now + 9999
+    try:
+        await db.create_schedule(schedule)
+        await db.trigger_schedule(schedule["id"])
+        abandoned = await db.claim_due_schedule("dead-worker")
+        assert abandoned is not None and abandoned["manual_trigger_claimed"] is True
+
+        stale_fence = now - 600
+        await db.update_schedule(schedule["id"], locked_at=stale_fence)
+        with patch("agno.db.postgres.async_postgres.time.time", return_value=stale_fence):
+            renewed_at = await db.renew_schedule_claim(
+                schedule["id"],
+                worker_id="dead-worker",
+                locked_at=stale_fence,
+            )
+        assert renewed_at == stale_fence + 1
+        assert not await db.release_schedule(schedule["id"], worker_id="dead-worker", locked_at=stale_fence)
+
+        await db.update_schedule(schedule["id"], locked_at=now - 600, next_run_at=now - 1)
+        recovered = await db.claim_due_schedule("recovery-worker")
+        assert recovered is not None
+        assert recovered["pending_trigger_count"] == 0
+        assert recovered["manual_trigger_claimed"] is True
+        assert not await db.release_schedule(
+            schedule["id"],
+            worker_id=abandoned["locked_by"],
+            locked_at=abandoned["locked_at"],
+        )
+        assert await db.release_schedule(
+            schedule["id"],
+            worker_id=recovered["locked_by"],
+            locked_at=recovered["locked_at"],
+        )
+
+        cron_claim = await db.claim_due_schedule("cron-worker")
+        assert cron_claim is not None and cron_claim["manual_trigger_claimed"] is False
+        assert await db.release_schedule(
+            schedule["id"],
+            next_run_at=future,
+            worker_id=cron_claim["locked_by"],
+            locked_at=cron_claim["locked_at"],
+        )
+        assert await db.claim_due_schedule("extra-worker") is None
+    finally:
+        async with db.db_engine.begin() as connection:
+            await connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        await db.close()

--- a/libs/agno/tests/integration/db/sqlite/test_component_lifecycle.py
+++ b/libs/agno/tests/integration/db/sqlite/test_component_lifecycle.py
@@ -1,0 +1,1258 @@
+"""SQLite integration tests for guarded component lifecycle operations."""
+
+import multiprocessing
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier
+from typing import Any, Dict, List, Optional, cast
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.exc import IntegrityError
+
+from agno.db.base import (
+    DELETED_CONFIG_STAGE,
+    ComponentAlreadyExistsError,
+    ComponentCycleError,
+    ComponentDependencyError,
+    ComponentDependencyUnavailableError,
+    ComponentDraftRequiredError,
+    ComponentProjection,
+    ComponentType,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+)
+from agno.db.sqlite.sqlite import SqliteDb
+
+
+def _first_component_write_in_process(
+    db_file: str,
+    component_id: str,
+    ready: Any,
+    results: Any,
+) -> None:
+    try:
+        db = SqliteDb(db_file=db_file)
+        ready.wait(timeout=10)
+        db.create_component_with_config(
+            component_id=component_id,
+            component_type=ComponentType.AGENT,
+            name=component_id,
+            config={"name": component_id},
+            stage="draft",
+        )
+        results.put(("created", component_id))
+    except Exception as exc:
+        results.put(("error", f"{type(exc).__name__}: {exc}"))
+
+
+def _create_component(
+    db: SqliteDb,
+    component_id: str,
+    *,
+    component_type: ComponentType = ComponentType.AGENT,
+    stage: str = "published",
+    name: Optional[str] = None,
+    config: Optional[Dict[str, object]] = None,
+    links: Optional[List[Dict[str, object]]] = None,
+) -> None:
+    db.create_component_with_config(
+        component_id=component_id,
+        component_type=component_type,
+        name=name or component_id,
+        config=config or {"name": name or component_id},
+        stage=stage,
+        links=links,
+    )
+
+
+def _guard(latest_version: Optional[int], current_version: Optional[int]) -> ComponentVersionGuard:
+    return ComponentVersionGuard(latest_version=latest_version, current_version=current_version)
+
+
+def _component_link(child_id: str, *, link_key: str = "step_0") -> Dict[str, object]:
+    return {
+        "link_kind": "step_agent",
+        "link_key": link_key,
+        "child_component_id": child_id,
+        "child_version": 1,
+        "position": 0,
+    }
+
+
+def test_generic_read_falls_back_to_latest_draft_but_current_read_does_not(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "draft-agent", stage="draft")
+
+    component = sqlite_db_real.get_component("draft-agent")
+    assert component is not None
+    assert component["current_version"] is None
+    assert sqlite_db_real.get_current_config("draft-agent") is None
+
+    draft = sqlite_db_real.get_config("draft-agent")
+    assert draft is not None
+    assert draft["version"] == 1
+    assert draft["stage"] == "draft"
+    assert sqlite_db_real.get_latest_config("draft-agent") == draft
+
+
+def test_bulk_component_reads_are_complete_bounded_and_single_query(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "bulk-active", name="Published", config={"name": "Published"})
+    sqlite_db_real.upsert_config(
+        "bulk-active",
+        config={"name": "Draft"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    _create_component(
+        sqlite_db_real,
+        "bulk-team",
+        component_type=ComponentType.TEAM,
+    )
+    _create_component(sqlite_db_real, "bulk-archived")
+    assert sqlite_db_real.delete_component("bulk-archived")
+
+    statements: List[str] = []
+
+    def record_statement(_conn: Any, _cursor: Any, statement: str, _parameters: Any, _context: Any, _many: bool):
+        statements.append(statement)
+
+    event.listen(sqlite_db_real.db_engine, "before_cursor_execute", record_statement)
+    try:
+        rows = sqlite_db_real.get_components(
+            {"bulk-active", "bulk-team", "bulk-archived", "bulk-missing"},
+            include_deleted=True,
+        )
+    finally:
+        event.remove(sqlite_db_real.db_engine, "before_cursor_execute", record_statement)
+
+    assert [row["component_id"] for row in rows] == ["bulk-active", "bulk-archived", "bulk-team"]
+    assert len(statements) == 1
+    assert statements[0].lstrip().upper().startswith("SELECT")
+    assert [
+        row["component_id"]
+        for row in sqlite_db_real.get_components(
+            {"bulk-active", "bulk-team", "bulk-archived"},
+            component_type=ComponentType.AGENT,
+        )
+    ] == ["bulk-active"]
+    assert sqlite_db_real.get_components(set()) == []
+
+    statements.clear()
+    event.listen(sqlite_db_real.db_engine, "before_cursor_execute", record_statement)
+    try:
+        latest = sqlite_db_real.get_latest_configs(
+            {"bulk-active", "bulk-archived", "bulk-missing"},
+        )
+    finally:
+        event.remove(sqlite_db_real.db_engine, "before_cursor_execute", record_statement)
+
+    assert set(latest) == {"bulk-active", "bulk-archived", "bulk-missing"}
+    assert latest["bulk-active"] is not None
+    assert latest["bulk-active"]["version"] == 2
+    assert latest["bulk-active"]["stage"] == "draft"
+    assert latest["bulk-archived"] is None
+    assert latest["bulk-missing"] is None
+    assert len(statements) == 1
+    assert statements[0].lstrip().upper().startswith("SELECT")
+
+    archived_latest = sqlite_db_real.get_latest_configs({"bulk-archived"}, include_deleted=True)
+    assert archived_latest["bulk-archived"] is not None
+    assert archived_latest["bulk-archived"]["version"] == 1
+    assert sqlite_db_real.get_latest_configs(set()) == {}
+
+
+def test_draft_projection_tracks_latest_only_until_first_publish(sqlite_db_real: SqliteDb) -> None:
+    _create_component(
+        sqlite_db_real,
+        "draft-projection",
+        stage="draft",
+        name="Draft one",
+        config={"name": "Draft one"},
+    )
+
+    sqlite_db_real.upsert_config(
+        "draft-projection",
+        config={"name": "Draft two"},
+        stage="draft",
+        projection={"name": "Draft two"},
+    )
+    component = sqlite_db_real.get_component("draft-projection")
+    assert component is not None
+    assert component["current_version"] is None
+    assert component["name"] == "Draft two"
+
+    sqlite_db_real.upsert_config(
+        "draft-projection",
+        config={"name": "Published"},
+        stage="published",
+        projection={"name": "Published"},
+    )
+    latest_draft = sqlite_db_real.upsert_config(
+        "draft-projection",
+        config={"name": "Must not leak"},
+        stage="draft",
+        projection={"name": "Must not leak"},
+    )
+
+    component = sqlite_db_real.get_component("draft-projection")
+    assert component is not None
+    assert component["current_version"] == 3
+    assert component["name"] == "Published"
+    assert latest_draft["version"] == 4
+    assert sqlite_db_real.get_latest_config("draft-projection") == latest_draft
+    assert sqlite_db_real.get_current_config("draft-projection")["version"] == 3  # type: ignore[index]
+
+
+def test_only_draft_cannot_be_deleted_into_a_zombie(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "sole-draft", stage="draft")
+
+    with pytest.raises(ValueError, match="last config.*archive"):
+        sqlite_db_real.delete_config(
+            "sole-draft",
+            1,
+            guard=_guard(1, None),
+        )
+
+    assert [row["version"] for row in sqlite_db_real.list_configs("sole-draft")] == [1]
+    assert sqlite_db_real.get_config("sole-draft", version=1) is not None
+    assert sqlite_db_real.delete_component("sole-draft", guard=_guard(1, None)) is True
+
+
+def test_generic_component_update_cannot_move_current_pointer(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "pointer-agent", name="Version one")
+    sqlite_db_real.upsert_config(
+        "pointer-agent",
+        config={"name": "Version two"},
+        stage="published",
+        projection={"name": "Version two"},
+    )
+
+    with pytest.raises(ValueError, match="set_current_version"):
+        sqlite_db_real.upsert_component("pointer-agent", current_version=1)
+
+    component = sqlite_db_real.get_component("pointer-agent")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Version two"
+
+
+def test_mutation_results_are_captured_before_commit(
+    sqlite_db_real: SqliteDb,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_public_read(*args: object, **kwargs: object) -> None:
+        raise AssertionError("mutation must not perform a post-commit public read")
+
+    monkeypatch.setattr(sqlite_db_real, "get_component", fail_public_read)
+    monkeypatch.setattr(sqlite_db_real, "get_config", fail_public_read)
+
+    component, initial = sqlite_db_real.create_component_with_config(
+        component_id="atomic-response",
+        component_type=ComponentType.AGENT,
+        name="Initial",
+        config={"name": "Initial"},
+        stage="published",
+    )
+    assert component["component_id"] == "atomic-response"
+    assert initial["version"] == 1
+
+    updated = sqlite_db_real.upsert_component("atomic-response", name="Updated")
+    draft = sqlite_db_real.upsert_config(
+        "atomic-response",
+        config={"name": "Draft"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    assert updated["name"] == "Updated"
+    assert draft["version"] == 2
+    assert draft["stage"] == "draft"
+
+
+def test_guarded_draft_append_rejects_stale_writer_and_in_place_mutation(sqlite_db_real: SqliteDb) -> None:
+    _create_component(
+        sqlite_db_real,
+        "guarded-agent",
+        config={"instructions": "published"},
+    )
+
+    draft = sqlite_db_real.upsert_config(
+        component_id="guarded-agent",
+        config={"instructions": "first writer"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    assert draft["version"] == 2
+
+    with pytest.raises(ComponentVersionConflictError) as conflict:
+        sqlite_db_real.upsert_config(
+            component_id="guarded-agent",
+            config={"instructions": "stale writer"},
+            stage="draft",
+            guard=_guard(1, 1),
+        )
+
+    assert conflict.value.expected == _guard(1, 1)
+    assert conflict.value.actual == _guard(2, 1)
+
+    with pytest.raises(ValueError):
+        sqlite_db_real.upsert_config(
+            component_id="guarded-agent",
+            version=2,
+            config={"instructions": "in-place mutation"},
+            guard=_guard(2, 1),
+        )
+
+    published = sqlite_db_real.get_config("guarded-agent", version=1)
+    persisted_draft = sqlite_db_real.get_config("guarded-agent", version=2)
+    assert published is not None
+    assert persisted_draft is not None
+    assert published["config"] == {"instructions": "published"}
+    assert persisted_draft["config"] == {"instructions": "first writer"}
+    assert [config["version"] for config in sqlite_db_real.list_configs("guarded-agent")] == [2, 1]
+
+
+def test_concurrent_guarded_appends_serialize_to_success_and_conflict(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "concurrent-agent", config={"instructions": "published"})
+    ready = Barrier(2)
+
+    def append_draft(instructions: str) -> str:
+        ready.wait()
+        try:
+            sqlite_db_real.upsert_config(
+                component_id="concurrent-agent",
+                config={"instructions": instructions},
+                stage="draft",
+                guard=_guard(1, 1),
+            )
+        except ComponentVersionConflictError:
+            return "conflict"
+        return "created"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(append_draft, ["writer one", "writer two"]))
+
+    assert sorted(outcomes) == ["conflict", "created"]
+    configs = sqlite_db_real.list_configs("concurrent-agent", include_config=True)
+    assert [config["version"] for config in configs] == [2, 1]
+    assert configs[0]["config"]["instructions"] in {"writer one", "writer two"}
+
+
+def test_atomic_create_rejects_self_cycle_without_rows(sqlite_db_real: SqliteDb) -> None:
+    with pytest.raises(ComponentCycleError) as exc:
+        _create_component(
+            sqlite_db_real,
+            "self-cycle",
+            component_type=ComponentType.WORKFLOW,
+            stage="draft",
+            links=[_component_link("self-cycle")],
+        )
+
+    assert exc.value.cycle_path == ["self-cycle", "self-cycle"]
+    assert sqlite_db_real.get_component("self-cycle", include_deleted=True) is None
+    assert sqlite_db_real.get_config("self-cycle", version=1) is None
+
+
+def test_two_node_and_multi_node_cycles_fail_transactionally(sqlite_db_real: SqliteDb) -> None:
+    for component_id in ("cycle-a", "cycle-b", "cycle-c"):
+        _create_component(sqlite_db_real, component_id)
+
+    sqlite_db_real.upsert_config(
+        "cycle-a",
+        config={"child": "cycle-b"},
+        stage="draft",
+        guard=_guard(1, 1),
+        links=[_component_link("cycle-b")],
+    )
+    with pytest.raises(ComponentCycleError) as two_node:
+        sqlite_db_real.upsert_config(
+            "cycle-b",
+            config={"child": "cycle-a"},
+            stage="draft",
+            guard=_guard(1, 1),
+            links=[_component_link("cycle-a")],
+        )
+    assert two_node.value.cycle_path == ["cycle-b", "cycle-a", "cycle-b"]
+    assert [row["version"] for row in sqlite_db_real.list_configs("cycle-b")] == [1]
+
+    sqlite_db_real.upsert_config(
+        "cycle-b",
+        config={"child": "cycle-c"},
+        stage="draft",
+        guard=_guard(1, 1),
+        links=[_component_link("cycle-c")],
+    )
+    with pytest.raises(ComponentCycleError) as multi_node:
+        sqlite_db_real.upsert_config(
+            "cycle-c",
+            config={"child": "cycle-a"},
+            stage="draft",
+            guard=_guard(1, 1),
+            links=[_component_link("cycle-a")],
+        )
+    assert multi_node.value.cycle_path == ["cycle-c", "cycle-a", "cycle-b", "cycle-c"]
+    assert [row["version"] for row in sqlite_db_real.list_configs("cycle-c")] == [1]
+
+
+def test_concurrent_cross_component_edges_commit_at_most_one(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "cross-a")
+    _create_component(sqlite_db_real, "cross-b")
+    ready = Barrier(2)
+
+    def append_link(parent_id: str, child_id: str) -> str:
+        ready.wait()
+        try:
+            sqlite_db_real.upsert_config(
+                parent_id,
+                config={"child": child_id},
+                stage="draft",
+                guard=_guard(1, 1),
+                links=[_component_link(child_id)],
+            )
+        except ComponentCycleError:
+            return "cycle"
+        return "created"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(lambda pair: append_link(*pair), [("cross-a", "cross-b"), ("cross-b", "cross-a")]))
+
+    assert sorted(outcomes) == ["created", "cycle"]
+    created_versions = sum(
+        len(sqlite_db_real.list_configs(component_id)) - 1 for component_id in ("cross-a", "cross-b")
+    )
+    assert created_versions == 1
+
+
+def test_first_component_write_is_safe_across_processes(tmp_path: Path) -> None:
+    db_file = str(tmp_path / "multi-process-components.db")
+    context = multiprocessing.get_context("spawn")
+    ready = context.Barrier(2)
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_first_component_write_in_process,
+            args=(db_file, component_id, ready, results),
+        )
+        for component_id in ("process-a", "process-b")
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=20)
+
+    assert all(not process.is_alive() for process in processes)
+    assert all(process.exitcode == 0 for process in processes)
+    outcomes = sorted(results.get(timeout=5) for _ in processes)
+    assert outcomes == [("created", "process-a"), ("created", "process-b")]
+
+    db = SqliteDb(db_file=db_file)
+    rows, total = db.list_components(limit=10)
+    assert total == 2
+    assert {row["component_id"] for row in rows} == {"process-a", "process-b"}
+
+
+def test_publish_updates_stage_current_pointer_and_projection_together(sqlite_db_real: SqliteDb) -> None:
+    _create_component(
+        sqlite_db_real,
+        "publish-agent",
+        name="Published name",
+        config={"instructions": "v1"},
+    )
+    draft = sqlite_db_real.upsert_config(
+        component_id="publish-agent",
+        config={"instructions": "v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    projection: ComponentProjection = {
+        "name": "Draft promoted",
+        "description": "Projected from version two",
+        "metadata": {"release": 2},
+    }
+
+    published = sqlite_db_real.upsert_config(
+        component_id="publish-agent",
+        version=draft["version"],
+        stage="published",
+        guard=_guard(2, 1),
+        projection=projection,
+    )
+
+    assert published["stage"] == "published"
+    assert published["config"] == {"instructions": "v2"}
+    component = sqlite_db_real.get_component("publish-agent")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Draft promoted"
+    assert component["description"] == "Projected from version two"
+    assert component["metadata"] == {"release": 2}
+    assert sqlite_db_real.get_config("publish-agent") == published
+
+
+def test_existing_draft_payload_is_immutable_and_publish_derives_projection(sqlite_db_real: SqliteDb) -> None:
+    sqlite_db_real.create_component_with_config(
+        component_id="immutable-draft",
+        component_type=ComponentType.AGENT,
+        name="Catalog placeholder",
+        config={
+            "name": "Locked draft",
+            "description": "Derived from the stored payload",
+            "metadata": {"release": 1},
+            "instructions": "original",
+        },
+        description="Catalog placeholder",
+        metadata={"release": 0},
+        stage="draft",
+    )
+
+    with pytest.raises(ValueError, match="requires a component version guard"):
+        sqlite_db_real.upsert_config(
+            "immutable-draft",
+            version=1,
+            config={"name": "mutated"},
+            stage="draft",
+        )
+    with pytest.raises(ValueError, match="cannot mutate config"):
+        sqlite_db_real.upsert_config(
+            "immutable-draft",
+            version=1,
+            config={"name": "mutated"},
+            stage="published",
+            guard=_guard(1, None),
+        )
+
+    published = sqlite_db_real.upsert_config(
+        "immutable-draft",
+        version=1,
+        stage="published",
+        guard=_guard(1, None),
+    )
+    component = sqlite_db_real.get_component("immutable-draft")
+
+    assert published["config"]["instructions"] == "original"
+    assert component is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Locked draft"
+    assert component["description"] == "Derived from the stored payload"
+    assert component["metadata"] == {"release": 1}
+
+
+def test_publish_and_set_current_derive_projection_from_target_config(sqlite_db_real: SqliteDb) -> None:
+    sqlite_db_real.create_component_with_config(
+        component_id="derived-pointer",
+        component_type=ComponentType.AGENT,
+        name="Version one",
+        config={"name": "Version one", "description": "First", "metadata": {"release": 1}},
+        description="First",
+        metadata={"release": 1},
+        stage="published",
+    )
+
+    sqlite_db_real.upsert_config(
+        "derived-pointer",
+        config={"name": "Version two", "description": "Second", "metadata": {"release": 2}},
+        stage="published",
+    )
+    component = sqlite_db_real.get_component("derived-pointer")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Version two"
+    assert component["description"] == "Second"
+    assert component["metadata"] == {"release": 2}
+
+    assert sqlite_db_real.set_current_version("derived-pointer", 1, guard=_guard(2, 2))
+    component = sqlite_db_real.get_component("derived-pointer")
+    assert component is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Version one"
+    assert component["description"] == "First"
+    assert component["metadata"] == {"release": 1}
+
+
+def test_projection_failure_rolls_back_publish_transition(sqlite_db_real: SqliteDb) -> None:
+    _create_component(
+        sqlite_db_real,
+        "invalid-projection-agent",
+        name="Original name",
+        config={"instructions": "v1"},
+    )
+    sqlite_db_real.upsert_config(
+        component_id="invalid-projection-agent",
+        config={"instructions": "v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    invalid_projection = cast(ComponentProjection, {"unknown_field": "must fail"})
+    with pytest.raises(ValueError, match="projection"):
+        sqlite_db_real.upsert_config(
+            component_id="invalid-projection-agent",
+            version=2,
+            stage="published",
+            guard=_guard(2, 1),
+            projection=invalid_projection,
+        )
+
+    component = sqlite_db_real.get_component("invalid-projection-agent")
+    draft = sqlite_db_real.get_config("invalid-projection-agent", version=2)
+    assert component is not None
+    assert draft is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Original name"
+    assert draft["stage"] == "draft"
+
+
+def test_stale_publish_guard_leaves_draft_and_component_projection_unchanged(sqlite_db_real: SqliteDb) -> None:
+    _create_component(
+        sqlite_db_real,
+        "stale-publish-agent",
+        name="Original name",
+        config={"instructions": "v1"},
+    )
+    sqlite_db_real.upsert_config(
+        component_id="stale-publish-agent",
+        config={"instructions": "v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    with pytest.raises(ComponentVersionConflictError):
+        sqlite_db_real.upsert_config(
+            component_id="stale-publish-agent",
+            version=2,
+            stage="published",
+            guard=_guard(1, 1),
+            projection={"name": "Must not leak"},
+        )
+
+    component = sqlite_db_real.get_component("stale-publish-agent")
+    draft = sqlite_db_real.get_config("stale-publish-agent", version=2)
+    assert component is not None
+    assert draft is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Original name"
+    assert draft["stage"] == "draft"
+
+
+def test_rollback_updates_current_pointer_and_projection_together(sqlite_db_real: SqliteDb) -> None:
+    _create_component(
+        sqlite_db_real,
+        "rollback-agent",
+        name="Version one",
+        config={"instructions": "v1"},
+    )
+    sqlite_db_real.upsert_config(
+        component_id="rollback-agent",
+        config={"instructions": "v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    sqlite_db_real.upsert_config(
+        component_id="rollback-agent",
+        version=2,
+        stage="published",
+        guard=_guard(2, 1),
+        projection={"name": "Version two", "metadata": {"release": 2}},
+    )
+
+    did_rollback = sqlite_db_real.set_current_version(
+        component_id="rollback-agent",
+        version=1,
+        guard=_guard(2, 2),
+        projection={"name": "Version one", "description": "Restored", "metadata": {"release": 1}},
+    )
+
+    assert did_rollback is True
+    component = sqlite_db_real.get_component("rollback-agent")
+    assert component is not None
+    assert component["current_version"] == 1
+    assert component["name"] == "Version one"
+    assert component["description"] == "Restored"
+    assert component["metadata"] == {"release": 1}
+    current = sqlite_db_real.get_config("rollback-agent")
+    assert current is not None
+    assert current["version"] == 1
+
+
+def test_non_current_published_config_cannot_be_deleted(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "published-delete-agent", config={"instructions": "v1"})
+    sqlite_db_real.upsert_config(
+        component_id="published-delete-agent",
+        config={"instructions": "v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    sqlite_db_real.upsert_config(
+        component_id="published-delete-agent",
+        version=2,
+        stage="published",
+        guard=_guard(2, 1),
+        projection={"name": "Version two"},
+    )
+    sqlite_db_real.set_current_version(
+        component_id="published-delete-agent",
+        version=1,
+        guard=_guard(2, 2),
+        projection={"name": "Version one"},
+    )
+
+    with pytest.raises(ComponentDraftRequiredError, match="only draft configs") as exc:
+        sqlite_db_real.delete_config(
+            component_id="published-delete-agent",
+            version=2,
+            guard=_guard(2, 1),
+        )
+
+    assert exc.value.component_id == "published-delete-agent"
+    assert exc.value.version == 2
+
+    assert sqlite_db_real.get_config("published-delete-agent", version=2) is not None
+
+
+def test_draft_delete_and_projection_are_one_transaction(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "audited-delete", config={"instructions": "v1"})
+    sqlite_db_real.upsert_config(
+        component_id="audited-delete",
+        config={"instructions": "discard me"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    invalid_projection = cast(ComponentProjection, {"unknown_field": "must fail"})
+    with pytest.raises(ValueError, match="projection"):
+        sqlite_db_real.delete_config(
+            "audited-delete",
+            2,
+            guard=_guard(2, 1),
+            projection=invalid_projection,
+        )
+
+    assert sqlite_db_real.get_config("audited-delete", version=2) is not None
+    assert sqlite_db_real.delete_config(
+        "audited-delete",
+        2,
+        guard=_guard(2, 1),
+        projection={"metadata": {"last_action": "delete_version"}},
+    )
+    component = sqlite_db_real.get_component("audited-delete")
+    assert component is not None
+    assert component["metadata"] == {"last_action": "delete_version"}
+    assert sqlite_db_real.get_config("audited-delete", version=2) is None
+
+
+def test_deleted_draft_tombstone_allows_visible_state_cas_without_version_reuse(sqlite_db_real: SqliteDb) -> None:
+    """Deleting v2 restores visible latest=v1, but its audit tombstone reserves v2 forever."""
+    _create_component(sqlite_db_real, "aba-agent")
+    sqlite_db_real.upsert_config(
+        "aba-agent",
+        config={"instructions": "discarded v2"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+    assert sqlite_db_real.delete_config("aba-agent", 2, guard=_guard(2, 1))
+
+    configs_table = sqlite_db_real._get_table(table_type="component_configs")
+    assert configs_table is not None
+    with sqlite_db_real.Session() as session:
+        tombstone = (
+            session.execute(
+                configs_table.select().where(
+                    configs_table.c.component_id == "aba-agent",
+                    configs_table.c.version == 2,
+                )
+            )
+            .mappings()
+            .one()
+        )
+    assert tombstone["stage"] == DELETED_CONFIG_STAGE
+    assert tombstone["config"] == {}
+    assert tombstone["updated_at"] is not None
+
+    # Guards intentionally compare visible lifecycle state. After deleting the
+    # only draft, latest=v1/current=v1 is fresh again; the high-water mark still
+    # makes this append v3 rather than overwriting or reusing the audited v2.
+    replacement = sqlite_db_real.upsert_config(
+        "aba-agent",
+        config={"instructions": "replacement"},
+        stage="draft",
+        guard=_guard(1, 1),
+    )
+
+    assert replacement["version"] == 3
+    assert sqlite_db_real.get_config("aba-agent", version=2) is None
+    with sqlite_db_real.Session() as session:
+        history = session.execute(
+            configs_table.select().where(configs_table.c.component_id == "aba-agent").order_by(configs_table.c.version)
+        ).fetchall()
+    assert [(row.version, row.stage) for row in history] == [
+        (1, "published"),
+        (2, DELETED_CONFIG_STAGE),
+        (3, "draft"),
+    ]
+    with pytest.raises(ValueError, match="not found"):
+        sqlite_db_real.upsert_config(
+            "aba-agent",
+            version=2,
+            stage="published",
+            guard=_guard(3, 1),
+            projection={"name": "Must not publish"},
+        )
+
+
+def test_publishing_existing_draft_revalidates_stored_links(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "draft-child-for-publish", stage="draft")
+    _create_component(sqlite_db_real, "parent-for-publish", component_type=ComponentType.TEAM)
+    sqlite_db_real.upsert_config(
+        "parent-for-publish",
+        config={"members": ["draft-child-for-publish"]},
+        stage="draft",
+        guard=_guard(1, 1),
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "draft-child-for-publish",
+                "child_version": 1,
+                "position": 0,
+                "meta": {"type": "agent"},
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="not published"):
+        sqlite_db_real.upsert_config(
+            "parent-for-publish",
+            version=2,
+            stage="published",
+            guard=_guard(2, 1),
+            projection={"name": "Must remain draft"},
+        )
+
+    parent = sqlite_db_real.get_component("parent-for-publish")
+    draft = sqlite_db_real.get_config("parent-for-publish", version=2)
+    assert parent is not None
+    assert draft is not None
+    assert parent["current_version"] == 1
+    assert draft["stage"] == "draft"
+
+
+def test_guarded_publish_can_atomically_derive_and_persist_links(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "published-child-for-derived-link")
+    _create_component(
+        sqlite_db_real,
+        "draft-parent-for-derived-link",
+        component_type=ComponentType.TEAM,
+        stage="draft",
+    )
+
+    published = sqlite_db_real.upsert_config(
+        "draft-parent-for-derived-link",
+        version=1,
+        stage="published",
+        guard=_guard(1, None),
+        projection={"name": "Published parent"},
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "published-child-for-derived-link",
+                "child_version": 1,
+                "position": 0,
+                "meta": {"type": "agent"},
+            }
+        ],
+    )
+
+    assert published["stage"] == "published"
+    component = sqlite_db_real.get_component("draft-parent-for-derived-link")
+    assert component is not None and component["current_version"] == 1
+    links = sqlite_db_real.get_links("draft-parent-for-derived-link", 1)
+    assert [(link["child_component_id"], link["child_version"]) for link in links] == [
+        ("published-child-for-derived-link", 1)
+    ]
+
+
+def test_draft_config_with_inbound_pin_cannot_be_deleted(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "pinned-draft", stage="draft")
+    _create_component(
+        sqlite_db_real,
+        "legacy-parent",
+        component_type=ComponentType.TEAM,
+    )
+
+    # Simulate a legacy or externally inserted link to isolate the inbound-pin
+    # deletion guard. New writes must reject links to unpublished children.
+    links_table = sqlite_db_real._get_table(table_type="component_links", create_table_if_not_found=True)
+    assert links_table is not None
+    with sqlite_db_real.Session() as sess, sess.begin():
+        sess.execute(
+            links_table.insert().values(
+                parent_component_id="legacy-parent",
+                parent_version=1,
+                link_kind="member",
+                link_key="member_0",
+                child_component_id="pinned-draft",
+                child_version=1,
+                position=0,
+            )
+        )
+
+    with pytest.raises(ComponentDependencyError) as dependency:
+        sqlite_db_real.delete_config(
+            component_id="pinned-draft",
+            version=1,
+            guard=_guard(1, None),
+        )
+
+    assert dependency.value.component_id == "pinned-draft"
+    assert dependency.value.version == 1
+    assert sqlite_db_real.get_config("pinned-draft", version=1) is not None
+
+
+def test_create_rejects_unpublished_child_pin_without_parent_rows(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "draft-child", stage="draft")
+
+    with pytest.raises(ValueError, match="not published"):
+        _create_component(
+            sqlite_db_real,
+            "invalid-parent",
+            component_type=ComponentType.TEAM,
+            links=[
+                {
+                    "link_kind": "member",
+                    "link_key": "member_0",
+                    "child_component_id": "draft-child",
+                    "child_version": 1,
+                    "position": 0,
+                    "meta": {"type": "agent"},
+                }
+            ],
+        )
+
+    assert sqlite_db_real.get_component("invalid-parent", include_deleted=True) is None
+    assert sqlite_db_real.get_config("invalid-parent", version=1) is None
+    assert sqlite_db_real.get_links("invalid-parent", version=1) == []
+
+
+def test_link_insert_failure_rolls_back_atomic_component_create(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "published-child")
+    duplicate_link: Dict[str, object] = {
+        "link_kind": "member",
+        "link_key": "member_0",
+        "child_component_id": "published-child",
+        "child_version": 1,
+        "position": 0,
+        "meta": {"type": "agent"},
+    }
+
+    with pytest.raises(IntegrityError):
+        _create_component(
+            sqlite_db_real,
+            "rolled-back-parent",
+            component_type=ComponentType.TEAM,
+            links=[duplicate_link, dict(duplicate_link)],
+        )
+
+    assert sqlite_db_real.get_component("rolled-back-parent", include_deleted=True) is None
+    assert sqlite_db_real.get_config("rolled-back-parent", version=1) is None
+    assert sqlite_db_real.get_links("rolled-back-parent", version=1) == []
+
+
+def test_archive_is_dependency_safe_and_ignores_archived_parents(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "child-agent")
+    _create_component(
+        sqlite_db_real,
+        "parent-team",
+        component_type=ComponentType.TEAM,
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "child-agent",
+                "child_version": 1,
+                "position": 0,
+                "meta": {"type": "agent"},
+            }
+        ],
+    )
+
+    with pytest.raises(ComponentDependencyError) as dependency:
+        sqlite_db_real.delete_component(
+            "child-agent",
+            guard=_guard(1, 1),
+            require_no_dependents=True,
+        )
+
+    assert dependency.value.component_id == "child-agent"
+    assert sqlite_db_real.get_component("child-agent") is not None
+
+    assert sqlite_db_real.delete_component(
+        "parent-team",
+        guard=_guard(1, 1),
+        require_no_dependents=True,
+    )
+    assert sqlite_db_real.get_dependents("child-agent")
+    assert sqlite_db_real.get_dependents("child-agent", active_parents_only=True) == []
+
+    assert sqlite_db_real.delete_component(
+        "child-agent",
+        guard=_guard(1, 1),
+        require_no_dependents=True,
+    )
+    assert sqlite_db_real.get_component("child-agent") is None
+    archived_child = sqlite_db_real.get_component("child-agent", include_deleted=True)
+    assert archived_child is not None
+    assert archived_child["deleted_at"] is not None
+
+
+def test_archived_component_id_remains_occupied(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "occupied-agent")
+    assert sqlite_db_real.delete_component(
+        "occupied-agent",
+        guard=_guard(1, 1),
+        require_no_dependents=True,
+        projection={
+            "name": "Archived projection",
+            "description": "Last published view",
+            "metadata": {"release": 1},
+        },
+    )
+    assert sqlite_db_real.delete_component("occupied-agent") is False
+    with pytest.raises(ValueError, match="hard delete"):
+        sqlite_db_real.delete_component(
+            "occupied-agent",
+            hard_delete=True,
+            projection={"name": "Must not apply"},
+        )
+
+    with pytest.raises(ComponentAlreadyExistsError):
+        _create_component(
+            sqlite_db_real,
+            "occupied-agent",
+            name="Replacement",
+            config={"instructions": "replacement"},
+        )
+
+    archived = sqlite_db_real.get_component("occupied-agent", include_deleted=True)
+    assert archived is not None
+    assert archived["name"] == "Archived projection"
+    assert archived["description"] == "Last published view"
+    assert archived["metadata"] == {"release": 1}
+    assert archived["deleted_at"] is not None
+
+
+def test_restore_component_is_guarded_and_preserves_history(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "restored-agent", name="Published")
+    assert sqlite_db_real.delete_component("restored-agent", guard=_guard(1, 1))
+
+    assert sqlite_db_real.get_config("restored-agent") is None
+    archived_latest = sqlite_db_real.get_latest_config("restored-agent", include_deleted=True)
+    assert archived_latest is not None
+    assert archived_latest["version"] == 1
+
+    with pytest.raises(ComponentVersionConflictError):
+        sqlite_db_real.restore_component("restored-agent", guard=_guard(0, 1))
+    assert sqlite_db_real.get_component("restored-agent") is None
+
+    assert sqlite_db_real.restore_component(
+        "restored-agent",
+        guard=_guard(1, 1),
+        projection={"name": "Restored", "description": "Same identity", "metadata": {"restored": True}},
+    )
+    restored = sqlite_db_real.get_component("restored-agent")
+    assert restored is not None
+    assert restored["name"] == "Restored"
+    assert restored["description"] == "Same identity"
+    assert restored["metadata"] == {"restored": True}
+    assert sqlite_db_real.get_current_config("restored-agent")["version"] == 1  # type: ignore[index]
+    assert [row["version"] for row in sqlite_db_real.list_configs("restored-agent")] == [1]
+
+
+def test_restore_rejects_an_archived_pinned_dependency_but_allows_draft_only_components(
+    sqlite_db_real: SqliteDb,
+) -> None:
+    _create_component(sqlite_db_real, "restore-child")
+    _create_component(
+        sqlite_db_real,
+        "restore-parent",
+        component_type=ComponentType.WORKFLOW,
+        links=[_component_link("restore-child")],
+    )
+    assert sqlite_db_real.delete_component("restore-parent", guard=_guard(1, 1))
+    assert sqlite_db_real.delete_component("restore-child", guard=_guard(1, 1))
+
+    with pytest.raises(ComponentDependencyUnavailableError) as unavailable:
+        sqlite_db_real.restore_component("restore-parent", guard=_guard(1, 1))
+
+    assert unavailable.value.component_id == "restore-parent"
+    assert unavailable.value.dependencies == [
+        {
+            "component_id": "restore-child",
+            "version": 1,
+            "referenced_by": {"component_id": "restore-parent", "version": 1},
+            "reason": "component_archived",
+        }
+    ]
+    parent = sqlite_db_real.get_component("restore-parent", include_deleted=True)
+    assert parent is not None and parent["deleted_at"] is not None
+
+    assert sqlite_db_real.restore_component("restore-child", guard=_guard(1, 1))
+    assert sqlite_db_real.restore_component("restore-parent", guard=_guard(1, 1))
+
+    _create_component(sqlite_db_real, "restore-draft", stage="draft")
+    assert sqlite_db_real.delete_component("restore-draft", guard=_guard(1, None))
+    assert sqlite_db_real.restore_component("restore-draft", guard=_guard(1, None))
+    restored_draft = sqlite_db_real.get_component("restore-draft")
+    assert restored_draft is not None and restored_draft["current_version"] is None
+
+
+def test_restore_and_dependency_archive_race_never_exposes_a_broken_graph(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "restore-race-child")
+    _create_component(
+        sqlite_db_real,
+        "restore-race-parent",
+        component_type=ComponentType.WORKFLOW,
+        links=[_component_link("restore-race-child")],
+    )
+    assert sqlite_db_real.delete_component("restore-race-parent", guard=_guard(1, 1))
+    ready = Barrier(2)
+
+    def restore_parent() -> str:
+        ready.wait()
+        try:
+            sqlite_db_real.restore_component("restore-race-parent", guard=_guard(1, 1))
+        except ComponentDependencyUnavailableError:
+            return "restore_blocked"
+        return "restored"
+
+    def archive_child() -> str:
+        ready.wait()
+        try:
+            sqlite_db_real.delete_component("restore-race-child", guard=_guard(1, 1))
+        except ComponentDependencyError:
+            return "archive_blocked"
+        return "archived"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        restore_future = executor.submit(restore_parent)
+        archive_future = executor.submit(archive_child)
+        outcomes = {restore_future.result(timeout=10), archive_future.result(timeout=10)}
+
+    assert outcomes in ({"restored", "archive_blocked"}, {"restore_blocked", "archived"})
+    parent_is_active = sqlite_db_real.get_component("restore-race-parent") is not None
+    child_is_active = sqlite_db_real.get_component("restore-race-child") is not None
+    if outcomes == {"restored", "archive_blocked"}:
+        assert parent_is_active and child_is_active
+    else:
+        assert not parent_is_active and not child_is_active
+
+
+def test_atomic_restore_and_draft_append_roll_back_when_the_current_graph_is_unavailable(
+    sqlite_db_real: SqliteDb,
+) -> None:
+    _create_component(sqlite_db_real, "restore-append-child")
+    _create_component(
+        sqlite_db_real,
+        "restore-append-parent",
+        component_type=ComponentType.WORKFLOW,
+        links=[_component_link("restore-append-child")],
+    )
+    assert sqlite_db_real.delete_component("restore-append-parent", guard=_guard(1, 1))
+    assert sqlite_db_real.delete_component("restore-append-child", guard=_guard(1, 1))
+
+    with pytest.raises(ComponentDependencyUnavailableError):
+        sqlite_db_real.upsert_config(
+            "restore-append-parent",
+            config={"name": "Draft edit"},
+            stage="draft",
+            guard=_guard(1, 1),
+            restore_if_deleted=True,
+            expected_component_type=ComponentType.WORKFLOW,
+        )
+
+    parent = sqlite_db_real.get_component("restore-append-parent", include_deleted=True)
+    assert parent is not None and parent["deleted_at"] is not None
+    latest = sqlite_db_real.get_latest_config("restore-append-parent", include_deleted=True)
+    assert latest is not None and latest["version"] == 1
+
+    _create_component(sqlite_db_real, "restore-repair-child")
+    repaired = sqlite_db_real.upsert_config(
+        "restore-append-parent",
+        config={"name": "Published repair"},
+        stage="published",
+        guard=_guard(1, 1),
+        links=[_component_link("restore-repair-child")],
+        restore_if_deleted=True,
+        expected_component_type=ComponentType.WORKFLOW,
+    )
+    assert repaired["version"] == 2
+    parent = sqlite_db_real.get_component("restore-append-parent")
+    assert parent is not None and parent["current_version"] == 2
+    assert sqlite_db_real.get_component("restore-append-child") is None
+
+
+def test_atomic_restore_and_append_rolls_back_on_duplicate_label(sqlite_db_real: SqliteDb) -> None:
+    sqlite_db_real.create_component_with_config(
+        component_id="restore-append-agent",
+        component_type=ComponentType.AGENT,
+        name="Version one",
+        config={"name": "Version one"},
+        stage="published",
+        label="stable",
+    )
+    assert sqlite_db_real.delete_component("restore-append-agent", guard=_guard(1, 1))
+
+    with pytest.raises(ValueError, match="Label 'stable' already exists"):
+        sqlite_db_real.upsert_config(
+            "restore-append-agent",
+            config={"name": "Rejected version"},
+            stage="published",
+            label="stable",
+            projection={"name": "Rejected version"},
+            restore_if_deleted=True,
+        )
+
+    assert sqlite_db_real.get_component("restore-append-agent") is None
+    archived = sqlite_db_real.get_component("restore-append-agent", include_deleted=True)
+    assert archived is not None and archived["deleted_at"] is not None
+    assert sqlite_db_real.get_latest_config("restore-append-agent", include_deleted=True)["version"] == 1  # type: ignore[index]
+
+    appended = sqlite_db_real.upsert_config(
+        "restore-append-agent",
+        config={"name": "Version two"},
+        stage="published",
+        label="next",
+        projection={"name": "Version two"},
+        restore_if_deleted=True,
+    )
+    assert appended["version"] == 2
+    restored = sqlite_db_real.get_component("restore-append-agent")
+    assert restored is not None
+    assert restored["current_version"] == 2
+    assert restored["name"] == "Version two"
+
+
+def test_expected_component_type_rejects_replaced_identity(sqlite_db_real: SqliteDb) -> None:
+    _create_component(sqlite_db_real, "replaced-identity", component_type=ComponentType.AGENT)
+    assert sqlite_db_real.delete_component(
+        "replaced-identity",
+        hard_delete=True,
+        require_no_dependents=False,
+    )
+    _create_component(sqlite_db_real, "replaced-identity", component_type=ComponentType.TEAM)
+
+    with pytest.raises(ValueError, match="has type team, not agent"):
+        sqlite_db_real.upsert_config(
+            "replaced-identity",
+            config={"name": "Agent payload"},
+            stage="published",
+            projection={"name": "Agent payload"},
+            expected_component_type=ComponentType.AGENT,
+        )
+
+    component = sqlite_db_real.get_component("replaced-identity")
+    assert component is not None
+    assert component["component_type"] == ComponentType.TEAM.value
+    assert component["current_version"] == 1
+    assert [row["version"] for row in sqlite_db_real.list_configs("replaced-identity")] == [1]

--- a/libs/agno/tests/integration/db/sqlite/test_scheduler.py
+++ b/libs/agno/tests/integration/db/sqlite/test_scheduler.py
@@ -7,7 +7,9 @@ import uuid
 
 import pytest
 
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY, ScheduleNameConflictError
 from agno.db.sqlite import SqliteDb
+from agno.db.sqlite.async_sqlite import AsyncSqliteDb
 
 
 @pytest.fixture
@@ -99,6 +101,42 @@ class TestScheduleCRUD:
         result = db.get_schedule_by_name("nonexistent")
         assert result is None
 
+    def test_generic_and_studio_names_are_isolated_per_actor(self, db):
+        generic = _make_schedule(name="shared-name")
+        studio_a = _make_schedule(
+            name="shared-name",
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            owner_actor_id="actor-a",
+        )
+        studio_b = _make_schedule(
+            name="shared-name",
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            owner_actor_id="actor-b",
+        )
+        db.create_schedule(generic)
+        db.create_schedule(studio_a)
+        db.create_schedule(studio_b)
+
+        assert (
+            db.get_schedule_by_name("shared-name", exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY)["id"] == generic["id"]
+        )
+        assert (
+            db.get_schedule_by_name(
+                "shared-name",
+                managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+                owner_actor_id="actor-a",
+            )["id"]
+            == studio_a["id"]
+        )
+        with pytest.raises(ScheduleNameConflictError):
+            db.create_schedule(
+                _make_schedule(
+                    name="shared-name",
+                    managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+                    owner_actor_id="actor-a",
+                )
+            )
+
     def test_get_not_found(self, db):
         result = db.get_schedule("nonexistent-id")
         assert result is None
@@ -116,6 +154,36 @@ class TestScheduleCRUD:
         assert s1["id"] in ids
         assert s2["id"] in ids
 
+    def test_list_excludes_studio_before_count_and_pagination(self, db):
+        studio = _make_schedule(
+            name="aaa-studio-hidden",
+            created_at=3,
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            owner_actor_id="studio-actor",
+            target_type="agent",
+            target_id="studio-agent",
+        )
+        ordinary_first = _make_schedule(name="bbb-ordinary-first", created_at=2)
+        ordinary_second = _make_schedule(name="ccc-ordinary-second", created_at=1)
+        db.create_schedule(studio)
+        db.create_schedule(ordinary_first)
+        db.create_schedule(ordinary_second)
+
+        page_one, total_count = db.get_schedules(
+            limit=1,
+            page=1,
+            exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        )
+        page_two, second_total_count = db.get_schedules(
+            limit=1,
+            page=2,
+            exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        )
+
+        assert total_count == second_total_count == 2
+        assert [schedule["id"] for schedule in page_one] == [ordinary_first["id"]]
+        assert [schedule["id"] for schedule in page_two] == [ordinary_second["id"]]
+
     def test_update_schedule(self, db):
         sched = _make_schedule()
         db.create_schedule(sched)
@@ -124,6 +192,51 @@ class TestScheduleCRUD:
         assert updated is not None
         assert updated["description"] == "Updated description"
         assert updated["updated_at"] is not None
+
+    def test_disable_schedules_for_target_is_atomic_and_scoped(self, db):
+        matching = [
+            _make_schedule(
+                name=f"studio-target-{index}",
+                managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+                owner_actor_id="actor-a",
+                target_type="agent",
+                target_id="agent-a",
+            )
+            for index in range(101)
+        ]
+        other_target = _make_schedule(
+            name="studio-other-target",
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            owner_actor_id="actor-a",
+            target_type="agent",
+            target_id="agent-b",
+        )
+        generic_same_target = _make_schedule(
+            name="generic-same-target",
+            target_type="agent",
+            target_id="agent-a",
+        )
+        for schedule in [*matching, other_target, generic_same_target]:
+            db.create_schedule(schedule)
+
+        disabled = db.disable_schedules_for_target(
+            "agent",
+            "agent-a",
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        )
+
+        assert disabled == 101
+        assert (
+            db.disable_schedules_for_target(
+                "agent",
+                "agent-a",
+                managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            )
+            == 0
+        )
+        assert all(db.get_schedule(schedule["id"])["enabled"] is False for schedule in matching)
+        assert db.get_schedule(other_target["id"])["enabled"] is True
+        assert db.get_schedule(generic_same_target["id"])["enabled"] is True
 
     def test_delete_schedule(self, db):
         sched = _make_schedule()
@@ -167,6 +280,135 @@ class TestEnabledFilter:
 
 
 class TestClaimAndRelease:
+    def test_manual_trigger_survives_an_in_flight_release_and_is_consumed_once(self, db):
+        future = int(time.time()) + 9999
+        sched = _make_schedule(
+            next_run_at=future,
+            enabled=True,
+            locked_by="worker-1",
+            locked_at=int(time.time()),
+        )
+        db.create_schedule(sched)
+
+        queued = db.trigger_schedule(sched["id"])
+        assert queued is not None and queued["pending_trigger_count"] == 1
+        assert db.claim_due_schedule("worker-2") is None
+
+        assert (
+            db.release_schedule(
+                sched["id"],
+                next_run_at=future,
+                worker_id="worker-1",
+                locked_at=sched["locked_at"],
+            )
+            is True
+        )
+        claimed = db.claim_due_schedule("worker-2")
+        assert claimed is not None
+        assert claimed["id"] == sched["id"]
+        assert claimed["pending_trigger_count"] == 0
+        assert claimed["manual_trigger_claimed"] is True
+        assert claimed["next_run_at"] == future
+
+        assert (
+            db.release_schedule(
+                sched["id"],
+                worker_id=claimed["locked_by"],
+                locked_at=claimed["locked_at"],
+            )
+            is True
+        )
+        assert db.claim_due_schedule("worker-3") is None
+
+    def test_due_cron_and_manual_trigger_are_claimed_as_two_executions(self, db):
+        now = int(time.time())
+        future = now + 9999
+        sched = _make_schedule(next_run_at=now - 1, enabled=True)
+        db.create_schedule(sched)
+        assert db.trigger_schedule(sched["id"])["pending_trigger_count"] == 1
+
+        cron_claim = db.claim_due_schedule("cron-worker")
+        assert cron_claim is not None
+        assert cron_claim["pending_trigger_count"] == 1
+        assert cron_claim["manual_trigger_claimed"] is False
+        assert (
+            db.release_schedule(
+                sched["id"],
+                next_run_at=future,
+                worker_id=cron_claim["locked_by"],
+                locked_at=cron_claim["locked_at"],
+            )
+            is True
+        )
+
+        manual_claim = db.claim_due_schedule("manual-worker")
+        assert manual_claim is not None
+        assert manual_claim["pending_trigger_count"] == 0
+        assert manual_claim["manual_trigger_claimed"] is True
+        assert manual_claim["next_run_at"] == future
+
+        assert (
+            db.release_schedule(
+                sched["id"],
+                worker_id=manual_claim["locked_by"],
+                locked_at=manual_claim["locked_at"],
+            )
+            is True
+        )
+        assert db.claim_due_schedule("extra-worker") is None
+
+    def test_stale_manual_claim_is_recovered_once_without_swallowing_due_cron(self, db):
+        now = int(time.time())
+        future = now + 9999
+        sched = _make_schedule(next_run_at=future, enabled=True)
+        db.create_schedule(sched)
+        db.trigger_schedule(sched["id"])
+
+        abandoned = db.claim_due_schedule("dead-worker")
+        assert abandoned is not None
+        assert abandoned["pending_trigger_count"] == 0
+        assert abandoned["manual_trigger_claimed"] is True
+
+        # The worker dies. By the time its lock is stale, the cron occurrence
+        # is also due; recovery must finish the manual unit first.
+        db.update_schedule(sched["id"], locked_at=now - 600, next_run_at=now - 1)
+        recovered = db.claim_due_schedule("recovery-worker")
+        assert recovered is not None
+        assert recovered["pending_trigger_count"] == 0
+        assert recovered["manual_trigger_claimed"] is True
+
+        assert (
+            db.release_schedule(
+                sched["id"],
+                worker_id=abandoned["locked_by"],
+                locked_at=abandoned["locked_at"],
+            )
+            is False
+        )
+        assert db.get_schedule(sched["id"])["manual_trigger_claimed"] is True
+
+        assert (
+            db.release_schedule(
+                sched["id"],
+                worker_id=recovered["locked_by"],
+                locked_at=recovered["locked_at"],
+            )
+            is True
+        )
+        cron_claim = db.claim_due_schedule("cron-worker")
+        assert cron_claim is not None
+        assert cron_claim["manual_trigger_claimed"] is False
+        assert (
+            db.release_schedule(
+                sched["id"],
+                next_run_at=future,
+                worker_id=cron_claim["locked_by"],
+                locked_at=cron_claim["locked_at"],
+            )
+            is True
+        )
+        assert db.claim_due_schedule("extra-worker") is None
+
     def test_claim_due_schedule(self, db):
         now = int(time.time())
         sched = _make_schedule(next_run_at=now - 10, enabled=True)
@@ -237,6 +479,185 @@ class TestClaimAndRelease:
         assert refreshed["locked_by"] is None
         assert refreshed["locked_at"] is None
         assert refreshed["next_run_at"] == next_run
+
+    def test_renew_schedule_claim_rotates_fence_without_touching_manual_work(self, db, monkeypatch):
+        sched = _make_schedule(
+            locked_by="worker-1",
+            locked_at=100,
+            pending_trigger_count=2,
+            manual_trigger_claimed=True,
+        )
+        db.create_schedule(sched)
+
+        monkeypatch.setattr("agno.db.sqlite.sqlite.time.time", lambda: 100)
+        renewed_at = db.renew_schedule_claim(
+            sched["id"],
+            worker_id="worker-1",
+            locked_at=100,
+        )
+
+        assert renewed_at == 101
+        refreshed = db.get_schedule(sched["id"])
+        assert refreshed["pending_trigger_count"] == 2
+        assert refreshed["manual_trigger_claimed"] is True
+        assert not db.release_schedule(sched["id"], worker_id="worker-1", locked_at=100)
+        assert db.release_schedule(sched["id"], worker_id="worker-1", locked_at=renewed_at)
+
+
+@pytest.mark.asyncio
+async def test_async_due_cron_and_manual_trigger_are_claimed_as_two_executions(tmp_path):
+    db = AsyncSqliteDb(db_file=str(tmp_path / "async-due-and-manual.db"))
+    now = int(time.time())
+    future = now + 9999
+    sched = _make_schedule(next_run_at=now - 1, enabled=True)
+    try:
+        await db.create_schedule(sched)
+        queued = await db.trigger_schedule(sched["id"])
+        assert queued is not None and queued["pending_trigger_count"] == 1
+
+        cron_claim = await db.claim_due_schedule("cron-worker")
+        assert cron_claim is not None
+        assert cron_claim["pending_trigger_count"] == 1
+        assert cron_claim["manual_trigger_claimed"] is False
+        assert (
+            await db.release_schedule(
+                sched["id"],
+                next_run_at=future,
+                worker_id=cron_claim["locked_by"],
+                locked_at=cron_claim["locked_at"],
+            )
+            is True
+        )
+
+        manual_claim = await db.claim_due_schedule("manual-worker")
+        assert manual_claim is not None
+        assert manual_claim["pending_trigger_count"] == 0
+        assert manual_claim["manual_trigger_claimed"] is True
+        assert manual_claim["next_run_at"] == future
+
+        assert (
+            await db.release_schedule(
+                sched["id"],
+                worker_id=manual_claim["locked_by"],
+                locked_at=manual_claim["locked_at"],
+            )
+            is True
+        )
+        assert await db.claim_due_schedule("extra-worker") is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_async_stale_manual_claim_is_recovered_exactly_once(tmp_path):
+    db = AsyncSqliteDb(db_file=str(tmp_path / "async-stale-manual.db"))
+    now = int(time.time())
+    future = now + 9999
+    sched = _make_schedule(next_run_at=future, enabled=True)
+    try:
+        await db.create_schedule(sched)
+        await db.trigger_schedule(sched["id"])
+        abandoned = await db.claim_due_schedule("dead-worker")
+        assert abandoned is not None and abandoned["manual_trigger_claimed"] is True
+
+        await db.update_schedule(sched["id"], locked_at=now - 600, next_run_at=now - 1)
+        recovered = await db.claim_due_schedule("recovery-worker")
+        assert recovered is not None
+        assert recovered["pending_trigger_count"] == 0
+        assert recovered["manual_trigger_claimed"] is True
+
+        assert (
+            await db.release_schedule(
+                sched["id"],
+                worker_id=abandoned["locked_by"],
+                locked_at=abandoned["locked_at"],
+            )
+            is False
+        )
+        assert (
+            await db.release_schedule(
+                sched["id"],
+                worker_id=recovered["locked_by"],
+                locked_at=recovered["locked_at"],
+            )
+            is True
+        )
+
+        cron_claim = await db.claim_due_schedule("cron-worker")
+        assert cron_claim is not None and cron_claim["manual_trigger_claimed"] is False
+        assert (
+            await db.release_schedule(
+                sched["id"],
+                next_run_at=future,
+                worker_id=cron_claim["locked_by"],
+                locked_at=cron_claim["locked_at"],
+            )
+            is True
+        )
+        assert await db.claim_due_schedule("extra-worker") is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_async_renew_schedule_claim_rotates_fence_without_touching_manual_work(tmp_path, monkeypatch):
+    db = AsyncSqliteDb(db_file=str(tmp_path / "async-heartbeat.db"))
+    sched = _make_schedule(
+        locked_by="worker-1",
+        locked_at=100,
+        pending_trigger_count=2,
+        manual_trigger_claimed=True,
+    )
+    try:
+        await db.create_schedule(sched)
+
+        monkeypatch.setattr("agno.db.sqlite.async_sqlite.time.time", lambda: 100)
+        renewed_at = await db.renew_schedule_claim(
+            sched["id"],
+            worker_id="worker-1",
+            locked_at=100,
+        )
+
+        assert renewed_at == 101
+        refreshed = await db.get_schedule(sched["id"])
+        assert refreshed["pending_trigger_count"] == 2
+        assert refreshed["manual_trigger_claimed"] is True
+        assert not await db.release_schedule(sched["id"], worker_id="worker-1", locked_at=100)
+        assert await db.release_schedule(sched["id"], worker_id="worker-1", locked_at=renewed_at)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_async_disable_schedules_for_target_is_atomic_and_scoped(tmp_path):
+    db = AsyncSqliteDb(db_file=str(tmp_path / "async-disable-target.db"))
+    matching = _make_schedule(
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+        target_type="workflow",
+        target_id="workflow-a",
+    )
+    unrelated = _make_schedule(
+        managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        owner_actor_id="actor-a",
+        target_type="workflow",
+        target_id="workflow-b",
+    )
+    try:
+        await db.create_schedule(matching)
+        await db.create_schedule(unrelated)
+
+        disabled = await db.disable_schedules_for_target(
+            "workflow",
+            "workflow-a",
+            managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        )
+
+        assert disabled == 1
+        assert (await db.get_schedule(matching["id"]))["enabled"] is False
+        assert (await db.get_schedule(unrelated["id"]))["enabled"] is True
+    finally:
+        await db.close()
 
 
 # =============================================================================

--- a/libs/agno/tests/integration/os/test_workflow_runs.py
+++ b/libs/agno/tests/integration/os/test_workflow_runs.py
@@ -2,7 +2,8 @@
 
 import json
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import jwt
@@ -15,6 +16,7 @@ from agno.db.base import ComponentType
 from agno.db.sqlite import SqliteDb
 from agno.os import AgentOS
 from agno.os.config import AuthorizationConfig
+from agno.os.routers.workflows.router import handle_workflow_via_websocket
 from agno.workflow.factory import WorkflowFactory
 from agno.workflow.step import Step
 from agno.workflow.types import StepInput, StepOutput
@@ -365,6 +367,53 @@ def test_websocket_workflow_factory_rejects_missing_scope(
         assert "permission" in error_frame["error"].lower()
 
     assert factory_calls == [], "Factory must not be invoked when RBAC rejects the call"
+
+
+@pytest.mark.asyncio
+async def test_websocket_workflow_start_forwards_version_to_resolver():
+    """A Studio WebSocket start action must resolve the requested workflow version."""
+    websocket = AsyncMock()
+    workflow = Mock(session_id=None)
+    workflow.arun = AsyncMock()
+    agent_os = SimpleNamespace(workflows=None, db=Mock(), registry=None)
+
+    with patch(
+        "agno.os.routers.workflows.router.get_workflow_by_id",
+        return_value=workflow,
+    ) as get_workflow_by_id:
+        await handle_workflow_via_websocket(
+            websocket,
+            {"workflow_id": "versioned-wf", "message": "go", "version": 1},
+            agent_os,
+        )
+
+    assert get_workflow_by_id.call_args.kwargs["version"] == 1
+    workflow.arun.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_websocket_factory_workflow_start_forwards_version_to_resolver():
+    """WebSocket factory resolution must preserve a requested workflow version."""
+    websocket = AsyncMock()
+    workflow = Mock(session_id=None)
+    workflow.arun = AsyncMock()
+    db = Mock()
+    factory = WorkflowFactory(id="versioned-factory-wf", db=db, factory=lambda _: workflow)
+    agent_os = SimpleNamespace(workflows=[factory], db=db, registry=None)
+
+    with patch(
+        "agno.os.routers.workflows.router.get_workflow_by_id_async",
+        new_callable=AsyncMock,
+        return_value=workflow,
+    ) as get_workflow_by_id_async:
+        await handle_workflow_via_websocket(
+            websocket,
+            {"workflow_id": "versioned-factory-wf", "message": "go", "version": 1},
+            agent_os,
+        )
+
+    assert get_workflow_by_id_async.await_args.kwargs["version"] == 1
+    workflow.arun.assert_awaited_once()
 
 
 # =============================================================================

--- a/libs/agno/tests/integration/tools/test_studio_postgres.py
+++ b/libs/agno/tests/integration/tools/test_studio_postgres.py
@@ -1,0 +1,200 @@
+"""End-to-end Studio 2.9 lifecycle tests against PostgreSQL."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
+from agno.db.postgres import PostgresDb
+from agno.models.openai import OpenAIResponses
+from agno.registry import Registry
+from agno.run import RunContext
+from agno.tools.studio import StudioTools
+from agno.tools.studio_schema import (
+    AgentCreate,
+    AgentPatch,
+    ComponentRef,
+    ModelRef,
+    TeamCreate,
+    TeamWorkflowStep,
+    WorkflowCreate,
+)
+
+MODEL_REF = ModelRef(id="gpt-5.4", provider="OpenAI", name="OpenAIResponses")
+RUN_CONTEXT = RunContext(run_id="postgres-run", session_id="postgres-session", user_id="studio-admin")
+
+
+def _studio(postgres_db_real: PostgresDb, authorize=lambda *_: True) -> StudioTools:
+    registry = Registry(models=[OpenAIResponses(id=MODEL_REF.id)], dbs=[postgres_db_real])
+    return StudioTools(
+        registry=registry,
+        db=postgres_db_real,
+        authorize=authorize,
+        default_model=MODEL_REF,
+        teams=True,
+        workflows=True,
+    )
+
+
+def _agent(component_id: str, name: str | None = None) -> AgentCreate:
+    return AgentCreate(
+        component_id=component_id,
+        name=name or component_id,
+        instructions="Work carefully.",
+    )
+
+
+def test_postgres_studio_publish_edit_rollback_and_archive_are_atomic(postgres_db_real: PostgresDb) -> None:
+    studio = _studio(postgres_db_real)
+
+    created = studio.create_agent(_agent("release-agent", "Version one"), _agno_run_context=RUN_CONTEXT)
+    assert created.ok and created.data is not None
+    assert postgres_db_real.get_current_config("release-agent") is None
+    assert postgres_db_real.get_latest_config("release-agent") is not None
+
+    published_v1 = studio.publish_component(
+        "release-agent",
+        version=1,
+        expected_current_version=None,
+        _agno_run_context=RUN_CONTEXT,
+    )
+    edited_v2 = studio.edit_agent(
+        "release-agent",
+        AgentPatch(name="Version two", description="Second release"),
+        expected_version=1,
+        _agno_run_context=RUN_CONTEXT,
+    )
+    assert published_v1.ok and edited_v2.ok
+    assert studio.publish_component(
+        "release-agent",
+        version=2,
+        expected_current_version=1,
+        _agno_run_context=RUN_CONTEXT,
+    ).ok
+
+    component = postgres_db_real.get_component("release-agent")
+    assert component is not None
+    assert (component["current_version"], component["name"], component["description"]) == (
+        2,
+        "Version two",
+        "Second release",
+    )
+
+    rollback = studio.set_current_version(
+        "release-agent",
+        version=1,
+        expected_current_version=2,
+        _agno_run_context=RUN_CONTEXT,
+    )
+    assert rollback.ok and rollback.data is not None
+    component = postgres_db_real.get_component("release-agent")
+    assert component is not None
+    assert (component["current_version"], component["name"], component["description"]) == (
+        1,
+        "Version one",
+        None,
+    )
+
+    stored = postgres_db_real.get_config("release-agent", version=1)
+    assert stored is not None and "db" not in stored["config"]
+    published_delete = studio.delete_version(
+        "release-agent",
+        version=2,
+        expected_latest_version=2,
+        _agno_run_context=RUN_CONTEXT,
+    )
+    assert not published_delete.ok and published_delete.error is not None
+    assert published_delete.error.code == "draft_required"
+    assert published_delete.error.retryable is False
+
+    archived = studio.archive_agent(
+        "release-agent",
+        expected_current_version=1,
+        _agno_run_context=RUN_CONTEXT,
+    )
+    assert archived.ok
+    assert postgres_db_real.get_component("release-agent") is None
+    assert postgres_db_real.get_component("release-agent", include_deleted=True) is not None
+
+
+def test_postgres_studio_composites_pin_versions_and_archive_dependency_order(
+    postgres_db_real: PostgresDb,
+) -> None:
+    studio = _studio(postgres_db_real)
+    assert studio.create_agent(
+        _agent("researcher"),
+        save_as="published",
+        _agno_run_context=RUN_CONTEXT,
+    ).ok
+    team = studio.create_team(
+        TeamCreate(
+            component_id="editors",
+            name="Editors",
+            instructions="Edit the result.",
+            members=[ComponentRef(component_type="agent", component_id="researcher")],
+        ),
+        save_as="published",
+        _agno_run_context=RUN_CONTEXT,
+    )
+    assert team.ok and team.data is not None
+    assert team.data.members[0].version == 1
+
+    workflow = studio.create_workflow(
+        WorkflowCreate(
+            component_id="editorial-flow",
+            name="Editorial flow",
+            steps=[TeamWorkflowStep(kind="team", name="Review", component_id="editors")],
+        ),
+        save_as="published",
+        _agno_run_context=RUN_CONTEXT,
+    )
+    assert workflow.ok and workflow.data is not None
+    assert workflow.data.steps[0].version == 1
+
+    blocked = studio.archive_agent(
+        "researcher",
+        expected_current_version=1,
+        _agno_run_context=RUN_CONTEXT,
+    )
+    assert not blocked.ok and blocked.error is not None
+    assert blocked.error.code == "component_has_dependents"
+
+    assert studio.archive_workflow(
+        "editorial-flow",
+        expected_current_version=1,
+        _agno_run_context=RUN_CONTEXT,
+    ).ok
+    assert studio.archive_team(
+        "editors",
+        expected_current_version=1,
+        _agno_run_context=RUN_CONTEXT,
+    ).ok
+    assert studio.archive_agent(
+        "researcher",
+        expected_current_version=1,
+        _agno_run_context=RUN_CONTEXT,
+    ).ok
+
+
+def test_postgres_studio_concurrent_identical_retries_create_once(postgres_db_real: PostgresDb) -> None:
+    ready = Barrier(2)
+
+    def authorize(_context: RunContext, _access: str, action: str) -> bool:
+        if action == "create_agent":
+            ready.wait()
+        return True
+
+    studio = _studio(postgres_db_real, authorize=authorize)
+    request = _agent("concurrent-agent")
+
+    def create() -> str:
+        result = studio.create_agent(
+            request.model_copy(update={"if_exists": "return_existing"}),
+            _agno_run_context=RUN_CONTEXT,
+        )
+        assert result.ok
+        return result.status
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        statuses = list(executor.map(lambda _index: create(), range(2)))
+
+    assert sorted(statuses) == ["created", "existing"]
+    assert [row["version"] for row in postgres_db_real.list_configs("concurrent-agent")] == [1]

--- a/libs/agno/tests/unit/agent/test_agent_config.py
+++ b/libs/agno/tests/unit/agent/test_agent_config.py
@@ -40,12 +40,17 @@ def mock_db():
     """Create a mock database instance that passes isinstance(db, BaseDb)."""
     MockDbClass = _create_mock_db_class()
     db = MockDbClass()
+    db.component_catalog_api_version = 2
 
     # Configure common mock methods
+    db.get_component = MagicMock(return_value=None)
+    db.create_component_with_config = MagicMock(return_value=({"component_id": "test-agent"}, {"version": 1}))
     db.upsert_component = MagicMock()
     db.upsert_config = MagicMock(return_value={"version": 1})
     db.delete_component = MagicMock(return_value=True)
     db.get_config = MagicMock()
+    db.get_current_config = db.get_config
+    db.get_latest_config = db.get_config
     db.list_components = MagicMock()
     db.to_dict = MagicMock(return_value={"type": "postgres", "id": "test-db"})
 
@@ -612,24 +617,28 @@ class TestAgentKnowledgeRoundtrip:
 class TestAgentSave:
     """Tests for Agent.save() method."""
 
-    def test_save_calls_upsert_component(self, basic_agent, mock_db):
-        """Test save calls upsert_component with correct parameters."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+    def test_save_creates_component_and_initial_config_atomically(self, basic_agent, mock_db):
+        """Test first save creates the component and config together."""
         basic_agent.db = mock_db
         version = basic_agent.save()
 
-        mock_db.upsert_component.assert_called_once_with(
-            component_id="test-agent",
-            component_type=ComponentType.AGENT,
-            name="Test Agent",
-            description="A test agent for unit testing",
-            metadata=None,
-        )
+        call_args = mock_db.create_component_with_config.call_args
+        assert call_args.kwargs["component_id"] == "test-agent"
+        assert call_args.kwargs["component_type"] == ComponentType.AGENT
+        assert call_args.kwargs["name"] == "Test Agent"
+        assert call_args.kwargs["description"] == "A test agent for unit testing"
+        assert call_args.kwargs["config"]["id"] == "test-agent"
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_not_called()
         assert version == 1
 
-    def test_save_calls_upsert_config(self, basic_agent, mock_db):
-        """Test save calls upsert_config with agent config."""
+    def test_existing_save_upserts_config_with_projection(self, basic_agent, mock_db):
+        """Test a published save updates config and projection together."""
+        mock_db.get_component.return_value = {
+            "component_id": "test-agent",
+            "component_type": "agent",
+            "deleted_at": None,
+        }
         mock_db.upsert_config.return_value = {"version": 2}
 
         basic_agent.db = mock_db
@@ -639,46 +648,44 @@ class TestAgentSave:
         call_args = mock_db.upsert_config.call_args
         assert call_args.kwargs["component_id"] == "test-agent"
         assert "config" in call_args.kwargs
+        assert call_args.kwargs["projection"] == {
+            "name": "Test Agent",
+            "description": "A test agent for unit testing",
+            "metadata": None,
+        }
         assert version == 2
 
     def test_save_with_explicit_db(self, basic_agent, mock_db):
         """Test save uses explicitly provided db."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
         version = basic_agent.save(db=mock_db)
 
-        mock_db.upsert_component.assert_called_once()
-        mock_db.upsert_config.assert_called_once()
+        mock_db.create_component_with_config.assert_called_once()
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_not_called()
         assert version == 1
 
     def test_save_with_label(self, basic_agent, mock_db):
-        """Test save passes label to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes the label to the atomic create."""
         basic_agent.db = mock_db
         basic_agent.save(label="production")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["label"] == "production"
 
     def test_save_with_stage(self, basic_agent, mock_db):
-        """Test save passes stage to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes the stage to the atomic create."""
         basic_agent.db = mock_db
         basic_agent.save(stage="draft")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["stage"] == "draft"
 
     def test_save_with_notes(self, basic_agent, mock_db):
-        """Test save passes notes to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes notes to the atomic create."""
         basic_agent.db = mock_db
         basic_agent.save(notes="Initial version")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["notes"] == "Initial version"
 
     def test_save_without_db_raises_error(self, basic_agent):
@@ -688,19 +695,17 @@ class TestAgentSave:
 
     def test_save_generates_id_from_name(self, mock_db):
         """Test save generates id from name if not provided."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
         agent = Agent(name="My Test Agent", db=mock_db)
         agent.save()
 
         # ID should be generated from name
         assert agent.id is not None
-        call_args = mock_db.upsert_component.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["component_id"] is not None
 
     def test_save_handles_db_error(self, basic_agent, mock_db):
         """Test save raises error when database operation fails."""
-        mock_db.upsert_component.side_effect = Exception("Database error")
+        mock_db.create_component_with_config.side_effect = Exception("Database error")
 
         basic_agent.db = mock_db
 
@@ -786,14 +791,14 @@ class TestAgentLoad:
         """Test that store_history_messages=True survives save/load round-trip."""
         agent = Agent(id="persist-agent", name="Persist Agent", store_history_messages=True, db=mock_db)
 
-        # Capture the config passed to upsert_config during save
+        # Capture the config passed to the atomic first-save operation.
         saved_config = {}
 
         def capture_config(**kwargs):
             saved_config.update(kwargs.get("config", {}))
-            return {"version": 1}
+            return {"component_id": "persist-agent"}, {"version": 1}
 
-        mock_db.upsert_config.side_effect = capture_config
+        mock_db.create_component_with_config.side_effect = capture_config
         agent.save()
 
         assert saved_config.get("store_history_messages") is True
@@ -823,7 +828,9 @@ class TestAgentDelete:
         basic_agent.db = mock_db
         result = basic_agent.delete()
 
-        mock_db.delete_component.assert_called_once_with(component_id="test-agent", hard_delete=False)
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-agent", hard_delete=False, require_no_dependents=True
+        )
         assert result is True
 
     def test_delete_with_hard_delete(self, basic_agent, mock_db):
@@ -833,8 +840,35 @@ class TestAgentDelete:
         basic_agent.db = mock_db
         result = basic_agent.delete(hard_delete=True)
 
-        mock_db.delete_component.assert_called_once_with(component_id="test-agent", hard_delete=True)
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-agent", hard_delete=True, require_no_dependents=True
+        )
         assert result is True
+
+    def test_delete_can_explicitly_bypass_dependency_check(self, basic_agent, mock_db):
+        """Test delete forwards the dangerous dependency-check escape hatch."""
+        basic_agent.db = mock_db
+
+        assert basic_agent.delete(require_no_dependents=False) is True
+
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-agent", hard_delete=False, require_no_dependents=False
+        )
+
+    def test_delete_uses_exact_catalog_v1_signature(self, basic_agent, mock_db):
+        """The v2 dependency keyword must never reach a legacy override."""
+        calls = []
+
+        def legacy_delete(component_id, hard_delete=False):
+            calls.append((component_id, hard_delete))
+            return True
+
+        mock_db.component_catalog_api_version = 1
+        mock_db.delete_component = legacy_delete
+        basic_agent.db = mock_db
+
+        assert basic_agent.delete(require_no_dependents=False) is True
+        assert calls == [("test-agent", False)]
 
     def test_delete_with_explicit_db(self, basic_agent, mock_db):
         """Test delete uses explicitly provided db."""
@@ -877,6 +911,21 @@ class TestGetAgentById:
         assert agent is not None
         assert agent.id == "found-agent"
         assert agent.name == "Found Agent"
+        mock_db.get_config.assert_called_once_with(component_id="found-agent", label=None, version=None)
+
+    def test_get_agent_by_id_returns_a_draft_only_component(self, tmp_path):
+        """An ordinary by-id read retains the pre-2.9 draft fallback."""
+        from agno.db.sqlite import SqliteDb
+
+        db = SqliteDb(db_file=str(tmp_path / "draft-only-agent.db"))
+        assert Agent(id="draft-agent", name="Draft Agent", db=db).save(stage="draft") == 1
+        assert db.get_current_config("draft-agent") is None
+
+        loaded = get_agent_by_id(db=db, id="draft-agent")
+
+        assert loaded is not None
+        assert loaded.id == "draft-agent"
+        assert loaded.name == "Draft Agent"
 
     def test_get_agent_by_id_with_version(self, mock_db):
         """Test get_agent_by_id retrieves specific version."""
@@ -959,16 +1008,20 @@ class TestGetAgents:
             ],
             None,
         )
-        mock_db.get_config.side_effect = [
-            {"config": {"id": "agent-1", "name": "Agent 1"}},
-            {"config": {"id": "agent-2", "name": "Agent 2"}},
-        ]
+        mock_db.get_latest_config = MagicMock(
+            side_effect=[
+                {"config": {"id": "agent-1", "name": "Agent 1"}},
+                {"config": {"id": "agent-2", "name": "Agent 2"}},
+            ]
+        )
 
         agents = get_agents(db=mock_db)
 
         assert len(agents) == 2
         assert agents[0].id == "agent-1"
         assert agents[1].id == "agent-2"
+        assert mock_db.get_latest_config.call_count == 2
+        mock_db.get_config.assert_not_called()
 
     def test_get_agents_filters_by_type(self, mock_db):
         """Test get_agents filters by AGENT component type."""

--- a/libs/agno/tests/unit/db/test_component_save_atomicity.py
+++ b/libs/agno/tests/unit/db/test_component_save_atomicity.py
@@ -1,0 +1,470 @@
+"""Regression tests for atomic component/config saves through core objects."""
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from agno.agent.agent import Agent, get_agent_by_id, get_agents
+from agno.db.base import BaseDb, ComponentDependencyError, ComponentType
+from agno.db.sqlite import SqliteDb
+from agno.os.utils import (
+    get_agent_by_id as get_runtime_agent_by_id,
+)
+from agno.os.utils import (
+    get_team_by_id as get_runtime_team_by_id,
+)
+from agno.os.utils import (
+    get_workflow_by_id as get_runtime_workflow_by_id,
+)
+from agno.team.team import Team, get_team_by_id, get_teams
+from agno.utils.string import generate_id_from_name
+from agno.workflow.workflow import Workflow, get_workflow_by_id, get_workflows
+
+
+class _LegacyComponentSqliteDb(SqliteDb):
+    """Custom adapter exposing only the exact pre-2.9 catalog signatures."""
+
+    supports_component_persistence = False
+    component_catalog_api_version = 1
+
+    def get_component(
+        self,
+        component_id: str,
+        component_type: Optional[ComponentType] = None,
+    ) -> Optional[Dict[str, Any]]:
+        return super().get_component(component_id, component_type)
+
+    def upsert_config(
+        self,
+        component_id: str,
+        config: Optional[Dict[str, Any]] = None,
+        version: Optional[int] = None,
+        label: Optional[str] = None,
+        stage: Optional[str] = None,
+        notes: Optional[str] = None,
+        links: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        return super().upsert_config(
+            component_id=component_id,
+            config=config,
+            version=version,
+            label=label,
+            stage=stage,
+            notes=notes,
+            links=links,
+        )
+
+    def create_component_with_config(self, *args, **kwargs):
+        raise AssertionError("catalog API v1 must not probe the v2 atomic primitive")
+
+
+class _BrokenAtomicSqliteDb(SqliteDb):
+    """An opted-in adapter must not silently downgrade atomic creation."""
+
+    def create_component_with_config(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class _PublishDuringReadSqliteDb(SqliteDb):
+    """Inject a publication after save's initial read to reproduce the race."""
+
+    publish_during_next_get = False
+
+    def get_component(
+        self,
+        component_id: str,
+        component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        component = super().get_component(
+            component_id,
+            component_type,
+            include_deleted=include_deleted,
+        )
+        if self.publish_during_next_get and component is not None:
+            self.publish_during_next_get = False
+            super().upsert_config(
+                component_id,
+                config={"id": component_id, "name": "Published concurrently"},
+                stage="published",
+                projection={"name": "Published concurrently"},
+            )
+        return component
+
+
+class _ReplaceDuringReadSqliteDb(SqliteDb):
+    """Replace an ID after save's optimistic read to reproduce identity ABA."""
+
+    replace_during_next_get = False
+
+    def get_component(
+        self,
+        component_id: str,
+        component_type: Optional[ComponentType] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        component = super().get_component(
+            component_id,
+            component_type,
+            include_deleted=include_deleted,
+        )
+        if self.replace_during_next_get and component is not None:
+            self.replace_during_next_get = False
+            super().delete_component(component_id, hard_delete=True, require_no_dependents=False)
+            super().create_component_with_config(
+                component_id=component_id,
+                component_type=ComponentType.TEAM,
+                name="Replacement team",
+                config={"name": "Replacement team", "members": []},
+                stage="published",
+            )
+        return component
+
+
+def _assert_no_component_or_configs(db: SqliteDb, component_id: str) -> None:
+    assert db.get_component(component_id, include_deleted=True) is None
+    assert db.list_configs(component_id, include_config=True) == []
+
+
+def _assert_original_projection_and_config(db: SqliteDb, component_id: str) -> None:
+    component = db.get_component(component_id)
+    assert component is not None
+    assert component["name"] == "Version one"
+    assert component["description"] == "Original description"
+    assert component["metadata"] == {"revision": 1}
+    assert component["current_version"] == 1
+
+    configs = db.list_configs(component_id, include_config=True)
+    assert len(configs) == 1
+    assert configs[0]["version"] == 1
+    assert configs[0]["label"] == "stable"
+    assert configs[0]["config"]["name"] == "Version one"
+    assert configs[0]["config"]["description"] == "Original description"
+    assert configs[0]["config"]["metadata"] == {"revision": 1}
+
+
+def test_agent_first_save_invalid_stage_leaves_no_orphan(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "agent-invalid-stage.db"))
+    agent = Agent(id="atomic-agent", name="Agent")
+
+    with pytest.raises(ValueError, match="Invalid stage"):
+        agent.save(db=db, stage="invalid")
+
+    _assert_no_component_or_configs(db, "atomic-agent")
+
+
+def test_team_first_save_invalid_stage_leaves_no_orphan(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "team-invalid-stage.db"))
+    team = Team(id="atomic-team", name="Team", members=[])
+
+    with pytest.raises(ValueError, match="Invalid stage"):
+        team.save(db=db, stage="invalid")
+
+    _assert_no_component_or_configs(db, "atomic-team")
+
+
+def test_workflow_first_save_invalid_stage_leaves_no_orphan(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "workflow-invalid-stage.db"))
+    workflow = Workflow(id="atomic-workflow", name="Workflow")
+
+    assert workflow.save(db=db, stage="invalid") is None
+
+    _assert_no_component_or_configs(db, "atomic-workflow")
+
+
+def test_agent_duplicate_label_does_not_drift_published_projection(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "agent-duplicate-label.db"))
+    agent = Agent(
+        id="atomic-agent",
+        name="Version one",
+        description="Original description",
+        metadata={"revision": 1},
+    )
+    assert agent.save(db=db, stage="published", label="stable") == 1
+
+    agent.name = "Version two"
+    agent.description = "Changed description"
+    agent.metadata = {"revision": 2}
+    with pytest.raises(ValueError, match="Label 'stable' already exists"):
+        agent.save(db=db, stage="published", label="stable")
+
+    _assert_original_projection_and_config(db, "atomic-agent")
+
+
+def test_team_duplicate_label_does_not_drift_published_projection(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "team-duplicate-label.db"))
+    team = Team(
+        id="atomic-team",
+        name="Version one",
+        description="Original description",
+        metadata={"revision": 1},
+        members=[],
+    )
+    assert team.save(db=db, stage="published", label="stable") == 1
+
+    team.name = "Version two"
+    team.description = "Changed description"
+    team.metadata = {"revision": 2}
+    with pytest.raises(ValueError, match="Label 'stable' already exists"):
+        team.save(db=db, stage="published", label="stable")
+
+    _assert_original_projection_and_config(db, "atomic-team")
+
+
+def test_workflow_duplicate_label_does_not_drift_published_projection(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "workflow-duplicate-label.db"))
+    workflow = Workflow(
+        id="atomic-workflow",
+        name="Version one",
+        description="Original description",
+        metadata={"revision": 1},
+    )
+    assert workflow.save(db=db, stage="published", label="stable") == 1
+
+    workflow.name = "Version two"
+    workflow.description = "Changed description"
+    workflow.metadata = {"revision": 2}
+    assert workflow.save(db=db, stage="published", label="stable") is None
+
+    _assert_original_projection_and_config(db, "atomic-workflow")
+
+
+def test_first_save_falls_back_for_legacy_custom_component_adapter(tmp_path) -> None:
+    db = _LegacyComponentSqliteDb(db_file=str(tmp_path / "legacy-component-adapter.db"))
+    agent = Agent(
+        id="legacy-agent",
+        name="Legacy adapter agent",
+        description="Saved through the compatibility path",
+    )
+
+    assert agent.save(db=db, stage="published") == 1
+
+    component = db.get_component("legacy-agent")
+    config = db.get_config("legacy-agent", version=1)
+    assert component is not None
+    assert component["name"] == "Legacy adapter agent"
+    assert component["current_version"] == 1
+    assert config is not None and config["stage"] == "published"
+
+
+def test_base_bulk_read_fallback_preserves_legacy_scalar_signatures(tmp_path) -> None:
+    db = _LegacyComponentSqliteDb(db_file=str(tmp_path / "legacy-bulk-read-adapter.db"))
+    agent = Agent(id="legacy-bulk-agent", name="Legacy bulk agent")
+    assert agent.save(db=db, stage="published") == 1
+
+    components = BaseDb.get_components(
+        db,
+        {"legacy-bulk-agent", "missing-agent"},
+        component_type=ComponentType.AGENT,
+    )
+    latest = BaseDb.get_latest_configs(db, {"legacy-bulk-agent", "missing-agent"})
+
+    assert [component["component_id"] for component in components] == ["legacy-bulk-agent"]
+    assert set(latest) == {"legacy-bulk-agent", "missing-agent"}
+    assert latest["legacy-bulk-agent"] is not None
+    assert latest["legacy-bulk-agent"]["version"] == 1
+    assert latest["missing-agent"] is None
+
+
+def test_opted_in_atomic_adapter_cannot_silently_use_legacy_fallback(tmp_path) -> None:
+    db = _BrokenAtomicSqliteDb(db_file=str(tmp_path / "broken-atomic-adapter.db"))
+    agent = Agent(id="broken-atomic-agent", name="Broken atomic adapter")
+
+    with pytest.raises(NotImplementedError):
+        agent.save(db=db, stage="published")
+
+    _assert_no_component_or_configs(db, "broken-atomic-agent")
+
+
+def test_draft_only_projection_tracks_latest_draft_then_freezes_after_publish(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "draft-projection.db"))
+    agent = Agent(
+        id="draft-projection-agent",
+        name="Draft one",
+        description="First draft",
+        metadata={"revision": 1},
+    )
+    assert agent.save(db=db, stage="draft") == 1
+
+    agent.name = "Draft two"
+    agent.description = "Second draft"
+    agent.metadata = {"revision": 2}
+    assert agent.save(db=db, stage="draft") == 2
+
+    component = db.get_component("draft-projection-agent")
+    assert component is not None
+    assert component["current_version"] is None
+    assert component["name"] == "Draft two"
+    assert component["description"] == "Second draft"
+    assert component["metadata"] == {"revision": 2}
+
+    agent.name = "Published"
+    agent.description = "Published description"
+    agent.metadata = {"revision": 3}
+    assert agent.save(db=db, stage="published") == 3
+
+    agent.name = "Unpublished draft"
+    agent.description = "Must not leak"
+    agent.metadata = {"revision": 4}
+    assert agent.save(db=db, stage="draft") == 4
+
+    component = db.get_component("draft-projection-agent")
+    assert component is not None
+    assert component["current_version"] == 3
+    assert component["name"] == "Published"
+    assert component["description"] == "Published description"
+    assert component["metadata"] == {"revision": 3}
+
+
+def test_save_restores_archived_component_and_appends_history(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "restore-on-save.db"))
+    agent = Agent(id="restorable-agent", name="Version one", description="Before archive", db=db)
+    assert agent.save(stage="published") == 1
+    assert agent.delete() is True
+
+    agent.name = "Version two"
+    agent.description = "After restore"
+    assert agent.save(stage="published") == 2
+
+    component = db.get_component("restorable-agent")
+    assert component is not None
+    assert component["deleted_at"] is None
+    assert component["current_version"] == 2
+    assert component["name"] == "Version two"
+    assert [row["version"] for row in db.list_configs("restorable-agent")] == [2, 1]
+
+
+def test_failed_save_does_not_restore_archived_component(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "failed-restore-on-save.db"))
+    agent = Agent(id="archived-agent", name="Version one", db=db)
+    assert agent.save(stage="published", label="stable") == 1
+    assert agent.delete() is True
+
+    agent.name = "Rejected version"
+    with pytest.raises(ValueError, match="Label 'stable' already exists"):
+        agent.save(stage="published", label="stable")
+
+    assert db.get_component("archived-agent") is None
+    archived = db.get_component("archived-agent", include_deleted=True)
+    assert archived is not None
+    assert archived["deleted_at"] is not None
+    latest = db.get_latest_config("archived-agent", include_deleted=True)
+    assert latest is not None
+    assert latest["version"] == 1
+
+
+def test_public_delete_dependency_check_has_explicit_escape_hatch(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "delete-dependency.db"))
+    db.create_component_with_config(
+        component_id="child-agent",
+        component_type=ComponentType.AGENT,
+        name="Child",
+        config={"name": "Child"},
+        stage="published",
+    )
+    db.create_component_with_config(
+        component_id="parent-team",
+        component_type=ComponentType.TEAM,
+        name="Parent",
+        config={"name": "Parent"},
+        stage="published",
+        links=[
+            {
+                "link_kind": "member",
+                "link_key": "member_0",
+                "child_component_id": "child-agent",
+                "child_version": 1,
+                "position": 0,
+            }
+        ],
+    )
+    child = Agent(id="child-agent", db=db)
+
+    with pytest.raises(ComponentDependencyError):
+        child.delete()
+
+    assert child.delete(require_no_dependents=False) is True
+    assert db.get_component("child-agent") is None
+
+
+def test_draft_save_survives_publish_after_initial_component_read(tmp_path) -> None:
+    db = _PublishDuringReadSqliteDb(db_file=str(tmp_path / "publish-race.db"))
+    agent = Agent(id="race-agent", name="Initial draft", db=db)
+    assert agent.save(stage="draft") == 1
+
+    agent.name = "Later draft"
+    db.publish_during_next_get = True
+    assert agent.save(stage="draft") == 3
+
+    component = db.get_component("race-agent")
+    assert component is not None
+    assert component["current_version"] == 2
+    assert component["name"] == "Published concurrently"
+    assert db.get_current_config("race-agent")["version"] == 2  # type: ignore[index]
+    latest = db.get_latest_config("race-agent")
+    assert latest is not None
+    assert latest["version"] == 3
+    assert latest["stage"] == "draft"
+    assert latest["config"]["name"] == "Later draft"
+
+
+def test_save_rejects_component_type_replacement_after_initial_read(tmp_path) -> None:
+    db = _ReplaceDuringReadSqliteDb(db_file=str(tmp_path / "component-type-race.db"))
+    agent = Agent(id="replaced-component", name="Original agent", db=db)
+    assert agent.save(stage="published") == 1
+
+    db.replace_during_next_get = True
+    agent.name = "Must not reach the replacement"
+    with pytest.raises(ValueError, match="has type team, not agent"):
+        agent.save(stage="published")
+
+    component = db.get_component("replaced-component")
+    assert component is not None
+    assert component["component_type"] == ComponentType.TEAM.value
+    assert component["name"] == "Replacement team"
+    assert component["current_version"] == 1
+    assert [row["version"] for row in db.list_configs("replaced-component")] == [1]
+
+
+def test_direct_component_saves_share_the_historical_name_id_contract(tmp_path) -> None:
+    name = "R&D Jörg"
+    expected = generate_id_from_name(name)
+    agent = Agent(name=name, db=SqliteDb(db_file=str(tmp_path / "agent-id.db")))
+    team = Team(name=name, members=[], db=SqliteDb(db_file=str(tmp_path / "team-id.db")))
+    workflow = Workflow(name=name, db=SqliteDb(db_file=str(tmp_path / "workflow-id.db")))
+
+    assert expected == "r&d-jörg"
+    assert agent.save(stage="draft") == 1
+    assert team.save(stage="draft") == 1
+    assert workflow.save(stage="draft") == 1
+    assert agent.id == expected
+    assert team.id == expected
+    assert workflow.id == expected
+
+
+def test_draft_only_components_load_list_and_read_but_do_not_runtime_resolve(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "draft-read-contract.db"))
+    agent = Agent(id="draft-agent", name="Draft agent", db=db)
+    team = Team(id="draft-team", name="Draft team", members=[], db=db)
+    workflow = Workflow(id="draft-workflow", name="Draft workflow", db=db)
+    assert agent.save(stage="draft") == 1
+    assert team.save(stage="draft") == 1
+    assert workflow.save(stage="draft") == 1
+
+    assert Agent.load("draft-agent", db=db) is not None
+    assert Team.load("draft-team", db=db) is not None
+    assert Workflow.load("draft-workflow", db=db) is not None
+
+    assert get_agent_by_id(db, "draft-agent") is not None
+    assert get_team_by_id(db, "draft-team") is not None
+    assert get_workflow_by_id(db, "draft-workflow") is not None
+
+    assert [item.id for item in get_agents(db)] == ["draft-agent"]
+    assert [item.id for item in get_teams(db)] == ["draft-team"]
+    assert [item.id for item in get_workflows(db)] == ["draft-workflow"]
+
+    assert get_runtime_agent_by_id("draft-agent", db=db) is None
+    assert get_runtime_team_by_id("draft-team", db=db) is None
+    assert get_runtime_workflow_by_id("draft-workflow", db=db) is None

--- a/libs/agno/tests/unit/db/test_mongo_scheduler.py
+++ b/libs/agno/tests/unit/db/test_mongo_scheduler.py
@@ -4,6 +4,7 @@ import pytest
 
 from agno.db.mongo import AsyncMongoDb, MongoDb
 from agno.db.mongo.schemas import get_collection_indexes
+from agno.db.mongo.utils import create_collection_indexes, create_collection_indexes_async
 
 
 @pytest.fixture
@@ -138,6 +139,31 @@ def test_mongo_update_schedule_updates_and_returns_schedule(monkeypatch: pytest.
     assert collection.update_one.call_count == 1
 
 
+def test_mongo_disable_schedules_for_target_is_atomic_and_scoped(monkeypatch: pytest.MonkeyPatch):
+    db = MongoDb(db_client=MagicMock(), db_name="test_db")  # type: ignore[arg-type]
+    collection = Mock()
+    update_result = Mock(modified_count=101)
+    collection.update_many.return_value = update_result
+    monkeypatch.setattr(db, "_get_collection", lambda table_type: collection)
+
+    disabled = db.disable_schedules_for_target(
+        "agent",
+        "agent-a",
+        managed_by="studio",
+    )
+
+    assert disabled == 101
+    query, update = collection.update_many.call_args.args
+    assert query == {
+        "managed_by": "studio",
+        "target_type": "agent",
+        "target_id": "agent-a",
+        "enabled": True,
+    }
+    assert update["$set"]["enabled"] is False
+    assert isinstance(update["$set"]["updated_at"], int)
+
+
 def test_mongo_delete_schedule_cascades_runs(monkeypatch: pytest.MonkeyPatch):
     db = MongoDb(db_client=MagicMock(), db_name="test_db")  # type: ignore[arg-type]
     schedules_collection = Mock()
@@ -183,6 +209,87 @@ def test_mongo_claim_due_schedule_returns_claimed_schedule(monkeypatch: pytest.M
         "locked_by": "worker-1",
     }
     assert collection.find_one_and_update.call_count == 1
+
+
+def test_mongo_claims_due_cron_without_consuming_pending_manual_work(monkeypatch: pytest.MonkeyPatch):
+    db = MongoDb(db_client=MagicMock(), db_name="test_db")  # type: ignore[arg-type]
+    collection = Mock()
+    collection.find_one_and_update.side_effect = [
+        None,
+        None,
+        {
+            "_id": "mongo-id",
+            "id": "sched-1",
+            "enabled": True,
+            "next_run_at": 123,
+            "pending_trigger_count": 1,
+            "locked_by": "worker-1",
+        },
+    ]
+    monkeypatch.setattr(db, "_get_collection", lambda table_type: collection)
+
+    result = db.claim_due_schedule("worker-1", lock_grace_seconds=300)
+
+    assert result is not None and result["pending_trigger_count"] == 1
+    recovery_query, recovery_update = collection.find_one_and_update.call_args_list[0].args[:2]
+    manual_query, manual_update = collection.find_one_and_update.call_args_list[1].args[:2]
+    cron_query, cron_update = collection.find_one_and_update.call_args_list[2].args[:2]
+    assert recovery_query["manual_trigger_claimed"] is True
+    assert "$inc" not in recovery_update
+    assert "$nor" in manual_query
+    assert "$inc" in manual_update
+    assert "next_run_at" in cron_query
+    assert "$inc" not in cron_update
+
+
+def test_mongo_recovers_stale_manual_claim_without_consuming_another_trigger(monkeypatch: pytest.MonkeyPatch):
+    db = MongoDb(db_client=MagicMock(), db_name="test_db")  # type: ignore[arg-type]
+    collection = Mock()
+    collection.find_one_and_update.return_value = {
+        "_id": "mongo-id",
+        "id": "sched-1",
+        "enabled": True,
+        "next_run_at": 123,
+        "pending_trigger_count": 0,
+        "manual_trigger_claimed": True,
+        "locked_by": "recovery-worker",
+        "locked_at": 456,
+    }
+    monkeypatch.setattr(db, "_get_collection", lambda table_type: collection)
+
+    recovered = db.claim_due_schedule("recovery-worker", lock_grace_seconds=300)
+
+    assert recovered is not None and recovered["manual_trigger_claimed"] is True
+    query, update = collection.find_one_and_update.call_args.args[:2]
+    assert query["manual_trigger_claimed"] is True
+    assert "$inc" not in update
+
+    collection.update_one.return_value = Mock(matched_count=1)
+    assert db.release_schedule("sched-1", worker_id="recovery-worker", locked_at=456) is True
+    release_query, release_update = collection.update_one.call_args.args
+    assert release_query == {"id": "sched-1", "locked_by": "recovery-worker", "locked_at": 456}
+    assert release_update["$set"]["manual_trigger_claimed"] is False
+    assert "next_run_at" not in release_update["$set"]
+
+
+def test_mongo_renews_only_the_exact_claim_fence(monkeypatch: pytest.MonkeyPatch):
+    db = MongoDb(db_client=MagicMock(), db_name="test_db")  # type: ignore[arg-type]
+    collection = Mock()
+    collection.find_one_and_update.return_value = {"id": "sched-1"}
+    monkeypatch.setattr(db, "_get_collection", lambda table_type: collection)
+    monkeypatch.setattr("agno.db.mongo.mongo.time.time", lambda: 123)
+
+    renewed_at = db.renew_schedule_claim("sched-1", worker_id="worker-1", locked_at=123)
+
+    assert renewed_at == 124
+    query, update = collection.find_one_and_update.call_args.args
+    assert query == {"id": "sched-1", "locked_by": "worker-1", "locked_at": 123}
+    assert update["$set"]["locked_at"] == renewed_at
+    assert "manual_trigger_claimed" not in update["$set"]
+    assert "pending_trigger_count" not in update["$set"]
+    collection.update_one.side_effect = [Mock(matched_count=0), Mock(matched_count=1)]
+    assert not db.release_schedule("sched-1", worker_id="worker-1", locked_at=123)
+    assert db.release_schedule("sched-1", worker_id="worker-1", locked_at=renewed_at)
 
 
 def test_mongo_release_schedule_unlocks_and_returns_true(monkeypatch: pytest.MonkeyPatch):
@@ -308,9 +415,144 @@ def test_scheduler_index_schemas_registered():
     schedule_runs_indexes = get_collection_indexes("schedule_runs")
 
     assert any(i.get("key") == "id" and i.get("unique") for i in schedules_indexes)
-    assert any(i.get("key") == "name" and i.get("unique") for i in schedules_indexes)
+    assert any(
+        i.get("key") == [("name", 1), ("managed_by", 1)]
+        and i.get("unique")
+        and i.get("name") == "uq_generic_name"
+        and i.get("partialFilterExpression") == {"managed_by": None}
+        for i in schedules_indexes
+    )
+    assert any(
+        i.get("key") == [("owner_actor_id", 1), ("name", 1)]
+        and i.get("unique")
+        and i.get("name") == "uq_studio_owner_name"
+        for i in schedules_indexes
+    )
+    assert any(i.get("key") == "pending_trigger_count" for i in schedules_indexes)
+    assert any(i.get("key") == "manual_trigger_claimed" for i in schedules_indexes)
     assert any(i.get("key") == "id" and i.get("unique") for i in schedule_runs_indexes)
     assert any(i.get("key") == "schedule_id" for i in schedule_runs_indexes)
+
+
+def test_schedule_index_migration_fails_loudly_before_dropping_legacy_authority():
+    collection = MagicMock()
+    collection.list_indexes.return_value = [{"name": "name_1", "key": {"name": 1}, "unique": True}]
+
+    def create_index(_keys, **options):
+        if options.get("name") == "uq_studio_owner_name":
+            raise RuntimeError("cannot build actor index")
+
+    collection.create_index.side_effect = create_index
+
+    with pytest.raises(RuntimeError, match="actor index"):
+        create_collection_indexes(collection, "schedules")
+
+    collection.drop_index.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_schedule_index_migration_fails_loudly_before_dropping_legacy_authority():
+    class AsyncCursor:
+        def __init__(self, rows):
+            self.rows = iter(rows)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self.rows)
+            except StopIteration:
+                raise StopAsyncIteration
+
+    collection = MagicMock()
+    collection.list_indexes = AsyncMock(
+        return_value=AsyncCursor([{"name": "name_1", "key": {"name": 1}, "unique": True}])
+    )
+
+    async def create_index(_keys, **options):
+        if options.get("name") == "uq_studio_owner_name":
+            raise RuntimeError("cannot build actor index")
+
+    collection.create_index = AsyncMock(side_effect=create_index)
+    collection.drop_index = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="actor index"):
+        await create_collection_indexes_async(collection, "schedules")
+
+    collection.drop_index.assert_not_awaited()
+
+
+def test_schedule_index_migration_uses_distinct_key_before_dropping_legacy_authority():
+    collection = MagicMock()
+    collection.list_indexes.return_value = [{"name": "name_1", "key": {"name": 1}, "unique": True}]
+    created_names = []
+
+    def create_index(keys, **options):
+        # Real upgraded MongoDB collections reject a replacement index that
+        # reuses the legacy key pattern with different partial options.
+        if keys == [("name", 1)] and options.get("name") == "uq_generic_name":
+            raise RuntimeError("cannot coexist with legacy same-key index")
+        created_names.append(options.get("name"))
+
+    def drop_index(index_name):
+        assert "uq_generic_name" in created_names
+        assert "uq_studio_owner_name" in created_names
+        assert index_name == "name_1"
+
+    collection.create_index.side_effect = create_index
+    collection.drop_index.side_effect = drop_index
+
+    create_collection_indexes(collection, "schedules")
+
+    generic_call = next(
+        call for call in collection.create_index.call_args_list if call.kwargs.get("name") == "uq_generic_name"
+    )
+    assert generic_call.args[0] == [("name", 1), ("managed_by", 1)]
+    collection.drop_index.assert_called_once_with("name_1")
+
+
+@pytest.mark.asyncio
+async def test_async_schedule_index_migration_uses_distinct_key_before_dropping_legacy_authority():
+    class AsyncCursor:
+        def __init__(self, rows):
+            self.rows = iter(rows)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self.rows)
+            except StopIteration:
+                raise StopAsyncIteration
+
+    collection = MagicMock()
+    collection.list_indexes = AsyncMock(
+        return_value=AsyncCursor([{"name": "name_1", "key": {"name": 1}, "unique": True}])
+    )
+    created_names = []
+
+    async def create_index(keys, **options):
+        if keys == [("name", 1)] and options.get("name") == "uq_generic_name":
+            raise RuntimeError("cannot coexist with legacy same-key index")
+        created_names.append(options.get("name"))
+
+    async def drop_index(index_name):
+        assert "uq_generic_name" in created_names
+        assert "uq_studio_owner_name" in created_names
+        assert index_name == "name_1"
+
+    collection.create_index = AsyncMock(side_effect=create_index)
+    collection.drop_index = AsyncMock(side_effect=drop_index)
+
+    await create_collection_indexes_async(collection, "schedules")
+
+    generic_call = next(
+        call for call in collection.create_index.call_args_list if call.kwargs.get("name") == "uq_generic_name"
+    )
+    assert generic_call.args[0] == [("name", 1), ("managed_by", 1)]
+    collection.drop_index.assert_awaited_once_with("name_1")
 
 
 def test_async_mongo_constructor_maps_scheduler_collections():
@@ -428,6 +670,33 @@ async def test_async_mongo_update_schedule_updates_and_returns_schedule(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_async_mongo_disable_schedules_for_target_is_atomic_and_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_db")
+    collection = AsyncMock()
+    collection.update_many.return_value = MagicMock(modified_count=2)
+    monkeypatch.setattr(db, "_get_collection", AsyncMock(return_value=collection))
+
+    disabled = await db.disable_schedules_for_target(
+        "team",
+        "team-a",
+        managed_by="studio",
+    )
+
+    assert disabled == 2
+    query, update = collection.update_many.call_args.args
+    assert query == {
+        "managed_by": "studio",
+        "target_type": "team",
+        "target_id": "team-a",
+        "enabled": True,
+    }
+    assert update["$set"]["enabled"] is False
+    assert isinstance(update["$set"]["updated_at"], int)
+
+
+@pytest.mark.asyncio
 async def test_async_mongo_delete_schedule_cascades_runs(monkeypatch: pytest.MonkeyPatch):
     db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_db")
     schedules_collection = AsyncMock()
@@ -474,6 +743,94 @@ async def test_async_mongo_claim_due_schedule_returns_claimed_schedule(monkeypat
         "locked_by": "worker-1",
     }
     collection.find_one_and_update.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_mongo_claims_due_cron_without_consuming_pending_manual_work(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_db")
+    collection = AsyncMock()
+    collection.find_one_and_update.side_effect = [
+        None,
+        None,
+        {
+            "_id": "mongo-id",
+            "id": "sched-1",
+            "enabled": True,
+            "next_run_at": 123,
+            "pending_trigger_count": 1,
+            "locked_by": "worker-1",
+        },
+    ]
+    monkeypatch.setattr(db, "_get_collection", AsyncMock(return_value=collection))
+
+    result = await db.claim_due_schedule("worker-1", lock_grace_seconds=300)
+
+    assert result is not None and result["pending_trigger_count"] == 1
+    recovery_query, recovery_update = collection.find_one_and_update.call_args_list[0].args[:2]
+    manual_query, manual_update = collection.find_one_and_update.call_args_list[1].args[:2]
+    cron_query, cron_update = collection.find_one_and_update.call_args_list[2].args[:2]
+    assert recovery_query["manual_trigger_claimed"] is True
+    assert "$inc" not in recovery_update
+    assert "$nor" in manual_query
+    assert "$inc" in manual_update
+    assert "next_run_at" in cron_query
+    assert "$inc" not in cron_update
+
+
+@pytest.mark.asyncio
+async def test_async_mongo_recovers_stale_manual_claim_without_consuming_another_trigger(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_db")
+    collection = AsyncMock()
+    collection.find_one_and_update.return_value = {
+        "_id": "mongo-id",
+        "id": "sched-1",
+        "enabled": True,
+        "next_run_at": 123,
+        "pending_trigger_count": 0,
+        "manual_trigger_claimed": True,
+        "locked_by": "recovery-worker",
+        "locked_at": 456,
+    }
+    monkeypatch.setattr(db, "_get_collection", AsyncMock(return_value=collection))
+
+    recovered = await db.claim_due_schedule("recovery-worker", lock_grace_seconds=300)
+
+    assert recovered is not None and recovered["manual_trigger_claimed"] is True
+    query, update = collection.find_one_and_update.call_args.args[:2]
+    assert query["manual_trigger_claimed"] is True
+    assert "$inc" not in update
+
+    collection.update_one.return_value = MagicMock(matched_count=1)
+    assert await db.release_schedule("sched-1", worker_id="recovery-worker", locked_at=456) is True
+    release_query, release_update = collection.update_one.call_args.args
+    assert release_query == {"id": "sched-1", "locked_by": "recovery-worker", "locked_at": 456}
+    assert release_update["$set"]["manual_trigger_claimed"] is False
+    assert "next_run_at" not in release_update["$set"]
+
+
+@pytest.mark.asyncio
+async def test_async_mongo_renews_only_the_exact_claim_fence(monkeypatch: pytest.MonkeyPatch):
+    db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_db")
+    collection = AsyncMock()
+    collection.find_one_and_update.return_value = {"id": "sched-1"}
+    monkeypatch.setattr(db, "_get_collection", AsyncMock(return_value=collection))
+    monkeypatch.setattr("agno.db.mongo.async_mongo.time.time", lambda: 123)
+
+    renewed_at = await db.renew_schedule_claim("sched-1", worker_id="worker-1", locked_at=123)
+
+    assert renewed_at == 124
+    query, update = collection.find_one_and_update.call_args.args
+    assert query == {"id": "sched-1", "locked_by": "worker-1", "locked_at": 123}
+    assert update["$set"]["locked_at"] == renewed_at
+    assert "manual_trigger_claimed" not in update["$set"]
+    assert "pending_trigger_count" not in update["$set"]
+    collection.update_one.side_effect = [MagicMock(matched_count=0), MagicMock(matched_count=1)]
+    assert not await db.release_schedule("sched-1", worker_id="worker-1", locked_at=123)
+    assert await db.release_schedule("sched-1", worker_id="worker-1", locked_at=renewed_at)
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/db/test_postgres_component_reactivation.py
+++ b/libs/agno/tests/unit/db/test_postgres_component_reactivation.py
@@ -1,4 +1,4 @@
-"""Regression coverage for PostgreSQL component reactivation."""
+"""Regression coverage for PostgreSQL component reactivation boundaries."""
 
 from unittest.mock import patch
 
@@ -34,14 +34,17 @@ def postgres_components_db(tmp_path):
     def get_table(table_type, create_table_if_not_found=False):
         return components if table_type == "components" else None
 
-    with patch.object(db, "_get_table", side_effect=get_table):
+    with (
+        patch.object(db, "_get_table", side_effect=get_table),
+        patch.object(db, "_lock_component_graph_writes"),
+    ):
         yield db
 
     db.Session.remove()
     engine.dispose()
 
 
-def test_upsert_component_reactivates_soft_deleted_component(postgres_components_db):
+def test_upsert_component_does_not_reactivate_soft_deleted_component(postgres_components_db):
     db = postgres_components_db
 
     created = db.upsert_component(
@@ -58,17 +61,15 @@ def test_upsert_component_reactivates_soft_deleted_component(postgres_components
     assert total == 1
     assert deleted_rows[0]["deleted_at"] is not None
 
-    reactivated = db.upsert_component(
-        component_id="agent-1",
-        component_type=ComponentType.AGENT,
-        name="after",
-    )
-
-    assert reactivated["component_id"] == "agent-1"
-    assert reactivated["component_type"] == ComponentType.AGENT.value
-    assert reactivated["name"] == "after"
-    assert reactivated["deleted_at"] is None
+    with pytest.raises(ValueError, match="archived and remains reserved"):
+        db.upsert_component(
+            component_id="agent-1",
+            component_type=ComponentType.AGENT,
+            name="after",
+        )
 
     all_rows, total = db.list_components(include_deleted=True)
     assert total == 1
     assert [row["component_id"] for row in all_rows] == ["agent-1"]
+    assert all_rows[0]["name"] == "before"
+    assert all_rows[0]["deleted_at"] is not None

--- a/libs/agno/tests/unit/db/test_schedule_migration_v2_9.py
+++ b/libs/agno/tests/unit/db/test_schedule_migration_v2_9.py
@@ -1,0 +1,603 @@
+"""Schedule provenance and uniqueness migration tests for 2.9."""
+
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import text
+
+from agno.db.migrations.manager import MigrationManager
+from agno.db.migrations.versions import v2_9_0
+from agno.db.postgres import AsyncPostgresDb, PostgresDb
+from agno.db.schemas.scheduler import ScheduleNameConflictError
+from agno.db.sqlite import SqliteDb
+from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+
+
+def _create_legacy_schedule_table(path: Path, names: list[str]) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE agno_schedules (
+                id TEXT PRIMARY KEY NOT NULL,
+                name TEXT NOT NULL,
+                description TEXT,
+                method TEXT NOT NULL,
+                endpoint TEXT NOT NULL,
+                payload JSON,
+                cron_expr TEXT NOT NULL,
+                timezone TEXT NOT NULL,
+                timeout_seconds BIGINT NOT NULL,
+                max_retries BIGINT NOT NULL,
+                retry_delay_seconds BIGINT NOT NULL,
+                enabled BOOLEAN NOT NULL,
+                next_run_at BIGINT,
+                locked_by TEXT,
+                locked_at BIGINT,
+                created_at BIGINT NOT NULL,
+                updated_at BIGINT
+            )
+            """
+        )
+        for index, name in enumerate(names):
+            connection.execute(
+                """
+                INSERT INTO agno_schedules (
+                    id, name, method, endpoint, cron_expr, timezone,
+                    timeout_seconds, max_retries, retry_delay_seconds,
+                    enabled, created_at
+                ) VALUES (?, ?, 'POST', '/external', '0 9 * * *', 'UTC', 3600, 0, 60, 1, 1)
+                """,
+                (f"schedule-{index}", name),
+            )
+
+
+def _studio_schedule(schedule_id: str = "studio-schedule") -> dict:
+    return {
+        "id": schedule_id,
+        "name": "Private Studio schedule",
+        "method": "POST",
+        "endpoint": "/agents/private-agent/runs",
+        "payload": {"message": "private prompt"},
+        "cron_expr": "0 9 * * *",
+        "timezone": "UTC",
+        "timeout_seconds": 3600,
+        "max_retries": 0,
+        "retry_delay_seconds": 60,
+        "managed_by": "studio",
+        "owner_actor_id": "actor-1",
+        "target_type": "agent",
+        "target_id": "private-agent",
+        "enabled": True,
+        "created_at": 1,
+    }
+
+
+def _studio_schedule_run(schedule_id: str = "studio-schedule") -> dict:
+    return {
+        "id": "studio-run",
+        "schedule_id": schedule_id,
+        "attempt": 1,
+        "status": "success",
+        "input": {"message": "private prompt"},
+        "output": {"content": "private response"},
+        "created_at": 1,
+    }
+
+
+def _generic_schedule(schedule_id: str = "generic-schedule") -> dict:
+    schedule = _studio_schedule(schedule_id)
+    schedule.update(
+        name="Generic schedule",
+        endpoint="/external",
+        payload=None,
+        managed_by=None,
+        owner_actor_id=None,
+        target_type=None,
+        target_id=None,
+    )
+    return schedule
+
+
+def _install_caller_owned_schedule_schema(path: Path) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.execute("ALTER TABLE agno_schedules ADD COLUMN caller_note TEXT DEFAULT 'keep-me'")
+        connection.execute("CREATE INDEX caller_schedule_endpoint_idx ON agno_schedules (endpoint)")
+        connection.execute(
+            "CREATE TABLE caller_schedule_audit (schedule_id TEXT NOT NULL, old_note TEXT, new_note TEXT)"
+        )
+        connection.execute(
+            """
+            CREATE TRIGGER caller_schedule_update_audit
+            AFTER UPDATE ON agno_schedules
+            BEGIN
+                INSERT INTO caller_schedule_audit (schedule_id, old_note, new_note)
+                VALUES (OLD.id, OLD.caller_note, NEW.caller_note);
+            END
+            """
+        )
+
+
+def _sqlite_schedule_state(path: Path) -> tuple:
+    with sqlite3.connect(path) as connection:
+        schema = tuple(
+            connection.execute(
+                """
+                SELECT type, name, tbl_name, sql
+                FROM sqlite_master
+                WHERE tbl_name = 'agno_schedules'
+                   OR name IN ('agno_schedules', 'caller_schedule_audit', 'agno_schedules__v2_9_down')
+                ORDER BY type, name
+                """
+            )
+        )
+        columns = tuple(connection.execute("PRAGMA table_xinfo(agno_schedules)"))
+        schedule = connection.execute("SELECT * FROM agno_schedules WHERE id='generic-schedule'").fetchone()
+        audit_rows = tuple(connection.execute("SELECT * FROM caller_schedule_audit"))
+    return schema, columns, schedule, audit_rows
+
+
+def test_sync_sqlite_upgrade_preserves_generic_rows_and_enforces_unique_names(tmp_path: Path):
+    class CustomSqliteDb(SqliteDb):
+        pass
+
+    db_path = tmp_path / "legacy-sync.sqlite"
+    _create_legacy_schedule_table(db_path, ["legacy-one", "legacy-two"])
+    db = CustomSqliteDb(db_file=str(db_path))
+
+    assert v2_9_0.up(db, "schedules", db.schedules_table_name) is True
+    assert v2_9_0.up(db, "schedules", db.schedules_table_name) is False
+
+    with sqlite3.connect(db_path) as connection:
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+        row = connection.execute(
+            "SELECT managed_by, owner_actor_id, target_type, target_id FROM agno_schedules WHERE id='schedule-0'"
+        ).fetchone()
+        unique_indexes = {
+            index[1] for index in connection.execute("PRAGMA index_list(agno_schedules)") if index[2] == 1
+        }
+
+    assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+    assert row == (None, None, None, None)
+    assert {
+        "agno_schedules_uq_generic_name",
+        "agno_schedules_uq_studio_owner_name",
+    }.issubset(unique_indexes)
+
+    first = db.get_schedule("schedule-0")
+    assert first is not None
+    assert first["managed_by"] is None
+    with pytest.raises(ScheduleNameConflictError):
+        db.update_schedule("schedule-1", name="legacy-one")
+    assert v2_9_0.down(db, "schedules", db.schedules_table_name) is True
+
+
+def test_sync_sqlite_down_refuses_caller_owned_schema_without_partial_changes(tmp_path: Path):
+    db_path = tmp_path / "caller-schema-sync.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    db.create_schedule(_generic_schedule())
+    _install_caller_owned_schedule_schema(db_path)
+    state_before = _sqlite_schedule_state(db_path)
+
+    with pytest.raises(ValueError, match="caller-owned or unrecognized schema") as exc_info:
+        v2_9_0.down(db, "schedules", db.schedules_table_name)
+
+    message = str(exc_info.value)
+    assert "column 'caller_note'" in message
+    assert "index 'caller_schedule_endpoint_idx'" in message
+    assert "trigger 'caller_schedule_update_audit'" in message
+    assert _sqlite_schedule_state(db_path) == state_before
+
+
+def test_sync_sqlite_down_does_not_delete_a_caller_table_using_the_temporary_name(tmp_path: Path):
+    db_path = tmp_path / "caller-temp-table-sync.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    db.create_schedule(_generic_schedule())
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("CREATE TABLE agno_schedules__v2_9_down (secret TEXT NOT NULL)")
+        connection.execute("INSERT INTO agno_schedules__v2_9_down VALUES ('keep-me')")
+
+    with pytest.raises(ValueError, match="existing downgrade temporary object"):
+        v2_9_0.down(db, "schedules", db.schedules_table_name)
+
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("SELECT secret FROM agno_schedules__v2_9_down").fetchone() == ("keep-me",)
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+    assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+
+
+def test_sync_sqlite_down_refuses_to_expose_studio_schedule_and_run_history(tmp_path: Path):
+    db_path = tmp_path / "studio-sync.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    db.create_schedule(_studio_schedule())
+    db.create_schedule_run(_studio_schedule_run())
+
+    with pytest.raises(ValueError, match="Cannot remove Studio schedule provenance"):
+        v2_9_0.down(db, "schedules", db.schedules_table_name)
+
+    with sqlite3.connect(db_path) as connection:
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+        indexes = {row[1] for row in connection.execute("PRAGMA index_list(agno_schedules)")}
+        schedule = connection.execute(
+            "SELECT managed_by, owner_actor_id, payload FROM agno_schedules WHERE id='studio-schedule'"
+        ).fetchone()
+        run = connection.execute("SELECT input, output FROM agno_schedule_runs WHERE id='studio-run'").fetchone()
+
+    assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+    assert "agno_schedules_uq_studio_owner_name" in indexes
+    assert schedule is not None and schedule[:2] == ("studio", "actor-1")
+    assert run is not None
+
+    assert db.delete_schedule("studio-schedule") is True
+    assert v2_9_0.down(db, "schedules", db.schedules_table_name) is True
+
+
+def test_sync_sqlite_down_refuses_to_drop_pending_or_claimed_manual_work(tmp_path: Path):
+    db_path = tmp_path / "pending-trigger-sync.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    schedule = _studio_schedule("generic-schedule")
+    schedule.update(managed_by=None, owner_actor_id=None, next_run_at=2**62)
+    db.create_schedule(schedule)
+    assert db.trigger_schedule("generic-schedule")["pending_trigger_count"] == 1
+
+    with pytest.raises(ValueError, match="pending or claimed manual triggers"):
+        v2_9_0.down(db, "schedules", db.schedules_table_name)
+
+    claimed = db.claim_due_schedule("worker")
+    assert claimed is not None and claimed["pending_trigger_count"] == 0
+    assert claimed["manual_trigger_claimed"] is True
+    with pytest.raises(ValueError, match="pending or claimed manual triggers"):
+        v2_9_0.down(db, "schedules", db.schedules_table_name)
+
+    assert db.release_schedule(
+        "generic-schedule",
+        worker_id=claimed["locked_by"],
+        locked_at=claimed["locked_at"],
+    )
+    assert db.get_schedule("generic-schedule")["manual_trigger_claimed"] is False
+    assert v2_9_0.down(db, "schedules", db.schedules_table_name) is True
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_down_refuses_claimed_manual_work_then_succeeds_after_release(tmp_path: Path):
+    db = AsyncSqliteDb(db_file=str(tmp_path / "claimed-trigger-async.sqlite"))
+    schedule = _generic_schedule()
+    schedule["next_run_at"] = 2**62
+    try:
+        await db.create_schedule(schedule)
+        await db.trigger_schedule(schedule["id"])
+        claimed = await db.claim_due_schedule("worker")
+        assert claimed is not None
+        assert claimed["pending_trigger_count"] == 0
+        assert claimed["manual_trigger_claimed"] is True
+
+        with pytest.raises(ValueError, match="pending or claimed manual triggers"):
+            await v2_9_0.async_down(db, "schedules", db.schedules_table_name)
+
+        assert await db.release_schedule(
+            schedule["id"],
+            worker_id=claimed["locked_by"],
+            locked_at=claimed["locked_at"],
+        )
+        assert (await db.get_schedule(schedule["id"]))["manual_trigger_claimed"] is False
+        assert await v2_9_0.async_down(db, "schedules", db.schedules_table_name) is True
+    finally:
+        await db.close()
+
+
+def test_sync_sqlite_upgrade_fails_clearly_without_partially_migrating_duplicates(tmp_path: Path):
+    db_path = tmp_path / "legacy-duplicates.sqlite"
+    _create_legacy_schedule_table(db_path, ["duplicate", "duplicate"])
+    db = SqliteDb(db_file=str(db_path))
+
+    with pytest.raises(ValueError, match="duplicates already exist"):
+        v2_9_0.up(db, "schedules", db.schedules_table_name)
+
+    with sqlite3.connect(db_path) as connection:
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+    assert set(v2_9_0._V2_9_COLUMNS).isdisjoint(columns)
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_upgrade_preserves_generic_rows_and_enforces_unique_names(tmp_path: Path):
+    class CustomAsyncSqliteDb(AsyncSqliteDb):
+        pass
+
+    db_path = tmp_path / "legacy-async.sqlite"
+    _create_legacy_schedule_table(db_path, ["legacy-one"])
+    db = CustomAsyncSqliteDb(db_file=str(db_path))
+    try:
+        assert await v2_9_0.async_up(db, "schedules", db.schedules_table_name) is True
+        async with db.async_session_factory() as session:
+            columns = {row[1] for row in (await session.execute(text("PRAGMA table_info(agno_schedules)"))).fetchall()}
+            row = (
+                await session.execute(
+                    text("SELECT managed_by, owner_actor_id FROM agno_schedules WHERE id='schedule-0'")
+                )
+            ).fetchone()
+        assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+        assert tuple(row) == (None, None)
+        assert await v2_9_0.async_down(db, "schedules", db.schedules_table_name) is True
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_down_refuses_caller_owned_schema_without_partial_changes(tmp_path: Path):
+    db_path = tmp_path / "caller-schema-async.sqlite"
+    db = AsyncSqliteDb(db_file=str(db_path))
+    try:
+        await db.create_schedule(_generic_schedule())
+        _install_caller_owned_schedule_schema(db_path)
+        state_before = _sqlite_schedule_state(db_path)
+
+        with pytest.raises(ValueError, match="caller-owned or unrecognized schema") as exc_info:
+            await v2_9_0.async_down(db, "schedules", db.schedules_table_name)
+
+        message = str(exc_info.value)
+        assert "column 'caller_note'" in message
+        assert "index 'caller_schedule_endpoint_idx'" in message
+        assert "trigger 'caller_schedule_update_audit'" in message
+        assert _sqlite_schedule_state(db_path) == state_before
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_down_refuses_to_expose_studio_schedule_and_run_history(tmp_path: Path):
+    db_path = tmp_path / "studio-async.sqlite"
+    db = AsyncSqliteDb(db_file=str(db_path))
+    try:
+        await db.create_schedule(_studio_schedule())
+        await db.create_schedule_run(_studio_schedule_run())
+
+        with pytest.raises(ValueError, match="Cannot remove Studio schedule provenance"):
+            await v2_9_0.async_down(db, "schedules", db.schedules_table_name)
+
+        async with db.async_session_factory() as session:
+            columns = {row[1] for row in (await session.execute(text("PRAGMA table_info(agno_schedules)"))).fetchall()}
+            indexes = {row[1] for row in (await session.execute(text("PRAGMA index_list(agno_schedules)"))).fetchall()}
+            schedule = (
+                await session.execute(
+                    text("SELECT managed_by, owner_actor_id, payload FROM agno_schedules WHERE id='studio-schedule'")
+                )
+            ).fetchone()
+            run = (
+                await session.execute(text("SELECT input, output FROM agno_schedule_runs WHERE id='studio-run'"))
+            ).fetchone()
+
+        assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+        assert "agno_schedules_uq_studio_owner_name" in indexes
+        assert schedule is not None and tuple(schedule[:2]) == ("studio", "actor-1")
+        assert run is not None
+
+        assert await db.delete_schedule("studio-schedule") is True
+        assert await v2_9_0.async_down(db, "schedules", db.schedules_table_name) is True
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_manager_includes_schedule_tables(tmp_path: Path):
+    db_path = tmp_path / "legacy-manager.sqlite"
+    _create_legacy_schedule_table(db_path, ["legacy-one"])
+    db = SqliteDb(db_file=str(db_path))
+
+    await MigrationManager(db).up(target_version="2.9.0", table_type="schedules")
+
+    assert db.get_latest_schema_version(db.schedules_table_name) == "2.9.0"
+    assert db.get_schedule("schedule-0") is not None
+
+    await MigrationManager(db).down(target_version="2.5.6", table_type="schedules")
+
+    assert db.get_latest_schema_version(db.schedules_table_name) == "2.5.6"
+    with sqlite3.connect(db_path) as connection:
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+    assert set(v2_9_0._V2_9_COLUMNS).isdisjoint(columns)
+
+
+@pytest.mark.asyncio
+async def test_migration_manager_keeps_version_when_studio_downgrade_is_refused(tmp_path: Path):
+    db_path = tmp_path / "studio-manager.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    db.create_schedule(_studio_schedule())
+    db.create_schedule_run(_studio_schedule_run())
+    db.upsert_schema_version(db.schedules_table_name, "2.9.0")
+
+    with pytest.raises(ValueError, match="Cannot remove Studio schedule provenance"):
+        await MigrationManager(db).down(target_version="2.5.6", table_type="schedules")
+
+    assert db.get_latest_schema_version(db.schedules_table_name) == "2.9.0"
+    with sqlite3.connect(db_path) as connection:
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+        assert connection.execute("SELECT 1 FROM agno_schedule_runs WHERE id='studio-run'").fetchone() == (1,)
+    assert set(v2_9_0._V2_9_COLUMNS).issubset(columns)
+
+
+@pytest.mark.asyncio
+async def test_sync_migration_manager_keeps_version_and_schema_when_caller_schema_is_refused(tmp_path: Path):
+    db_path = tmp_path / "caller-schema-manager-sync.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    db.create_schedule(_generic_schedule())
+    db.upsert_schema_version(db.schedules_table_name, "2.9.0")
+    _install_caller_owned_schedule_schema(db_path)
+    state_before = _sqlite_schedule_state(db_path)
+
+    with pytest.raises(ValueError, match="caller-owned or unrecognized schema"):
+        await MigrationManager(db).down(target_version="2.5.6", table_type="schedules")
+
+    assert db.get_latest_schema_version(db.schedules_table_name) == "2.9.0"
+    assert _sqlite_schedule_state(db_path) == state_before
+
+
+@pytest.mark.asyncio
+async def test_async_migration_manager_keeps_version_and_schema_when_caller_schema_is_refused(tmp_path: Path):
+    db_path = tmp_path / "caller-schema-manager-async.sqlite"
+    db = AsyncSqliteDb(db_file=str(db_path))
+    try:
+        await db.create_schedule(_generic_schedule())
+        await db.upsert_schema_version(db.schedules_table_name, "2.9.0")
+        _install_caller_owned_schedule_schema(db_path)
+        state_before = _sqlite_schedule_state(db_path)
+
+        with pytest.raises(ValueError, match="caller-owned or unrecognized schema"):
+            await MigrationManager(db).down(target_version="2.5.6", table_type="schedules")
+
+        assert await db.get_latest_schema_version(db.schedules_table_name) == "2.9.0"
+        assert _sqlite_schedule_state(db_path) == state_before
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_fresh_sqlite_scoped_indexes_are_reversible_without_losing_run_history(tmp_path: Path):
+    db_path = tmp_path / "fresh-manager.sqlite"
+    db = SqliteDb(db_file=str(db_path))
+    db.create_schedule(
+        {
+            "id": "schedule-0",
+            "name": "reusable-after-down",
+            "method": "POST",
+            "endpoint": "/external",
+            "cron_expr": "0 9 * * *",
+            "timezone": "UTC",
+            "timeout_seconds": 3600,
+            "max_retries": 0,
+            "retry_delay_seconds": 60,
+            "enabled": True,
+            "created_at": 1,
+        }
+    )
+    db.create_schedule_run(
+        {
+            "id": "run-0",
+            "schedule_id": "schedule-0",
+            "attempt": 1,
+            "status": "success",
+            "created_at": 1,
+        }
+    )
+
+    with sqlite3.connect(db_path) as connection:
+        indexes_before = {row[1] for row in connection.execute("PRAGMA index_list(agno_schedules)")}
+    assert "agno_schedules_uq_generic_name" in indexes_before
+    assert "agno_schedules_uq_studio_owner_name" in indexes_before
+
+    await MigrationManager(db).down(target_version="2.5.6", table_type="schedules")
+
+    with sqlite3.connect(db_path) as connection:
+        indexes_after = {row[1] for row in connection.execute("PRAGMA index_list(agno_schedules)")}
+        columns_after = {row[1] for row in connection.execute("PRAGMA table_info(agno_schedules)")}
+        assert connection.execute("SELECT schedule_id FROM agno_schedule_runs WHERE id='run-0'").fetchone() == (
+            "schedule-0",
+        )
+        assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+        connection.execute(
+            """
+            INSERT INTO agno_schedules (
+                id, name, method, endpoint, cron_expr, timezone,
+                timeout_seconds, max_retries, retry_delay_seconds,
+                enabled, created_at
+            ) VALUES ('schedule-1', 'reusable-after-down', 'POST', '/external',
+                      '0 9 * * *', 'UTC', 3600, 0, 60, 1, 1)
+            """
+        )
+
+    assert "agno_schedules_uq_generic_name" not in indexes_after
+    assert "agno_schedules_uq_studio_owner_name" not in indexes_after
+    assert set(v2_9_0._V2_9_COLUMNS).isdisjoint(columns_after)
+    assert v2_9_0.down(db, "schedules", db.schedules_table_name) is False
+
+
+def test_sync_sqlite_down_is_safe_when_schedule_table_was_never_created(tmp_path: Path):
+    db = SqliteDb(db_file=str(tmp_path / "missing-sync.sqlite"))
+
+    assert v2_9_0.down(db, "schedules", db.schedules_table_name) is False
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_down_is_idempotent_and_missing_table_safe(tmp_path: Path):
+    db_path = tmp_path / "missing-async.sqlite"
+    db = AsyncSqliteDb(db_file=str(db_path))
+    try:
+        assert await v2_9_0.async_down(db, "schedules", db.schedules_table_name) is False
+        _create_legacy_schedule_table(db_path, ["legacy-one"])
+        assert await v2_9_0.async_up(db, "schedules", db.schedules_table_name) is True
+        assert await v2_9_0.async_down(db, "schedules", db.schedules_table_name) is True
+        assert await v2_9_0.async_down(db, "schedules", db.schedules_table_name) is False
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_manager_does_not_log_backend_exception_details(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    db = SqliteDb(db_file=str(tmp_path / "redaction.sqlite"))
+    secret = "postgresql://admin:private-password@internal.example/agno"
+    logs: list[str] = []
+
+    def fail_migration(_db, _table_type: str, _table_name: str) -> bool:
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(v2_9_0, "up", fail_migration)
+    monkeypatch.setattr("agno.db.migrations.manager.log_error", logs.append)
+
+    with pytest.raises(RuntimeError, match="private-password"):
+        await MigrationManager(db)._up_migration("v2_9_0", "schedules", db.schedules_table_name)
+
+    assert logs == ["Migration to version v2_9_0 failed"]
+    assert secret not in "".join(logs)
+
+
+@pytest.mark.asyncio
+async def test_postgres_dispatch_covers_sync_and_async(monkeypatch: pytest.MonkeyPatch):
+    calls: list[tuple[str, str]] = []
+
+    class CustomPostgresDb(PostgresDb):
+        pass
+
+    class CustomAsyncPostgresDb(AsyncPostgresDb):
+        pass
+
+    monkeypatch.setattr(
+        v2_9_0,
+        "_migrate_postgres",
+        lambda _db, table_name: calls.append(("sync", table_name)) or True,
+    )
+
+    async def migrate_async(_db, table_name: str) -> bool:
+        calls.append(("async", table_name))
+        return True
+
+    monkeypatch.setattr(v2_9_0, "_migrate_async_postgres", migrate_async)
+
+    monkeypatch.setattr(
+        v2_9_0,
+        "_revert_postgres",
+        lambda _db, table_name: calls.append(("sync-down", table_name)) or True,
+    )
+
+    async def revert_async(_db, table_name: str) -> bool:
+        calls.append(("async-down", table_name))
+        return True
+
+    monkeypatch.setattr(v2_9_0, "_revert_async_postgres", revert_async)
+
+    sync_db = object.__new__(CustomPostgresDb)
+    async_db = object.__new__(CustomAsyncPostgresDb)
+
+    assert v2_9_0.up(sync_db, "schedules", "agno_schedules") is True
+    assert await v2_9_0.async_up(async_db, "schedules", "agno_schedules") is True
+    assert v2_9_0.down(sync_db, "schedules", "agno_schedules") is True
+    assert await v2_9_0.async_down(async_db, "schedules", "agno_schedules") is True
+    assert calls == [
+        ("sync", "agno_schedules"),
+        ("async", "agno_schedules"),
+        ("sync-down", "agno_schedules"),
+        ("async-down", "agno_schedules"),
+    ]
+
+    assert v2_9_0.up(SimpleNamespace(), "sessions", "agno_sessions") is False  # type: ignore[arg-type]

--- a/libs/agno/tests/unit/db/test_schedule_name_conflicts.py
+++ b/libs/agno/tests/unit/db/test_schedule_name_conflicts.py
@@ -1,0 +1,343 @@
+"""Backend contract tests for typed schedule-name uniqueness failures."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pymongo.errors import DuplicateKeyError
+from sqlalchemy.exc import IntegrityError
+
+from agno.db.mongo.async_mongo import AsyncMongoDb
+from agno.db.mongo.mongo import MongoDb
+from agno.db.postgres.async_postgres import AsyncPostgresDb
+from agno.db.postgres.postgres import PostgresDb
+from agno.db.schemas.scheduler import ScheduleNameConflictError
+from agno.db.sqlite.async_sqlite import AsyncSqliteDb
+from agno.db.sqlite.sqlite import SqliteDb
+
+
+def _schedule(schedule_id: str, name: str) -> dict:
+    return {
+        "id": schedule_id,
+        "name": name,
+        "description": None,
+        "method": "POST",
+        "endpoint": "/agents/test/runs",
+        "payload": None,
+        "cron_expr": "0 9 * * *",
+        "timezone": "UTC",
+        "timeout_seconds": 3600,
+        "max_retries": 0,
+        "retry_delay_seconds": 60,
+        "enabled": True,
+        "next_run_at": None,
+        "locked_by": None,
+        "locked_at": None,
+        "created_at": 1,
+        "updated_at": None,
+    }
+
+
+@pytest.mark.parametrize(
+    "read",
+    [
+        lambda db: db.get_schedule("first"),
+        lambda db: db.get_schedule_by_name("shared-name"),
+        lambda db: db.get_schedules(),
+        lambda db: db.claim_due_schedule("worker"),
+        lambda db: db.get_schedule_run("run-1"),
+        lambda db: db.get_schedule_runs("first"),
+    ],
+)
+def test_sqlite_schedule_reads_propagate_backend_failures(tmp_path, read, caplog):
+    db = SqliteDb(db_file=str(tmp_path / "read-failure.db"), schedules_table="read_failure_schedules")
+    db.create_schedule(_schedule("first", "shared-name"))
+    db.create_schedule_run({"id": "run-1", "schedule_id": "first", "attempt": 1, "status": "success", "created_at": 1})
+    secret = "postgresql://admin:private-password@internal/agno"
+    db.Session = MagicMock(side_effect=RuntimeError(secret))  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="private-password"):
+        read(db)
+
+    assert secret not in caplog.text
+
+
+def test_sqlite_maps_only_schedule_name_integrity_errors(tmp_path):
+    db = SqliteDb(
+        db_file=str(tmp_path / "schedule-name-conflicts.db"),
+        schedules_table="typed_schedule_conflicts",
+    )
+    first = _schedule("first", "shared-name")
+    second = _schedule("second", "second-name")
+    db.create_schedule(first)
+
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        db.create_schedule(_schedule("duplicate-name", "shared-name"))
+
+    with pytest.raises(IntegrityError):
+        db.create_schedule(_schedule("first", "duplicate-id"))
+
+    db.create_schedule(second)
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        db.update_schedule("second", name="shared-name")
+
+    with pytest.raises(IntegrityError):
+        db.update_schedule("second", id="first")
+    assert db.get_schedule("second")["name"] == "second-name"
+
+    db.create_schedule({**_schedule("studio-a", "shared-name"), "managed_by": "studio", "owner_actor_id": "a"})
+    db.create_schedule({**_schedule("studio-b", "shared-name"), "managed_by": "studio", "owner_actor_id": "b"})
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        db.create_schedule(
+            {**_schedule("studio-a-duplicate", "shared-name"), "managed_by": "studio", "owner_actor_id": "a"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_maps_only_schedule_name_integrity_errors(tmp_path):
+    db = AsyncSqliteDb(
+        db_file=str(tmp_path / "async-schedule-name-conflicts.db"),
+        schedules_table="typed_async_schedule_conflicts",
+    )
+    first = _schedule("first", "shared-name")
+    second = _schedule("second", "second-name")
+    await db.create_schedule(first)
+
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        await db.create_schedule(_schedule("duplicate-name", "shared-name"))
+
+    with pytest.raises(IntegrityError):
+        await db.create_schedule(_schedule("first", "duplicate-id"))
+
+    await db.create_schedule(second)
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        await db.update_schedule("second", name="shared-name")
+
+    with pytest.raises(IntegrityError):
+        await db.update_schedule("second", id="first")
+    assert (await db.get_schedule("second"))["name"] == "second-name"
+    await db.db_engine.dispose()
+
+
+class _SyncFailingSession:
+    def __init__(self, error: Exception):
+        self.error = error
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def begin(self):
+        return self
+
+    def execute(self, *_args, **_kwargs):
+        raise self.error
+
+
+class _AsyncFailingSession:
+    def __init__(self, error: Exception):
+        self.error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    def begin(self):
+        return self
+
+    async def execute(self, *_args, **_kwargs):
+        raise self.error
+
+
+def _psycopg_integrity_error(
+    *, table_name: str = "test_schedules", constraint_name: str = "test_schedules_uq_generic_name"
+) -> IntegrityError:
+    original = RuntimeError("duplicate key")
+    original.sqlstate = "23505"  # type: ignore[attr-defined]
+    original.diag = SimpleNamespace(  # type: ignore[attr-defined]
+        constraint_name=constraint_name,
+        table_name=table_name,
+        schema_name="test_schema",
+    )
+    return IntegrityError("INSERT", {}, original)
+
+
+def _asyncpg_integrity_error(
+    *, table_name: str = "test_schedules", constraint_name: str = "test_schedules_uq_generic_name"
+) -> IntegrityError:
+    cause = RuntimeError("duplicate key")
+    cause.sqlstate = "23505"  # type: ignore[attr-defined]
+    cause.constraint_name = constraint_name  # type: ignore[attr-defined]
+    cause.table_name = table_name  # type: ignore[attr-defined]
+    cause.schema_name = "test_schema"  # type: ignore[attr-defined]
+    original = RuntimeError("asyncpg adapter integrity error")
+    original.sqlstate = "23505"  # type: ignore[attr-defined]
+    original.__cause__ = cause
+    return IntegrityError("INSERT", {}, original)
+
+
+def _sync_postgres_db(error: IntegrityError) -> PostgresDb:
+    db = object.__new__(PostgresDb)
+    db.schedules_table_name = "test_schedules"
+    db.db_schema = "test_schema"
+    db._get_table = MagicMock(return_value=MagicMock())  # type: ignore[method-assign]
+    db.Session = MagicMock(return_value=_SyncFailingSession(error))  # type: ignore[method-assign]
+    return db
+
+
+def _async_postgres_db(error: IntegrityError) -> AsyncPostgresDb:
+    db = object.__new__(AsyncPostgresDb)
+    db.schedules_table_name = "test_schedules"
+    db.db_schema = "test_schema"
+    db._get_table = AsyncMock(return_value=MagicMock())  # type: ignore[method-assign]
+    db.async_session_factory = MagicMock(return_value=_AsyncFailingSession(error))
+    return db
+
+
+@pytest.mark.parametrize("operation", ["create", "update"])
+@pytest.mark.parametrize("constraint_suffix", ["uq_generic_name", "uq_studio_owner_name"])
+def test_postgres_maps_exact_psycopg_schedule_name_constraint(operation, constraint_suffix):
+    db = _sync_postgres_db(_psycopg_integrity_error(constraint_name=f"test_schedules_{constraint_suffix}"))
+
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        if operation == "create":
+            db.create_schedule({"id": "loser", "name": "shared-name"})
+        else:
+            db.update_schedule("loser", name="shared-name")
+
+
+@pytest.mark.parametrize("operation", ["create", "update"])
+def test_postgres_does_not_map_same_constraint_reported_for_another_table(operation):
+    error = _psycopg_integrity_error(table_name="other_table")
+    db = _sync_postgres_db(error)
+
+    if operation == "create":
+        with pytest.raises(IntegrityError) as exc_info:
+            db.create_schedule({"id": "loser", "name": "shared-name"})
+        assert exc_info.value is error
+    else:
+        with pytest.raises(IntegrityError) as exc_info:
+            db.update_schedule("loser", name="shared-name")
+        assert exc_info.value is error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["create", "update"])
+@pytest.mark.parametrize("constraint_suffix", ["uq_generic_name", "uq_studio_owner_name"])
+async def test_async_postgres_maps_wrapped_asyncpg_schedule_name_constraint(operation, constraint_suffix):
+    db = _async_postgres_db(_asyncpg_integrity_error(constraint_name=f"test_schedules_{constraint_suffix}"))
+
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        if operation == "create":
+            await db.create_schedule({"id": "loser", "name": "shared-name"})
+        else:
+            await db.update_schedule("loser", name="shared-name")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["create", "update"])
+async def test_async_postgres_does_not_map_same_constraint_reported_for_another_table(operation):
+    error = _asyncpg_integrity_error(table_name="other_table")
+    db = _async_postgres_db(error)
+
+    if operation == "create":
+        with pytest.raises(IntegrityError) as exc_info:
+            await db.create_schedule({"id": "loser", "name": "shared-name"})
+        assert exc_info.value is error
+    else:
+        with pytest.raises(IntegrityError) as exc_info:
+            await db.update_schedule("loser", name="shared-name")
+        assert exc_info.value is error
+
+
+def _mongo_duplicate_error(key_pattern: dict) -> DuplicateKeyError:
+    return DuplicateKeyError(
+        "duplicate key",
+        11000,
+        {
+            "keyPattern": key_pattern,
+            "errmsg": "index: id_1 dup key: { id: ' index: name_1 dup key' }",
+        },
+    )
+
+
+def _sync_mongo_db(error: DuplicateKeyError, operation: str) -> MongoDb:
+    db = object.__new__(MongoDb)
+    collection = MagicMock()
+    if operation == "create":
+        collection.insert_one.side_effect = error
+    else:
+        collection.update_one.side_effect = error
+    db._get_collection = MagicMock(return_value=collection)  # type: ignore[method-assign]
+    return db
+
+
+def _async_mongo_db(error: DuplicateKeyError, operation: str) -> AsyncMongoDb:
+    db = object.__new__(AsyncMongoDb)
+    collection = AsyncMock()
+    if operation == "create":
+        collection.insert_one.side_effect = error
+    else:
+        collection.update_one.side_effect = error
+    db._get_collection = AsyncMock(return_value=collection)  # type: ignore[method-assign]
+    return db
+
+
+@pytest.mark.parametrize("operation", ["create", "update"])
+@pytest.mark.parametrize("key_pattern", [{"name": 1}, {"owner_actor_id": 1, "name": 1}])
+def test_mongo_maps_only_structured_schedule_name_key_pattern(operation, key_pattern):
+    db = _sync_mongo_db(_mongo_duplicate_error(key_pattern), operation)
+
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        if operation == "create":
+            db.create_schedule({"id": "loser", "name": "shared-name"})
+        else:
+            db.update_schedule("loser", name="shared-name")
+
+
+@pytest.mark.parametrize("operation", ["create", "update"])
+def test_mongo_does_not_map_misleading_message_for_id_key_pattern(operation):
+    error = _mongo_duplicate_error({"id": 1})
+    db = _sync_mongo_db(error, operation)
+
+    if operation == "create":
+        with pytest.raises(DuplicateKeyError) as exc_info:
+            db.create_schedule({"id": "loser", "name": "shared-name"})
+        assert exc_info.value is error
+    else:
+        with pytest.raises(DuplicateKeyError) as exc_info:
+            db.update_schedule("loser", name="shared-name")
+        assert exc_info.value is error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["create", "update"])
+@pytest.mark.parametrize("key_pattern", [{"name": 1}, {"owner_actor_id": 1, "name": 1}])
+async def test_async_mongo_maps_only_structured_schedule_name_key_pattern(operation, key_pattern):
+    db = _async_mongo_db(_mongo_duplicate_error(key_pattern), operation)
+
+    with pytest.raises(ScheduleNameConflictError, match="shared-name"):
+        if operation == "create":
+            await db.create_schedule({"id": "loser", "name": "shared-name"})
+        else:
+            await db.update_schedule("loser", name="shared-name")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["create", "update"])
+async def test_async_mongo_does_not_map_misleading_message_for_id_key_pattern(operation):
+    error = _mongo_duplicate_error({"id": 1})
+    db = _async_mongo_db(error, operation)
+
+    if operation == "create":
+        with pytest.raises(DuplicateKeyError) as exc_info:
+            await db.create_schedule({"id": "loser", "name": "shared-name"})
+        assert exc_info.value is error
+    else:
+        with pytest.raises(DuplicateKeyError) as exc_info:
+            await db.update_schedule("loser", name="shared-name")
+        assert exc_info.value is error

--- a/libs/agno/tests/unit/os/routers/test_components_router.py
+++ b/libs/agno/tests/unit/os/routers/test_components_router.py
@@ -22,9 +22,23 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from agno.db.base import BaseDb, ComponentType
-from agno.os.routers.components import get_components_router
+from agno.agent import Agent
+from agno.db.base import (
+    BaseDb,
+    ComponentDependencyError,
+    ComponentDraftRequiredError,
+    ComponentLastConfigError,
+    ComponentType,
+    ComponentVersionConflictError,
+    ComponentVersionGuard,
+)
+from agno.db.in_memory import InMemoryDb
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.routers.components import get_components_router, supports_component_routes
 from agno.os.settings import AgnoAPISettings
+from agno.registry import Registry
 
 # =============================================================================
 # Fixtures
@@ -41,11 +55,132 @@ def _create_mock_db_class():
     return type("MockDb", (BaseDb,), abstract_methods)
 
 
+def _create_legacy_catalog_db():
+    """Build a catalog-v1 adapter with the exact pre-2.9 method signatures."""
+    MockDbClass = _create_mock_db_class()
+
+    class LegacyCatalogDb(MockDbClass):
+        component_catalog_api_version = 1
+        # Deliberately inherit supports_component_persistence=False: the flag
+        # did not exist when third-party adapters implemented this contract.
+
+        def __init__(self):
+            super().__init__(id="legacy-catalog")
+            self.calls = []
+            self.component = None
+            self.config = None
+
+        def get_component(self, component_id, component_type=None):
+            self.calls.append(("get_component", component_id, component_type))
+            return self.component
+
+        def upsert_component(
+            self,
+            component_id,
+            component_type=None,
+            name=None,
+            description=None,
+            current_version=None,
+            metadata=None,
+        ):
+            self.calls.append(
+                (
+                    "upsert_component",
+                    component_id,
+                    component_type,
+                    name,
+                    description,
+                    current_version,
+                    metadata,
+                )
+            )
+            self.component = {
+                "component_id": component_id,
+                "component_type": component_type,
+                "name": name,
+                "description": description,
+                "current_version": current_version,
+                "metadata": metadata,
+                "created_at": 1,
+            }
+            return self.component
+
+        def delete_component(self, component_id, hard_delete=False):
+            self.calls.append(("delete_component", component_id, hard_delete))
+            self.component = None
+            return True
+
+        def list_components(
+            self,
+            component_type=None,
+            include_deleted=False,
+            limit=20,
+            offset=0,
+            exclude_component_ids=None,
+        ):
+            self.calls.append(
+                (
+                    "list_components",
+                    component_type,
+                    include_deleted,
+                    limit,
+                    offset,
+                    exclude_component_ids,
+                )
+            )
+            return ([self.component] if self.component is not None else [], int(self.component is not None))
+
+        def get_config(self, component_id, version=None, label=None):
+            self.calls.append(("get_config", component_id, version, label))
+            return self.config
+
+        def upsert_config(
+            self,
+            component_id,
+            config=None,
+            version=None,
+            label=None,
+            stage=None,
+            notes=None,
+            links=None,
+        ):
+            self.calls.append(("upsert_config", component_id, config, version, label, stage, notes, links))
+            self.config = {
+                "component_id": component_id,
+                "version": version or 1,
+                "label": label,
+                "stage": stage or "draft",
+                "config": config or {},
+                "notes": notes,
+                "created_at": 1,
+            }
+            return self.config
+
+        def delete_config(self, component_id, version):
+            self.calls.append(("delete_config", component_id, version))
+            self.config = None
+            return True
+
+        def list_configs(self, component_id, include_config=False):
+            self.calls.append(("list_configs", component_id, include_config))
+            return [self.config] if self.config is not None else []
+
+        def set_current_version(self, component_id, version):
+            self.calls.append(("set_current_version", component_id, version))
+            if self.component is not None:
+                self.component["current_version"] = version
+            return self.component is not None
+
+    return LegacyCatalogDb()
+
+
 @pytest.fixture
 def mock_db():
     """Create a mock database instance."""
     MockDbClass = _create_mock_db_class()
     db = MockDbClass()
+    db.supports_component_persistence = True
+    db.component_catalog_api_version = 2
     db.id = "test-db"
     db.list_components = MagicMock()
     db.get_component = MagicMock()
@@ -54,9 +189,12 @@ def mock_db():
     db.create_component_with_config = MagicMock()
     db.list_configs = MagicMock()
     db.get_config = MagicMock()
+    db.get_current_config = db.get_config
+    db.get_latest_config = db.get_config
     db.upsert_config = MagicMock()
     db.delete_config = MagicMock()
     db.set_current_version = MagicMock()
+    db.get_links = MagicMock(return_value=[])
     db.to_dict = MagicMock(return_value={"type": "postgres", "id": "test-db"})
     return db
 
@@ -74,6 +212,116 @@ def client(mock_db, settings):
     router = get_components_router(os_db=mock_db, settings=settings)
     app.include_router(router)
     return TestClient(app)
+
+
+@pytest.fixture
+def sqlite_client(tmp_path, settings):
+    """Create a components router backed by the real SQLite persistence layer."""
+    db = SqliteDb(db_file=str(tmp_path / "components-router.db"))
+    app = FastAPI()
+    app.include_router(get_components_router(os_db=db, settings=settings))
+    return TestClient(app), db
+
+
+def _guard(latest_version=1, current_version=1):
+    return {"guard": {"latest_version": latest_version, "current_version": current_version}}
+
+
+# =============================================================================
+# Router Capability Tests
+# =============================================================================
+
+
+class TestComponentPersistenceCapability:
+    def test_router_rejects_unsupported_sync_db(self, settings):
+        unsupported_db = _create_mock_db_class()()
+
+        with pytest.raises(ValueError, match="component persistence support"):
+            get_components_router(os_db=unsupported_db, settings=settings)
+
+    def test_complete_v1_override_is_detected_without_the_new_capability_flag(self):
+        from agno.os.app import _supports_component_routes
+
+        db = _create_legacy_catalog_db()
+
+        assert db.supports_component_persistence is False
+        assert supports_component_routes(db) is True
+        assert _supports_component_routes(db) is True
+
+        # A v2 adapter must explicitly opt into its stronger contract; method
+        # names alone cannot prove guarded atomic semantics.
+        db.component_catalog_api_version = 2
+        assert supports_component_routes(db) is False
+
+    def test_v1_router_keeps_legacy_http_and_exact_adapter_call_shapes(self, settings):
+        db = _create_legacy_catalog_db()
+        app = FastAPI()
+        app.include_router(get_components_router(os_db=db, settings=settings))
+        client = TestClient(app)
+
+        schema = app.openapi()
+        component_path = schema["paths"]["/components/{component_id}"]
+        assert "Legacy Catalog" in component_path["patch"]["summary"]
+        assert "requestBody" not in component_path["delete"]
+
+        created = client.post(
+            "/components",
+            json={"name": "Analyst v2.5", "component_type": "agent", "config": {"instructions": "Review"}},
+        )
+
+        assert created.status_code == 201
+        assert created.json()["component_id"] == "analyst-v2.5"
+        assert db.calls[0][:4] == (
+            "upsert_component",
+            "analyst-v2.5",
+            ComponentType.AGENT,
+            "Analyst v2.5",
+        )
+        assert db.calls[1] == (
+            "upsert_config",
+            "analyst-v2.5",
+            {"instructions": "Review"},
+            None,
+            None,
+            "draft",
+            None,
+            None,
+        )
+
+        current = client.get("/components/analyst-v2.5/configs/current")
+        assert current.status_code == 200
+        assert db.calls[-1] == ("get_config", "analyst-v2.5", None, None)
+
+        deleted = client.delete("/components/analyst-v2.5")
+        assert deleted.status_code == 204
+        assert db.calls[-1] == ("delete_component", "analyst-v2.5", False)
+
+    def test_agentos_mounts_the_detected_v1_router(self):
+        db = _create_legacy_catalog_db()
+        app = AgentOS(db=db, telemetry=False).get_app()
+
+        response = TestClient(app).get("/components")
+
+        assert response.status_code == 200
+        assert response.json()["data"] == []
+
+    def test_agentos_mounts_disabled_router_for_unsupported_sync_db(self):
+        agent_os = AgentOS(db=InMemoryDb(), telemetry=False)
+
+        response = TestClient(agent_os.get_app()).get("/components")
+
+        assert response.status_code == 503
+        assert "component persistence support" in response.json()["detail"]
+
+    def test_agentos_reprovision_keeps_unsupported_sync_db_disabled(self):
+        agent_os = AgentOS(db=InMemoryDb(), telemetry=False)
+        app = agent_os.get_app()
+
+        agent_os._reprovision_routers(app)
+        response = TestClient(app).get("/components")
+
+        assert response.status_code == 503
+        assert "component persistence support" in response.json()["detail"]
 
 
 # =============================================================================
@@ -185,6 +433,32 @@ class TestCreateComponent:
         call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["component_id"] == "my-agent"
 
+    def test_generated_id_matches_direct_agent_save(self, client, mock_db, tmp_path):
+        """REST and direct saves retain the same historical identity key."""
+        name = "R&D Jörg"
+        direct_agent = Agent(name=name, db=SqliteDb(db_file=str(tmp_path / "direct-id.db")))
+        assert direct_agent.save(stage="draft") == 1
+        direct_id = direct_agent.id
+        mock_db.create_component_with_config.return_value = (
+            {
+                "component_id": direct_id,
+                "name": name,
+                "component_type": "agent",
+                "created_at": 1234567890,
+            },
+            {"version": 1},
+        )
+
+        response = client.post(
+            "/components",
+            json={"name": name, "component_type": "agent"},
+        )
+
+        assert response.status_code == 201
+        assert direct_id == "r&d-jörg"
+        call_args = mock_db.create_component_with_config.call_args
+        assert call_args.kwargs["component_id"] == direct_id
+
     def test_create_component_with_explicit_id(self, client, mock_db):
         """Test create_component uses provided component_id."""
         mock_db.create_component_with_config.return_value = (
@@ -215,6 +489,15 @@ class TestCreateComponent:
         )
 
         assert response.status_code == 400
+
+    def test_create_component_rejects_removed_set_current_field(self, client, mock_db):
+        response = client.post(
+            "/components",
+            json={"name": "Test", "component_type": "agent", "set_current": False},
+        )
+
+        assert response.status_code == 422
+        mock_db.create_component_with_config.assert_not_called()
 
     def test_create_team_persists_links_for_db_members(self, client, mock_db):
         """Test create_component builds component links for DB-persisted members."""
@@ -248,7 +531,7 @@ class TestCreateComponent:
         ]
 
     def test_create_team_with_registry_member_succeeds_without_link(self, mock_db, settings):
-        """Test create_component allows a code-defined (registry) member with no link."""
+        """Draft teams may use a code-defined registry member without a durable link."""
         from agno.agent.agent import Agent
         from agno.registry import Registry
 
@@ -270,6 +553,76 @@ class TestCreateComponent:
                 "name": "My Team",
                 "component_type": "team",
                 "component_id": "my-team",
+                "config": {"id": "my-team", "members": [{"type": "agent", "agent_id": "member-agent"}]},
+            },
+        )
+
+        assert response.status_code == 201
+        assert mock_db.create_component_with_config.call_args.kwargs["links"] is None
+
+    def test_create_published_team_rejects_code_defined_member_without_durable_pin(self, mock_db, settings):
+        """A live registry object is not an exact version pin for publication."""
+        from agno.agent.agent import Agent
+        from agno.registry import Registry
+
+        mock_db.get_component.return_value = None
+        registry = Registry(agents=[Agent(id="member-agent", name="Member Agent")])
+
+        app = FastAPI()
+        app.include_router(get_components_router(os_db=mock_db, settings=settings, registry=registry))
+        client = TestClient(app)
+
+        response = client.post(
+            "/components",
+            json={
+                "name": "My Team",
+                "component_type": "team",
+                "component_id": "my-team",
+                "stage": "published",
+                "config": {"id": "my-team", "members": [{"type": "agent", "agent_id": "member-agent"}]},
+            },
+        )
+
+        assert response.status_code == 400
+        assert "durable published versions" in response.json()["detail"]
+        assert "member-agent" in response.json()["detail"]
+        mock_db.create_component_with_config.assert_not_called()
+
+    def test_create_published_team_rejects_draft_only_db_member(self, client, mock_db):
+        """A DB component without a current published version cannot be pinned."""
+        mock_db.get_component.return_value = {"component_id": "member-agent", "current_version": None}
+
+        response = client.post(
+            "/components",
+            json={
+                "name": "My Team",
+                "component_type": "team",
+                "component_id": "my-team",
+                "stage": "published",
+                "config": {"id": "my-team", "members": [{"type": "agent", "agent_id": "member-agent"}]},
+            },
+        )
+
+        assert response.status_code == 400
+        assert "durable published versions" in response.json()["detail"]
+        assert "member-agent" in response.json()["detail"]
+        mock_db.create_component_with_config.assert_not_called()
+
+    def test_create_draft_team_allows_draft_only_db_member_without_link(self, client, mock_db):
+        """Draft composition remains flexible until every child can be pinned."""
+        mock_db.get_component.return_value = {"component_id": "member-agent", "current_version": None}
+        mock_db.create_component_with_config.return_value = (
+            {"component_id": "my-team", "name": "My Team", "component_type": "team", "created_at": 1},
+            {"version": 1},
+        )
+
+        response = client.post(
+            "/components",
+            json={
+                "name": "My Team",
+                "component_type": "team",
+                "component_id": "my-team",
+                "stage": "draft",
                 "config": {"id": "my-team", "members": [{"type": "agent", "agent_id": "member-agent"}]},
             },
         )
@@ -344,33 +697,91 @@ class TestUpdateComponent:
     """Tests for PATCH /components/{component_id} endpoint."""
 
     def test_update_component_success(self, client, mock_db):
-        """Test update_component updates component."""
+        """A metadata edit appends a guarded draft and leaves the projection alone."""
         mock_db.get_component.return_value = {
             "component_id": "agent-1",
             "name": "Old Name",
             "component_type": "agent",
+            "current_version": 1,
             "created_at": 1234567890,
         }
-        mock_db.upsert_component.return_value = {
+        mock_db.get_config.return_value = {
             "component_id": "agent-1",
-            "name": "New Name",
-            "component_type": "agent",
+            "version": 1,
+            "stage": "published",
+            "config": {"id": "agent-1", "name": "Old Name", "instructions": "Help"},
             "created_at": 1234567890,
+        }
+        mock_db.upsert_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "stage": "draft",
+            "config": {"id": "agent-1", "name": "New Name", "instructions": "Help"},
+            "created_at": 1234567891,
         }
 
-        response = client.patch("/components/agent-1", json={"name": "New Name"})
+        response = client.patch("/components/agent-1", json={"name": "New Name", **_guard(1, 1)})
 
         assert response.status_code == 200
         data = response.json()
-        assert data["name"] == "New Name"
+        assert data["version"] == 2
+        assert data["stage"] == "draft"
+        assert data["config"]["name"] == "New Name"
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_called_once_with(
+            component_id="agent-1",
+            config={
+                "id": "agent-1",
+                "name": "New Name",
+                "instructions": "Help",
+                "description": None,
+                "metadata": None,
+            },
+            stage="draft",
+            links=[],
+            guard=ComponentVersionGuard(latest_version=1, current_version=1),
+            projection=None,
+        )
 
     def test_update_component_not_found(self, client, mock_db):
         """Test update_component returns 404 when not found."""
         mock_db.get_component.return_value = None
 
-        response = client.patch("/components/nonexistent", json={"name": "New Name"})
+        response = client.patch("/components/nonexistent", json={"name": "New Name", **_guard()})
 
         assert response.status_code == 404
+
+    def test_update_component_rejects_direct_current_pointer_mutation(self, client, mock_db):
+        """Current-version changes must use the guarded set-current endpoint."""
+        response = client.patch("/components/agent-1", json={"current_version": 2, **_guard()})
+
+        assert response.status_code == 422
+        mock_db.upsert_component.assert_not_called()
+
+    def test_update_component_requires_guard_and_nonempty_patch(self, client, mock_db):
+        assert client.patch("/components/agent-1", json={"name": "New Name"}).status_code == 422
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "current_version": 1,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "stage": "published",
+            "config": {"id": "agent-1", "name": "Agent"},
+        }
+        assert client.patch("/components/agent-1", json=_guard()).status_code == 400
+        mock_db.upsert_config.assert_not_called()
+
+    def test_update_component_guard_rejects_null_latest_version(self, client, mock_db):
+        response = client.patch(
+            "/components/agent-1",
+            json={"name": "New Name", "guard": {"latest_version": None, "current_version": None}},
+        )
+
+        assert response.status_code == 422
+        mock_db.upsert_config.assert_not_called()
 
 
 # =============================================================================
@@ -382,20 +793,292 @@ class TestDeleteComponent:
     """Tests for DELETE /components/{component_id} endpoint."""
 
     def test_delete_component_success(self, client, mock_db):
-        """Test delete_component deletes component."""
+        """Archive is guarded and projects the current published config."""
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "current_version": 1,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "stage": "published",
+            "config": {"name": "Published", "description": "Current", "metadata": {"release": 1}},
+        }
         mock_db.delete_component.return_value = True
 
-        response = client.delete("/components/agent-1")
+        response = client.request("DELETE", "/components/agent-1", json=_guard(2, 1))
 
         assert response.status_code == 204
+        mock_db.delete_component.assert_called_once_with(
+            "agent-1",
+            hard_delete=False,
+            guard=ComponentVersionGuard(latest_version=2, current_version=1),
+            projection={"name": "Published", "description": "Current", "metadata": {"release": 1}},
+        )
 
     def test_delete_component_not_found(self, client, mock_db):
         """Test delete_component returns 404 when not found."""
-        mock_db.delete_component.return_value = False
+        mock_db.get_component.return_value = None
 
-        response = client.delete("/components/nonexistent")
+        response = client.request("DELETE", "/components/nonexistent", json=_guard())
 
         assert response.status_code == 404
+
+    def test_delete_component_dependency_conflict_is_stable(self, client, mock_db):
+        """The dependency-safe default must not turn an expected conflict into 500."""
+        mock_db.delete_component.side_effect = ComponentDependencyError(
+            "agent-1",
+            [
+                {
+                    "parent_component_id": "team-1",
+                    "parent_version": 3,
+                    "link_kind": "member",
+                    "link_key": "member_0",
+                }
+            ],
+        )
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "current_version": 1,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "stage": "published",
+            "config": {"name": "Agent"},
+        }
+
+        response = client.request("DELETE", "/components/agent-1", json=_guard())
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == "Cannot delete agent-1: it is referenced by 1 component link(s)"
+
+    def test_delete_component_requires_guard(self, client, mock_db):
+        response = client.delete("/components/agent-1")
+
+        assert response.status_code == 422
+        mock_db.delete_component.assert_not_called()
+
+
+class TestGuardedGenericLifecycle:
+    """Real SQLite regressions for append-only edits, CAS, and soft archive."""
+
+    @staticmethod
+    def _agent_config(name: str, description: str | None, metadata: dict | None):
+        return {
+            "id": "guarded-agent",
+            "name": name,
+            "instructions": "Be useful",
+            "description": description,
+            "metadata": metadata,
+        }
+
+    def _create(self, client, *, stage: str, name: str = "Version one"):
+        return client.post(
+            "/components",
+            json={
+                "component_id": "guarded-agent",
+                "component_type": "agent",
+                "name": name,
+                "description": "Original description",
+                "metadata": {"revision": 1},
+                "stage": stage,
+                "config": self._agent_config(
+                    name,
+                    "Original description",
+                    {"revision": 1},
+                ),
+            },
+        )
+
+    @staticmethod
+    def _stored_config_versions(db, component_id: str):
+        table = db._get_table(table_type="component_configs")
+        assert table is not None
+        with db.Session() as session:
+            return [
+                row.version
+                for row in session.execute(
+                    table.select().where(table.c.component_id == component_id).order_by(table.c.version)
+                ).fetchall()
+            ]
+
+    def test_patch_appends_generic_draft_and_preserves_current_projection(self, sqlite_client):
+        client, db = sqlite_client
+        assert self._create(client, stage="published").status_code == 201
+
+        response = client.patch(
+            "/components/guarded-agent",
+            json={
+                "name": "Draft edit",
+                "description": None,
+                "metadata": {"revision": 2},
+                **_guard(1, 1),
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["version"] == 2
+        assert data["stage"] == "draft"
+        assert data["config"]["name"] == "Draft edit"
+        assert data["config"]["description"] is None
+        assert data["config"]["metadata"] == {"revision": 2}
+
+        component = db.get_component("guarded-agent")
+        assert component is not None
+        assert component["current_version"] == 1
+        assert component["name"] == "Version one"
+        assert component["description"] == "Original description"
+        assert component["metadata"] == {"revision": 1}
+
+        stale = client.patch(
+            "/components/guarded-agent",
+            json={"name": "Lost update", **_guard(1, 1)},
+        )
+        assert stale.status_code == 409
+        assert [row["version"] for row in db.list_configs("guarded-agent")] == [2, 1]
+
+    def test_archive_uses_current_projection_and_preserves_all_history(self, sqlite_client):
+        client, db = sqlite_client
+        assert self._create(client, stage="published").status_code == 201
+        assert (
+            client.patch(
+                "/components/guarded-agent",
+                json={"name": "Unpublished draft", "metadata": {"revision": 2}, **_guard(1, 1)},
+            ).status_code
+            == 200
+        )
+
+        response = client.request("DELETE", "/components/guarded-agent", json=_guard(2, 1))
+
+        assert response.status_code == 204
+        archived = db.get_component("guarded-agent", include_deleted=True)
+        assert archived is not None
+        assert archived["deleted_at"] is not None
+        assert archived["current_version"] == 1
+        assert archived["name"] == "Version one"
+        assert archived["metadata"] == {"revision": 1}
+        assert self._stored_config_versions(db, "guarded-agent") == [1, 2]
+
+    def test_draft_only_patch_and_archive_project_latest_draft(self, sqlite_client):
+        client, db = sqlite_client
+        assert self._create(client, stage="draft").status_code == 201
+        assert (
+            client.patch(
+                "/components/guarded-agent",
+                json={"name": "Latest draft", "metadata": {"revision": 2}, **_guard(1, None)},
+            ).status_code
+            == 200
+        )
+
+        component = db.get_component("guarded-agent")
+        assert component is not None
+        assert component["current_version"] is None
+        assert component["name"] == "Latest draft"
+        assert component["metadata"] == {"revision": 2}
+
+        assert (
+            client.request(
+                "DELETE",
+                "/components/guarded-agent",
+                json=_guard(2, None),
+            ).status_code
+            == 204
+        )
+        archived = db.get_component("guarded-agent", include_deleted=True)
+        assert archived is not None
+        assert archived["name"] == "Latest draft"
+        assert archived["metadata"] == {"revision": 2}
+        assert self._stored_config_versions(db, "guarded-agent") == [1, 2]
+
+    def test_delete_latest_draft_requires_fresh_guard_and_restores_draft_projection(self, sqlite_client):
+        client, db = sqlite_client
+        assert self._create(client, stage="draft").status_code == 201
+        assert (
+            client.patch(
+                "/components/guarded-agent",
+                json={"name": "Version two", "metadata": {"revision": 2}, **_guard(1, None)},
+            ).status_code
+            == 200
+        )
+
+        stale = client.request(
+            "DELETE",
+            "/components/guarded-agent/configs/2",
+            json=_guard(1, None),
+        )
+        assert stale.status_code == 409
+        assert db.get_config("guarded-agent", version=2) is not None
+
+        deleted = client.request(
+            "DELETE",
+            "/components/guarded-agent/configs/2",
+            json=_guard(2, None),
+        )
+        assert deleted.status_code == 204
+        assert db.get_config("guarded-agent", version=2) is None
+        component = db.get_component("guarded-agent")
+        assert component is not None
+        assert component["name"] == "Version one"
+        assert component["metadata"] == {"revision": 1}
+        assert self._stored_config_versions(db, "guarded-agent") == [1, 2]
+
+    def test_generic_creation_rejects_reserved_studio_manifest(self, sqlite_client):
+        client, db = sqlite_client
+        config = self._agent_config("Version one", "Original description", {"revision": 1})
+        config["_agno_studio"] = {"schema_version": 999, "request": {}}
+        response = client.post(
+            "/components",
+            json={
+                "component_id": "guarded-agent",
+                "component_type": "agent",
+                "name": "Version one",
+                "stage": "draft",
+                "config": config,
+            },
+        )
+
+        assert response.status_code == 400
+        assert "reserved for StudioTools" in response.json()["detail"]
+        assert db.get_component("guarded-agent") is None
+
+
+class TestStudioWriteIsolation:
+    """The generic Components API is read-only for Studio-owned records."""
+
+    def test_generic_config_append_cannot_claim_studio_manifest_namespace(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            client.post(
+                "/components",
+                json={
+                    "component_id": "generic-agent",
+                    "component_type": "agent",
+                    "name": "Generic agent",
+                    "config": {"id": "generic-agent", "name": "Generic agent"},
+                },
+            ).status_code
+            == 201
+        )
+
+        response = client.post(
+            "/components/generic-agent/configs",
+            json={
+                "config": {
+                    "id": "generic-agent",
+                    "name": "Forged Studio version",
+                    "_agno_studio": {"schema_version": 2, "request": {}},
+                },
+                **_guard(1, None),
+            },
+        )
+
+        assert response.status_code == 400
+        assert "reserved for StudioTools" in response.json()["detail"]
+        assert [row["version"] for row in db.list_configs("generic-agent")] == [1]
 
 
 # =============================================================================
@@ -420,12 +1103,27 @@ class TestListConfigs:
         assert len(data) == 2
 
     def test_list_configs_with_include_config(self, client, mock_db):
-        """Test list_configs passes include_config parameter."""
-        mock_db.list_configs.return_value = []
+        """Config summaries remain valid when the payload is intentionally omitted."""
+        mock_db.list_configs.return_value = [
+            {
+                "component_id": "agent-1",
+                "version": 2,
+                "stage": "published",
+                "created_at": 1234567890,
+            }
+        ]
 
         response = client.get("/components/agent-1/configs?include_config=false")
 
         assert response.status_code == 200
+        assert response.json() == [
+            {
+                "component_id": "agent-1",
+                "version": 2,
+                "stage": "published",
+                "created_at": 1234567890,
+            }
+        ]
         mock_db.list_configs.assert_called_once_with("agent-1", include_config=False)
 
 
@@ -449,12 +1147,170 @@ class TestCreateConfig:
 
         response = client.post(
             "/components/agent-1/configs",
-            json={"config": {"name": "Agent"}, "stage": "draft"},
+            json={"config": {"name": "Agent"}, "stage": "draft", **_guard()},
         )
 
         assert response.status_code == 201
         data = response.json()
         assert data["version"] == 1
+        mock_db.upsert_config.assert_called_once_with(
+            component_id="agent-1",
+            version=None,
+            config={"name": "Agent", "description": None, "metadata": None},
+            label=None,
+            stage="draft",
+            notes=None,
+            links=None,
+            guard=ComponentVersionGuard(latest_version=1, current_version=1),
+            projection=None,
+        )
+
+    def test_create_config_stores_inherited_fields_and_explicit_nulls(self, client, mock_db):
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "name": "Current name",
+            "description": "Current description",
+            "metadata": {"release": 1},
+            "current_version": 1,
+        }
+        mock_db.upsert_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "config": {"instructions": "v2"},
+            "stage": "draft",
+            "created_at": 1234567890,
+        }
+
+        response = client.post(
+            "/components/agent-1/configs",
+            json={"config": {"instructions": "v2", "description": None}, "stage": "draft", **_guard()},
+        )
+
+        assert response.status_code == 201
+        assert mock_db.upsert_config.call_args.kwargs["config"] == {
+            "instructions": "v2",
+            "name": "Current name",
+            "description": None,
+            "metadata": {"release": 1},
+        }
+
+    def test_create_config_requires_guard(self, client, mock_db):
+        response = client.post("/components/agent-1/configs", json={"config": {"name": "Agent"}})
+
+        assert response.status_code == 422
+        mock_db.upsert_config.assert_not_called()
+
+    def test_agent_config_rejects_caller_owned_component_links(self, client, mock_db):
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "current_version": 1,
+        }
+
+        response = client.post(
+            "/components/agent-1/configs",
+            json={
+                "config": {"name": "Agent"},
+                "links": [
+                    {
+                        "link_kind": "step_agent",
+                        "link_key": "forged",
+                        "child_component_id": "victim",
+                        "child_version": 1,
+                        "position": 0,
+                    }
+                ],
+                **_guard(),
+            },
+        )
+
+        assert response.status_code == 400
+        assert "do not support component links" in response.json()["detail"]
+        mock_db.upsert_config.assert_not_called()
+
+    def test_create_published_config_projects_catalog_fields(self, client, mock_db):
+        config = {
+            "name": "Published Agent",
+            "description": "Projected description",
+            "metadata": {"release": 2},
+            "instructions": "Be useful",
+        }
+        mock_db.upsert_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "config": config,
+            "stage": "published",
+            "created_at": 1234567890,
+        }
+
+        response = client.post(
+            "/components/agent-1/configs",
+            json={"config": config, "stage": "published", **_guard(1, 1)},
+        )
+
+        assert response.status_code == 201
+        assert mock_db.upsert_config.call_args.kwargs["projection"] == {
+            "name": "Published Agent",
+            "description": "Projected description",
+            "metadata": {"release": 2},
+        }
+
+    def test_create_draft_config_projects_catalog_fields_before_first_publish(self, client, mock_db):
+        config = {
+            "name": "Second draft",
+            "description": "Latest draft projection",
+            "metadata": {"revision": 2},
+        }
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "current_version": None,
+        }
+        mock_db.upsert_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "config": config,
+            "stage": "draft",
+            "created_at": 1234567890,
+        }
+
+        response = client.post(
+            "/components/agent-1/configs",
+            json={"config": config, "stage": "draft", **_guard(1, None)},
+        )
+
+        assert response.status_code == 201
+        assert mock_db.upsert_config.call_args.kwargs["projection"] == {
+            "name": "Second draft",
+            "description": "Latest draft projection",
+            "metadata": {"revision": 2},
+        }
+
+    def test_create_config_maps_stale_guard_to_conflict(self, client, mock_db):
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "name": "Agent",
+            "current_version": 1,
+        }
+        mock_db.upsert_config.side_effect = ComponentVersionConflictError(
+            "agent-1",
+            expected=ComponentVersionGuard(latest_version=1, current_version=1),
+            actual=ComponentVersionGuard(latest_version=2, current_version=1),
+        )
+
+        response = client.post("/components/agent-1/configs", json={"config": {}, **_guard()})
+
+        assert response.status_code == 409
+        assert "version conflict" in response.json()["detail"]
+
+    @pytest.mark.parametrize("removed_field", [{"version": 2}, {"set_current": False}])
+    def test_create_config_rejects_removed_noop_fields(self, client, mock_db, removed_field):
+        response = client.post("/components/agent-1/configs", json={"config": {}, **_guard(), **removed_field})
+
+        assert response.status_code == 422
+        mock_db.upsert_config.assert_not_called()
 
     def test_create_config_handles_value_error(self, client, mock_db):
         """Test create_config returns 400 on ValueError."""
@@ -462,10 +1318,734 @@ class TestCreateConfig:
 
         response = client.post(
             "/components/agent-1/configs",
-            json={"config": {}},
+            json={"config": {}, **_guard()},
         )
 
         assert response.status_code == 400
+
+
+class TestTeamLinkTrustBoundary:
+    """Published Team configs must derive durable member pins server-side."""
+
+    @staticmethod
+    def _create_component(
+        client,
+        *,
+        component_id: str,
+        component_type: str,
+        stage: str,
+        config: dict,
+    ):
+        return client.post(
+            "/components",
+            json={
+                "component_id": component_id,
+                "name": config.get("name", component_id),
+                "component_type": component_type,
+                "stage": stage,
+                "config": config,
+            },
+        )
+
+    def test_draft_team_promotion_rejects_draft_only_member(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="draft-child",
+                component_type="agent",
+                stage="draft",
+                config={"id": "draft-child", "name": "Draft child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="draft-team",
+                component_type="team",
+                stage="draft",
+                config={
+                    "id": "draft-team",
+                    "name": "Draft team",
+                    "members": [{"type": "agent", "agent_id": "draft-child"}],
+                },
+            ).status_code
+            == 201
+        )
+
+        response = client.patch(
+            "/components/draft-team/configs/1",
+            json={"stage": "published", **_guard(1, None)},
+        )
+
+        assert response.status_code == 400
+        assert "durable published versions" in response.json()["detail"]
+        component = db.get_component("draft-team")
+        draft = db.get_config("draft-team", version=1)
+        assert component is not None and component["current_version"] is None
+        assert draft is not None and draft["stage"] == "draft"
+        assert db.get_links("draft-team", 1) == []
+
+    def test_draft_team_promotion_derives_pin_after_member_is_published(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="child",
+                component_type="agent",
+                stage="draft",
+                config={"id": "child", "name": "Child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="team",
+                component_type="team",
+                stage="draft",
+                config={
+                    "id": "team",
+                    "name": "Team",
+                    "members": [{"type": "agent", "agent_id": "child"}],
+                },
+            ).status_code
+            == 201
+        )
+        assert db.get_links("team", 1) == []
+
+        child_publish = client.patch(
+            "/components/child/configs/1",
+            json={"stage": "published", **_guard(1, None)},
+        )
+        assert child_publish.status_code == 200
+
+        team_publish = client.patch(
+            "/components/team/configs/1",
+            json={"stage": "published", **_guard(1, None)},
+        )
+
+        assert team_publish.status_code == 200
+        assert team_publish.json()["stage"] == "published"
+        component = db.get_component("team")
+        assert component is not None and component["current_version"] == 1
+        links = db.get_links("team", 1)
+        assert [(link["child_component_id"], link["child_version"]) for link in links] == [("child", 1)]
+
+    def test_published_team_config_create_rejects_draft_only_member(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="draft-child",
+                component_type="agent",
+                stage="draft",
+                config={"id": "draft-child", "name": "Draft child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="team",
+                component_type="team",
+                stage="draft",
+                config={"id": "team", "name": "Team", "members": []},
+            ).status_code
+            == 201
+        )
+
+        response = client.post(
+            "/components/team/configs",
+            json={
+                "stage": "published",
+                "config": {
+                    "id": "team",
+                    "name": "Team",
+                    "members": [{"type": "agent", "agent_id": "draft-child"}],
+                },
+                **_guard(1, None),
+            },
+        )
+
+        assert response.status_code == 400
+        assert "durable published versions" in response.json()["detail"]
+        assert [row["version"] for row in db.list_configs("team")] == [1]
+
+    def test_team_config_create_rejects_caller_supplied_mismatched_links(self, sqlite_client):
+        client, db = sqlite_client
+        for child_id in ("member-a", "member-b"):
+            assert (
+                self._create_component(
+                    client,
+                    component_id=child_id,
+                    component_type="agent",
+                    stage="published",
+                    config={"id": child_id, "name": child_id},
+                ).status_code
+                == 201
+            )
+        assert (
+            self._create_component(
+                client,
+                component_id="team",
+                component_type="team",
+                stage="draft",
+                config={"id": "team", "name": "Team", "members": []},
+            ).status_code
+            == 201
+        )
+
+        response = client.post(
+            "/components/team/configs",
+            json={
+                "stage": "draft",
+                "config": {
+                    "id": "team",
+                    "name": "Team",
+                    "members": [{"type": "agent", "agent_id": "member-a"}],
+                },
+                "links": [
+                    {
+                        "link_kind": "member",
+                        "link_key": "member_0",
+                        "child_component_id": "member-b",
+                        "child_version": 1,
+                        "position": 0,
+                        "meta": {"type": "agent"},
+                    }
+                ],
+                **_guard(1, None),
+            },
+        )
+
+        assert response.status_code == 400
+        assert "derived from config.members" in response.json()["detail"]
+        assert [row["version"] for row in db.list_configs("team")] == [1]
+
+    def test_draft_team_config_keeps_flexible_member_and_persists_resolvable_pin(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="draft-child",
+                component_type="agent",
+                stage="draft",
+                config={"id": "draft-child", "name": "Draft child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="published-child",
+                component_type="agent",
+                stage="published",
+                config={"id": "published-child", "name": "Published child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="team",
+                component_type="team",
+                stage="draft",
+                config={"id": "team", "name": "Team", "members": []},
+            ).status_code
+            == 201
+        )
+
+        response = client.post(
+            "/components/team/configs",
+            json={
+                "stage": "draft",
+                "config": {
+                    "id": "team",
+                    "name": "Team",
+                    "members": [
+                        {"type": "agent", "agent_id": "draft-child"},
+                        {"type": "agent", "agent_id": "published-child"},
+                    ],
+                },
+                **_guard(1, None),
+            },
+        )
+
+        assert response.status_code == 201
+        assert response.json()["version"] == 2
+        links = db.get_links("team", 2)
+        assert [(link["link_key"], link["child_component_id"], link["child_version"]) for link in links] == [
+            ("member_1", "published-child", 1)
+        ]
+
+    @pytest.mark.parametrize(
+        "members,detail",
+        [
+            ({"type": "agent", "agent_id": "child"}, "must be a list"),
+            ({}, "must be a list"),
+            ("", "must be a list"),
+            (0, "must be a list"),
+            (False, "must be a list"),
+            (None, "must be a list"),
+            (["child"], "must be an object"),
+            ([{"type": "unknown", "agent_id": "child"}], "must be 'agent' or 'team'"),
+            ([{"type": "agent", "agent_id": ""}], "must be a non-empty string"),
+            (
+                [{"type": "agent", "agent_id": "child", "team_id": "other"}],
+                "exactly one of agent_id or team_id",
+            ),
+        ],
+    )
+    def test_team_members_fail_closed_before_component_creation(self, sqlite_client, members, detail):
+        client, db = sqlite_client
+
+        response = self._create_component(
+            client,
+            component_id="malformed-team",
+            component_type="team",
+            stage="draft",
+            config={"id": "malformed-team", "name": "Malformed team", "members": members},
+        )
+
+        assert response.status_code == 400
+        assert detail in response.json()["detail"]
+        assert db.get_component("malformed-team") is None
+
+    def test_explicit_empty_team_members_list_is_allowed(self, sqlite_client):
+        client, db = sqlite_client
+
+        response = self._create_component(
+            client,
+            component_id="empty-team",
+            component_type="team",
+            stage="draft",
+            config={"id": "empty-team", "name": "Empty team", "members": []},
+        )
+
+        assert response.status_code == 201
+        assert db.get_component("empty-team") is not None
+        assert db.get_links("empty-team", 1) == []
+
+
+class TestWorkflowLinkTrustBoundary:
+    """Workflow links are validated and derived from every nested Step."""
+
+    @staticmethod
+    def _create_component(
+        client,
+        *,
+        component_id: str,
+        component_type: str,
+        stage: str,
+        config: dict,
+    ):
+        return client.post(
+            "/components",
+            json={
+                "component_id": component_id,
+                "name": config.get("name", component_id),
+                "component_type": component_type,
+                "stage": stage,
+                "config": config,
+            },
+        )
+
+    def test_published_workflow_rejects_draft_only_step_component_atomically(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="draft-agent",
+                component_type="agent",
+                stage="draft",
+                config={"id": "draft-agent", "name": "Draft agent"},
+            ).status_code
+            == 201
+        )
+
+        response = self._create_component(
+            client,
+            component_id="published-workflow",
+            component_type="workflow",
+            stage="published",
+            config={
+                "id": "published-workflow",
+                "name": "Published workflow",
+                "steps": [{"type": "Step", "step_id": "draft-step", "name": "Draft step", "agent_id": "draft-agent"}],
+            },
+        )
+
+        assert response.status_code == 400
+        assert "durable published versions" in response.json()["detail"]
+        assert db.get_component("published-workflow") is None
+
+    def test_published_workflow_derives_exact_links_through_nested_branches(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="agent-child",
+                component_type="agent",
+                stage="published",
+                config={"id": "agent-child", "name": "Agent child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="team-child",
+                component_type="team",
+                stage="published",
+                config={"id": "team-child", "name": "Team child", "members": []},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="workflow-child",
+                component_type="workflow",
+                stage="published",
+                config={"id": "workflow-child", "name": "Workflow child", "steps": []},
+            ).status_code
+            == 201
+        )
+
+        response = self._create_component(
+            client,
+            component_id="workflow-parent",
+            component_type="workflow",
+            stage="published",
+            config={
+                "id": "workflow-parent",
+                "name": "Workflow parent",
+                "steps": [
+                    {
+                        "type": "Parallel",
+                        "name": "parallel",
+                        "steps": [
+                            {
+                                "type": "Step",
+                                "step_id": "agent-step",
+                                "name": "Agent step",
+                                "agent_id": "agent-child",
+                            },
+                            {
+                                "type": "Condition",
+                                "name": "condition",
+                                "steps": [
+                                    {
+                                        "type": "Step",
+                                        "step_id": "team-step",
+                                        "name": "Team step",
+                                        "team_id": "team-child",
+                                    }
+                                ],
+                                "else_steps": [
+                                    {
+                                        "type": "Router",
+                                        "name": "router",
+                                        "choices": [
+                                            {
+                                                "type": "Step",
+                                                "step_id": "workflow-step",
+                                                "name": "Workflow step",
+                                                "workflow_id": "workflow-child",
+                                            }
+                                        ],
+                                    }
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+
+        assert response.status_code == 201
+        links = sorted(db.get_links("workflow-parent", 1), key=lambda link: link["position"])
+        assert [
+            (
+                link["link_kind"],
+                link["link_key"],
+                link["child_component_id"],
+                link["child_version"],
+                link["position"],
+            )
+            for link in links
+        ] == [
+            ("step_agent", "agent-step", "agent-child", 1, 0),
+            ("step_team", "team-step", "team-child", 1, 1),
+            ("step_workflow", "workflow-step", "workflow-child", 1, 2),
+        ]
+
+    @pytest.mark.parametrize(
+        "bad_step",
+        [
+            {"type": "Mystery", "steps": []},
+            {
+                "type": "Step",
+                "step_id": "ambiguous",
+                "agent_id": "agent-child",
+                "team_id": "team-child",
+            },
+        ],
+    )
+    def test_malformed_workflow_reference_fails_closed_atomically(self, sqlite_client, bad_step):
+        client, db = sqlite_client
+
+        response = self._create_component(
+            client,
+            component_id="bad-workflow",
+            component_type="workflow",
+            stage="draft",
+            config={"id": "bad-workflow", "name": "Bad workflow", "steps": [bad_step]},
+        )
+
+        assert response.status_code == 400
+        assert db.get_component("bad-workflow") is None
+
+    def test_unregistered_function_step_fails_closed_atomically(self, sqlite_client):
+        client, db = sqlite_client
+
+        response = self._create_component(
+            client,
+            component_id="missing-function-workflow",
+            component_type="workflow",
+            stage="draft",
+            config={
+                "id": "missing-function-workflow",
+                "name": "Missing function workflow",
+                "steps": [{"type": "Step", "step_id": "function-step", "executor_ref": "not_registered"}],
+            },
+        )
+
+        assert response.status_code == 400
+        assert "not_registered" in response.json()["detail"]
+        assert db.get_component("missing-function-workflow") is None
+
+    def test_ambiguous_registered_function_step_fails_closed(self, tmp_path, settings):
+        def first_function():
+            return None
+
+        def second_function():
+            return None
+
+        first_function.__name__ = "duplicate_function"
+        second_function.__name__ = "duplicate_function"
+        db = SqliteDb(db_file=str(tmp_path / "ambiguous-workflow-function.db"))
+        app = FastAPI()
+        app.include_router(
+            get_components_router(
+                os_db=db,
+                settings=settings,
+                registry=Registry(functions=[first_function, second_function]),
+            )
+        )
+        client = TestClient(app)
+
+        response = self._create_component(
+            client,
+            component_id="ambiguous-function-workflow",
+            component_type="workflow",
+            stage="draft",
+            config={
+                "id": "ambiguous-function-workflow",
+                "name": "Ambiguous function workflow",
+                "steps": [{"type": "Step", "step_id": "function-step", "executor_ref": "duplicate_function"}],
+            },
+        )
+
+        assert response.status_code == 400
+        assert "ambiguous" in response.json()["detail"]
+        assert db.get_component("ambiguous-function-workflow") is None
+
+    def test_draft_workflow_keeps_draft_reference_flexible_and_pins_published_child(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="draft-child",
+                component_type="agent",
+                stage="draft",
+                config={"id": "draft-child", "name": "Draft child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="published-child",
+                component_type="agent",
+                stage="published",
+                config={"id": "published-child", "name": "Published child"},
+            ).status_code
+            == 201
+        )
+
+        response = self._create_component(
+            client,
+            component_id="draft-workflow",
+            component_type="workflow",
+            stage="draft",
+            config={
+                "id": "draft-workflow",
+                "name": "Draft workflow",
+                "steps": [
+                    {"type": "Step", "step_id": "draft-step", "agent_id": "draft-child"},
+                    {"type": "Step", "step_id": "published-step", "agent_id": "published-child"},
+                ],
+            },
+        )
+
+        assert response.status_code == 201
+        links = db.get_links("draft-workflow", 1)
+        assert [(link["link_key"], link["child_component_id"], link["child_version"]) for link in links] == [
+            ("published-step", "published-child", 1)
+        ]
+
+    def test_workflow_config_create_rejects_caller_supplied_links(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="workflow",
+                component_type="workflow",
+                stage="draft",
+                config={"id": "workflow", "name": "Workflow", "steps": []},
+            ).status_code
+            == 201
+        )
+
+        response = client.post(
+            "/components/workflow/configs",
+            json={
+                "config": {"id": "workflow", "name": "Workflow", "steps": []},
+                "links": [
+                    {
+                        "link_kind": "step_agent",
+                        "link_key": "forged",
+                        "child_component_id": "other",
+                        "child_version": 1,
+                        "position": 0,
+                    }
+                ],
+                **_guard(1, None),
+            },
+        )
+
+        assert response.status_code == 400
+        assert "derived from config.steps" in response.json()["detail"]
+        assert [row["version"] for row in db.list_configs("workflow")] == [1]
+
+    def test_workflow_promotion_derives_pin_after_child_is_published(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="child",
+                component_type="agent",
+                stage="draft",
+                config={"id": "child", "name": "Child"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="workflow",
+                component_type="workflow",
+                stage="draft",
+                config={
+                    "id": "workflow",
+                    "name": "Workflow",
+                    "steps": [{"type": "Step", "step_id": "child-step", "agent_id": "child"}],
+                },
+            ).status_code
+            == 201
+        )
+        assert db.get_links("workflow", 1) == []
+
+        rejected = client.patch(
+            "/components/workflow/configs/1",
+            json={"stage": "published", **_guard(1, None)},
+        )
+        assert rejected.status_code == 400
+        assert db.get_links("workflow", 1) == []
+
+        assert (
+            client.patch(
+                "/components/child/configs/1",
+                json={"stage": "published", **_guard(1, None)},
+            ).status_code
+            == 200
+        )
+        published = client.patch(
+            "/components/workflow/configs/1",
+            json={"stage": "published", **_guard(1, None)},
+        )
+
+        assert published.status_code == 200
+        links = db.get_links("workflow", 1)
+        assert [(link["link_key"], link["child_component_id"], link["child_version"]) for link in links] == [
+            ("child-step", "child", 1)
+        ]
+
+    def test_metadata_patch_copies_guarded_workflow_pins_without_retargeting(self, sqlite_client):
+        client, db = sqlite_client
+        assert (
+            self._create_component(
+                client,
+                component_id="child",
+                component_type="agent",
+                stage="published",
+                config={"id": "child", "name": "Child v1"},
+            ).status_code
+            == 201
+        )
+        assert (
+            self._create_component(
+                client,
+                component_id="workflow",
+                component_type="workflow",
+                stage="draft",
+                config={
+                    "id": "workflow",
+                    "name": "Workflow",
+                    "steps": [{"type": "Step", "step_id": "child-step", "agent_id": "child"}],
+                },
+            ).status_code
+            == 201
+        )
+        assert db.get_links("workflow", 1)[0]["child_version"] == 1
+
+        assert (
+            client.post(
+                "/components/child/configs",
+                json={
+                    "stage": "published",
+                    "config": {"id": "child", "name": "Child v2"},
+                    **_guard(1, 1),
+                },
+            ).status_code
+            == 201
+        )
+        assert db.get_component("child")["current_version"] == 2  # type: ignore[index]
+
+        patched = client.patch(
+            "/components/workflow",
+            json={"description": "Metadata-only edit", **_guard(1, None)},
+        )
+
+        assert patched.status_code == 200
+        assert patched.json()["version"] == 2
+        links = db.get_links("workflow", 2)
+        assert [(link["link_key"], link["child_component_id"], link["child_version"]) for link in links] == [
+            ("child-step", "child", 1)
+        ]
 
 
 # =============================================================================
@@ -478,23 +2058,27 @@ class TestGetCurrentConfig:
 
     def test_get_current_config_success(self, client, mock_db):
         """Test get_current_config returns current config."""
-        mock_db.get_config.return_value = {
-            "component_id": "agent-1",
-            "version": 2,
-            "config": {"name": "Agent"},
-            "stage": "published",
-            "created_at": 1234567890,
-        }
+        mock_db.get_current_config = MagicMock(
+            return_value={
+                "component_id": "agent-1",
+                "version": 2,
+                "config": {"name": "Agent"},
+                "stage": "published",
+                "created_at": 1234567890,
+            }
+        )
 
         response = client.get("/components/agent-1/configs/current")
 
         assert response.status_code == 200
         data = response.json()
         assert data["version"] == 2
+        mock_db.get_current_config.assert_called_once_with(component_id="agent-1")
+        mock_db.get_config.assert_not_called()
 
     def test_get_current_config_not_found(self, client, mock_db):
         """Test get_current_config returns 404 when no current config."""
-        mock_db.get_config.return_value = None
+        mock_db.get_current_config = MagicMock(return_value=None)
 
         response = client.get("/components/agent-1/configs/current")
 
@@ -543,31 +2127,92 @@ class TestUpdateConfig:
     """Tests for PATCH /components/{component_id}/configs/{version} endpoint."""
 
     def test_update_config_success(self, client, mock_db):
-        """Test update_config updates config version."""
+        """Test update_config publishes the latest draft with its projection."""
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "config": {
+                "name": "Updated Agent",
+                "description": "Version two",
+                "metadata": {"release": 2},
+            },
+            "stage": "draft",
+            "created_at": 1234567890,
+        }
         mock_db.upsert_config.return_value = {
             "component_id": "agent-1",
-            "version": 1,
+            "version": 2,
             "config": {"name": "Updated Agent"},
-            "stage": "draft",
+            "stage": "published",
             "created_at": 1234567890,
         }
 
         response = client.patch(
-            "/components/agent-1/configs/1",
-            json={"config": {"name": "Updated Agent"}},
+            "/components/agent-1/configs/2",
+            json={"stage": "published", **_guard(2, 1)},
         )
 
         assert response.status_code == 200
-        data = response.json()
-        assert data["config"]["name"] == "Updated Agent"
+        assert response.json()["stage"] == "published"
+        mock_db.upsert_config.assert_called_once_with(
+            component_id="agent-1",
+            version=2,
+            stage="published",
+            guard=ComponentVersionGuard(latest_version=2, current_version=1),
+            projection={
+                "name": "Updated Agent",
+                "description": "Version two",
+                "metadata": {"release": 2},
+            },
+        )
+
+    def test_update_config_requires_guard(self, client, mock_db):
+        response = client.patch("/components/agent-1/configs/2", json={"stage": "published"})
+
+        assert response.status_code == 422
+        mock_db.upsert_config.assert_not_called()
+
+    def test_update_config_maps_stale_guard_to_conflict(self, client, mock_db):
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "config": {"name": "Agent"},
+            "stage": "draft",
+            "created_at": 1234567890,
+        }
+        mock_db.upsert_config.side_effect = ComponentVersionConflictError(
+            "agent-1",
+            expected=ComponentVersionGuard(latest_version=2, current_version=1),
+            actual=ComponentVersionGuard(latest_version=3, current_version=1),
+        )
+
+        response = client.patch("/components/agent-1/configs/2", json={"stage": "published", **_guard(2, 1)})
+
+        assert response.status_code == 409
+
+    def test_update_config_rejects_payload_mutation(self, client, mock_db):
+        response = client.patch(
+            "/components/agent-1/configs/2",
+            json={"stage": "published", "config": {"name": "Changed"}, **_guard(2, 1)},
+        )
+
+        assert response.status_code == 422
+        mock_db.upsert_config.assert_not_called()
 
     def test_update_config_handles_value_error(self, client, mock_db):
         """Test update_config returns 400 on ValueError."""
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "config": {},
+            "stage": "draft",
+            "created_at": 1234567890,
+        }
         mock_db.upsert_config.side_effect = ValueError("Cannot update published config")
 
         response = client.patch(
             "/components/agent-1/configs/1",
-            json={"stage": "published"},
+            json={"stage": "published", **_guard()},
         )
 
         assert response.status_code == 400
@@ -581,29 +2226,91 @@ class TestUpdateConfig:
 class TestDeleteConfig:
     """Tests for DELETE /components/{component_id}/configs/{version} endpoint."""
 
+    @staticmethod
+    def _published_component(mock_db):
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "component_type": "agent",
+            "current_version": 1,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "stage": "published",
+            "config": {"name": "Published", "description": "Current"},
+        }
+
     def test_delete_config_success(self, client, mock_db):
         """Test delete_config deletes config version."""
+        self._published_component(mock_db)
         mock_db.delete_config.return_value = True
 
-        response = client.delete("/components/agent-1/configs/1")
+        response = client.request("DELETE", "/components/agent-1/configs/2", json=_guard(2, 1))
 
         assert response.status_code == 204
+        mock_db.delete_config.assert_called_once_with(
+            "agent-1",
+            version=2,
+            guard=ComponentVersionGuard(latest_version=2, current_version=1),
+            projection={"name": "Published", "description": "Current", "metadata": None},
+        )
 
     def test_delete_config_not_found(self, client, mock_db):
         """Test delete_config returns 404 when not found."""
+        self._published_component(mock_db)
         mock_db.delete_config.return_value = False
 
-        response = client.delete("/components/agent-1/configs/999")
+        response = client.request("DELETE", "/components/agent-1/configs/999", json=_guard())
 
         assert response.status_code == 404
 
     def test_delete_config_handles_value_error(self, client, mock_db):
         """Test delete_config returns 400 on ValueError."""
+        self._published_component(mock_db)
         mock_db.delete_config.side_effect = ValueError("Cannot delete current config")
 
-        response = client.delete("/components/agent-1/configs/1")
+        response = client.request("DELETE", "/components/agent-1/configs/1", json=_guard())
 
         assert response.status_code == 400
+
+    def test_delete_config_dependency_conflict_is_stable(self, client, mock_db):
+        self._published_component(mock_db)
+        mock_db.delete_config.side_effect = ComponentDependencyError(
+            "agent-1",
+            [{"parent_component_id": "team-1", "parent_version": 2}],
+            version=1,
+        )
+
+        response = client.request("DELETE", "/components/agent-1/configs/1", json=_guard())
+
+        assert response.status_code == 409
+        assert "referenced by 1 component link" in response.json()["detail"]
+
+    def test_delete_sole_last_config_conflict_is_stable(self, client, mock_db):
+        self._published_component(mock_db)
+        mock_db.delete_config.side_effect = ComponentLastConfigError("agent-1", 1)
+
+        response = client.request("DELETE", "/components/agent-1/configs/1", json=_guard())
+
+        assert response.status_code == 409
+        assert "last config" in response.json()["detail"]
+
+    def test_delete_published_config_conflict_is_stable(self, client, mock_db):
+        self._published_component(mock_db)
+        mock_db.delete_config.side_effect = ComponentDraftRequiredError("agent-1", 1)
+
+        response = client.request("DELETE", "/components/agent-1/configs/1", json=_guard())
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == (
+            "Cannot delete published config agent-1 v1; only draft configs can be deleted"
+        )
+
+    def test_delete_config_requires_guard(self, client, mock_db):
+        response = client.delete("/components/agent-1/configs/2")
+
+        assert response.status_code == 422
+        mock_db.delete_config.assert_not_called()
 
 
 # =============================================================================
@@ -614,36 +2321,211 @@ class TestDeleteConfig:
 class TestSetCurrentConfig:
     """Tests for POST /components/{component_id}/configs/{version}/set-current endpoint."""
 
+    def test_sqlite_rollback_restores_explicit_null_projection_from_canonical_v1(self, sqlite_client):
+        client, db = sqlite_client
+        component_id = "rollback-canonical-projection"
+
+        created = client.post(
+            "/components",
+            json={
+                "component_id": component_id,
+                "component_type": "agent",
+                "name": "Version one",
+                "stage": "published",
+                "config": {"id": component_id, "instructions": "v1"},
+            },
+        )
+        assert created.status_code == 201
+
+        version_two = client.post(
+            f"/components/{component_id}/configs",
+            json={
+                "config": {
+                    "id": component_id,
+                    "name": "Version two",
+                    "description": "Newer description",
+                    "metadata": {"release": 2},
+                    "instructions": "v2",
+                },
+                "stage": "published",
+                **_guard(1, 1),
+            },
+        )
+        assert version_two.status_code == 201
+
+        rolled_back = client.post(
+            f"/components/{component_id}/configs/1/set-current",
+            json=_guard(2, 2),
+        )
+
+        assert rolled_back.status_code == 200
+        assert rolled_back.json()["current_version"] == 1
+        assert rolled_back.json()["name"] == "Version one"
+        assert rolled_back.json().get("description") is None
+        assert rolled_back.json().get("metadata") is None
+
+        component = db.get_component(component_id)
+        version_one = db.get_config(component_id, version=1)
+        assert component is not None
+        assert version_one is not None
+        assert component["current_version"] == 1
+        assert component["name"] == "Version one"
+        assert component["description"] is None
+        assert component["metadata"] is None
+        assert version_one["config"]["name"] == "Version one"
+        assert version_one["config"]["description"] is None
+        assert version_one["config"]["metadata"] is None
+
+    def test_sqlite_rollback_restores_projection_from_direct_agent_save(self, sqlite_client):
+        client, db = sqlite_client
+        component_id = "direct-save-projection"
+        agent = Agent(
+            id=component_id,
+            name="Version one",
+            description=None,
+            metadata=None,
+            model=OpenAIResponses(id="gpt-5.4"),
+        )
+        assert agent.save(db=db) == 1
+        agent.name = "Version two"
+        agent.description = "Newer description"
+        agent.metadata = {"release": 2}
+        assert agent.save(db=db) == 2
+
+        rolled_back = client.post(
+            f"/components/{component_id}/configs/1/set-current",
+            json=_guard(2, 2),
+        )
+
+        assert rolled_back.status_code == 200
+        assert rolled_back.json()["current_version"] == 1
+        assert rolled_back.json()["name"] == "Version one"
+        assert rolled_back.json().get("description") is None
+        assert rolled_back.json().get("metadata") is None
+        component = db.get_component(component_id)
+        version_one = db.get_config(component_id, version=1)
+        assert component is not None
+        assert version_one is not None
+        assert component["name"] == "Version one"
+        assert component["description"] is None
+        assert component["metadata"] is None
+        assert version_one["config"]["name"] == "Version one"
+        assert version_one["config"]["description"] is None
+        assert version_one["config"]["metadata"] is None
+
     def test_set_current_config_success(self, client, mock_db):
         """Test set_current_config sets version as current."""
         mock_db.set_current_version.return_value = True
         mock_db.get_component.return_value = {
             "component_id": "agent-1",
-            "name": "Agent 1",
+            "name": "Agent 3",
+            "description": "Current description",
+            "metadata": {"release": 3},
             "component_type": "agent",
             "current_version": 3,
             "created_at": 1234567890,
         }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "config": {
+                "name": "Agent 1",
+                "description": "Restored description",
+                "metadata": {"release": 1},
+            },
+            "stage": "published",
+            "created_at": 1234567890,
+        }
 
-        response = client.post("/components/agent-1/configs/3/set-current")
+        response = client.post("/components/agent-1/configs/1/set-current", json=_guard(3, 3))
 
         assert response.status_code == 200
         data = response.json()
-        assert data["current_version"] == 3
+        assert data["current_version"] == 1
+        assert data["name"] == "Agent 1"
+        assert data["description"] == "Restored description"
+        assert data["metadata"] == {"release": 1}
+        mock_db.set_current_version.assert_called_once_with(
+            "agent-1",
+            version=1,
+            guard=ComponentVersionGuard(latest_version=3, current_version=3),
+            projection={
+                "name": "Agent 1",
+                "description": "Restored description",
+                "metadata": {"release": 1},
+            },
+        )
+        # The response is synthesized from the pre-mutation row and committed
+        # projection, so it cannot observe a later mutation through a re-read.
+        mock_db.get_component.assert_called_once_with("agent-1")
+        mock_db.get_config.assert_called_once_with("agent-1", version=1)
+
+    def test_set_current_config_requires_guard(self, client, mock_db):
+        response = client.post("/components/agent-1/configs/1/set-current")
+
+        assert response.status_code == 422
+        mock_db.set_current_version.assert_not_called()
 
     def test_set_current_config_not_found(self, client, mock_db):
         """Test set_current_config returns 404 when version not found."""
-        mock_db.set_current_version.return_value = False
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "name": "Agent 1",
+            "component_type": "agent",
+            "current_version": 1,
+            "created_at": 1234567890,
+        }
+        mock_db.get_config.return_value = None
 
-        response = client.post("/components/agent-1/configs/999/set-current")
+        response = client.post("/components/agent-1/configs/999/set-current", json=_guard())
 
         assert response.status_code == 404
+        mock_db.set_current_version.assert_not_called()
+
+    def test_set_current_config_maps_stale_guard_to_conflict(self, client, mock_db):
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "name": "Agent 1",
+            "component_type": "agent",
+            "current_version": 2,
+            "created_at": 1234567890,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 1,
+            "config": {"name": "Agent 1"},
+            "stage": "published",
+            "created_at": 1234567890,
+        }
+        mock_db.set_current_version.side_effect = ComponentVersionConflictError(
+            "agent-1",
+            expected=ComponentVersionGuard(latest_version=2, current_version=2),
+            actual=ComponentVersionGuard(latest_version=3, current_version=2),
+        )
+
+        response = client.post("/components/agent-1/configs/1/set-current", json=_guard(2, 2))
+
+        assert response.status_code == 409
 
     def test_set_current_config_handles_value_error(self, client, mock_db):
         """Test set_current_config returns 400 on ValueError."""
+        mock_db.get_component.return_value = {
+            "component_id": "agent-1",
+            "name": "Agent 1",
+            "component_type": "agent",
+            "current_version": 1,
+            "created_at": 1234567890,
+        }
+        mock_db.get_config.return_value = {
+            "component_id": "agent-1",
+            "version": 2,
+            "config": {"name": "Agent 2"},
+            "stage": "draft",
+            "created_at": 1234567890,
+        }
         mock_db.set_current_version.side_effect = ValueError("Version not published")
 
-        response = client.post("/components/agent-1/configs/1/set-current")
+        response = client.post("/components/agent-1/configs/2/set-current", json=_guard())
 
         assert response.status_code == 400
 

--- a/libs/agno/tests/unit/os/routers/test_schedules_router.py
+++ b/libs/agno/tests/unit/os/routers/test_schedules_router.py
@@ -1,14 +1,22 @@
 """Tests for the schedule REST API router."""
 
 import time
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Event
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY, ScheduleNameConflictError
+from agno.db.sqlite import SqliteDb
 from agno.os.routers.schedules import get_schedule_router
 from agno.os.settings import AgnoAPISettings
+
+STUDIO_SCHEDULE_ID = "studio-router-private-id"
+STUDIO_PROMPT = "studio-router-private-prompt"
+STUDIO_ACTOR = "studio-router-private-actor"
 
 # =============================================================================
 # Fixtures
@@ -41,10 +49,28 @@ def _make_schedule_dict(**overrides):
     return d
 
 
+def _make_studio_schedule_dict(**overrides):
+    """Create a Studio-owned schedule whose private fields must stay hidden."""
+    defaults = {
+        "id": STUDIO_SCHEDULE_ID,
+        "name": "studio-router-private-schedule",
+        "payload": {"message": STUDIO_PROMPT},
+        "managed_by": "studio",
+        "owner_actor_id": STUDIO_ACTOR,
+        "target_type": "agent",
+        "target_id": "studio-private-agent",
+        "created_by_run_id": "studio-router-private-run",
+        "created_by_session_id": "studio-router-private-session",
+    }
+    defaults.update(overrides)
+    return _make_schedule_dict(**defaults)
+
+
 @pytest.fixture
 def mock_db():
     """Create a mock DB with schedule methods."""
     db = MagicMock()
+    db.scheduler_api_version = 2
     db.get_schedules = MagicMock(return_value=[])
     db.get_schedule = MagicMock(return_value=None)
     db.get_schedule_by_name = MagicMock(return_value=None)
@@ -68,6 +94,112 @@ def client(mock_db, settings):
     router = get_schedule_router(os_db=mock_db, settings=settings)
     app.include_router(router)
     return TestClient(app)
+
+
+def _make_client_for_db(db) -> TestClient:
+    app = FastAPI()
+    app.include_router(get_schedule_router(os_db=db, settings=AgnoAPISettings()))
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class _RacingCreateSqliteDb:
+    """Coordinate two requests so both miss create's name preflight."""
+
+    def __init__(self, db, barrier, winner_created, wins_insert):
+        self._db = db
+        self._barrier = barrier
+        self._winner_created = winner_created
+        self._wins_insert = wins_insert
+        self._first_lookup = True
+
+    def __getattr__(self, name):
+        return getattr(self._db, name)
+
+    def get_schedule_by_name(
+        self,
+        name,
+        *,
+        managed_by=None,
+        owner_actor_id=None,
+        exclude_managed_by=None,
+    ):
+        result = self._db.get_schedule_by_name(
+            name,
+            managed_by=managed_by,
+            owner_actor_id=owner_actor_id,
+            exclude_managed_by=exclude_managed_by,
+        )
+        if self._first_lookup:
+            self._first_lookup = False
+            self._barrier.wait(timeout=5)
+        return result
+
+    def create_schedule(self, schedule_data):
+        if self._wins_insert:
+            try:
+                return self._db.create_schedule(schedule_data)
+            finally:
+                self._winner_created.set()
+        if not self._winner_created.wait(timeout=5):
+            raise RuntimeError("winning insert did not complete")
+        try:
+            return self._db.create_schedule(schedule_data)
+        except ScheduleNameConflictError:
+            winner = self._db.get_schedule_by_name(schedule_data["name"])
+            assert winner is not None
+            assert self._db.delete_schedule(winner["id"]) is True
+            raise
+
+
+class _RacingRenameSqliteDb:
+    """Coordinate two requests so both miss rename's name preflight."""
+
+    def __init__(self, db, barrier, winner_updated, wins_update, raced_name):
+        self._db = db
+        self._barrier = barrier
+        self._winner_updated = winner_updated
+        self._wins_update = wins_update
+        self._raced_name = raced_name
+        self._first_lookup = True
+
+    def __getattr__(self, name):
+        return getattr(self._db, name)
+
+    def get_schedule_by_name(
+        self,
+        name,
+        *,
+        managed_by=None,
+        owner_actor_id=None,
+        exclude_managed_by=None,
+    ):
+        result = self._db.get_schedule_by_name(
+            name,
+            managed_by=managed_by,
+            owner_actor_id=owner_actor_id,
+            exclude_managed_by=exclude_managed_by,
+        )
+        if name == self._raced_name and self._first_lookup:
+            self._first_lookup = False
+            self._barrier.wait(timeout=5)
+        return result
+
+    def update_schedule(self, schedule_id, **kwargs):
+        if self._wins_update:
+            try:
+                return self._db.update_schedule(schedule_id, **kwargs)
+            finally:
+                self._winner_updated.set()
+        if not self._winner_updated.wait(timeout=5):
+            raise RuntimeError("winning update did not complete")
+        try:
+            return self._db.update_schedule(schedule_id, **kwargs)
+        except ScheduleNameConflictError:
+            winner = self._db.get_schedule_by_name(self._raced_name)
+            assert winner is not None
+            renamed = self._db.update_schedule(winner["id"], name="winner-after-race")
+            assert renamed is not None
+            raise
 
 
 # =============================================================================
@@ -97,6 +229,43 @@ class TestListSchedules:
         mock_db.get_schedules.assert_called_once()
         call_kwargs = mock_db.get_schedules.call_args[1]
         assert call_kwargs["enabled"] is True
+        assert call_kwargs["exclude_managed_by"] == STUDIO_SCHEDULE_MANAGED_BY
+
+    def test_legacy_v1_adapter_is_called_without_v2_kwargs_and_filtered_before_pagination(self, settings):
+        class LegacyScheduleDb:
+            scheduler_api_version = 1
+
+            def __init__(self):
+                self.calls = []
+
+            def get_schedules(self, enabled=None, limit=100, page=1):
+                self.calls.append({"enabled": enabled, "limit": limit, "page": page})
+                return (
+                    [
+                        _make_schedule_dict(id="generic-1", name="generic-1"),
+                        _make_studio_schedule_dict(),
+                        _make_schedule_dict(id="generic-2", name="generic-2"),
+                    ],
+                    3,
+                )
+
+        db = LegacyScheduleDb()
+        app = FastAPI()
+        app.include_router(get_schedule_router(os_db=db, settings=settings))
+
+        with TestClient(app) as legacy_client:
+            response = legacy_client.get("/schedules?limit=1&page=2")
+
+        assert response.status_code == 200
+        assert [schedule["id"] for schedule in response.json()["data"]] == ["generic-2"]
+        assert response.json()["meta"] | {"search_time_ms": 0.0} == {
+            "page": 2,
+            "limit": 1,
+            "total_pages": 2,
+            "total_count": 2,
+            "search_time_ms": 0.0,
+        }
+        assert db.calls == [{"enabled": None, "limit": 1000, "page": 1}]
 
 
 # =============================================================================
@@ -105,6 +274,22 @@ class TestListSchedules:
 
 
 class TestCreateSchedule:
+    def test_missing_scheduler_dependency_does_not_expose_exception_details(self, client):
+        secret = "postgresql://admin:private-password@internal.example/agno"
+        with patch("agno.scheduler.cron._require_croniter", side_effect=ImportError(secret)):
+            response = client.post(
+                "/schedules",
+                json={
+                    "name": "dependency-check",
+                    "cron_expr": "0 9 * * *",
+                    "endpoint": "/agents/a1/runs",
+                },
+            )
+
+        assert response.status_code == 503
+        assert response.json() == {"detail": "Scheduler dependencies are not installed"}
+        assert secret not in response.text
+
     @patch("agno.scheduler.cron._require_pytz")
     @patch("agno.scheduler.cron._require_croniter")
     @patch("agno.scheduler.cron.validate_cron_expr", return_value=True)
@@ -161,6 +346,36 @@ class TestCreateSchedule:
         assert resp.status_code == 409
         assert "already exists" in resp.json()["detail"]
 
+    def test_concurrent_sqlite_create_returns_conflict_after_winner_is_deleted(self, tmp_path):
+        db_path = str(tmp_path / "router-create-race.db")
+        winner_db = SqliteDb(db_file=db_path, schedules_table="router_create_race_schedules")
+        winner_db.create_schedule(_make_schedule_dict(id="prime", name="prime"))
+        assert winner_db.delete_schedule("prime") is True
+        loser_db = SqliteDb(db_file=db_path, schedules_table="router_create_race_schedules")
+
+        barrier = Barrier(2)
+        winner_created = Event()
+        winner_client = _make_client_for_db(_RacingCreateSqliteDb(winner_db, barrier, winner_created, wins_insert=True))
+        loser_client = _make_client_for_db(_RacingCreateSqliteDb(loser_db, barrier, winner_created, wins_insert=False))
+        body = {
+            "name": "shared-name",
+            "cron_expr": "0 9 * * *",
+            "endpoint": "/agents/a1/runs",
+        }
+
+        with winner_client, loser_client, ThreadPoolExecutor(max_workers=2) as pool:
+            winner_future = pool.submit(winner_client.post, "/schedules", json=body)
+            loser_future = pool.submit(loser_client.post, "/schedules", json=body)
+            winner_response = winner_future.result(timeout=10)
+            loser_response = loser_future.result(timeout=10)
+
+        assert winner_response.status_code == 201
+        assert loser_response.status_code == 409
+        assert loser_response.json() == {"detail": "Schedule with name 'shared-name' already exists"}
+        schedules, total = winner_db.get_schedules()
+        assert total == 0
+        assert schedules == []
+
 
 # =============================================================================
 # Tests: GET /schedules/{schedule_id}
@@ -208,6 +423,36 @@ class TestUpdateSchedule:
         resp = client.patch("/schedules/sched-1", json={})
         assert resp.status_code == 200
         mock_db.update_schedule.assert_not_called()
+
+    def test_concurrent_sqlite_rename_returns_conflict_after_winner_is_renamed(self, tmp_path):
+        db_path = str(tmp_path / "router-rename-race.db")
+        winner_db = SqliteDb(db_file=db_path, schedules_table="router_rename_race_schedules")
+        winner_db.create_schedule(_make_schedule_dict(id="winner", name="winner-old"))
+        winner_db.create_schedule(_make_schedule_dict(id="loser", name="loser-old"))
+        loser_db = SqliteDb(db_file=db_path, schedules_table="router_rename_race_schedules")
+
+        raced_name = "shared-name"
+        barrier = Barrier(2)
+        winner_updated = Event()
+        winner_client = _make_client_for_db(
+            _RacingRenameSqliteDb(winner_db, barrier, winner_updated, wins_update=True, raced_name=raced_name)
+        )
+        loser_client = _make_client_for_db(
+            _RacingRenameSqliteDb(loser_db, barrier, winner_updated, wins_update=False, raced_name=raced_name)
+        )
+
+        with winner_client, loser_client, ThreadPoolExecutor(max_workers=2) as pool:
+            winner_future = pool.submit(winner_client.patch, "/schedules/winner", json={"name": raced_name})
+            loser_future = pool.submit(loser_client.patch, "/schedules/loser", json={"name": raced_name})
+            winner_response = winner_future.result(timeout=10)
+            loser_response = loser_future.result(timeout=10)
+
+        assert winner_response.status_code == 200
+        assert loser_response.status_code == 409
+        assert loser_response.json() == {"detail": "Schedule with name 'shared-name' already exists"}
+        assert winner_db.get_schedule_by_name(raced_name) is None
+        assert winner_db.get_schedule("winner")["name"] == "winner-after-race"
+        assert winner_db.get_schedule("loser")["name"] == "loser-old"
 
 
 # =============================================================================
@@ -351,12 +596,14 @@ class TestGetScheduleRun:
             "error": None,
             "created_at": now,
         }
+        mock_db.get_schedule = MagicMock(return_value=_make_schedule_dict())
         mock_db.get_schedule_run = MagicMock(return_value=run)
         resp = client.get("/schedules/sched-1/runs/r1")
         assert resp.status_code == 200
         assert resp.json()["id"] == "r1"
 
     def test_get_run_not_found(self, client, mock_db):
+        mock_db.get_schedule = MagicMock(return_value=_make_schedule_dict())
         mock_db.get_schedule_run = MagicMock(return_value=None)
         resp = client.get("/schedules/sched-1/runs/missing")
         assert resp.status_code == 404
@@ -369,9 +616,103 @@ class TestGetScheduleRun:
             "status": "success",
             "created_at": int(time.time()),
         }
+        mock_db.get_schedule = MagicMock(return_value=_make_schedule_dict())
         mock_db.get_schedule_run = MagicMock(return_value=run)
         resp = client.get("/schedules/sched-1/runs/r1")
         assert resp.status_code == 404
+
+
+# =============================================================================
+# Tests: Studio-managed schedule isolation
+# =============================================================================
+
+
+class TestStudioManagedIsolation:
+    @staticmethod
+    def _assert_private_values_hidden(response_text: str) -> None:
+        assert STUDIO_SCHEDULE_ID not in response_text
+        assert STUDIO_PROMPT not in response_text
+        assert STUDIO_ACTOR not in response_text
+        assert "studio-router-private-run" not in response_text
+        assert "studio-router-private-session" not in response_text
+        assert "managed_by" not in response_text
+
+    def test_list_hides_studio_schedule_and_provenance(self, client, mock_db):
+        ordinary = _make_schedule_dict(id="ordinary-id", name="ordinary")
+        studio = _make_studio_schedule_dict()
+        # A custom/non-compliant adapter may ignore the query filter. The
+        # response boundary must still refuse to serialize the Studio row.
+        mock_db.get_schedules = MagicMock(return_value=([studio, ordinary], 1))
+
+        response = client.get("/schedules")
+
+        assert response.status_code == 200
+        assert [schedule["id"] for schedule in response.json()["data"]] == ["ordinary-id"]
+        assert response.json()["meta"]["total_count"] == 1
+        self._assert_private_values_hidden(response.text)
+        assert mock_db.get_schedules.call_count == 2
+        assert mock_db.get_schedules.call_args_list[0].kwargs == {
+            "enabled": None,
+            "limit": 100,
+            "page": 1,
+            "exclude_managed_by": STUDIO_SCHEDULE_MANAGED_BY,
+        }
+        assert mock_db.get_schedules.call_args_list[1].kwargs == {
+            "enabled": None,
+            "limit": 1000,
+            "page": 1,
+            "exclude_managed_by": STUDIO_SCHEDULE_MANAGED_BY,
+        }
+
+    @pytest.mark.parametrize(
+        ("method", "path", "body"),
+        [
+            ("GET", f"/schedules/{STUDIO_SCHEDULE_ID}", None),
+            ("PATCH", f"/schedules/{STUDIO_SCHEDULE_ID}", {"description": "changed"}),
+            ("DELETE", f"/schedules/{STUDIO_SCHEDULE_ID}", None),
+            ("POST", f"/schedules/{STUDIO_SCHEDULE_ID}/enable", None),
+            ("POST", f"/schedules/{STUDIO_SCHEDULE_ID}/disable", None),
+            ("POST", f"/schedules/{STUDIO_SCHEDULE_ID}/trigger", None),
+            ("GET", f"/schedules/{STUDIO_SCHEDULE_ID}/runs", None),
+            ("GET", f"/schedules/{STUDIO_SCHEDULE_ID}/runs/private-run-id", None),
+        ],
+    )
+    def test_direct_reads_and_mutations_treat_studio_schedule_as_not_found(self, method, path, body, client, mock_db):
+        mock_db.get_schedule = MagicMock(return_value=_make_studio_schedule_dict())
+
+        response = client.request(method, path, json=body)
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Schedule not found"}
+        self._assert_private_values_hidden(response.text)
+        mock_db.update_schedule.assert_not_called()
+        mock_db.delete_schedule.assert_not_called()
+        mock_db.get_schedule_runs.assert_not_called()
+        mock_db.get_schedule_run.assert_not_called()
+
+    @patch("agno.scheduler.cron._require_pytz")
+    @patch("agno.scheduler.cron._require_croniter")
+    @patch("agno.scheduler.cron.validate_cron_expr", return_value=True)
+    @patch("agno.scheduler.cron.validate_timezone", return_value=True)
+    @patch("agno.scheduler.cron.compute_next_run", return_value=int(time.time()) + 60)
+    def test_create_uses_a_separate_name_namespace_from_studio(
+        self, mock_compute, mock_tz, mock_cron, mock_req_cron, mock_req_pytz, client, mock_db
+    ):
+        studio = _make_studio_schedule_dict()
+        mock_db.get_schedule_by_name = MagicMock(return_value=studio)
+
+        response = client.post(
+            "/schedules",
+            json={
+                "name": studio["name"],
+                "cron_expr": "0 9 * * *",
+                "endpoint": "/agents/a1/runs",
+            },
+        )
+
+        assert response.status_code == 201
+        self._assert_private_values_hidden(response.text)
+        mock_db.create_schedule.assert_called_once()
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/os/routers/test_studio_components_boundary.py
+++ b/libs/agno/tests/unit/os/routers/test_studio_components_boundary.py
@@ -1,0 +1,114 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os.routers.components import get_components_router
+from agno.os.settings import AgnoAPISettings
+from agno.registry import Registry
+from agno.run import RunContext
+from agno.tools.studio import StudioTools
+from agno.tools.studio_schema import AgentCreate, ModelRef
+
+
+@pytest.fixture
+def studio_sqlite_client(tmp_path):
+    """Real typed Studio control plane and generic router over one catalog."""
+    db = SqliteDb(id="studio-boundary-db", db_file=str(tmp_path / "studio-boundary.db"))
+    model = OpenAIResponses(id="gpt-5.4")
+    registry = Registry(name="Studio boundary registry", models=[model], dbs=[db])
+    studio = StudioTools(
+        registry=registry,
+        db=db,
+        authorize=lambda _context, _access, _action: True,
+        default_model=ModelRef(id="gpt-5.4", provider="OpenAI", name="OpenAIResponses"),
+    )
+    run_context = RunContext(run_id="studio-run", session_id="studio-session", user_id="studio-admin")
+    app = FastAPI()
+    app.include_router(
+        get_components_router(
+            os_db=db,
+            settings=AgnoAPISettings(),
+            registry=registry,
+        )
+    )
+    return TestClient(app), db, studio, run_context
+
+
+def _guard(latest_version=1, current_version=1):
+    return {"guard": {"latest_version": latest_version, "current_version": current_version}}
+
+
+class TestStudioWriteIsolation:
+    """The generic Components API is read-only for Studio-owned records."""
+
+    def test_all_generic_mutations_reject_studio_owned_component_without_corrupting_discovery(
+        self, studio_sqlite_client
+    ):
+        client, db, studio, run_context = studio_sqlite_client
+        created = studio.create_agent(
+            AgentCreate(
+                component_id="studio-agent",
+                name="Studio agent",
+                instructions="Keep the typed request intact.",
+            ),
+            _agno_run_context=run_context,
+        )
+        assert created.ok is True
+        assert created.data is not None and created.data.version == 1
+
+        responses = [
+            client.patch(
+                "/components/studio-agent",
+                json={"name": "Generic rename", **_guard(1, None)},
+            ),
+            client.request(
+                "DELETE",
+                "/components/studio-agent",
+                json=_guard(1, None),
+            ),
+            client.post(
+                "/components/studio-agent/configs",
+                json={
+                    "config": {
+                        "id": "studio-agent",
+                        "name": "Raw overwrite",
+                        "instructions": "Bypass the typed manifest.",
+                    },
+                    **_guard(1, None),
+                },
+            ),
+            client.patch(
+                "/components/studio-agent/configs/1",
+                json={"stage": "published", **_guard(1, None)},
+            ),
+            client.request(
+                "DELETE",
+                "/components/studio-agent/configs/1",
+                json=_guard(1, None),
+            ),
+            client.post(
+                "/components/studio-agent/configs/1/set-current",
+                json=_guard(1, None),
+            ),
+        ]
+
+        for response in responses:
+            assert response.status_code == 409
+            assert response.json()["detail"] == "Studio-owned components must be mutated through StudioTools."
+
+        configs = db.list_configs("studio-agent", include_config=True)
+        assert [row["version"] for row in configs] == [1]
+        assert "_agno_studio" in configs[0]["config"]
+        component = db.get_component("studio-agent")
+        assert component is not None and component["current_version"] is None
+
+        listed = studio.list_agents(_agno_run_context=run_context)
+        assert listed.ok is True
+        assert listed.data is not None
+        assert [(item.component_id, item.latest_version) for item in listed.data] == [("studio-agent", 1)]
+
+        read_response = client.get("/components/studio-agent/configs/1")
+        assert read_response.status_code == 200
+        assert "_agno_studio" in read_response.json()["config"]

--- a/libs/agno/tests/unit/os/test_draft_component_visibility.py
+++ b/libs/agno/tests/unit/os/test_draft_component_visibility.py
@@ -1,0 +1,53 @@
+"""Draft catalog reads stay visible without becoming runtime-dispatchable."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.os import AgentOS
+from agno.os.utils import get_agent_by_id, get_team_by_id, get_workflow_by_id
+from agno.team import Team
+from agno.workflow import Workflow
+
+
+@pytest.fixture
+def draft_component_client(tmp_path) -> TestClient:
+    db = SqliteDb(db_file=str(tmp_path / "draft-component-routes.db"))
+    assert Agent(id="draft-agent", name="Draft Agent", db=db).save(stage="draft") == 1
+    assert Team(id="draft-team", name="Draft Team", members=[], db=db).save(stage="draft") == 1
+    assert Workflow(id="draft-workflow", name="Draft Workflow", db=db).save(stage="draft") == 1
+
+    return TestClient(AgentOS(id="draft-component-os", db=db, telemetry=False).get_app())
+
+
+@pytest.mark.parametrize(
+    ("detail_path", "run_path"),
+    [
+        ("/agents/draft-agent", "/agents/draft-agent/runs"),
+        ("/teams/draft-team", "/teams/draft-team/runs"),
+        ("/workflows/draft-workflow", "/workflows/draft-workflow/runs"),
+    ],
+)
+def test_draft_details_are_readable_but_run_dispatch_is_published_only(
+    draft_component_client: TestClient,
+    detail_path: str,
+    run_path: str,
+) -> None:
+    detail = draft_component_client.get(detail_path)
+    dispatched = draft_component_client.post(run_path, data={"message": "must not run", "stream": "false"})
+
+    assert detail.status_code == 200
+    assert dispatched.status_code == 404
+    assert dispatched.json()["detail"] in {"Agent not found", "Team not found", "Workflow not found"}
+
+
+def test_exact_version_explicitly_previews_draft_components(tmp_path) -> None:
+    db = SqliteDb(db_file=str(tmp_path / "draft-component-preview.db"))
+    assert Agent(id="draft-agent", name="Draft Agent", db=db).save(stage="draft") == 1
+    assert Team(id="draft-team", name="Draft Team", members=[], db=db).save(stage="draft") == 1
+    assert Workflow(id="draft-workflow", name="Draft Workflow", db=db).save(stage="draft") == 1
+
+    assert get_agent_by_id("draft-agent", db=db, version=1) is not None
+    assert get_team_by_id("draft-team", db=db, version=1) is not None
+    assert get_workflow_by_id("draft-workflow", db=db, version=1) is not None

--- a/libs/agno/tests/unit/os/test_registry_mcp_tools.py
+++ b/libs/agno/tests/unit/os/test_registry_mcp_tools.py
@@ -5,7 +5,7 @@ declared on the registry.
 MCP toolkits in ``registry.tools`` are not attached to any agent, team or
 workflow, so they are not covered by the per-component collectors. AgentOS
 must still connect them in its lifespan: components created from registry
-tools (e.g. via StudioTool) serialize a toolkit's functions at persist time,
+tools (e.g. via StudioTools) serialize a toolkit's functions at persist time,
 and an unconnected MCP toolkit has none -- its tools would be silently and
 permanently dropped from the persisted config.
 

--- a/libs/agno/tests/unit/scheduler/test_manager.py
+++ b/libs/agno/tests/unit/scheduler/test_manager.py
@@ -1,6 +1,8 @@
 """Tests for the ScheduleManager Pythonic API."""
 
 import time
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Event
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -8,6 +10,8 @@ import pytest
 pytest.importorskip("croniter", reason="croniter not installed")
 pytest.importorskip("pytz", reason="pytz not installed")
 
+from agno.db.schemas.scheduler import ScheduleNameConflictError  # noqa: E402
+from agno.db.sqlite import SqliteDb  # noqa: E402
 from agno.scheduler.manager import ScheduleManager  # noqa: E402
 
 # =============================================================================
@@ -43,12 +47,14 @@ def _make_schedule(**overrides):
 @pytest.fixture
 def mock_db():
     db = MagicMock()
+    db.scheduler_api_version = 2
     db.get_schedule = MagicMock(return_value=_make_schedule())
     db.get_schedule_by_name = MagicMock(return_value=None)
     db.get_schedules = MagicMock(return_value=[_make_schedule()])
     db.create_schedule = MagicMock(side_effect=lambda d: d)
     db.update_schedule = MagicMock(return_value=_make_schedule())
     db.delete_schedule = MagicMock(return_value=True)
+    db.trigger_schedule = MagicMock(return_value=_make_schedule())
     db.get_schedule_runs = MagicMock(return_value=[])
     return db
 
@@ -102,6 +108,153 @@ class TestManagerCreate:
         with pytest.raises(RuntimeError, match="Failed to create"):
             mgr.create(name="fail", cron="0 9 * * *", endpoint="/test")
 
+    def test_create_skip_recovers_when_another_creator_wins_the_name_race(self, mgr, mock_db):
+        winner = _make_schedule(id="winner", name="raced")
+        mock_db.get_schedule_by_name = MagicMock(side_effect=[None, winner])
+        mock_db.create_schedule = MagicMock(side_effect=ScheduleNameConflictError("raced"))
+
+        result = mgr.create(name="raced", cron="0 9 * * *", endpoint="/loser", if_exists="skip")
+
+        assert result.id == "winner"
+        assert result.endpoint == "/agents/a1/runs"
+        mock_db.update_schedule.assert_not_called()
+
+    def test_create_update_recovers_when_another_creator_wins_the_name_race(self, mgr, mock_db):
+        winner = _make_schedule(id="winner", name="raced", endpoint="/winner")
+        updated = _make_schedule(id="winner", name="raced", endpoint="/loser", method="PATCH")
+        mock_db.get_schedule_by_name = MagicMock(side_effect=[None, winner])
+        mock_db.create_schedule = MagicMock(side_effect=ScheduleNameConflictError("raced"))
+        mock_db.update_schedule = MagicMock(return_value=updated)
+
+        result = mgr.create(
+            name="raced",
+            cron="15 10 * * *",
+            endpoint="/loser",
+            method="patch",
+            if_exists="update",
+        )
+
+        assert result.id == "winner"
+        assert result.endpoint == "/loser"
+        mock_db.update_schedule.assert_called_once()
+        assert mock_db.update_schedule.call_args.args == ("winner",)
+        assert mock_db.update_schedule.call_args.kwargs["cron_expr"] == "15 10 * * *"
+        assert mock_db.update_schedule.call_args.kwargs["method"] == "PATCH"
+
+    def test_create_raise_converts_a_lost_name_race_to_value_error(self, mgr, mock_db):
+        mock_db.get_schedule_by_name = MagicMock(side_effect=[None, _make_schedule(id="winner", name="raced")])
+        mock_db.create_schedule = MagicMock(side_effect=ScheduleNameConflictError("raced"))
+
+        with pytest.raises(ValueError, match="already exists") as exc_info:
+            mgr.create(name="raced", cron="0 9 * * *", endpoint="/loser")
+
+        assert exc_info.value.__cause__ is None
+        assert exc_info.value.__context__ is None
+
+    def test_create_does_not_classify_an_unrelated_backend_failure_as_a_name_race(self, mgr, mock_db):
+        backend_error = RuntimeError("database unavailable")
+        mock_db.get_schedule_by_name = MagicMock(side_effect=[None, _make_schedule(id="unrelated", name="raced")])
+        mock_db.create_schedule = MagicMock(side_effect=backend_error)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            mgr.create(name="raced", cron="0 9 * * *", endpoint="/loser", if_exists="skip")
+
+        assert exc_info.value is backend_error
+        mock_db.get_schedule_by_name.assert_called_once_with(
+            "raced",
+            managed_by=None,
+            owner_actor_id=None,
+            exclude_managed_by="studio",
+        )
+
+
+class _RacingSqliteDb:
+    """Coordinate two managers so both miss the preflight name lookup."""
+
+    def __init__(self, db, barrier, winner_created, wins_insert):
+        self._db = db
+        self._barrier = barrier
+        self._winner_created = winner_created
+        self._wins_insert = wins_insert
+        self._first_lookup = True
+
+    def __getattr__(self, name):
+        return getattr(self._db, name)
+
+    def get_schedule_by_name(
+        self,
+        name,
+        *,
+        managed_by=None,
+        owner_actor_id=None,
+        exclude_managed_by=None,
+    ):
+        result = self._db.get_schedule_by_name(
+            name,
+            managed_by=managed_by,
+            owner_actor_id=owner_actor_id,
+            exclude_managed_by=exclude_managed_by,
+        )
+        if self._first_lookup:
+            self._first_lookup = False
+            self._barrier.wait(timeout=5)
+        return result
+
+    def create_schedule(self, schedule_data):
+        if self._wins_insert:
+            try:
+                return self._db.create_schedule(schedule_data)
+            finally:
+                self._winner_created.set()
+        if not self._winner_created.wait(timeout=5):
+            raise RuntimeError("winning insert did not complete")
+        return self._db.create_schedule(schedule_data)
+
+
+@pytest.mark.parametrize(
+    ("if_exists", "expected_endpoint"),
+    [("skip", "/winner"), ("update", "/loser")],
+)
+def test_concurrent_sqlite_create_recovers_from_the_unique_name_race(tmp_path, if_exists, expected_endpoint):
+    db_path = str(tmp_path / f"schedule-{if_exists}.db")
+    winner_db = SqliteDb(session_table="manager_race_sessions", db_file=db_path)
+    # Materialize the table and unique index before the two inserts race.
+    winner_db.create_schedule(_make_schedule(id="prime", name="prime"))
+    assert winner_db.delete_schedule("prime") is True
+    loser_db = SqliteDb(session_table="manager_race_sessions", db_file=db_path)
+
+    barrier = Barrier(2)
+    winner_created = Event()
+    winner = ScheduleManager(_RacingSqliteDb(winner_db, barrier, winner_created, wins_insert=True))
+    loser = ScheduleManager(_RacingSqliteDb(loser_db, barrier, winner_created, wins_insert=False))
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        winner_future = pool.submit(
+            winner.create,
+            name="shared-name",
+            cron="0 9 * * *",
+            endpoint="/winner",
+            if_exists=if_exists,
+        )
+        loser_future = pool.submit(
+            loser.create,
+            name="shared-name",
+            cron="30 10 * * *",
+            endpoint="/loser",
+            if_exists=if_exists,
+        )
+        winner_result = winner_future.result(timeout=10)
+        loser_result = loser_future.result(timeout=10)
+
+    stored = winner_db.get_schedule_by_name("shared-name")
+    assert stored is not None
+    assert winner_result.id == loser_result.id == stored["id"]
+    assert loser_result.endpoint == expected_endpoint
+    assert stored["endpoint"] == expected_endpoint
+    schedules, total = winner_db.get_schedules()
+    assert total == 1
+    assert [schedule["name"] for schedule in schedules] == ["shared-name"]
+
 
 class TestManagerList:
     def test_list_all(self, mgr, mock_db):
@@ -112,6 +265,40 @@ class TestManagerList:
     def test_list_with_filters(self, mgr, mock_db):
         mgr.list(enabled=True, limit=10, page=2)
         mock_db.get_schedules.assert_called_once_with(enabled=True, limit=10, page=2)
+
+    def test_list_can_exclude_a_management_surface(self, mgr, mock_db):
+        mgr.list(exclude_managed_by="studio")
+        mock_db.get_schedules.assert_called_once_with(
+            enabled=None,
+            limit=100,
+            page=1,
+            exclude_managed_by="studio",
+        )
+
+    def test_v1_list_uses_exact_signature_and_filters_before_pagination(self):
+        class LegacyScheduleDb:
+            scheduler_api_version = 1
+
+            def __init__(self):
+                self.calls = []
+
+            def get_schedules(self, enabled=None, limit=100, page=1):
+                self.calls.append({"enabled": enabled, "limit": limit, "page": page})
+                return (
+                    [
+                        _make_schedule(id="generic-1", name="generic-1"),
+                        _make_schedule(id="studio", name="private", managed_by="studio"),
+                        _make_schedule(id="generic-2", name="generic-2"),
+                    ],
+                    3,
+                )
+
+        db = LegacyScheduleDb()
+
+        result = ScheduleManager(db).list(limit=1, page=2, exclude_managed_by="studio")
+
+        assert [schedule.id for schedule in result] == ["generic-2"]
+        assert db.calls == [{"enabled": None, "limit": 1000, "page": 1}]
 
 
 class TestManagerGet:
@@ -161,9 +348,25 @@ class TestManagerDisable:
 
 
 class TestManagerTrigger:
-    def test_trigger_returns_none(self, mgr, mock_db):
+    def test_trigger_durably_queues_schedule(self, mgr, mock_db):
         result = mgr.trigger("sched-1")
-        assert result is None
+        assert result is not None
+        assert result.id == "sched-1"
+        mock_db.trigger_schedule.assert_called_once_with("sched-1")
+
+    def test_v1_trigger_uses_historical_due_now_fallback(self):
+        db = MagicMock()
+        db.scheduler_api_version = 1
+        db.update_schedule.return_value = _make_schedule(next_run_at=123)
+        manager = ScheduleManager(db)
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(time, "time", lambda: 123.9)
+            result = manager.trigger("sched-1")
+
+        assert result is not None
+        db.update_schedule.assert_called_once_with("sched-1", next_run_at=123)
+        db.trigger_schedule.assert_not_called()
 
 
 class TestManagerGetRuns:
@@ -192,6 +395,7 @@ class TestManagerCallMissingMethod:
 @pytest.fixture
 def mock_async_db():
     db = MagicMock()
+    db.scheduler_api_version = 2
     db.get_schedule = AsyncMock(return_value=_make_schedule())
     db.get_schedule_by_name = AsyncMock(return_value=None)
     db.get_schedules = AsyncMock(return_value=[_make_schedule()])
@@ -225,12 +429,86 @@ class TestAsyncCreate:
         with pytest.raises(ValueError, match="already exists"):
             await async_mgr.acreate(name="test-schedule", cron="0 9 * * *", endpoint="/test")
 
+    @pytest.mark.asyncio
+    async def test_acreate_update_recovers_when_another_creator_wins_the_name_race(self, async_mgr, mock_async_db):
+        winner = _make_schedule(id="winner", name="raced", endpoint="/winner")
+        updated = _make_schedule(id="winner", name="raced", endpoint="/async-loser")
+        mock_async_db.get_schedule_by_name = AsyncMock(side_effect=[None, winner])
+        mock_async_db.create_schedule = AsyncMock(side_effect=ScheduleNameConflictError("raced"))
+        mock_async_db.update_schedule = AsyncMock(return_value=updated)
+
+        result = await async_mgr.acreate(
+            name="raced",
+            cron="0 9 * * *",
+            endpoint="/async-loser",
+            if_exists="update",
+        )
+
+        assert result.id == "winner"
+        assert result.endpoint == "/async-loser"
+        mock_async_db.update_schedule.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_acreate_does_not_classify_an_unrelated_backend_failure_as_a_name_race(
+        self, async_mgr, mock_async_db
+    ):
+        backend_error = RuntimeError("database unavailable")
+        mock_async_db.get_schedule_by_name = AsyncMock(side_effect=[None, _make_schedule(id="unrelated", name="raced")])
+        mock_async_db.create_schedule = AsyncMock(side_effect=backend_error)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await async_mgr.acreate(name="raced", cron="0 9 * * *", endpoint="/loser", if_exists="skip")
+
+        assert exc_info.value is backend_error
+        mock_async_db.get_schedule_by_name.assert_awaited_once_with(
+            "raced",
+            managed_by=None,
+            owner_actor_id=None,
+            exclude_managed_by="studio",
+        )
+
 
 class TestAsyncList:
     @pytest.mark.asyncio
     async def test_alist(self, async_mgr, mock_async_db):
         result = await async_mgr.alist()
         assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_alist_can_exclude_a_management_surface(self, async_mgr, mock_async_db):
+        await async_mgr.alist(exclude_managed_by="studio")
+        mock_async_db.get_schedules.assert_awaited_once_with(
+            enabled=None,
+            limit=100,
+            page=1,
+            exclude_managed_by="studio",
+        )
+
+    @pytest.mark.asyncio
+    async def test_v1_alist_uses_exact_signature_and_filters_before_pagination(self):
+        class LegacyAsyncScheduleDb:
+            scheduler_api_version = 1
+
+            def __init__(self):
+                self.calls = []
+
+            async def get_schedules(self, enabled=None, limit=100, page=1):
+                self.calls.append({"enabled": enabled, "limit": limit, "page": page})
+                return (
+                    [
+                        _make_schedule(id="generic-1", name="generic-1"),
+                        _make_schedule(id="studio", name="private", managed_by="studio"),
+                        _make_schedule(id="generic-2", name="generic-2"),
+                    ],
+                    3,
+                )
+
+        db = LegacyAsyncScheduleDb()
+
+        result = await ScheduleManager(db).alist(limit=1, page=2, exclude_managed_by="studio")
+
+        assert [schedule.id for schedule in result] == ["generic-2"]
+        assert db.calls == [{"enabled": None, "limit": 1000, "page": 1}]
 
 
 class TestAsyncGet:
@@ -273,6 +551,31 @@ class TestAsyncDisable:
     async def test_adisable(self, async_mgr, mock_async_db):
         result = await async_mgr.adisable("sched-1")
         assert result is not None
+
+
+class TestAsyncTrigger:
+    @pytest.mark.asyncio
+    async def test_v2_atrigger_uses_durable_primitive(self, async_mgr, mock_async_db):
+        mock_async_db.trigger_schedule = AsyncMock(return_value=_make_schedule())
+
+        result = await async_mgr.atrigger("sched-1")
+
+        assert result is not None
+        mock_async_db.trigger_schedule.assert_awaited_once_with("sched-1")
+
+    @pytest.mark.asyncio
+    async def test_v1_atrigger_uses_historical_due_now_fallback(self):
+        db = MagicMock()
+        db.scheduler_api_version = 1
+        db.update_schedule = AsyncMock(return_value=_make_schedule(next_run_at=456))
+        manager = ScheduleManager(db)
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(time, "time", lambda: 456.7)
+            result = await manager.atrigger("sched-1")
+
+        assert result is not None
+        db.update_schedule.assert_awaited_once_with("sched-1", next_run_at=456)
 
 
 class TestAsyncGetRuns:

--- a/libs/agno/tests/unit/scheduler/test_schedule_model.py
+++ b/libs/agno/tests/unit/scheduler/test_schedule_model.py
@@ -15,6 +15,8 @@ class TestSchedule:
         assert s.method == "POST"
         assert s.timezone == "UTC"
         assert s.enabled is True
+        assert s.pending_trigger_count == 0
+        assert s.manual_trigger_claimed is False
         assert s.created_at is not None
 
     def test_to_dict(self):
@@ -26,6 +28,7 @@ class TestSchedule:
         assert d["endpoint"] == "/test"
         assert d["method"] == "POST"
         assert d["enabled"] is True
+        assert d["manual_trigger_claimed"] is False
         assert "created_at" in d
 
     def test_from_dict(self):

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -28,6 +28,21 @@ from agno.team.team import Team, get_team_by_id, get_teams
 # =============================================================================
 
 
+def _corrupt_delete_config_row(db: SqliteDb, component_id: str, version: int) -> None:
+    """Simulate an externally corrupted pin without weakening the public API."""
+    configs_table = db._get_table(table_type="component_configs")
+    assert configs_table is not None
+    with db.Session() as session:
+        result = session.execute(
+            configs_table.delete().where(
+                configs_table.c.component_id == component_id,
+                configs_table.c.version == version,
+            )
+        )
+        session.commit()
+    assert result.rowcount == 1
+
+
 def _create_mock_db_class():
     """Create a concrete BaseDb subclass with all abstract methods stubbed."""
     abstract_methods = {}
@@ -43,12 +58,17 @@ def mock_db():
     """Create a mock database instance that passes isinstance(db, BaseDb)."""
     MockDbClass = _create_mock_db_class()
     db = MockDbClass()
+    db.component_catalog_api_version = 2
 
     # Configure common mock methods
+    db.get_component = MagicMock(return_value=None)
+    db.create_component_with_config = MagicMock(return_value=({"component_id": "test-team"}, {"version": 1}))
     db.upsert_component = MagicMock()
     db.upsert_config = MagicMock(return_value={"version": 1})
     db.delete_component = MagicMock(return_value=True)
     db.get_config = MagicMock()
+    db.get_current_config = db.get_config
+    db.get_latest_config = db.get_config
     db.list_components = MagicMock()
     db.upsert_component_link = MagicMock()
     db.load_component_graph = MagicMock()
@@ -649,24 +669,28 @@ class TestTeamFromDict:
 class TestTeamSave:
     """Tests for Team.save() method."""
 
-    def test_save_calls_upsert_component(self, basic_team, mock_db):
-        """Test save calls upsert_component with correct parameters."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+    def test_save_creates_component_and_initial_config_atomically(self, basic_team, mock_db):
+        """Test first save creates the component and config together."""
         basic_team.db = mock_db
         version = basic_team.save()
 
-        mock_db.upsert_component.assert_called_once_with(
-            component_id="test-team",
-            component_type=ComponentType.TEAM,
-            name="Test Team",
-            description="A test team for unit testing",
-            metadata=None,
-        )
+        call_args = mock_db.create_component_with_config.call_args
+        assert call_args.kwargs["component_id"] == "test-team"
+        assert call_args.kwargs["component_type"] == ComponentType.TEAM
+        assert call_args.kwargs["name"] == "Test Team"
+        assert call_args.kwargs["description"] == "A test team for unit testing"
+        assert call_args.kwargs["config"]["id"] == "test-team"
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_not_called()
         assert version == 1
 
-    def test_save_calls_upsert_config(self, basic_team, mock_db):
-        """Test save calls upsert_config with team config."""
+    def test_existing_save_upserts_config_with_projection(self, basic_team, mock_db):
+        """Test a published save updates config and projection together."""
+        mock_db.get_component.return_value = {
+            "component_id": "test-team",
+            "component_type": "team",
+            "deleted_at": None,
+        }
         mock_db.upsert_config.return_value = {"version": 2}
 
         basic_team.db = mock_db
@@ -676,6 +700,11 @@ class TestTeamSave:
         call_args = mock_db.upsert_config.call_args
         assert call_args.kwargs["component_id"] == "test-team"
         assert "config" in call_args.kwargs
+        assert call_args.kwargs["projection"] == {
+            "name": "Test Team",
+            "description": "A test team for unit testing",
+            "metadata": None,
+        }
         assert version == 2
 
     def test_save_with_members_saves_each_member(self, mock_db, member_agent):
@@ -709,8 +738,8 @@ class TestTeamSave:
         )
         team.save()
 
-        # Check that links were passed to upsert_config
-        call_args = mock_db.upsert_config.call_args
+        # Check that links were committed with the initial config
+        call_args = mock_db.create_component_with_config.call_args
         links = call_args.kwargs.get("links")
         assert links is not None
         assert len(links) == 1
@@ -721,33 +750,47 @@ class TestTeamSave:
 
     def test_save_with_explicit_db(self, basic_team, mock_db):
         """Test save uses explicitly provided db."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
         version = basic_team.save(db=mock_db)
 
-        mock_db.upsert_component.assert_called_once()
-        mock_db.upsert_config.assert_called_once()
+        mock_db.create_component_with_config.assert_called_once()
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_not_called()
         assert version == 1
 
     def test_save_with_label(self, basic_team, mock_db):
-        """Test save passes label to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes the label to the atomic create."""
         basic_team.db = mock_db
         basic_team.save(label="production")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["label"] == "production"
 
     def test_save_with_stage(self, basic_team, mock_db):
-        """Test save passes stage to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes the stage to the atomic create."""
         basic_team.db = mock_db
         basic_team.save(stage="draft")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["stage"] == "draft"
+
+    def test_save_draft_team_with_draft_member_on_real_sqlite(self, tmp_path):
+        """A draft composite may pin a draft child; publication validates it later."""
+        db = SqliteDb(db_file=str(tmp_path / "draft_team.db"))
+        member = Agent(id="draft-member", name="Draft Member")
+        team = Team(id="draft-team", name="Draft Team", members=[member], db=db)
+
+        version = team.save(stage="draft")
+
+        assert version == 1
+        assert db.get_config("draft-member", version=1)["stage"] == "draft"  # type: ignore[index]
+        assert db.get_config("draft-team", version=1)["stage"] == "draft"  # type: ignore[index]
+        links = db.get_links("draft-team", 1)
+        assert len(links) == 1
+        assert links[0]["link_kind"] == "member"
+        assert links[0]["link_key"] == "member_0"
+        assert links[0]["child_component_id"] == "draft-member"
+        assert links[0]["child_version"] == 1
+        assert links[0]["meta"] == {"type": "agent"}
 
     def test_save_without_db_raises_error(self, basic_team):
         """Test save raises error when no db is available."""
@@ -756,7 +799,7 @@ class TestTeamSave:
 
     def test_save_handles_db_error(self, basic_team, mock_db):
         """Test save raises error when database operation fails."""
-        mock_db.upsert_component.side_effect = Exception("Database error")
+        mock_db.create_component_with_config.side_effect = Exception("Database error")
 
         basic_team.db = mock_db
 
@@ -1064,7 +1107,9 @@ class TestTeamDelete:
         basic_team.db = mock_db
         result = basic_team.delete()
 
-        mock_db.delete_component.assert_called_once_with(component_id="test-team", hard_delete=False)
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-team", hard_delete=False, require_no_dependents=True
+        )
         assert result is True
 
     def test_delete_with_hard_delete(self, basic_team, mock_db):
@@ -1074,8 +1119,35 @@ class TestTeamDelete:
         basic_team.db = mock_db
         result = basic_team.delete(hard_delete=True)
 
-        mock_db.delete_component.assert_called_once_with(component_id="test-team", hard_delete=True)
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-team", hard_delete=True, require_no_dependents=True
+        )
         assert result is True
+
+    def test_delete_can_explicitly_bypass_dependency_check(self, basic_team, mock_db):
+        """Test delete forwards the dangerous dependency-check escape hatch."""
+        basic_team.db = mock_db
+
+        assert basic_team.delete(require_no_dependents=False) is True
+
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-team", hard_delete=False, require_no_dependents=False
+        )
+
+    def test_delete_uses_exact_catalog_v1_signature(self, basic_team, mock_db):
+        """The v2 dependency keyword must never reach a legacy override."""
+        calls = []
+
+        def legacy_delete(component_id, hard_delete=False):
+            calls.append((component_id, hard_delete))
+            return True
+
+        mock_db.component_catalog_api_version = 1
+        mock_db.delete_component = legacy_delete
+        basic_team.db = mock_db
+
+        assert basic_team.delete(require_no_dependents=False) is True
+        assert calls == [("test-team", False)]
 
     def test_delete_with_explicit_db(self, basic_team, mock_db):
         """Test delete uses explicitly provided db."""
@@ -1132,6 +1204,37 @@ class TestGetTeamById:
         assert team is not None
         assert team.id == "found-team"
         assert team.name == "Found Team"
+        mock_db.get_config.assert_called_once_with(component_id="found-team", version=None, label=None)
+
+    def test_get_team_by_id_returns_draft_only_team_and_member(self, tmp_path):
+        """Draft fallback also applies to an unpinned member loaded by Team.from_dict."""
+        db = SqliteDb(db_file=str(tmp_path / "draft-only-team.db"))
+        member = Agent(id="draft-member", name="Draft Member", db=db)
+        assert member.save(stage="draft") == 1
+        assert db.get_current_config("draft-member") is None
+
+        db.upsert_component(
+            component_id="draft-team",
+            component_type=ComponentType.TEAM,
+            name="Draft Team",
+        )
+        db.upsert_config(
+            component_id="draft-team",
+            stage="draft",
+            config={
+                "id": "draft-team",
+                "name": "Draft Team",
+                "members": [{"type": "agent", "agent_id": "draft-member"}],
+            },
+        )
+        assert db.get_current_config("draft-team") is None
+
+        loaded = get_team_by_id(db=db, id="draft-team")
+
+        assert loaded is not None
+        assert loaded.id == "draft-team"
+        assert len(loaded.members) == 1
+        assert loaded.members[0].id == "draft-member"
 
     def test_get_team_by_id_with_version(self, mock_db):
         """Test get_team_by_id retrieves specific version."""
@@ -1214,16 +1317,20 @@ class TestGetTeams:
             ],
             None,
         )
-        mock_db.get_config.side_effect = [
-            {"config": {"id": "team-1", "name": "Team 1"}},
-            {"config": {"id": "team-2", "name": "Team 2"}},
-        ]
+        mock_db.get_latest_config = MagicMock(
+            side_effect=[
+                {"config": {"id": "team-1", "name": "Team 1"}},
+                {"config": {"id": "team-2", "name": "Team 2"}},
+            ]
+        )
 
         teams = get_teams(db=mock_db)
 
         assert len(teams) == 2
         assert teams[0].id == "team-1"
         assert teams[1].id == "team-2"
+        assert mock_db.get_latest_config.call_count == 2
+        mock_db.get_config.assert_not_called()
 
     def test_get_teams_filters_by_type(self, mock_db):
         """Test get_teams filters by TEAM component type."""
@@ -1340,7 +1447,7 @@ class TestMemberPinFailures:
         member.save(db=db)
         links = db.get_links(component_id="pm-team", version=1)
         pinned = next(link for link in links if link["link_kind"] == "member")["child_version"]
-        assert db.delete_config(component_id="pm-member", version=pinned)
+        _corrupt_delete_config_row(db, "pm-member", pinned)
 
         with pytest.raises(ComponentRehydrationError, match=f"pins member agent 'pm-member' at version {pinned}"):
             get_team_by_id(db=db, id="pm-team", strict=True)
@@ -1357,7 +1464,7 @@ class TestMemberPinFailures:
         member.save(db=db)
         links = db.get_links(component_id="ps-team", version=1)
         pinned = next(link for link in links if link["link_kind"] == "member")["child_version"]
-        assert db.delete_config(component_id="ps-member", version=pinned)
+        _corrupt_delete_config_row(db, "ps-member", pinned)
         registry = Registry(agents=[Agent(id="ps-member", name="Code Member")])
 
         with pytest.raises(ComponentRehydrationError, match="pins member agent 'ps-member'"):

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -908,15 +908,15 @@ class TestEditAgent:
         assert out["stage"] == "draft"
         assert out["draft_version"] == 2
 
-    def test_second_edit_updates_same_draft_in_place(self, studio_versioned):
+    def test_second_edit_appends_an_immutable_draft(self, studio_versioned):
         self._create(studio_versioned)
         studio_versioned.edit_agent(agent_id="tutor", instructions="updated once")
         out = _loads(studio_versioned.edit_agent(agent_id="tutor", instructions="updated twice"))
-        assert out["draft_version"] == 2  # same draft, no new version
+        assert out["draft_version"] == 3
 
         versions = _loads(studio_versioned.list_versions("tutor"))
         stages = [v["stage"] for v in versions["versions"]]
-        assert stages.count("draft") == 1
+        assert stages.count("draft") == 2
         assert stages.count("published") == 1
 
     def test_successive_partial_edits_accumulate_in_draft(self, studio_versioned):
@@ -948,7 +948,7 @@ class TestEditAgent:
         assert got["add_history_to_context"] is True  # untouched from create
         assert got["num_history_runs"] == 7
 
-    def test_history_edit_accumulates_in_same_draft(self, studio_versioned):
+    def test_history_edit_accumulates_in_latest_draft(self, studio_versioned):
         self._create(studio_versioned)
         studio_versioned.edit_agent(agent_id="tutor", add_history_to_context=False)
         out = _loads(studio_versioned.edit_agent(agent_id="tutor", description="new description"))
@@ -956,6 +956,33 @@ class TestEditAgent:
         draft = _loads(studio_versioned.get_version("tutor", version=out["draft_version"]))
         assert "add_history_to_context" not in draft["config"]  # history off survives edit 2
         assert draft["config"]["description"] == "new description"
+
+    def test_edit_rejects_a_competing_append_after_its_snapshot(self, studio_versioned, db, monkeypatch):
+        from agno.db.base import ComponentVersionGuard
+
+        self._create(studio_versioned)
+        original_save = studio_versioned._save_edit
+
+        def save_after_competing_append(*args, **kwargs):
+            stored = db.get_config("tutor", version=1)
+            assert stored is not None
+            competing = dict(stored["config"])
+            competing["description"] = "competing edit"
+            db.upsert_config(
+                component_id="tutor",
+                config=competing,
+                stage="draft",
+                guard=ComponentVersionGuard(latest_version=1, current_version=1),
+            )
+            return original_save(*args, **kwargs)
+
+        monkeypatch.setattr(studio_versioned, "_save_edit", save_after_competing_append)
+        out = _loads(studio_versioned.edit_agent(agent_id="tutor", instructions="stale edit"))
+
+        assert "version conflict" in out["error"]
+        versions = sorted(db.list_configs("tutor", include_config=True), key=lambda row: row["version"])
+        assert [row["version"] for row in versions] == [1, 2]
+        assert versions[1]["config"]["description"] == "competing edit"
 
     def test_get_agent_reports_history_settings(self, studio):
         self._create(studio)
@@ -1162,6 +1189,60 @@ class TestVersioning:
         out = _loads(studio_versioned.publish_component("tutor", version=2))
         assert out["status"] == "already_published"
         assert out["version"] == 2
+
+    def test_publish_rejects_a_competing_append_after_its_snapshot(self, studio_versioned, db, monkeypatch):
+        from agno.db.base import ComponentVersionGuard
+
+        self._create_and_edit(studio_versioned)
+        original_upsert = db.upsert_config
+
+        def upsert_after_competing_append(*args, **kwargs):
+            stored = db.get_config("tutor", version=2)
+            assert stored is not None
+            competing = dict(stored["config"])
+            competing["description"] = "newer draft"
+            original_upsert(
+                component_id="tutor",
+                config=competing,
+                stage="draft",
+                guard=ComponentVersionGuard(latest_version=2, current_version=1),
+            )
+            return original_upsert(*args, **kwargs)
+
+        monkeypatch.setattr(db, "upsert_config", upsert_after_competing_append)
+        out = _loads(studio_versioned.publish_component("tutor"))
+
+        assert "version conflict" in out["error"]
+        assert db.get_component("tutor")["current_version"] == 1
+        versions = sorted(db.list_configs("tutor"), key=lambda row: row["version"])
+        assert [(row["version"], row["stage"]) for row in versions] == [
+            (1, "published"),
+            (2, "draft"),
+            (3, "draft"),
+        ]
+
+    def test_catalog_v1_bridge_keeps_legacy_upsert_call_shape(self, studio_versioned, db, monkeypatch):
+        self._create_and_edit(studio_versioned)
+        calls: list[Dict[str, Any]] = []
+
+        def capture_upsert(*args, **kwargs):
+            calls.append(kwargs)
+            return {"version": kwargs.get("version") or 3}
+
+        monkeypatch.setattr(db, "component_catalog_api_version", 1)
+        monkeypatch.setattr(db, "upsert_config", capture_upsert)
+
+        edited = _loads(studio_versioned.edit_agent("tutor", description="legacy edit"))
+        published = _loads(studio_versioned.publish_component("tutor"))
+
+        assert edited["status"] == "edited"
+        assert published["status"] == "published"
+        assert len(calls) == 2
+        assert calls[0]["version"] == 2
+        assert calls[0]["stage"] == "draft"
+        assert calls[1]["version"] == 2
+        assert calls[1]["stage"] == "published"
+        assert all("guard" not in call for call in calls)
 
     def test_publish_unknown_version_returns_error(self, studio_versioned):
         studio_versioned.create_agent(name="tutor", instructions="i", model_id="gpt-5.4")
@@ -1670,16 +1751,16 @@ class TestLifecycle:
         )
         assert out["db_version"] == 1
 
-        # Edit twice — should collapse into one draft
+        # Every edit appends an immutable draft and builds on the latest one.
         studio_versioned.edit_agent(agent_id="lc", instructions="edit1")
         studio_versioned.edit_agent(agent_id="lc", instructions="edit2")
 
         versions: list[Dict[str, Any]] = _loads(studio_versioned.list_versions("lc"))["versions"]
-        assert len(versions) == 2
+        assert len(versions) == 3
 
-        # Publish draft
+        # Publish the latest draft.
         pub = _loads(studio_versioned.publish_component("lc"))
-        assert pub["version"] == 2
+        assert pub["version"] == 3
 
         # Rollback
         rb = _loads(studio_versioned.set_current_version("lc", 1))

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -1,2370 +1,3624 @@
-"""Unit tests for StudioTools toolkit.
+"""Contract tests for the typed StudioTools 2.9 control plane.
 
-Uses a real SqliteDb backed by a pytest tmp_path so the full component +
-config persistence path is exercised, not mocked.
+These tests deliberately exercise a real SQLite component catalog. Studio 2.9
+is a breaking API: requests are typed, one database is fixed at construction,
+authorization is mandatory, creates are draft-first, and lifecycle mutations
+use compare-and-set guards.
 """
 
+from __future__ import annotations
+
+import asyncio
+import inspect
 import json
-import time
-from datetime import datetime
-from importlib.util import find_spec
-from typing import Any, Dict
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
 from agno.agent import Agent
-from agno.agent._tools import parse_tools
+from agno.db.base import ComponentType, ComponentVersionGuard
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY, ScheduleNameConflictError
 from agno.db.sqlite import SqliteDb
-from agno.models.openai import OpenAIResponses
+from agno.models.openai import OpenAIChat, OpenAIResponses
 from agno.registry import Registry
-from agno.session import AgentSession
+from agno.run import RunContext
+from agno.scheduler.manager import ScheduleManager
 from agno.tools.calculator import CalculatorTools
-from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.function import Function
-from agno.tools.studio import StudioTool, StudioTools
+from agno.tools.studio import StudioTools
+from agno.tools.studio_schema import (
+    AgentCreate,
+    AgentPatch,
+    AgentView,
+    AgentWorkflowStep,
+    ComponentRef,
+    ContextPolicy,
+    ContextPolicyPatch,
+    FunctionWorkflowStep,
+    ModelRef,
+    ScheduleActionView,
+    ScheduleCreate,
+    ScheduleRunView,
+    ScheduleView,
+    StudioResult,
+    TeamCreate,
+    TeamPatch,
+    TeamView,
+    TeamWorkflowStep,
+    ToolRef,
+    WorkflowCreate,
+    WorkflowPatch,
+    WorkflowView,
+)
 from agno.tools.toolkit import Toolkit
 
-# ----------------------------------------------------------------------
-# Fixtures
-# ----------------------------------------------------------------------
+MODEL_ID = "gpt-5.4"
+MODEL_PROVIDER = "OpenAI"
+MODEL_NAME = "OpenAIResponses"
+MODEL_BASE_URL_SECRET = "https://model-secret.invalid/v1"
+MODEL_API_KEY_SECRET = "sk-studio-test-secret"
+
+
+def _model_ref() -> ModelRef:
+    return ModelRef(id=MODEL_ID, provider=MODEL_PROVIDER, name=MODEL_NAME)
+
+
+def _allow(_context: RunContext, _access: str, _action: str) -> bool:
+    return True
+
+
+def _error_code(result: StudioResult[Any]) -> str:
+    assert result.ok is False
+    assert result.data is None
+    assert result.error is not None
+    return result.error.code
 
 
 @pytest.fixture
-def db(tmp_path):
-    return SqliteDb(id="studio-test-db", db_file=str(tmp_path / "studio.db"))
+def run_context() -> RunContext:
+    return RunContext(
+        run_id="studio-run",
+        session_id="studio-session",
+        user_id="studio-admin",
+    )
 
 
 @pytest.fixture
-def registry(db):
+def db(tmp_path) -> SqliteDb:
+    return SqliteDb(
+        id="fixed-studio-catalog",
+        db_file=str(tmp_path / "private-catalog-location.sqlite"),
+    )
+
+
+@pytest.fixture
+def registry(db: SqliteDb) -> Registry:
+    model = OpenAIResponses(
+        id=MODEL_ID,
+        base_url=MODEL_BASE_URL_SECRET,
+        api_key=MODEL_API_KEY_SECRET,
+    )
     return Registry(
-        name="Test Registry",
-        tools=[DuckDuckGoTools(), CalculatorTools()],
-        models=[OpenAIResponses(id="gpt-5.4"), OpenAIResponses(id="gpt-5.5")],
+        name="Studio contract registry",
+        tools=[CalculatorTools()],
+        models=[model],
         dbs=[db],
     )
 
 
 @pytest.fixture
-def studio(registry, db):
-    return StudioTools(registry=registry, db=db)
+def studio(registry: Registry, db: SqliteDb) -> StudioTools:
+    return StudioTools(
+        registry=registry,
+        db=db,
+        authorize=_allow,
+        default_model=_model_ref(),
+        default_context=ContextPolicy(history_runs=4),
+    )
 
 
-@pytest.fixture
-def studio_versioned(registry, db):
-    return StudioTools(registry=registry, db=db, versions=True)
+def _agent_request(
+    *,
+    component_id: str | None = None,
+    name: str = "Research Agent",
+    instructions: str = "Research the topic and cite sources.",
+) -> AgentCreate:
+    return AgentCreate(
+        component_id=component_id,
+        name=name,
+        instructions=instructions,
+    )
 
 
-@pytest.fixture
-def studio_schedules(registry, db):
-    return StudioTools(registry=registry, db=db, schedules=True)
+def _create_agent(
+    studio: StudioTools,
+    run_context: RunContext,
+    *,
+    component_id: str,
+    save_as: str = "draft",
+) -> StudioResult[AgentView]:
+    return studio.create_agent(
+        _agent_request(component_id=component_id, name=component_id),
+        save_as=save_as,  # type: ignore[arg-type]
+        _agno_run_context=run_context,
+    )
 
 
-def _loads(s: str) -> Dict[str, Any]:
-    return json.loads(s)
+class TestConstructionAndToolContract:
+    def test_fixed_db_and_authorizer_are_required(self, registry: Registry, db: SqliteDb):
+        async def async_authorize(_context: RunContext, _access: str, _action: str) -> bool:
+            return True
 
+        with pytest.raises(TypeError):
+            StudioTools(registry=registry, authorize=_allow)  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            StudioTools(registry=registry, db=db)  # type: ignore[call-arg]
+        with pytest.raises(ValueError, match="fixed catalog db"):
+            StudioTools(registry=registry, db=None, authorize=_allow)  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="authorize must be callable"):
+            StudioTools(registry=registry, db=db, authorize=None)  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="authorize must be synchronous"):
+            StudioTools(registry=registry, db=db, authorize=async_authorize)
+        with pytest.raises(ValueError, match="synchronous catalog db with atomic component persistence"):
+            StudioTools(
+                registry=registry,
+                db=SimpleNamespace(supports_component_persistence=False),  # type: ignore[arg-type]
+                authorize=_allow,
+            )
+        with pytest.raises(ValueError, match="component catalog API version 2"):
+            StudioTools(
+                registry=registry,
+                db=SimpleNamespace(  # type: ignore[arg-type]
+                    supports_component_persistence=True,
+                    component_catalog_api_version=1,
+                ),
+                authorize=_allow,
+            )
+        with pytest.raises(ValueError, match="scheduler API version 2"):
+            StudioTools(
+                registry=registry,
+                db=SimpleNamespace(  # type: ignore[arg-type]
+                    supports_component_persistence=True,
+                    component_catalog_api_version=2,
+                    scheduler_api_version=1,
+                ),
+                authorize=_allow,
+                schedules=True,
+            )
 
-def _tool(toolkit: StudioTools, name: str):
-    """The registered entrypoint for a tool -- what an agent actually calls."""
-    return toolkit.functions[name].entrypoint
+    def test_explicit_catalog_is_used_instead_of_a_registry_db(self, tmp_path):
+        registry_db = SqliteDb(id="registry-db", db_file=str(tmp_path / "registry.sqlite"))
+        fixed_db = SqliteDb(id="fixed-db", db_file=str(tmp_path / "fixed.sqlite"))
+        registry = Registry(
+            name="Two DB registry",
+            models=[OpenAIResponses(id=MODEL_ID)],
+            dbs=[registry_db],
+        )
+        tool = StudioTools(
+            registry=registry,
+            db=fixed_db,
+            authorize=_allow,
+            default_model=_model_ref(),
+        )
+        context = RunContext(run_id="r", session_id="s", user_id="u")
 
+        result = tool.create_agent(_agent_request(component_id="fixed"), _agno_run_context=context)
 
-# ----------------------------------------------------------------------
-# Backward-compatible alias
-# ----------------------------------------------------------------------
+        assert result.ok is True
+        assert tool.db is fixed_db
+        assert tool._runner_tools.db is fixed_db
+        assert fixed_db.get_component("fixed") is not None
+        assert registry_db.get_component("fixed") is None
+        assert "list_dbs" not in tool.functions
 
+    def test_reference_lists_mirror_exact_objects_into_the_registry(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+    ):
+        from agno.team import Team
 
-class TestStudioToolAlias:
-    def test_singular_alias_resolves_to_canonical_class(self):
-        assert StudioTool is StudioTools
+        list_agent = Agent(id="listed-agent", name="Listed agent", model=registry.models[0])
+        list_team = Team(id="listed-team", name="Listed team", members=[list_agent], model=registry.models[0])
 
-    def test_alias_constructs_a_working_toolkit(self, registry, db):
-        tool = StudioTool(registry=registry, db=db)
-        assert isinstance(tool, StudioTools)
-        assert "create_agent" in tool.functions
+        StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            agents_list=[list_agent],
+            teams_list=[list_team],
+        )
 
+        assert next(agent for agent in registry.agents if agent.id == "listed-agent") is list_agent
+        assert next(team for team in registry.teams if team.id == "listed-team") is list_team
 
-# ----------------------------------------------------------------------
-# Initialization
-# ----------------------------------------------------------------------
+    def test_construction_refuses_split_registry_and_list_identity(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+    ):
+        registry_agent = Agent(id="split-agent", name="Registry object", model=registry.models[0])
+        list_agent = Agent(id="split-agent", name="List object", model=registry.models[0])
+        registry.agents.append(registry_agent)
 
+        with pytest.raises(ValueError, match="distinct components with id 'split-agent'"):
+            StudioTools(
+                registry=registry,
+                db=db,
+                authorize=_allow,
+                default_model=_model_ref(),
+                agents_list=[list_agent],
+            )
 
-VERSIONING_TOOLS = {
-    "list_versions",
-    "get_version",
-    "publish_component",
-    "set_current_version",
-    "delete_version",
-}
+    def test_late_live_list_reference_is_mirrored_before_persistence(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        from agno.team import get_team_by_id
 
-SCHEDULE_TOOLS = {
-    "create_schedule",
-    "list_schedules",
-    "get_schedule",
-    "get_schedule_runs",
-    "trigger_schedule",
-    "enable_schedule",
-    "disable_schedule",
-    "delete_schedule",
-}
+        live_agents: list[Agent] = []
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            agents_list=live_agents,
+            teams=True,
+        )
+        late_agent = Agent(id="late-agent", name="Late agent", model=registry.models[0])
+        live_agents.append(late_agent)
 
+        created = tool.create_team(
+            TeamCreate(
+                component_id="late-team",
+                name="Late team",
+                instructions="Delegate to the late agent.",
+                members=[ComponentRef(component_type="agent", component_id="late-agent")],
+            ),
+            _agno_run_context=run_context,
+        )
 
-class TestInitialization:
-    def test_default_registers_agents_plus_discovery(self, studio):
-        expected = {
-            # Discovery (always)
-            "list_models",
-            "list_tools",
-            "list_functions",
-            "list_dbs",
-            "list_agents",
-            "list_teams",
-            "list_workflows",
-            # Agent ops (enabled by default)
-            "get_agent",
+        assert created.ok is True
+        assert next(agent for agent in registry.agents if agent.id == "late-agent") is late_agent
+        loaded = get_team_by_id(db=db, id="late-team", registry=registry, strict=True)
+        assert loaded is not None
+        assert loaded.members[0].id == "late-agent"
+        assert loaded.members[0].name == "Late agent"
+
+    def test_replaced_live_list_reference_refuses_reload_identity_flip(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        original = Agent(id="replace-agent", name="Original", model=registry.models[0])
+        live_agents = [original]
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            agents_list=live_agents,
+            teams=True,
+        )
+        live_agents[0] = Agent(id="replace-agent", name="Replacement", model=registry.models[0])
+
+        created = tool.create_team(
+            TeamCreate(
+                component_id="replace-team",
+                name="Replace team",
+                instructions="This reference must remain stable.",
+                members=[ComponentRef(component_type="agent", component_id="replace-agent")],
+            ),
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(created) == "component_identity_mismatch"
+        assert db.get_component("replace-team") is None
+
+    @pytest.mark.parametrize(
+        ("list_argument", "expected_flags"),
+        [
+            ("agents_list", (True, True, True)),
+            ("teams_list", (True, True, True)),
+            ("workflows_list", (True, False, True)),
+        ],
+    )
+    def test_component_lists_auto_enable_their_own_and_downstream_surfaces(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        list_argument: str,
+        expected_flags: tuple[bool, bool, bool],
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            **{list_argument: []},
+        )
+
+        assert (tool.enable_agents, tool.enable_teams, tool.enable_workflows) == expected_flags
+        surfaces = {
+            "agent": {
+                "list_agents",
+                "get_agent",
+                "create_agent",
+                "edit_agent",
+                "archive_agent",
+                "restore_agent",
+                "run_agent",
+            },
+            "team": {
+                "list_teams",
+                "get_team",
+                "create_team",
+                "edit_team",
+                "archive_team",
+                "restore_team",
+                "run_team",
+            },
+            "workflow": {
+                "list_workflows",
+                "get_workflow",
+                "create_workflow",
+                "edit_workflow",
+                "archive_workflow",
+                "restore_workflow",
+                "run_workflow",
+            },
+        }
+        for enabled, surface in zip(expected_flags, surfaces.values()):
+            if enabled:
+                assert surface <= set(tool.functions)
+                assert surface <= set(tool.async_functions)
+            else:
+                assert surface.isdisjoint(tool.functions)
+                assert surface.isdisjoint(tool.async_functions)
+
+    @pytest.mark.parametrize(
+        ("list_argument", "flag_argument", "surface"),
+        [
+            ("agents_list", "agents", {"list_agents", "create_agent", "restore_agent", "run_agent"}),
+            ("teams_list", "teams", {"list_teams", "create_team", "restore_team", "run_team"}),
+            (
+                "workflows_list",
+                "workflows",
+                {"list_workflows", "create_workflow", "restore_workflow", "run_workflow"},
+            ),
+        ],
+    )
+    def test_explicit_false_overrides_list_auto_enablement(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        list_argument: str,
+        flag_argument: str,
+        surface: set[str],
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            **{list_argument: [], flag_argument: False},
+        )
+
+        assert surface.isdisjoint(tool.functions)
+        assert surface.isdisjoint(tool.async_functions)
+
+    @pytest.mark.parametrize(
+        "method",
+        [StudioTools.create_agent, StudioTools.create_team, StudioTools.create_workflow],
+    )
+    def test_create_python_signatures_are_the_typed_breaking_api(self, method: Any):
+        parameters = inspect.signature(method).parameters
+
+        assert list(parameters) == ["self", "request", "save_as", "_agno_run_context"]
+        legacy_names = {
+            "name",
+            "instructions",
+            "model_id",
+            "tool_names",
+            "agent_ids",
+            "team_ids",
+            "step_specs",
+            "db_id",
+        }
+        assert not legacy_names & set(parameters)
+
+    def test_workflows_reject_duplicate_registered_function_names_at_construction(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+    ):
+        def first(value: str) -> str:
+            return value
+
+        def second(value: str) -> str:
+            return value
+
+        second.__name__ = first.__name__
+        registry.functions.extend([first, second])
+
+        with pytest.raises(ValueError, match="unique registered function names.*first"):
+            StudioTools(
+                registry=registry,
+                db=db,
+                authorize=_allow,
+                default_model=_model_ref(),
+                workflows=True,
+            )
+
+    def test_agent_facing_create_schema_is_typed_and_hides_run_context(self, studio: StudioTools):
+        function = studio.functions["create_agent"]
+        function.process_entrypoint()
+        schema = function.parameters
+        properties = schema["properties"]
+
+        assert set(properties) == {"request", "save_as"}
+        assert schema["required"] == ["request"]
+        assert properties["request"]["additionalProperties"] is False
+        assert properties["request"]["required"] == ["name", "instructions"]
+        assert set(properties["save_as"]["enum"]) == {"draft", "published"}
+        assert set(properties["request"]["properties"]["if_exists"]["enum"]) == {"error", "return_existing"}
+        assert "_agno_run_context" not in properties
+        assert "db_id" not in properties
+
+    def test_sync_and_async_registered_tool_schemas_match(self, studio: StudioTools):
+        assert set(studio.functions) == set(studio.async_functions)
+        for name, sync_function in studio.functions.items():
+            async_function = studio.async_functions[name]
+            sync_function.process_entrypoint()
+            async_function.process_entrypoint()
+            assert async_function.parameters == sync_function.parameters, name
+            assert async_function.description == sync_function.description, name
+
+    def test_required_nullable_lifecycle_guards_accept_null_in_tool_schema(self, studio: StudioTools):
+        for name in ("publish_component", "set_current_version", "archive_agent", "restore_agent"):
+            function = studio.functions[name]
+            function.process_entrypoint()
+            schema = function.parameters
+            guard = schema["properties"]["expected_current_version"]
+
+            assert "expected_current_version" in schema["required"]
+            assert {branch.get("type") for branch in guard["anyOf"]} == {"integer", "null"}
+            assert guard["description"]
+
+    def test_every_publish_capable_or_destructive_tool_requires_framework_confirmation(self, studio: StudioTools):
+        for name in (
             "create_agent",
             "edit_agent",
-            "delete_agent",
-            "run_agent",
-        }
-        assert expected == set(studio.functions.keys())
-
-    def test_versioning_tools_not_registered_by_default(self, studio):
-        assert studio.enable_versions is False
-        assert not VERSIONING_TOOLS & set(studio.functions.keys())
-        assert not VERSIONING_TOOLS & set(studio.async_functions.keys())
-
-    def test_versions_flag_registers_versioning_tools(self, studio_versioned):
-        assert studio_versioned.enable_versions is True
-        assert VERSIONING_TOOLS.issubset(set(studio_versioned.functions.keys()))
-        assert VERSIONING_TOOLS.issubset(set(studio_versioned.async_functions.keys()))
-
-    def test_schedule_tools_not_registered_by_default(self, studio):
-        assert studio.enable_schedules is False
-        assert not SCHEDULE_TOOLS & set(studio.functions.keys())
-        assert not SCHEDULE_TOOLS & set(studio.async_functions.keys())
-        assert "Schedules:" not in studio.instructions
-
-    def test_schedules_flag_registers_schedule_tools(self, studio_schedules):
-        assert studio_schedules.enable_schedules is True
-        assert SCHEDULE_TOOLS.issubset(set(studio_schedules.functions.keys()))
-        assert SCHEDULE_TOOLS.issubset(set(studio_schedules.async_functions.keys()))
-        assert "Schedules:" in studio_schedules.instructions
-
-    def test_management_tools_are_shared_with_scheduler_toolkit(self, studio_schedules):
-        from agno.tools.scheduler import SchedulerTools
-
-        for tool_name in SCHEDULE_TOOLS - {"create_schedule"}:
-            sync_owner = studio_schedules.functions[tool_name].entrypoint.__self__
-            async_owner = studio_schedules.async_functions[tool_name].entrypoint.__self__
-            assert isinstance(sync_owner, SchedulerTools), tool_name
-            assert isinstance(async_owner, SchedulerTools), tool_name
-        assert studio_schedules.functions["create_schedule"].entrypoint.__self__ is studio_schedules
-
-    def test_instructions_reflect_versioning_flag(self, studio, studio_versioned):
-        assert "published immediately" in studio.instructions
-        assert "publish_component" not in studio.instructions
-        assert "publish_component" in studio_versioned.instructions
-        assert "published immediately" not in studio_versioned.instructions
-
-    def test_instructions_include_component_rules_only_when_enabled(self, registry, db):
-        default = StudioTools(registry=registry, db=db)
-        assert "Team rules" not in default.instructions
-        assert "Workflow rules" not in default.instructions
-
-        full = StudioTools(registry=registry, db=db, teams=True, workflows=True)
-        assert "Team rules" in full.instructions
-        assert "Workflow rules" in full.instructions
-
-    def test_add_instructions_defaults_on_and_respects_override(self, registry, db):
-        assert StudioTools(registry=registry, db=db).add_instructions is True
-        assert StudioTools(registry=registry, db=db, add_instructions=False).add_instructions is False
-
-    def test_default_does_not_register_team_or_workflow_tools(self, studio):
-        names = set(studio.functions.keys())
-        for absent in ("create_team", "create_workflow", "edit_team", "edit_workflow"):
-            assert absent not in names
-
-    def test_registers_async_run_agent_by_default(self, studio):
-        assert "run_agent" in studio.async_functions
-        assert set(studio.async_functions.keys()) == set(studio.functions.keys())
-        assert "run_team" not in studio.async_functions
-        assert "run_workflow" not in studio.async_functions
-
-    def test_registers_all_async_run_tools_when_enabled(self, registry, db):
-        tool = StudioTools(registry=registry, db=db, teams=True, workflows=True)
-        assert {"run_agent", "run_team", "run_workflow"}.issubset(set(tool.async_functions.keys()))
-        assert set(tool.async_functions.keys()) == set(tool.functions.keys())
-
-    def test_db_defaults_to_first_registry_db(self, registry):
-        tool = StudioTools(registry=registry)
-        assert tool.db is registry.dbs[0]
-
-    def test_explicit_db_overrides_registry(self, registry, db):
-        other = SqliteDb(id="other", db_file=":memory:")
-        tool = StudioTools(registry=registry, db=other)
-        assert tool.db is other
-
-
-# ----------------------------------------------------------------------
-# Discovery
-# ----------------------------------------------------------------------
-
-
-class TestDiscovery:
-    def test_list_models(self, studio):
-        result = _loads(studio.list_models())
-        ids = {m["id"] for m in result["models"]}
-        assert ids == {"gpt-5.4", "gpt-5.5"}
-
-    def test_list_tools(self, studio):
-        result = _loads(studio.list_tools())
-        names = {t["name"] for t in result["tools"]}
-        assert "calculator" in names
-        assert "websearch" in names  # DuckDuckGoTools registers as 'websearch'
-        for t in result["tools"]:
-            if t["name"] == "calculator":
-                assert "add" in t["functions"]
-
-    def test_list_functions(self, registry, db):
-        def transform_content(value: str) -> str:
-            """Transform content for a workflow step."""
-            return value.upper()
-
-        registry.functions.append(transform_content)
-        studio = StudioTools(registry=registry, db=db)
-
-        result = _loads(studio.list_functions())
-        assert result["count"] == 1
-        assert result["functions"][0]["name"] == "transform_content"
-        assert result["functions"][0]["description"] == "Transform content for a workflow step."
-        assert result["functions"][0]["signature"] == "(value: str) -> str"
-
-    def test_list_dbs(self, studio, db):
-        result = _loads(studio.list_dbs())
-        assert result["count"] == 1
-        assert result["dbs"][0]["id"] == db.id
-
-    def test_list_agents_includes_studio_created_db_components(self, registry, db):
-        code_agent = Agent(id="code-only", name="Code Only", model=OpenAIResponses(id="gpt-5.4"))
-        tool = StudioTools(registry=registry, db=db, agents_list=[code_agent])
-        tool.create_agent(name="math-king", instructions="i", model_id="gpt-5.4")
-
-        result = _loads(tool.list_agents())
-        ids = {a["id"]: a.get("source") for a in result["agents"]}
-        assert ids.get("code-only") == "code"
-        assert ids.get("math-king") == "db"
-
-    def test_list_agents_dedupes_when_code_shadows_db(self, registry, db):
-        tool = StudioTools(registry=registry, db=db)
-        tool.create_agent(name="shared", instructions="i", model_id="gpt-5.4")
-
-        code_agent = Agent(id="shared", name="Shared Code", model=OpenAIResponses(id="gpt-5.4"))
-        tool2 = StudioTools(registry=registry, db=db, agents_list=[code_agent])
-
-        result = _loads(tool2.list_agents())
-        shared_entries = [a for a in result["agents"] if a["id"] == "shared"]
-        assert len(shared_entries) == 1
-        assert shared_entries[0]["source"] == "code"
-
-    def test_list_agents_dedupes_code_without_id_by_name(self, registry, db):
-        tool = StudioTools(registry=registry, db=db)
-        tool.create_agent(name="Shared Name", instructions="i", model_id="gpt-5.4")
-
-        code_agent = Agent(name="Shared Name", model=OpenAIResponses(id="gpt-5.4"))
-        tool2 = StudioTools(registry=registry, db=db, agents_list=[code_agent])
-
-        result = _loads(tool2.list_agents())
-        shared_entries = [a for a in result["agents"] if a["name"] == "Shared Name"]
-        assert len(shared_entries) == 1
-        assert shared_entries[0]["source"] == "code"
-
-    def test_list_agents_keeps_db_component_whose_id_equals_a_code_name(self, registry, db):
-        # A code agent id="code-1" is *named* "support"; a distinct DB agent has id "support".
-        # get_/run_/edit_ all resolve "support" to the DB component (exact id wins), so the
-        # listing must not hide it behind the code agent's name.
-        seed = StudioTools(registry=registry, db=db)
-        seed.create_agent(name="support", instructions="i", model_id="gpt-5.4")  # DB id "support"
-
-        code_agent = Agent(id="code-1", name="support", model=OpenAIResponses(id="gpt-5.4"))
-        studio = StudioTools(registry=registry, db=db, agents_list=[code_agent])
-        out = _loads(studio.list_agents())
-        ids = {a["id"] for a in out["agents"]}
-        assert "code-1" in ids
-        assert "support" in ids  # DB component stays discoverable, not shadowed by the code name
-
-    def test_list_teams_includes_db_components(self, registry, db):
-        tool = StudioTools(registry=registry, db=db, teams=True)
-        tool.create_agent(name="a1", instructions="i", model_id="gpt-5.4")
-        tool.create_team(name="squad", instructions="i", member_ids=["a1"], model_id="gpt-5.4")
-
-        result = _loads(tool.list_teams())
-        ids = {t["id"]: t.get("source") for t in result["teams"]}
-        assert ids.get("squad") == "db"
-
-    def test_list_workflows_includes_db_components(self, registry, db):
-        tool = StudioTools(registry=registry, db=db, workflows=True)
-        tool.create_agent(name="a1", instructions="i", model_id="gpt-5.4")
-        tool.create_workflow(name="pipeline", description="d", step_specs=[{"name": "s1", "agent_id": "a1"}])
-
-        result = _loads(tool.list_workflows())
-        ids = {w["id"]: w.get("source") for w in result["workflows"]}
-        assert ids.get("pipeline") == "db"
-
-
-# ----------------------------------------------------------------------
-# Creation
-# ----------------------------------------------------------------------
-
-
-class TestCreateAgent:
-    def test_happy_path_persists_component(self, studio, db):
-        out = _loads(
-            studio.create_agent(
-                name="news-scout",
-                instructions="Summarize tech news.",
-                model_id="gpt-5.4",
-                tool_names=["calculator"],
-            )
-        )
-        assert out["status"] == "created"
-        assert out["id"] == "news-scout"
-        assert out["tools"] == ["calculator"]
-        assert out["db_version"] == 1
-
-        component = db.get_component("news-scout")
-        assert component is not None
-        assert component["component_type"] == "agent"
-
-    def test_unknown_model_returns_error(self, studio):
-        out = _loads(studio.create_agent(name="x", instructions="i", model_id="does-not-exist", tool_names=[]))
-        assert "error" in out
-        assert "Model not found" in out["error"]
-
-    def test_unknown_tool_returns_error(self, studio):
-        out = _loads(studio.create_agent(name="x", instructions="i", model_id="gpt-5.4", tool_names=["nonexistent"]))
-        assert "error" in out
-        assert "Tools not found" in out["error"]
-
-    def test_create_without_tools(self, studio):
-        out = _loads(studio.create_agent(name="plain", instructions="i", model_id="gpt-5.4"))
-        assert out["status"] == "created"
-        assert out["tools"] == []
-
-    def test_slug_collisions_get_unique_ids(self, studio, db):
-        first = _loads(studio.create_agent(name="My Agent", instructions="i", model_id="gpt-5.4"))
-        second = _loads(studio.create_agent(name="my-agent", instructions="i", model_id="gpt-5.4"))
-        third = _loads(studio.create_agent(name="My--Agent", instructions="i", model_id="gpt-5.4"))
-
-        assert first["id"] == "my-agent"
-        assert second["id"] == "my-agent-2"
-        assert third["id"] == "my-agent-3"
-        assert db.get_component("my-agent")["name"] == "My Agent"
-        assert db.get_component("my-agent-2")["name"] == "my-agent"
-        assert db.get_component("my-agent-3")["name"] == "My--Agent"
-
-    def test_component_ids_share_global_namespace(self, studio):
-        studio.create_agent(name="member", instructions="i", model_id="gpt-5.4")
-        team = _loads(studio.create_team(name="Reporter", instructions="i", member_ids=["member"], model_id="gpt-5.4"))
-        agent = _loads(studio.create_agent(name="reporter", instructions="i", model_id="gpt-5.4"))
-
-        assert team["id"] == "reporter"
-        assert agent["id"] == "reporter-2"
-
-    def test_persist_failure_returns_error(self, studio, db, monkeypatch):
-        def fail_upsert_config(*args, **kwargs):
-            raise RuntimeError("persist failed")
-
-        monkeypatch.setattr(db, "upsert_config", fail_upsert_config)
-
-        out = _loads(studio.create_agent(name="broken", instructions="i", model_id="gpt-5.4"))
-        assert "error" in out
-        assert "persist failed" in out["error"]
-
-    @pytest.mark.asyncio
-    async def test_async_create_agent_persists_component(self, studio, db):
-        out = _loads(await studio.acreate_agent(name="async-agent", instructions="i", model_id="gpt-5.4"))
-        assert out["status"] == "created"
-        assert db.get_component("async-agent") is not None
-
-    def test_history_on_by_default(self, studio, db):
-        out = _loads(studio.create_agent(name="mem", instructions="i", model_id="gpt-5.4"))
-        assert out["add_history_to_context"] is True
-
-        config = db.get_config("mem")["config"]
-        assert config["add_history_to_context"] is True
-        assert config["num_history_runs"] == 3  # Agent.__init__ normalization
-
-    def test_stateless_opt_out_omits_history_from_config(self, studio, db):
-        out = _loads(
-            studio.create_agent(name="stateless", instructions="i", model_id="gpt-5.4", add_history_to_context=False)
-        )
-        assert out["add_history_to_context"] is False
-
-        # to_dict omits falsy add_history_to_context, so the key is absent.
-        config = db.get_config("stateless")["config"]
-        assert "add_history_to_context" not in config
-
-    def test_explicit_num_history_runs_round_trips(self, studio, db):
-        studio.create_agent(name="deep", instructions="i", model_id="gpt-5.4", num_history_runs=10)
-
-        config = db.get_config("deep")["config"]
-        assert config["num_history_runs"] == 10
-
-        agent = studio._load_agent_from_db("deep")
-        assert agent.add_history_to_context is True
-        assert agent.num_history_runs == 10
-
-    def test_toolkit_default_num_history_runs_applies(self, registry, db):
-        tool = StudioTools(registry=registry, db=db, default_num_history_runs=5)
-        tool.create_agent(name="five", instructions="i", model_id="gpt-5.4")
-
-        config = db.get_config("five")["config"]
-        assert config["num_history_runs"] == 5
-
-    @pytest.mark.asyncio
-    async def test_async_create_agent_stateless(self, studio, db):
-        out = _loads(
-            await studio.acreate_agent(
-                name="async-stateless", instructions="i", model_id="gpt-5.4", add_history_to_context=False
-            )
-        )
-        assert out["add_history_to_context"] is False
-        config = db.get_config("async-stateless")["config"]
-        assert "add_history_to_context" not in config
-
-    def test_datetime_on_by_default(self, studio, db):
-        out = _loads(studio.create_agent(name="dated", instructions="i", model_id="gpt-5.4"))
-        assert out["add_datetime_to_context"] is True
-
-        config = db.get_config("dated")["config"]
-        assert config["add_datetime_to_context"] is True
-
-    def test_datetime_opt_out_omits_key_from_config(self, studio, db):
-        out = _loads(
-            studio.create_agent(name="undated", instructions="i", model_id="gpt-5.4", add_datetime_to_context=False)
-        )
-        assert out["add_datetime_to_context"] is False
-
-        # to_dict omits falsy add_datetime_to_context, so the key is absent.
-        config = db.get_config("undated")["config"]
-        assert "add_datetime_to_context" not in config
-
-    @pytest.mark.asyncio
-    async def test_async_create_agent_datetime_opt_out(self, studio, db):
-        out = _loads(
-            await studio.acreate_agent(
-                name="async-undated", instructions="i", model_id="gpt-5.4", add_datetime_to_context=False
-            )
-        )
-        assert out["add_datetime_to_context"] is False
-        config = db.get_config("async-undated")["config"]
-        assert "add_datetime_to_context" not in config
-
-
-class TestToolNameResolution:
-    """Multiple MCP servers in one registry must stay independently addressable."""
-
-    @pytest.fixture
-    def mcp_registry(self, db):
-        pytest.importorskip("mcp")
-        from agno.tools.mcp import MCPTools
-
-        docs = MCPTools(url="https://docs.example.com/mcp")
-        search = MCPTools(url="https://search.example.com/mcp")
-        registry = Registry(
-            name="MCP Registry",
-            tools=[docs, search],
-            models=[OpenAIResponses(id="gpt-5.5")],
-            dbs=[db],
-        )
-        return registry, docs, search
-
-    def test_two_mcp_toolkits_are_independently_listable(self, mcp_registry, db):
-        registry, docs, search = mcp_registry
-        studio = StudioTool(registry=registry, db=db)
-
-        result = _loads(studio.list_tools())
-        names = [t["name"] for t in result["tools"]]
-        assert len(names) == len(set(names))
-        assert docs.name in names and search.name in names
-
-    def test_two_mcp_toolkits_survive_add_tool_dedup(self, mcp_registry):
-        registry, docs, search = mcp_registry
-        fresh = Registry()
-        fresh.add_tool(docs)
-        fresh.add_tool(search)
-        assert docs in fresh.tools and search in fresh.tools
-
-    def test_create_agent_selects_the_right_mcp_toolkit_by_name(self, mcp_registry, db):
-        registry, docs, search = mcp_registry
-        studio = StudioTool(registry=registry, db=db)
-
-        assert studio._find_tool(docs.name) is docs
-        assert studio._find_tool(search.name) is search
-
-        # Simulate a connected toolkit: create_agent refuses toolkits with no
-        # functions, since they would persist as an empty tool set.
-        search.functions["web_search"] = Function(
-            name="web_search",
-            parameters={"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
-            skip_entrypoint_processing=True,
+            "publish_component",
+            "set_current_version",
+            "delete_version",
+            "archive_agent",
+            "restore_agent",
+        ):
+            assert studio.functions[name].requires_confirmation is True
+            assert studio.async_functions[name].requires_confirmation is True
+        for name in ("run_agent", "get_agent"):
+            assert studio.functions[name].requires_confirmation is not True
+
+        assert "require confirmation even for drafts" in studio.instructions
+
+    def test_team_and_workflow_create_edit_confirmation_is_symmetric(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            teams=True,
+            workflows=True,
         )
 
-        out = _loads(
-            studio.create_agent(name="web-search-agent", instructions="Search the web.", tool_names=[search.name])
+        for name in (
+            "create_agent",
+            "edit_agent",
+            "create_team",
+            "edit_team",
+            "create_workflow",
+            "edit_workflow",
+        ):
+            assert tool.functions[name].requires_confirmation is True
+            assert tool.async_functions[name].requires_confirmation is True
+
+    def test_all_enabled_tool_schemas_are_complete_and_match_async(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            teams=True,
+            workflows=True,
         )
-        assert out["status"] == "created"
-        assert out["tools"] == [search.name]
+        missing: list[str] = []
+        unresolved_refs: list[str] = []
 
-    def test_ambiguous_tool_name_errors_instead_of_first_matching(self, db):
-        def alpha():
-            pass
+        def collect_missing(value: Any, path: str) -> None:
+            if isinstance(value, dict):
+                for unsupported_key in ("$defs", "$ref"):
+                    if unsupported_key in value:
+                        unresolved_refs.append(f"{path}/{unsupported_key}")
+                properties = value.get("properties")
+                if isinstance(properties, dict):
+                    for field_name, field_schema in properties.items():
+                        if not isinstance(field_schema, dict) or not field_schema.get("description"):
+                            missing.append(f"{path}/{field_name}")
+                for key, nested in value.items():
+                    collect_missing(nested, f"{path}/{key}")
+            elif isinstance(value, list):
+                for index, nested in enumerate(value):
+                    collect_missing(nested, f"{path}/{index}")
 
-        def beta():
-            pass
+        for name, function in tool.functions.items():
+            async_function = tool.async_functions[name]
+            function.process_entrypoint()
+            async_function.process_entrypoint()
+            collect_missing(function.parameters, name)
+            assert async_function.parameters == function.parameters, name
+            assert async_function.description == function.description, name
 
-        registry = Registry(
-            name="Ambiguous Registry",
-            tools=[Toolkit(name="dup", tools=[alpha]), Toolkit(name="dup", tools=[beta])],
-            models=[OpenAIResponses(id="gpt-5.5")],
-            dbs=[db],
-        )
-        studio = StudioTool(registry=registry, db=db)
+        assert missing == []
+        assert unresolved_refs == []
 
-        with pytest.raises(ValueError, match="ambiguous"):
-            studio._find_tool("dup")
-
-        out = _loads(studio.create_agent(name="x", instructions="i", tool_names=["dup"]))
-        assert "error" in out
-        assert "ambiguous" in out["error"]
-
-    def test_find_tool_by_function_name_stamps_owning_toolkit(self, db):
-        """Selecting a toolkit member by its function name hands back a bare
-        Function; it must carry its toolkit attribution so a component saved
-        with it keeps the "toolkit" key (see Registry.rehydrate_function)."""
-
-        def read_file(path: str) -> str:
-            """Read a file."""
-            return path
-
-        registry = Registry(
-            name="Stamp Registry",
-            tools=[Toolkit(name="agent_files", tools=[read_file])],
-            models=[OpenAIResponses(id="gpt-5.5")],
-            dbs=[db],
-        )
-        studio = StudioTool(registry=registry, db=db)
-
-        member = studio._find_tool("read_file")
-
-        assert isinstance(member, Function)
-        assert member.owning_toolkit == "agent_files"
-
-
-class TestToolkitInstructionPersistence:
-    def test_source_toolkit_survives_every_copy_path(self):
-        """The live Toolkit must survive both copy entry points, including
-        pydantic's own model_copy(deep=True), which calls __deepcopy__() with
-        no memo."""
-        from copy import deepcopy
-
-        from pydantic import BaseModel
-
-        def read_file(path: str) -> str:
-            return path
-
-        toolkit = Toolkit(name="agent_files", tools=[read_file])
-        function = toolkit.get_functions()["read_file"].model_copy()
-        function.source_toolkit = toolkit
-
-        assert deepcopy(function).source_toolkit is toolkit
-        assert function.model_copy(deep=True).source_toolkit is toolkit
-        assert BaseModel.model_copy(function, deep=True).source_toolkit is toolkit
-
-        # The pin must not overwrite a stand-in the in-progress copy already
-        # made: one original may not end up with two stand-ins.
-        copied_toolkit, copied_function = deepcopy([toolkit, function])
-        assert copied_function.source_toolkit is copied_toolkit
-
-    def test_db_loaded_agent_includes_live_toolkit_guidance_once(self, db):
-        creation_guidance = "CREATION_TOOLKIT_GUIDANCE"
-        live_guidance = "LIVE_TOOLKIT_GUIDANCE"
-        first_guidance = "FIRST_FUNCTION_GUIDANCE"
-        second_guidance = "SECOND_FUNCTION_GUIDANCE"
-
-        def first_tool() -> str:
-            return "first"
-
-        def second_tool() -> str:
-            return "second"
-
-        toolkit = Toolkit(
-            name="guided_tools",
-            tools=[first_tool, second_tool],
-            instructions=creation_guidance,
-            add_instructions=True,
-        )
-        toolkit.functions["first_tool"].instructions = first_guidance
-        toolkit.functions["second_tool"].instructions = second_guidance
-        registry = Registry(
-            tools=[toolkit],
-            models=[OpenAIResponses(id="gpt-5.5")],
-            dbs=[db],
-        )
-        studio = StudioTools(registry=registry, db=db)
-
-        result = _loads(
-            studio.create_agent(
-                name="guided-agent",
-                instructions="Base agent guidance.",
-                model_id="gpt-5.5",
-                tool_names=[toolkit.name],
-            )
-        )
-        assert result["status"] == "created"
-
-        persisted_tools = db.get_config("guided-agent")["config"]["tools"]
-        assert len(persisted_tools) == 2
-        assert all(tool["toolkit"] == toolkit.name for tool in persisted_tools)
-        assert all("instructions" not in tool for tool in persisted_tools)
-        assert all("add_instructions" not in tool for tool in persisted_tools)
-
-        # A registry edit after persistence must be visible on the next load.
-        toolkit.instructions = live_guidance
-
-        loaded = studio._load_agent_from_db("guided-agent")
-        assert loaded is not None
-        # AgentOS request resolution deep-copies DB-loaded components.
-        loaded = loaded.deep_copy()
-        assert loaded.tools is not None
-        assert loaded.model is not None
-        assert all(isinstance(tool, Function) for tool in loaded.tools)
-        assert all(tool.source_toolkit is toolkit for tool in loaded.tools if isinstance(tool, Function))
-
-        model_tools = parse_tools(agent=loaded, tools=loaded.tools, model=loaded.model)
-        assert loaded._tool_instructions == [first_guidance, second_guidance, live_guidance]
-        message = loaded.get_system_message(
-            session=AgentSession(session_id="test-session", agent_id=loaded.id),
-            tools=model_tools,
+    def test_schedule_mutations_require_framework_confirmation(self, registry: Registry, db: SqliteDb):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            schedules=True,
         )
 
-        assert message is not None
-        assert isinstance(message.content, str)
-        assert creation_guidance not in message.content
-        assert message.content.count(live_guidance) == 1
+        for name in (
+            "create_schedule",
+            "trigger_schedule",
+            "enable_schedule",
+            "disable_schedule",
+            "delete_schedule",
+        ):
+            assert tool.functions[name].requires_confirmation is True
+            assert tool.async_functions[name].requires_confirmation is True
 
 
-class TestMCPToolkitPersistence:
-    """Registry MCP toolkits must persist their functions and survive rehydration.
+class TestAuthorization:
+    @pytest.mark.parametrize(
+        ("context", "expected_code"),
+        [
+            (None, "auth_context_required"),
+            (RunContext(run_id="r", session_id="s"), "unauthenticated"),
+        ],
+    )
+    def test_missing_framework_context_or_actor_fails_closed(
+        self,
+        studio: StudioTools,
+        context: RunContext | None,
+        expected_code: str,
+    ):
+        result = studio.list_models(_agno_run_context=context)
 
-    Uses stub toolkits with the connected-MCP shape: functions registered on
-    the toolkit at connect time, with a fixed schema and
-    skip_entrypoint_processing=True.
-    """
+        assert _error_code(result) == expected_code
 
-    @staticmethod
-    def _connect(toolkit: Toolkit) -> Function:
-        """Simulate MCPTools.connect(): register a fixed-schema function."""
-
-        async def call_proxy(**kwargs) -> str:
-            return "docs result"
-
-        func = Function(
-            name="search_docs",
-            description="Search the docs.",
-            parameters={"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
-            entrypoint=call_proxy,
-            skip_entrypoint_processing=True,
-        )
-        toolkit.functions[func.name] = func
-        return func
-
-    def _registry(self, db, toolkit: Toolkit) -> Registry:
-        return Registry(
-            name="MCP Persistence Registry",
-            tools=[toolkit],
-            models=[OpenAIResponses(id="gpt-5.5")],
-            dbs=[db],
+    def test_context_lookalike_cannot_spoof_framework_injection(self, studio: StudioTools):
+        spoof = SimpleNamespace(
+            run_id="spoofed-run",
+            session_id="spoofed-session",
+            user_id="admin",
         )
 
-    def test_create_agent_refuses_unconnected_toolkit(self, db):
-        toolkit = Toolkit(name="agno_docs")  # no functions: never connected
-        studio = StudioTool(registry=self._registry(db, toolkit), db=db)
-
-        out = _loads(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
-
-        assert "error" in out
-        assert "agno_docs" in out["error"]
-        assert db.get_component("docs-agent") is None
-
-    def test_edit_agent_refuses_unconnected_toolkit(self, db):
-        toolkit = Toolkit(name="agno_docs")
-        studio = StudioTool(registry=self._registry(db, toolkit), db=db)
-        studio.create_agent(name="docs-agent", instructions="i")
-
-        out = _loads(studio.edit_agent(agent_id="docs-agent", tool_names=["agno_docs"]))
-
-        assert "error" in out
-        assert "agno_docs" in out["error"]
-
-    def test_create_agent_persists_connected_toolkit_functions(self, db):
-        toolkit = Toolkit(name="agno_docs")
-        self._connect(toolkit)
-        studio = StudioTool(registry=self._registry(db, toolkit), db=db)
-
-        out = _loads(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
-        assert out["status"] == "created"
-
-        config = db.get_config("docs-agent")["config"]
-        persisted_tools = config.get("tools")
-        assert persisted_tools, "connected toolkit functions must be persisted"
-        assert [t["name"] for t in persisted_tools] == ["search_docs"]
-        assert persisted_tools[0]["parameters"]["required"] == ["query"]
-
-    def test_rehydrated_agent_resolves_mcp_tools_after_late_connect(self, db):
-        """Simulate a restart: persist with a connected toolkit, then rehydrate
-        against a fresh registry whose toolkit connects only after the
-        entrypoint lookup cache was first built."""
-        toolkit = Toolkit(name="agno_docs")
-        self._connect(toolkit)
-        studio = StudioTool(registry=self._registry(db, toolkit), db=db)
-        studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"])
-
-        # Fresh process: new registry, toolkit not yet connected
-        fresh_toolkit = Toolkit(name="agno_docs")
-        fresh_registry = self._registry(db, fresh_toolkit)
-
-        # Prime the lookup cache before "connect", as startup code paths may
-        assert fresh_registry._entrypoint_lookup == {}
-
-        # The AgentOS lifespan connects the toolkit
-        func = self._connect(fresh_toolkit)
-
-        config = db.get_config("docs-agent")["config"]
-        agent = Agent.from_dict(config, registry=fresh_registry)
-
-        assert agent.tools, "rehydrated agent must keep its MCP tools"
-        rehydrated = {t.name: t for t in agent.tools if isinstance(t, Function)}
-        assert "search_docs" in rehydrated
-        assert rehydrated["search_docs"].entrypoint is func.entrypoint
-        assert rehydrated["search_docs"].skip_entrypoint_processing is True
-
-
-class TestCreateTeam:
-    def _make_members(self, studio):
-        studio.create_agent(name="a1", instructions="i", model_id="gpt-5.4")
-        studio.create_agent(name="a2", instructions="i", model_id="gpt-5.4")
-
-    def test_happy_path(self, studio, db):
-        self._make_members(studio)
-        out = _loads(
-            studio.create_team(
-                name="squad",
-                instructions="coordinate",
-                member_ids=["a1", "a2"],
-                model_id="gpt-5.4",
-            )
-        )
-        assert out["status"] == "created"
-        assert out["member_ids"] == ["a1", "a2"]
-        assert db.get_component("squad")["component_type"] == "team"
-
-    def test_missing_member_returns_error(self, studio):
-        self._make_members(studio)
-        out = _loads(
-            studio.create_team(
-                name="squad",
-                instructions="i",
-                member_ids=["a1", "ghost"],
-                model_id="gpt-5.4",
-            )
-        )
-        assert "error" in out
-        assert "Members not found" in out["error"]
-
-    def test_empty_members_returns_error(self, studio):
-        out = _loads(studio.create_team(name="squad", instructions="i", member_ids=[], model_id="gpt-5.4"))
-        assert "error" in out
-
-    def test_history_and_datetime_on_by_default(self, studio, db):
-        self._make_members(studio)
-        out = _loads(studio.create_team(name="squad", instructions="i", member_ids=["a1"], model_id="gpt-5.4"))
-        assert out["add_history_to_context"] is True
-        assert out["add_datetime_to_context"] is True
-
-        config = db.get_config("squad")["config"]
-        assert config["add_history_to_context"] is True
-        assert config["num_history_runs"] == 3  # Team.__init__ normalization
-        assert config["add_datetime_to_context"] is True
-
-    def test_stateless_opt_out_omits_history_from_config(self, studio, db):
-        self._make_members(studio)
-        out = _loads(
-            studio.create_team(
-                name="squad",
-                instructions="i",
-                member_ids=["a1"],
-                model_id="gpt-5.4",
-                add_history_to_context=False,
-                add_datetime_to_context=False,
-            )
-        )
-        assert out["add_history_to_context"] is False
-        assert out["add_datetime_to_context"] is False
-
-        # to_dict omits falsy flags, so the keys are absent.
-        config = db.get_config("squad")["config"]
-        assert "add_history_to_context" not in config
-        assert "add_datetime_to_context" not in config
-
-    def test_explicit_num_history_runs_round_trips(self, studio, db):
-        self._make_members(studio)
-        studio.create_team(name="squad", instructions="i", member_ids=["a1"], model_id="gpt-5.4", num_history_runs=10)
-
-        config = db.get_config("squad")["config"]
-        assert config["num_history_runs"] == 10
-
-        team = studio._load_team_from_db("squad")
-        assert team.add_history_to_context is True
-        assert team.num_history_runs == 10
-
-    def test_toolkit_default_num_history_runs_applies(self, registry, db):
-        tool = StudioTools(registry=registry, db=db, default_num_history_runs=5)
-        tool.create_agent(name="a1", instructions="i", model_id="gpt-5.4")
-        tool.create_team(name="five", instructions="i", member_ids=["a1"], model_id="gpt-5.4")
-
-        config = db.get_config("five")["config"]
-        assert config["num_history_runs"] == 5
-
-    @pytest.mark.asyncio
-    async def test_async_create_team_stateless(self, studio, db):
-        self._make_members(studio)
-        out = _loads(
-            await studio.acreate_team(
-                name="async-squad",
-                instructions="i",
-                member_ids=["a1"],
-                model_id="gpt-5.4",
-                add_history_to_context=False,
-            )
-        )
-        assert out["add_history_to_context"] is False
-        config = db.get_config("async-squad")["config"]
-        assert "add_history_to_context" not in config
-
-
-class TestCreateWorkflow:
-    def _make_agents(self, studio):
-        studio.create_agent(name="a1", instructions="i", model_id="gpt-5.4")
-        studio.create_agent(name="a2", instructions="i", model_id="gpt-5.4")
-
-    def test_happy_path(self, studio, db):
-        self._make_agents(studio)
-        out = _loads(
-            studio.create_workflow(
-                name="pipeline",
-                description="two steps",
-                step_specs=[
-                    {"name": "s1", "agent_id": "a1"},
-                    {"name": "s2", "agent_id": "a2"},
-                ],
-            )
-        )
-        assert out["status"] == "created"
-        assert out["steps"] == ["s1", "s2"]
-        assert db.get_component("pipeline")["component_type"] == "workflow"
-
-    def test_empty_step_specs_returns_error(self, studio):
-        out = _loads(studio.create_workflow(name="x", description="d", step_specs=[]))
-        assert "error" in out
-
-    def test_missing_agent_in_step_returns_error(self, studio):
-        out = _loads(
-            studio.create_workflow(name="x", description="d", step_specs=[{"name": "s1", "agent_id": "ghost"}])
-        )
-        assert "error" in out
-        assert "Agent not found" in out["error"]
-
-    def test_step_without_executor_returns_error(self, studio):
-        out = _loads(studio.create_workflow(name="x", description="d", step_specs=[{"name": "s1"}]))
-        assert "error" in out
-
-
-# ----------------------------------------------------------------------
-# Edit: draft lifecycle with versions=True, immediate publish without
-# ----------------------------------------------------------------------
-
-
-class TestEditAgent:
-    def _create(self, studio):
-        return _loads(
-            studio.create_agent(name="tutor", instructions="orig", model_id="gpt-5.4", tool_names=["calculator"])
-        )
-
-    def test_edit_produces_draft_v2(self, studio_versioned):
-        self._create(studio_versioned)
-        out = _loads(studio_versioned.edit_agent(agent_id="tutor", instructions="updated"))
-        assert out["status"] == "edited"
-        assert out["stage"] == "draft"
-        assert out["draft_version"] == 2
-
-    def test_second_edit_appends_an_immutable_draft(self, studio_versioned):
-        self._create(studio_versioned)
-        studio_versioned.edit_agent(agent_id="tutor", instructions="updated once")
-        out = _loads(studio_versioned.edit_agent(agent_id="tutor", instructions="updated twice"))
-        assert out["draft_version"] == 3
-
-        versions = _loads(studio_versioned.list_versions("tutor"))
-        stages = [v["stage"] for v in versions["versions"]]
-        assert stages.count("draft") == 2
-        assert stages.count("published") == 1
-
-    def test_successive_partial_edits_accumulate_in_draft(self, studio_versioned):
-        # A second edit must build on the pending draft, not reset to the
-        # published config (which would silently discard the first edit).
-        self._create(studio_versioned)
-        studio_versioned.edit_agent(agent_id="tutor", instructions="new instructions")
-        out = _loads(studio_versioned.edit_agent(agent_id="tutor", description="new description"))
-
-        draft = _loads(studio_versioned.get_version("tutor", version=out["draft_version"]))
-        assert draft["config"]["instructions"] == "new instructions"
-        assert draft["config"]["description"] == "new description"
-
-    def test_edit_turns_history_off_and_keeps_other_fields(self, studio):
-        self._create(studio)
-        out = _loads(studio.edit_agent(agent_id="tutor", add_history_to_context=False))
-        assert out["status"] == "edited"
-
-        got = _loads(studio.get_agent("tutor"))
-        assert got["add_history_to_context"] is False
-        assert got["instructions"] == "orig"
-        assert got["tools"] == ["calculator"]
-
-    def test_edit_num_history_runs_only_keeps_history_on(self, studio):
-        self._create(studio)
-        _loads(studio.edit_agent(agent_id="tutor", num_history_runs=7))
-
-        got = _loads(studio.get_agent("tutor"))
-        assert got["add_history_to_context"] is True  # untouched from create
-        assert got["num_history_runs"] == 7
-
-    def test_history_edit_accumulates_in_latest_draft(self, studio_versioned):
-        self._create(studio_versioned)
-        studio_versioned.edit_agent(agent_id="tutor", add_history_to_context=False)
-        out = _loads(studio_versioned.edit_agent(agent_id="tutor", description="new description"))
-
-        draft = _loads(studio_versioned.get_version("tutor", version=out["draft_version"]))
-        assert "add_history_to_context" not in draft["config"]  # history off survives edit 2
-        assert draft["config"]["description"] == "new description"
-
-    def test_edit_rejects_a_competing_append_after_its_snapshot(self, studio_versioned, db, monkeypatch):
-        from agno.db.base import ComponentVersionGuard
-
-        self._create(studio_versioned)
-        original_save = studio_versioned._save_edit
-
-        def save_after_competing_append(*args, **kwargs):
-            stored = db.get_config("tutor", version=1)
-            assert stored is not None
-            competing = dict(stored["config"])
-            competing["description"] = "competing edit"
-            db.upsert_config(
-                component_id="tutor",
-                config=competing,
-                stage="draft",
-                guard=ComponentVersionGuard(latest_version=1, current_version=1),
-            )
-            return original_save(*args, **kwargs)
-
-        monkeypatch.setattr(studio_versioned, "_save_edit", save_after_competing_append)
-        out = _loads(studio_versioned.edit_agent(agent_id="tutor", instructions="stale edit"))
-
-        assert "version conflict" in out["error"]
-        versions = sorted(db.list_configs("tutor", include_config=True), key=lambda row: row["version"])
-        assert [row["version"] for row in versions] == [1, 2]
-        assert versions[1]["config"]["description"] == "competing edit"
-
-    def test_get_agent_reports_history_settings(self, studio):
-        self._create(studio)
-        got = _loads(studio.get_agent("tutor"))
-        assert got["add_history_to_context"] is True
-        assert got["num_history_runs"] == 3
-
-    def test_edit_turns_datetime_off_and_keeps_other_fields(self, studio):
-        self._create(studio)
-        out = _loads(studio.edit_agent(agent_id="tutor", add_datetime_to_context=False))
-        assert out["status"] == "edited"
-
-        got = _loads(studio.get_agent("tutor"))
-        assert got["add_datetime_to_context"] is False
-        assert got["instructions"] == "orig"
-        assert got["tools"] == ["calculator"]
-
-    def test_get_agent_reports_datetime_setting(self, studio):
-        self._create(studio)
-        got = _loads(studio.get_agent("tutor"))
-        assert got["add_datetime_to_context"] is True
-
-    def test_edit_unknown_agent_returns_error(self, studio):
-        out = _loads(studio.edit_agent(agent_id="ghost", instructions="x"))
-        assert "error" in out
-
-    def test_edit_unknown_model_returns_error(self, studio):
-        self._create(studio)
-        out = _loads(studio.edit_agent(agent_id="tutor", model_id="does-not-exist"))
-        assert "error" in out
-
-    def test_edit_unknown_tool_returns_error(self, studio):
-        self._create(studio)
-        out = _loads(studio.edit_agent(agent_id="tutor", tool_names=["nonexistent"]))
-        assert "error" in out
-
-
-class TestEditWithoutVersioning:
-    """With versions=False (default), edits publish immediately -- no drafts."""
-
-    def test_edit_publishes_immediately(self, studio, db):
-        studio.create_agent(name="tutor", instructions="orig", model_id="gpt-5.4")
-        out = _loads(studio.edit_agent(agent_id="tutor", instructions="updated"))
-        assert out["status"] == "edited"
-        assert out["stage"] == "published"
-        assert out["version"] == 2
-
-        configs = db.list_configs("tutor")
-        assert [c["stage"] for c in configs] == ["published", "published"]
-
-        current = db.get_config("tutor")
-        assert current["version"] == 2
-
-    def test_second_edit_creates_new_published_version(self, studio, db):
-        studio.create_agent(name="tutor", instructions="orig", model_id="gpt-5.4")
-        studio.edit_agent(agent_id="tutor", instructions="edit1")
-        out = _loads(studio.edit_agent(agent_id="tutor", instructions="edit2"))
-        assert out["version"] == 3
-        assert db.get_config("tutor")["version"] == 3
-
-
-class TestEditTeam:
-    def _setup(self, studio):
-        studio.create_agent(name="a1", instructions="i", model_id="gpt-5.4")
-        studio.create_agent(name="a2", instructions="i", model_id="gpt-5.4")
-        studio.create_team(name="squad", instructions="orig", member_ids=["a1"], model_id="gpt-5.4")
-
-    def test_edit_team_members(self, studio_versioned):
-        self._setup(studio_versioned)
-        out = _loads(studio_versioned.edit_team(team_id="squad", member_ids=["a1", "a2"]))
-        assert out["status"] == "edited"
-        assert out["stage"] == "draft"
-
-    def test_edit_team_missing_member_returns_error(self, studio):
-        self._setup(studio)
-        out = _loads(studio.edit_team(team_id="squad", member_ids=["ghost"]))
-        assert "error" in out
-
-    def test_edit_turns_history_off_and_keeps_other_fields(self, studio):
-        self._setup(studio)
-        out = _loads(studio.edit_team(team_id="squad", add_history_to_context=False))
-        assert out["status"] == "edited"
-
-        got = _loads(studio.get_team("squad"))
-        assert got["add_history_to_context"] is False
-        assert got["instructions"] == "orig"
-        assert got["member_ids"] == ["a1"]
-
-    def test_edit_num_history_runs_only_keeps_history_on(self, studio):
-        self._setup(studio)
-        _loads(studio.edit_team(team_id="squad", num_history_runs=7))
-
-        got = _loads(studio.get_team("squad"))
-        assert got["add_history_to_context"] is True  # untouched from create
-        assert got["num_history_runs"] == 7
-
-    def test_get_team_reports_history_and_datetime_settings(self, studio):
-        self._setup(studio)
-        got = _loads(studio.get_team("squad"))
-        assert got["add_history_to_context"] is True
-        assert got["num_history_runs"] == 3
-        assert got["add_datetime_to_context"] is True
-
-    @pytest.mark.asyncio
-    async def test_async_edit_team_datetime_off(self, studio):
-        self._setup(studio)
-        out = _loads(await studio.aedit_team(team_id="squad", add_datetime_to_context=False))
-        assert out["status"] == "edited"
-
-        got = _loads(studio.get_team("squad"))
-        assert got["add_datetime_to_context"] is False
-
-
-class TestEditWorkflow:
-    def _setup(self, studio):
-        studio.create_agent(name="a1", instructions="i", model_id="gpt-5.4")
-        studio.create_workflow(name="pipeline", description="orig", step_specs=[{"name": "s1", "agent_id": "a1"}])
-
-    def test_edit_workflow_description(self, studio):
-        self._setup(studio)
-        out = _loads(studio.edit_workflow(workflow_id="pipeline", description="updated"))
-        assert out["status"] == "edited"
-        assert out["stage"] == "published"
-
-    def test_edit_workflow_produces_draft(self, studio_versioned):
-        self._setup(studio_versioned)
-        out = _loads(studio_versioned.edit_workflow(workflow_id="pipeline", description="updated"))
-        assert out["status"] == "edited"
-        assert out["stage"] == "draft"
-        assert out["draft_version"] == 2
-
-    def test_edit_workflow_bad_step(self, studio):
-        self._setup(studio)
-        out = _loads(studio.edit_workflow(workflow_id="pipeline", step_specs=[{"name": "s1", "agent_id": "ghost"}]))
-        assert "error" in out
-
-
-# ----------------------------------------------------------------------
-# Versioning
-# ----------------------------------------------------------------------
-
-
-class TestVersioning:
-    def _create_and_edit(self, studio):
-        studio.create_agent(name="tutor", instructions="orig", model_id="gpt-5.4", tool_names=["calculator"])
-        studio.edit_agent(agent_id="tutor", instructions="updated")
-
-    def test_list_versions_returns_both(self, studio_versioned):
-        self._create_and_edit(studio_versioned)
-        result = _loads(studio_versioned.list_versions("tutor"))
-        assert result["count"] == 2
-        stages = sorted(v["stage"] for v in result["versions"])
-        assert stages == ["draft", "published"]
-
-    def test_get_version_returns_config(self, studio_versioned):
-        self._create_and_edit(studio_versioned)
-        result = _loads(studio_versioned.get_version("tutor", version=1))
-        assert result.get("version") == 1
-        assert result.get("stage") == "published"
-
-    def test_get_current_version_omits_version(self, studio_versioned):
-        self._create_and_edit(studio_versioned)
-        # The published v1 is current; the pending draft v2 must not be returned.
-        result = _loads(studio_versioned.get_version("tutor"))
-        assert result.get("version") == 1
-        assert result.get("stage") == "published"
-
-    def test_list_versions_marks_current(self, studio_versioned):
-        self._create_and_edit(studio_versioned)
-        by_version = {v["version"]: v for v in _loads(studio_versioned.list_versions("tutor"))["versions"]}
-        assert by_version[1]["is_current"] is True
-        assert by_version[2]["is_current"] is False
-
-        studio_versioned.publish_component("tutor")
-        by_version = {v["version"]: v for v in _loads(studio_versioned.list_versions("tutor"))["versions"]}
-        assert by_version[2]["is_current"] is True
-        assert by_version[1]["is_current"] is False
-
-    def test_draft_metadata_not_visible_until_publish(self, studio_versioned, db):
-        studio_versioned.create_agent(name="tutor", instructions="i", model_id="gpt-5.4", description="original")
-        studio_versioned.edit_agent(agent_id="tutor", description="draft-only")
-        assert db.get_component("tutor")["description"] == "original"
-
-        studio_versioned.publish_component("tutor")
-        assert db.get_component("tutor")["description"] == "draft-only"
-
-    def test_publish_promotes_draft_to_current(self, studio_versioned):
-        self._create_and_edit(studio_versioned)
-        out = _loads(studio_versioned.publish_component("tutor"))
-        assert out["status"] == "published"
-        assert out["version"] == 2
-
-        versions = _loads(studio_versioned.list_versions("tutor"))
-        stages = [v["stage"] for v in versions["versions"]]
-        assert stages.count("published") == 2
-        assert stages.count("draft") == 0
-
-    def test_publish_already_published_version_is_noop(self, studio_versioned):
-        self._create_and_edit(studio_versioned)
-        studio_versioned.publish_component("tutor")  # draft v2 -> published
-
-        # Re-publishing the same (now published) version must not raise the db's
-        # "Cannot update published config" error; it is an idempotent no-op.
-        out = _loads(studio_versioned.publish_component("tutor", version=2))
-        assert out["status"] == "already_published"
-        assert out["version"] == 2
-
-    def test_publish_rejects_a_competing_append_after_its_snapshot(self, studio_versioned, db, monkeypatch):
-        from agno.db.base import ComponentVersionGuard
-
-        self._create_and_edit(studio_versioned)
-        original_upsert = db.upsert_config
-
-        def upsert_after_competing_append(*args, **kwargs):
-            stored = db.get_config("tutor", version=2)
-            assert stored is not None
-            competing = dict(stored["config"])
-            competing["description"] = "newer draft"
-            original_upsert(
-                component_id="tutor",
-                config=competing,
-                stage="draft",
-                guard=ComponentVersionGuard(latest_version=2, current_version=1),
-            )
-            return original_upsert(*args, **kwargs)
-
-        monkeypatch.setattr(db, "upsert_config", upsert_after_competing_append)
-        out = _loads(studio_versioned.publish_component("tutor"))
-
-        assert "version conflict" in out["error"]
-        assert db.get_component("tutor")["current_version"] == 1
-        versions = sorted(db.list_configs("tutor"), key=lambda row: row["version"])
-        assert [(row["version"], row["stage"]) for row in versions] == [
-            (1, "published"),
-            (2, "draft"),
-            (3, "draft"),
+        result = studio.list_models(_agno_run_context=spoof)  # type: ignore[arg-type]
+
+        assert _error_code(result) == "auth_context_required"
+
+    def test_denial_happens_before_component_or_model_lookup(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        calls: list[tuple[str, str, str]] = []
+
+        def deny(context: RunContext, access: str, action: str) -> bool:
+            calls.append((context.user_id or "", access, action))
+            return False
+
+        tool = StudioTools(registry=registry, db=db, authorize=deny, default_model=_model_ref())
+
+        def unexpected_lookup(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("authorization must run before lookup")
+
+        monkeypatch.setattr(db, "get_component", unexpected_lookup)
+        monkeypatch.setattr(registry, "get_model", unexpected_lookup)
+
+        read = tool.get_agent("possibly-secret", _agno_run_context=run_context)
+        mutate = tool.create_agent(_agent_request(component_id="blocked"), _agno_run_context=run_context)
+
+        assert _error_code(read) == "forbidden"
+        assert _error_code(mutate) == "forbidden"
+        assert calls == [
+            ("studio-admin", "read", "get_agent"),
+            ("studio-admin", "mutate", "create_agent"),
         ]
 
-    def test_catalog_v1_bridge_keeps_legacy_upsert_call_shape(self, studio_versioned, db, monkeypatch):
-        self._create_and_edit(studio_versioned)
-        calls: list[Dict[str, Any]] = []
+    def test_denial_does_not_disclose_component_existence(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        allowed = StudioTools(registry=registry, db=db, authorize=_allow, default_model=_model_ref())
+        assert _create_agent(allowed, run_context, component_id="exists").ok is True
+        denied = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=lambda _context, _access, _action: False,
+            default_model=_model_ref(),
+        )
 
-        def capture_upsert(*args, **kwargs):
-            calls.append(kwargs)
-            return {"version": kwargs.get("version") or 3}
+        existing = denied.get_agent("exists", _agno_run_context=run_context)
+        missing = denied.get_agent("missing", _agno_run_context=run_context)
 
-        monkeypatch.setattr(db, "component_catalog_api_version", 1)
-        monkeypatch.setattr(db, "upsert_config", capture_upsert)
+        assert existing.model_dump() == missing.model_dump()
+        assert _error_code(existing) == "forbidden"
 
-        edited = _loads(studio_versioned.edit_agent("tutor", description="legacy edit"))
-        published = _loads(studio_versioned.publish_component("tutor"))
+    def test_authorizer_exception_is_closed_and_sanitized(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        def broken(_context: RunContext, _access: str, _action: str) -> bool:
+            raise RuntimeError("policy backend at postgres://private-policy-db")
 
-        assert edited["status"] == "edited"
-        assert published["status"] == "published"
-        assert len(calls) == 2
-        assert calls[0]["version"] == 2
-        assert calls[0]["stage"] == "draft"
-        assert calls[1]["version"] == 2
-        assert calls[1]["stage"] == "published"
-        assert all("guard" not in call for call in calls)
+        tool = StudioTools(registry=registry, db=db, authorize=broken, default_model=_model_ref())
 
-    def test_publish_unknown_version_returns_error(self, studio_versioned):
-        studio_versioned.create_agent(name="tutor", instructions="i", model_id="gpt-5.4")
-        out = _loads(studio_versioned.publish_component("tutor", version=99))
-        assert "error" in out
+        result = tool.list_agents(_agno_run_context=run_context)
 
-    def test_publish_without_draft_returns_error(self, studio_versioned):
-        studio_versioned.create_agent(name="tutor", instructions="i", model_id="gpt-5.4")
-        out = _loads(studio_versioned.publish_component("tutor"))
-        assert "error" in out
+        assert _error_code(result) == "authorization_failed"
+        assert result.error is not None
+        assert "postgres://" not in result.error.message
+        assert "private-policy-db" not in caplog.text
 
-    def test_set_current_version_rollback(self, studio_versioned):
-        self._create_and_edit(studio_versioned)
-        studio_versioned.publish_component("tutor")  # v2 published & current
-        out = _loads(studio_versioned.set_current_version("tutor", 1))
-        assert out["status"] == "set_current"
-        assert out["version"] == 1
+    def test_non_boolean_authorizer_result_fails_closed(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=lambda _context, _access, _action: "allow",  # type: ignore[arg-type,return-value]
+            default_model=_model_ref(),
+        )
 
-    def test_delete_draft_version(self, studio_versioned):
-        self._create_and_edit(studio_versioned)
-        out = _loads(studio_versioned.delete_version("tutor", 2))
-        assert out["status"] == "deleted"
+        result = tool.list_models(_agno_run_context=run_context)
 
-        versions = _loads(studio_versioned.list_versions("tutor"))
-        assert versions["count"] == 1
-        assert versions["versions"][0]["version"] == 1
+        assert _error_code(result) == "authorization_failed"
 
-    def test_delete_published_version_returns_error(self, studio_versioned):
-        self._create_and_edit(studio_versioned)
-        # v1 is published+current — DB should refuse to delete it
-        out = _loads(studio_versioned.delete_version("tutor", 1))
-        assert "error" in out
+    def test_run_is_denied_before_runner_dispatch(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=lambda _context, _access, _action: False,
+            default_model=_model_ref(),
+        )
 
+        def unexpected_dispatch(*_args: Any, **_kwargs: Any) -> str:
+            raise AssertionError("denied calls must not reach the runner")
 
-# ----------------------------------------------------------------------
-# Schedules: component-aware schedule tools with schedules=True
-# ----------------------------------------------------------------------
+        monkeypatch.setattr(tool._runner_tools, "run_agent", unexpected_dispatch)
 
+        payload = json.loads(tool.run_agent("hidden", "hello", _agno_run_context=run_context))
 
-@pytest.mark.skipif(
-    find_spec("croniter") is None or find_spec("pytz") is None,
-    reason="scheduler extras not installed (pip install agno[scheduler])",
-)
-class TestSchedules:
-    def _create_target_agent(self, studio, name="digest"):
-        return _loads(studio.create_agent(name=name, instructions="i", model_id="gpt-5.4"))
-
-    def _create_schedule(self, studio, **overrides):
-        params = {
-            "name": "daily-digest",
-            "cron": "0 9 * * *",
-            "target_type": "agent",
-            "target_id": "digest",
-            "message": "Send the daily digest.",
-        }
-        params.update(overrides)
-        return _loads(studio.create_schedule(**params))
-
-    def test_create_schedule_for_created_agent_persists_endpoint_and_payload(self, studio_schedules):
-        self._create_target_agent(studio_schedules)
-        out = self._create_schedule(studio_schedules)
-
-        assert out["status"] == "created"
-        assert out["target_type"] == "agent"
-        assert out["target_id"] == "digest"
-        assert out["endpoint"] == "/agents/digest/runs"
-        assert out["enabled"] is True
-
-        schedule = studio_schedules._get_schedule_manager().get(out["id"])
-        assert schedule is not None
-        assert schedule.endpoint == "/agents/digest/runs"
-        assert schedule.method == "POST"
-        assert schedule.payload == {"message": "Send the daily digest."}
-
-    def test_name_based_target_resolves_to_real_component_id(self, registry, db):
-        live = Agent(id="live-agent", name="Live Agent", model=OpenAIResponses(id="gpt-5.4"))
-        tool = StudioTools(registry=registry, db=db, agents_list=[live], schedules=True)
-
-        out = self._create_schedule(tool, target_id="Live Agent")
-        assert out["status"] == "created"
-        assert out["target_id"] == "live-agent"
-        assert out["endpoint"] == "/agents/live-agent/runs"
-
-    def test_unknown_target_returns_error(self, studio_schedules):
-        out = self._create_schedule(studio_schedules, target_id="ghost")
-        assert "error" in out
-        assert "Agent not found: ghost" in out["error"]
-
-    def test_bad_target_type_returns_error(self, studio_schedules):
-        self._create_target_agent(studio_schedules)
-        out = self._create_schedule(studio_schedules, target_type="cron-job")
-        assert "error" in out
-        assert "Invalid target_type" in out["error"]
-
-    def test_invalid_cron_returns_error(self, studio_schedules):
-        self._create_target_agent(studio_schedules)
-        out = self._create_schedule(studio_schedules, cron="not-a-cron")
-        assert "error" in out
-        assert "Invalid cron expression" in out["error"]
-
-    def test_invalid_timezone_returns_error(self, studio_schedules):
-        self._create_target_agent(studio_schedules)
-        out = self._create_schedule(studio_schedules, timezone="Mars/Olympus")
-        assert "error" in out
-        assert "Invalid timezone" in out["error"]
-
-    def test_empty_message_returns_error(self, studio_schedules):
-        self._create_target_agent(studio_schedules)
-        out = self._create_schedule(studio_schedules, message="   ")
-        assert "error" in out
-        assert "message" in out["error"]
-
-    def test_same_name_create_updates_in_place(self, studio_schedules):
-        self._create_target_agent(studio_schedules)
-        first = self._create_schedule(studio_schedules)
-        second = self._create_schedule(studio_schedules, cron="30 18 * * *")
-
-        assert second["id"] == first["id"]
-        assert second["cron"] == "30 18 * * *"
-
-        listed = _loads(_tool(studio_schedules, "list_schedules")())
-        assert listed["count"] == 1
-        assert listed["schedules"][0]["cron"] == "30 18 * * *"
-
-    def test_get_schedule_reports_endpoint_and_payload(self, studio_schedules):
-        self._create_target_agent(studio_schedules)
-        schedule_id = self._create_schedule(studio_schedules)["id"]
-
-        out = _loads(_tool(studio_schedules, "get_schedule")(schedule_id))
-        assert out["endpoint"] == "/agents/digest/runs"
-        assert out["payload"] == {"message": "Send the daily digest."}
-
-    def test_enable_disable_delete_roundtrip(self, studio_schedules):
-        self._create_target_agent(studio_schedules)
-        schedule_id = self._create_schedule(studio_schedules)["id"]
-
-        disabled = _loads(_tool(studio_schedules, "disable_schedule")(schedule_id))
-        assert disabled["status"] == "disabled"
-        assert disabled["enabled"] is False
-        assert _loads(_tool(studio_schedules, "list_schedules")(enabled_only=True))["count"] == 0
-
-        enabled = _loads(_tool(studio_schedules, "enable_schedule")(schedule_id))
-        assert enabled["status"] == "enabled"
-        assert enabled["enabled"] is True
-        assert _loads(_tool(studio_schedules, "list_schedules")(enabled_only=True))["count"] == 1
-
-        deleted = _loads(_tool(studio_schedules, "delete_schedule")(schedule_id))
-        assert deleted["status"] == "deleted"
-        assert _loads(_tool(studio_schedules, "list_schedules")())["count"] == 0
-
-    def test_delete_unknown_schedule_returns_error(self, studio_schedules):
-        out = _loads(_tool(studio_schedules, "delete_schedule")("ghost"))
-        assert "error" in out
-
-    def test_get_schedule_runs_empty_for_new_schedule(self, studio_schedules):
-        self._create_target_agent(studio_schedules)
-        schedule_id = self._create_schedule(studio_schedules)["id"]
-        out = _loads(_tool(studio_schedules, "get_schedule_runs")(schedule_id))
-        assert out["runs"] == []
-        assert out["count"] == 0
-
-    def test_trigger_sets_next_run_at_to_now(self, studio_schedules):
-        self._create_target_agent(studio_schedules)
-        schedule_id = self._create_schedule(studio_schedules)["id"]
-
-        out = _loads(_tool(studio_schedules, "trigger_schedule")(schedule_id))
-        assert out["status"] == "triggered"
-        assert out["id"] == schedule_id
-        assert "poll interval" in out["note"]
-
-        # The poller claims schedules with next_run_at <= now, so the trigger
-        # must have moved next_run_at into the claimable window.
-        schedule = studio_schedules._get_schedule_manager().get(schedule_id)
-        assert schedule.next_run_at <= int(time.time())
-
-    def test_trigger_disabled_schedule_returns_error(self, studio_schedules):
-        self._create_target_agent(studio_schedules)
-        schedule_id = self._create_schedule(studio_schedules)["id"]
-        _tool(studio_schedules, "disable_schedule")(schedule_id)
-
-        out = _loads(_tool(studio_schedules, "trigger_schedule")(schedule_id))
-        assert "error" in out
-        assert "disabled" in out["error"]
-
-    def test_trigger_unknown_schedule_returns_error(self, studio_schedules):
-        out = _loads(_tool(studio_schedules, "trigger_schedule")("ghost"))
-        assert "error" in out
-        assert "Schedule not found" in out["error"]
+        assert payload["ok"] is False
+        assert payload["error"]["code"] == "forbidden"
 
     @pytest.mark.asyncio
-    async def test_async_create_schedule(self, studio_schedules):
-        self._create_target_agent(studio_schedules)
-        out = _loads(
-            await studio_schedules.acreate_schedule(
-                name="async-digest",
+    async def test_async_calls_use_the_same_fail_closed_authorization(self, studio: StudioTools):
+        result = await studio.alist_models()
+
+        assert _error_code(result) == "auth_context_required"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "runner_method"),
+        [
+            ("arun_agent", "arun_agent"),
+            ("arun_team", "arun_team"),
+            ("arun_workflow", "arun_workflow"),
+        ],
+    )
+    async def test_async_run_authorization_does_not_block_the_event_loop_and_denies_before_lookup(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+        method_name: str,
+        runner_method: str,
+    ):
+        from threading import Event, Timer
+
+        started = Event()
+        release = Event()
+
+        def blocking_denial(_context: RunContext, _access: str, _action: str) -> bool:
+            started.set()
+            assert release.wait(timeout=2)
+            return False
+
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=blocking_denial,
+            default_model=_model_ref(),
+            agents=True,
+            teams=True,
+            workflows=True,
+        )
+
+        async def unexpected_lookup(*_args: Any, **_kwargs: Any) -> str:
+            raise AssertionError("denied calls must not reach component lookup or dispatch")
+
+        monkeypatch.setattr(tool._runner_tools, runner_method, unexpected_lookup)
+        failsafe = Timer(0.3, release.set)
+        failsafe.start()
+        try:
+            task = asyncio.create_task(getattr(tool, method_name)("hidden", "hello", _agno_run_context=run_context))
+            while not started.is_set():
+                await asyncio.sleep(0)
+            await asyncio.sleep(0.01)
+            assert not release.is_set(), "the synchronous authorizer blocked the AgentOS event loop"
+            release.set()
+            payload = json.loads(await task)
+        finally:
+            release.set()
+            failsafe.cancel()
+
+        assert payload["error"]["code"] == "forbidden"
+
+    @pytest.mark.asyncio
+    async def test_async_run_methods_honor_disabled_component_flags(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            agents=False,
+            teams=False,
+            workflows=False,
+        )
+        dispatched: list[str] = []
+
+        async def unexpected_dispatch(*_args: Any, **_kwargs: Any) -> str:
+            dispatched.append("called")
+            return "{}"
+
+        for runner_method in ("arun_agent", "arun_team", "arun_workflow"):
+            monkeypatch.setattr(tool._runner_tools, runner_method, unexpected_dispatch)
+
+        for method_name, component_type in (
+            ("arun_agent", "agent"),
+            ("arun_team", "team"),
+            ("arun_workflow", "workflow"),
+        ):
+            payload = json.loads(await getattr(tool, method_name)("hidden", "hello", _agno_run_context=run_context))
+            assert payload["error"]["code"] == "component_type_disabled"
+            assert payload["error"]["details"] == {"component_type": component_type}
+
+        assert dispatched == []
+
+    def test_schedule_is_denied_before_target_or_manager_access(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=lambda _context, _access, _action: False,
+            default_model=_model_ref(),
+            schedules=True,
+        )
+
+        def unexpected_lookup(*_args: Any, **_kwargs: Any) -> str:
+            raise AssertionError("denied schedule calls must not resolve targets")
+
+        monkeypatch.setattr(tool, "_resolve_schedule_target", unexpected_lookup)
+
+        result = tool.create_schedule(
+            ScheduleCreate(
+                name="blocked",
                 cron="0 9 * * *",
                 target_type="agent",
-                target_id="digest",
-                message="Send it.",
+                target_id="hidden",
+                message="hello",
+            ),
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(result) == "forbidden"
+
+
+class TestTypedDiscoveryAndCreate:
+    def test_discovery_returns_copyable_exact_model_and_tool_refs(
+        self,
+        studio: StudioTools,
+        run_context: RunContext,
+    ):
+        model_result = studio.list_models(_agno_run_context=run_context)
+        tool_result = studio.list_tools(_agno_run_context=run_context)
+
+        assert model_result.ok is True
+        assert model_result.data == [_model_ref()]
+        assert tool_result.ok is True
+        assert tool_result.data is not None
+        assert ToolRef(kind="toolkit", name="calculator") in tool_result.data
+        assert ToolRef(kind="function", name="add", toolkit="calculator") in tool_result.data
+
+    def test_agent_create_returns_resolved_safe_view_and_persists_draft(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        request = AgentCreate(
+            component_id="news-scout",
+            name="News Scout",
+            instructions="Summarize technology news.",
+            description="A concise research agent.",
+            tools=[ToolRef(kind="toolkit", name="calculator")],
+        )
+
+        result = studio.create_agent(request, _agno_run_context=run_context)
+
+        assert result.ok is True
+        assert result.status == "created"
+        assert isinstance(result.data, AgentView)
+        assert result.data.component_id == "news-scout"
+        assert result.data.model == _model_ref()
+        assert result.data.tools == request.tools
+        assert result.data.context == ContextPolicy(history_runs=4)
+        assert result.data.version == 1
+        assert result.data.stage == "draft"
+        assert result.data.is_current is False
+        assert result.data.source == "studio"
+
+        component = db.get_component("news-scout", component_type=ComponentType.AGENT)
+        config = db.get_config("news-scout", version=1)
+        assert component is not None
+        assert component["current_version"] is None
+        assert config is not None
+        assert config["stage"] == "draft"
+
+    def test_team_create_reports_wrong_type_stored_member_without_persisting_parent(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            teams=True,
+        )
+        assert _create_agent(tool, run_context, component_id="wrong-type-child", save_as="published").ok
+
+        result = tool.create_team(
+            TeamCreate(
+                component_id="wrong-type-parent",
+                name="Wrong type parent",
+                instructions="Delegate to the referenced team.",
+                members=[ComponentRef(component_type="team", component_id="wrong-type-child")],
+            ),
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(result) == "component_type_mismatch"
+        assert db.get_component("wrong-type-parent", include_deleted=True) is None
+
+    @pytest.mark.parametrize("version", [None, 1])
+    def test_team_create_requires_a_published_stored_member_without_persisting_parent(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        version: int | None,
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            teams=True,
+        )
+        assert _create_agent(tool, run_context, component_id="draft-child").ok
+
+        result = tool.create_team(
+            TeamCreate(
+                component_id="draft-parent",
+                name="Draft parent",
+                instructions="Delegate to the referenced agent.",
+                members=[
+                    ComponentRef(
+                        component_type="agent",
+                        component_id="draft-child",
+                        version=version,
+                    )
+                ],
+            ),
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(result) == "published_version_required"
+        assert db.get_component("draft-parent", include_deleted=True) is None
+
+    def test_exact_model_and_tool_refs_are_enforced(
+        self,
+        studio: StudioTools,
+        run_context: RunContext,
+    ):
+        wrong_model = studio.create_agent(
+            AgentCreate(
+                component_id="wrong-model",
+                name="Wrong model",
+                instructions="Do work.",
+                model=ModelRef(id=MODEL_ID, provider="Not OpenAI", name=MODEL_NAME),
+            ),
+            _agno_run_context=run_context,
+        )
+        unqualified_function = studio.create_agent(
+            AgentCreate(
+                component_id="wrong-tool",
+                name="Wrong tool",
+                instructions="Do work.",
+                tools=[ToolRef(kind="function", name="add")],
+            ),
+            _agno_run_context=run_context,
+        )
+        exact_function = studio.create_agent(
+            AgentCreate(
+                component_id="exact-tool",
+                name="Exact tool",
+                instructions="Do work.",
+                tools=[ToolRef(kind="function", name="add", toolkit="calculator")],
+            ),
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(wrong_model) == "model_not_found"
+        assert _error_code(unqualified_function) == "tool_not_found"
+        assert exact_function.ok is True
+        assert exact_function.data is not None
+        assert exact_function.data.tools == [ToolRef(kind="function", name="add", toolkit="calculator")]
+
+    def test_ambiguous_model_id_requires_provider_and_name(
+        self,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        registry = Registry(
+            models=[OpenAIResponses(id=MODEL_ID), OpenAIChat(id=MODEL_ID)],
+            dbs=[db],
+        )
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=ModelRef(id=MODEL_ID),
+        )
+
+        ambiguous = tool.create_agent(
+            _agent_request(component_id="ambiguous-model"),
+            _agno_run_context=run_context,
+        )
+        exact = tool.create_agent(
+            _agent_request(component_id="exact-model").model_copy(
+                update={"model": ModelRef(id=MODEL_ID, provider=MODEL_PROVIDER, name=MODEL_NAME)}
+            ),
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(ambiguous) == "ambiguous_model"
+        assert exact.ok is True
+
+    def test_selected_tool_refs_cannot_expose_the_same_agent_function_name(
+        self,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        def first_lookup(query: str) -> str:
+            return f"first: {query}"
+
+        def second_lookup(query: str) -> str:
+            return f"second: {query}"
+
+        first_lookup.__name__ = "lookup"
+        second_lookup.__name__ = "lookup"
+        registry = Registry(
+            tools=[Toolkit(name="firstkit", tools=[first_lookup]), Toolkit(name="secondkit", tools=[second_lookup])],
+            models=[OpenAIResponses(id=MODEL_ID)],
+            dbs=[db],
+        )
+        tool = StudioTools(registry=registry, db=db, authorize=_allow, default_model=_model_ref())
+
+        result = tool.create_agent(
+            _agent_request(component_id="duplicate-tool-name").model_copy(
+                update={
+                    "tools": [
+                        ToolRef(kind="function", name="lookup", toolkit="firstkit"),
+                        ToolRef(kind="function", name="lookup", toolkit="secondkit"),
+                    ]
+                }
+            ),
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(result) == "duplicate_tool_name"
+        assert db.get_component("duplicate-tool-name") is None
+
+    def test_unqualified_function_ref_rejects_a_different_toolkit_entrypoint(
+        self,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        def direct_lookup(query: str) -> str:
+            return f"direct: {query}"
+
+        def toolkit_lookup(query: str) -> str:
+            return f"toolkit: {query}"
+
+        direct_lookup.__name__ = "lookup"
+        toolkit_lookup.__name__ = "lookup"
+        registry = Registry(
+            tools=[direct_lookup, Toolkit(name="shadowkit", tools=[toolkit_lookup])],
+            models=[OpenAIResponses(id=MODEL_ID)],
+            dbs=[db],
+        )
+        tool = StudioTools(registry=registry, db=db, authorize=_allow, default_model=_model_ref())
+
+        result = tool.create_agent(
+            _agent_request(component_id="ambiguous-flat-tool").model_copy(
+                update={"tools": [ToolRef(kind="function", name="lookup")]}
+            ),
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(result) == "ambiguous_tool_binding"
+        assert db.get_component("ambiguous-flat-tool") is None
+
+    @pytest.mark.parametrize("select_toolkit", [False, True])
+    def test_agent_create_rejects_functions_without_an_execution_path(
+        self,
+        db: SqliteDb,
+        run_context: RunContext,
+        select_toolkit: bool,
+    ):
+        broken = Function(name="broken", entrypoint=None)
+        registered: Any
+        ref: ToolRef
+        if select_toolkit:
+            registered = Toolkit(name="brokenkit")
+            registered.functions[broken.name] = broken
+            ref = ToolRef(kind="toolkit", name="brokenkit")
+        else:
+            registered = broken
+            ref = ToolRef(kind="function", name="broken")
+        registry = Registry(
+            tools=[registered],
+            models=[OpenAIResponses(id=MODEL_ID)],
+            dbs=[db],
+        )
+        tool = StudioTools(registry=registry, db=db, authorize=_allow, default_model=_model_ref())
+
+        result = tool.create_agent(
+            _agent_request(component_id="broken-tool").model_copy(update={"tools": [ref]}),
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(result) == "tool_not_ready"
+        assert db.get_component("broken-tool", include_deleted=True) is None
+
+    @pytest.mark.parametrize("select_toolkit", [False, True])
+    def test_agent_create_allows_external_execution_without_a_local_entrypoint(
+        self,
+        db: SqliteDb,
+        run_context: RunContext,
+        select_toolkit: bool,
+    ):
+        external = Function(name="handoff", entrypoint=None, external_execution=True)
+        registered: Any
+        ref: ToolRef
+        if select_toolkit:
+            registered = Toolkit(name="external-kit")
+            registered.functions[external.name] = external
+            ref = ToolRef(kind="toolkit", name="external-kit")
+        else:
+            registered = external
+            ref = ToolRef(kind="function", name="handoff")
+        registry = Registry(
+            tools=[registered],
+            models=[OpenAIResponses(id=MODEL_ID)],
+            dbs=[db],
+        )
+        tool = StudioTools(registry=registry, db=db, authorize=_allow, default_model=_model_ref())
+
+        result = tool.create_agent(
+            _agent_request(component_id="external-tool").model_copy(update={"tools": [ref]}),
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+
+        assert result.ok is True
+        assert result.data is not None
+        assert result.data.stage == "published"
+        assert result.data.is_current is True
+
+    def test_code_defined_component_ids_are_reserved(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        code_agent = Agent(id="reserved-id", name="Code agent", model=registry.models[0])
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            agents_list=[code_agent],
+        )
+
+        result = tool.create_agent(
+            _agent_request(component_id="reserved-id"),
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(result) == "component_conflict"
+        assert db.get_component("reserved-id", include_deleted=True) is None
+
+    @pytest.mark.parametrize("stored_type", [ComponentType.AGENT, ComponentType.TEAM])
+    @pytest.mark.parametrize("archived", [False, True])
+    def test_existing_db_and_code_id_collision_fails_closed_for_list_get_and_run(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        stored_type: ComponentType,
+        archived: bool,
+    ):
+        db.create_component_with_config(
+            component_id="collision",
+            component_type=stored_type,
+            name="Stored collision",
+            config={"name": "Stored collision"},
+            stage="published",
+        )
+        if archived:
+            assert db.delete_component("collision")
+
+        code_agent = Agent(
+            id="collision",
+            name="Code collision",
+            instructions="This must never shadow the stored agent.",
+            model=registry.models[0],
+        )
+        collided = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            agents_list=[code_agent],
+        )
+
+        listed = collided.list_agents(_agno_run_context=run_context)
+        fetched = collided.get_agent("collision", _agno_run_context=run_context)
+        run_payload = json.loads(collided.run_agent("collision", "hello", _agno_run_context=run_context))
+
+        assert _error_code(listed) == "component_source_collision"
+        assert _error_code(fetched) == "component_source_collision"
+        assert run_payload["error"]["code"] == "component_source_collision"
+
+    def test_component_list_snapshots_a_volatile_code_id_once_before_collision_lookup(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        db.create_component_with_config(
+            component_id="volatile-collision",
+            component_type=ComponentType.AGENT,
+            name="Stored collision",
+            config={"name": "Stored collision"},
+            stage="published",
+        )
+
+        class VolatileId:
+            name = "Volatile code agent"
+
+            def __init__(self) -> None:
+                self.reads = 0
+
+            @property
+            def id(self) -> str:
+                self.reads += 1
+                return "volatile-collision" if self.reads == 1 else "changed-after-snapshot"
+
+        code_agent = VolatileId()
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            agents_list=[code_agent],  # type: ignore[list-item]
+        )
+
+        result = tool.list_agents(_agno_run_context=run_context)
+
+        assert _error_code(result) == "component_source_collision"
+        assert code_agent.reads == 1
+
+    def test_runtime_create_and_edit_literals_are_validated(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        assert _create_agent(studio, run_context, component_id="literal-guard").ok
+
+        invalid_if_exists = studio.create_agent(
+            _agent_request(component_id="literal-guard", name="literal-guard").model_copy(
+                update={"if_exists": "bogus"}
+            ),
+            _agno_run_context=run_context,
+        )
+        invalid_create_stage = studio.create_agent(
+            _agent_request(component_id="invalid-stage"),
+            save_as="garbage",  # type: ignore[arg-type]
+            _agno_run_context=run_context,
+        )
+        invalid_edit_stage = studio.edit_agent(
+            "literal-guard",
+            AgentPatch(description="Must not persist"),
+            expected_version=1,
+            save_as="garbage",  # type: ignore[arg-type]
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(invalid_if_exists) == "invalid_if_exists"
+        assert _error_code(invalid_create_stage) == "invalid_save_stage"
+        assert _error_code(invalid_edit_stage) == "invalid_save_stage"
+        assert db.get_component("invalid-stage") is None
+        assert [row["version"] for row in db.list_configs("literal-guard")] == [1]
+
+    def test_omitted_component_id_is_deterministic_and_retry_is_idempotent(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        request = _agent_request(name="My GTM Agent")
+
+        first = studio.create_agent(request, _agno_run_context=run_context)
+        duplicate = studio.create_agent(request, _agno_run_context=run_context)
+        retry = studio.create_agent(
+            request.model_copy(update={"if_exists": "return_existing"}),
+            _agno_run_context=run_context,
+        )
+        changed_retry = studio.create_agent(
+            request.model_copy(update={"instructions": "Different instructions.", "if_exists": "return_existing"}),
+            _agno_run_context=run_context,
+        )
+
+        assert first.ok is True
+        assert first.data is not None
+        assert first.data.component_id == "my-gtm-agent"
+        assert _error_code(duplicate) == "component_conflict"
+        assert retry.ok is True
+        assert retry.status == "existing"
+        assert retry.data == first.data
+        assert _error_code(changed_retry) == "component_conflict"
+        assert len(db.list_configs("my-gtm-agent")) == 1
+        assert db.get_component("my-gtm-agent-2") is None
+        stored = db.get_latest_config("my-gtm-agent")
+        assert stored is not None
+        assert "if_exists" not in stored["config"]["_agno_studio"]["request"]
+
+    def test_omitted_component_id_preserves_legacy_safe_slug_punctuation(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        from agno.utils.string import generate_id_from_name
+
+        name = "Analyst v2.5"
+        result = studio.create_agent(_agent_request(name=name), _agno_run_context=run_context)
+
+        assert result.ok
+        assert result.data is not None
+        assert result.data.component_id == "analyst-v2.5"
+        assert result.data.component_id == generate_id_from_name(name)
+        assert db.get_component(generate_id_from_name(name)) is not None
+
+    @pytest.mark.parametrize("name", ["R&D Jörg", "Research/Review", "研究助手", "🚀", "---"])
+    def test_omitted_component_id_requires_an_explicit_path_safe_id_when_legacy_slug_is_unsafe(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+        name: str,
+    ):
+        from agno.utils.string import generate_id_from_name
+
+        legacy_id = generate_id_from_name(name)
+        result = studio.create_agent(_agent_request(name=name), _agno_run_context=run_context)
+
+        assert _error_code(result) == "invalid_component_id"
+        assert db.get_component(legacy_id) is None
+
+    def test_context_patch_rejects_history_runs_while_history_is_disabled(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        created = studio.create_agent(
+            AgentCreate(
+                component_id="context-policy",
+                name="Context policy",
+                instructions="Keep the context contract explicit.",
+                context=ContextPolicy(include_history=False),
+            ),
+            _agno_run_context=run_context,
+        )
+        assert created.ok
+
+        rejected = studio.edit_agent(
+            "context-policy",
+            AgentPatch(context=ContextPolicyPatch(history_runs=7)),
+            expected_version=1,
+            _agno_run_context=run_context,
+        )
+        accepted = studio.edit_agent(
+            "context-policy",
+            AgentPatch(context=ContextPolicyPatch(include_history=True, history_runs=7)),
+            expected_version=1,
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(rejected) == "invalid_context_policy"
+        assert accepted.ok
+        assert accepted.data is not None
+        assert accepted.data.context.include_history is True
+        assert accepted.data.context.history_runs == 7
+        assert sorted(row["version"] for row in db.list_configs("context-policy")) == [1, 2]
+
+    def test_concurrent_first_create_is_atomic_and_idempotent(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        ready = Barrier(2)
+
+        def authorize(_context: RunContext, _access: str, action: str) -> bool:
+            if action == "create_agent":
+                ready.wait()
+            return True
+
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=authorize,
+            default_model=_model_ref(),
+        )
+        request = _agent_request(component_id="concurrent-first-create")
+
+        def create() -> str:
+            result = tool.create_agent(
+                request.model_copy(update={"if_exists": "return_existing"}),
+                _agno_run_context=run_context,
             )
-        )
-        assert out["status"] == "created"
-        assert out["endpoint"] == "/agents/digest/runs"
+            assert result.ok
+            return result.status
 
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            statuses = list(executor.map(lambda _index: create(), range(2)))
 
-# ----------------------------------------------------------------------
-# Delete
-# ----------------------------------------------------------------------
-
-
-class TestDelete:
-    def test_delete_agent_removes_from_db(self, studio, db):
-        studio.create_agent(name="temp", instructions="i", model_id="gpt-5.4")
-        out = _loads(studio.delete_agent("temp"))
-        assert out["status"] == "deleted"
-        assert db.get_component("temp") is None
-
-    def test_delete_unknown_agent_returns_error(self, studio):
-        out = _loads(studio.delete_agent("ghost"))
-        assert "error" in out
-
-    def test_delete_agent_only_deletes_db_component_when_live_agent_shadows_id(self, registry, db):
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="temp", instructions="i", model_id="gpt-5.4")
-
-        class ShadowAgent:
-            id = "temp"
-            name = "temp"
-
-            def delete(self, **kwargs):
-                raise AssertionError("delete_agent should not call delete() on live agents")
-
-        tool = StudioTools(registry=registry, db=db, agents_list=[ShadowAgent()])
-
-        out = _loads(tool.delete_agent("temp"))
-        assert out["status"] == "deleted"
-        assert db.get_component("temp") is None
-
-
-# ----------------------------------------------------------------------
-# Lookup priority
-# ----------------------------------------------------------------------
-
-
-class TestLookup:
-    def test_find_agent_finds_just_created_via_db(self, studio):
-        studio.create_agent(name="cached", instructions="i", model_id="gpt-5.4")
-        agent = studio._find_agent("cached")
-        assert agent is not None
-        assert agent.id == "cached"
-
-    def test_find_agent_falls_back_to_live_list(self, registry, db):
-        live = Agent(id="live-one", name="Live", model=OpenAIResponses(id="gpt-5.4"), db=db)
-        tool = StudioTools(registry=registry, db=db, agents_list=[live])
-        found = tool._find_agent("live-one")
-        assert found is live
-
-    def test_find_agent_falls_back_to_db(self, studio, registry, db):
-        studio.create_agent(name="persisted", instructions="i", model_id="gpt-5.4")
-        fresh = StudioTools(registry=registry, db=db)
-        found = fresh._find_agent("persisted")
-        assert found is not None
-        assert found.id == "persisted"
-
-    def test_edit_code_defined_agent_is_rejected(self, studio, registry, db):
-        # A code-defined (live) agent shadows any DB row at lookup time, so editing
-        # it would write an unreachable draft. edit_* must reject it instead of
-        # silently returning "edited" (review findings 9-12).
-        studio.create_agent(name="shared", instructions="db", model_id="gpt-5.4")
-        live = Agent(id="shared", name="Shared", model=OpenAIResponses(id="gpt-5.4"), instructions="live")
-        tool = StudioTools(registry=registry, db=db, agents_list=[live], versions=True)
-
-        out = _loads(tool.edit_agent(agent_id="shared", instructions="updated-live"))
-
-        assert "error" in out
-        assert "code-defined" in out["error"]
-        assert live.instructions == "live"
-
-
-# ----------------------------------------------------------------------
-# Type guards (a component id of one type must not load as another)
-# ----------------------------------------------------------------------
-
-
-class TestTypeGuards:
-    def _full(self, registry, db):
-        return StudioTools(registry=registry, db=db, teams=True, workflows=True)
-
-    def test_get_agent_rejects_team_id(self, registry, db):
-        tool = self._full(registry, db)
-        tool.create_agent(name="member", instructions="i", model_id="gpt-5.4")
-        tool.create_team(name="squad", instructions="i", member_ids=["member"], model_id="gpt-5.4")
-
-        # 'squad' is a team; loading it as an agent must fail, not return a team-as-agent.
-        out = _loads(tool.get_agent("squad"))
-        assert "error" in out
-
-    def test_run_agent_rejects_team_id(self, registry, db):
-        tool = self._full(registry, db)
-        tool.create_agent(name="member", instructions="i", model_id="gpt-5.4")
-        tool.create_team(name="squad", instructions="i", member_ids=["member"], model_id="gpt-5.4")
-
-        out = _loads(_tool(tool, "run_agent")("squad", message="hi"))
-        assert "error" in out
-
-    def test_get_team_rejects_agent_id(self, registry, db):
-        tool = self._full(registry, db)
-        tool.create_agent(name="solo", instructions="i", model_id="gpt-5.4")
-
-        out = _loads(tool.get_team("solo"))
-        assert "error" in out
-
-    def test_team_member_rejects_workflow_id(self, registry, db):
-        tool = self._full(registry, db)
-        tool.create_agent(name="a1", instructions="i", model_id="gpt-5.4")
-        tool.create_workflow(name="flow", description="d", step_specs=[{"name": "s1", "agent_id": "a1"}])
-
-        # A workflow id is neither an agent nor a team, so it cannot be a member.
-        out = _loads(tool.create_team(name="squad", instructions="i", member_ids=["flow"], model_id="gpt-5.4"))
-        assert "error" in out
-        assert "flow" in out["error"]
-
-    def test_workflow_step_agent_id_rejects_team_id(self, registry, db):
-        tool = self._full(registry, db)
-        tool.create_agent(name="member", instructions="i", model_id="gpt-5.4")
-        tool.create_team(name="squad", instructions="i", member_ids=["member"], model_id="gpt-5.4")
-
-        # 'squad' is a team, so an agent_id step pointing at it must error.
-        out = _loads(
-            tool.create_workflow(name="flow", description="d", step_specs=[{"name": "s1", "agent_id": "squad"}])
-        )
-        assert "error" in out
-
-    def test_get_agent_tool_names_match_create(self, registry, db):
-        tool = self._full(registry, db)
-        created = _loads(
-            tool.create_agent(name="calc", instructions="i", model_id="gpt-5.4", tool_names=["calculator"])
-        )
-        got = _loads(tool.get_agent("calc"))
-        # create_* and get_* must report tools the same way (toolkit name, not expanded fns).
-        assert created["tools"] == ["calculator"]
-        assert got["tools"] == ["calculator"]
-
-
-# ----------------------------------------------------------------------
-# Enable flags
-# ----------------------------------------------------------------------
-
-
-class TestEnableFlags:
-    def test_default_enables_agents_only(self, registry, db):
-        tool = StudioTools(registry=registry, db=db)
-        assert tool.enable_agents is True
-        assert tool.enable_teams is False
-        assert tool.enable_workflows is False
-        names = set(tool.functions.keys())
-        assert "create_agent" in names
-        assert "create_team" not in names
-        assert "create_workflow" not in names
-
-    def test_opt_in_teams(self, registry, db):
-        tool = StudioTools(registry=registry, db=db, teams=True)
-        assert tool.enable_agents is True  # agents stays on by default
-        assert tool.enable_teams is True
-        assert tool.enable_workflows is False
-        names = set(tool.functions.keys())
-        assert "create_team" in names
-
-    def test_agents_disabled_explicitly(self, registry, db):
-        tool = StudioTools(registry=registry, db=db, agents=False, teams=True)
-        assert tool.enable_agents is False
-        assert tool.enable_teams is True
-        names = set(tool.functions.keys())
-        assert "create_agent" not in names
-        assert "create_team" in names
-
-    def test_workflows_only(self, registry, db):
-        tool = StudioTools(registry=registry, db=db, agents=False, workflows=True)
-        assert tool.enable_agents is False
-        assert tool.enable_teams is False
-        assert tool.enable_workflows is True
-        names = set(tool.functions.keys())
-        assert "create_workflow" in names
-        assert "create_agent" not in names
-
-    def test_agents_list_auto_enables_teams_and_workflows(self, registry, db):
-        tool = StudioTools(registry=registry, db=db, agents_list=[])
-        assert tool.enable_agents is True
-        assert tool.enable_teams is True
-        assert tool.enable_workflows is True
-
-    def test_teams_list_auto_enables_workflows(self, registry, db):
-        tool = StudioTools(registry=registry, db=db, teams_list=[])
-        assert tool.enable_workflows is True
-
-    def test_explicit_flag_overrides_auto_enable(self, registry, db):
-        # User passes agents_list but explicitly disables workflows.
-        tool = StudioTools(registry=registry, db=db, agents_list=[], workflows=False)
-        assert tool.enable_workflows is False
-
-    def test_discovery_tools_always_registered(self, registry, db):
-        # Even with everything disabled, discovery tools stay registered.
-        tool = StudioTools(registry=registry, db=db, agents=False)
-        names = set(tool.functions.keys())
-        assert {
-            "list_models",
-            "list_tools",
-            "list_functions",
-            "list_dbs",
-            "list_agents",
-            "list_teams",
-            "list_workflows",
-        }.issubset(names)
-
-
-# ----------------------------------------------------------------------
-# Run serialization: non-JSON content must not crash run_* tools
-# ----------------------------------------------------------------------
-
-
-class _StubRunOutput:
-    def __init__(self):
-        self.content = datetime(2026, 1, 1)
-
-
-class _StubAgent:
-    id = "stub"
-    name = "Stub"
-
-    def run(self, message, stream=None, user_id=None, session_id=None):
-        return _StubRunOutput()
-
-    async def arun(self, message, stream=None, user_id=None, session_id=None):
-        return _StubRunOutput()
-
-    def deep_copy(self):
-        # A distinct instance that shares state, the shape _fresh_copy accepts.
-        clone = object.__new__(type(self))
-        clone.__dict__ = self.__dict__
-        return clone
-
-
-class TestRunSerialization:
-    def test_run_agent_serializes_non_json_content(self, registry, db):
-        tool = StudioTools(registry=registry, db=db, agents_list=[_StubAgent()])
-        out = _loads(_tool(tool, "run_agent")("stub", "hi"))
-        assert "error" not in out
-        assert out["content"].startswith("2026-01-01")
+        assert sorted(statuses) == ["created", "existing"]
+        assert [row["version"] for row in db.list_configs("concurrent-first-create")] == [1]
 
     @pytest.mark.asyncio
-    async def test_arun_agent_serializes_non_json_content(self, registry, db):
-        tool = StudioTools(registry=registry, db=db, agents_list=[_StubAgent()])
-        out = _loads(await tool.async_functions["run_agent"].entrypoint("stub", "hi"))
-        assert "error" not in out
-        assert out["content"].startswith("2026-01-01")
-
-
-# ----------------------------------------------------------------------
-# Non-cascading persistence: code-defined members should NOT land in DB
-# ----------------------------------------------------------------------
-
-
-class TestNoCascadePersistence:
-    def test_create_team_does_not_persist_code_defined_member(self, registry, db):
-        greeter = Agent(id="greeter-code", name="Greeter", model=OpenAIResponses(id="gpt-5.4"))
-        tool = StudioTools(registry=registry, db=db, agents_list=[greeter])
-
-        tool.create_agent(name="studio-agent", instructions="i", model_id="gpt-5.4")
-        tool.create_team(
-            name="mixed-team",
-            instructions="i",
-            member_ids=["greeter-code", "studio-agent"],
-            model_id="gpt-5.4",
+    async def test_async_create_uses_the_same_typed_result_contract(
+        self,
+        studio: StudioTools,
+        run_context: RunContext,
+    ):
+        result = await studio.acreate_agent(
+            _agent_request(component_id="async-agent"),
+            _agno_run_context=run_context,
         )
 
-        # Team row exists
-        assert db.get_component("mixed-team") is not None
-        # Studio-created agent row exists
-        assert db.get_component("studio-agent") is not None
-        # Code-defined agent MUST NOT be in DB
-        assert db.get_component("greeter-code") is None
-
-    def test_create_workflow_does_not_persist_code_defined_agent(self, registry, db):
-        greeter = Agent(id="greeter-code", name="Greeter", model=OpenAIResponses(id="gpt-5.4"))
-        tool = StudioTools(registry=registry, db=db, agents_list=[greeter])
-
-        tool.create_workflow(
-            name="wf",
-            description="d",
-            step_specs=[{"name": "s1", "agent_id": "greeter-code"}],
-        )
-        assert db.get_component("wf") is not None
-        assert db.get_component("greeter-code") is None
-
-
-# ----------------------------------------------------------------------
-# Integration: whole lifecycle in order
-# ----------------------------------------------------------------------
+        assert isinstance(result, StudioResult)
+        assert result.ok is True
+        assert isinstance(result.data, AgentView)
+        assert result.data.component_id == "async-agent"
+        assert result.data.stage == "draft"
 
 
 class TestLifecycle:
-    def test_full_lifecycle(self, studio_versioned, db):
-        # Create
-        out = _loads(
-            studio_versioned.create_agent(name="lc", instructions="orig", model_id="gpt-5.4", tool_names=["calculator"])
+    def test_draft_is_not_current_until_explicit_publish(
+        self,
+        studio: StudioTools,
+        run_context: RunContext,
+    ):
+        created = _create_agent(studio, run_context, component_id="draft-only")
+
+        current = studio.get_agent("draft-only", _agno_run_context=run_context)
+        exact_draft = studio.get_agent("draft-only", version=1, _agno_run_context=run_context)
+        run_payload = json.loads(studio.run_agent("draft-only", "hello", _agno_run_context=run_context))
+
+        assert created.data is not None
+        assert created.data.stage == "draft"
+        assert created.data.is_current is False
+        assert _error_code(current) == "published_version_not_found"
+        assert exact_draft.ok is True
+        assert exact_draft.data is not None
+        assert exact_draft.data.stage == "draft"
+        assert "error" in run_payload
+
+    def test_publish_edit_cas_and_rollback_lifecycle(
+        self,
+        studio: StudioTools,
+        run_context: RunContext,
+    ):
+        assert _create_agent(studio, run_context, component_id="lifecycle").ok is True
+
+        published_v1 = studio.publish_component(
+            "lifecycle",
+            version=1,
+            expected_current_version=None,
+            _agno_run_context=run_context,
         )
-        assert out["db_version"] == 1
+        edited_v2 = studio.edit_agent(
+            "lifecycle",
+            AgentPatch(description="Version two"),
+            expected_version=1,
+            _agno_run_context=run_context,
+        )
+        still_current_v1 = studio.get_agent("lifecycle", _agno_run_context=run_context)
+        stale_edit = studio.edit_agent(
+            "lifecycle",
+            AgentPatch(description="Stale edit"),
+            expected_version=1,
+            _agno_run_context=run_context,
+        )
+        stale_publish = studio.publish_component(
+            "lifecycle",
+            version=2,
+            expected_current_version=None,
+            _agno_run_context=run_context,
+        )
+        published_v2 = studio.publish_component(
+            "lifecycle",
+            version=2,
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+        stale_rollback = studio.set_current_version(
+            "lifecycle",
+            version=1,
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+        rollback = studio.set_current_version(
+            "lifecycle",
+            version=1,
+            expected_current_version=2,
+            _agno_run_context=run_context,
+        )
 
-        # Every edit appends an immutable draft and builds on the latest one.
-        studio_versioned.edit_agent(agent_id="lc", instructions="edit1")
-        studio_versioned.edit_agent(agent_id="lc", instructions="edit2")
+        assert published_v1.ok is True
+        assert published_v1.data is not None
+        assert published_v1.data.stage == "published"
+        assert published_v1.data.is_current is True
+        assert edited_v2.ok is True
+        assert edited_v2.data is not None
+        assert edited_v2.data.version == 2
+        assert edited_v2.data.stage == "draft"
+        assert edited_v2.data.is_current is False
+        assert still_current_v1.ok is True
+        assert still_current_v1.data is not None
+        assert still_current_v1.data.version == 1
+        assert still_current_v1.data.description is None
+        assert _error_code(stale_edit) == "version_conflict"
+        assert _error_code(stale_publish) == "version_conflict"
+        assert published_v2.ok is True
+        assert published_v2.data is not None
+        assert published_v2.data.version == 2
+        assert published_v2.data.is_current is True
+        assert _error_code(stale_rollback) == "version_conflict"
+        assert rollback.ok is True
+        assert rollback.status == "current_version_set"
+        assert rollback.data is not None
+        assert rollback.data.version == 1
+        assert rollback.data.is_current is True
 
-        versions: list[Dict[str, Any]] = _loads(studio_versioned.list_versions("lc"))["versions"]
-        assert len(versions) == 3
+        versions = studio.list_versions("lifecycle", _agno_run_context=run_context)
+        assert versions.ok is True
+        assert versions.data is not None
+        assert {item.version: item.is_current for item in versions.data} == {1: True, 2: False}
 
-        # Publish the latest draft.
-        pub = _loads(studio_versioned.publish_component("lc"))
-        assert pub["version"] == 3
+    def test_publish_and_set_current_revalidate_registry_dependencies(
+        self,
+        studio: StudioTools,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        draft = studio.create_agent(
+            AgentCreate(
+                component_id="publishability-draft",
+                name="Publishability draft",
+                instructions="Use the registered calculator.",
+                tools=[ToolRef(kind="function", name="add", toolkit="calculator")],
+            ),
+            _agno_run_context=run_context,
+        )
+        assert draft.ok
 
-        # Rollback
-        rb = _loads(studio_versioned.set_current_version("lc", 1))
-        assert rb["status"] == "set_current"
+        assert _create_agent(studio, run_context, component_id="rollback-publishability", save_as="published").ok
+        published_v2 = studio.edit_agent(
+            "rollback-publishability",
+            AgentPatch(tools=[ToolRef(kind="function", name="add", toolkit="calculator")]),
+            expected_version=1,
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+        assert published_v2.ok
+        assert studio.set_current_version(
+            "rollback-publishability",
+            version=1,
+            expected_current_version=2,
+            _agno_run_context=run_context,
+        ).ok
 
-        # Delete
-        _loads(studio_versioned.delete_agent("lc"))
-        assert db.get_component("lc") is None
+        registry.tools.clear()
+
+        publish = studio.publish_component(
+            "publishability-draft",
+            version=1,
+            expected_current_version=None,
+            _agno_run_context=run_context,
+        )
+        set_current = studio.set_current_version(
+            "rollback-publishability",
+            version=2,
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(publish) == "tool_not_found"
+        assert _error_code(set_current) == "tool_not_found"
+        assert db.get_component("publishability-draft")["current_version"] is None  # type: ignore[index]
+        assert db.get_component("rollback-publishability")["current_version"] == 1  # type: ignore[index]
+
+    def test_immediate_publish_recursively_revalidates_pinned_children(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            teams=True,
+        )
+        child = tool.create_agent(
+            AgentCreate(
+                component_id="strict-child",
+                name="Strict child",
+                instructions="Use the registered calculator.",
+                tools=[ToolRef(kind="function", name="add", toolkit="calculator")],
+            ),
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+        assert child.ok
+
+        registry.tools.clear()
+
+        parent = tool.create_team(
+            TeamCreate(
+                component_id="strict-parent",
+                name="Strict parent",
+                instructions="Delegate to the pinned child.",
+                members=[ComponentRef(component_type="agent", component_id="strict-child", version=1)],
+            ),
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(parent) in {"tool_not_found", "component_not_publishable"}
+        assert db.get_component("strict-parent") is None
+
+    def test_immediate_publish_refuses_a_new_root_past_the_runner_depth_bound(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from agno.tools import studio_runner as runner_module
+
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            teams=True,
+        )
+        monkeypatch.setattr(runner_module, "_GRAPH_MAX_DEPTH", 1)
+
+        assert _create_agent(tool, run_context, component_id="depth-leaf", save_as="published").ok
+        boundary = tool.create_team(
+            TeamCreate(
+                component_id="depth-boundary",
+                name="Depth boundary",
+                instructions="Coordinate the leaf.",
+                members=[ComponentRef(component_type="agent", component_id="depth-leaf", version=1)],
+            ),
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+        refused = tool.create_team(
+            TeamCreate(
+                component_id="depth-past-boundary",
+                name="Depth past boundary",
+                instructions="Coordinate the nested team.",
+                members=[ComponentRef(component_type="team", component_id="depth-boundary", version=1)],
+            ),
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+
+        assert boundary.ok
+        assert _error_code(refused) == "component_not_publishable"
+        assert db.get_component("depth-past-boundary") is None
+
+    def test_immediate_published_edit_refuses_a_root_past_the_runner_node_bound(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from agno.tools import studio_runner as runner_module
+
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            teams=True,
+        )
+        for component_id in ("node-a", "node-b", "node-c"):
+            assert _create_agent(tool, run_context, component_id=component_id, save_as="published").ok
+        created = tool.create_team(
+            TeamCreate(
+                component_id="node-root",
+                name="Node root",
+                instructions="Coordinate the members.",
+                members=[ComponentRef(component_type="agent", component_id="node-a", version=1)],
+            ),
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+        assert created.ok
+        monkeypatch.setattr(runner_module, "_GRAPH_MAX_NODES", 3)
+
+        boundary = tool.edit_team(
+            "node-root",
+            TeamPatch(
+                members=[
+                    ComponentRef(component_type="agent", component_id="node-a", version=1),
+                    ComponentRef(component_type="agent", component_id="node-b", version=1),
+                ]
+            ),
+            expected_version=1,
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+        refused = tool.edit_team(
+            "node-root",
+            TeamPatch(
+                members=[
+                    ComponentRef(component_type="agent", component_id="node-a", version=1),
+                    ComponentRef(component_type="agent", component_id="node-b", version=1),
+                    ComponentRef(component_type="agent", component_id="node-c", version=1),
+                ]
+            ),
+            expected_version=2,
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+
+        assert boundary.ok and boundary.data is not None and boundary.data.version == 2
+        assert _error_code(refused) == "component_not_publishable"
+        assert len(db.list_configs("node-root")) == 2
+        assert db.get_component("node-root")["current_version"] == 2  # type: ignore[index]
+
+    def test_publish_rejects_runtime_config_that_diverges_from_typed_manifest(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        created = studio.create_agent(
+            AgentCreate(
+                component_id="diverged-runtime",
+                name="Diverged runtime",
+                instructions="Use the registered calculator.",
+                tools=[ToolRef(kind="function", name="add", toolkit="calculator")],
+            ),
+            _agno_run_context=run_context,
+        )
+        assert created.ok
+        row = db.get_config("diverged-runtime", version=1)
+        assert row is not None
+        corrupted = dict(row["config"])
+        corrupted.pop("tools")
+        # Simulate out-of-band storage corruption. The public DB lifecycle now
+        # keeps version payloads immutable, so an adversarial fidelity test must
+        # bypass that contract deliberately rather than weakening it.
+        configs_table = db._get_table(table_type="component_configs")
+        assert configs_table is not None
+        with db.Session() as session, session.begin():
+            session.execute(
+                configs_table.update()
+                .where(
+                    configs_table.c.component_id == "diverged-runtime",
+                    configs_table.c.version == 1,
+                )
+                .values(config=corrupted)
+            )
+
+        result = studio.publish_component(
+            "diverged-runtime",
+            version=1,
+            expected_current_version=None,
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(result) == "component_not_publishable"
+        assert db.get_component("diverged-runtime")["current_version"] is None  # type: ignore[index]
+
+    def test_draft_delete_is_guarded_and_does_not_delete_component(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        assert _create_agent(studio, run_context, component_id="delete-draft").ok is True
+        edited = studio.edit_agent(
+            "delete-draft",
+            AgentPatch(description="Disposable draft"),
+            expected_version=1,
+            _agno_run_context=run_context,
+        )
+        assert edited.ok is True
+
+        stale_delete = studio.delete_version(
+            "delete-draft",
+            version=2,
+            expected_latest_version=1,
+            _agno_run_context=run_context,
+        )
+        deleted = studio.delete_version(
+            "delete-draft",
+            version=2,
+            expected_latest_version=2,
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(stale_delete) == "version_conflict"
+        assert deleted.ok is True
+        assert deleted.status == "draft_deleted"
+        assert deleted.data is not None
+        assert deleted.data.version == 2
+        component = db.get_component("delete-draft")
+        assert component is not None
+        assert component["metadata"]["_agno"]["studio"]["last_action"] == "delete_version"
+        assert component["metadata"]["_agno"]["studio"]["last_actor_id"] == run_context.user_id
+        assert db.get_config("delete-draft", version=2) is None
+        assert [row["version"] for row in db.list_configs("delete-draft")] == [1]
+
+    def test_published_version_delete_returns_stable_non_retryable_error(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        assert _create_agent(studio, run_context, component_id="published-delete", save_as="published").ok
+
+        result = studio.delete_version(
+            "published-delete",
+            version=1,
+            expected_latest_version=1,
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(result) == "draft_required"
+        assert result.error is not None
+        assert result.error.retryable is False
+        assert result.error.details == {"component_id": "published-delete", "version": 1}
+        assert db.get_config("published-delete", version=1) is not None
+
+    def test_archive_is_soft_delete_idempotent_and_reserves_id(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        assert _create_agent(studio, run_context, component_id="archived", save_as="published").ok is True
+
+        archived = studio.archive_agent(
+            "archived",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+        archived_again = studio.archive_agent(
+            "archived",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+        recreate = studio.create_agent(
+            _agent_request(component_id="archived"),
+            _agno_run_context=run_context,
+        )
+
+        assert archived.ok is True
+        assert archived.status == "archived"
+        assert archived_again.ok is True
+        assert archived_again.status == "already_archived"
+        assert _error_code(recreate) == "component_archived"
+        assert db.get_component("archived") is None
+        tombstone = db.get_component("archived", include_deleted=True)
+        assert tombstone is not None
+        assert tombstone["deleted_at"] is not None
+
+    def test_restore_is_explicit_type_safe_and_current_version_guarded(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        tool = StudioTools(
+            registry=studio.registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            teams=True,
+        )
+        assert _create_agent(tool, run_context, component_id="restore-me", save_as="published").ok
+        assert tool.archive_agent(
+            "restore-me",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        ).ok
+
+        recreate = tool.create_agent(
+            _agent_request(component_id="restore-me"),
+            _agno_run_context=run_context,
+        )
+        wrong_type = tool.restore_team(
+            "restore-me",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+        stale = tool.restore_agent(
+            "restore-me",
+            expected_current_version=2,
+            _agno_run_context=run_context,
+        )
+        restored = tool.restore_agent(
+            "restore-me",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+        restored_again = tool.restore_agent(
+            "restore-me",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(recreate) == "component_archived"
+        assert _error_code(wrong_type) == "component_type_mismatch"
+        assert _error_code(stale) == "version_conflict"
+        assert restored.ok
+        assert restored.status == "restored"
+        assert restored.data is not None
+        assert restored.data.version == 1
+        assert _error_code(restored_again) == "component_not_archived"
+        active = db.get_component("restore-me")
+        assert active is not None
+        assert active["current_version"] == 1
+        assert active["metadata"]["_agno"]["studio"]["last_action"] == "restore_agent"
+
+    def test_restore_reports_an_archived_pinned_dependency_without_reactivating_the_parent(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        tool = StudioTools(
+            registry=studio.registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            teams=True,
+        )
+        assert _create_agent(tool, run_context, component_id="restore-child", save_as="published").ok
+        created = tool.create_team(
+            TeamCreate(
+                component_id="restore-parent",
+                name="Restore parent",
+                instructions="Delegate to the pinned child.",
+                members=[ComponentRef(component_type="agent", component_id="restore-child", version=1)],
+            ),
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+        assert created.ok
+        assert tool.archive_team(
+            "restore-parent",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        ).ok
+        assert tool.archive_agent(
+            "restore-child",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        ).ok
+
+        result = tool.restore_team(
+            "restore-parent",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(result) == "component_dependency_unavailable"
+        assert result.error is not None
+        assert result.error.details == {
+            "component_id": "restore-parent",
+            "dependencies": [
+                {
+                    "component_id": "restore-child",
+                    "version": 1,
+                    "referenced_by": {"component_id": "restore-parent", "version": 1},
+                    "reason": "component_archived",
+                }
+            ],
+        }
+        parent = db.get_component("restore-parent", include_deleted=True)
+        assert parent is not None and parent["deleted_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_async_restore_uses_the_same_typed_contract(
+        self,
+        studio: StudioTools,
+        run_context: RunContext,
+    ):
+        assert _create_agent(studio, run_context, component_id="async-restore", save_as="published").ok
+        assert studio.archive_agent(
+            "async-restore",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        ).ok
+
+        result = await studio.arestore_agent(
+            "async-restore",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+
+        assert result.ok
+        assert result.status == "restored"
+
+    def test_generic_catalog_component_is_read_only_to_studio_lifecycle(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        db.create_component_with_config(
+            component_id="generic-agent",
+            component_type=ComponentType.AGENT,
+            name="Generic agent",
+            description=None,
+            metadata=None,
+            config={"id": "generic-agent", "name": "Generic agent"},
+            stage="published",
+        )
+
+        result = studio.archive_agent(
+            "generic-agent",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(result) == "unsupported_component_config"
+        assert db.get_component("generic-agent") is not None
+
+        from agno.db.base import ComponentVersionGuard
+
+        assert db.delete_component(
+            "generic-agent",
+            guard=ComponentVersionGuard(latest_version=1, current_version=1),
+        )
+        restore = studio.restore_agent(
+            "generic-agent",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+        assert _error_code(restore) == "unsupported_component_config"
+        assert db.get_component("generic-agent", include_deleted=True)["deleted_at"] is not None  # type: ignore[index]
+
+    def test_spoofed_or_mismatched_studio_manifest_cannot_claim_lifecycle_ownership(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        from agno.db.base import ComponentVersionGuard
+
+        cases = {
+            "spoofed-agent": {},
+            "unresolved-agent": _agent_request(component_id="unresolved-agent").model_dump(
+                mode="json", exclude={"if_exists"}
+            ),
+            "mismatched-agent": _agent_request(component_id="different-agent").model_dump(
+                mode="json", exclude={"if_exists"}
+            ),
+        }
+        for component_id, request_manifest in cases.items():
+            db.create_component_with_config(
+                component_id=component_id,
+                component_type=ComponentType.AGENT,
+                name=component_id,
+                description=None,
+                metadata=None,
+                config={
+                    "id": component_id,
+                    "name": component_id,
+                    "_agno_studio": {"schema_version": 2, "request": request_manifest},
+                },
+                stage="published",
+            )
+
+            archived = studio.archive_agent(
+                component_id,
+                expected_current_version=1,
+                _agno_run_context=run_context,
+            )
+            assert _error_code(archived) == "invalid_component_config"
+            assert db.get_component(component_id) is not None
+
+            assert db.delete_component(
+                component_id,
+                guard=ComponentVersionGuard(latest_version=1, current_version=1),
+            )
+            restored = studio.restore_agent(
+                component_id,
+                expected_current_version=1,
+                _agno_run_context=run_context,
+            )
+            assert _error_code(restored) == "invalid_component_config"
+            tombstone = db.get_component(component_id, include_deleted=True)
+            assert tombstone is not None
+            assert tombstone["deleted_at"] is not None
+
+    def test_dependency_errors_project_safe_parent_refs_without_link_metadata(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        assert _create_agent(studio, run_context, component_id="dependency-child", save_as="published").ok
+        db.create_component_with_config(
+            component_id="dependency-parent",
+            component_type=ComponentType.TEAM,
+            name="Dependency parent",
+            description=None,
+            metadata=None,
+            config={"name": "Dependency parent"},
+            stage="published",
+            links=[
+                {
+                    "link_kind": "member",
+                    "link_key": "member_0",
+                    "child_component_id": "dependency-child",
+                    "child_version": 1,
+                    "position": 0,
+                    "meta": {"type": "agent", "api_key": MODEL_API_KEY_SECRET},
+                }
+            ],
+        )
+
+        result = studio.archive_agent(
+            "dependency-child",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(result) == "component_has_dependents"
+        assert result.error is not None
+        assert result.error.details == {"dependents": [{"component_id": "dependency-parent", "version": 1}]}
+        assert MODEL_API_KEY_SECRET not in str(result)
+        assert "meta" not in str(result)
 
 
-def test_studio_loads_component_with_broken_refs_for_repair(tmp_path):
-    """StudioTools read/edit paths load leniently: a component whose registry
-    references are broken must still load so an edit can repair it."""
-    from agno.db.sqlite import SqliteDb
-    from agno.models.openai import OpenAIChat
-    from agno.registry import Registry
-    from agno.tools.studio import StudioTools
+class TestSafeViewsAndComposites:
+    def test_component_list_skips_invalid_code_defined_components_with_a_safe_warning(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        private_invalid_id = "private/tenant-secret"
 
-    db = SqliteDb(db_file=str(tmp_path / "studio_repair.db"))
+        class BrokenId:
+            name = "Broken id property"
+
+            @property
+            def id(self):
+                raise RuntimeError(private_invalid_id)
+
+        code_agent = Agent(id="valid-code-agent", name="Valid code agent", model=registry.models[0])
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            agents_list=[
+                code_agent,
+                SimpleNamespace(id=private_invalid_id, name="Invalid path"),
+                SimpleNamespace(id=42, name="Invalid type"),
+                SimpleNamespace(name="Missing id"),
+                BrokenId(),
+            ],  # type: ignore[list-item]
+        )
+
+        result = tool.list_agents(_agno_run_context=run_context)
+
+        assert result.ok
+        assert result.data is not None
+        assert [item.component_id for item in result.data] == ["valid-code-agent"]
+        assert result.warnings == ["Skipped 4 invalid code-defined agent(s) during discovery."]
+        assert private_invalid_id not in str(result)
+
+    def test_component_list_skips_only_invalid_rows_and_returns_a_safe_warning(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        assert _create_agent(studio, run_context, component_id="valid-summary").ok
+        db.create_component_with_config(
+            component_id="invalid-summary",
+            component_type=ComponentType.AGENT,
+            name="Invalid summary",
+            description=None,
+            metadata=None,
+            config={"name": "Invalid summary"},
+            stage="draft",
+        )
+
+        result = studio.list_agents(_agno_run_context=run_context)
+
+        assert result.ok
+        assert result.data is not None
+        assert [item.component_id for item in result.data] == ["valid-summary"]
+        assert result.warnings == ["Skipped 1 invalid stored agent row(s) during discovery."]
+        assert "invalid-summary" not in str(result)
+
+    @pytest.mark.parametrize("method_name", ["get_components", "list_components", "get_latest_configs"])
+    def test_component_list_does_not_misreport_a_backend_failure_as_bad_rows(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+        method_name: str,
+    ):
+        initial = StudioTools(registry=registry, db=db, authorize=_allow, default_model=_model_ref())
+        assert _create_agent(initial, run_context, component_id="stored-summary").ok
+        code_agent = Agent(id="code-summary", name="Code summary", model=registry.models[0])
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            agents_list=[code_agent],
+        )
+        private_backend_detail = "private-catalog-endpoint"
+
+        def unavailable(*_args: Any, **_kwargs: Any):
+            raise RuntimeError(private_backend_detail)
+
+        monkeypatch.setattr(tool.db, method_name, unavailable)
+
+        result = tool.list_agents(_agno_run_context=run_context)
+
+        assert _error_code(result) == "internal_error"
+        assert result.warnings == []
+        assert private_backend_detail not in str(result)
+
+    def test_component_list_treats_an_incomplete_bulk_latest_result_as_a_backend_failure(
+        self,
+        studio: StudioTools,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        assert _create_agent(studio, run_context, component_id="stored-summary").ok
+        monkeypatch.setattr(studio.db, "get_latest_configs", lambda **_kwargs: {})
+
+        result = studio.list_agents(_agno_run_context=run_context)
+
+        assert _error_code(result) == "internal_error"
+        assert result.warnings == []
+
+    def test_component_list_uses_bounded_bulk_catalog_reads(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        initial = StudioTools(registry=registry, db=db, authorize=_allow, default_model=_model_ref())
+        for index in range(4):
+            assert _create_agent(initial, run_context, component_id=f"stored-{index}").ok
+
+        code_agents = [Agent(id=f"code-{index}", name=f"Code {index}", model=registry.models[0]) for index in range(3)]
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            agents_list=code_agents,
+        )
+        calls = {
+            "get_component": 0,
+            "get_components": 0,
+            "get_latest_config": 0,
+            "get_latest_configs": 0,
+            "list_components": 0,
+        }
+        arguments = {method_name: [] for method_name in calls}
+
+        def counted(name: str, function: Any):
+            def wrapper(*args: Any, **kwargs: Any):
+                calls[name] += 1
+                arguments[name].append((args, kwargs))
+                return function(*args, **kwargs)
+
+            return wrapper
+
+        for method_name in calls:
+            monkeypatch.setattr(db, method_name, counted(method_name, getattr(db, method_name)))
+
+        result = tool.list_agents(_agno_run_context=run_context)
+
+        assert result.ok
+        assert result.data is not None
+        assert len(result.data) == 7
+        assert calls == {
+            "get_component": 0,
+            "get_components": 1,
+            "get_latest_config": 0,
+            "get_latest_configs": 1,
+            "list_components": 1,
+        }
+        assert arguments["get_components"] == [
+            (
+                (),
+                {
+                    "component_ids": {"code-0", "code-1", "code-2"},
+                    "include_deleted": True,
+                },
+            )
+        ]
+        assert arguments["get_latest_configs"] == [
+            (
+                (),
+                {
+                    "component_ids": {"stored-0", "stored-1", "stored-2", "stored-3"},
+                    "include_deleted": False,
+                },
+            )
+        ]
+
+    @pytest.mark.parametrize(
+        "shape",
+        ["parallel", "loop", "condition", "router", "steps"],
+    )
+    def test_code_defined_composite_workflow_is_refused_instead_of_returning_a_lossy_view(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        shape: str,
+    ):
+        from agno.workflow import Condition, Loop, Parallel, Router, Step, Steps, Workflow
+
+        def execute(_value: str) -> str:
+            return "done"
+
+        leaf = Step(name="Leaf", executor=execute)
+        composite = {
+            "parallel": lambda: Parallel(leaf, name="Parallel branch"),
+            "loop": lambda: Loop([leaf], name="Loop branch"),
+            "condition": lambda: Condition([leaf], name="Conditional branch"),
+            "router": lambda: Router([leaf], selector=None, name="Router branch"),
+            "steps": lambda: Steps(name="Sequential branch", steps=[leaf]),
+        }[shape]()
+        workflow = Workflow(id=f"{shape}-workflow", name=f"{shape} workflow", steps=[composite])
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            workflows_list=[workflow],
+        )
+
+        result = tool.get_workflow(workflow.id, _agno_run_context=run_context)
+
+        assert _error_code(result) == "unsupported_workflow_shape"
+        assert result.error is not None
+        assert "refuses to return" in result.error.message
+
+    def test_discovery_distinguishes_latest_draft_from_current_publication(
+        self,
+        studio: StudioTools,
+        run_context: RunContext,
+    ):
+        assert studio.create_agent(
+            _agent_request(component_id="summary-agent", name="Published name"),
+            save_as="published",
+            _agno_run_context=run_context,
+        ).ok
+        assert studio.edit_agent(
+            "summary-agent",
+            AgentPatch(name="Draft name"),
+            expected_version=1,
+            _agno_run_context=run_context,
+        ).ok
+
+        result = studio.list_agents(_agno_run_context=run_context)
+
+        assert result.ok
+        assert result.data is not None
+        summary = next(item for item in result.data if item.component_id == "summary-agent")
+        assert summary.name == "Draft name"
+        assert summary.latest_version == 2
+        assert summary.latest_stage == "draft"
+        assert summary.current_version == 1
+
+    def test_public_reads_never_expose_raw_config_or_connection_secrets(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        created = _create_agent(studio, run_context, component_id="safe-view", save_as="published")
+        version = studio.get_version("safe-view", version=1, _agno_run_context=run_context)
+        versions = studio.list_versions("safe-view", _agno_run_context=run_context)
+
+        public_payload = json.dumps(
+            {
+                "created": created.model_dump(mode="json"),
+                "version": version.model_dump(mode="json"),
+                "versions": versions.model_dump(mode="json"),
+            }
+        )
+        for secret in (
+            db.db_file,
+            MODEL_BASE_URL_SECRET,
+            MODEL_API_KEY_SECRET,
+            "_agno_studio",
+            "db_file",
+            "db_url",
+        ):
+            assert secret not in public_payload
+
+        assert version.ok is True
+        assert version.data is not None
+        assert "config" not in version.data.model_dump()
+        assert "metadata" not in version.data.model_dump()
+        assert json.loads(str(version))["data"]["component_id"] == "safe-view"
+
+        stored = db.get_config("safe-view", version=1)
+        assert stored is not None
+        assert "db" not in stored["config"]
+        stored_payload = json.dumps(stored["config"])
+        assert db.db_file not in stored_payload
+        assert MODEL_BASE_URL_SECRET not in stored_payload
+        assert MODEL_API_KEY_SECRET not in stored_payload
+
+    def test_team_and_workflow_views_pin_exact_component_versions(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        def publish_copy(value: str) -> str:
+            """Publish a prepared value."""
+
+            return value
+
+        registry.functions.append(publish_copy)
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            teams=True,
+            workflows=True,
+        )
+        assert _create_agent(tool, run_context, component_id="researcher", save_as="published").ok is True
+
+        team = tool.create_team(
+            TeamCreate(
+                component_id="editors",
+                name="Editors",
+                instructions="Edit the research.",
+                members=[ComponentRef(component_type="agent", component_id="researcher")],
+            ),
+            _agno_run_context=run_context,
+        )
+        assert team.ok is True
+        assert isinstance(team.data, TeamView)
+        assert team.data.members == [ComponentRef(component_type="agent", component_id="researcher", version=1)]
+        assert (
+            tool.publish_component(
+                "editors",
+                version=1,
+                expected_current_version=None,
+                _agno_run_context=run_context,
+            ).ok
+            is True
+        )
+
+        workflow = tool.create_workflow(
+            WorkflowCreate(
+                component_id="editorial-flow",
+                name="Editorial flow",
+                steps=[
+                    TeamWorkflowStep(kind="team", name="Review", component_id="editors"),
+                    FunctionWorkflowStep(kind="function", name="Publish", function_name="publish_copy"),
+                ],
+            ),
+            _agno_run_context=run_context,
+        )
+
+        assert workflow.ok is True
+        assert isinstance(workflow.data, WorkflowView)
+        assert isinstance(workflow.data.steps[0], TeamWorkflowStep)
+        assert workflow.data.steps[0].version == 1
+        assert workflow.data.steps[0].step_id == "review-1"
+        assert workflow.data.steps[1].step_id == "publish-2"
+        assert (
+            tool.publish_component(
+                "editorial-flow",
+                version=1,
+                expected_current_version=None,
+                _agno_run_context=run_context,
+            ).ok
+            is True
+        )
+
+    def test_workflow_dispatch_preserves_two_exact_versions_of_one_agent(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            workflows=True,
+        )
+        assert _create_agent(tool, run_context, component_id="shared-versioned-agent", save_as="published").ok
+        edited = tool.edit_agent(
+            "shared-versioned-agent",
+            AgentPatch(tools=[ToolRef(kind="toolkit", name="calculator")]),
+            expected_version=1,
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+        assert edited.ok and edited.data is not None and edited.data.version == 2
+
+        created = tool.create_workflow(
+            WorkflowCreate(
+                component_id="two-exact-pins",
+                name="Two exact pins",
+                steps=[
+                    AgentWorkflowStep(
+                        kind="agent",
+                        step_id="old",
+                        name="Old behavior",
+                        component_id="shared-versioned-agent",
+                        version=1,
+                    ),
+                    AgentWorkflowStep(
+                        kind="agent",
+                        step_id="new",
+                        name="New behavior",
+                        component_id="shared-versioned-agent",
+                        version=2,
+                    ),
+                ],
+            ),
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+
+        assert created.ok
+        assert [
+            (link["link_key"], link["child_component_id"], link["child_version"])
+            for link in db.get_links("two-exact-pins", 1)
+        ] == [
+            ("old", "shared-versioned-agent", 1),
+            ("new", "shared-versioned-agent", 2),
+        ]
+        loaded = tool._runner_tools._load_workflow_from_db("two-exact-pins", version=1, for_dispatch=True)
+        assert loaded is not None and isinstance(loaded.steps, list)
+        assert [len(step.agent.tools or []) for step in loaded.steps] == [
+            0,
+            len(registry.tools[0].get_functions()),
+        ]
+
+    def test_parent_dispatch_does_not_mix_direct_and_nested_pin_occurrences(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            teams=True,
+        )
+        assert _create_agent(tool, run_context, component_id="nested-shared-agent", save_as="published").ok
+        nested = tool.create_team(
+            TeamCreate(
+                component_id="nested-version-holder",
+                name="Nested version holder",
+                instructions="Use the old member.",
+                members=[
+                    ComponentRef(component_type="agent", component_id="nested-shared-agent", version=1),
+                ],
+            ),
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+        assert nested.ok
+        edited = tool.edit_agent(
+            "nested-shared-agent",
+            AgentPatch(tools=[ToolRef(kind="toolkit", name="calculator")]),
+            expected_version=1,
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+        assert edited.ok and edited.data is not None and edited.data.version == 2
+        parent = tool.create_team(
+            TeamCreate(
+                component_id="mixed-depth-parent",
+                name="Mixed depth parent",
+                instructions="Use both members.",
+                members=[
+                    ComponentRef(component_type="team", component_id="nested-version-holder", version=1),
+                    ComponentRef(component_type="agent", component_id="nested-shared-agent", version=2),
+                ],
+            ),
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+
+        assert parent.ok
+        loaded = tool._runner_tools._load_team_from_db("mixed-depth-parent", version=1, for_dispatch=True)
+        assert loaded is not None and isinstance(loaded.members, list)
+        nested_runtime, direct_runtime = loaded.members
+        assert isinstance(nested_runtime.members, list)
+        assert len(nested_runtime.members[0].tools or []) == 0
+        assert len(direct_runtime.tools or []) == len(registry.tools[0].get_functions())
+
+    def test_single_function_ref_stays_narrow_while_whole_toolkit_stays_whole(
+        self,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        from agno.agent._tools import parse_tools
+
+        toolkit_guidance = "Use every calculator operation when the complete toolkit is attached."
+        calculator = CalculatorTools(instructions=toolkit_guidance, add_instructions=True)
+        registry = Registry(
+            name="Exact tool registry",
+            tools=[calculator],
+            models=[OpenAIResponses(id=MODEL_ID)],
+            dbs=[db],
+        )
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+        )
+        selected_ref = ToolRef(kind="function", name="add", toolkit="calculator")
+        toolkit_ref = ToolRef(kind="toolkit", name="calculator")
+
+        selected = tool.create_agent(
+            AgentCreate(
+                component_id="selected-calculator-function",
+                name="Selected calculator function",
+                instructions="Only add numbers.",
+                tools=[selected_ref],
+            ),
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+        whole = tool.create_agent(
+            AgentCreate(
+                component_id="whole-calculator-toolkit",
+                name="Whole calculator toolkit",
+                instructions="Use any calculator operation.",
+                tools=[toolkit_ref],
+            ),
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+
+        assert selected.ok and selected.data is not None
+        assert whole.ok and whole.data is not None
+        assert selected.data.tools == [selected_ref]
+        assert whole.data.tools == [toolkit_ref]
+        selected_view = tool.get_agent("selected-calculator-function", _agno_run_context=run_context)
+        whole_view = tool.get_agent("whole-calculator-toolkit", _agno_run_context=run_context)
+        assert selected_view.ok and selected_view.data is not None and selected_view.data.tools == [selected_ref]
+        assert whole_view.ok and whole_view.data is not None and whole_view.data.tools == [toolkit_ref]
+
+        selected_row = db.get_config("selected-calculator-function", version=1)
+        whole_row = db.get_config("whole-calculator-toolkit", version=1)
+        assert selected_row is not None and whole_row is not None
+        selected_tools = selected_row["config"]["tools"]
+        whole_tools = whole_row["config"]["tools"]
+        assert [(item["toolkit"], item["name"]) for item in selected_tools] == [("calculator", "add")]
+        assert {item["name"] for item in whole_tools} == set(calculator.get_functions())
+        assert {item["toolkit"] for item in whole_tools} == {"calculator"}
+
+        selected_runtime = tool._runner_tools._agent_for_run("selected-calculator-function")
+        whole_runtime = tool._runner_tools._agent_for_run("whole-calculator-toolkit")
+        assert isinstance(selected_runtime.tools, list)
+        assert isinstance(whole_runtime.tools, list)
+        selected_functions = parse_tools(selected_runtime, selected_runtime.tools, selected_runtime.model)
+        whole_functions = parse_tools(whole_runtime, whole_runtime.tools, whole_runtime.model)
+
+        assert [getattr(function, "name", None) for function in selected_functions] == ["add"]
+        assert toolkit_guidance not in (selected_runtime._tool_instructions or [])
+        assert {getattr(function, "name", None) for function in whole_functions} == set(calculator.get_functions())
+        assert whole_runtime._tool_instructions == [toolkit_guidance]
+
+    def test_workflow_step_identity_and_descriptions_survive_unrelated_edits(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        def publish_copy(value: str) -> str:
+            """Publish a prepared value."""
+
+            return value
+
+        registry.functions.append(publish_copy)
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            teams=True,
+            workflows=True,
+        )
+        assert _create_agent(tool, run_context, component_id="workflow-agent", save_as="published").ok
+        assert tool.create_team(
+            TeamCreate(
+                component_id="workflow-team",
+                name="Workflow team",
+                instructions="Coordinate the work.",
+                members=[ComponentRef(component_type="agent", component_id="workflow-agent")],
+            ),
+            save_as="published",
+            _agno_run_context=run_context,
+        ).ok
+
+        request = WorkflowCreate(
+            component_id="described-workflow",
+            name="Described workflow",
+            description="Original workflow description.",
+            steps=[
+                AgentWorkflowStep(
+                    kind="agent",
+                    step_id="research-step",
+                    name="Research",
+                    component_id="workflow-agent",
+                    description="Collect the source material.",
+                ),
+                TeamWorkflowStep(
+                    kind="team",
+                    step_id="review-step",
+                    name="Review",
+                    component_id="workflow-team",
+                    description="Review the material as a team.",
+                ),
+                FunctionWorkflowStep(
+                    kind="function",
+                    step_id="publish-step",
+                    name="Publish",
+                    function_name="publish_copy",
+                    description="Publish the reviewed result.",
+                ),
+            ],
+        )
+        created = tool.create_workflow(
+            request,
+            save_as="published",
+            _agno_run_context=run_context,
+        )
+        assert created.ok and created.data is not None
+        expected_steps = [
+            request.steps[0].model_copy(update={"version": 1}),
+            request.steps[1].model_copy(update={"version": 1}),
+            request.steps[2],
+        ]
+        assert created.data.steps == expected_steps
+
+        current = tool.get_workflow("described-workflow", _agno_run_context=run_context)
+        exact_v1 = tool.get_version("described-workflow", 1, _agno_run_context=run_context)
+        versions_v1 = tool.list_versions("described-workflow", _agno_run_context=run_context)
+        assert current.ok and current.data is not None and current.data.steps == expected_steps
+        assert exact_v1.ok and isinstance(exact_v1.data, WorkflowView) and exact_v1.data.steps == expected_steps
+        assert versions_v1.ok and versions_v1.data is not None
+        assert [(item.version, item.stage) for item in versions_v1.data] == [(1, "published")]
+
+        edited = tool.edit_workflow(
+            "described-workflow",
+            WorkflowPatch(description="Updated workflow description only."),
+            expected_version=1,
+            _agno_run_context=run_context,
+        )
+        exact_v2 = tool.get_workflow("described-workflow", version=2, _agno_run_context=run_context)
+        generic_v2 = tool.get_version("described-workflow", 2, _agno_run_context=run_context)
+        versions_v2 = tool.list_versions("described-workflow", _agno_run_context=run_context)
+
+        assert edited.ok and edited.data is not None and edited.data.steps == expected_steps
+        assert exact_v2.ok and exact_v2.data is not None and exact_v2.data.steps == expected_steps
+        assert generic_v2.ok and isinstance(generic_v2.data, WorkflowView) and generic_v2.data.steps == expected_steps
+        assert versions_v2.ok and versions_v2.data is not None
+        assert sorted((item.version, item.stage) for item in versions_v2.data) == [(1, "published"), (2, "draft")]
+
+
+def test_studio_lenient_internal_load_keeps_broken_reference_component_repairable(tmp_path):
+    """The typed control plane retains the runner's lenient repair-load path."""
 
     def search(query: str) -> str:
         """Search for a query."""
+
         return f"results for {query}"
 
-    agent = Agent(id="repair-agent", name="Repair Agent", model=OpenAIChat(id="gpt-4o-mini"), tools=[search])
-    agent.save(db=db)
+    db = SqliteDb(db_file=str(tmp_path / "studio-repair.db"))
+    model = OpenAIChat(id="gpt-4o-mini")
+    Agent(id="repair-agent", name="Repair Agent", model=model, tools=[search]).save(db=db)
+    tool = StudioTools(
+        registry=Registry(models=[model], dbs=[db]),
+        db=db,
+        authorize=_allow,
+        default_model=ModelRef(id="gpt-4o-mini", provider="OpenAI", name="OpenAIChat"),
+    )
 
-    # Registry lacks the tool the saved agent references
-    studio = StudioTools(registry=Registry(), db=db)
-    loaded = studio._load_agent_from_db("repair-agent")
+    # The stored callable is intentionally absent from the registry. Reads for
+    # repair remain lenient; dispatch still applies the runner's strict guard.
+    loaded = tool._load_db_component("agent", "repair-agent", version=1)
 
     assert loaded is not None
     assert loaded.id == "repair-agent"
 
 
 class TestEditPreservation:
-    """Edits round-trip through leniently loaded objects; the persisted config
-    must not lose what the load could not resolve, nor its member pins."""
+    """Typed edits preserve omitted state and re-emit exact dependency pins."""
 
-    def test_description_edit_preserves_unresolved_output_schema(self, tmp_path):
-        from pydantic import BaseModel
-
-        from agno.db.sqlite import SqliteDb
-        from agno.models.openai import OpenAIChat
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
-
-        class Report(BaseModel):
-            text: str
-
-        db = SqliteDb(db_file=str(tmp_path / "preserve.db"))
-        Agent(id="schema-agent", name="S", model=OpenAIChat(id="gpt-4o-mini"), output_schema=Report).save(db=db)
-
-        studio = StudioTools(registry=Registry(), db=db)
-        out = _loads(studio.edit_agent("schema-agent", description="edited"))
-        assert out.get("status") == "edited"
-
-        row = db.get_config(component_id="schema-agent")
-        assert row["config"]["output_schema"] == "Report"
-        assert row["config"]["description"] == "edited"
-
-    def test_team_edit_repins_members(self, tmp_path):
-        from agno.db.sqlite import SqliteDb
-        from agno.registry import Registry
-        from agno.team.team import Team
-        from agno.tools.studio import StudioTools
-
-        db = SqliteDb(db_file=str(tmp_path / "repin_team.db"))
-        member = Agent(id="rp-member", name="Member")
-        Team(id="rp-team", name="Team", members=[member]).save(db=db)
-
-        studio = StudioTools(registry=Registry(), db=db, teams=True)
-        out = _loads(studio.edit_team("rp-team", description="edited"))
-        assert out.get("status") == "edited"
-
-        version = out.get("version") or out.get("draft_version")
-        links = db.get_links(component_id="rp-team", version=version)
-        assert [link["child_component_id"] for link in links] == ["rp-member"]
-        assert all(link["child_version"] is not None for link in links)
-
-    def test_workflow_edit_repins_step_members(self, tmp_path):
-        from agno.db.sqlite import SqliteDb
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
-        from agno.workflow.step import Step
-        from agno.workflow.workflow import Workflow
-
-        db = SqliteDb(db_file=str(tmp_path / "repin_wf.db"))
-        agent = Agent(id="rw-agent", name="A")
-        Workflow(id="rw-wf", name="WF", steps=[Step(name="s1", agent=agent)]).save(db=db)
-
-        studio = StudioTools(registry=Registry(), db=db, workflows=True)
-        out = _loads(studio.edit_workflow("rw-wf", description="edited"))
-        assert out.get("status") == "edited"
-
-        version = out.get("version") or out.get("draft_version")
-        links = db.get_links(component_id="rw-wf", version=version)
-        assert "rw-agent" in [link["child_component_id"] for link in links]
-
-
-class TestSnapshotSafety:
-    def test_create_team_pins_members_at_creation(self, tmp_path):
-        from agno.db.sqlite import SqliteDb
-        from agno.models.openai import OpenAIChat
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
-
-        db = SqliteDb(db_file=str(tmp_path / "create_pin.db"))
-        Agent(id="cp-member", name="Member").save(db=db)
-        model = OpenAIChat(id="gpt-4o-mini")
-        studio = StudioTools(registry=Registry(models=[model], dbs=[db]), db=db, teams=True)
-
-        out = _loads(
-            studio.create_team(name="CP Crew", instructions="i", member_ids=["cp-member"], model_id="gpt-4o-mini")
+    def test_description_edit_preserves_typed_request_and_immutable_base(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        request = AgentCreate(
+            component_id="preserved-agent",
+            name="Preserved agent",
+            instructions="Use the calculator carefully.",
+            model=_model_ref(),
+            tools=[ToolRef(kind="function", name="add", toolkit="calculator")],
+            context=ContextPolicy(include_history=True, history_runs=7, include_datetime=False),
         )
-        assert out.get("status") == "created"
+        created = studio.create_agent(request, _agno_run_context=run_context)
+        assert created.ok
+        version_one = db.get_config("preserved-agent", version=1)
+        assert version_one is not None
+        immutable_config = json.loads(json.dumps(version_one["config"]))
 
-        links = db.get_links(component_id=out["id"], version=1)
-        assert [link["child_component_id"] for link in links] == ["cp-member"]
-
-    def test_unrelated_edit_carries_base_pins_forward(self, tmp_path):
-        from agno.db.sqlite import SqliteDb
-        from agno.registry import Registry
-        from agno.team.team import Team
-        from agno.tools.studio import StudioTools
-
-        db = SqliteDb(db_file=str(tmp_path / "carry.db"))
-        member = Agent(id="cf-member", name="Member", description="v1")
-        Team(id="cf-team", name="Team", members=[member]).save(db=db)
-        base_pin = next(
-            link["child_version"]
-            for link in db.get_links(component_id="cf-team", version=1)
-            if link["link_kind"] == "member"
+        edited = studio.edit_agent(
+            "preserved-agent",
+            AgentPatch(description="Description only."),
+            expected_version=1,
+            _agno_run_context=run_context,
         )
-        member.description = "v2"
-        member.save(db=db)
 
-        studio = StudioTools(registry=Registry(dbs=[db]), db=db, teams=True)
-        out = _loads(studio.edit_team("cf-team", description="edited"))
-        assert out.get("status") == "edited"
+        assert edited.ok and edited.data is not None
+        assert edited.data.description == "Description only."
+        assert edited.data.instructions == request.instructions
+        assert edited.data.model == request.model
+        assert edited.data.tools == request.tools
+        assert edited.data.context == request.context
+        version_two = db.get_config("preserved-agent", version=2)
+        assert version_two is not None
+        assert version_two["config"]["_agno_studio"]["request"] == request.model_copy(
+            update={"description": "Description only."}
+        ).model_dump(mode="json", exclude={"if_exists"})
+        assert db.get_config("preserved-agent", version=1)["config"] == immutable_config  # type: ignore[index]
 
-        version = out.get("version") or out.get("draft_version")
-        links = db.get_links(component_id="cf-team", version=version)
-        assert [link["child_version"] for link in links if link["link_kind"] == "member"] == [base_pin]
-
-    def test_unrelated_edit_keeps_the_stored_db_reference(self, tmp_path):
-        from agno.db.base import ComponentType
-        from agno.db.sqlite import SqliteDb
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
-
-        db = SqliteDb(db_file=str(tmp_path / "dbref.db"))
-        db.upsert_component(component_id="opaque-agent", component_type=ComponentType.AGENT, name="A")
-        stored_db = {"id": "private", "type": "custom-opaque"}
+    def test_omitted_model_preserves_the_exact_stored_model_subtree(
+        self,
+        studio: StudioTools,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        created = studio.create_agent(
+            AgentCreate(
+                component_id="future-model-agent",
+                name="Future model agent",
+                instructions="Keep provider-specific model configuration intact.",
+                model=_model_ref(),
+            ),
+            _agno_run_context=run_context,
+        )
+        assert created.ok
+        version_one = db.get_config("future-model-agent", version=1)
+        assert version_one is not None
+        future_config = json.loads(json.dumps(version_one["config"]))
+        future_config["model"]["future_transport"] = {
+            "mode": "opaque",
+            "options": ["one", "two"],
+        }
         db.upsert_config(
-            component_id="opaque-agent",
-            config={"id": "opaque-agent", "name": "A", "db": stored_db},
-            stage="published",
+            component_id="future-model-agent",
+            config=future_config,
+            stage="draft",
+            links=[],
+            guard=ComponentVersionGuard(latest_version=1, current_version=None),
         )
 
-        studio = StudioTools(registry=Registry(dbs=[db]), db=db)
-        out = _loads(studio.edit_agent("opaque-agent", description="edited"))
-        assert out.get("status") == "edited"
+        edited = studio.edit_agent(
+            "future-model-agent",
+            AgentPatch(description="Description only."),
+            expected_version=2,
+            _agno_run_context=run_context,
+        )
 
-        row = db.get_config(component_id="opaque-agent")
-        assert row["config"]["db"] == stored_db
-        assert row["config"]["description"] == "edited"
+        assert edited.ok
+        version_three = db.get_config("future-model-agent", version=3)
+        assert version_three is not None
+        assert version_three["config"]["model"] == future_config["model"]
+
+        replaced = studio.edit_agent(
+            "future-model-agent",
+            AgentPatch(model=None),
+            expected_version=3,
+            _agno_run_context=run_context,
+        )
+
+        assert replaced.ok
+        version_four = db.get_config("future-model-agent", version=4)
+        assert version_four is not None
+        assert "future_transport" not in version_four["config"]["model"]
+
+    def test_team_edit_repins_members(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            teams=True,
+        )
+        assert _create_agent(tool, run_context, component_id="repin-member", save_as="published").ok
+        created = tool.create_team(
+            TeamCreate(
+                component_id="repin-team",
+                name="Repin team",
+                instructions="Coordinate the member.",
+                members=[ComponentRef(component_type="agent", component_id="repin-member", version=1)],
+            ),
+            _agno_run_context=run_context,
+        )
+        assert created.ok
+
+        edited = tool.edit_team(
+            "repin-team",
+            TeamPatch(description="Description only."),
+            expected_version=1,
+            _agno_run_context=run_context,
+        )
+
+        assert edited.ok and edited.data is not None
+        assert edited.data.members == [ComponentRef(component_type="agent", component_id="repin-member", version=1)]
+        for version in (1, 2):
+            links = db.get_links("repin-team", version)
+            assert [(link["child_component_id"], link["child_version"]) for link in links] == [("repin-member", 1)]
+
+    def test_workflow_edit_repins_step_members(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        tool = StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            workflows=True,
+        )
+        assert _create_agent(tool, run_context, component_id="repin-step-agent", save_as="published").ok
+        step = AgentWorkflowStep(
+            kind="agent",
+            step_id="pinned-step",
+            name="Pinned step",
+            component_id="repin-step-agent",
+            version=1,
+        )
+        created = tool.create_workflow(
+            WorkflowCreate(component_id="repin-workflow", name="Repin workflow", steps=[step]),
+            _agno_run_context=run_context,
+        )
+        assert created.ok
+
+        edited = tool.edit_workflow(
+            "repin-workflow",
+            WorkflowPatch(description="Description only."),
+            expected_version=1,
+            _agno_run_context=run_context,
+        )
+
+        assert edited.ok and edited.data is not None
+        assert edited.data.steps == [step]
+        for version in (1, 2):
+            links = db.get_links("repin-workflow", version)
+            assert [(link["link_key"], link["child_component_id"], link["child_version"]) for link in links] == [
+                ("pinned-step", "repin-step-agent", 1)
+            ]
 
 
-class TestEditIdentityStability:
-    def test_description_edit_keeps_step_ids_and_per_step_pins(self, tmp_path):
-        """An unrelated edit must not re-mint step_ids: carried-forward link
-        keys name steps by step_id, so churn orphans every pin."""
-        from agno.db.sqlite import SqliteDb
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
-        from agno.workflow.step import Step
-        from agno.workflow.workflow import Workflow
+class TestScheduleControlPlane:
+    @staticmethod
+    def _tool(registry: Registry, db: SqliteDb, *, schedules: bool = True) -> StudioTools:
+        return StudioTools(
+            registry=registry,
+            db=db,
+            authorize=_allow,
+            default_model=_model_ref(),
+            schedules=schedules,
+        )
 
-        db = SqliteDb(db_file=str(tmp_path / "stepid.db"))
-        agent = Agent(id="si-agent", name="A")
-        Workflow(id="si-wf", name="WF", steps=[Step(name="s1", agent=agent)]).save(db=db)
-        base_ids = [s["step_id"] for s in db.get_config(component_id="si-wf")["config"]["steps"]]
+    @staticmethod
+    def _request(name: str = "daily-research", *, cron: str = "0 9 * * *") -> ScheduleCreate:
+        return ScheduleCreate(
+            name=name,
+            cron=cron,
+            target_type="agent",
+            target_id="scheduled-agent",
+            message="sk-schedule-message-secret",
+            description="Daily research",
+        )
 
-        studio = StudioTools(registry=Registry(dbs=[db]), db=db, workflows=True)
-        out = _loads(studio.edit_workflow("si-wf", description="edited"))
-        assert out.get("status") == "edited"
+    def test_create_schedule_schema_is_typed_and_descriptive(self, registry: Registry, db: SqliteDb):
+        tool = self._tool(registry, db)
+        function = tool.functions["create_schedule"]
+        async_function = tool.async_functions["create_schedule"]
 
-        version = out.get("version") or out.get("draft_version")
-        new_config = db.get_config(component_id="si-wf", version=version)["config"]
-        assert [s["step_id"] for s in new_config["steps"]] == base_ids
-        link_keys = {link["link_key"] for link in db.get_links(component_id="si-wf", version=version)}
-        assert link_keys <= set(base_ids)
+        function.process_entrypoint()
+        async_function.process_entrypoint()
+        schema = function.parameters
+        properties = schema["properties"]
+        request_schema = properties["request"]
 
-    def test_description_edit_keeps_auxiliary_model_keys(self, tmp_path):
-        """to_dict emits reasoning/parser/output models that from_dict does not
-        yet consume; an unrelated edit must not persist their loss."""
-        from agno.db.base import ComponentType
-        from agno.db.sqlite import SqliteDb
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
+        assert set(properties) == {"request", "if_exists"}
+        assert schema["required"] == ["request"]
+        assert request_schema["additionalProperties"] is False
+        assert set(request_schema["required"]) == {"name", "cron", "target_type", "target_id", "message"}
+        assert set(properties["if_exists"]["enum"]) == {"error", "update"}
+        assert all(field.get("description") for field in request_schema["properties"].values())
+        assert async_function.parameters == schema
 
-        db = SqliteDb(db_file=str(tmp_path / "auxmodels.db"))
-        db.upsert_component(component_id="aux-agent", component_type=ComponentType.AGENT, name="A")
-        aux = {"provider": "OpenAI", "id": "gpt-5.5"}
-        db.upsert_config(
-            component_id="aux-agent",
-            config={
-                "id": "aux-agent",
-                "name": "A",
-                "reasoning_model": aux,
-                "parser_model": aux,
-                "output_model": aux,
-                "parser_model_prompt": "parse",
+    @pytest.mark.parametrize("actor_id", [" actor", "actor\nspoof", "a" * 256])
+    def test_create_schedule_rejects_actor_ids_that_cannot_be_delegated(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        actor_id: str,
+    ):
+        tool = self._tool(registry, db)
+        assert _create_agent(tool, run_context, component_id="scheduled-agent", save_as="published").ok
+        invalid_context = RunContext(
+            run_id="invalid-actor-run",
+            session_id="invalid-actor-session",
+            user_id=actor_id,
+        )
+
+        result = tool.create_schedule(self._request(), _agno_run_context=invalid_context)
+
+        assert _error_code(result) == "invalid_schedule_actor"
+        assert db.get_schedule_by_name("daily-research") is None
+
+    def test_create_schedule_accepts_unicode_actor_ids(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        tool = self._tool(registry, db)
+        assert _create_agent(tool, run_context, component_id="scheduled-agent", save_as="published").ok
+        unicode_context = RunContext(
+            run_id="unicode-actor-run",
+            session_id="unicode-actor-session",
+            user_id="jörg@example.com",
+        )
+
+        result = tool.create_schedule(self._request(), _agno_run_context=unicode_context)
+
+        assert result.ok is True
+        assert isinstance(result.data, ScheduleView)
+        assert result.data.owner_actor_id == "jörg@example.com"
+
+    def test_schedule_views_are_actor_scoped_and_redact_payload_and_run_secrets(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        tool = self._tool(registry, db)
+        assert _create_agent(tool, run_context, component_id="scheduled-agent", save_as="published").ok
+
+        created = tool.create_schedule(self._request(), _agno_run_context=run_context)
+        assert created.ok is True
+        assert isinstance(created.data, ScheduleView)
+        schedule_id = created.data.schedule_id
+
+        stored = ScheduleManager(db).get(schedule_id)
+        assert stored is not None
+        assert stored.payload == {"message": "sk-schedule-message-secret"}
+        assert stored.managed_by == STUDIO_SCHEDULE_MANAGED_BY
+        assert stored.owner_actor_id == run_context.user_id
+        assert stored.target_type == "agent"
+        assert stored.target_id == "scheduled-agent"
+        assert stored.created_by_run_id == run_context.run_id
+        assert stored.created_by_session_id == run_context.session_id
+
+        db.create_schedule_run(
+            {
+                "id": "schedule-run-1",
+                "schedule_id": schedule_id,
+                "attempt": 1,
+                "triggered_at": 10,
+                "completed_at": 20,
+                "status": "failed",
+                "status_code": 500,
+                "run_id": "component-run-1",
+                "session_id": "component-session-1",
+                "error": "sk-schedule-error-secret",
+                "input": {"api_key": "sk-schedule-input-secret"},
+                "output": {"token": "sk-schedule-output-secret"},
+                "requirements": [{"secret": "sk-schedule-requirement-secret"}],
+                "created_at": 10,
+            }
+        )
+
+        listed = tool.list_schedules(_agno_run_context=run_context)
+        fetched = tool.get_schedule(schedule_id, _agno_run_context=run_context)
+        runs = tool.get_schedule_runs(schedule_id, _agno_run_context=run_context)
+
+        assert listed.data == [created.data]
+        assert fetched.data == created.data
+        assert runs.ok is True
+        assert isinstance(runs.data, list)
+        assert len(runs.data) == 1
+        assert isinstance(runs.data[0], ScheduleRunView)
+        assert runs.data[0].has_error is True
+        assert runs.data[0].has_requirements is True
+        public_payload = "".join(str(result) for result in (created, listed, fetched, runs))
+        for secret in (
+            "sk-schedule-message-secret",
+            "sk-schedule-error-secret",
+            "sk-schedule-input-secret",
+            "sk-schedule-output-secret",
+            "sk-schedule-requirement-secret",
+            "_agno_studio",
+            '"payload"',
+            '"input"',
+            '"output"',
+            '"requirements"',
+            '"error"',
+        ):
+            assert secret not in public_payload
+
+        other_actor = RunContext(run_id="other-run", session_id="other-session", user_id="other-actor")
+        other_list = tool.list_schedules(_agno_run_context=other_actor)
+        assert other_list.ok is True
+        assert other_list.data == []
+        assert _error_code(tool.get_schedule(schedule_id, _agno_run_context=other_actor)) == "schedule_not_found"
+        assert _error_code(tool.get_schedule_runs(schedule_id, _agno_run_context=other_actor)) == "schedule_not_found"
+        for operation in (
+            tool.trigger_schedule,
+            tool.enable_schedule,
+            tool.disable_schedule,
+            tool.delete_schedule,
+        ):
+            assert _error_code(operation(schedule_id, _agno_run_context=other_actor)) == "schedule_not_found"
+        assert ScheduleManager(db).get(schedule_id) is not None
+
+    def test_owner_update_is_in_place_and_generic_same_name_is_independent(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        tool = self._tool(registry, db)
+        assert _create_agent(tool, run_context, component_id="scheduled-agent", save_as="published").ok
+
+        created = tool.create_schedule(self._request(), _agno_run_context=run_context)
+        assert isinstance(created.data, ScheduleView)
+        conflict = tool.create_schedule(self._request(), _agno_run_context=run_context)
+        updated = tool.create_schedule(
+            self._request(cron="0 10 * * *"),
+            if_exists="update",
+            _agno_run_context=run_context,
+        )
+
+        assert _error_code(conflict) == "schedule_conflict"
+        assert updated.ok is True
+        assert updated.status == "updated"
+        assert isinstance(updated.data, ScheduleView)
+        assert updated.data.schedule_id == created.data.schedule_id
+        assert updated.data.cron == "0 10 * * *"
+
+        foreign = ScheduleManager(db).create(
+            name="foreign-shared-name",
+            cron="0 8 * * *",
+            endpoint="/agents/scheduled-agent/runs",
+            payload={
+                "api_key": "sk-foreign-schedule-secret",
+                "_agno_studio": {
+                    "schema_version": 1,
+                    "owner_actor_id": run_context.user_id,
+                    "target_type": "agent",
+                    "target_id": "scheduled-agent",
+                },
             },
-            stage="published",
         )
-
-        studio = StudioTools(registry=Registry(dbs=[db]), db=db)
-        out = _loads(studio.edit_agent("aux-agent", description="edited"))
-        assert out.get("status") == "edited"
-
-        config = db.get_config(component_id="aux-agent")["config"]
-        assert config["reasoning_model"] == aux
-        assert config["parser_model"] == aux
-        assert config["output_model"] == aux
-
-
-class TestPinProvenance:
-    def test_links_skip_children_shadowed_by_code_defined_components(self, tmp_path):
-        """A code-defined component with the child's exact id wins resolution,
-        so pinning the same-id db shadow row would bind an unrelated config."""
-        from agno.db.sqlite import SqliteDb
-        from agno.registry import Registry
-        from agno.team.team import Team
-        from agno.tools.studio import StudioTools
-
-        db = SqliteDb(db_file=str(tmp_path / "shadow.db"))
-        Agent(id="dual", name="DB Shadow").save(db=db)
-        code_agent = Agent(id="dual", name="Live Code Agent")
-        team = Team(id="sh-team", name="Team", members=[code_agent])
-
-        studio = StudioTools(registry=Registry(dbs=[db]), db=db, teams=True, agents_list=[code_agent])
-        links = studio._links_for_component(team)
-
-        assert links == []
-
-    def test_description_edit_preserves_the_exact_stored_model(self, tmp_path):
-        """The primary model subtree is base-authoritative: a lossy round trip
-        must not rewrite fields from_dict does not model."""
-        from agno.db.base import ComponentType
-        from agno.db.sqlite import SqliteDb
-        from agno.models.openai import OpenAIChat
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
-
-        db = SqliteDb(db_file=str(tmp_path / "modelkeep.db"))
-        db.upsert_component(component_id="fm-agent", component_type=ComponentType.AGENT, name="A")
-        stored_model = {"provider": "OpenAI", "id": "gpt-5.5", "future_config": {"region": "private"}}
-        db.upsert_config(
-            component_id="fm-agent",
-            config={"id": "fm-agent", "name": "A", "model": stored_model},
-            stage="published",
+        actor_owned = tool.create_schedule(
+            self._request(name="foreign-shared-name"),
+            if_exists="update",
+            _agno_run_context=run_context,
         )
+        unchanged = ScheduleManager(db).get(foreign.id)
 
-        studio = StudioTools(registry=Registry(models=[OpenAIChat(id="gpt-4o-mini")], dbs=[db]), db=db)
-        out = _loads(studio.edit_agent("fm-agent", description="edited"))
-        assert out.get("status") == "edited"
-        assert db.get_config(component_id="fm-agent")["config"]["model"] == stored_model
+        assert actor_owned.ok is True
+        assert actor_owned.status == "created"
+        assert isinstance(actor_owned.data, ScheduleView)
+        assert actor_owned.data.schedule_id != foreign.id
+        assert unchanged is not None
+        assert unchanged.endpoint == "/agents/scheduled-agent/runs"
+        assert unchanged.payload is not None
+        assert unchanged.payload["api_key"] == "sk-foreign-schedule-secret"
+        assert unchanged.managed_by is None
+        assert _error_code(tool.get_schedule(foreign.id, _agno_run_context=run_context)) == "schedule_not_found"
+        assert "sk-foreign-schedule-secret" not in str(tool.list_schedules(_agno_run_context=run_context))
 
-        # An explicit model edit still replaces it.
-        out = _loads(studio.edit_agent("fm-agent", model_id="gpt-4o-mini"))
-        assert out.get("status") == "edited"
-        assert db.get_config(component_id="fm-agent")["config"]["model"].get("id") == "gpt-4o-mini"
+    def test_concurrent_schedule_create_is_database_unique(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        tool = self._tool(registry, db)
+        assert _create_agent(tool, run_context, component_id="scheduled-agent", save_as="published").ok
+        barrier = Barrier(2)
+        create_record = tool._create_studio_schedule_record
 
+        def racing_create(request: ScheduleCreate, target_id: str, context: RunContext):
+            barrier.wait(timeout=5)
+            return create_record(request, target_id, context)
 
-class TestTargetDbBinding:
-    def _studio(self, db, **kwargs):
-        from agno.models.openai import OpenAIChat
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
-
-        model = OpenAIChat(id="gpt-4o-mini")
-        registry = Registry(models=[model], dbs=kwargs.pop("dbs"))
-        return StudioTools(registry=registry, db=db, teams=True, workflows=True, **kwargs), model
-
-    def test_create_refuses_a_member_absent_from_the_target_db(self, tmp_path):
-        from agno.db.sqlite import SqliteDb
-
-        db_a = SqliteDb(id="cat-a", db_file=str(tmp_path / "a.db"))
-        db_b = SqliteDb(id="cat-b", db_file=str(tmp_path / "b.db"))
-        Agent(id="only-a", name="A").save(db=db_a)
-        studio, _ = self._studio(db_a, dbs=[db_a, db_b])
-
-        out = _loads(
-            studio.create_team(
-                name="XT", instructions="i", member_ids=["only-a"], db_id="cat-b", model_id="gpt-4o-mini"
+        monkeypatch.setattr(tool, "_create_studio_schedule_record", racing_create)
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(
+                executor.map(
+                    lambda _: tool.create_schedule(self._request(), _agno_run_context=run_context),
+                    range(2),
+                )
             )
+
+        assert sum(result.ok for result in results) == 1
+        assert [_error_code(result) for result in results if not result.ok] == ["schedule_conflict"]
+        stored = [schedule for schedule in ScheduleManager(db).list() if schedule.name == "daily-research"]
+        assert len(stored) == 1
+
+        other = ScheduleManager(db).create(
+            name="other-name",
+            cron="0 8 * * *",
+            endpoint="/external/webhook",
         )
+        renamed = ScheduleManager(db).update(other.id, name="daily-research")
+        assert renamed is not None
+        assert renamed.name == "daily-research"
+        assert len([schedule for schedule in ScheduleManager(db).list() if schedule.name == "daily-research"]) == 2
+        assert "sk-schedule-message-secret" not in caplog.text
 
-        assert "not stored in db 'cat-b'" in out.get("error", "")
+    def test_concurrent_schedule_create_stays_conflict_after_winner_is_deleted(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        tool = self._tool(registry, db)
+        assert _create_agent(tool, run_context, component_id="scheduled-agent", save_as="published").ok
+        barrier = Barrier(2)
+        create_record = tool._create_studio_schedule_record
 
-    def test_create_into_b_binds_and_pins_bs_row(self, tmp_path):
-        """A same-id child existing in both catalogs must resolve, pin and
-        reload exclusively from the selected target db."""
-        from agno.db.sqlite import SqliteDb
-        from agno.team.team import get_team_by_id
+        def racing_create(request: ScheduleCreate, target_id: str, context: RunContext):
+            barrier.wait(timeout=5)
+            try:
+                return create_record(request, target_id, context)
+            except ScheduleNameConflictError:
+                winner = db.get_schedule_by_name(request.name)
+                assert winner is not None
+                assert db.delete_schedule(winner["id"]) is True
+                raise
 
-        db_a = SqliteDb(id="cat-a", db_file=str(tmp_path / "a2.db"))
-        db_b = SqliteDb(id="cat-b", db_file=str(tmp_path / "b2.db"))
-        Agent(id="dual", name="A", description="from-A").save(db=db_a)
-        Agent(id="dual", name="A", description="from-B").save(db=db_b)
-        studio, _ = self._studio(db_a, dbs=[db_a, db_b])
-
-        out = _loads(
-            studio.create_team(name="BT", instructions="i", member_ids=["dual"], db_id="cat-b", model_id="gpt-4o-mini")
-        )
-        assert out.get("status") == "created"
-
-        loaded = get_team_by_id(db=db_b, id=out["id"], strict=True)
-        assert loaded is not None
-        assert loaded.members[0].description == "from-B"
-
-    def test_create_refuses_an_id_claimed_by_code_and_the_target_db(self, tmp_path):
-        from agno.db.sqlite import SqliteDb
-
-        db = SqliteDb(id="cat", db_file=str(tmp_path / "amb.db"))
-        Agent(id="both", name="DB Row").save(db=db)
-        code_agent = Agent(id="both", name="Live Code")
-        studio, _ = self._studio(db, dbs=[db], agents_list=[code_agent])
-
-        out = _loads(studio.create_team(name="AT", instructions="i", member_ids=["both"], model_id="gpt-4o-mini"))
-
-        assert "claimed by both" in out.get("error", "")
-
-    def test_agents_list_member_survives_a_strict_reload(self, tmp_path):
-        """List members mirror into the registry, so a stored reference to
-        them rehydrates instead of vanishing."""
-        from agno.db.sqlite import SqliteDb
-        from agno.team.team import get_team_by_id
-
-        db = SqliteDb(id="cat", db_file=str(tmp_path / "list.db"))
-        list_agent = Agent(id="listed", name="Listed")
-        studio, _ = self._studio(db, dbs=[db], agents_list=[list_agent])
-
-        out = _loads(studio.create_team(name="LT", instructions="i", member_ids=["listed"], model_id="gpt-4o-mini"))
-        assert out.get("status") == "created"
-
-        loaded = get_team_by_id(db=db, id=out["id"], registry=studio.registry, strict=True)
-        assert loaded is not None
-        assert loaded.members[0].id == "listed"
-
-
-class TestSourceConsistency:
-    def test_construction_refuses_distinct_list_and_registry_objects_sharing_an_id(self):
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
-
-        registry_agent = Agent(id="split", name="Registry Object")
-        list_agent = Agent(id="split", name="List Object")
-
-        with pytest.raises(ValueError, match="distinct components with id 'split'"):
-            StudioTools(registry=Registry(agents=[registry_agent]), agents_list=[list_agent])
-
-        # The same object in both places is consistent and accepted.
-        shared = Agent(id="shared", name="Shared")
-        StudioTools(registry=Registry(agents=[shared]), agents_list=[shared])
-
-    def test_edit_workflow_step_replacement_refuses_code_db_ambiguity(self, tmp_path):
-        from agno.db.sqlite import SqliteDb
-        from agno.models.openai import OpenAIChat
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
-        from agno.workflow.step import Step
-        from agno.workflow.workflow import Workflow
-
-        db = SqliteDb(id="cat", db_file=str(tmp_path / "ewb.db"))
-        Agent(id="amb", name="DB Row").save(db=db)
-        clean = Agent(id="clean", name="Clean")
-        clean.save(db=db)
-        Workflow(id="ew-wf", name="WF", steps=[Step(name="s1", agent=clean)]).save(db=db)
-        code_agent = Agent(id="amb", name="Live Code")
-        model = OpenAIChat(id="gpt-4o-mini")
-        studio = StudioTools(
-            registry=Registry(models=[model], dbs=[db]), db=db, workflows=True, agents_list=[code_agent]
-        )
-
-        out = _loads(studio.edit_workflow("ew-wf", step_specs=[{"name": "s1", "agent_id": "amb"}]))
-
-        assert "claimed by both" in out.get("error", "")
-
-    def test_create_refuses_a_same_id_row_of_the_wrong_type(self, tmp_path):
-        from agno.db.sqlite import SqliteDb
-        from agno.models.openai import OpenAIChat
-        from agno.registry import Registry
-        from agno.team.team import Team
-        from agno.tools.studio import StudioTools
-
-        db_a = SqliteDb(id="cat-a", db_file=str(tmp_path / "wt_a.db"))
-        db_b = SqliteDb(id="cat-b", db_file=str(tmp_path / "wt_b.db"))
-        Agent(id="typed", name="Agent In A").save(db=db_a)
-        Team(id="typed", name="Team In B", members=[Agent(id="tm", name="M")]).save(db=db_b)
-        model = OpenAIChat(id="gpt-4o-mini")
-        studio = StudioTools(registry=Registry(models=[model], dbs=[db_a, db_b]), db=db_a, teams=True)
-
-        out = _loads(
-            studio.create_team(name="WT", instructions="i", member_ids=["typed"], db_id="cat-b", model_id="gpt-4o-mini")
-        )
-
-        assert "as a" in out.get("error", "") and "not the referenced type" in out.get("error", "")
-
-    def test_create_pins_the_version_the_binder_selected(self, tmp_path):
-        """The binder's verified snapshot decides the pin: a publish between
-        its reads refuses, a publish after them stays self-consistent."""
-        from agno.db.sqlite import SqliteDb
-        from agno.models.openai import OpenAIChat
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
-
-        db = SqliteDb(id="cat", db_file=str(tmp_path / "snap.db"))
-        member = Agent(id="sn-member", name="M", description="v1")
-        member.save(db=db)
-        model = OpenAIChat(id="gpt-4o-mini")
-        studio = StudioTools(registry=Registry(models=[model], dbs=[db]), db=db, teams=True)
-
-        real_get_config = db.get_config
-        state = {"calls": 0}
-
-        def racy_get_config(trigger_call):
-            def wrapper(component_id=None, version=None, **kwargs):
-                row = real_get_config(component_id=component_id, version=version, **kwargs)
-                if component_id == "sn-member":
-                    state["calls"] += 1
-                    if state["calls"] == trigger_call:
-                        member.description = "v2"
-                        member.save(db=db)
-                return row
-
-            return wrapper
-
-        # A publish BETWEEN the binder's snapshot and verify reads is detected
-        # and refused rather than persisted torn.
-        db.get_config = racy_get_config(2)
-        try:
-            out = _loads(
-                studio.create_team(name="SN", instructions="i", member_ids=["sn-member"], model_id="gpt-4o-mini")
+        monkeypatch.setattr(tool, "_create_studio_schedule_record", racing_create)
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(
+                executor.map(
+                    lambda _: tool.create_schedule(self._request(), _agno_run_context=run_context),
+                    range(2),
+                )
             )
-        finally:
-            del db.get_config
-        assert "changed while it was being referenced" in out.get("error", "")
 
-        # A publish AFTER the verified snapshot leaves a self-consistent pin:
-        # the committed version rides through to the link and the reload.
-        member.description = "v1"
-        member.save(db=db)
-        committed = db.get_config(component_id="sn-member")["version"]
-        state["calls"] = 0
-        db.get_config = racy_get_config(3)
-        try:
-            out = _loads(
-                studio.create_team(name="SN2", instructions="i", member_ids=["sn-member"], model_id="gpt-4o-mini")
+        assert sum(result.ok for result in results) == 1
+        assert [_error_code(result) for result in results if not result.ok] == ["schedule_conflict"]
+        assert db.get_schedule_by_name("daily-research") is None
+
+    def test_archive_disables_owned_schedules_even_when_schedule_tools_are_hidden(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        schedule_tool = self._tool(registry, db)
+        assert _create_agent(schedule_tool, run_context, component_id="scheduled-agent", save_as="published").ok
+        created = schedule_tool.create_schedule(self._request(), _agno_run_context=run_context)
+        assert isinstance(created.data, ScheduleView)
+
+        archive_tool = self._tool(registry, db, schedules=False)
+        archived = archive_tool.archive_agent(
+            "scheduled-agent",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+        stored = ScheduleManager(db).get(created.data.schedule_id)
+
+        assert archived.ok is True
+        assert archived.status == "archived"
+        assert archived.warnings == []
+        assert stored is not None
+        assert stored.enabled is False
+
+    def test_archive_atomically_disables_more_than_one_schedule_page(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        schedule_tool = self._tool(registry, db)
+        assert _create_agent(schedule_tool, run_context, component_id="scheduled-agent", save_as="published").ok
+        created_ids = [
+            schedule_tool._create_studio_schedule_record(
+                self._request(name=f"scheduled-agent-{index}"),
+                "scheduled-agent",
+                run_context,
+            ).id
+            for index in range(101)
+        ]
+        generic = ScheduleManager(db).create(
+            name="generic-same-target",
+            cron="0 8 * * *",
+            endpoint="/agents/scheduled-agent/runs",
+        )
+
+        archive_tool = self._tool(registry, db, schedules=False)
+        archived = archive_tool.archive_agent(
+            "scheduled-agent",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+
+        assert archived.ok is True
+        assert archived.warnings == []
+        assert all(db.get_schedule(schedule_id)["enabled"] is False for schedule_id in created_ids)
+        assert db.get_schedule(generic.id)["enabled"] is True
+
+    def test_schedule_create_cleans_up_when_archive_wins_after_target_validation(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        tool = self._tool(registry, db)
+        assert _create_agent(tool, run_context, component_id="scheduled-agent", save_as="published").ok
+        create_record = tool._create_studio_schedule_record
+
+        def create_after_archive(request: ScheduleCreate, target_id: str, context: RunContext):
+            archived = tool.archive_agent(
+                "scheduled-agent",
+                expected_current_version=1,
+                _agno_run_context=run_context,
             )
-        finally:
-            del db.get_config
+            assert archived.ok
+            return create_record(request, target_id, context)
 
-        assert out.get("status") == "created"
-        from agno.team.team import get_team_by_id
+        monkeypatch.setattr(tool, "_create_studio_schedule_record", create_after_archive)
+        result = tool.create_schedule(self._request(), _agno_run_context=run_context)
 
-        links = db.get_links(component_id=out["id"], version=1)
-        pins = [link["child_version"] for link in links if link["link_kind"] == "member"]
-        assert pins == [committed]
-        loaded = get_team_by_id(db=db, id=out["id"], strict=True)
-        assert loaded is not None
-        assert loaded.members[0].description == "v1"
+        assert _error_code(result) == "published_target_not_found"
+        assert db.get_schedule_by_name("daily-research") is None
 
-    def test_member_existing_only_in_the_target_db_resolves(self, tmp_path):
-        from agno.db.sqlite import SqliteDb
-        from agno.models.openai import OpenAIChat
-        from agno.registry import Registry
-        from agno.team.team import get_team_by_id
-        from agno.tools.studio import StudioTools
+    def test_schedule_enable_reverts_when_archive_wins_after_target_validation(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        tool = self._tool(registry, db)
+        assert _create_agent(tool, run_context, component_id="scheduled-agent", save_as="published").ok
+        created = tool.create_schedule(self._request(), _agno_run_context=run_context)
+        assert isinstance(created.data, ScheduleView)
+        assert tool.disable_schedule(created.data.schedule_id, _agno_run_context=run_context).ok
+        manager = tool._schedule_manager()
+        enable = manager.enable
 
-        db_a = SqliteDb(id="cat-a", db_file=str(tmp_path / "only_a.db"))
-        db_b = SqliteDb(id="cat-b", db_file=str(tmp_path / "only_b.db"))
-        Agent(id="b-only", name="B Only").save(db=db_b)
-        model = OpenAIChat(id="gpt-4o-mini")
-        studio = StudioTools(registry=Registry(models=[model], dbs=[db_a, db_b]), db=db_a, teams=True)
-
-        out = _loads(
-            studio.create_team(
-                name="BO", instructions="i", member_ids=["b-only"], db_id="cat-b", model_id="gpt-4o-mini"
+        def enable_after_archive(schedule_id: str):
+            archived = tool.archive_agent(
+                "scheduled-agent",
+                expected_current_version=1,
+                _agno_run_context=run_context,
             )
+            assert archived.ok
+            return enable(schedule_id)
+
+        monkeypatch.setattr(manager, "enable", enable_after_archive)
+        result = tool.enable_schedule(created.data.schedule_id, _agno_run_context=run_context)
+        stored = ScheduleManager(db).get(created.data.schedule_id)
+
+        assert _error_code(result) == "published_target_not_found"
+        assert stored is not None
+        assert stored.enabled is False
+
+    @pytest.mark.parametrize("delete_on_failure", [False, True])
+    def test_schedule_revalidation_requires_the_cleanup_write_to_succeed(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+        delete_on_failure: bool,
+    ):
+        tool = self._tool(registry, db)
+        assert _create_agent(tool, run_context, component_id="scheduled-agent", save_as="published").ok
+        archived = tool.archive_agent(
+            "scheduled-agent",
+            expected_current_version=1,
+            _agno_run_context=run_context,
         )
-        assert out.get("status") == "created"
-
-        loaded = get_team_by_id(db=db_b, id=out["id"], strict=True)
-        assert loaded is not None
-        assert loaded.members[0].id == "b-only"
-
-    def test_step_workflow_pins_are_not_suppressed_by_a_same_id_agent(self, tmp_path):
-        from agno.db.sqlite import SqliteDb
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
-        from agno.workflow.step import Step, StepInput, StepOutput
-        from agno.workflow.workflow import Workflow
-
-        def leaf(step_input: StepInput) -> StepOutput:
-            return StepOutput(content="x")
-
-        db = SqliteDb(id="cat", db_file=str(tmp_path / "swf.db"))
-        sub = Workflow(id="sub-flow", name="Sub", steps=[Step(name="x", executor=leaf)])
-        sub.save(db=db)
-        parent = Workflow(id="par-flow", name="Par", steps=[Step(name="n", workflow=sub)])
-        lookalike_agent = Agent(id="sub-flow", name="Unrelated Agent")
-
-        studio = StudioTools(registry=Registry(dbs=[db]), db=db, workflows=True, agents_list=[lookalike_agent])
-        links = studio._links_for_component(parent)
-
-        nested = [link for link in links if link["link_kind"] == "step_workflow"]
-        assert nested and nested[0]["child_component_id"] == "sub-flow"
-
-
-class TestResolutionPrecedence:
-    def test_target_db_exact_id_beats_catalog_display_name(self, tmp_path):
-        """A live component merely NAMED like a target-db id must not steal
-        the reference from the target db's exact-id row."""
-        from agno.db.sqlite import SqliteDb
-        from agno.models.openai import OpenAIChat
-        from agno.registry import Registry
-        from agno.team.team import get_team_by_id
-        from agno.tools.studio import StudioTools
-
-        db_a = SqliteDb(id="cat-a", db_file=str(tmp_path / "prec_a.db"))
-        db_b = SqliteDb(id="cat-b", db_file=str(tmp_path / "prec_b.db"))
-        Agent(id="target-id", name="Target Row", description="from-target").save(db=db_b)
-        impostor = Agent(id="impostor", name="target-id")
-        model = OpenAIChat(id="gpt-4o-mini")
-        studio = StudioTools(
-            registry=Registry(models=[model], dbs=[db_a, db_b]), db=db_a, teams=True, agents_list=[impostor]
+        assert archived.ok
+        schedule = tool._create_studio_schedule_record(self._request(), "scheduled-agent", run_context)
+        failed_cleanup = SimpleNamespace(
+            delete=lambda _schedule_id: False,
+            disable=lambda _schedule_id: None,
+            # Official getters also use None for backend read failures. It is
+            # not evidence that a failed cleanup made the schedule safe.
+            get=lambda _schedule_id: None,
         )
+        monkeypatch.setattr(tool, "_catalog_schedule_manager", lambda: failed_cleanup)
 
-        out = _loads(
-            studio.create_team(
-                name="PT", instructions="i", member_ids=["target-id"], db_id="cat-b", model_id="gpt-4o-mini"
+        with pytest.raises(RuntimeError, match="could not be cleaned up"):
+            tool._revalidate_schedule_target_after_write(
+                schedule,
+                "agent",
+                "scheduled-agent",
+                delete_on_failure=delete_on_failure,
             )
-        )
-        assert out.get("status") == "created"
 
-        loaded = get_team_by_id(db=db_b, id=out["id"], strict=True)
-        assert loaded is not None
-        assert loaded.members[0].description == "from-target"
+        stored = ScheduleManager(db).get(schedule.id)
+        assert stored is not None
+        assert stored.enabled is True
 
-    def test_agent_appended_to_the_live_list_after_construction_reloads(self, tmp_path):
-        from agno.db.sqlite import SqliteDb
-        from agno.models.openai import OpenAIChat
-        from agno.registry import Registry
-        from agno.team.team import get_team_by_id
-        from agno.tools.studio import StudioTools
+    def test_archive_reports_success_with_warning_when_schedule_disable_fails(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        schedule_tool = self._tool(registry, db)
+        assert _create_agent(schedule_tool, run_context, component_id="scheduled-agent", save_as="published").ok
+        created = schedule_tool.create_schedule(self._request(), _agno_run_context=run_context)
+        assert isinstance(created.data, ScheduleView)
 
-        db = SqliteDb(id="cat", db_file=str(tmp_path / "late.db"))
-        live: list = []
-        model = OpenAIChat(id="gpt-4o-mini")
-        studio = StudioTools(registry=Registry(models=[model], dbs=[db]), db=db, teams=True, agents_list=live)
-        live.append(Agent(id="late", name="Late Arrival"))
+        tool = self._tool(registry, db, schedules=False)
+        disable_schedules = tool._disable_studio_schedules_for_target
 
-        out = _loads(studio.create_team(name="LL", instructions="i", member_ids=["late"], model_id="gpt-4o-mini"))
-        assert out.get("status") == "created"
+        def fail_disable(_component_type: str, _component_id: str) -> int:
+            raise RuntimeError("scheduler backend at postgres://private-scheduler")
 
-        loaded = get_team_by_id(db=db, id=out["id"], registry=studio.registry, strict=True)
-        assert loaded is not None
-        assert loaded.members[0].id == "late"
-
-    def test_replaced_live_list_entry_refuses_instead_of_reload_flipping(self, tmp_path):
-        from agno.db.sqlite import SqliteDb
-        from agno.models.openai import OpenAIChat
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
-
-        db = SqliteDb(id="cat", db_file=str(tmp_path / "replace.db"))
-        original = Agent(id="swap", name="Original")
-        live = [original]
-        model = OpenAIChat(id="gpt-4o-mini")
-        studio = StudioTools(registry=Registry(models=[model], dbs=[db]), db=db, teams=True, agents_list=live)
-        live[0] = Agent(id="swap", name="Replacement")
-
-        out = _loads(studio.create_team(name="RL", instructions="i", member_ids=["swap"], model_id="gpt-4o-mini"))
-
-        assert "not the registry's object" in out.get("error", "")
-
-    def test_create_refuses_a_draft_only_child(self, tmp_path):
-        from agno.db.base import ComponentType
-        from agno.db.sqlite import SqliteDb
-        from agno.models.openai import OpenAIChat
-        from agno.registry import Registry
-        from agno.tools.studio import StudioTools
-
-        db = SqliteDb(id="cat", db_file=str(tmp_path / "draft.db"))
-        db.upsert_component(component_id="draft-child", component_type=ComponentType.AGENT, name="D")
-        db.upsert_config(component_id="draft-child", config={"id": "draft-child", "name": "D"}, stage="draft")
-        model = OpenAIChat(id="gpt-4o-mini")
-        studio = StudioTools(registry=Registry(models=[model], dbs=[db]), db=db, teams=True)
-
-        out = _loads(
-            studio.create_team(name="DC", instructions="i", member_ids=["draft-child"], model_id="gpt-4o-mini")
+        monkeypatch.setattr(tool, "_disable_studio_schedules_for_target", fail_disable)
+        archived = tool.archive_agent(
+            "scheduled-agent",
+            expected_current_version=1,
+            _agno_run_context=run_context,
         )
 
-        assert "Publish the child first" in out.get("error", "")
+        assert archived.ok is True
+        assert archived.status == "archived"
+        assert archived.warnings == [
+            "The component was archived, but one or more schedules could not be disabled; inspect the scheduler."
+        ]
+        assert "private-scheduler" not in str(archived)
+        assert "private-scheduler" not in caplog.text
+        assert db.get_component("scheduled-agent") is None
+        assert db.get_component("scheduled-agent", include_deleted=True) is not None
+        stored = ScheduleManager(db).get(created.data.schedule_id)
+        assert stored is not None
+        assert stored.enabled is True
+
+        monkeypatch.setattr(tool, "_disable_studio_schedules_for_target", disable_schedules)
+        retried = tool.archive_agent(
+            "scheduled-agent",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+        stored = ScheduleManager(db).get(created.data.schedule_id)
+
+        assert retried.ok is True
+        assert retried.status == "already_archived"
+        assert retried.warnings == []
+        assert stored is not None
+        assert stored.enabled is False
+
+    def test_archive_warns_when_the_catalog_cannot_prove_v2_schedule_cleanup(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        schedule_tool = self._tool(registry, db)
+        assert _create_agent(schedule_tool, run_context, component_id="scheduled-agent", save_as="published").ok
+        created = schedule_tool.create_schedule(self._request(), _agno_run_context=run_context)
+        assert isinstance(created.data, ScheduleView)
+
+        tool = self._tool(registry, db, schedules=False)
+        monkeypatch.setattr(db, "scheduler_api_version", 1)
+        archived = tool.archive_agent(
+            "scheduled-agent",
+            expected_current_version=1,
+            _agno_run_context=run_context,
+        )
+
+        assert archived.ok is True
+        assert archived.warnings == [
+            "The component was archived, but one or more schedules could not be disabled; inspect the scheduler."
+        ]
+        stored = ScheduleManager(db).get(created.data.schedule_id)
+        assert stored is not None
+        assert stored.enabled is True
+
+    @pytest.mark.asyncio
+    async def test_async_schedule_surface_returns_the_same_typed_results(
+        self,
+        registry: Registry,
+        db: SqliteDb,
+        run_context: RunContext,
+    ):
+        tool = self._tool(registry, db)
+        assert _create_agent(tool, run_context, component_id="scheduled-agent", save_as="published").ok
+
+        created = await tool.acreate_schedule(self._request(), _agno_run_context=run_context)
+        assert isinstance(created.data, ScheduleView)
+        schedule_id = created.data.schedule_id
+        listed = await tool.alist_schedules(_agno_run_context=run_context)
+        fetched = await tool.aget_schedule(schedule_id, _agno_run_context=run_context)
+        disabled = await tool.adisable_schedule(schedule_id, _agno_run_context=run_context)
+        enabled = await tool.aenable_schedule(schedule_id, _agno_run_context=run_context)
+        triggered = await tool.atrigger_schedule(schedule_id, _agno_run_context=run_context)
+        runs = await tool.aget_schedule_runs(schedule_id, _agno_run_context=run_context)
+        deleted = await tool.adelete_schedule(schedule_id, _agno_run_context=run_context)
+
+        assert isinstance(listed.data, list)
+        assert isinstance(fetched.data, ScheduleView)
+        for result in (disabled, enabled, triggered, deleted):
+            assert result.ok is True
+            assert isinstance(result.data, ScheduleActionView)
+        assert runs.ok is True
+        assert runs.data == []

--- a/libs/agno/tests/unit/tools/test_studio_runner.py
+++ b/libs/agno/tests/unit/tools/test_studio_runner.py
@@ -7,11 +7,12 @@ stream kwargs the runner threads through.
 """
 
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 import pytest
 from pydantic import BaseModel
 
+from agno.db.base import ComponentVersionGuard
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.registry import Registry
@@ -19,7 +20,21 @@ from agno.run import RunContext
 from agno.run.base import RunStatus
 from agno.tools.function import FunctionCall
 from agno.tools.studio import StudioTools
-from agno.tools.studio_runner import StudioRunnerTools
+from agno.tools.studio_runner import ComponentNeedsRegistryError, StudioRunnerTools
+from agno.tools.studio_schema import (
+    AgentCreate,
+    AgentPatch,
+    AgentWorkflowStep,
+    ComponentRef,
+    FunctionWorkflowStep,
+    ModelRef,
+    StudioResult,
+    TeamCreate,
+    TeamPatch,
+    ToolRef,
+    WorkflowCreate,
+    WorkflowPatch,
+)
 
 # ----------------------------------------------------------------------
 # Fixtures and stubs
@@ -46,6 +61,82 @@ def _loads(s: str) -> Dict[str, Any]:
 
 def _context(user_id: Optional[str] = "ash", session_id: str = "caller-sess") -> RunContext:
     return RunContext(run_id="caller-run", session_id=session_id, user_id=user_id)
+
+
+def _authorize_studio(_run_context: RunContext, _access: str, _action: str) -> bool:
+    return True
+
+
+def _studio(registry: Registry, db: SqliteDb, **kwargs: Any) -> StudioTools:
+    return StudioTools(registry=registry, db=db, authorize=_authorize_studio, **kwargs)
+
+
+def _data(result: StudioResult[Any]) -> Any:
+    assert result.ok, result.error
+    assert result.data is not None
+    return result.data
+
+
+def _agent_request(
+    name: str,
+    instructions: str = "i",
+    *,
+    component_id: Optional[str] = None,
+    description: Optional[str] = None,
+    tools: Optional[List[ToolRef]] = None,
+) -> AgentCreate:
+    return AgentCreate(
+        component_id=component_id,
+        name=name,
+        instructions=instructions,
+        description=description,
+        model=ModelRef(id="gpt-5.4"),
+        tools=tools or [],
+    )
+
+
+def _team_request(
+    name: str,
+    members: List[ComponentRef],
+    instructions: str = "i",
+    *,
+    component_id: Optional[str] = None,
+) -> TeamCreate:
+    return TeamCreate(
+        component_id=component_id,
+        name=name,
+        instructions=instructions,
+        members=members,
+        model=ModelRef(id="gpt-5.4"),
+    )
+
+
+def _workflow_request(
+    name: str,
+    steps: List[AgentWorkflowStep],
+    *,
+    component_id: Optional[str] = None,
+    description: Optional[str] = "d",
+) -> WorkflowCreate:
+    return WorkflowCreate(component_id=component_id, name=name, description=description, steps=steps)
+
+
+def _create_agent(
+    studio: StudioTools, request: AgentCreate, *, save_as: Literal["draft", "published"] = "published"
+) -> Any:
+    return _data(studio.create_agent(request, save_as=save_as, _agno_run_context=_context()))
+
+
+def _create_team(
+    studio: StudioTools, request: TeamCreate, *, save_as: Literal["draft", "published"] = "published"
+) -> Any:
+    return _data(studio.create_team(request, save_as=save_as, _agno_run_context=_context()))
+
+
+def _create_workflow(
+    studio: StudioTools, request: WorkflowCreate, *, save_as: Literal["draft", "published"] = "published"
+) -> Any:
+    return _data(studio.create_workflow(request, save_as=save_as, _agno_run_context=_context()))
 
 
 def _sub_session(component_type: str, component_id: str, caller_session: str = "caller-sess") -> Optional[str]:
@@ -167,6 +258,33 @@ class _StubWorkflow:
         return clone
 
 
+PRIVATE_RUNTIME_ERROR = "postgres://admin:private-password@db.internal/catalog"
+
+
+class _FailingAgent(_StubAgent):
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(PRIVATE_RUNTIME_ERROR)
+
+    async def arun(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(PRIVATE_RUNTIME_ERROR)
+
+
+class _FailingTeam(_StubTeam):
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(PRIVATE_RUNTIME_ERROR)
+
+    async def arun(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(PRIVATE_RUNTIME_ERROR)
+
+
+class _FailingWorkflow(_StubWorkflow):
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(PRIVATE_RUNTIME_ERROR)
+
+    async def arun(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(PRIVATE_RUNTIME_ERROR)
+
+
 # ----------------------------------------------------------------------
 # Registration
 # ----------------------------------------------------------------------
@@ -199,6 +317,19 @@ class TestRegistration:
             function.process_entrypoint()
             properties = (function.parameters or {}).get("properties") or {}
             assert set(properties) == {"agent_id", "message"}
+
+    def test_model_guidance_does_not_promise_slug_aliases_for_explicit_ids(self, db):
+        runner = StudioRunnerTools(db=db)
+        instructions = str(runner.instructions or "")
+        assert "Use the exact id from a list tool; an exact display name also resolves" in instructions
+        assert "display name or its slug" not in instructions
+
+        for functions in (runner.functions, runner.async_functions):
+            function = functions["run_agent"]
+            function.process_entrypoint()
+            agent_id_description = function.parameters["properties"]["agent_id"]["description"]
+            assert "Exact agent id, or an exact display name" in agent_id_description
+            assert "or its slug" not in agent_id_description
 
 
 # ----------------------------------------------------------------------
@@ -470,15 +601,15 @@ class TestInjectionGuard:
 
 
 # ----------------------------------------------------------------------
-# Resolution: exact ids, display names, ambiguity, slug fallback
+# Resolution: exact ids, exact display names, ambiguity, and no slug aliases
 # ----------------------------------------------------------------------
 
 
 class TestResolution:
     def test_find_agent_resolves_db_component_by_display_name(self, registry, db):
-        studio = StudioTools(registry=registry, db=db)
-        created = _loads(studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4"))
-        assert created["id"] == "radar-scout"
+        studio = _studio(registry, db)
+        created = _create_agent(studio, _agent_request("Radar Scout"))
+        assert created.component_id == "radar-scout"
 
         runner = StudioRunnerTools(registry=registry, db=db)
         by_id = runner._find_agent("radar-scout")
@@ -492,9 +623,12 @@ class TestResolution:
         assert out == {"error": "Agent not found: nope"}
 
     def test_run_agent_rejects_team_id(self, registry, db):
-        studio = StudioTools(registry=registry, db=db, teams=True)
-        studio.create_agent(name="member", instructions="i", model_id="gpt-5.4")
-        studio.create_team(name="squad", instructions="i", member_ids=["member"], model_id="gpt-5.4")
+        studio = _studio(registry, db, teams=True)
+        _create_agent(studio, _agent_request("member"))
+        _create_team(
+            studio,
+            _team_request("squad", [ComponentRef(component_type="agent", component_id="member")]),
+        )
 
         runner = StudioRunnerTools(registry=registry, db=db)
         out = _loads(runner.run_agent("squad", "hi"))
@@ -511,8 +645,8 @@ class TestResolution:
         assert runner._find_agent("researcher") is target
 
     def test_db_exact_id_beats_code_defined_display_name(self, registry, db):
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="radar", instructions="i", model_id="gpt-5.4")
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("radar"))
         shadow = _StubAgent()
         shadow.id = "other"
         shadow.name = "radar"
@@ -522,24 +656,45 @@ class TestResolution:
         assert getattr(found, "id", None) == "radar"
 
     def test_display_name_resolves_across_type_slug_collision(self, registry, db):
-        # The team owns the base slug; the same-named agent got a -2 suffix.
-        # Name resolution is typed, so each type's lookup reaches its own component.
-        studio = StudioTools(registry=registry, db=db, teams=True)
-        studio.create_agent(name="member", instructions="i", model_id="gpt-5.4")
-        studio.create_team(name="Radar Scout", instructions="i", member_ids=["member"], model_id="gpt-5.4")
-        created = _loads(studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4"))
-        assert created["id"] == "radar-scout-2"
+        # Stable ids are global, while display-name resolution remains typed.
+        studio = _studio(registry, db, teams=True)
+        _create_agent(studio, _agent_request("member"))
+        _create_team(
+            studio,
+            _team_request(
+                "Radar Scout",
+                [ComponentRef(component_type="agent", component_id="member")],
+                component_id="radar-scout-team",
+            ),
+        )
+        created = _create_agent(
+            studio,
+            _agent_request("Radar Scout", component_id="radar-scout-agent"),
+        )
+        assert created.component_id == "radar-scout-agent"
 
         runner = StudioRunnerTools(registry=registry, db=db)
         agent = runner._find_agent("Radar Scout")
         team = runner._find_team("Radar Scout")
-        assert agent is not None and agent.id == "radar-scout-2"
-        assert team is not None and team.id == "radar-scout"
+        assert agent is not None and agent.id == "radar-scout-agent"
+        assert team is not None and team.id == "radar-scout-team"
+
+    def test_display_name_slug_is_not_an_alias_for_an_explicit_component_id(self, registry, db):
+        studio = _studio(registry, db)
+        _create_agent(
+            studio,
+            _agent_request("Radar Scout", component_id="radar-scout-agent"),
+        )
+
+        runner = StudioRunnerTools(registry=registry, db=db)
+        assert runner._find_agent("Radar Scout") is not None
+        assert runner._find_agent("radar-scout") is None
+        assert runner._find_agent("radar-scout-agent") is not None
 
     def test_ambiguous_display_name_errors_with_matching_ids(self, registry, db):
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4")
-        studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4")
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Radar Scout", component_id="radar-scout"))
+        _create_agent(studio, _agent_request("Radar Scout", component_id="radar-scout-2"))
 
         runner = StudioRunnerTools(registry=registry, db=db)
         out = _loads(runner.run_agent("Radar Scout", "hi"))
@@ -551,29 +706,28 @@ class TestResolution:
 
     @pytest.mark.asyncio
     async def test_async_ambiguous_display_name_errors(self, registry, db):
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4")
-        studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4")
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Radar Scout", component_id="radar-scout"))
+        _create_agent(studio, _agent_request("Radar Scout", component_id="radar-scout-2"))
 
         runner = StudioRunnerTools(registry=registry, db=db)
         out = _loads(await runner.arun_agent("Radar Scout", "hi"))
         assert "Ambiguous" in out["error"]
 
-    def test_slug_fallback_resolves_when_name_lookup_misses(self, registry, db):
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4")
+    def test_fuzzy_display_name_is_not_inferred_as_an_id(self, registry, db):
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Radar Scout"))
 
         runner = StudioRunnerTools(registry=registry, db=db)
-        found = runner._find_agent("radar scout!")
-        assert found is not None and found.id == "radar-scout"
+        assert runner._find_agent("radar scout!") is None
 
     def test_name_lookup_pages_beyond_first_page(self, registry, db, monkeypatch):
         import agno.tools.studio_runner as studio_runner_module
 
         monkeypatch.setattr(studio_runner_module, "_NAME_LOOKUP_PAGE", 1)
-        studio = StudioTools(registry=registry, db=db)
+        studio = _studio(registry, db)
         for name in ("Oldest Match", "newer-a", "newer-b"):
-            studio.create_agent(name=name, instructions="i", model_id="gpt-5.4")
+            _create_agent(studio, _agent_request(name))
 
         runner = StudioRunnerTools(registry=registry, db=db)
         found = runner._find_agent("Oldest Match")
@@ -597,10 +751,10 @@ class TestResolution:
         # silently dispatch the name match.
         from agno.agent.agent import Agent as AgentClass
 
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="Reports", instructions="i", model_id="gpt-5.4")
-        created = _loads(studio.create_agent(name="reports", instructions="i", model_id="gpt-5.4"))
-        assert created["id"] == "reports-2"
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Reports", component_id="reports"))
+        created = _create_agent(studio, _agent_request("reports", component_id="reports-2"))
+        assert created.component_id == "reports-2"
 
         original_from_dict = AgentClass.from_dict
 
@@ -628,15 +782,113 @@ class TestResolution:
         missing = _loads(runner.run_agent("nope", "hi"))
         assert missing == {"error": "Agent not found: nope"}
 
-    def test_db_failure_during_resolution_returns_error_payload(self, db):
+    def test_db_failure_during_resolution_is_sanitized(self, db, caplog):
         runner = StudioRunnerTools(db=db)
 
         def boom(*args, **kwargs):
-            raise RuntimeError("connection reset")
+            raise RuntimeError(PRIVATE_RUNTIME_ERROR)
 
         runner.db.list_components = boom  # type: ignore[method-assign]
         out = _loads(runner.run_agent("Some Name", "hi"))
-        assert "connection reset" in out["error"]
+        assert out == {"error": "StudioRunnerTools could not resolve agent."}
+        assert PRIVATE_RUNTIME_ERROR not in json.dumps(out)
+        assert PRIVATE_RUNTIME_ERROR not in caplog.text
+
+
+class TestUnexpectedFailureSanitization:
+    def test_deep_copy_failure_does_not_expose_exception_text(self, db, caplog):
+        class _SecretCopyAgent(_StubAgent):
+            def deep_copy(self):
+                raise RuntimeError(PRIVATE_RUNTIME_ERROR)
+
+        runner = StudioRunnerTools(db=db, agents_list=[_SecretCopyAgent()])
+
+        out = _loads(runner.run_agent("stub", "hi"))
+
+        assert "deep_copy failed for 'stub'" in out["error"]
+        assert PRIVATE_RUNTIME_ERROR not in json.dumps(out)
+        assert PRIVATE_RUNTIME_ERROR not in caplog.text
+
+    @pytest.mark.parametrize(
+        ("component_type", "method_name", "component_id", "component"),
+        [
+            ("agent", "run_agent", "stub", _FailingAgent()),
+            ("team", "run_team", "stub-team", _FailingTeam()),
+            ("workflow", "run_workflow", "stub-wf", _FailingWorkflow()),
+        ],
+    )
+    def test_sync_runtime_errors_are_sanitized(
+        self,
+        db,
+        caplog,
+        component_type: str,
+        method_name: str,
+        component_id: str,
+        component: Any,
+    ):
+        runner = StudioRunnerTools(db=db, **{f"{component_type}s_list": [component]})
+
+        out = _loads(getattr(runner, method_name)(component_id, "hi", _agno_run_context=_context()))
+
+        assert out == {"error": f"StudioRunnerTools could not run {component_type}."}
+        assert PRIVATE_RUNTIME_ERROR not in json.dumps(out)
+        assert PRIVATE_RUNTIME_ERROR not in caplog.text
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("component_type", "method_name", "component_id", "component"),
+        [
+            ("agent", "arun_agent", "stub", _FailingAgent()),
+            ("team", "arun_team", "stub-team", _FailingTeam()),
+            ("workflow", "arun_workflow", "stub-wf", _FailingWorkflow()),
+        ],
+    )
+    async def test_async_runtime_errors_are_sanitized(
+        self,
+        db,
+        caplog,
+        component_type: str,
+        method_name: str,
+        component_id: str,
+        component: Any,
+    ):
+        runner = StudioRunnerTools(db=db, **{f"{component_type}s_list": [component]})
+
+        out = _loads(await getattr(runner, method_name)(component_id, "hi", _agno_run_context=_context()))
+
+        assert out == {"error": f"StudioRunnerTools could not run {component_type}."}
+        assert PRIVATE_RUNTIME_ERROR not in json.dumps(out)
+        assert PRIVATE_RUNTIME_ERROR not in caplog.text
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("component_type", "method_name", "resolver_name"),
+        [
+            ("agent", "arun_agent", "_agent_for_run"),
+            ("team", "arun_team", "_team_for_run"),
+            ("workflow", "arun_workflow", "_workflow_for_run"),
+        ],
+    )
+    async def test_async_resolution_errors_are_sanitized(
+        self,
+        db,
+        caplog,
+        monkeypatch: pytest.MonkeyPatch,
+        component_type: str,
+        method_name: str,
+        resolver_name: str,
+    ):
+        runner = StudioRunnerTools(db=db)
+
+        def fail_resolution(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError(PRIVATE_RUNTIME_ERROR)
+
+        monkeypatch.setattr(runner, resolver_name, fail_resolution)
+        out = _loads(await getattr(runner, method_name)("hidden", "hi"))
+
+        assert out == {"error": f"StudioRunnerTools could not resolve {component_type}."}
+        assert PRIVATE_RUNTIME_ERROR not in json.dumps(out)
+        assert PRIVATE_RUNTIME_ERROR not in caplog.text
 
 
 # ----------------------------------------------------------------------
@@ -820,8 +1072,8 @@ class TestDispatchIsolation:
         # table overrides) must not be overwritten by the catalog db.
         from agno.agent.agent import Agent as AgentClass
 
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="Radar", instructions="i", model_id="gpt-5.4")
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Radar"))
 
         own_db = SqliteDb(id="component-own-db", db_file=str(tmp_path / "own.db"))
         original_from_dict = AgentClass.from_dict
@@ -849,14 +1101,15 @@ class TestDiscovery:
         # component that runs and cannot be found leaves it no way in. An
         # explicit agents_list is an allowlist FOR dispatch, so it is listed --
         # code first, which is the order dispatch resolves in.
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="Radar", instructions="i", model_id="gpt-5.4", description="scans the week")
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Radar", description="scans the week"))
 
         runner = StudioRunnerTools(registry=registry, db=db, agents_list=[_StubAgent()])
         out = _loads(runner.list_agents())
         assert out["agents"][-1] == {"id": "radar", "name": "Radar", "description": "scans the week"}
         assert any(entry["id"] == _StubAgent().id for entry in out["agents"])
         assert out["count"] == len(out["agents"])
+        assert out["total"] == 2
 
     def test_a_registry_agent_stays_unlisted_until_it_is_admitted(self, registry, db):
         # The privacy half of the rule is unchanged: a registry is passed so
@@ -872,9 +1125,9 @@ class TestDiscovery:
         assert any(entry["id"] == "internal" for entry in admitted["agents"])
 
     def test_list_agents_reports_total_beyond_cap(self, registry, db):
-        studio = StudioTools(registry=registry, db=db)
+        studio = _studio(registry, db)
         for name in ("one", "two", "three"):
-            studio.create_agent(name=name, instructions="i", model_id="gpt-5.4")
+            _create_agent(studio, _agent_request(name))
 
         runner = StudioRunnerTools(registry=registry, db=db, list_limit=2)
         out = _loads(runner.list_agents())
@@ -895,6 +1148,19 @@ class TestDiscovery:
         out = _loads(runner.list_agents())
         assert out == {"agents": [], "count": 0, "total": 0}
 
+    def test_list_failure_does_not_expose_exception_text(self, db, caplog):
+        def fail_list(*_args, **_kwargs):
+            raise RuntimeError(PRIVATE_RUNTIME_ERROR)
+
+        db.list_components = fail_list
+        runner = StudioRunnerTools(db=db)
+
+        out = _loads(runner.list_agents())
+
+        assert out == {"error": "StudioRunnerTools could not list agents."}
+        assert PRIVATE_RUNTIME_ERROR not in json.dumps(out)
+        assert PRIVATE_RUNTIME_ERROR not in caplog.text
+
 
 # ----------------------------------------------------------------------
 # StudioTools embedding
@@ -904,25 +1170,25 @@ class TestDiscovery:
 class TestStudioEmbedding:
     def test_public_run_methods_forward_to_the_runner(self, registry, db):
         stub = _StubAgent()
-        studio = StudioTools(registry=registry, db=db, agents_list=[stub])
+        studio = _studio(registry, db, agents_list=[stub])
         for name in ("run_agent", "run_team", "run_workflow", "arun_agent", "arun_team", "arun_workflow"):
             assert hasattr(studio, name)
-        out = _loads(studio.run_agent("stub", "hi"))
+        out = _loads(studio.run_agent("stub", "hi", _agno_run_context=_context()))
         assert out["agent_id"] == "stub"
         assert stub.seen is not None
 
     @pytest.mark.asyncio
     async def test_public_arun_agent_forwards_to_the_runner(self, registry, db):
         stub = _StubAgent()
-        studio = StudioTools(registry=registry, db=db, agents_list=[stub])
-        out = _loads(await studio.arun_agent("stub", "hi"))
+        studio = _studio(registry, db, agents_list=[stub])
+        out = _loads(await studio.arun_agent("stub", "hi", _agno_run_context=_context()))
         assert out["agent_id"] == "stub"
 
     def test_studio_registers_its_own_run_methods(self, registry, db):
         # The registered tool must be StudioTools' own method, not the embedded
         # runner's bound method, or a subclass override never sits on the path the
         # model takes.
-        studio = StudioTools(registry=registry, db=db, teams=True, workflows=True)
+        studio = _studio(registry, db, teams=True, workflows=True)
         for name in ("run_agent", "run_team", "run_workflow"):
             entrypoint = studio.functions[name].entrypoint
             assert getattr(entrypoint, "__self__", None) is studio
@@ -938,16 +1204,20 @@ class TestStudioEmbedding:
                 return super().run_agent(agent_id, message, _agno_run_context)
 
         stub = _StubAgent()
-        studio = Guarded(registry=registry, db=db, agents_list=[stub])
+        studio = Guarded(
+            registry=registry,
+            db=db,
+            authorize=_authorize_studio,
+            agents_list=[stub],
+        )
         out = _loads(studio.functions["run_agent"].entrypoint("stub", "hi", _agno_run_context=_context()))
         assert calls == ["stub"]
         assert out["agent_id"] == "stub"
-        # The compat alias survives the override.
-        assert out["id"] == "stub"
+        assert "id" not in out
 
     def test_identity_threads_through_studio_registered_tool(self, registry, db):
         stub = _StubAgent()
-        studio = StudioTools(registry=registry, db=db, agents_list=[stub])
+        studio = _studio(registry, db, agents_list=[stub])
         out = _loads(studio.functions["run_agent"].entrypoint("stub", "hi", _agno_run_context=_context()))
         assert stub.seen == {
             "message": "hi",
@@ -957,85 +1227,130 @@ class TestStudioEmbedding:
         }
         assert out["agent_id"] == "stub"
 
-    def test_studio_lookups_gain_name_resolution(self, registry, db):
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4")
-        # get_agent by display name resolves via the shared runner lookup path.
-        out = _loads(studio.get_agent("Radar Scout"))
-        assert out.get("id") == "radar-scout"
+    def test_studio_lookup_uses_exact_component_id(self, registry, db):
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Radar Scout"))
+        missing = studio.get_agent("Radar Scout", _agno_run_context=_context())
+        assert missing.error is not None and missing.error.code == "invalid_component_id"
+        assert _data(studio.get_agent("radar-scout", _agno_run_context=_context())).component_id == "radar-scout"
 
-    def test_get_agent_ambiguous_name_errors(self, registry, db):
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4")
-        studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4")
-        out = _loads(studio.get_agent("Radar Scout"))
-        assert "Ambiguous" in out.get("error", "")
+    def test_same_display_name_is_safe_with_exact_component_ids(self, registry, db):
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Radar Scout", component_id="radar-a"))
+        _create_agent(studio, _agent_request("Radar Scout", component_id="radar-b"))
+        first = _data(studio.get_agent("radar-a", _agno_run_context=_context()))
+        second = _data(studio.get_agent("radar-b", _agno_run_context=_context()))
+        assert first.component_id == "radar-a"
+        assert second.component_id == "radar-b"
 
-    def test_edit_resolves_display_name_to_canonical_id(self, registry, db):
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4")
-        out = _loads(studio.edit_agent("Radar Scout", instructions="updated"))
-        assert out.get("status") == "edited"
-        assert out.get("id") == "radar-scout"
-        fetched = _loads(studio.get_agent("radar-scout"))
-        assert fetched["instructions"] == "updated"
+    def test_edit_uses_exact_component_id(self, registry, db):
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Radar Scout"))
+        out = studio.edit_agent(
+            "radar-scout",
+            AgentPatch(instructions="updated"),
+            expected_version=1,
+            save_as="published",
+            _agno_run_context=_context(),
+        )
+        assert out.ok and out.status == "edited"
+        assert out.data is not None and out.data.component_id == "radar-scout"
+        fetched = _data(studio.get_agent("radar-scout", _agno_run_context=_context()))
+        assert fetched.instructions == "updated"
 
     def test_exact_team_member_id_beats_agent_display_name(self, registry, db):
-        studio = StudioTools(registry=registry, db=db, teams=True)
-        studio.create_agent(name="member", instructions="i", model_id="gpt-5.4")
-        studio.create_team(name="support", instructions="i", member_ids=["member"], model_id="gpt-5.4")
-        # An agent NAMED "support" (stored as support-2) must not steal the
-        # team's exact id in member resolution.
-        created_agent = _loads(studio.create_agent(name="support", instructions="i", model_id="gpt-5.4"))
-        assert created_agent["id"] == "support-2"
+        studio = _studio(registry, db, teams=True)
+        _create_agent(studio, _agent_request("member"))
+        _create_team(
+            studio,
+            _team_request(
+                "support",
+                [ComponentRef(component_type="agent", component_id="member")],
+                component_id="support-team",
+            ),
+        )
+        _create_agent(studio, _agent_request("support", component_id="support-agent"))
 
-        created = _loads(studio.create_team(name="squad", instructions="i", member_ids=["support"], model_id="gpt-5.4"))
-        assert created.get("member_ids") == ["support"]
+        created = _create_team(
+            studio,
+            _team_request(
+                "squad",
+                [ComponentRef(component_type="team", component_id="support-team")],
+            ),
+        )
+        assert created.members == [ComponentRef(component_type="team", component_id="support-team", version=1)]
 
     def test_list_shows_db_component_named_like_a_code_id(self, registry, db):
         code_agent = _StubAgent()
         code_agent.id = "support"
         code_agent.name = "Support Code"
-        shadowed = StudioTools(registry=registry, db=db, agents_list=[code_agent])
-        created = _loads(shadowed.create_agent(name="support", instructions="i", model_id="gpt-5.4"))
-        assert created["id"] == "support-2"
+        shadowed = _studio(registry, db, agents_list=[code_agent])
+        created = _create_agent(
+            shadowed,
+            _agent_request("Support Code", component_id="support-db"),
+        )
+        assert created.component_id == "support-db"
 
-        listed = _loads(shadowed.list_agents())
-        ids = {row["id"] for row in listed["agents"]}
+        listed = _data(shadowed.list_agents(_agno_run_context=_context()))
+        ids = {row.component_id for row in listed}
         assert "support" in ids
-        assert "support-2" in ids
+        assert "support-db" in ids
 
-    def test_edit_collision_error_points_at_the_editable_component(self, registry, db):
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4")
+    def test_exact_db_id_remains_editable_when_code_name_collides(self, registry, db):
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Radar Scout"))
         shadow = _StubAgent()
         shadow.id = "code-1"
         shadow.name = "Radar Scout"
-        shadowed = StudioTools(registry=registry, db=db, agents_list=[shadow])
-        out = _loads(shadowed.edit_agent("Radar Scout", instructions="x"))
-        assert "Cannot edit code-defined agent" in out["error"]
-        assert "radar-scout" in out["error"]
+        shadowed = _studio(registry, db, agents_list=[shadow])
+        out = shadowed.edit_agent(
+            "radar-scout",
+            AgentPatch(instructions="x"),
+            expected_version=1,
+            save_as="published",
+            _agno_run_context=_context(),
+        )
+        assert out.ok
+        assert out.data is not None and out.data.component_id == "radar-scout"
 
-    def test_cross_type_member_id_collision_errors(self, registry, db):
-        # An agent and team may legally share an id (uniqueness is per type);
-        # member resolution must refuse rather than silently pick the agent.
-        studio = StudioTools(registry=registry, db=db, teams=True)
-        studio.create_agent(name="helper", instructions="i", model_id="gpt-5.4")
-        studio.create_team(name="shared", instructions="i", member_ids=["helper"], model_id="gpt-5.4")
+    def test_typed_member_ref_rejects_cross_source_id_collision(self, registry, db):
+        studio = _studio(registry, db, teams=True)
+        _create_agent(studio, _agent_request("helper"))
+        _create_team(
+            studio,
+            _team_request(
+                "shared",
+                [ComponentRef(component_type="agent", component_id="helper")],
+            ),
+        )
         code_agent = _StubAgent()
         code_agent.id = "shared"
         code_agent.name = "Shared Agent"
-        shadowed = StudioTools(registry=registry, db=db, teams=True, agents_list=[code_agent])
-        out = _loads(shadowed.create_team(name="squad", instructions="i", member_ids=["shared"], model_id="gpt-5.4"))
-        assert "matches both an agent and a team" in out.get("error", "")
+        shadowed = _studio(registry, db, teams=True, agents_list=[code_agent])
+        result = shadowed.create_team(
+            _team_request("squad", [ComponentRef(component_type="team", component_id="shared")]),
+            _agno_run_context=_context(),
+        )
+        assert not result.ok
+        assert result.error is not None and result.error.code == "component_source_collision"
 
-    def test_cross_type_member_name_collision_errors(self, registry, db):
-        studio = StudioTools(registry=registry, db=db, teams=True)
-        studio.create_agent(name="Ops", instructions="i", model_id="gpt-5.4")
-        studio.create_agent(name="helper", instructions="i", model_id="gpt-5.4")
-        studio.create_team(name="Ops", instructions="i", member_ids=["helper"], model_id="gpt-5.4")
-        out = _loads(studio.create_team(name="squad", instructions="i", member_ids=["Ops"], model_id="gpt-5.4"))
-        assert "matches both an agent and a team" in out.get("error", "")
+    def test_typed_member_ref_ignores_cross_type_name_collision(self, registry, db):
+        studio = _studio(registry, db, teams=True)
+        _create_agent(studio, _agent_request("Ops", component_id="ops-agent"))
+        _create_agent(studio, _agent_request("helper"))
+        _create_team(
+            studio,
+            _team_request(
+                "Ops",
+                [ComponentRef(component_type="agent", component_id="helper")],
+                component_id="ops-team",
+            ),
+        )
+        created = _create_team(
+            studio,
+            _team_request("squad", [ComponentRef(component_type="team", component_id="ops-team")]),
+        )
+        assert created.members[0].component_id == "ops-team"
 
     def test_registry_less_runner_refuses_tool_bearing_component(self, db):
         from agno.tools.calculator import CalculatorTools
@@ -1046,8 +1361,11 @@ class TestStudioEmbedding:
             tools=[CalculatorTools()],
             dbs=[db],
         )
-        studio = StudioTools(registry=armed_registry, db=db)
-        studio.create_agent(name="Armed", instructions="i", model_id="gpt-5.4", tool_names=["calculator"])
+        studio = _studio(armed_registry, db)
+        _create_agent(
+            studio,
+            _agent_request("Armed", tools=[ToolRef(kind="toolkit", name="calculator")]),
+        )
         runner = StudioRunnerTools(db=db)
         out = _loads(runner.run_agent("armed", "hi"))
         assert "registry" in out.get("error", "")
@@ -1064,9 +1382,15 @@ class TestStudioEmbedding:
             tools=[CalculatorTools()],
             dbs=[db],
         )
-        studio = StudioTools(registry=armed_registry, db=db, teams=True)
-        studio.create_agent(name="Armed", instructions="i", model_id="gpt-5.4", tool_names=["calculator"])
-        studio.create_team(name="Crew", instructions="i", member_ids=["armed"], model_id="gpt-5.4")
+        studio = _studio(armed_registry, db, teams=True)
+        _create_agent(
+            studio,
+            _agent_request("Armed", tools=[ToolRef(kind="toolkit", name="calculator")]),
+        )
+        _create_team(
+            studio,
+            _team_request("Crew", [ComponentRef(component_type="agent", component_id="armed")]),
+        )
 
         runner = StudioRunnerTools(db=db)
         out = _loads(runner.run_team("crew", "hi"))
@@ -1085,21 +1409,34 @@ class TestStudioEmbedding:
             tools=[CalculatorTools()],
             dbs=[db],
         )
-        studio = StudioTools(registry=armed_registry, db=db, teams=True, workflows=True)
-        studio.create_agent(name="Armed", instructions="i", model_id="gpt-5.4", tool_names=["calculator"])
-        studio.create_team(name="Crew", instructions="i", member_ids=["armed"], model_id="gpt-5.4")
-        studio.create_workflow(name="Flow", description="d", step_specs=[{"name": "s1", "agent_id": "armed"}])
+        studio = _studio(armed_registry, db, teams=True, workflows=True)
+        _create_agent(
+            studio,
+            _agent_request("Armed", tools=[ToolRef(kind="toolkit", name="calculator")]),
+        )
+        _create_team(
+            studio,
+            _team_request("Crew", [ComponentRef(component_type="agent", component_id="armed")]),
+        )
+        _create_workflow(
+            studio,
+            _workflow_request(
+                "Flow",
+                [AgentWorkflowStep(kind="agent", name="s1", component_id="armed")],
+            ),
+        )
 
         toolless_registry = Registry(name="Toolless", models=[OpenAIResponses(id="gpt-5.4")], dbs=[db])
         runner = StudioRunnerTools(registry=toolless_registry, db=db)
 
         out = _loads(runner.run_team("crew", "hi"))
-        # The refusal names the member and the tool functions it lost.
+        # The refusal names the nested member and the tool functions it lost.
         assert "nested component armed" in out.get("error", "")
         assert "add" in out.get("error", "")
 
         out = _loads(runner.run_workflow("flow", "go"))
         assert "nested component armed" in out.get("error", "")
+        assert "add" in out.get("error", "")
 
         # The complete registry still dispatches: the guard refuses degradation,
         # not composition.
@@ -1108,8 +1445,25 @@ class TestStudioEmbedding:
 
     def test_registry_less_runner_refuses_workflow_with_code_defined_step(self, registry, db):
         code_agent = _StubAgent()
-        studio = StudioTools(registry=registry, db=db, workflows=True, agents_list=[code_agent])
-        studio.create_workflow(name="Flow", description="d", step_specs=[{"name": "s1", "agent_id": "stub"}])
+        studio = _studio(registry, db, workflows=True, agents_list=[code_agent])
+        created = _create_workflow(
+            studio,
+            _workflow_request(
+                "Flow",
+                [AgentWorkflowStep(kind="agent", name="s1", component_id="stub")],
+            ),
+            save_as="draft",
+        )
+        assert created.stage == "draft"
+
+        # Persisted legacy/external configs can still carry code-defined refs;
+        # runner dispatch must fail closed without the registry.
+        db.upsert_config(
+            component_id="flow",
+            version=1,
+            stage="published",
+            guard=ComponentVersionGuard(latest_version=1, current_version=None),
+        )
 
         runner = StudioRunnerTools(db=db)
         out = _loads(runner.run_workflow("flow", "go"))
@@ -1146,9 +1500,18 @@ class TestStudioEmbedding:
         armed_registry = Registry(
             name="Armed Registry", models=[OpenAIResponses(id="gpt-5.4")], tools=[CalculatorTools()], dbs=[db]
         )
-        studio = StudioTools(registry=armed_registry, db=db, workflows=True)
-        studio.create_agent(name="Armed", instructions="i", model_id="gpt-5.4", tool_names=["calculator"])
-        studio.create_workflow(name="Direct", description="d", step_specs=[{"name": "s", "agent_id": "armed"}])
+        studio = _studio(armed_registry, db, workflows=True)
+        _create_agent(
+            studio,
+            _agent_request("Armed", tools=[ToolRef(kind="toolkit", name="calculator")]),
+        )
+        _create_workflow(
+            studio,
+            _workflow_request(
+                "Direct",
+                [AgentWorkflowStep(kind="agent", name="s", component_id="armed")],
+            ),
+        )
         # StudioTools cannot author a compound step, so the persisted config for
         # the nested shape is written directly, the way a posted config arrives.
         db.upsert_component(component_id="nested", component_type="workflow", name="Nested")
@@ -1423,7 +1786,7 @@ class TestStudioEmbedding:
         runner = StudioRunnerTools(registry=registry, db=db)
         assert "cannot reconstruct" not in _loads(runner.run_workflow("fy", "hi")).get("error", "")
 
-    def test_a_failed_reference_read_refuses_rather_than_passes(self, db, registry):
+    def test_a_failed_reference_read_refuses_without_exposing_exception_text(self, db, registry, caplog):
         """A db read that fails is not evidence of fidelity. Swallowing it would
         turn "could not check" into "checked and fine" for the one component the
         check exists to inspect."""
@@ -1453,11 +1816,15 @@ class TestStudioEmbedding:
 
         def failing(component_id, **kwargs):
             if component_id == "worker":
-                raise RuntimeError("transient db failure")
+                raise RuntimeError(PRIVATE_RUNTIME_ERROR)
             return original(component_id, **kwargs)
 
         runner._load_config_row_from_db = failing  # type: ignore[method-assign]
-        assert "transient db failure" in _loads(runner.run_team("crew", "hi"))["error"]
+        out = _loads(runner.run_team("crew", "hi"))
+
+        assert out == {"error": "StudioRunnerTools could not resolve team."}
+        assert PRIVATE_RUNTIME_ERROR not in json.dumps(out)
+        assert PRIVATE_RUNTIME_ERROR not in caplog.text
 
     def test_reference_stored_under_another_type_is_refused(self, db, registry):
         """A code-defined reference is simply absent from the components table.
@@ -1520,32 +1887,14 @@ class TestStudioEmbedding:
         assert whole._workflow_for_run("flow").steps[0].agent.output_schema is Report
 
     def test_create_refuses_an_idless_member_or_step(self, registry, db):
-        # Persisting a reference to a code-defined component with no id would
-        # store agent_id null; on reload a registry lookup by id=None binds
-        # whichever id-less component it sees first. Refuse at write time.
-        from agno.agent.agent import Agent as AgentClass
-
-        helper = AgentClass(name="Helper", model=OpenAIResponses(id="gpt-5.4"))
-        studio = StudioTools(registry=registry, db=db, teams=True, workflows=True, agents_list=[helper])
-
-        created = _loads(studio.create_team(name="crew", instructions="i", member_ids=["Helper"], model_id="gpt-5.4"))
-        assert "no id" in created.get("error", "")
+        # Typed component refs require a stable non-empty id before Studio can
+        # persist either a team member or workflow executor.
+        with pytest.raises(ValueError):
+            ComponentRef(component_type="agent", component_id="")
+        with pytest.raises(ValueError):
+            AgentWorkflowStep(kind="agent", name="s1", component_id="")
         assert db.get_component("crew") is None
-
-        created = _loads(
-            studio.create_workflow(name="flow", description="d", step_specs=[{"name": "s1", "agent_id": "Helper"}])
-        )
-        assert "no id" in created.get("error", "")
-
-        # An empty-string id is refused the same way: the write guard matches
-        # the load guard's falsiness test, or the component is created and
-        # listed but never loadable.
-        blank = AgentClass(id="", name="Blank", model=OpenAIResponses(id="gpt-5.4"))
-        studio_blank = StudioTools(registry=registry, db=db, teams=True, agents_list=[blank])
-        created = _loads(
-            studio_blank.create_team(name="crew2", instructions="i", member_ids=["Blank"], model_id="gpt-5.4")
-        )
-        assert "no id" in created.get("error", "")
+        assert db.get_component("flow") is None
 
     def test_edit_team_keeps_agents_list_members_resolvable(self, registry, db):
         # StudioTools mirrors agents_list into the registry so rehydration can
@@ -1555,16 +1904,26 @@ class TestStudioEmbedding:
         from agno.agent.agent import Agent as AgentClass
 
         worker = AgentClass(id="worker", name="Worker", model=OpenAIResponses(id="gpt-5.4"))
-        studio = StudioTools(registry=registry, db=db, teams=True, agents_list=[worker])
-        created = _loads(studio.create_team(name="crew", instructions="i", member_ids=["worker"], model_id="gpt-5.4"))
-        assert "error" not in created
+        studio = _studio(registry, db, teams=True, agents_list=[worker])
+        created = _create_team(
+            studio,
+            _team_request("crew", [ComponentRef(component_type="agent", component_id="worker")]),
+            save_as="draft",
+        )
+        assert created.members == [ComponentRef(component_type="agent", component_id="worker")]
 
-        out = _loads(studio.edit_team("crew", instructions="new"))
-        assert out.get("status") == "edited"
+        out = studio.edit_team(
+            "crew",
+            TeamPatch(instructions="new"),
+            expected_version=1,
+            _agno_run_context=_context(),
+        )
+        assert out.ok, out.error
+        assert out.data is not None
+        assert out.data.members == [ComponentRef(component_type="agent", component_id="worker")]
 
         # The stored roster is intact and still names the member.
-        version = out.get("version") or out.get("draft_version")
-        row = db.get_config(component_id="crew", version=version)
+        row = db.get_config(component_id="crew", version=2)
         stored = row.get("config") if isinstance(row, dict) else {}
         assert [m.get("agent_id") for m in (stored or {}).get("members", [])] == ["worker"]
 
@@ -1646,47 +2005,84 @@ class TestStudioEmbedding:
                 self.topic = topic
                 super().__init__(**kwargs)
 
-        researcher = _UncopyableAgent(
-            "ai", id="researcher", name="Researcher", model=OpenAIResponses(id="gpt-5.4"), db=db
+        live_model = OpenAIResponses(id="gpt-5.4")
+        researcher = _UncopyableAgent("ai", id="researcher", name="Researcher", model=live_model, db=db)
+        reg = Registry(name="Singleton Registry", agents=[researcher], models=[live_model], dbs=[db])
+        studio = _studio(reg, db, workflows=True)
+        created = _create_workflow(
+            studio,
+            _workflow_request(
+                "Flow",
+                [AgentWorkflowStep(kind="agent", name="s1", component_id="researcher")],
+            ),
+            save_as="draft",
         )
-        reg = Registry(name="Singleton Registry", agents=[researcher], models=[OpenAIResponses(id="gpt-5.4")], dbs=[db])
-        studio = StudioTools(registry=reg, db=db, workflows=True)
-        created = _loads(
-            studio.create_workflow(name="Flow", description="d", step_specs=[{"name": "s1", "agent_id": "researcher"}])
+        assert created.stage == "draft"
+        db.upsert_config(
+            component_id="flow",
+            version=1,
+            stage="published",
+            guard=ComponentVersionGuard(latest_version=1, current_version=None),
         )
-        assert "error" not in created
 
         out = _loads(StudioRunnerTools(registry=reg, db=db).run_workflow("flow", "go"))
         assert "shared registry instance" in out.get("error", "")
 
         # Reads reach the workflow, and no read or edit reports the dispatch
         # refusal, so the offending step stays repairable.
-        assert "error" not in _loads(studio.get_workflow("flow"))
-        assert "shared registry instance" not in _loads(studio.edit_workflow("flow", description="new")).get(
-            "error", ""
+        assert studio.get_workflow("flow", _agno_run_context=_context()).ok
+        edited = studio.edit_workflow(
+            "flow",
+            WorkflowPatch(description="new"),
+            expected_version=1,
+            _agno_run_context=_context(),
         )
+        assert edited.ok, edited.error
 
     def test_healthy_workflow_step_dispatches(self, registry, db):
         # The isolation check must not refuse a step whose registry agent
         # copies cleanly.
         from agno.agent.agent import Agent as AgentClass
 
-        researcher = AgentClass(id="researcher", name="Researcher", model=OpenAIResponses(id="gpt-5.4"), db=db)
-        reg = Registry(name="Healthy Registry", agents=[researcher], models=[OpenAIResponses(id="gpt-5.4")], dbs=[db])
-        studio = StudioTools(registry=reg, db=db, workflows=True)
-        studio.create_workflow(name="Flow", description="d", step_specs=[{"name": "s1", "agent_id": "researcher"}])
+        live_model = OpenAIResponses(id="gpt-5.4")
+        researcher = AgentClass(id="researcher", name="Researcher", model=live_model, db=db)
+        reg = Registry(name="Healthy Registry", agents=[researcher], models=[live_model], dbs=[db])
+        studio = _studio(reg, db, workflows=True)
+        _create_workflow(
+            studio,
+            _workflow_request(
+                "Flow",
+                [AgentWorkflowStep(kind="agent", name="s1", component_id="researcher")],
+            ),
+            save_as="draft",
+        )
+        db.upsert_config(
+            component_id="flow",
+            version=1,
+            stage="published",
+            guard=ComponentVersionGuard(latest_version=1, current_version=None),
+        )
 
         loaded = StudioRunnerTools(registry=reg, db=db)._workflow_for_run("flow")
         assert loaded is not None
         assert loaded.steps[0].agent is not researcher
 
-    def test_model_rebuild_warning_fires_on_dispatch_without_registry(self, registry, db):
-        # Model connection settings are never persisted; a rebuilt model must
-        # announce that provider defaults apply. Reads stay quiet.
+    def test_legacy_model_rebuild_warning_fires_on_dispatch_without_registry(self, registry, db):
+        # Legacy configs retain the warning-only behavior. Typed Studio configs
+        # are covered below and fail closed instead. Reads stay quiet.
         import logging
 
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="Plain", instructions="i", model_id="gpt-5.4")
+        db.upsert_component(component_id="plain", component_type="agent", name="Plain")
+        db.upsert_config(
+            component_id="plain",
+            stage="published",
+            config={
+                "id": "plain",
+                "name": "Plain",
+                "instructions": "hi",
+                "model": {"id": "gpt-5.4", "provider": "OpenAI", "name": "OpenAIResponses"},
+            },
+        )
 
         records: list = []
         handler = logging.Handler()
@@ -1718,54 +2114,207 @@ class TestStudioEmbedding:
             logging.getLogger("agno").removeHandler(handler)
         assert not any("rebuilt from its stored config" in message for message in records)
 
-    def test_compat_run_methods_carry_legacy_id_key(self, registry, db):
-        stub = _StubAgent()
-        studio = StudioTools(registry=registry, db=db, agents_list=[stub])
-        payload = _loads(studio.run_agent("stub", "hi"))
-        assert payload["id"] == payload["agent_id"] == "stub"
+    def test_typed_agent_requires_registry_before_any_model_call(self, db, monkeypatch):
+        private_model = OpenAIResponses(
+            id="private-model",
+            base_url="https://private-model.invalid/v1",
+            api_key="private-key",
+        )
+        full = Registry(name="Full", models=[private_model], dbs=[db])
+        studio = _studio(full, db)
+        _create_agent(
+            studio,
+            AgentCreate(
+                component_id="private-agent",
+                name="Private Agent",
+                instructions="Use the private endpoint",
+                model=ModelRef(id="private-model", provider="OpenAI", name="OpenAIResponses"),
+            ),
+        )
 
-        error = _loads(studio.run_agent("no-such-agent", "hi"))
+        stored = db.get_config("private-agent")
+        assert stored is not None
+        assert stored["config"]["model"] == {
+            "id": "private-model",
+            "provider": "OpenAI",
+            "name": "OpenAIResponses",
+        }
+
+        network_calls: List[str] = []
+
+        def fail_network(*_args: Any, **_kwargs: Any) -> None:
+            network_calls.append("invoke")
+            raise AssertionError("model network path must not be reached")
+
+        monkeypatch.setattr(OpenAIResponses, "invoke", fail_network)
+        error = _loads(StudioRunnerTools(db=db).run_agent("private-agent", "hi"))["error"]
+
+        assert "typed Studio" in error
+        assert "registry" in error
+        assert network_calls == []
+
+    def test_typed_agent_refuses_a_rebuilt_model_from_an_incomplete_registry(self, db, monkeypatch):
+        private_model = OpenAIResponses(
+            id="private-model",
+            base_url="https://private-model.invalid/v1",
+            api_key="private-key",
+        )
+        full = Registry(name="Full", models=[private_model], dbs=[db])
+        _create_agent(
+            _studio(full, db),
+            AgentCreate(
+                component_id="private-agent",
+                name="Private Agent",
+                instructions="Use the private endpoint",
+                model=ModelRef(id="private-model", provider="OpenAI", name="OpenAIResponses"),
+            ),
+        )
+        incomplete = Registry(name="Incomplete", models=[OpenAIResponses(id="another-model")], dbs=[db])
+
+        network_calls: List[str] = []
+
+        def fail_network(*_args: Any, **_kwargs: Any) -> None:
+            network_calls.append("invoke")
+            raise AssertionError("model network path must not be reached")
+
+        monkeypatch.setattr(OpenAIResponses, "invoke", fail_network)
+        error = _loads(StudioRunnerTools(registry=incomplete, db=db).run_agent("private-agent", "hi"))["error"]
+
+        assert "private-model" in error
+        assert "registry.models" in error
+        assert "base_url" in error
+        assert network_calls == []
+
+    def test_typed_team_and_workflow_require_registered_nested_models(self, db, monkeypatch):
+        coordinator_model = OpenAIResponses(id="gpt-5.4")
+        private_model = OpenAIResponses(
+            id="private-model",
+            base_url="https://private-model.invalid/v1",
+            api_key="private-key",
+        )
+        full = Registry(name="Full", models=[coordinator_model, private_model], dbs=[db])
+        studio = _studio(full, db, teams=True, workflows=True)
+        _create_agent(
+            studio,
+            AgentCreate(
+                component_id="private-agent",
+                name="Private Agent",
+                instructions="Use the private endpoint",
+                model=ModelRef(id="private-model", provider="OpenAI", name="OpenAIResponses"),
+            ),
+        )
+        _create_team(
+            studio,
+            _team_request(
+                "Crew",
+                [ComponentRef(component_type="agent", component_id="private-agent")],
+            ),
+        )
+        _create_workflow(
+            studio,
+            _workflow_request(
+                "Flow",
+                [AgentWorkflowStep(kind="agent", name="private-step", component_id="private-agent")],
+            ),
+        )
+
+        incomplete = Registry(name="Incomplete", models=[coordinator_model], dbs=[db])
+        network_calls: List[str] = []
+
+        def fail_network(*_args: Any, **_kwargs: Any) -> None:
+            network_calls.append("invoke")
+            raise AssertionError("model network path must not be reached")
+
+        monkeypatch.setattr(OpenAIResponses, "invoke", fail_network)
+        runner = StudioRunnerTools(registry=incomplete, db=db)
+        team_error = _loads(runner.run_team("crew", "hi"))["error"]
+        workflow_error = _loads(runner.run_workflow("flow", "hi"))["error"]
+
+        for error in (team_error, workflow_error):
+            assert "private-agent" in error
+            assert "private-model" in error
+            assert "registry.models" in error
+        assert network_calls == []
+
+    def test_code_defined_custom_model_keeps_existing_runner_behavior(self, db):
+        stub = _StubAgent()
+        stub.model = OpenAIResponses(
+            id="code-model",
+            base_url="https://code-model.invalid/v1",
+            api_key="code-key",
+        )
+
+        result = _loads(StudioRunnerTools(db=db, agents_list=[stub]).run_agent("stub", "hi"))
+
+        assert result["status"] == "COMPLETED"
+        assert stub.seen is not None
+
+    def test_studio_run_methods_preserve_runner_payload(self, registry, db):
+        stub = _StubAgent()
+        studio = _studio(registry, db, agents_list=[stub])
+        payload = _loads(studio.run_agent("stub", "hi", _agno_run_context=_context()))
+        assert payload["agent_id"] == "stub"
+        assert "id" not in payload
+
+        error = _loads(studio.run_agent("no-such-agent", "hi", _agno_run_context=_context()))
         assert "error" in error and "id" not in error
 
-    def test_create_team_ambiguous_member_name_errors(self, registry, db):
-        studio = StudioTools(registry=registry, db=db, teams=True)
-        studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4")
-        studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4")
-        out = _loads(studio.create_team(name="squad", instructions="i", member_ids=["Radar Scout"], model_id="gpt-5.4"))
-        assert "Ambiguous" in out.get("error", "")
+    def test_create_team_uses_exact_typed_member_ref(self, registry, db):
+        studio = _studio(registry, db, teams=True)
+        _create_agent(studio, _agent_request("Radar Scout", component_id="radar-a"))
+        _create_agent(studio, _agent_request("Radar Scout", component_id="radar-b"))
+        created = _create_team(
+            studio,
+            _team_request("squad", [ComponentRef(component_type="agent", component_id="radar-b")]),
+        )
+        assert created.members == [ComponentRef(component_type="agent", component_id="radar-b", version=1)]
 
-    def test_delete_requires_exact_id_and_points_to_it(self, registry, db):
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="Radar Scout", instructions="i", model_id="gpt-5.4")
-        out = _loads(studio.delete_agent("Radar Scout"))
-        assert "error" in out
-        assert "radar-scout" in out["error"]
-        assert _loads(studio.delete_agent("radar-scout"))["status"] == "deleted"
+    def test_archive_requires_exact_component_id(self, registry, db):
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Radar Scout"))
+        missing = studio.archive_agent("Radar Scout", expected_current_version=1, _agno_run_context=_context())
+        assert missing.error is not None and missing.error.code == "invalid_component_id"
+        archived = studio.archive_agent("radar-scout", expected_current_version=1, _agno_run_context=_context())
+        assert archived.ok and archived.status == "archived"
 
     def test_edit_reaches_db_component_shadowed_by_code_defined_name(self, registry, db):
         # A code-defined component NAMED like a DB component's id must not make
         # the DB component uneditable: exact ids win on every path.
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="support", instructions="i", model_id="gpt-5.4")
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("support"))
         shadow = _StubAgent()
         shadow.id = "code-1"
         shadow.name = "support"
-        shadowed = StudioTools(registry=registry, db=db, agents_list=[shadow])
-        got = _loads(shadowed.get_agent("support"))
-        assert got["id"] == "support"
-        out = _loads(shadowed.edit_agent("support", instructions="updated"))
-        assert out.get("status") == "edited"
-        assert out.get("id") == "support"
+        shadowed = _studio(registry, db, agents_list=[shadow])
+        got = _data(shadowed.get_agent("support", _agno_run_context=_context()))
+        assert got.component_id == "support"
+        out = shadowed.edit_agent(
+            "support",
+            AgentPatch(instructions="updated"),
+            expected_version=1,
+            save_as="published",
+            _agno_run_context=_context(),
+        )
+        assert out.ok and out.status == "edited"
+        assert out.data is not None and out.data.component_id == "support"
 
-    def test_edit_by_display_name_accumulates_drafts_with_versions(self, registry, db):
-        # The edit base version must come from the RESOLVED id: a display-name
-        # edit picks up the pending draft, not the published config.
-        studio = StudioTools(registry=registry, db=db, versions=True)
-        studio.create_agent(name="Radar Scout", instructions="original", model_id="gpt-5.4")
-        first = _loads(studio.edit_agent("radar-scout", instructions="first-change"))
-        assert first.get("status") == "edited"
-        second = _loads(studio.edit_agent("Radar Scout", description="second-change"))
-        assert second.get("status") == "edited"
+    def test_exact_id_edits_accumulate_drafts_with_expected_version(self, registry, db):
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Radar Scout", instructions="original"))
+        first = studio.edit_agent(
+            "radar-scout",
+            AgentPatch(instructions="first-change"),
+            expected_version=1,
+            _agno_run_context=_context(),
+        )
+        assert first.ok and first.status == "edited"
+        second = studio.edit_agent(
+            "radar-scout",
+            AgentPatch(description="second-change"),
+            expected_version=2,
+            _agno_run_context=_context(),
+        )
+        assert second.ok and second.status == "edited"
 
         configs = db.list_configs("radar-scout", include_config=True)
         drafts = [c for c in configs if c.get("stage") == "draft"]
@@ -1773,11 +2322,192 @@ class TestStudioEmbedding:
         assert latest["config"]["instructions"] == "first-change"
         assert latest["config"]["description"] == "second-change"
 
+    def test_dispatch_uses_the_current_publication_not_the_latest_draft(self, registry, db):
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Dispatch target", instructions="published"))
+        edited = studio.edit_agent(
+            "dispatch-target",
+            AgentPatch(instructions="draft-only"),
+            expected_version=1,
+            _agno_run_context=_context(),
+        )
+        assert edited.ok and edited.data is not None and edited.data.stage == "draft"
+
+        loaded = StudioRunnerTools(registry=registry, db=db)._agent_for_run("dispatch-target")
+
+        assert loaded is not None
+        assert loaded.instructions == "published"
+
     def test_studio_instructions_carry_run_guidance(self, registry, db):
-        studio = StudioTools(registry=registry, db=db)
+        studio = _studio(registry, db)
         instructions = studio.instructions or ""
-        assert "sequentially" in instructions
-        assert "ambiguous display name" in instructions.lower()
+        assert "current published version" in instructions
+        assert "exact typed references" in instructions.lower()
+
+
+class TestTypedRegistryExactness:
+    def test_dispatch_refuses_an_ambiguous_exact_model_reference(self, db):
+        intended = OpenAIResponses(
+            id="private-model",
+            base_url="https://intended-model.invalid/v1",
+            api_key="intended-secret",
+        )
+        initial_registry = Registry(name="initial", models=[intended], dbs=[db])
+        studio = _studio(initial_registry, db)
+        _create_agent(
+            studio,
+            AgentCreate(
+                component_id="model-bound-agent",
+                name="Model bound agent",
+                instructions="Use the exact private model.",
+                model=ModelRef(id="private-model", provider=intended.provider, name=intended.name),
+            ),
+        )
+        wrong = OpenAIResponses(
+            id="private-model",
+            base_url="https://wrong-model.invalid/v1",
+            api_key="wrong-secret",
+        )
+        ambiguous_registry = Registry(name="ambiguous", models=[wrong, intended], dbs=[db])
+
+        with pytest.raises(ComponentNeedsRegistryError, match="model reference.*ambiguous") as error:
+            StudioRunnerTools(registry=ambiguous_registry, db=db)._agent_for_run("model-bound-agent")
+
+        assert "wrong-model.invalid" not in str(error.value)
+        assert "wrong-secret" not in str(error.value)
+
+    def test_dispatch_refuses_an_ambiguous_exact_tool_reference(self, db):
+        model = OpenAIResponses(id="gpt-5.4")
+
+        def intended_lookup(query: str) -> str:
+            return f"intended: {query}"
+
+        def wrong_lookup(query: str) -> str:
+            return f"wrong: {query}"
+
+        intended_lookup.__name__ = "lookup"
+        wrong_lookup.__name__ = "lookup"
+        initial_registry = Registry(name="initial", tools=[intended_lookup], models=[model], dbs=[db])
+        studio = _studio(initial_registry, db)
+        _create_agent(
+            studio,
+            _agent_request(
+                "Tool bound agent",
+                component_id="tool-bound-agent",
+                tools=[ToolRef(kind="function", name="lookup")],
+            ),
+        )
+        ambiguous_registry = Registry(
+            name="ambiguous",
+            tools=[intended_lookup, wrong_lookup],
+            models=[model],
+            dbs=[db],
+        )
+
+        with pytest.raises(ComponentNeedsRegistryError, match="tool reference.*ambiguous"):
+            StudioRunnerTools(registry=ambiguous_registry, db=db)._agent_for_run("tool-bound-agent")
+
+    def test_dispatch_refuses_when_a_toolkit_member_shadows_a_direct_function(self, db):
+        from agno.tools.toolkit import Toolkit
+
+        model = OpenAIResponses(id="gpt-5.4")
+
+        def intended_lookup(query: str) -> str:
+            return f"intended: {query}"
+
+        def wrong_lookup(query: str) -> str:
+            return f"wrong: {query}"
+
+        intended_lookup.__name__ = "lookup"
+        wrong_lookup.__name__ = "lookup"
+        wrong_toolkit = Toolkit(name="wrongkit", tools=[wrong_lookup])
+        initial_registry = Registry(
+            name="initial",
+            tools=[intended_lookup],
+            models=[model],
+            dbs=[db],
+        )
+        studio = _studio(initial_registry, db)
+        _create_agent(
+            studio,
+            _agent_request(
+                "Shadowed tool agent",
+                component_id="shadowed-tool-agent",
+                tools=[ToolRef(kind="function", name="lookup")],
+            ),
+        )
+
+        shadowed_registry = Registry(
+            name="shadowed",
+            tools=[intended_lookup, wrong_toolkit],
+            models=[model],
+            dbs=[db],
+        )
+
+        with pytest.raises(ComponentNeedsRegistryError, match="runtime binding.*diverges"):
+            StudioRunnerTools(registry=shadowed_registry, db=db)._agent_for_run("shadowed-tool-agent")
+
+    def test_same_entrypoint_registered_directly_and_in_a_toolkit_is_safe(self, db):
+        from agno.tools.toolkit import Toolkit
+
+        model = OpenAIResponses(id="gpt-5.4")
+
+        def lookup(query: str) -> str:
+            return f"same: {query}"
+
+        registry = Registry(
+            name="same behavior",
+            tools=[lookup, Toolkit(name="samekit", tools=[lookup])],
+            models=[model],
+            dbs=[db],
+        )
+        studio = _studio(registry, db)
+        _create_agent(
+            studio,
+            _agent_request(
+                "Same behavior agent",
+                component_id="same-behavior-agent",
+                tools=[ToolRef(kind="function", name="lookup")],
+            ),
+        )
+
+        loaded = StudioRunnerTools(registry=registry, db=db)._agent_for_run("same-behavior-agent")
+        assert loaded is not None
+
+    def test_dispatch_refuses_an_ambiguous_workflow_function_reference(self, db):
+        def intended_execute(value: str) -> str:
+            return f"intended: {value}"
+
+        def wrong_execute(value: str) -> str:
+            return f"wrong: {value}"
+
+        intended_execute.__name__ = "execute"
+        wrong_execute.__name__ = "execute"
+        initial_registry = Registry(name="initial", functions=[intended_execute], dbs=[db])
+        studio = _studio(initial_registry, db, workflows=True)
+        _create_workflow(
+            studio,
+            WorkflowCreate(
+                component_id="function-bound-workflow",
+                name="Function bound workflow",
+                steps=[
+                    FunctionWorkflowStep(
+                        kind="function",
+                        step_id="execute-step",
+                        name="Execute",
+                        function_name="execute",
+                    )
+                ],
+            ),
+        )
+        ambiguous_registry = Registry(
+            name="ambiguous",
+            functions=[wrong_execute, intended_execute],
+            dbs=[db],
+        )
+
+        with pytest.raises(ComponentNeedsRegistryError, match="function reference.*ambiguous"):
+            StudioRunnerTools(registry=ambiguous_registry, db=db)._workflow_for_run("function-bound-workflow")
 
 
 class TestDispatchCheckInvariants:
@@ -1799,7 +2529,8 @@ class TestDispatchCheckInvariants:
         # reports "nothing wrong" for a graph it never finished reading.
         source = self._walkers()
         assert "depth > 12" not in source, "a walk still carries its own depth bound"
-        assert source.count("_GRAPH_DEPTH_CAP") >= 6
+        assert source.count("_GRAPH_MAX_DEPTH") >= 6
+        assert source.count("_GRAPH_MAX_NODES") >= 3
 
     def test_the_depth_bound_refuses_rather_than_returns(self, db):
         from agno.agent import Agent
@@ -1811,6 +2542,26 @@ class TestDispatchCheckInvariants:
             node = Team(id=f"t{index}", name=f"t{index}", model=OpenAIResponses(id="gpt-5.4"), members=[node])
         runner = StudioRunnerTools(registry=Registry(name="R", dbs=[db]), db=db, teams_list=[node])
         assert "nests deeper than" in _loads(runner.run_team(node.id, "hi"))["error"]
+
+    def test_the_node_bound_refuses_rather_than_silently_skipping_wide_siblings(
+        self, db, monkeypatch: pytest.MonkeyPatch
+    ):
+        from agno.agent import Agent
+        from agno.registry import Registry
+        from agno.team import Team
+        from agno.tools import studio_runner as module
+
+        members = [
+            Agent(id=f"member-{index}", name=f"Member {index}", model=OpenAIResponses(id="gpt-5.4"))
+            for index in range(4)
+        ]
+        team = Team(id="wide-team", name="Wide team", model=OpenAIResponses(id="gpt-5.4"), members=members)
+        runner = StudioRunnerTools(registry=Registry(name="R", dbs=[db]), db=db, teams_list=[team])
+        monkeypatch.setattr(module, "_GRAPH_MAX_NODES", 4)
+
+        result = _loads(runner.run_team("wide-team", "hi"))
+
+        assert "more than 4 inspectable graph nodes" in result["error"]
 
     def test_shared_member_search_reaches_past_the_old_bound(self):
         from agno.agent import Agent
@@ -2173,11 +2924,13 @@ class TestDispatchCheckInvariants:
         # report, and saying so beats an empty list.
         assert "error" in _loads(StudioRunnerTools(registry=Registry(name="R")).list_agents())
 
-    def test_an_edit_does_not_delete_what_the_rebuild_could_not_restore(self, db, registry):
-        """An edit works on a rebuilt component, so anything from_dict cannot
-        restore is already gone by the time the edit runs. Resaving would
-        delete a declaration the edit never mentioned -- and quietly lift the
-        refusal that declaration causes."""
+    def test_a_legacy_edit_refuses_without_deleting_unrestored_config(self, db, registry):
+        """The typed control plane does not guess how to edit a legacy config.
+
+        Refusing the unsupported manifest leaves declarations that from_dict
+        cannot restore untouched, so an unrelated edit cannot quietly lift the
+        runner's dispatch refusal.
+        """
         from agno.agent import Agent
 
         Agent(
@@ -2190,43 +2943,48 @@ class TestDispatchCheckInvariants:
         runner = StudioRunnerTools(registry=registry, db=db)
         assert "reasoning_model" in _loads(runner.run_agent("rich", "hi"))["error"]
 
-        studio = StudioTools(registry=registry, db=db)
-        assert "error" not in _loads(studio.edit_agent("rich", description="an unrelated change"))
+        studio = _studio(registry, db)
+        result = studio.edit_agent(
+            "rich",
+            AgentPatch(description="an unrelated change"),
+            expected_version=1,
+            save_as="published",
+            _agno_run_context=_context(),
+        )
+
+        assert result.error is not None and result.error.code == "unsupported_component_config"
 
         stored = db.get_config(component_id="rich") or {}
         assert (stored.get("config") or {}).get("reasoning_model") is not None
+        assert len(db.list_configs("rich", include_config=True)) == 1
         assert "reasoning_model" in _loads(runner.run_agent("rich", "hi"))["error"]
 
-    def test_an_edit_refuses_rather_than_guessing_when_it_cannot_read_the_original(self, db, registry):
+    def test_an_edit_refuses_rather_than_guessing_when_it_cannot_read_the_original(self, db, registry, monkeypatch):
         """A read that fails is not evidence there was nothing to carry. Taking
         it as an empty set publishes an edit that deletes the declaration and
         lifts the refusal it causes, so the failure has to reach the caller."""
-        from agno.agent import Agent
-
-        Agent(
-            id="rich",
-            name="Rich",
-            model=OpenAIResponses(id="gpt-5.4"),
-            reasoning_model=OpenAIResponses(id="o3-deep"),
-        ).save(db=db)
-
-        studio = StudioTools(registry=registry, db=db)
-        original = studio._runner_tools._load_config_row_from_db
-        calls = {"count": 0}
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Rich", component_id="rich"))
+        original = db.get_config
+        before = original(component_id="rich")
 
         def failing(component_id, **kwargs):
-            calls["count"] += 1
-            if calls["count"] > 1 and component_id == "rich":
+            if component_id == "rich":
                 raise RuntimeError("transient db failure")
             return original(component_id, **kwargs)
 
-        studio._runner_tools._load_config_row_from_db = failing  # type: ignore[method-assign]
-        result = _loads(studio.edit_agent("rich", description="an unrelated change"))
-        studio._runner_tools._load_config_row_from_db = original  # type: ignore[method-assign]
+        monkeypatch.setattr(db, "get_config", failing)
+        result = studio.edit_agent(
+            "rich",
+            AgentPatch(description="an unrelated change"),
+            expected_version=1,
+            save_as="published",
+            _agno_run_context=_context(),
+        )
 
-        assert "error" in result
-        stored = (db.get_config(component_id="rich") or {}).get("config") or {}
-        assert stored.get("reasoning_model") is not None
+        assert result.error is not None and result.error.code == "internal_error"
+        assert original(component_id="rich") == before
+        assert len(db.list_configs("rich", include_config=True)) == 1
 
     def test_a_teams_reasoning_model_survives_being_saved(self, db, registry):
         """It was dropped at save time, so the loader had nothing to notice and
@@ -2265,8 +3023,8 @@ class TestDispatchCheckInvariants:
         runs something that was never discoverable."""
         from agno.agent import Agent
 
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="Database Target", instructions="i", model_id="gpt-5.4")
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("Database Target"))
         runner = StudioRunnerTools(
             registry=registry,
             db=db,
@@ -2280,7 +3038,7 @@ class TestDispatchCheckInvariants:
         assert runner._find_agent("Database Target").name == "Database Target"
 
         # An unshadowed name is untouched.
-        studio.create_agent(name="Solo", instructions="i", model_id="gpt-5.4")
+        _create_agent(studio, _agent_request("Solo"))
         assert runner._agent_for_run("Solo") is not None
 
     def test_total_counts_a_shadowed_row_beyond_the_page(self, db, registry):
@@ -2289,10 +3047,10 @@ class TestDispatchCheckInvariants:
         inflated the total."""
         from agno.agent import Agent
 
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="shadowed", instructions="i", model_id="gpt-5.4")
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("shadowed"))
         for index in range(4):
-            studio.create_agent(name=f"other{index}", instructions="i", model_id="gpt-5.4")
+            _create_agent(studio, _agent_request(f"other{index}"))
 
         runner = StudioRunnerTools(
             registry=registry,
@@ -2320,8 +3078,8 @@ class TestDispatchCheckInvariants:
         count."""
         from agno.agent import Agent
 
-        studio = StudioTools(registry=registry, db=db)
-        studio.create_agent(name="dup", instructions="i", model_id="gpt-5.4")
+        studio = _studio(registry, db)
+        _create_agent(studio, _agent_request("dup"))
 
         runner = StudioRunnerTools(
             registry=registry,
@@ -2672,7 +3430,7 @@ class TestIncludeAllComponents:
 
     def test_studio_tools_keeps_its_reach(self, registry_with_agent, db):
         # StudioTools holds the registry as its build palette, so its run_* are unchanged.
-        assert StudioTools(registry=registry_with_agent, db=db)._runner_tools.include_all_components is True
+        assert _studio(registry_with_agent, db)._runner_tools.include_all_components is True
 
 
 class TestPartialRegistryFailsClosed:
@@ -2740,8 +3498,14 @@ class TestPartialRegistryFailsClosed:
         from agno.tools.calculator import CalculatorTools
 
         full = Registry(name="full", dbs=[db], models=[OpenAIResponses(id="gpt-5.4")], tools=[CalculatorTools()])
-        StudioTools(registry=full, db=db, default_model_id="gpt-5.4").create_agent(
-            name="Calc Agent", instructions="math", model_id="gpt-5.4", tool_names=["calculator"]
+        studio = _studio(full, db, default_model=ModelRef(id="gpt-5.4"))
+        _create_agent(
+            studio,
+            AgentCreate(
+                name="Calc Agent",
+                instructions="math",
+                tools=[ToolRef(kind="toolkit", name="calculator")],
+            ),
         )
 
         partial = Registry(name="partial", dbs=[db], models=[OpenAIResponses(id="gpt-5.4")])
@@ -2751,14 +3515,17 @@ class TestPartialRegistryFailsClosed:
         assert "calc-agent" in error and "registry" in error
 
         # The component stays loadable and repairable on the same partial registry.
-        assert _loads(StudioTools(registry=partial, db=db).get_agent("calc-agent"))["id"] == "calc-agent"
+        partial_studio = _studio(partial, db)
+        assert _data(partial_studio.get_agent("calc-agent", _agno_run_context=_context())).component_id == "calc-agent"
 
     def test_a_component_without_registry_references_is_unaffected(self, db):
         from agno.registry import Registry
 
         registry = Registry(name="r", dbs=[db], models=[OpenAIResponses(id="gpt-5.4")])
-        StudioTools(registry=registry, db=db, default_model_id="gpt-5.4").create_agent(
-            name="Plain", instructions="hi", model_id="gpt-5.4"
+        studio = _studio(registry, db, default_model=ModelRef(id="gpt-5.4"))
+        _create_agent(
+            studio,
+            AgentCreate(name="Plain", instructions="hi"),
         )
         assert StudioRunnerTools(registry=registry, db=db)._find_agent("plain", for_dispatch=True) is not None
 

--- a/libs/agno/tests/unit/tools/test_studio_schema.py
+++ b/libs/agno/tests/unit/tools/test_studio_schema.py
@@ -1,0 +1,552 @@
+"""Tests for Studio's typed public request and response contract."""
+
+import json
+from typing import Literal
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+import agno.tools.studio_schema as studio_schema
+from agno.tools.function import Function
+from agno.tools.studio_schema import (
+    AgentCreate,
+    AgentPatch,
+    AgentView,
+    AgentWorkflowStep,
+    ComponentActionView,
+    ComponentRef,
+    ComponentSummary,
+    ComponentView,
+    ContextPolicy,
+    ContextPolicyPatch,
+    FunctionRef,
+    FunctionWorkflowStep,
+    ModelRef,
+    ScheduleActionView,
+    ScheduleCreate,
+    ScheduleRunView,
+    ScheduleView,
+    StudioError,
+    StudioResult,
+    TeamCreate,
+    TeamPatch,
+    TeamView,
+    TeamWorkflowStep,
+    ToolRef,
+    VersionSummary,
+    WorkflowCreate,
+    WorkflowPatch,
+    WorkflowView,
+)
+
+
+def _model() -> ModelRef:
+    return ModelRef(id="gpt-5", provider="OpenAI", name="OpenAIResponses")
+
+
+def _context() -> ContextPolicy:
+    return ContextPolicy()
+
+
+def _contains_key(value: object, key: str) -> bool:
+    if isinstance(value, dict):
+        return key in value or any(_contains_key(item, key) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_key(item, key) for item in value)
+    return False
+
+
+def _agent_view() -> AgentView:
+    return AgentView(
+        component_id="researcher",
+        name="Researcher",
+        instructions="Research the topic.",
+        model=_model(),
+        context=_context(),
+        version=1,
+        stage="draft",
+        is_current=False,
+        source="studio",
+    )
+
+
+def test_schema_models_are_strict_and_forbid_extra_fields():
+    with pytest.raises(ValidationError, match="Input should be a valid string"):
+        ModelRef(id=5)  # type: ignore[arg-type]
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ModelRef(id="gpt-5", unknown=True)  # type: ignore[call-arg]
+
+
+def test_tool_ref_supports_whole_toolkits_and_qualified_functions():
+    whole_toolkit = ToolRef(kind="toolkit", name="calculator")
+    top_level_function = ToolRef(kind="function", name="search")
+    toolkit_function = ToolRef(kind="function", name="add", toolkit="calculator")
+
+    assert whole_toolkit.toolkit is None
+    assert top_level_function.toolkit is None
+    assert toolkit_function.toolkit == "calculator"
+
+    with pytest.raises(ValidationError, match="only valid when kind='function'"):
+        ToolRef(kind="toolkit", name="calculator", toolkit="calculator")
+
+
+def test_function_ref_is_a_strict_copyable_discovery_projection():
+    function = FunctionRef(name="publish_article", description="Publish an article.")
+
+    assert function.model_dump() == {"name": "publish_article", "description": "Publish an article."}
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        FunctionRef(name="publish_article", signature="()")  # type: ignore[call-arg]
+
+
+def test_context_policy_rejects_history_depth_when_history_is_disabled():
+    with pytest.raises(ValidationError, match="history_runs.*disabled"):
+        ContextPolicy(include_history=False, history_runs=2)
+
+    assert ContextPolicy(include_history=False).history_runs is None
+
+
+def test_agent_create_has_safe_defaults_and_independent_tool_lists():
+    first = AgentCreate(name="Researcher", instructions="Research the topic.")
+    second = AgentCreate(name="Writer", instructions="Write the answer.")
+
+    first.tools.append(ToolRef(kind="toolkit", name="web"))
+
+    assert first.component_id is None
+    assert first.context is None
+    assert first.if_exists == "error"
+    assert second.tools == []
+
+    explicit_context = AgentCreate(
+        name="Reviewer",
+        instructions="Review the answer.",
+        context=ContextPolicy(include_history=False),
+    )
+    assert explicit_context.context == ContextPolicy(include_history=False)
+
+
+@pytest.mark.parametrize(
+    "create_request",
+    [
+        AgentCreate(name="Agent", instructions="Work.", if_exists="return_existing"),
+        TeamCreate(
+            name="Team",
+            instructions="Coordinate.",
+            members=[ComponentRef(component_type="agent", component_id="member")],
+            if_exists="return_existing",
+        ),
+        WorkflowCreate(
+            name="Workflow",
+            steps=[AgentWorkflowStep(kind="agent", name="Run", component_id="member")],
+            if_exists="return_existing",
+        ),
+    ],
+)
+def test_create_requests_carry_the_idempotency_policy(create_request):
+    assert create_request.if_exists == "return_existing"
+
+    with pytest.raises(ValidationError):
+        type(create_request).model_validate({**create_request.model_dump(), "if_exists": "overwrite"})
+
+
+@pytest.mark.parametrize("component_id", [" ", "../escape", "foo/bar", "foo%2Fbar", "café"])
+def test_component_ids_are_path_safe(component_id: str):
+    with pytest.raises(ValidationError):
+        AgentCreate(component_id=component_id, name="Agent", instructions="Work.")
+    with pytest.raises(ValidationError):
+        ComponentRef(component_type="agent", component_id=component_id)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: AgentCreate(name="   ", instructions="Work."),
+        lambda: AgentCreate(name="Agent", instructions="\n\t"),
+        lambda: TeamCreate(
+            name=" ",
+            instructions="Coordinate.",
+            members=[ComponentRef(component_type="agent", component_id="member")],
+        ),
+        lambda: WorkflowCreate(
+            name="Workflow",
+            steps=[AgentWorkflowStep(kind="agent", name=" ", component_id="member")],
+        ),
+    ],
+)
+def test_public_names_and_instructions_must_be_nonblank(factory):
+    with pytest.raises(ValidationError, match="non-whitespace"):
+        factory()
+
+
+def test_agent_create_generates_descriptive_nested_tool_schema():
+    def create_agent(
+        request: AgentCreate,
+        save_as: Literal["draft", "published"] = "draft",
+    ) -> str:
+        return request.name + save_as
+
+    function = Function.from_callable(create_agent)
+    request_schema = function.parameters["properties"]["request"]
+
+    assert request_schema["additionalProperties"] is False
+    assert request_schema["required"] == ["name", "instructions"]
+    assert request_schema["properties"]["component_id"]["description"].startswith("Stable path-safe component id")
+    assert all(property_schema.get("description") for property_schema in request_schema["properties"].values())
+    assert request_schema["properties"]["model"]["anyOf"][0]["properties"]["id"]["description"].startswith(
+        "Exact model id"
+    )
+
+
+def test_agent_patch_distinguishes_omission_null_and_empty_list():
+    description_patch = AgentPatch(description=None)
+    model_patch = AgentPatch(model=None)
+    tools_patch = AgentPatch(tools=[])
+
+    assert description_patch.model_dump(exclude_unset=True) == {"description": None}
+    assert model_patch.model_dump(exclude_unset=True) == {"model": None}
+    assert tools_patch.model_dump(exclude_unset=True) == {"tools": []}
+
+    with pytest.raises(ValidationError, match="at least one field"):
+        AgentPatch()
+    with pytest.raises(ValidationError, match="'instructions' cannot be set to null"):
+        AgentPatch(instructions=None)
+    with pytest.raises(ValidationError, match="'tools' cannot be set to null"):
+        AgentPatch(tools=None)
+
+
+def test_context_patch_is_omission_aware():
+    reset_depth = ContextPolicyPatch(history_runs=None)
+    assert reset_depth.model_dump(exclude_unset=True) == {"history_runs": None}
+
+    with pytest.raises(ValidationError, match="at least one field"):
+        ContextPolicyPatch()
+    with pytest.raises(ValidationError, match="'include_datetime' cannot be set to null"):
+        ContextPolicyPatch(include_datetime=None)
+    with pytest.raises(ValidationError, match="history_runs.*disabled"):
+        ContextPolicyPatch(include_history=False, history_runs=2)
+
+
+def test_team_models_use_typed_versioned_member_refs():
+    member = ComponentRef(component_type="agent", component_id="researcher", version=2)
+    request = TeamCreate(
+        name="Editorial team",
+        instructions="Research and write.",
+        members=[member],
+    )
+
+    assert request.members == [member]
+    assert request.context is None
+
+    with pytest.raises(ValidationError):
+        TeamCreate(name="Empty team", instructions="Coordinate.", members=[])
+    with pytest.raises(ValidationError):
+        ComponentRef(component_type="workflow", component_id="pipeline")  # type: ignore[arg-type]
+    with pytest.raises(ValidationError, match="at least one field"):
+        TeamPatch()
+    with pytest.raises(ValidationError):
+        TeamPatch(members=[])
+    with pytest.raises(ValidationError, match="unique component_id.*shared"):
+        TeamCreate(
+            name="Ambiguous team",
+            instructions="Coordinate.",
+            members=[
+                ComponentRef(component_type="agent", component_id="shared", version=1),
+                ComponentRef(component_type="team", component_id="shared", version=2),
+            ],
+        )
+    with pytest.raises(ValidationError, match="unique component_id.*researcher"):
+        TeamPatch(
+            members=[
+                ComponentRef(component_type="agent", component_id="researcher", version=1),
+                ComponentRef(component_type="agent", component_id="researcher", version=2),
+            ]
+        )
+
+
+def test_workflow_steps_are_discriminated_and_round_trip_without_null_executors():
+    workflow = WorkflowCreate.model_validate(
+        {
+            "name": "Editorial workflow",
+            "steps": [
+                {
+                    "kind": "agent",
+                    "step_id": "research",
+                    "name": "Research",
+                    "component_id": "researcher",
+                    "version": 2,
+                },
+                {"kind": "team", "step_id": "edit", "name": "Edit", "component_id": "editors"},
+                {
+                    "kind": "function",
+                    "step_id": "publish",
+                    "name": "Publish",
+                    "function_name": "publish_article",
+                },
+            ],
+        }
+    )
+
+    assert isinstance(workflow.steps[0], AgentWorkflowStep)
+    assert isinstance(workflow.steps[1], TeamWorkflowStep)
+    assert isinstance(workflow.steps[2], FunctionWorkflowStep)
+    assert workflow.model_dump()["steps"][1] == {
+        "kind": "team",
+        "step_id": "edit",
+        "name": "Edit",
+        "component_id": "editors",
+        "version": None,
+        "description": None,
+    }
+
+    items_schema = WorkflowCreate.model_json_schema()["properties"]["steps"]["items"]
+    assert items_schema["discriminator"]["propertyName"] == "kind"
+    assert len(items_schema["oneOf"]) == 3
+
+    with pytest.raises(ValidationError, match="Unable to extract tag"):
+        WorkflowCreate(name="Broken", steps=[{"name": "Step", "component_id": "agent"}])
+    with pytest.raises(ValidationError):
+        WorkflowCreate(name="Empty", steps=[])
+    with pytest.raises(ValidationError):
+        AgentWorkflowStep(kind="agent", step_id="", name="Step", component_id="agent")
+
+
+def test_workflow_create_function_schema_inlines_discriminated_steps():
+    def create_workflow(request: WorkflowCreate) -> str:
+        return request.name
+
+    function = Function.from_callable(create_workflow)
+    request_schema = function.parameters["properties"]["request"]
+    items_schema = request_schema["properties"]["steps"]["items"]
+
+    assert not _contains_key(request_schema, "$defs")
+    assert not _contains_key(request_schema, "$ref")
+    assert items_schema["discriminator"] == {"propertyName": "kind"}
+    assert {branch["properties"]["kind"]["const"] for branch in items_schema["oneOf"]} == {
+        "agent",
+        "team",
+        "function",
+    }
+    for branch in items_schema["oneOf"]:
+        assert all(property_schema.get("description") for property_schema in branch["properties"].values())
+
+
+def test_workflow_patch_distinguishes_clearable_description_from_required_steps():
+    assert WorkflowPatch(description=None).model_dump(exclude_unset=True) == {"description": None}
+
+    with pytest.raises(ValidationError, match="at least one field"):
+        WorkflowPatch()
+    with pytest.raises(ValidationError, match="'steps' cannot be set to null"):
+        WorkflowPatch(steps=None)
+    with pytest.raises(ValidationError):
+        WorkflowPatch(steps=[])
+
+
+def test_views_are_typed_safe_projections():
+    agent = _agent_view()
+    team = TeamView(
+        component_id="editorial-team",
+        name="Editorial team",
+        instructions="Research and write.",
+        members=[ComponentRef(component_type="agent", component_id=agent.component_id, version=agent.version)],
+        model=_model(),
+        context=_context(),
+        version=1,
+        stage="published",
+        is_current=True,
+        source="studio",
+    )
+    workflow = WorkflowView(
+        component_id="editorial-workflow",
+        name="Editorial workflow",
+        steps=[AgentWorkflowStep(kind="agent", name="Research", component_id=agent.component_id, version=1)],
+        version=1,
+        stage="published",
+        is_current=True,
+        source="studio",
+    )
+
+    assert agent.component_type == "agent"
+    assert team.component_type == "team"
+    assert workflow.component_type == "workflow"
+
+
+def test_component_support_views_are_strict_and_version_aware():
+    code_summary = ComponentSummary(
+        component_id=None,
+        component_type="agent",
+        name="Code agent",
+        source="code",
+        latest_version=None,
+        latest_stage="code",
+        current_version=None,
+    )
+    stored_summary = ComponentSummary(
+        component_id="researcher",
+        component_type="agent",
+        name="Researcher",
+        source="studio",
+        latest_version=2,
+        latest_stage="draft",
+        current_version=1,
+    )
+    version = VersionSummary(
+        version=1,
+        stage="published",
+        label="stable",
+        is_current=True,
+        created_at=1,
+    )
+    action = ComponentActionView(component_id="researcher", component_type="agent", version=2)
+
+    assert code_summary.component_id is None
+    assert stored_summary.latest_version == 2
+    assert stored_summary.current_version == 1
+    assert version.updated_at is None
+    assert action.model_dump() == {"component_id": "researcher", "component_type": "agent", "version": 2}
+
+    with pytest.raises(ValidationError):
+        VersionSummary(version=0, stage="draft", label=None, is_current=False)
+    with pytest.raises(ValidationError):
+        ComponentActionView(component_id="researcher", component_type="function")  # type: ignore[arg-type]
+
+
+def test_component_view_union_discriminates_safe_views():
+    adapter = TypeAdapter(ComponentView)
+
+    agent = adapter.validate_python(_agent_view().model_dump())
+    workflow = adapter.validate_python(
+        WorkflowView(
+            component_id="pipeline",
+            name="Pipeline",
+            version=1,
+            stage="published",
+            is_current=True,
+            source="studio",
+        ).model_dump()
+    )
+
+    assert isinstance(agent, AgentView)
+    assert isinstance(workflow, WorkflowView)
+    schema = adapter.json_schema()
+    assert schema["discriminator"]["propertyName"] == "component_type"
+
+
+def test_studio_result_requires_exactly_one_coherent_data_or_error():
+    success = StudioResult[AgentView](ok=True, status="created", data=_agent_view())
+    failure = StudioResult[AgentView](
+        ok=False,
+        status="error",
+        error=StudioError(code="component_conflict", message="The component changed."),
+    )
+
+    assert success.data is not None
+    assert failure.error is not None
+
+    with pytest.raises(ValidationError, match="exactly one"):
+        StudioResult[AgentView](ok=True, status="created")
+    with pytest.raises(ValidationError, match="exactly one"):
+        StudioResult[AgentView](
+            ok=True,
+            status="created",
+            data=_agent_view(),
+            error=StudioError(code="unexpected", message="Unexpected."),
+        )
+    with pytest.raises(ValidationError, match="'ok' must be true"):
+        StudioResult[AgentView](ok=False, status="created", data=_agent_view())
+
+
+def test_studio_result_string_is_valid_json_and_excludes_none():
+    success = StudioResult[AgentView](ok=True, status="created", data=_agent_view())
+    failure = StudioResult[AgentView](
+        ok=False,
+        status="error",
+        error=StudioError(code="not_found", message="Component not found."),
+    )
+
+    success_json = json.loads(str(success))
+    failure_json = json.loads(str(failure))
+
+    assert success_json["data"]["component_id"] == "researcher"
+    assert "error" not in success_json
+    assert failure_json["error"]["code"] == "not_found"
+    assert "data" not in failure_json
+
+
+def test_result_and_view_collection_defaults_are_not_shared():
+    first = StudioResult[AgentView](ok=True, status="created", data=_agent_view())
+    second = StudioResult[AgentView](ok=True, status="created", data=_agent_view())
+    first.warnings.append("warning")
+
+    assert second.warnings == []
+
+
+def test_schedule_models_are_typed_safe_and_publicly_exported():
+    request = ScheduleCreate(
+        name="Daily research",
+        cron="0 9 * * *",
+        target_type="agent",
+        target_id="researcher",
+        message="Research the latest topic.",
+    )
+    view = ScheduleView(
+        schedule_id="schedule-1",
+        name=request.name,
+        cron=request.cron,
+        target_type=request.target_type,
+        target_id=request.target_id,
+        timezone=request.timezone,
+        enabled=True,
+        owner_actor_id="studio-admin",
+    )
+    run = ScheduleRunView(
+        schedule_run_id="schedule-run-1",
+        schedule_id=view.schedule_id,
+        attempt=1,
+        status="failed",
+        has_error=True,
+        has_requirements=True,
+    )
+    action = ScheduleActionView(
+        schedule_id=view.schedule_id,
+        name=view.name,
+        target_type=view.target_type,
+        target_id=view.target_id,
+        enabled=False,
+    )
+
+    assert request.timezone == "UTC"
+    assert view.model_dump().keys().isdisjoint({"payload", "message", "endpoint", "method"})
+    assert run.model_dump().keys().isdisjoint({"input", "output", "error", "requirements"})
+    assert action.enabled is False
+    assert {
+        "ScheduleActionView",
+        "ScheduleCreate",
+        "ScheduleRunView",
+        "ScheduleTargetType",
+        "ScheduleView",
+    }.issubset(studio_schema.__all__)
+
+    request_schema = ScheduleCreate.model_json_schema()
+    assert request_schema["additionalProperties"] is False
+    assert all(field.get("description") for field in request_schema["properties"].values())
+
+    with pytest.raises(ValidationError, match="non-whitespace"):
+        ScheduleCreate(
+            name="Daily research",
+            cron="0 9 * * *",
+            target_type="agent",
+            target_id="researcher",
+            message="   ",
+        )
+    with pytest.raises(ValidationError, match="Extra inputs"):
+        ScheduleView(
+            schedule_id="schedule-1",
+            name="Daily research",
+            cron="0 9 * * *",
+            target_type="agent",
+            target_id="researcher",
+            timezone="UTC",
+            enabled=True,
+            owner_actor_id="studio-admin",
+            payload={"secret": "hidden"},
+        )

--- a/libs/agno/tests/unit/utils/test_json_schema.py
+++ b/libs/agno/tests/unit/utils/test_json_schema.py
@@ -1,12 +1,14 @@
+from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from agno.utils.json_schema import (
     get_json_schema,
     get_json_schema_for_arg,
     get_json_type_for_py_type,
+    inline_pydantic_schema,
     is_origin_union_type,
 )
 
@@ -45,6 +47,41 @@ class UserProfileModel(BaseModel):
     age: int
     contact_info: ContactInfoModel
     preferences: Dict[str, Any] = field(default_factory=dict)
+
+
+class CatModel(BaseModel):
+    kind: Literal["cat"]
+    lives: int
+
+
+class DogModel(BaseModel):
+    kind: Literal["dog"]
+    breed: str
+
+
+DiscriminatedPet = Annotated[Union[CatModel, DogModel], Field(discriminator="kind")]
+
+
+class PetOwnerModel(BaseModel):
+    name: str
+    pets: List[DiscriminatedPet]
+
+
+class OpaqueSchemaMetadataModel(BaseModel):
+    config: Dict[str, Any] = Field(
+        default={
+            "$defs": {"payload-key": "must survive"},
+            "discriminator": {"mapping": {"payload-tag": "#/$defs/PayloadValue"}},
+        }
+    )
+
+
+def _contains_key(value: Any, key: str) -> bool:
+    if isinstance(value, dict):
+        return key in value or any(_contains_key(item, key) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_key(item, key) for item in value)
+    return False
 
 
 # Nested dataclasses
@@ -374,6 +411,82 @@ def test_get_json_schema_with_nested_pydantic_models():
     preferences = user_profile["properties"]["preferences"]
     assert preferences["type"] == "object"
     assert "additionalProperties" in preferences
+
+
+def test_inline_pydantic_schema_inlines_discriminated_one_of_without_dangling_refs():
+    raw_schema = PetOwnerModel.model_json_schema()
+    original_schema = deepcopy(raw_schema)
+    raw_pet_items = raw_schema["properties"]["pets"]["items"]
+
+    assert "mapping" in raw_pet_items["discriminator"]
+
+    schema = inline_pydantic_schema(raw_schema)
+
+    # Inlining is side-effect free and removes every local definition/ref.
+    assert raw_schema == original_schema
+    assert not _contains_key(schema, "$defs")
+    assert not _contains_key(schema, "$ref")
+
+    pet_items = schema["properties"]["pets"]["items"]
+    assert pet_items["discriminator"] == {"propertyName": "kind"}
+    assert len(pet_items["oneOf"]) == 2
+    assert {branch["properties"]["kind"]["const"] for branch in pet_items["oneOf"]} == {"cat", "dog"}
+
+
+def test_get_json_schema_for_arg_inlines_discriminated_union_model():
+    schema = get_json_schema_for_arg(PetOwnerModel)
+
+    assert schema is not None
+    assert not _contains_key(schema, "$defs")
+    assert not _contains_key(schema, "$ref")
+    pet_items = schema["properties"]["pets"]["items"]
+    assert pet_items["discriminator"] == {"propertyName": "kind"}
+    assert {branch["properties"]["kind"]["const"] for branch in pet_items["oneOf"]} == {"cat", "dog"}
+
+
+def test_inline_pydantic_schema_preserves_opaque_model_defaults():
+    raw_schema = OpaqueSchemaMetadataModel.model_json_schema()
+    original_schema = deepcopy(raw_schema)
+
+    schema = inline_pydantic_schema(raw_schema)
+
+    assert schema["properties"]["config"]["default"] == original_schema["properties"]["config"]["default"]
+    schema["properties"]["config"]["default"]["$defs"]["payload-key"] = "changed"
+    assert raw_schema == original_schema
+
+
+def test_inline_pydantic_schema_preserves_all_opaque_annotation_payloads():
+    opaque = {
+        "$defs": {"payload-key": "must survive"},
+        "discriminator": {"mapping": {"payload-tag": "#/$defs/PayloadValue"}},
+    }
+    raw_schema = {
+        "$defs": {
+            "Payload": {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+            }
+        },
+        "type": "object",
+        "properties": {
+            "payload": {
+                "$ref": "#/$defs/Payload",
+                "default": deepcopy(opaque),
+                "examples": [deepcopy(opaque)],
+                "const": deepcopy(opaque),
+                "enum": [deepcopy(opaque)],
+            }
+        },
+    }
+
+    schema = inline_pydantic_schema(raw_schema)
+    payload_schema = schema["properties"]["payload"]
+
+    assert payload_schema["properties"] == {"value": {"type": "string"}}
+    assert payload_schema["default"] == opaque
+    assert payload_schema["examples"] == [opaque]
+    assert payload_schema["const"] == opaque
+    assert payload_schema["enum"] == [opaque]
 
 
 def test_get_json_schema_with_nested_dataclasses():

--- a/libs/agno/tests/unit/utils/test_string.py
+++ b/libs/agno/tests/unit/utils/test_string.py
@@ -386,10 +386,15 @@ def test_parse_json_with_python_code_in_value():
 
 
 def test_generate_id_from_name_with_name():
-    """Test that named IDs are deterministic kebab-case"""
+    """Named IDs preserve the historical persisted-identity transformation."""
     assert generate_id_from_name("My Agent") == "my-agent"
     assert generate_id_from_name("hello_world") == "hello-world"
     assert generate_id_from_name("UPPER") == "upper"
+    assert generate_id_from_name("Analyst v2.5") == "analyst-v2.5"
+    assert generate_id_from_name("R&D Jörg") == "r&d-jörg"
+    assert generate_id_from_name("Research/Review") == "research/review"
+    assert generate_id_from_name("  Repeated  Spaces  ") == "--repeated--spaces--"
+    assert generate_id_from_name("日本語") == "日本語"
 
 
 def test_generate_id_from_name_without_name():

--- a/libs/agno/tests/unit/workflow/test_workflow_config.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_config.py
@@ -25,6 +25,21 @@ from agno.workflow.workflow import Workflow, get_workflow_by_id, get_workflows
 # =============================================================================
 
 
+def _corrupt_delete_config_row(db: Any, component_id: str, version: int) -> None:
+    """Simulate an externally corrupted pin without weakening the public API."""
+    configs_table = db._get_table(table_type="component_configs")
+    assert configs_table is not None
+    with db.Session() as session:
+        result = session.execute(
+            configs_table.delete().where(
+                configs_table.c.component_id == component_id,
+                configs_table.c.version == version,
+            )
+        )
+        session.commit()
+    assert result.rowcount == 1
+
+
 def _create_mock_db_class():
     """Create a concrete BaseDb subclass with all abstract methods stubbed."""
     abstract_methods = {}
@@ -40,12 +55,17 @@ def mock_db():
     """Create a mock database instance that passes isinstance(db, BaseDb)."""
     MockDbClass = _create_mock_db_class()
     db = MockDbClass()
+    db.component_catalog_api_version = 2
 
     # Configure common mock methods
+    db.get_component = MagicMock(return_value=None)
+    db.create_component_with_config = MagicMock(return_value=({"component_id": "test-workflow"}, {"version": 1}))
     db.upsert_component = MagicMock()
     db.upsert_config = MagicMock(return_value={"version": 1})
     db.delete_component = MagicMock(return_value=True)
     db.get_config = MagicMock()
+    db.get_current_config = db.get_config
+    db.get_latest_config = db.get_config
     db.list_components = MagicMock()
     db.get_links = MagicMock()
     db.to_dict = MagicMock(return_value={"type": "postgres", "id": "test-db"})
@@ -284,24 +304,28 @@ class TestWorkflowFromDict:
 class TestWorkflowSave:
     """Tests for Workflow.save() method."""
 
-    def test_save_calls_upsert_component(self, basic_workflow, mock_db):
-        """Test save calls upsert_component with correct parameters."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+    def test_save_creates_component_and_initial_config_atomically(self, basic_workflow, mock_db):
+        """Test first save creates the component and config together."""
         basic_workflow.db = mock_db
         version = basic_workflow.save()
 
-        mock_db.upsert_component.assert_called_once_with(
-            component_id="test-workflow",
-            component_type=ComponentType.WORKFLOW,
-            name="Test Workflow",
-            description="A test workflow for unit testing",
-            metadata=None,
-        )
+        call_args = mock_db.create_component_with_config.call_args
+        assert call_args.kwargs["component_id"] == "test-workflow"
+        assert call_args.kwargs["component_type"] == ComponentType.WORKFLOW
+        assert call_args.kwargs["name"] == "Test Workflow"
+        assert call_args.kwargs["description"] == "A test workflow for unit testing"
+        assert call_args.kwargs["config"]["id"] == "test-workflow"
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_not_called()
         assert version == 1
 
-    def test_save_calls_upsert_config(self, basic_workflow, mock_db):
-        """Test save calls upsert_config with workflow config."""
+    def test_existing_save_upserts_config_with_projection(self, basic_workflow, mock_db):
+        """Test a published save updates config and projection together."""
+        mock_db.get_component.return_value = {
+            "component_id": "test-workflow",
+            "component_type": "workflow",
+            "deleted_at": None,
+        }
         mock_db.upsert_config.return_value = {"version": 2}
 
         basic_workflow.db = mock_db
@@ -311,46 +335,44 @@ class TestWorkflowSave:
         call_args = mock_db.upsert_config.call_args
         assert call_args.kwargs["component_id"] == "test-workflow"
         assert "config" in call_args.kwargs
+        assert call_args.kwargs["projection"] == {
+            "name": "Test Workflow",
+            "description": "A test workflow for unit testing",
+            "metadata": None,
+        }
         assert version == 2
 
     def test_save_with_explicit_db(self, basic_workflow, mock_db):
         """Test save uses explicitly provided db."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
         version = basic_workflow.save(db=mock_db)
 
-        mock_db.upsert_component.assert_called_once()
-        mock_db.upsert_config.assert_called_once()
+        mock_db.create_component_with_config.assert_called_once()
+        mock_db.upsert_component.assert_not_called()
+        mock_db.upsert_config.assert_not_called()
         assert version == 1
 
     def test_save_with_label(self, basic_workflow, mock_db):
-        """Test save passes label to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes the label to the atomic create."""
         basic_workflow.db = mock_db
         basic_workflow.save(label="production")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["label"] == "production"
 
     def test_save_with_stage(self, basic_workflow, mock_db):
-        """Test save passes stage to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes the stage to the atomic create."""
         basic_workflow.db = mock_db
         basic_workflow.save(stage="draft")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["stage"] == "draft"
 
     def test_save_with_notes(self, basic_workflow, mock_db):
-        """Test save passes notes to upsert_config."""
-        mock_db.upsert_config.return_value = {"version": 1}
-
+        """Test first save passes notes to the atomic create."""
         basic_workflow.db = mock_db
         basic_workflow.save(notes="Initial version")
 
-        call_args = mock_db.upsert_config.call_args
+        call_args = mock_db.create_component_with_config.call_args
         assert call_args.kwargs["notes"] == "Initial version"
 
     def test_save_without_db_raises_error(self, basic_workflow):
@@ -388,7 +410,7 @@ class TestWorkflowSave:
 
     def test_save_returns_none_on_error(self, basic_workflow, mock_db):
         """Test save returns None when database operation fails."""
-        mock_db.upsert_component.side_effect = Exception("Database error")
+        mock_db.create_component_with_config.side_effect = Exception("Database error")
 
         basic_workflow.db = mock_db
         version = basic_workflow.save()
@@ -471,7 +493,9 @@ class TestWorkflowDelete:
         basic_workflow.db = mock_db
         result = basic_workflow.delete()
 
-        mock_db.delete_component.assert_called_once_with(component_id="test-workflow", hard_delete=False)
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-workflow", hard_delete=False, require_no_dependents=True
+        )
         assert result is True
 
     def test_delete_with_hard_delete(self, basic_workflow, mock_db):
@@ -481,8 +505,35 @@ class TestWorkflowDelete:
         basic_workflow.db = mock_db
         result = basic_workflow.delete(hard_delete=True)
 
-        mock_db.delete_component.assert_called_once_with(component_id="test-workflow", hard_delete=True)
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-workflow", hard_delete=True, require_no_dependents=True
+        )
         assert result is True
+
+    def test_delete_can_explicitly_bypass_dependency_check(self, basic_workflow, mock_db):
+        """Test delete forwards the dangerous dependency-check escape hatch."""
+        basic_workflow.db = mock_db
+
+        assert basic_workflow.delete(require_no_dependents=False) is True
+
+        mock_db.delete_component.assert_called_once_with(
+            component_id="test-workflow", hard_delete=False, require_no_dependents=False
+        )
+
+    def test_delete_uses_exact_catalog_v1_signature(self, basic_workflow, mock_db):
+        """The v2 dependency keyword must never reach a legacy override."""
+        calls = []
+
+        def legacy_delete(component_id, hard_delete=False):
+            calls.append((component_id, hard_delete))
+            return True
+
+        mock_db.component_catalog_api_version = 1
+        mock_db.delete_component = legacy_delete
+        basic_workflow.db = mock_db
+
+        assert basic_workflow.delete(require_no_dependents=False) is True
+        assert calls == [("test-workflow", False)]
 
     def test_delete_with_explicit_db(self, basic_workflow, mock_db):
         """Test delete uses explicitly provided db."""
@@ -529,6 +580,21 @@ class TestGetWorkflowById:
         assert workflow is not None
         assert workflow.id == "found-workflow"
         assert workflow.name == "Found Workflow"
+        mock_db.get_config.assert_called_once_with(component_id="found-workflow", version=None, label=None)
+
+    def test_get_workflow_by_id_returns_a_draft_only_component(self, tmp_path):
+        """An ordinary workflow lookup remains able to inspect a first draft."""
+        from agno.db.sqlite import SqliteDb
+
+        db = SqliteDb(db_file=str(tmp_path / "draft-only-workflow.db"))
+        assert Workflow(id="draft-workflow", name="Draft Workflow", db=db).save(stage="draft") == 1
+        assert db.get_current_config("draft-workflow") is None
+
+        loaded = get_workflow_by_id(db=db, id="draft-workflow")
+
+        assert loaded is not None
+        assert loaded.id == "draft-workflow"
+        assert loaded.name == "Draft Workflow"
 
     def test_get_workflow_by_id_with_version(self, mock_db):
         """Test get_workflow_by_id retrieves specific version."""
@@ -622,16 +688,20 @@ class TestGetWorkflows:
             ],
             None,
         )
-        mock_db.get_config.side_effect = [
-            {"config": {"id": "workflow-1", "name": "Workflow 1"}},
-            {"config": {"id": "workflow-2", "name": "Workflow 2"}},
-        ]
+        mock_db.get_latest_config = MagicMock(
+            side_effect=[
+                {"config": {"id": "workflow-1", "name": "Workflow 1"}},
+                {"config": {"id": "workflow-2", "name": "Workflow 2"}},
+            ]
+        )
 
         workflows = get_workflows(db=mock_db)
 
         assert len(workflows) == 2
         assert workflows[0].id == "workflow-1"
         assert workflows[1].id == "workflow-2"
+        assert mock_db.get_latest_config.call_count == 2
+        mock_db.get_config.assert_not_called()
 
     def test_get_workflows_filters_by_type(self, mock_db):
         """Test get_workflows filters by WORKFLOW component type."""
@@ -817,7 +887,7 @@ class TestStepPinFailures:
         member.save(db=db)
         links = db.get_links(component_id="dp-wf", version=1)
         pinned = next(link for link in links if link["link_kind"] == "step_agent")["child_version"]
-        assert db.delete_config(component_id="dp-agent", version=pinned)
+        _corrupt_delete_config_row(db, "dp-agent", pinned)
 
         lenient = get_workflow_by_id(db=db, id="dp-wf", strict=False)
         assert lenient is not None
@@ -878,7 +948,10 @@ class TestWritePathFidelity:
 
         db = SqliteDb(db_file=str(tmp_path / "noname.db"))
         Workflow(id="nn-wf", name="WF", steps=[Step(agent=Agent(id="nn-agent", name="A"))]).save(db=db)
-        db.delete_component("nn-agent", hard_delete=True)
+        # Deliberately corrupt the graph to exercise lenient degradation. The
+        # normal lifecycle is dependency-safe, so this test-only setup must
+        # explicitly bypass that guard.
+        db.delete_component("nn-agent", hard_delete=True, require_no_dependents=False)
 
         loaded = Workflow.load(id="nn-wf", db=db, strict=False)
 
@@ -1012,6 +1085,34 @@ class TestLenientRunHonesty:
 
 
 class TestSaveCollisions:
+    def test_save_warns_and_keeps_first_when_duplicate_links_have_the_same_pin(self, tmp_path, caplog):
+        from agno.agent.agent import Agent
+        from agno.db.sqlite import SqliteDb
+        from agno.workflow.loop import Loop
+        from agno.workflow.step import Step
+
+        db = SqliteDb(db_file=str(tmp_path / "same-pin.db"))
+        agent = Agent(id="same-pin-agent", name="Same Pin")
+        assert agent.save(db=db, stage="draft") == 1
+        agent.save = MagicMock(return_value=1)  # type: ignore[method-assign]
+        workflow = Workflow(
+            id="same-pin-workflow",
+            name="Same Pin Workflow",
+            steps=[
+                Loop(name="left", steps=[Step(step_id="shared", name="shared", agent=agent)]),
+                Loop(name="right", steps=[Step(step_id="shared", name="shared", agent=agent)]),
+            ],
+        )
+
+        with caplog.at_level("WARNING"):
+            assert workflow.save(db=db, stage="draft") == 1
+
+        assert "dropping duplicate step_agent link" in caplog.text
+        links = db.get_links(component_id="same-pin-workflow", version=1)
+        assert len(links) == 1
+        assert links[0]["child_component_id"] == "same-pin-agent"
+        assert links[0]["child_version"] == 1
+
     def test_save_fails_loudly_when_two_pins_collide_on_one_key(self, tmp_path):
         from agno.agent.agent import Agent
         from agno.db.sqlite import SqliteDb


### PR DESCRIPTION
## Summary

This PR introduces the typed AgentOS 2.9 Studio control plane. It replaces the flat, argument-heavy `StudioTools` surface with explicit Pydantic request models, typed references, structured results, safe public views, and a draft-first component lifecycle that a model or application can use without guessing at hidden defaults.

### Public API and developer experience

- Create, edit, publish, rollback, archive, restore, inspect, list, run, and schedule operations accept typed request objects and return `StudioResult[T]`.
- Creation requests use explicit `component_id` identity, typed `ModelRef` and `ToolRef` values, a `ContextPolicy`, and a declared `if_exists` policy.
- `StudioTools` binds one component database at construction time; callers no longer choose a database on every operation.
- Components are created as drafts by default. Publication is a separate, guarded action, and stale edits or publications return structured conflicts.
- Legacy Studio call signatures are intentionally removed for the 2.9 release rather than maintained beside the typed API.

### Identity, authorization, and safe results

- Every read, mutation, and run operation uses server-derived `RunContext` identity and an explicit authorization callback; missing authorization fails closed.
- Component IDs are globally owned across component types and code/Studio sources, so ambiguous identity and display-name shadowing are rejected.
- Public results omit raw configs, credentials, catalog locations, and backend exception text.
- Discovery isolates malformed rows and returns safe partial-list warnings instead of failing an entire listing.

### References and runtime fidelity

- Agent, Team, and Workflow requests use exact component, model, tool, and database references.
- Dependencies are resolved to exact published versions before the parent is persisted; draft-only, wrong-type, cyclic, or ambiguous references fail without creating the parent.
- Registry/database rehydration is verified before dispatch so the executed object matches the stored type, identity, and configuration.
- Workflow steps use discriminated typed schemas and preserve composite `Parallel`, `Loop`, `Condition`, and `Router` structures.
- Reference verification has independent depth and node limits, and hitting either limit is reported as incomplete verification rather than a pass.
- Unversioned execution remains published-only; an explicit version is an intentional exact-version preview path.

### Studio schedules and examples

- Adds Studio-owned schedule operations with private actor and target provenance.
- Generic schedule mutation paths are kept separate from Studio-owned schedules.
- Updates all seven Studio cookbooks to the typed contract and separates control-plane examples from runner-only dispatch.

### Review boundary

Review this PR as the public Studio API, authorization boundary, graph/reference resolver, and Studio schedule control plane. It relies on the component and schedule persistence contract in #9455, but it does not change the scheduler worker retry or lease-execution loop.

### Current review status

One verified Greptile follow-up remains open on this head: public HTTP cookbook entry points still contain source-known development JWT fallbacks instead of requiring explicit secrets ([discussion](https://github.com/agno-agi/agno/pull/9456#discussion_r3762126497)). The same pattern also exists in the base stack cookbook and should be removed before merge.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Validation

- The full StudioRunner suite passed: 191 tests.
- The integrated three-PR matrix passed 1,519 local tests.
- 32 live PostgreSQL lifecycle, migration, scheduler-claim, and Studio integration tests passed.
- All seven Studio cookbook targets passed compilation, Ruff check/format, and construction-only execution.
- `./scripts/format.sh`, `./scripts/validate.sh`, and `git diff --check` passed with clean core and agnoctl mypy checks.
- The branch is one 23-file commit over #9455, with no merge commits.

## Security boundaries

- Authorization is evaluated against server-derived actor context, not caller-supplied identity.
- Exact component ID or exact display name are the only runtime selectors; fuzzy slug routing is not supported.
- Backend failures are mapped to structured, sanitized errors.

## Stack context

This is the control-plane layer in a three-PR review stack:

1. #9455 — component catalog and scheduler persistence
2. **#9456 — typed Studio control plane**
3. #9457 — scheduler execution and retry behavior

The descriptions above are the complete review scope for this PR; the stack note only records dependency and merge order.

Implementation was generated with Codex under author-directed API design, stack selection, testing, and review.