### PR TITLE
[fix] Stream Excel rows for RowChunking to avoid full-sheet OOM

### DIFF
--- a/libs/agno/agno/knowledge/reader/excel_reader.py
+++ b/libs/agno/agno/knowledge/reader/excel_reader.py
@@ -10,6 +10,7 @@ from agno.knowledge.reader.base import Reader
 from agno.knowledge.reader.utils import (
     convert_xls_cell_value,
     excel_rows_to_documents,
+    excel_rows_to_row_documents,
     get_workbook_name,
     infer_file_extension,
 )
@@ -30,6 +31,33 @@ class ExcelReader(Reader):
             chunking_strategy = RowChunking()
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
         self.sheets = sheets
+
+    def _uses_streaming_row_chunking(self) -> bool:
+        """True when rows should be emitted directly without a full-sheet Document.
+
+        Default Excel ingestion uses :class:`RowChunking`. Building one giant
+        sheet-level Document first forces the full worksheet into memory (OOM
+        risk for large .xlsx files). Stream row Documents instead when that
+        strategy is active and chunking is enabled.
+        """
+        return bool(self.chunk and isinstance(self.chunking_strategy, RowChunking))
+
+    def _sheets_to_documents(
+        self,
+        workbook_name: str,
+        sheets: List[Tuple[str, int, Iterable[Sequence[Any]]]],
+    ) -> List[Document]:
+        """Convert sheet row iterators to documents, streaming for RowChunking."""
+        if self._uses_streaming_row_chunking():
+            strategy = self.chunking_strategy
+            assert isinstance(strategy, RowChunking)
+            return excel_rows_to_row_documents(
+                workbook_name=workbook_name,
+                sheets=sheets,
+                skip_header=strategy.skip_header,
+                clean_rows=strategy.clean_rows,
+            )
+        return excel_rows_to_documents(workbook_name=workbook_name, sheets=sheets)
 
     @classmethod
     def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:
@@ -109,7 +137,7 @@ class ExcelReader(Reader):
 
                 sheets.append((worksheet.title, sheet_index + 1, worksheet.iter_rows(values_only=True)))
 
-            return excel_rows_to_documents(workbook_name=workbook_name, sheets=sheets)
+            return self._sheets_to_documents(workbook_name, sheets)
         finally:
             workbook.close()
 
@@ -151,14 +179,14 @@ class ExcelReader(Reader):
 
             sheets.append((sheet.name, sheet_index + 1, _iter_sheet_rows()))
 
-        return excel_rows_to_documents(workbook_name=workbook_name, sheets=sheets)
+        return self._sheets_to_documents(workbook_name, sheets)
 
     def read(
         self,
         file: Union[Path, IO[Any]],
         name: Optional[str] = None,
     ) -> List[Document]:
-        """Read an Excel file and return documents (one per sheet)."""
+        """Read an Excel file and return documents (one per sheet, or one per row when row-chunking)."""
         try:
             file_extension = infer_file_extension(file, name)
             workbook_name = get_workbook_name(file, name)
@@ -176,7 +204,8 @@ class ExcelReader(Reader):
             else:
                 raise ValueError(f"Unsupported file extension: '{file_extension}'. Expected .xlsx or .xls")
 
-            if self.chunk:
+            # RowChunking path already emits row-level Documents while iterating.
+            if self.chunk and not self._uses_streaming_row_chunking():
                 chunked_documents = []
                 for document in documents:
                     chunked_documents.extend(self.chunk_document(document))
@@ -214,7 +243,8 @@ class ExcelReader(Reader):
             else:
                 raise ValueError(f"Unsupported file extension: '{file_extension}'. Expected .xlsx or .xls")
 
-            if self.chunk:
+            # RowChunking path already emits row-level Documents while iterating.
+            if self.chunk and not self._uses_streaming_row_chunking():
                 documents = await self.chunk_documents_async(documents)
 
             return documents

