### PR TITLE
fix: harden scheduled execution

### DIFF
--- a/cookbook/05_agent_os/22_studio/TEST_LOG.md
+++ b/cookbook/05_agent_os/22_studio/TEST_LOG.md
@@ -1,9 +1,72 @@
 # Test Log: 22_studio
 
-The first five entries and the Validation section record the 2026-07-24 pass
-against Agno source commit `45bfff9f2aa6ec11b7386c3cd3bf6d1141d005dc`, loaded
-through `PYTHONPATH=/Users/ab/code/worktrees/agno-agent-os-rewrite/libs/agno`.
-The two `studio_runner_*` entries record the 2026-08-06 pass against the
+This file keeps historical live evidence separate from validation of the typed
+StudioTools 2.9 migration. The historical results below prove the examples that
+existed at those pinned revisions; they do not validate the current API.
+
+## Typed StudioTools 2.9 migration validation
+
+**Status:** PASS
+
+**Test mode:** LOCAL CONSTRUCTION + FOCUSED TESTS + LIVE POSTGRESQL
+
+**Date:** 2026-08-11
+
+Validated the seven Python targets against the final three-branch StudioTools
+2.9 stack in the `codex/studio-schedule-runtime-v2` worktree after rebasing its
+three single-commit layers onto `main` at
+`26bb90c612e94aeb32f46ba42ac541ded713e817`. The rebase retained the exact
+50/23/11-file layer boundaries; the only overlap is the two-file transition
+bridge that the typed control-plane layer replaces. It reconciled the final
+StudioRunner hardening and the selected-workflow-version WebSocket fix that
+landed on `main`, including fail-closed graph limits, occurrence-specific pins,
+declared model/database fidelity, code-only discovery, and shadow-safe totals.
+Every module was executed through
+`runpy.run_path(..., run_name="studio_validation")`, which exercises imports,
+toolkit construction, typed component seeding, SQLite persistence, and AgentOS
+app construction without entering each script's provider-backed `__main__`
+path.
+
+**Result:**
+
+- all seven Python files passed source compilation with the demo Python
+  runtime;
+- all seven passed targeted Ruff check and format validation;
+- all seven passed construction-only execution;
+- `studio_runner_direct.py` construction created published Agent, Team, and
+  Workflow components from `AgentCreate`, `TeamCreate`, and `WorkflowCreate`;
+- the consolidated predecessor-preservation, Studio, runner, component-router,
+  scheduler, authorization, serialization, SQLite lifecycle, and migration
+  matrices passed all `1519` tests;
+- the live PostgreSQL lifecycle, migration, and Studio integration matrix
+  passed all `32` tests, including immutable version payloads, guarded
+  publication, rollback projection, dependency cycles, and concurrent writes;
+- the current-main composition pass added `18` workflow-run integration tests
+  and `106` draft-visibility, workflow-config, and component-save tests;
+- after hosted CI exposed PostgreSQL constructor test-double and stale
+  implicit-reactivation assumptions, all `99` affected constructor, schema,
+  auth-token, component-archive, and serialization unit tests passed;
+- `./scripts/format.sh` and `./scripts/validate.sh` passed, including core and
+  agnoctl mypy, Ruff for every package, and cookbook validation;
+- `git diff --check` passed for the current worktree.
+
+Earlier in this migration pass, before the authoritative base advanced, the
+direct runner, standalone lifecycle, and JWT-authenticated AgentOS examples
+also completed live runs `c162c8ea-9b19-44b2-acd5-eb64068331c4`,
+`bcb0d1b4-4708-4dc1-9b00-99ff1f4984db`, and
+`b10eddea-a02c-4885-a5cf-637605b40697`. Those provider-backed runs were not
+repeated after the base refresh, so they are supporting evidence rather than
+proof of the final stacked source. The two HITL examples and
+`registry_and_components.py` were likewise construction-tested but not rerun
+end to end; their older live results remain below as historical evidence.
+
+## Historical live validation
+
+The first five entries and the historical Validation section record the
+2026-07-24 pass against Agno source commit
+`45bfff9f2aa6ec11b7386c3cd3bf6d1141d005dc`, loaded through
+`PYTHONPATH=/Users/ab/code/worktrees/agno-agent-os-rewrite/libs/agno`. The two
+`studio_runner_*` entries record the 2026-08-06 pass against the
 `feat/studio-runner-tools` worktree; each carries its own provenance.
 
 Provider credentials were loaded with `direnv exec .`; no credential values
@@ -17,9 +80,9 @@ with other AgentOS lessons, and the listener was stopped after every run.
 **Test mode:** LIVE
 
 **Description:** Ran a standalone Claude Studio Agent with Registry discovery,
-SQLite component persistence, and `StudioTools(versions=True)`. The Agent
-listed registered models and tools, created an Agent, edited it to a draft,
-listed both versions, and published the draft.
+SQLite component persistence, and the then-current pre-2.9 StudioTools
+contract. The Agent listed registered models and tools, created an Agent,
+edited it to a draft, listed both versions, and published the draft.
 
 **Result:** Run `5e61007c-7f6f-4611-be11-8ce2dd58468b` completed with exact
 model ID `claude-sonnet-4-6`. Component `studio-math-tutor-9794e075` progressed
@@ -34,8 +97,8 @@ from published v1 to draft v2 and then published v2; v2 became current.
 **Test mode:** LIVE
 
 **Description:** Started AgentOS on port `7792`, checked health plus Registry
-and Components discovery, then asked the live Studio Agent to discover the
-registered model, tool, and database and create one persisted Agent.
+and Components discovery, then asked the live Studio Agent to use the
+then-current flat request contract to create one persisted Agent.
 
 **Result:** Run `967a66e1-b258-41ba-82b4-e800b76f9242` completed. Component
 `api-math-guide-147c45ec` was stored as published v1 with `gpt-5.5`, the exact
@@ -83,14 +146,15 @@ confirmed call persisted `os-research-buddy-75a4e73f` with the selected
 **Test mode:** LIVE
 
 **Description:** Started AgentOS on port `7792` and exercised Registry
-discovery plus the Components create, read, filtered-list, update,
-current-config, and delete endpoints with real HTTP requests.
+discovery plus the then-current Components create, read, filtered-list,
+update, current-config, and removal endpoints with real HTTP requests.
 
 **Result:** Registry discovery returned all five registered resources,
 including both current model IDs, `calculator`, and the SQLite database.
 Component `registry-crud-agent-fa59682f` was created as published v1, renamed,
-read through `/configs/current`, deleted with HTTP 204, and confirmed absent
-with HTTP 404.
+read through `/configs/current`, removed through the historical router contract,
+and confirmed absent. This is provenance for that pinned revision, not current
+StudioTools lifecycle guidance.
 
 ---
 
@@ -128,7 +192,7 @@ with the registry to run it."
 
 ---
 
-## Validation (2026-07-24 pass)
+## Historical Validation (2026-07-24 pass)
 
 - All five Python targets of that pass passed worktree-pinned compilation and
   targeted Ruff format/check; the two 2026-08-06 `studio_runner_*` additions
@@ -146,4 +210,4 @@ with the registry to run it."
   overrides framework route metadata.
 - The assigned legacy `studio_tool/` lesson was removed after all replacements
   passed.
-- `git diff --check` passed for the rewritten and deleted paths.
+- `git diff --check` passed for the rewritten and removed paths.

--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -8,6 +8,7 @@ from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from starlette.concurrency import run_in_threadpool
 
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_ACTOR_HEADER, decode_studio_schedule_actor_id
 from agno.os.scopes import (
     get_accessible_resource_ids,
     get_default_scope_mappings,
@@ -41,6 +42,18 @@ INTERNAL_SERVICE_SCOPES: List[str] = [
     "schedules:write",
     "schedules:delete",
 ]
+
+
+def resolve_internal_scheduler_actor(request: Request) -> str:
+    """Resolve a server-delegated Studio actor carried by the internal token.
+
+    The header is ignored for every other credential path. The scheduler
+    executor derives it only from server-owned schedule provenance.
+    """
+    actor_id = request.headers.get(STUDIO_SCHEDULE_ACTOR_HEADER)
+    if actor_id is None:
+        return "__scheduler__"
+    return decode_studio_schedule_actor_id(actor_id)
 
 
 def get_auth_token_from_request(request: Request) -> Optional[str]:
@@ -230,6 +243,21 @@ def get_authentication_dependency(settings: AgnoAPISettings):
                 request, token, treat_unverifiable_as_anonymous=not instance_has_auth
             )
 
+        # The scheduler's internal token is meaningful even on an otherwise
+        # open AgentOS.  Open instances do not install AuthMiddleware, so this
+        # dependency is the only place that can attach the server-delegated
+        # actor to the run request.  Keep this ahead of the open/JWT fast paths
+        # and trust the actor header only after an exact internal-token match.
+        internal_token = getattr(request.app.state, "internal_service_token", None)
+        if token and internal_token and hmac.compare_digest(token, internal_token):
+            request.state.authenticated = True
+            try:
+                request.state.user_id = resolve_internal_scheduler_actor(request)
+            except ValueError:
+                raise HTTPException(status_code=401, detail="Invalid delegated scheduler actor")
+            request.state.scopes = list(INTERNAL_SERVICE_SCOPES)
+            return True
+
         # Also skip if JWT is configured via environment variables
         if _is_jwt_configured():
             return True
@@ -243,14 +271,6 @@ def get_authentication_dependency(settings: AgnoAPISettings):
             raise HTTPException(status_code=401, detail="Authorization header required")
 
         token = credentials.credentials
-
-        # Check internal service token (used by scheduler executor)
-        internal_token = getattr(request.app.state, "internal_service_token", None)
-        if internal_token and hmac.compare_digest(token, internal_token):
-            request.state.authenticated = True
-            request.state.user_id = "__scheduler__"
-            request.state.scopes = list(INTERNAL_SERVICE_SCOPES)
-            return True
 
         # Verify the token against security key
         if token != settings.os_security_key:

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -12,7 +12,11 @@ from fastapi import Request, Response
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from agno.os.auth import INTERNAL_SERVICE_SCOPES, build_insufficient_permissions_detail
+from agno.os.auth import (
+    INTERNAL_SERVICE_SCOPES,
+    build_insufficient_permissions_detail,
+    resolve_internal_scheduler_actor,
+)
 from agno.os.scopes import (
     AgentOSScope,
     check_route_scopes,
@@ -984,7 +988,15 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if internal_token and hmac.compare_digest(token, internal_token):
             request.state.authenticated = True
             setattr(request.state, _AUTH_COMPLETE_ATTR, True)
-            request.state.user_id = INTERNAL_SCHEDULER_USER_ID
+            try:
+                request.state.user_id = resolve_internal_scheduler_actor(request)
+            except ValueError:
+                return self._create_error_response(
+                    401,
+                    "Invalid delegated scheduler actor",
+                    origin,
+                    cors_allowed_origins,
+                )
             request.state.session_id = None
             internal_scopes = list(INTERNAL_SERVICE_SCOPES)
             request.state.scopes = internal_scopes

--- a/libs/agno/agno/scheduler/executor.py
+++ b/libs/agno/agno/scheduler/executor.py
@@ -1,13 +1,20 @@
 """Schedule executor -- fires HTTP requests for due schedules."""
 
 import asyncio
+import inspect
 import json
 import re
 import time
 from typing import Any, Dict, List, Optional, Union
 from uuid import uuid4
 
-from agno.db.schemas.scheduler import Schedule
+from agno.db.schemas.scheduler import (
+    STUDIO_SCHEDULE_ACTOR_HEADER,
+    Schedule,
+    encode_studio_schedule_actor_id,
+    is_studio_managed_schedule,
+    is_valid_studio_schedule_actor_id,
+)
 from agno.utils.log import log_error, log_info, log_warning
 
 try:
@@ -24,9 +31,32 @@ _TERMINAL_STATUSES = {"COMPLETED", "CANCELLED", "ERROR", "PAUSED"}
 # Default polling interval in seconds for background run status checks
 _DEFAULT_POLL_INTERVAL = 30
 
+# Schedule claims use the same default five-minute lease as the official DB
+# adapters. The executor renews a claimed lease well before it can be treated
+# as stale by another poller.
+_DEFAULT_LOCK_GRACE_SECONDS = 300
+
+# Internal result key used to distinguish a request that is safe to submit
+# again from a background run that has already been accepted by AgentOS.
+_RETRYABLE_RESULT_KEY = "_retryable"
+
+
+def match_run_endpoint(endpoint: str, method: str) -> Optional[re.Match[str]]:
+    """Return the canonical run-route match for a POST endpoint."""
+    if method.upper() != "POST":
+        return None
+    return _RUN_ENDPOINT_RE.fullmatch(endpoint)
+
+
+def is_run_endpoint(endpoint: str, method: str) -> bool:
+    """Return whether *endpoint* is a canonical AgentOS run route."""
+    return match_run_endpoint(endpoint, method) is not None
+
 
 def _to_form_value(v: Any) -> str:
     """Convert a payload value to a JSON-safe form string."""
+    if v is None:
+        return ""
     if isinstance(v, bool):
         return "true" if v else "false"
     if isinstance(v, (dict, list)):
@@ -50,6 +80,7 @@ class ScheduleExecutor:
         internal_service_token: str,
         timeout: int = 3600,
         poll_interval: int = _DEFAULT_POLL_INTERVAL,
+        lock_grace_seconds: int = _DEFAULT_LOCK_GRACE_SECONDS,
     ) -> None:
         if httpx is None:
             raise ImportError("`httpx` not installed. Please install it using `pip install httpx`")