--- a/libs/agno/agno/knowledge/reader/utils/__init__.py
+++ b/libs/agno/agno/knowledge/reader/utils/__init__.py
@@ -1,6 +1,7 @@
 from agno.knowledge.reader.utils.spreadsheet import (
     convert_xls_cell_value,
     excel_rows_to_documents,
+    excel_rows_to_row_documents,
     get_workbook_name,
     infer_file_extension,
     row_to_csv_line,
@@ -10,6 +11,7 @@ from agno.knowledge.reader.utils.spreadsheet import (
 __all__ = [
     "convert_xls_cell_value",
     "excel_rows_to_documents",
+    "excel_rows_to_row_documents",
     "get_workbook_name",
     "infer_file_extension",
     "row_to_csv_line",

--- a/libs/agno/agno/knowledge/reader/utils/spreadsheet.py
+++ b/libs/agno/agno/knowledge/reader/utils/spreadsheet.py
@@ -89,7 +89,12 @@ def excel_rows_to_documents(
     workbook_name: str,
     sheets: Iterable[Tuple[str, int, Iterable[Sequence[Any]]]],
 ) -> List[Document]:
-    """Convert Excel sheet rows to Documents (one per sheet)."""
+    """Convert Excel sheet rows to Documents (one per sheet).
+
+    Materializes each sheet into a single document. Prefer
+    :func:`excel_rows_to_row_documents` when using row-based chunking so
+    large workbooks do not require a full sheet-sized string in memory.
+    """
     documents = []
     for sheet_name, sheet_index, rows in sheets:
         lines = []
@@ -110,5 +115,82 @@ def excel_rows_to_documents(
                 content="\n".join(lines),
             )
         )
+
+    return documents
+
+
+def excel_rows_to_row_documents(
+    *,
+    workbook_name: str,
+    sheets: Iterable[Tuple[str, int, Iterable[Sequence[Any]]]],
+    skip_header: bool = False,
+    clean_rows: bool = True,
+) -> List[Document]:
+    """Stream Excel sheet rows into one Document per non-empty row.
+
+    Mirrors :class:`~agno.knowledge.chunking.row.RowChunking` output
+    (``row_number`` metadata, content cleaning, header skip) without
+    building a full sheet-level string first.
+    """
+    from agno.knowledge.chunking.row import RowChunking
+
+    documents: List[Document] = []
+    row_chunking = RowChunking(skip_header=skip_header, clean_rows=clean_rows)
+
+    for sheet_name, sheet_index, rows in sheets:
+        sheet_id = str(uuid4())
+        parent = Document(
+            name=workbook_name,
+            id=sheet_id,
+            meta_data={"sheet_name": sheet_name, "sheet_index": sheet_index},
+            content="",
+        )
+
+        # Logical index among non-empty CSV lines (matches RowChunking on joined content)
+        non_empty_line_index = 0
+        header_skipped = False
+        sheet_had_rows = False
+
+        for row in rows:
+            line = row_to_csv_line(row)
+            if not line:
+                continue
+
+            sheet_had_rows = True
+
+            if skip_header and not header_skipped:
+                header_skipped = True
+                continue
+
+            if clean_rows:
+                chunk_content = " ".join(line.split())
+            else:
+                chunk_content = line.strip()
+
+            # Keep numbering parity with RowChunking: index advances for every
+            # non-empty source line after header skip, even if cleaning empties it.
+            if skip_header:
+                row_number = 2 + non_empty_line_index
+            else:
+                row_number = 1 + non_empty_line_index
+            non_empty_line_index += 1
+
+            if not chunk_content:
+                continue
+
+            meta_data = parent.meta_data.copy()
+            meta_data["row_number"] = row_number
+            chunk_id = row_chunking._generate_chunk_id(parent, row_number, chunk_content, prefix="row")
+            documents.append(
+                Document(
+                    id=chunk_id,
+                    name=workbook_name,
+                    meta_data=meta_data,
+                    content=chunk_content,
+                )
+            )
+
+        if not sheet_had_rows:
+            log_debug(f"Sheet '{sheet_name}' is empty, skipping")
 
     return documents

--- a/libs/agno/tests/unit/knowledge/test_excel_reader.py
+++ b/libs/agno/tests/unit/knowledge/test_excel_reader.py
@@ -2062,3 +2062,245 @@ def test_default_chunking_strategy_is_not_shared_between_instances():
     reader_a.chunking_strategy.skip_header = True
 
     assert reader_b.chunking_strategy.skip_header is False
+
+
+def test_excel_reader_row_chunking_streams_without_sheet_document(tmp_path: Path):
+    """Default RowChunking must emit row Documents while iterating rows.
+
+    Regression for #9458: previously excel_rows_to_documents built a full
+    sheet string before RowChunking, which OOM'd large workbooks.
+    """
+    openpyxl = pytest.importorskip("openpyxl")
+    from agno.knowledge.chunking.row import RowChunking
+    from agno.knowledge.reader import utils as reader_utils
+
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.title = "Data"
+    sheet.append(["name", "age"])
+    sheet.append(["alice", 30])
+    sheet.append(["bob", 25])
+
+    buffer = io.BytesIO()
+    workbook.save(buffer)
+    workbook.close()
+
+    file_path = tmp_path / "stream_rows.xlsx"
+    file_path.write_bytes(buffer.getvalue())
+
+    reader = ExcelReader(chunk=True)
+    assert isinstance(reader.chunking_strategy, RowChunking)
+
+    with (
+        patch.object(
+            reader_utils,
+            "excel_rows_to_documents",
+            wraps=reader_utils.excel_rows_to_documents,
+        ) as full_sheet_path,
+        patch.object(
+            reader_utils,
+            "excel_rows_to_row_documents",
+            wraps=reader_utils.excel_rows_to_row_documents,
+        ) as stream_path,
+    ):
+        # Patch where ExcelReader resolves the helpers
+        with (
+            patch(
+                "agno.knowledge.reader.excel_reader.excel_rows_to_documents",
+                full_sheet_path,
+            ),
+            patch(
+                "agno.knowledge.reader.excel_reader.excel_rows_to_row_documents",
+                stream_path,
+            ),
+        ):
+            documents = reader.read(file_path)
+
+    stream_path.assert_called_once()
+    full_sheet_path.assert_not_called()
+
+    assert len(documents) == 3
+    assert [doc.meta_data["row_number"] for doc in documents] == [1, 2, 3]
+    assert all(doc.meta_data["sheet_name"] == "Data" for doc in documents)
+    assert documents[0].content == "name, age"
+    assert documents[1].content == "alice, 30"
+    assert documents[2].content == "bob, 25"
+    assert all(doc.id and "_row_" in doc.id for doc in documents)
+
+
+def test_excel_reader_row_chunking_skip_header_streams(tmp_path: Path):
+    openpyxl = pytest.importorskip("openpyxl")
+    from agno.knowledge.chunking.row import RowChunking
+
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.title = "Data"
+    sheet.append(["name", "age"])
+    sheet.append(["alice", 30])
+    sheet.append(["bob", 25])
+
+    buffer = io.BytesIO()
+    workbook.save(buffer)
+    workbook.close()
+
+    file_path = tmp_path / "skip_header.xlsx"
+    file_path.write_bytes(buffer.getvalue())
+
+    reader = ExcelReader(chunk=True, chunking_strategy=RowChunking(skip_header=True))
+    documents = reader.read(file_path)
+
+    assert len(documents) == 2
+    assert [doc.meta_data["row_number"] for doc in documents] == [2, 3]
+    assert documents[0].content == "alice, 30"
+    assert documents[1].content == "bob, 25"
+
+
+def test_excel_reader_non_row_chunking_still_uses_full_sheet_path(tmp_path: Path):
+    """Non-RowChunking strategies still materialize sheet Documents first."""
+    openpyxl = pytest.importorskip("openpyxl")
+    from agno.knowledge.chunking.fixed import FixedSizeChunking
+
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.title = "Data"
+    sheet.append(["name", "age"])
+    sheet.append(["alice", 30])
+
+    buffer = io.BytesIO()
+    workbook.save(buffer)
+    workbook.close()
+
+    file_path = tmp_path / "fixed_size.xlsx"
+    file_path.write_bytes(buffer.getvalue())
+
+    reader = ExcelReader(chunk=True, chunking_strategy=FixedSizeChunking(chunk_size=5000))
+
+    with (
+        patch(
+            "agno.knowledge.reader.excel_reader.excel_rows_to_documents",
+            wraps=__import__(
+                "agno.knowledge.reader.utils.spreadsheet", fromlist=["excel_rows_to_documents"]
+            ).excel_rows_to_documents,
+        ) as full_sheet_path,
+        patch(
+            "agno.knowledge.reader.excel_reader.excel_rows_to_row_documents",
+            wraps=__import__(
+                "agno.knowledge.reader.utils.spreadsheet", fromlist=["excel_rows_to_row_documents"]
+            ).excel_rows_to_row_documents,
+        ) as stream_path,
+    ):
+        documents = reader.read(file_path)
+
+    full_sheet_path.assert_called_once()
+    stream_path.assert_not_called()
+    assert len(documents) >= 1
+    # Fixed-size path should still preserve sheet metadata from the sheet Document
+    assert all("sheet_name" in doc.meta_data for doc in documents)
+
+
+def test_excel_reader_chunk_false_uses_full_sheet_path(tmp_path: Path):
+    openpyxl = pytest.importorskip("openpyxl")
+
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.title = "Data"
+    sheet.append(["name", "age"])
+    sheet.append(["alice", 30])
+
+    buffer = io.BytesIO()
+    workbook.save(buffer)
+    workbook.close()
+
+    file_path = tmp_path / "no_chunk.xlsx"
+    file_path.write_bytes(buffer.getvalue())
+
+    reader = ExcelReader(chunk=False)
+
+    with (
+        patch(
+            "agno.knowledge.reader.excel_reader.excel_rows_to_documents",
+            wraps=__import__(
+                "agno.knowledge.reader.utils.spreadsheet", fromlist=["excel_rows_to_documents"]
+            ).excel_rows_to_documents,
+        ) as full_sheet_path,
+        patch(
+            "agno.knowledge.reader.excel_reader.excel_rows_to_row_documents",
+            wraps=__import__(
+                "agno.knowledge.reader.utils.spreadsheet", fromlist=["excel_rows_to_row_documents"]
+            ).excel_rows_to_row_documents,
+        ) as stream_path,
+    ):
+        documents = reader.read(file_path)
+
+    full_sheet_path.assert_called_once()
+    stream_path.assert_not_called()
+    assert len(documents) == 1
+    assert documents[0].content.splitlines() == ["name, age", "alice, 30"]
+
+
+@pytest.mark.asyncio
+async def test_excel_reader_async_row_chunking_streams(tmp_path: Path):
+    openpyxl = pytest.importorskip("openpyxl")
+
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.title = "Data"
+    sheet.append(["id", "value"])
+    sheet.append(["1", "first"])
+    sheet.append(["2", "second"])
+
+    buffer = io.BytesIO()
+    workbook.save(buffer)
+    workbook.close()
+
+    file_path = tmp_path / "async_stream.xlsx"
+    file_path.write_bytes(buffer.getvalue())
+
+    reader = ExcelReader(chunk=True)
+    with (
+        patch(
+            "agno.knowledge.reader.excel_reader.excel_rows_to_row_documents",
+            wraps=__import__(
+                "agno.knowledge.reader.utils.spreadsheet", fromlist=["excel_rows_to_row_documents"]
+            ).excel_rows_to_row_documents,
+        ) as stream_path,
+        patch(
+            "agno.knowledge.reader.excel_reader.excel_rows_to_documents",
+            wraps=__import__(
+                "agno.knowledge.reader.utils.spreadsheet", fromlist=["excel_rows_to_documents"]
+            ).excel_rows_to_documents,
+        ) as full_sheet_path,
+    ):
+        documents = await reader.async_read(file_path)
+
+    stream_path.assert_called_once()
+    full_sheet_path.assert_not_called()
+    assert len(documents) == 3
+    assert [doc.meta_data["row_number"] for doc in documents] == [1, 2, 3]
+
+
+def test_excel_rows_to_row_documents_matches_row_chunking_semantics():
+    """Direct unit test for the streaming helper vs RowChunking on joined content."""
+    from agno.knowledge.chunking.row import RowChunking
+    from agno.knowledge.reader.utils.spreadsheet import (
+        excel_rows_to_documents,
+        excel_rows_to_row_documents,
+    )
+
+    rows = [
+        ["name", "age"],
+        ["alice", 30],
+        ["  bob  ", 25],
+        [],  # empty row skipped by both paths
+        ["carol", 40],
+    ]
+    sheets = [("Sheet1", 1, rows)]
+
+    streamed = excel_rows_to_row_documents(workbook_name="wb", sheets=sheets)
+    # Re-build sheet document path and chunk for comparison
+    sheet_docs = excel_rows_to_documents(workbook_name="wb", sheets=[("Sheet1", 1, rows)])
+    chunked = RowChunking().chunk(sheet_docs[0])
+
+    assert [d.content for d in streamed] == [d.content for d in chunked]
+    assert [d.meta_data["row_number"] for d in streamed] == [d.meta_data["row_number"] for d in chunked]
+    assert [d.meta_data["sheet_name"] for d in streamed] == [d.meta_data["sheet_name"] for d in chunked]


### PR DESCRIPTION
## Summary

Fixes #9458

`ExcelReader` already opens workbooks with `openpyxl` `read_only=True`, but when using the default `RowChunking` strategy it still built one full sheet-level `Document` (`"\n".join(lines)`) before splitting into row chunks. That forces memory proportional to the whole worksheet and can OOM or stall ingestion on large `.xlsx` files.

**Change:** when `chunk=True` and the active strategy is `RowChunking`, stream `iter_rows` into one `Document` per non-empty row (same `row_number` / cleaning / `skip_header` semantics as `RowChunking`). Other chunking strategies and `chunk=False` keep the existing full-sheet path so strategies that need full-document context are unchanged.

### Files
- `libs/agno/agno/knowledge/reader/utils/spreadsheet.py` — add `excel_rows_to_row_documents`
- `libs/agno/agno/knowledge/reader/excel_reader.py` — route RowChunking through the streaming helper; skip double-chunking
- `libs/agno/tests/unit/knowledge/test_excel_reader.py` — streaming path tests + parity vs `RowChunking`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

**AI disclosure:** This PR was developed with AI assistance (Grok / Cursor harness). I reviewed the change, verified behavior against existing ExcelReader tests, and confirmed no open PR already targets #9458.

---

## Additional Notes

**Tested:**
```text
pytest libs/agno/tests/unit/knowledge/test_excel_reader.py
# 87 passed
```

Includes coverage that:
- default RowChunking calls `excel_rows_to_row_documents` and never `excel_rows_to_documents`
- non-`RowChunking` strategies and `chunk=False` still use the full-sheet helper
- streaming output matches `RowChunking` content / `row_number` / sheet metadata
- `skip_header=True` works on the streaming path
- async read uses the same streaming path