@@ -57,6 +88,10 @@ class ScheduleExecutor:
         self.internal_service_token = internal_service_token
         self.timeout = timeout
         self.poll_interval = poll_interval
+        if lock_grace_seconds <= 0:
+            raise ValueError("lock_grace_seconds must be greater than zero")
+        self.lock_grace_seconds = lock_grace_seconds
+        self._heartbeat_interval = max(0.1, lock_grace_seconds / 3)
         self._client: Optional[httpx.AsyncClient] = None
 
     async def _get_client(self) -> httpx.AsyncClient:
@@ -70,6 +105,69 @@ class ScheduleExecutor:
         if self._client is not None and not self._client.is_closed:
             await self._client.aclose()
             self._client = None
+
+    @staticmethod
+    async def _call_db(db: Any, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        """Call a native async adapter directly and offload a sync adapter."""
+        method = getattr(db, method_name, None)
+        if method is None:
+            raise NotImplementedError(f"Database does not support {method_name}")
+        if asyncio.iscoroutinefunction(method):
+            result = await method(*args, **kwargs)
+        else:
+            result = await asyncio.to_thread(method, *args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    @staticmethod
+    def _log_run_persistence_failure(
+        schedule_id: Optional[str],
+        attempt: int,
+        studio_managed: bool,
+        exc: Exception,
+    ) -> None:
+        """Log a run-record failure without exposing Studio-owned details."""
+        if studio_managed:
+            log_error(f"Failed to persist Studio schedule {schedule_id} attempt {attempt}")
+        else:
+            log_error(f"Failed to persist schedule {schedule_id} attempt {attempt}: {exc}")
+
+    async def _heartbeat_claim(
+        self,
+        db: Any,
+        schedule_id: str,
+        worker_id: str,
+        lease: Dict[str, Any],
+        stop: asyncio.Event,
+    ) -> None:
+        """Renew one fenced claim until execution finishes or ownership is lost."""
+        while True:
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=self._heartbeat_interval)
+                return
+            except asyncio.TimeoutError:
+                pass
+
+            locked_at = lease["locked_at"]
+            try:
+                renewed_at = await self._call_db(
+                    db,
+                    "renew_schedule_claim",
+                    schedule_id,
+                    worker_id=worker_id,
+                    locked_at=locked_at,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log_error(f"Failed to renew schedule claim {schedule_id}")
+                continue
+
+            if not isinstance(renewed_at, int) or isinstance(renewed_at, bool):
+                log_error(f"Lost ownership of schedule claim {schedule_id}")
+                return
+            lease["locked_at"] = renewed_at
 
     # ------------------------------------------------------------------
     async def execute(
@@ -92,6 +190,7 @@ class ScheduleExecutor:
 
         # Normalize to Schedule dataclass for typed access
         sched = Schedule.from_dict(schedule) if isinstance(schedule, dict) else schedule
+        studio_managed = is_studio_managed_schedule(sched)
 
         schedule_id: Optional[str] = None
         run_id_value: Optional[str] = None
@@ -104,11 +203,27 @@ class ScheduleExecutor:
         last_requirements: Optional[List[Dict[str, Any]]] = None
         run_record_id: Optional[str] = None
         run_dict: Dict[str, Any] = {}
+        lease: Dict[str, Any] = {"locked_at": sched.locked_at}
+        heartbeat_stop: Optional[asyncio.Event] = None
+        heartbeat_task: Optional[asyncio.Task[None]] = None
 
         try:
             schedule_id = sched.id
+            scheduler_api_version = getattr(db, "scheduler_api_version", 1)
+            if (
+                isinstance(scheduler_api_version, int)
+                and scheduler_api_version >= 2
+                and sched.locked_by is not None
+                and sched.locked_at is not None
+                and callable(getattr(db, "renew_schedule_claim", None))
+            ):
+                heartbeat_stop = asyncio.Event()
+                heartbeat_task = asyncio.create_task(
+                    self._heartbeat_claim(db, schedule_id, sched.locked_by, lease, heartbeat_stop)
+                )
+
             max_attempts = max(1, (sched.max_retries or 0) + 1)
-            retry_delay = sched.retry_delay_seconds or 60
+            retry_delay = sched.retry_delay_seconds if sched.retry_delay_seconds is not None else 60
             for attempt in range(1, max_attempts + 1):
                 run_record_id = str(uuid4())
                 now = int(time.time())
@@ -130,13 +245,36 @@ class ScheduleExecutor:
                     "created_at": now,
                 }
 
-                if asyncio.iscoroutinefunction(getattr(db, "create_schedule_run", None)):
-                    await db.create_schedule_run(run_dict)
-                else:
-                    db.create_schedule_run(run_dict)
+                await self._call_db(db, "create_schedule_run", run_dict)
 
+                endpoint_retryable = True
                 try:
                     result = await self._call_endpoint(sched)
+                except Exception as exc:
+                    last_status = "failed"
+                    last_status_code = None
+                    if studio_managed:
+                        last_error = "Studio schedule execution failed"
+                        log_error(f"Studio schedule {schedule_id} attempt {attempt} failed")
+                    else:
+                        last_error = str(exc)
+                        log_error(f"Schedule {schedule_id} attempt {attempt} failed: {exc}")
+
+                    failure_updates = {
+                        "completed_at": int(time.time()),
+                        "status": "failed",
+                        "error": last_error,
+                    }
+                    try:
+                        await self._call_db(db, "update_schedule_run", run_record_id, **failure_updates)
+                    except Exception as persistence_exc:
+                        self._log_run_persistence_failure(
+                            schedule_id,
+                            attempt,
+                            studio_managed,
+                            persistence_exc,
+                        )
+                else:
                     last_status = result.get("status", "success")
                     last_status_code = result.get("status_code")
                     last_error = result.get("error")
@@ -157,28 +295,22 @@ class ScheduleExecutor:
                         "output": last_output,
                         "requirements": last_requirements,
                     }
-                    if asyncio.iscoroutinefunction(getattr(db, "update_schedule_run", None)):
-                        await db.update_schedule_run(run_record_id, **updates)
-                    else:
-                        db.update_schedule_run(run_record_id, **updates)
+                    try:
+                        await self._call_db(db, "update_schedule_run", run_record_id, **updates)
+                    except Exception as persistence_exc:
+                        self._log_run_persistence_failure(
+                            schedule_id,
+                            attempt,
+                            studio_managed,
+                            persistence_exc,
+                        )
+                    endpoint_retryable = bool(result.get(_RETRYABLE_RESULT_KEY, last_status == "failed"))
 
-                    if last_status in ("success", "paused"):
-                        break
-
-                except Exception as exc:
-                    last_status = "failed"
-                    last_error = str(exc)
-                    log_error(f"Schedule {schedule_id} attempt {attempt} failed: {exc}")
-
-                    updates = {
-                        "completed_at": int(time.time()),
-                        "status": "failed",
-                        "error": last_error,
-                    }
-                    if asyncio.iscoroutinefunction(getattr(db, "update_schedule_run", None)):
-                        await db.update_schedule_run(run_record_id, **updates)
-                    else:
-                        db.update_schedule_run(run_record_id, **updates)
+                # Persistence is deliberately outside the endpoint exception
+                # boundary. A DB write failure after AgentOS accepted a run
+                # must never turn that accepted outcome into a new submission.
+                if last_status in ("success", "paused") or not endpoint_retryable:
+                    break
 
                 if attempt < max_attempts:
                     log_info(f"Schedule {schedule_id}: retrying in {retry_delay}s (attempt {attempt}/{max_attempts})")
@@ -198,8 +330,11 @@ class ScheduleExecutor:
 
             return final_run
 
-        except asyncio.CancelledError as e:
-            log_warning(f"Schedule {schedule_id} execution cancelled: {str(e)}")
+        except asyncio.CancelledError as exc:
+            if studio_managed:
+                log_warning(f"Studio schedule {schedule_id} execution cancelled")
+            else:
+                log_warning(f"Schedule {schedule_id} execution cancelled: {exc}")
             if run_record_id is not None:
                 cancel_updates: Dict[str, Any] = {
                     "completed_at": int(time.time()),
@@ -207,44 +342,75 @@ class ScheduleExecutor:
                     "error": "Execution cancelled during shutdown",
                 }
                 try:
-                    if asyncio.iscoroutinefunction(getattr(db, "update_schedule_run", None)):
-                        await db.update_schedule_run(run_record_id, **cancel_updates)
-                    else:
-                        db.update_schedule_run(run_record_id, **cancel_updates)
+                    await self._call_db(db, "update_schedule_run", run_record_id, **cancel_updates)
                 except Exception:
                     pass
             raise
 
         finally:
+            # Stop between renewals, or wait for an in-progress renewal to
+            # publish its new fence before attempting the release.
+            if heartbeat_stop is not None:
+                heartbeat_stop.set()
+            if heartbeat_task is not None:
+                try:
+                    await heartbeat_task
+                except asyncio.CancelledError:
+                    heartbeat_task.cancel()
+                    raise
+
             # Always release the schedule lock so it doesn't stay stuck
             if release_schedule and schedule_id is not None:
-                try:
-                    next_run_at = compute_next_run(
-                        sched.cron_expr,
-                        sched.timezone or "UTC",
-                    )
-                except Exception as e:
-                    log_warning(
-                        f"Failed to compute next_run_at for schedule {schedule_id}; : {e}"
-                        f"disabling schedule to prevent it from becoming stuck: {e}",
-                    )
-
-                    next_run_at = None
+                # A manual trigger is independent from the cron cursor. Its
+                # claim marker is cleared by release_schedule, but the stored
+                # next_run_at must remain untouched -- especially when stale
+                # recovery happens after that cron occurrence became due.
+                next_run_at = None
+                if not sched.manual_trigger_claimed:
                     try:
-                        if asyncio.iscoroutinefunction(getattr(db, "update_schedule", None)):
-                            await db.update_schedule(schedule_id, enabled=False)
-                        else:
-                            db.update_schedule(schedule_id, enabled=False)
+                        next_run_at = compute_next_run(
+                            sched.cron_expr,
+                            sched.timezone or "UTC",
+                        )
                     except Exception as exc:
-                        log_error(f"Failed to disable schedule {schedule_id} after cron failure: {exc}")
+                        if studio_managed:
+                            log_warning(
+                                f"Failed to compute next_run_at for Studio schedule {schedule_id}; "
+                                "disabling it to prevent a stuck lock"
+                            )
+                        else:
+                            log_warning(
+                                f"Failed to compute next_run_at for schedule {schedule_id}; "
+                                f"disabling it to prevent a stuck lock: {exc}"
+                            )
+
+                        try:
+                            await self._call_db(db, "update_schedule", schedule_id, enabled=False)
+                        except Exception as exc:
+                            if studio_managed:
+                                log_error(f"Failed to disable Studio schedule {schedule_id} after cron failure")
+                            else:
+                                log_error(f"Failed to disable schedule {schedule_id} after cron failure: {exc}")
 
                 try:
-                    if asyncio.iscoroutinefunction(getattr(db, "release_schedule", None)):
-                        await db.release_schedule(schedule_id, next_run_at=next_run_at)
-                    else:
-                        db.release_schedule(schedule_id, next_run_at=next_run_at)
+                    release_kwargs: Dict[str, Any] = {"next_run_at": next_run_at}
+                    scheduler_api_version = getattr(db, "scheduler_api_version", 1)
+                    if (
+                        isinstance(scheduler_api_version, int)
+                        and scheduler_api_version >= 2
+                        and sched.locked_by is not None
+                        and sched.locked_at is not None
+                    ):
+                        # Fence release to the exact claim. A worker that wakes
+                        # after its stale lock was recovered must not clear the
+                        # replacement worker's lock or in-flight trigger marker.
+                        release_kwargs.update(worker_id=sched.locked_by, locked_at=lease["locked_at"])
+                    await self._call_db(db, "release_schedule", schedule_id, **release_kwargs)
                 except Exception as exc:
-                    log_error(f"Failed to release schedule {schedule_id}: {exc}")
+                    if studio_managed:
+                        log_error(f"Failed to release Studio schedule {schedule_id}")
+                    else:
+                        log_error(f"Failed to release schedule {schedule_id}: {exc}")
 
     # ------------------------------------------------------------------
     async def _call_endpoint(self, schedule: Schedule) -> Dict[str, Any]:
@@ -252,20 +418,41 @@ class ScheduleExecutor:
         method = (schedule.method or "POST").upper()
         endpoint = schedule.endpoint
         payload = schedule.payload or {}
-        timeout_seconds = schedule.timeout_seconds or self.timeout
+        timeout_seconds = schedule.timeout_seconds if schedule.timeout_seconds is not None else self.timeout
         url = f"{self.base_url}{endpoint}"
 
-        match = _RUN_ENDPOINT_RE.match(endpoint)
-        is_run_endpoint = match is not None and method == "POST"
+        match = match_run_endpoint(endpoint, method)
+        run_endpoint = match is not None
 
         headers: Dict[str, str] = {
             "Authorization": f"Bearer {self.internal_service_token}",
         }
 
+        if is_studio_managed_schedule(schedule):
+            owner_actor_id = schedule.owner_actor_id
+            expected_target_type = schedule.target_type
+            expected_target_id = schedule.target_id
+            if (
+                not is_valid_studio_schedule_actor_id(owner_actor_id)
+                or not run_endpoint
+                or match is None
+                or expected_target_type not in ("agent", "team", "workflow")
+                or match.group(1) != f"{expected_target_type}s"
+                or not isinstance(expected_target_id, str)
+                or match.group(2) != expected_target_id
+            ):
+                raise RuntimeError("Studio schedule provenance is invalid")
+            assert isinstance(owner_actor_id, str)
+            headers[STUDIO_SCHEDULE_ACTOR_HEADER] = encode_studio_schedule_actor_id(owner_actor_id)
+
         client = await self._get_client()
 
-        if is_run_endpoint and match is not None:
-            form_payload = {k: _to_form_value(v) for k, v in payload.items() if k not in ("stream", "background")}
+        if run_endpoint and match is not None:
+            # Optional form fields must be omitted when unset. Sending Python's
+            # ``str(None)`` creates a real user/session id named "None".
+            form_payload = {
+                k: _to_form_value(v) for k, v in payload.items() if k not in ("stream", "background") and v is not None
+            }
             form_payload["stream"] = "false"
             form_payload["background"] = "true"
 
@@ -311,6 +498,7 @@ class ScheduleExecutor:
             "input": None,
             "output": None,
             "requirements": None,
+            _RETRYABLE_RESULT_KEY: status == "failed",
         }
 
     async def _background_run(
@@ -328,7 +516,25 @@ class ScheduleExecutor:
         if payload is not None:
             kwargs["data"] = payload
 
-        resp = await client.request("POST", url, **kwargs)
+        try:
+            resp = await client.request("POST", url, **kwargs)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Without an idempotency key a transport failure is ambiguous: the
+            # server may have accepted the run before the connection failed.
+            log_warning("Background run submission outcome is unknown")
+            return {
+                "status": "failed",
+                "status_code": None,
+                "error": "Background run submission outcome is unknown",
+                "run_id": None,
+                "session_id": None,
+                "input": None,
+                "output": None,
+                "requirements": None,
+                _RETRYABLE_RESULT_KEY: False,
+            }
 
         if resp.status_code >= 400:
             return {
@@ -340,6 +546,7 @@ class ScheduleExecutor:
                 "input": None,
                 "output": None,
                 "requirements": None,
+                _RETRYABLE_RESULT_KEY: True,
             }
 
         try:
@@ -354,6 +561,9 @@ class ScheduleExecutor:
                 "input": None,
                 "output": None,
                 "requirements": None,
+                # A 2xx response means AgentOS may already be executing the
+                # run even if its acknowledgement cannot be decoded.
+                _RETRYABLE_RESULT_KEY: False,
             }
 
         run_id = body.get("run_id")
@@ -369,17 +579,35 @@ class ScheduleExecutor:
                 "input": None,
                 "output": None,
                 "requirements": None,
+                _RETRYABLE_RESULT_KEY: False,
             }
 
-        return await self._poll_run(
-            client,
-            headers,
-            resource_type,
-            resource_id,
-            run_id,
-            session_id,
-            timeout_seconds,
-        )
+        try:
+            result = await self._poll_run(
+                client,
+                headers,
+                resource_type,
+                resource_id,
+                run_id,
+                session_id,
+                timeout_seconds,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log_error(f"Failed while polling submitted run {run_id}")
+            result = {
+                "status": "failed",
+                "status_code": None,
+                "error": f"Failed while polling submitted run {run_id}",
+                "run_id": run_id,
+                "session_id": session_id,
+                "input": None,
+                "output": None,
+                "requirements": None,
+            }
+        result.setdefault(_RETRYABLE_RESULT_KEY, False)
+        return result
 
     async def _poll_run(
         self,
@@ -406,6 +634,7 @@ class ScheduleExecutor:
                     "input": None,
                     "output": None,
                     "requirements": None,
+                    _RETRYABLE_RESULT_KEY: False,
                 }
 
             try:
@@ -415,11 +644,13 @@ class ScheduleExecutor:
                     headers=headers,
                     params={"session_id": session_id},
                 )
-            except Exception as exc:
-                log_warning(f"Poll request failed for run {run_id}: {exc}: {exc}")
+            except Exception:
+                log_warning(f"Poll request failed for run {run_id}")
+                await self._sleep_before_next_poll(deadline)
                 continue
 
             if resp.status_code == 404:
+                await self._sleep_before_next_poll(deadline)
                 continue
 
             if resp.status_code >= 400:
@@ -432,12 +663,14 @@ class ScheduleExecutor:
                     "input": None,
                     "output": None,
                     "requirements": None,
+                    _RETRYABLE_RESULT_KEY: False,
                 }
 
             try:
                 data = resp.json()
-            except (json.JSONDecodeError, ValueError) as e:
-                log_warning(f"Invalid JSON in poll response for run {run_id}: {str(e)}")
+            except (json.JSONDecodeError, ValueError):
+                log_warning(f"Invalid JSON in poll response for run {run_id}")
+                await self._sleep_before_next_poll(deadline)
                 continue
 
             run_status = data.get("status")
@@ -470,9 +703,15 @@ class ScheduleExecutor:
                     "input": run_input,
                     "output": run_output,
                     "requirements": run_requirements,
+                    _RETRYABLE_RESULT_KEY: run_status == "ERROR",
                 }
 
-            await asyncio.sleep(self.poll_interval)
+            await self._sleep_before_next_poll(deadline)
+
+    async def _sleep_before_next_poll(self, deadline: float) -> None:
+        """Throttle every non-terminal poll path without oversleeping its deadline."""
+        remaining = max(0.0, deadline - time.monotonic())
+        await asyncio.sleep(min(float(self.poll_interval), remaining))
 
     # ------------------------------------------------------------------
     @staticmethod

--- a/libs/agno/agno/scheduler/poller.py
+++ b/libs/agno/agno/scheduler/poller.py
@@ -1,10 +1,12 @@
 """Schedule poller -- periodically claims and executes due schedules."""
 
 import asyncio
+import inspect
+import time
 from typing import Any, Dict, Optional, Set, Union
 from uuid import uuid4
 
-from agno.db.schemas.scheduler import Schedule
+from agno.db.schemas.scheduler import Schedule, is_studio_managed_schedule
 from agno.utils.log import log_error, log_info, log_warning
 
 # Default timeout (in seconds) when stopping the poller
@@ -34,9 +36,30 @@ class SchedulePoller:
         self.worker_id = worker_id or f"worker-{uuid4().hex[:8]}"
         self.max_concurrent = max_concurrent
         self.stop_timeout = stop_timeout
+        executor_lock_grace = getattr(executor, "lock_grace_seconds", 300)
+        self.lock_grace_seconds = (
+            executor_lock_grace
+            if isinstance(executor_lock_grace, int)
+            and not isinstance(executor_lock_grace, bool)
+            and executor_lock_grace > 0
+            else 300
+        )
         self._task: Optional[asyncio.Task] = None  # type: ignore[type-arg]
         self._running = False
         self._in_flight: Set[asyncio.Task] = set()  # type: ignore[type-arg]
+
+    async def _call_db(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        """Call async adapters natively and keep sync DB work off the event loop."""
+        method = getattr(self.db, method_name, None)
+        if method is None:
+            raise NotImplementedError(f"Database does not support {method_name}")
+        if asyncio.iscoroutinefunction(method):
+            result = await method(*args, **kwargs)
+        else:
+            result = await asyncio.to_thread(method, *args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
 
     async def start(self) -> None:
         """Start the polling loop as a background task."""
@@ -65,10 +88,8 @@ class SchedulePoller:
                     asyncio.gather(*self._in_flight, return_exceptions=True),
                     timeout=self.stop_timeout,
                 )
-            except asyncio.TimeoutError as e:
-                log_warning(
-                    f"Timed out waiting for {len(self._in_flight)} in-flight tasks during shutdown: {e}",
-                )
+            except asyncio.TimeoutError:
+                log_warning(f"Timed out waiting for {len(self._in_flight)} in-flight tasks during shutdown")
 
             self._in_flight.clear()
         # Close the executor's httpx client
@@ -86,8 +107,8 @@ class SchedulePoller:
                 await asyncio.sleep(self.poll_interval)
             except asyncio.CancelledError:
                 break
-            except Exception as exc:
-                log_error(f"Scheduler poll error: {exc}")
+            except Exception:
+                log_error("Scheduler poll error")
                 await asyncio.sleep(self.poll_interval)
 
     async def _poll_once(self) -> None:
@@ -100,10 +121,11 @@ class SchedulePoller:
                 break
 
             try:
-                if asyncio.iscoroutinefunction(getattr(self.db, "claim_due_schedule", None)):
-                    schedule = await self.db.claim_due_schedule(self.worker_id)
-                else:
-                    schedule = self.db.claim_due_schedule(self.worker_id)
+                schedule = await self._call_db(
+                    "claim_due_schedule",
+                    self.worker_id,
+                    lock_grace_seconds=self.lock_grace_seconds,
+                )
 
                 if schedule is None:
                     break
@@ -113,8 +135,8 @@ class SchedulePoller:
                 task = asyncio.create_task(self._execute_safe(sched))
                 self._in_flight.add(task)
                 task.add_done_callback(lambda t: self._in_flight.discard(t))
-            except Exception as exc:
-                log_error(f"Error claiming schedule: {exc}")
+            except Exception:
+                log_error("Error claiming schedule")
                 break
 
     async def _execute_safe(self, schedule: Union[Schedule, Dict[str, Any]]) -> None:
@@ -123,15 +145,15 @@ class SchedulePoller:
             await self.executor.execute(schedule, self.db)
         except Exception as exc:
             sched_id = schedule.id if isinstance(schedule, Schedule) else schedule.get("id")
-            log_error(f"Error executing schedule {sched_id}: {exc}")
+            if is_studio_managed_schedule(schedule):
+                log_error(f"Error executing Studio schedule {sched_id}")
+            else:
+                log_error(f"Error executing schedule {sched_id}: {exc}")
 
     async def trigger(self, schedule_id: str) -> None:
-        """Manually trigger a schedule by ID (immediate execution)."""
+        """Durably enqueue a manual execution by schedule ID."""
         try:
-            if asyncio.iscoroutinefunction(getattr(self.db, "get_schedule", None)):
-                schedule = await self.db.get_schedule(schedule_id)
-            else:
-                schedule = self.db.get_schedule(schedule_id)
+            schedule = await self._call_db("get_schedule", schedule_id)
 
             if schedule is None:
                 log_error(f"Schedule not found: {schedule_id}")
@@ -143,9 +165,21 @@ class SchedulePoller:
                 log_warning(f"Schedule {schedule_id} is disabled, skipping trigger")
                 return
 
-            log_info(f"Manually triggering schedule: {sched.name or schedule_id}")
-            task = asyncio.create_task(self.executor.execute(sched, self.db, release_schedule=False))
-            self._in_flight.add(task)
-            task.add_done_callback(self._in_flight.discard)
-        except Exception as exc:
-            log_error(f"Error triggering schedule {schedule_id}: {exc}")
+            scheduler_api_version = getattr(self.db, "scheduler_api_version", 1)
+            if (
+                isinstance(scheduler_api_version, int)
+                and not isinstance(scheduler_api_version, bool)
+                and scheduler_api_version >= 2
+            ):
+                queued = await self._call_db("trigger_schedule", schedule_id)
+            else:
+                # Legacy scheduler adapters predate the durable trigger queue.
+                # Moving the cursor due preserves their historical trigger
+                # behavior without requiring a v2-only method.
+                queued = await self._call_db("update_schedule", schedule_id, next_run_at=int(time.time()))
+            if queued is None:
+                log_error(f"Schedule not found: {schedule_id}")
+                return
+            log_info(f"Queued manual trigger for schedule: {sched.name or schedule_id}")
+        except Exception:
+            log_error(f"Error triggering schedule {schedule_id}")

--- a/libs/agno/agno/tools/scheduler.py
+++ b/libs/agno/agno/tools/scheduler.py
@@ -19,9 +19,10 @@ Example:
 """
 
 import json
-import time
 from typing import Any, Callable, Dict, List, Optional
 
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY, is_studio_managed_schedule
+from agno.scheduler.executor import is_run_endpoint
 from agno.scheduler.manager import ScheduleManager
 from agno.tools.toolkit import Toolkit
 from agno.utils.log import log_debug, logger
@@ -101,7 +102,12 @@ class SchedulerTools(Toolkit):
     @staticmethod
     def _is_run_endpoint(endpoint: str, method: str) -> bool:
         """Check if the endpoint targets an agent/team/workflow run route."""
-        return method.upper() == "POST" and endpoint.rstrip("/").endswith("/runs")
+        return is_run_endpoint(endpoint, method)
+
+    @staticmethod
+    def _not_found() -> str:
+        """Return a non-disclosing result for a Studio-managed schedule."""
+        return json.dumps({"error": "Schedule not found"})
 
     # ------------------------------------------------------------------
     # Sync tools
@@ -192,7 +198,10 @@ class SchedulerTools(Toolkit):
         """
         try:
             enabled_filter = True if enabled_only else None
-            schedules = self.manager.list(enabled=enabled_filter)
+            schedules = self.manager.list(
+                enabled=enabled_filter,
+                exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            )
             result = [
                 {
                     "id": s.id,
@@ -204,6 +213,7 @@ class SchedulerTools(Toolkit):
                     "description": s.description,
                 }
                 for s in schedules
+                if not is_studio_managed_schedule(s)
             ]
             return json.dumps({"schedules": result, "count": len(result)})
         except Exception as e:
@@ -223,6 +233,8 @@ class SchedulerTools(Toolkit):
             schedule = self.manager.get(schedule_id)
             if schedule is None:
                 return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+            if is_studio_managed_schedule(schedule):
+                return self._not_found()
             return json.dumps(
                 {
                     "id": schedule.id,
@@ -250,6 +262,9 @@ class SchedulerTools(Toolkit):
             str: JSON string confirming deletion.
         """
         try:
+            schedule = self.manager.get(schedule_id)
+            if schedule is not None and is_studio_managed_schedule(schedule):
+                return self._not_found()
             deleted = self.manager.delete(schedule_id)
             if deleted:
                 return json.dumps({"status": "deleted", "id": schedule_id})
@@ -268,6 +283,9 @@ class SchedulerTools(Toolkit):
             str: JSON string with the updated schedule details.
         """
         try:
+            existing = self.manager.get(schedule_id)
+            if existing is not None and is_studio_managed_schedule(existing):
+                return self._not_found()
             schedule = self.manager.enable(schedule_id)
             if schedule is None:
                 return json.dumps({"error": f"Schedule not found: {schedule_id}"})
@@ -293,6 +311,9 @@ class SchedulerTools(Toolkit):
             str: JSON string with the updated schedule details.
         """
         try:
+            existing = self.manager.get(schedule_id)
+            if existing is not None and is_studio_managed_schedule(existing):
+                return self._not_found()
             schedule = self.manager.disable(schedule_id)
             if schedule is None:
                 return json.dumps({"error": f"Schedule not found: {schedule_id}"})
@@ -311,9 +332,8 @@ class SchedulerTools(Toolkit):
     def trigger_schedule(self, schedule_id: str) -> str:
         """Queue an enabled schedule to run now.
 
-        Sets the schedule's next run time to now; the scheduler poller claims and
-        executes it within one poll interval. The regular cron cadence resumes
-        after the run.
+        Persists a pending trigger; the scheduler poller claims and executes it
+        within one poll interval without disturbing the regular cron cadence.
 
         Args:
             schedule_id (str): The ID of the schedule to trigger.
@@ -325,11 +345,15 @@ class SchedulerTools(Toolkit):
             schedule = self.manager.get(schedule_id)
             if schedule is None:
                 return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+            if is_studio_managed_schedule(schedule):
+                return self._not_found()
             if not schedule.enabled:
                 return json.dumps(
                     {"error": f"Schedule is disabled: {schedule_id}. Call enable_schedule first, then trigger it."}
                 )
-            self.manager.update(schedule_id, next_run_at=int(time.time()))
+            queued = self.manager.trigger(schedule_id)
+            if queued is None:
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
             return json.dumps(
                 {
                     "status": "triggered",
@@ -352,6 +376,9 @@ class SchedulerTools(Toolkit):
             str: JSON string with the list of runs.
         """
         try:
+            schedule = self.manager.get(schedule_id)
+            if schedule is not None and is_studio_managed_schedule(schedule):
+                return self._not_found()
             runs = self.manager.get_runs(schedule_id, limit=limit)
             result = [
                 {
@@ -457,7 +484,10 @@ class SchedulerTools(Toolkit):
         """
         try:
             enabled_filter = True if enabled_only else None
-            schedules = await self.manager.alist(enabled=enabled_filter)
+            schedules = await self.manager.alist(
+                enabled=enabled_filter,
+                exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+            )
             result = [
                 {
                     "id": s.id,
@@ -469,6 +499,7 @@ class SchedulerTools(Toolkit):
                     "description": s.description,
                 }
                 for s in schedules
+                if not is_studio_managed_schedule(s)
             ]
             return json.dumps({"schedules": result, "count": len(result)})
         except Exception as e:
@@ -488,6 +519,8 @@ class SchedulerTools(Toolkit):
             schedule = await self.manager.aget(schedule_id)
             if schedule is None:
                 return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+            if is_studio_managed_schedule(schedule):
+                return self._not_found()
             return json.dumps(
                 {
                     "id": schedule.id,
@@ -515,6 +548,9 @@ class SchedulerTools(Toolkit):
             str: JSON string confirming deletion.
         """
         try:
+            schedule = await self.manager.aget(schedule_id)
+            if schedule is not None and is_studio_managed_schedule(schedule):
+                return self._not_found()
             deleted = await self.manager.adelete(schedule_id)
             if deleted:
                 return json.dumps({"status": "deleted", "id": schedule_id})
@@ -533,6 +569,9 @@ class SchedulerTools(Toolkit):
             str: JSON string with the updated schedule details.
         """
         try:
+            existing = await self.manager.aget(schedule_id)
+            if existing is not None and is_studio_managed_schedule(existing):
+                return self._not_found()
             schedule = await self.manager.aenable(schedule_id)
             if schedule is None:
                 return json.dumps({"error": f"Schedule not found: {schedule_id}"})
@@ -558,6 +597,9 @@ class SchedulerTools(Toolkit):
             str: JSON string with the updated schedule details.
         """
         try:
+            existing = await self.manager.aget(schedule_id)
+            if existing is not None and is_studio_managed_schedule(existing):
+                return self._not_found()
             schedule = await self.manager.adisable(schedule_id)
             if schedule is None:
                 return json.dumps({"error": f"Schedule not found: {schedule_id}"})
@@ -576,9 +618,8 @@ class SchedulerTools(Toolkit):
     async def atrigger_schedule(self, schedule_id: str) -> str:
         """Queue an enabled schedule to run now.
 
-        Sets the schedule's next run time to now; the scheduler poller claims and
-        executes it within one poll interval. The regular cron cadence resumes
-        after the run.
+        Persists a pending trigger; the scheduler poller claims and executes it
+        within one poll interval without disturbing the regular cron cadence.
 
         Args:
             schedule_id (str): The ID of the schedule to trigger.
@@ -590,11 +631,15 @@ class SchedulerTools(Toolkit):
             schedule = await self.manager.aget(schedule_id)
             if schedule is None:
                 return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+            if is_studio_managed_schedule(schedule):
+                return self._not_found()
             if not schedule.enabled:
                 return json.dumps(
                     {"error": f"Schedule is disabled: {schedule_id}. Call enable_schedule first, then trigger it."}
                 )
-            await self.manager.aupdate(schedule_id, next_run_at=int(time.time()))
+            queued = await self.manager.atrigger(schedule_id)
+            if queued is None:
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
             return json.dumps(
                 {
                     "status": "triggered",
@@ -617,6 +662,9 @@ class SchedulerTools(Toolkit):
             str: JSON string with the list of runs.
         """
         try:
+            schedule = await self.manager.aget(schedule_id)
+            if schedule is not None and is_studio_managed_schedule(schedule):
+                return self._not_found()
             runs = await self.manager.aget_runs(schedule_id, limit=limit)
             result = [
                 {

--- a/libs/agno/tests/unit/os/test_jwt_middleware_helpers.py
+++ b/libs/agno/tests/unit/os/test_jwt_middleware_helpers.py
@@ -782,6 +782,160 @@ async def test_dispatch_allows_normal_subject():
     assert request.state.user_id == "alice"
 
 
+@pytest.mark.asyncio
+async def test_internal_scheduler_token_delegates_only_the_server_owned_actor_header():
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from agno.db.schemas.scheduler import STUDIO_SCHEDULE_ACTOR_HEADER, encode_studio_schedule_actor_id
+
+    middleware = JWTMiddleware(app=None, security_key="root-key", excluded_route_paths=[])
+    request = MagicMock()
+    request.url = SimpleNamespace(path="/agents/researcher/runs")
+    request.method = "POST"
+    request.headers = {
+        "Authorization": "Bearer internal-token",
+        STUDIO_SCHEDULE_ACTOR_HEADER: encode_studio_schedule_actor_id("studio-actor-josé"),
+        "origin": None,
+    }
+    request.cookies = {}
+    request.app = MagicMock()
+    request.app.state = SimpleNamespace(internal_service_token="internal-token")
+    request.state = _FakeState()
+    call_next = AsyncMock(return_value=MagicMock(status_code=200))
+
+    await middleware.dispatch(request, call_next)
+
+    call_next.assert_awaited_once()
+    assert request.state.user_id == "studio-actor-josé"
+
+
+@pytest.mark.asyncio
+async def test_open_rest_dependency_preserves_internal_scheduler_actor(monkeypatch):
+    from types import SimpleNamespace
+
+    from fastapi.security import HTTPAuthorizationCredentials
+
+    from agno.db.schemas.scheduler import STUDIO_SCHEDULE_ACTOR_HEADER, encode_studio_schedule_actor_id
+    from agno.os.auth import get_authentication_dependency
+    from agno.os.settings import AgnoAPISettings
+
+    monkeypatch.delenv("JWT_VERIFICATION_KEY", raising=False)
+    monkeypatch.delenv("JWT_JWKS_FILE", raising=False)
+    request = SimpleNamespace(
+        headers={STUDIO_SCHEDULE_ACTOR_HEADER: encode_studio_schedule_actor_id("jörg@example.com")},
+        app=SimpleNamespace(state=SimpleNamespace(internal_service_token="internal-token")),
+        state=SimpleNamespace(),
+    )
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="internal-token")
+    dependency = get_authentication_dependency(AgnoAPISettings(os_security_key=None))
+
+    assert await dependency(request, credentials) is True
+    assert request.state.authenticated is True
+    assert request.state.user_id == "jörg@example.com"
+
+
+@pytest.mark.asyncio
+async def test_open_rest_dependency_does_not_trust_actor_header_without_internal_token(monkeypatch):
+    from types import SimpleNamespace
+
+    from fastapi.security import HTTPAuthorizationCredentials
+
+    from agno.db.schemas.scheduler import STUDIO_SCHEDULE_ACTOR_HEADER, encode_studio_schedule_actor_id
+    from agno.os.auth import get_authentication_dependency
+    from agno.os.settings import AgnoAPISettings
+
+    monkeypatch.delenv("JWT_VERIFICATION_KEY", raising=False)
+    monkeypatch.delenv("JWT_JWKS_FILE", raising=False)
+    request = SimpleNamespace(
+        headers={STUDIO_SCHEDULE_ACTOR_HEADER: encode_studio_schedule_actor_id("spoofed-actor")},
+        app=SimpleNamespace(state=SimpleNamespace(internal_service_token="internal-token")),
+        state=SimpleNamespace(),
+    )
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="attacker-token")
+    dependency = get_authentication_dependency(AgnoAPISettings(os_security_key=None))
+
+    assert await dependency(request, credentials) is True
+    assert not hasattr(request.state, "user_id")
+
+
+def test_scheduler_actor_header_codec_round_trips_unicode_canonically():
+    from agno.db.schemas.scheduler import decode_studio_schedule_actor_id, encode_studio_schedule_actor_id
+
+    actor_id = "团队/équipe/🛰️"
+    encoded = encode_studio_schedule_actor_id(actor_id)
+
+    assert encoded.isascii()
+    assert decode_studio_schedule_actor_id(encoded) == actor_id
+
+
+@pytest.mark.parametrize(
+    "actor_id",
+    [" actor", "actor\nspoof", "actor\u202espoof", "actor\ud800"],
+)
+def test_scheduler_actor_header_codec_rejects_ambiguous_principals(actor_id):
+    from agno.db.schemas.scheduler import encode_studio_schedule_actor_id
+
+    with pytest.raises(ValueError, match="Invalid delegated scheduler actor"):
+        encode_studio_schedule_actor_id(actor_id)
+
+
+@pytest.mark.asyncio
+async def test_scheduler_actor_header_is_ignored_for_every_other_credential():
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from agno.db.schemas.scheduler import STUDIO_SCHEDULE_ACTOR_HEADER
+
+    middleware = JWTMiddleware(app=None, security_key="root-key", excluded_route_paths=[])
+    request = MagicMock()
+    request.url = SimpleNamespace(path="/agents/researcher/runs")
+    request.method = "POST"
+    request.headers = {
+        "Authorization": "Bearer root-key",
+        STUDIO_SCHEDULE_ACTOR_HEADER: "spoofed-actor",
+        "origin": None,
+    }
+    request.cookies = {}
+    request.app = MagicMock()
+    request.app.state = SimpleNamespace(internal_service_token="internal-token")
+    request.state = _FakeState()
+    call_next = AsyncMock(return_value=MagicMock(status_code=200))
+
+    await middleware.dispatch(request, call_next)
+
+    call_next.assert_awaited_once()
+    assert not hasattr(request.state, "user_id")
+
+
+@pytest.mark.asyncio
+async def test_internal_scheduler_rejects_malformed_delegated_actor():
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from agno.db.schemas.scheduler import STUDIO_SCHEDULE_ACTOR_HEADER
+
+    middleware = JWTMiddleware(app=None, security_key="root-key", excluded_route_paths=[])
+    request = MagicMock()
+    request.url = SimpleNamespace(path="/agents/researcher/runs")
+    request.method = "POST"
+    request.headers = {
+        "Authorization": "Bearer internal-token",
+        STUDIO_SCHEDULE_ACTOR_HEADER: " actor-with-whitespace ",
+        "origin": None,
+    }
+    request.cookies = {}
+    request.app = MagicMock()
+    request.app.state = SimpleNamespace(internal_service_token="internal-token")
+    request.state = _FakeState()
+    call_next = AsyncMock(return_value=MagicMock(status_code=200))
+
+    response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 401
+    call_next.assert_not_awaited()
+
+
 # -- C4: the mount short-circuit trusts only this middleware's private marker -----------
 
 

--- a/libs/agno/tests/unit/scheduler/test_executor.py
+++ b/libs/agno/tests/unit/scheduler/test_executor.py
@@ -2,10 +2,20 @@
 
 import asyncio
 import json
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
 
+from agno.db.schemas.scheduler import (
+    STUDIO_SCHEDULE_ACTOR_HEADER,
+    STUDIO_SCHEDULE_MANAGED_BY,
+    Schedule,
+    encode_studio_schedule_actor_id,
+)
+from agno.db.sqlite import SqliteDb
 from agno.scheduler.executor import ScheduleExecutor, _to_form_value
 
 
@@ -29,6 +39,9 @@ class TestToFormValue:
 
     def test_int(self):
         assert _to_form_value(42) == "42"
+
+    def test_none_is_not_python_literal(self):
+        assert _to_form_value(None) == ""
 
 
 class TestExecutorInit:
@@ -160,6 +173,100 @@ class TestExecutorBackgroundRun:
         assert "Missing run_id" in result["error"]
 
 
+class TestStudioScheduleIdentity:
+    @pytest.fixture
+    def executor(self):
+        return ScheduleExecutor(base_url="http://localhost:8000", internal_service_token="tok", poll_interval=0)
+
+    @staticmethod
+    def schedule(**overrides):
+        values = {
+            "id": "studio-schedule",
+            "name": "Daily research",
+            "cron_expr": "0 9 * * *",
+            "endpoint": "/agents/researcher/runs",
+            "method": "POST",
+            "payload": {"message": "private schedule prompt"},
+            "managed_by": STUDIO_SCHEDULE_MANAGED_BY,
+            "owner_actor_id": "actor-josé",
+            "target_type": "agent",
+            "target_id": "researcher",
+        }
+        values.update(overrides)
+        return Schedule(**values)
+
+    @pytest.mark.asyncio
+    async def test_studio_schedule_delegates_server_owned_actor_without_payload_provenance(self, executor):
+        client = AsyncMock()
+        with patch.object(executor, "_get_client", AsyncMock(return_value=client)):
+            with patch.object(
+                executor,
+                "_background_run",
+                AsyncMock(return_value={"status": "success"}),
+            ) as background_run:
+                await executor._call_endpoint(self.schedule())
+
+        _, _, headers, form_payload, _, _, _ = background_run.await_args.args
+        assert headers["Authorization"] == "Bearer tok"
+        assert headers[STUDIO_SCHEDULE_ACTOR_HEADER] == encode_studio_schedule_actor_id("actor-josé")
+        assert form_payload == {
+            "message": "private schedule prompt",
+            "stream": "false",
+            "background": "true",
+        }
+
+    @pytest.mark.asyncio
+    async def test_unset_optional_form_fields_are_omitted(self, executor):
+        client = AsyncMock()
+        schedule = self.schedule(payload={"message": "research", "user_id": None, "session_id": None})
+        with patch.object(executor, "_get_client", AsyncMock(return_value=client)):
+            with patch.object(
+                executor,
+                "_background_run",
+                AsyncMock(return_value={"status": "success"}),
+            ) as background_run:
+                await executor._call_endpoint(schedule)
+
+        form_payload = background_run.await_args.args[3]
+        assert form_payload == {"message": "research", "stream": "false", "background": "true"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"owner_actor_id": "  "},
+            {"owner_actor_id": "actor\nspoof"},
+            {"owner_actor_id": "actor\u202espoof"},
+            {"target_id": "different-agent"},
+            {"target_type": "team"},
+            {"method": "GET"},
+        ],
+    )
+    async def test_malformed_studio_provenance_fails_before_http(self, executor, overrides):
+        get_client = AsyncMock()
+        with patch.object(executor, "_get_client", get_client):
+            with pytest.raises(RuntimeError, match="provenance is invalid"):
+                await executor._call_endpoint(self.schedule(**overrides))
+        get_client.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_studio_execution_exception_is_redacted_from_runs_and_logs(self, executor, caplog):
+        secret = "postgresql://admin:private-password@internal.example/agno"
+        db = MagicMock()
+        db.create_schedule_run = MagicMock()
+        db.update_schedule_run = MagicMock()
+        db.release_schedule = MagicMock()
+        db.update_schedule = MagicMock()
+
+        with patch.object(executor, "_call_endpoint", AsyncMock(side_effect=RuntimeError(secret))):
+            result = await executor.execute(self.schedule(), db)
+
+        assert result["status"] == "failed"
+        assert result["error"] == "Studio schedule execution failed"
+        assert secret not in caplog.text
+        assert secret not in str(db.update_schedule_run.call_args_list)
+
+
 class TestExecutorPollRun:
     """Test _poll_run status polling."""
 
@@ -259,6 +366,27 @@ class TestExecutorPollRun:
         assert result["status"] == "success"
         assert call_count == 3
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("first_response", ["exception", "not_found", "invalid_json"])
+    async def test_every_transient_poll_path_is_throttled(self, executor, first_response):
+        completed = MagicMock(status_code=200)
+        completed.json.return_value = {"status": "COMPLETED"}
+        invalid = MagicMock(status_code=200)
+        invalid.json.side_effect = json.JSONDecodeError("bad", "", 0)
+        responses = {
+            "exception": RuntimeError("temporary"),
+            "not_found": MagicMock(status_code=404),
+            "invalid_json": invalid,
+        }
+        client = AsyncMock()
+        client.request = AsyncMock(side_effect=[responses[first_response], completed])
+
+        with patch.object(executor, "_sleep_before_next_poll", AsyncMock()) as sleep:
+            result = await executor._poll_run(client, {}, "agents", "a1", "run-1", "sess-1", 60)
+
+        assert result["status"] == "success"
+        sleep.assert_awaited_once()
+
 
 class TestExecutorExecute:
     """Test the full execute() flow with mocked DB and endpoint."""
@@ -326,3 +454,215 @@ class TestExecutorExecute:
         mock_db.update_schedule_run.assert_called()
         cancel_call = mock_db.update_schedule_run.call_args
         assert cancel_call[1]["status"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_sync_db_calls_are_offloaded_from_event_loop(self, executor, simple_schedule):
+        loop_thread = threading.get_ident()
+        db_threads = []
+
+        class SyncDb:
+            def create_schedule_run(self, run):
+                db_threads.append(threading.get_ident())
+
+            def update_schedule_run(self, schedule_run_id, **updates):
+                db_threads.append(threading.get_ident())
+
+            def release_schedule(self, schedule_id, **kwargs):
+                db_threads.append(threading.get_ident())
+                return True
+
+        with patch.object(
+            executor,
+            "_call_endpoint",
+            AsyncMock(return_value={"status": "success", "status_code": 200}),
+        ):
+            result = await executor.execute(simple_schedule, SyncDb())
+
+        assert result["status"] == "success"
+        assert db_threads
+        assert all(thread_id != loop_thread for thread_id in db_threads)
+
+    @pytest.mark.asyncio
+    async def test_sync_db_method_returning_awaitable_is_awaited(self, executor):
+        class SyncWrapperDb:
+            def operation(self):
+                async def result():
+                    return "complete"
+
+                return result()
+
+        assert await executor._call_db(SyncWrapperDb(), "operation") == "complete"
+
+    @pytest.mark.asyncio
+    async def test_in_memory_sqlite_survives_sync_db_thread_offload(self, executor):
+        db = SqliteDb(db_url="sqlite:///:memory:")
+        schedule = {
+            "id": "in-memory-schedule",
+            "name": "in-memory-schedule",
+            "cron_expr": "* * * * *",
+            "timezone": "UTC",
+            "endpoint": "/config",
+            "method": "GET",
+            "payload": None,
+            "timeout_seconds": 60,
+            "max_retries": 0,
+            "retry_delay_seconds": 0,
+            "enabled": True,
+            "next_run_at": 4_102_444_800,
+            "created_at": 1,
+        }
+        try:
+            db.create_schedule(schedule)
+            stored_schedule = db.get_schedule(schedule["id"])
+            assert stored_schedule is not None
+
+            with patch.object(
+                executor,
+                "_call_endpoint",
+                AsyncMock(return_value={"status": "success", "status_code": 200}),
+            ):
+                result = await executor.execute(stored_schedule, db)
+
+            runs, total = db.get_schedule_runs(schedule["id"])
+            assert result["status"] == "success"
+            assert total == 1
+            assert runs[0]["status"] == "success"
+            assert isinstance(db.db_engine.pool, StaticPool)
+        finally:
+            db.close()
+
+    def test_caller_owned_sqlite_engine_is_used_without_reconfiguration(self):
+        engine = create_engine("sqlite:///:memory:")
+        db = SqliteDb(db_engine=engine)
+        try:
+            assert db.db_engine is engine
+            assert not isinstance(db.db_engine.pool, StaticPool)
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_native_async_db_calls_remain_on_event_loop(self, executor, simple_schedule):
+        loop_thread = threading.get_ident()
+        db_threads = []
+
+        class AsyncDb:
+            async def create_schedule_run(self, run):
+                db_threads.append(threading.get_ident())
+
+            async def update_schedule_run(self, schedule_run_id, **updates):
+                db_threads.append(threading.get_ident())
+
+            async def release_schedule(self, schedule_id, **kwargs):
+                db_threads.append(threading.get_ident())
+                return True
+
+        with patch.object(
+            executor,
+            "_call_endpoint",
+            AsyncMock(return_value={"status": "success", "status_code": 200}),
+        ):
+            result = await executor.execute(simple_schedule, AsyncDb())
+
+        assert result["status"] == "success"
+        assert db_threads == [loop_thread, loop_thread, loop_thread]
+
+    @pytest.mark.asyncio
+    async def test_claim_heartbeat_updates_release_fence(self, simple_schedule):
+        executor = ScheduleExecutor(
+            base_url="http://localhost:8000",
+            internal_service_token="tok",
+            lock_grace_seconds=1,
+        )
+        executor._heartbeat_interval = 0.01
+
+        class Db:
+            scheduler_api_version = 2
+
+            def __init__(self):
+                self.renewals = []
+                self.renew_attempts = 0
+                self.release = None
+
+            def create_schedule_run(self, run):
+                return run
+
+            def update_schedule_run(self, schedule_run_id, **updates):
+                return updates
+
+            def renew_schedule_claim(self, schedule_id, *, worker_id, locked_at):
+                self.renew_attempts += 1
+                if self.renew_attempts == 1:
+                    raise RuntimeError("transient renewal failure")
+                renewed_at = locked_at + 1
+                self.renewals.append((worker_id, locked_at, renewed_at))
+                return renewed_at
+
+            def release_schedule(self, schedule_id, **kwargs):
+                self.release = kwargs
+                return True
+
+        db = Db()
+        claimed = {
+            **simple_schedule,
+            "locked_by": "worker-1",
+            "locked_at": 100,
+        }
+
+        async def long_endpoint(schedule):
+            await asyncio.sleep(0.035)
+            return {"status": "success", "status_code": 200}
+
+        with patch.object(executor, "_call_endpoint", side_effect=long_endpoint):
+            await executor.execute(claimed, db)
+
+        assert len(db.renewals) >= 2
+        assert db.renew_attempts > len(db.renewals)
+        assert db.release["worker_id"] == "worker-1"
+        assert db.release["locked_at"] == db.renewals[-1][2]
+
+    @pytest.mark.asyncio
+    async def test_claim_heartbeat_stops_after_lost_ownership(self, simple_schedule):
+        executor = ScheduleExecutor(
+            base_url="http://localhost:8000",
+            internal_service_token="tok",
+            lock_grace_seconds=1,
+        )
+        executor._heartbeat_interval = 0.01
+
+        class Db:
+            scheduler_api_version = 2
+
+            def __init__(self):
+                self.renew_attempts = 0
+                self.release = None
+
+            def create_schedule_run(self, run):
+                return run
+
+            def update_schedule_run(self, schedule_run_id, **updates):
+                return updates
+
+            def renew_schedule_claim(self, schedule_id, *, worker_id, locked_at):
+                self.renew_attempts += 1
+                return None
+
+            def release_schedule(self, schedule_id, **kwargs):
+                self.release = kwargs
+                return False
+
+        db = Db()
+        claimed = {
+            **simple_schedule,
+            "locked_by": "worker-1",
+            "locked_at": 100,
+        }
+
+        async def long_endpoint(schedule):
+            await asyncio.sleep(0.04)
+            return {"status": "success", "status_code": 200}
+
+        with patch.object(executor, "_call_endpoint", side_effect=long_endpoint):
+            await executor.execute(claimed, db)
+
+        assert db.renew_attempts == 1
+        assert db.release["locked_at"] == 100

--- a/libs/agno/tests/unit/scheduler/test_executor_retry.py
+++ b/libs/agno/tests/unit/scheduler/test_executor_retry.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY
 from agno.scheduler.executor import ScheduleExecutor
 
 
@@ -62,6 +63,184 @@ class TestRetrySucceedsOnSecondAttempt:
         assert mock_db.update_schedule_run.call_count == 2
         # Should have released the schedule
         mock_db.release_schedule.assert_called_once()
+        mock_sleep.assert_awaited_once_with(0)
+
+
+class TestBackgroundSubmissionRetryBoundary:
+    @pytest.mark.asyncio
+    async def test_poll_timeout_does_not_submit_a_second_background_run(self, executor, mock_db):
+        schedule = {
+            "id": "sched-1",
+            "name": "background",
+            "cron_expr": "* * * * *",
+            "timezone": "UTC",
+            "endpoint": "/agents/a1/runs",
+            "method": "POST",
+            "payload": {"message": "work"},
+            "timeout_seconds": 0,
+            "max_retries": 2,
+            "retry_delay_seconds": 0,
+        }
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"run_id": "run-1", "session_id": "session-1"}
+        client = AsyncMock()
+        client.request = AsyncMock(return_value=response)
+
+        with patch.object(executor, "_get_client", AsyncMock(return_value=client)):
+            result = await executor.execute(schedule, mock_db)
+
+        assert result["status"] == "failed"
+        assert result["run_id"] == "run-1"
+        assert "timed out after 0s" in result["error"]
+        client.request.assert_awaited_once()
+        mock_db.create_schedule_run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_known_terminal_error_retries_and_can_succeed(self, executor, mock_db):
+        schedule = {
+            "id": "sched-1",
+            "name": "background",
+            "cron_expr": "* * * * *",
+            "timezone": "UTC",
+            "endpoint": "/agents/a1/runs",
+            "method": "POST",
+            "payload": {"message": "work"},
+            "timeout_seconds": 60,
+            "max_retries": 1,
+            "retry_delay_seconds": 0,
+        }
+        submitted = MagicMock(status_code=200)
+        submitted.json.return_value = {"run_id": "run-1", "session_id": "session-1"}
+        failed = MagicMock(status_code=200)
+        failed.json.return_value = {"status": "ERROR", "error": "model failed"}
+        resubmitted = MagicMock(status_code=200)
+        resubmitted.json.return_value = {"run_id": "run-2", "session_id": "session-2"}
+        completed = MagicMock(status_code=200)
+        completed.json.return_value = {"status": "COMPLETED"}
+        client = AsyncMock()
+        client.request = AsyncMock(side_effect=[submitted, failed, resubmitted, completed])
+
+        with patch.object(executor, "_get_client", AsyncMock(return_value=client)):
+            result = await executor.execute(schedule, mock_db)
+
+        assert result["status"] == "success"
+        assert result["run_id"] == "run-2"
+        assert client.request.await_count == 4
+        assert mock_db.create_schedule_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_terminal_cancelled_run_does_not_resubmit(self, executor, mock_db):
+        schedule = {
+            "id": "sched-1",
+            "name": "background",
+            "cron_expr": "* * * * *",
+            "timezone": "UTC",
+            "endpoint": "/agents/a1/runs",
+            "method": "POST",
+            "payload": {"message": "work"},
+            "timeout_seconds": 60,
+            "max_retries": 2,
+            "retry_delay_seconds": 0,
+        }
+        submitted = MagicMock(status_code=200)
+        submitted.json.return_value = {"run_id": "run-1", "session_id": "session-1"}
+        cancelled = MagicMock(status_code=200)
+        cancelled.json.return_value = {"status": "CANCELLED"}
+        client = AsyncMock()
+        client.request = AsyncMock(side_effect=[submitted, cancelled])
+
+        with patch.object(executor, "_get_client", AsyncMock(return_value=client)):
+            result = await executor.execute(schedule, mock_db)
+
+        assert result["status"] == "failed"
+        assert "cancelled" in result["error"].lower()
+        assert client.request.await_count == 2
+        mock_db.create_schedule_run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_submission_rejection_remains_retryable(self, executor, mock_db):
+        schedule = {
+            "id": "sched-1",
+            "name": "background",
+            "cron_expr": "* * * * *",
+            "timezone": "UTC",
+            "endpoint": "/agents/a1/runs",
+            "method": "POST",
+            "payload": {"message": "work"},
+            "max_retries": 1,
+            "retry_delay_seconds": 0,
+        }
+        rejected = MagicMock(status_code=503, text="try later")
+        client = AsyncMock()
+        client.request = AsyncMock(return_value=rejected)
+
+        with patch.object(executor, "_get_client", AsyncMock(return_value=client)):
+            result = await executor.execute(schedule, mock_db)
+
+        assert result["status"] == "failed"
+        assert client.request.await_count == 2
+        assert mock_db.create_schedule_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_submission_transport_failure_is_not_retried_or_exposed(self, executor, mock_db, caplog):
+        secret = "postgresql://admin:private-password@internal.example/agno"
+        schedule = {
+            "id": "studio-sched-1",
+            "name": "background",
+            "cron_expr": "* * * * *",
+            "timezone": "UTC",
+            "endpoint": "/agents/a1/runs",
+            "method": "POST",
+            "payload": {"message": "work"},
+            "max_retries": 2,
+            "retry_delay_seconds": 0,
+            "managed_by": STUDIO_SCHEDULE_MANAGED_BY,
+            "owner_actor_id": "actor-jose",
+            "target_type": "agent",
+            "target_id": "a1",
+        }
+        client = AsyncMock()
+        client.request = AsyncMock(side_effect=RuntimeError(secret))
+
+        with patch.object(executor, "_get_client", AsyncMock(return_value=client)):
+            result = await executor.execute(schedule, mock_db)
+
+        assert result["status"] == "failed"
+        assert result["error"] == "Background run submission outcome is unknown"
+        client.request.assert_awaited_once()
+        mock_db.create_schedule_run.assert_called_once()
+        assert secret not in caplog.text
+        assert secret not in str(mock_db.update_schedule_run.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_post_accept_run_persistence_failure_never_resubmits(self, executor, mock_db):
+        schedule = {
+            "id": "sched-1",
+            "name": "background",
+            "cron_expr": "* * * * *",
+            "timezone": "UTC",
+            "endpoint": "/agents/a1/runs",
+            "method": "POST",
+            "payload": {"message": "work"},
+            "max_retries": 2,
+            "retry_delay_seconds": 0,
+        }
+        accepted = {
+            "status": "success",
+            "status_code": 200,
+            "error": None,
+            "run_id": "accepted-run",
+            "session_id": "session-1",
+        }
+        mock_db.update_schedule_run.side_effect = RuntimeError("database unavailable")
+
+        with patch.object(executor, "_call_endpoint", AsyncMock(return_value=accepted)) as call_endpoint:
+            result = await executor.execute(schedule, mock_db)
+
+        assert result["status"] == "success"
+        assert result["run_id"] == "accepted-run"
+        call_endpoint.assert_awaited_once()
+        mock_db.create_schedule_run.assert_called_once()
 
 
 class TestRetryAllFail:
@@ -165,6 +344,44 @@ class TestReleaseAlwaysCalled:
 
 
 class TestComputeNextRunFailure:
+    @pytest.mark.asyncio
+    async def test_manual_claim_preserves_cron_cursor_and_fences_release(self, executor):
+        db = MagicMock()
+        db.scheduler_api_version = 2
+        db.create_schedule_run = MagicMock()
+        db.update_schedule_run = MagicMock()
+        db.release_schedule = MagicMock()
+        db.update_schedule = MagicMock()
+        schedule = {
+            "id": "sched-1",
+            "name": "manual",
+            "cron_expr": "INVALID",
+            "timezone": "UTC",
+            "endpoint": "/config",
+            "method": "GET",
+            "payload": None,
+            "max_retries": 0,
+            "retry_delay_seconds": 0,
+            "manual_trigger_claimed": True,
+            "locked_by": "worker-1",
+            "locked_at": 123,
+        }
+
+        with patch.object(
+            executor,
+            "_call_endpoint",
+            AsyncMock(return_value={"status": "success", "status_code": 200, "error": None}),
+        ):
+            await executor.execute(schedule, db)
+
+        db.update_schedule.assert_not_called()
+        db.release_schedule.assert_called_once_with(
+            "sched-1",
+            next_run_at=None,
+            worker_id="worker-1",
+            locked_at=123,
+        )
+
     @pytest.mark.asyncio
     async def test_cron_failure_disables_schedule(self, executor, mock_db):
         """When compute_next_run raises, the schedule gets disabled."""

--- a/libs/agno/tests/unit/scheduler/test_poller.py
+++ b/libs/agno/tests/unit/scheduler/test_poller.py
@@ -1,11 +1,12 @@
 """Tests for the SchedulePoller."""
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from agno.db.schemas.scheduler import Schedule
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY, Schedule
 from agno.scheduler.poller import SchedulePoller
 
 
@@ -25,8 +26,11 @@ def _make_schedule_dict(**overrides):
 @pytest.fixture
 def mock_db():
     db = MagicMock()
+    db.scheduler_api_version = 2
     db.claim_due_schedule = MagicMock(return_value=None)
     db.get_schedule = MagicMock(return_value=None)
+    db.trigger_schedule = MagicMock(return_value=None)
+    db.update_schedule = MagicMock(return_value=None)
     return db
 
 
@@ -43,10 +47,12 @@ class TestPollerInit:
         poller = SchedulePoller(db=mock_db, executor=mock_executor)
         assert poller.poll_interval == 15
         assert poller.max_concurrent == 10
+        assert poller.lock_grace_seconds == 300
         assert poller._running is False
         assert poller.worker_id.startswith("worker-")
 
     def test_custom_params(self, mock_db, mock_executor):
+        mock_executor.lock_grace_seconds = 120
         poller = SchedulePoller(
             db=mock_db,
             executor=mock_executor,
@@ -57,6 +63,7 @@ class TestPollerInit:
         assert poller.poll_interval == 5
         assert poller.worker_id == "my-worker"
         assert poller.max_concurrent == 3
+        assert poller.lock_grace_seconds == 120
 
 
 class TestPollerStartStop:
@@ -110,7 +117,7 @@ class TestPollerPollOnce:
         schedule = _make_schedule_dict()
         call_count = 0
 
-        def claim_side_effect(worker_id):
+        def claim_side_effect(worker_id, lock_grace_seconds):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -169,7 +176,7 @@ class TestPollerPollOnce:
         schedule = _make_schedule_dict(name="async-test")
         call_count = 0
 
-        async def async_claim(worker_id):
+        async def async_claim(worker_id, lock_grace_seconds):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -191,26 +198,82 @@ class TestPollerPollOnce:
         assert isinstance(call_args[0][0], Schedule)
         assert call_args[0][0].id == "s1"
 
+    @pytest.mark.asyncio
+    async def test_sync_claim_runs_off_the_event_loop(self, mock_executor):
+        loop_thread = threading.get_ident()
+        db_threads = []
+
+        class SyncDb:
+            def claim_due_schedule(self, worker_id, lock_grace_seconds):
+                db_threads.append(threading.get_ident())
+                return None
+
+        poller = SchedulePoller(db=SyncDb(), executor=mock_executor)
+        poller._running = True
+        await poller._poll_once()
+
+        assert db_threads and db_threads[0] != loop_thread
+
+    @pytest.mark.asyncio
+    async def test_native_async_claim_stays_on_the_event_loop(self, mock_executor):
+        loop_thread = threading.get_ident()
+        db_threads = []
+
+        class AsyncDb:
+            async def claim_due_schedule(self, worker_id, lock_grace_seconds):
+                db_threads.append(threading.get_ident())
+                return None
+
+        poller = SchedulePoller(db=AsyncDb(), executor=mock_executor)
+        poller._running = True
+        await poller._poll_once()
+
+        assert db_threads == [loop_thread]
+
+    @pytest.mark.asyncio
+    async def test_sync_db_method_returning_awaitable_is_awaited(self, mock_executor):
+        class SyncWrapperDb:
+            def claim_due_schedule(self, worker_id, lock_grace_seconds):
+                async def result():
+                    return None
+
+                return result()
+
+        poller = SchedulePoller(db=SyncWrapperDb(), executor=mock_executor)
+        poller._running = True
+
+        await poller._poll_once()
+
+        assert poller._in_flight == set()
+
 
 class TestPollerTrigger:
     @pytest.mark.asyncio
     async def test_trigger_found(self, mock_db, mock_executor):
         schedule = _make_schedule_dict()
         mock_db.get_schedule = MagicMock(return_value=schedule)
+        mock_db.trigger_schedule = MagicMock(return_value=schedule)
 
         poller = SchedulePoller(db=mock_db, executor=mock_executor)
         await poller.trigger("s1")
 
-        # Wait for the task to execute
-        await asyncio.sleep(0.05)
+        mock_db.trigger_schedule.assert_called_once_with("s1")
+        mock_executor.execute.assert_not_called()
 
-        mock_executor.execute.assert_called_once()
-        call_args = mock_executor.execute.call_args
-        # First positional arg is a Schedule object
-        assert isinstance(call_args[0][0], Schedule)
-        assert call_args[0][0].id == "s1"
-        # release_schedule=False is passed as keyword
-        assert call_args[1]["release_schedule"] is False
+    @pytest.mark.asyncio
+    async def test_trigger_v1_moves_next_run_cursor_due(self, mock_executor):
+        schedule = _make_schedule_dict()
+        db = MagicMock()
+        db.scheduler_api_version = 1
+        db.get_schedule = MagicMock(return_value=schedule)
+        db.update_schedule = MagicMock(return_value=schedule)
+
+        poller = SchedulePoller(db=db, executor=mock_executor)
+        with patch("agno.scheduler.poller.time.time", return_value=1234):
+            await poller.trigger("s1")
+
+        db.update_schedule.assert_called_once_with("s1", next_run_at=1234)
+        db.trigger_schedule.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_trigger_not_found(self, mock_db, mock_executor):
@@ -241,3 +304,19 @@ class TestPollerExecuteSafe:
         poller = SchedulePoller(db=mock_db, executor=executor)
         # Should not raise
         await poller._execute_safe({"id": "s1"})
+
+    @pytest.mark.asyncio
+    async def test_studio_execution_error_does_not_log_backend_details(self, mock_db, caplog):
+        secret = "postgresql://admin:private-password@internal.example/agno"
+        executor = MagicMock()
+        executor.execute = AsyncMock(side_effect=RuntimeError(secret))
+        poller = SchedulePoller(db=mock_db, executor=executor)
+
+        await poller._execute_safe(
+            {
+                "id": "studio-schedule",
+                "managed_by": STUDIO_SCHEDULE_MANAGED_BY,
+            }
+        )
+
+        assert secret not in caplog.text

--- a/libs/agno/tests/unit/tools/test_scheduler.py
+++ b/libs/agno/tests/unit/tools/test_scheduler.py
@@ -8,8 +8,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from agno.db.schemas.scheduler import Schedule, ScheduleRun
+from agno.db.schemas.scheduler import STUDIO_SCHEDULE_MANAGED_BY, Schedule, ScheduleRun
 from agno.tools.scheduler import SchedulerTools
+
+STUDIO_SCHEDULE_ID = "studio-schedule-private-id"
+STUDIO_PROMPT = "studio-schedule-private-prompt"
+STUDIO_ACTOR = "studio-schedule-private-actor"
 
 
 def _make_schedule(**overrides):
@@ -27,6 +31,23 @@ def _make_schedule(**overrides):
     }
     defaults.update(overrides)
     return Schedule(**defaults)
+
+
+def _make_studio_schedule(**overrides):
+    """Create a Studio-owned schedule whose private fields must stay hidden."""
+    defaults = {
+        "id": STUDIO_SCHEDULE_ID,
+        "name": "studio-private-schedule",
+        "payload": {"message": STUDIO_PROMPT},
+        "managed_by": "studio",
+        "owner_actor_id": STUDIO_ACTOR,
+        "target_type": "agent",
+        "target_id": "studio-agent",
+        "created_by_run_id": "studio-private-run",
+        "created_by_session_id": "studio-private-session",
+    }
+    defaults.update(overrides)
+    return _make_schedule(**defaults)
 
 
 def _make_run(**overrides):
@@ -52,6 +73,8 @@ def mock_db():
 def tools(mock_db):
     with patch("agno.tools.scheduler.ScheduleManager") as MockManager:
         manager_instance = MagicMock()
+        manager_instance._call.return_value = None
+        manager_instance._acall = AsyncMock(return_value=None)
         MockManager.return_value = manager_instance
         t = SchedulerTools(
             db=mock_db,
@@ -66,6 +89,8 @@ def tools(mock_db):
 def tools_no_defaults(mock_db):
     with patch("agno.tools.scheduler.ScheduleManager") as MockManager:
         manager_instance = MagicMock()
+        manager_instance._call.return_value = None
+        manager_instance._acall = AsyncMock(return_value=None)
         MockManager.return_value = manager_instance
         t = SchedulerTools(db=mock_db)
         t.manager = manager_instance
@@ -145,6 +170,7 @@ class TestCreateSchedule:
         assert result["name"] == "daily-check"
         assert result["cron"] == "0 9 * * *"
         tools.manager.create.assert_called_once()
+        assert tools.manager.create.call_args.kwargs["if_exists"] == "update"
 
     def test_create_uses_defaults(self, tools):
         schedule = _make_schedule()
@@ -258,14 +284,20 @@ class TestListSchedules:
 
         tools.list_schedules(enabled_only=True)
 
-        tools.manager.list.assert_called_once_with(enabled=True)
+        tools.manager.list.assert_called_once_with(
+            enabled=True,
+            exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        )
 
     def test_list_all_no_filter(self, tools):
         tools.manager.list.return_value = []
 
         tools.list_schedules(enabled_only=False)
 
-        tools.manager.list.assert_called_once_with(enabled=None)
+        tools.manager.list.assert_called_once_with(
+            enabled=None,
+            exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        )
 
     def test_list_exception(self, tools):
         tools.manager.list.side_effect = RuntimeError("DB error")
@@ -343,14 +375,13 @@ class TestEnableDisableSchedule:
 class TestTriggerSchedule:
     def test_trigger_success(self, tools):
         tools.manager.get.return_value = _make_schedule()
+        tools.manager.trigger.return_value = _make_schedule()
 
         result = json.loads(tools.trigger_schedule("sched-001"))
 
         assert result["status"] == "triggered"
         assert result["id"] == "sched-001"
-        args, kwargs = tools.manager.update.call_args
-        assert args == ("sched-001",)
-        assert isinstance(kwargs["next_run_at"], int)
+        tools.manager.trigger.assert_called_once_with("sched-001")
 
     def test_trigger_not_found(self, tools):
         tools.manager.get.return_value = None
@@ -367,7 +398,7 @@ class TestTriggerSchedule:
 
         assert "error" in result
         assert "disabled" in result["error"]
-        tools.manager.update.assert_not_called()
+        tools.manager.trigger.assert_not_called()
 
 
 class TestGetScheduleRuns:
@@ -397,6 +428,121 @@ class TestGetScheduleRuns:
         assert "error" in result
 
 
+class TestStudioManagedIsolation:
+    @staticmethod
+    def _assert_private_values_hidden(result: str) -> None:
+        assert STUDIO_SCHEDULE_ID not in result
+        assert STUDIO_PROMPT not in result
+        assert STUDIO_ACTOR not in result
+        assert "studio-private-run" not in result
+        assert "studio-private-session" not in result
+        assert "managed_by" not in result
+
+    def test_sync_reads_and_mutations_treat_studio_schedule_as_not_found(self, tools):
+        ordinary = _make_schedule(id="ordinary-id", name="ordinary")
+        studio = _make_studio_schedule()
+        tools.manager.list.return_value = [studio, ordinary]
+        tools.manager.get.return_value = studio
+
+        listed = tools.list_schedules()
+        results = [
+            tools.get_schedule(STUDIO_SCHEDULE_ID),
+            tools.get_schedule_runs(STUDIO_SCHEDULE_ID),
+            tools.trigger_schedule(STUDIO_SCHEDULE_ID),
+            tools.enable_schedule(STUDIO_SCHEDULE_ID),
+            tools.disable_schedule(STUDIO_SCHEDULE_ID),
+            tools.delete_schedule(STUDIO_SCHEDULE_ID),
+        ]
+
+        assert json.loads(listed) == {
+            "schedules": [
+                {
+                    "id": "ordinary-id",
+                    "name": "ordinary",
+                    "cron": ordinary.cron_expr,
+                    "endpoint": ordinary.endpoint,
+                    "timezone": ordinary.timezone,
+                    "enabled": ordinary.enabled,
+                    "description": ordinary.description,
+                }
+            ],
+            "count": 1,
+        }
+        self._assert_private_values_hidden(listed)
+        tools.manager.list.assert_called_once_with(
+            enabled=None,
+            exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        )
+        for result in results:
+            assert json.loads(result) == {"error": "Schedule not found"}
+            self._assert_private_values_hidden(result)
+
+        tools.manager.get_runs.assert_not_called()
+        tools.manager.trigger.assert_not_called()
+        tools.manager.enable.assert_not_called()
+        tools.manager.disable.assert_not_called()
+        tools.manager.delete.assert_not_called()
+
+    def test_sync_create_uses_a_separate_name_namespace_from_studio(self, tools):
+        studio = _make_studio_schedule()
+        generic = _make_schedule(name=studio.name)
+        tools.manager.create.return_value = generic
+
+        result = tools.create_schedule(name=studio.name, cron="0 10 * * *")
+
+        assert json.loads(result)["status"] == "created"
+        tools.manager.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_reads_and_mutations_treat_studio_schedule_as_not_found(self, tools):
+        ordinary = _make_schedule(id="ordinary-id", name="ordinary")
+        studio = _make_studio_schedule()
+        tools.manager.alist = AsyncMock(return_value=[studio, ordinary])
+        tools.manager.aget = AsyncMock(return_value=studio)
+        tools.manager.aget_runs = AsyncMock()
+        tools.manager.atrigger = AsyncMock()
+        tools.manager.aenable = AsyncMock()
+        tools.manager.adisable = AsyncMock()
+        tools.manager.adelete = AsyncMock()
+
+        listed = await tools.alist_schedules()
+        results = [
+            await tools.aget_schedule(STUDIO_SCHEDULE_ID),
+            await tools.aget_schedule_runs(STUDIO_SCHEDULE_ID),
+            await tools.atrigger_schedule(STUDIO_SCHEDULE_ID),
+            await tools.aenable_schedule(STUDIO_SCHEDULE_ID),
+            await tools.adisable_schedule(STUDIO_SCHEDULE_ID),
+            await tools.adelete_schedule(STUDIO_SCHEDULE_ID),
+        ]
+
+        assert [item["id"] for item in json.loads(listed)["schedules"]] == ["ordinary-id"]
+        self._assert_private_values_hidden(listed)
+        tools.manager.alist.assert_awaited_once_with(
+            enabled=None,
+            exclude_managed_by=STUDIO_SCHEDULE_MANAGED_BY,
+        )
+        for result in results:
+            assert json.loads(result) == {"error": "Schedule not found"}
+            self._assert_private_values_hidden(result)
+
+        tools.manager.aget_runs.assert_not_awaited()
+        tools.manager.atrigger.assert_not_awaited()
+        tools.manager.aenable.assert_not_awaited()
+        tools.manager.adisable.assert_not_awaited()
+        tools.manager.adelete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_async_create_uses_a_separate_name_namespace_from_studio(self, tools):
+        studio = _make_studio_schedule()
+        generic = _make_schedule(name=studio.name)
+        tools.manager.acreate = AsyncMock(return_value=generic)
+
+        result = await tools.acreate_schedule(name=studio.name, cron="0 10 * * *")
+
+        assert json.loads(result)["status"] == "created"
+        tools.manager.acreate.assert_awaited_once()
+
+
 class TestIsRunEndpoint:
     def test_agent_runs(self):
         assert SchedulerTools._is_run_endpoint("/agents/test/runs", "POST") is True
@@ -416,6 +562,19 @@ class TestIsRunEndpoint:
     def test_get_method(self):
         assert SchedulerTools._is_run_endpoint("/agents/test/runs", "GET") is False
 
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "/api/agents/test/runs",
+            "/agents/test/nested/runs",
+            "/agents//runs",
+            "/agents/test/runs?stream=false",
+            "/webhooks/runs",
+        ],
+    )
+    def test_rejects_routes_the_executor_will_not_treat_as_runs(self, endpoint):
+        assert SchedulerTools._is_run_endpoint(endpoint, "POST") is False
+
 
 @pytest.mark.asyncio
 class TestAsyncCreateSchedule:
@@ -433,6 +592,8 @@ class TestAsyncCreateSchedule:
 
         assert result["status"] == "created"
         assert result["name"] == "daily-check"
+        tools.manager.acreate.assert_awaited_once()
+        assert tools.manager.acreate.call_args.kwargs["if_exists"] == "update"
 
     async def test_acreate_run_endpoint_requires_message(self, tools_no_defaults):
         result = json.loads(
@@ -465,25 +626,23 @@ class TestAsyncCreateSchedule:
 class TestAsyncTriggerSchedule:
     async def test_atrigger_success(self, tools):
         tools.manager.aget = AsyncMock(return_value=_make_schedule())
-        tools.manager.aupdate = AsyncMock()
+        tools.manager.atrigger = AsyncMock(return_value=_make_schedule())
 
         result = json.loads(await tools.atrigger_schedule("sched-001"))
 
         assert result["status"] == "triggered"
         assert result["id"] == "sched-001"
-        args, kwargs = tools.manager.aupdate.call_args
-        assert args == ("sched-001",)
-        assert isinstance(kwargs["next_run_at"], int)
+        tools.manager.atrigger.assert_awaited_once_with("sched-001")
 
     async def test_atrigger_disabled(self, tools):
         tools.manager.aget = AsyncMock(return_value=_make_schedule(enabled=False))
-        tools.manager.aupdate = AsyncMock()
+        tools.manager.atrigger = AsyncMock()
 
         result = json.loads(await tools.atrigger_schedule("sched-001"))
 
         assert "error" in result
         assert "disabled" in result["error"]
-        tools.manager.aupdate.assert_not_called()
+        tools.manager.atrigger.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR hardens the AgentOS scheduler worker around submission retries, lease fencing, manual triggers, and async execution. Its central rule is that once an AgentOS POST has been accepted, the same claim is not resubmitted merely because later status polling or persistence fails.

### Submission and retry behavior

- Successful POST acceptance is the retry boundary: failures while persisting or polling an accepted run do not cause the worker to submit that run again.
- Ambiguous transport failures are treated as non-retryable until the target API has an idempotency contract.
- Accepted background `ERROR` results remain retryable; `CANCELLED`, timeout, and unknown terminal states remain non-retryable.
- Endpoint matching and optional transport fields are centralized, and zero-valued timeout or poll settings retain their exact meaning.

### Lease and trigger behavior

- Lease fences rotate on renewal across sync and async SQLite, PostgreSQL, and MongoDB implementations.
- A stale worker cannot release or complete a claim owned under a newer fence.
- Heartbeats tolerate transient persistence failures and detect confirmed ownership loss.
- Manual triggers arriving during an in-flight cron run remain durable for a later claim, and stale manual claims can be recovered.

### Async execution and service identity

- Synchronous database calls are offloaded from async scheduler paths so they do not block the AgentOS event loop.
- Catalog-v1 poller fallback remains available without changing the catalog-v2 worker contract.
- Scheduler service principals are reserved against JWT spoofing.

### Review boundary

Review this PR as the scheduler execution layer: claim ownership, HTTP submission, status polling, retry classification, heartbeat behavior, and manual-trigger consumption. It does not define the typed Studio API or the underlying component catalog lifecycle.

### Current review status

This head is not yet merge-ready. A verified Greptile P1 remains open: when heartbeat renewal confirms that lease ownership was lost, the heartbeat task stops but the in-flight executor request is not cancelled, so the previous owner can continue running concurrently with a new claimant ([discussion](https://github.com/agno-agi/agno/pull/9457#discussion_r3762117788)).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Validation

- The five directly modified scheduler runtime suites passed 210 tests.
- The integrated three-PR matrix passed 1,519 local tests.
- Current-main composition checks passed: 18 workflow WebSocket tests and 106 draft-visibility, workflow-config, and component-save tests.
- 32 live PostgreSQL lifecycle, migration, scheduler-claim, and Studio integration tests passed.
- All seven Studio cookbook targets passed compilation, Ruff check/format, and construction-only execution.
- `./scripts/format.sh`, `./scripts/validate.sh`, and `git diff --check` passed; core and agnoctl mypy checks were clean.
- The branch is one 11-file commit over #9456, with no merge commits.

## Stack context

This is the execution layer at the top of a three-PR review stack:

1. #9455 — component catalog and scheduler persistence
2. #9456 — typed Studio control plane
3. **#9457 — scheduler execution and retry behavior**

The descriptions above are the complete review scope for this PR; the stack note only records dependency and merge order.

Implementation was generated with Codex under author-directed API design, stack selection, testing, and review.