### PR TITLE
[fix] pass Jina timeout to httpx

### DIFF
--- a/libs/agno/agno/tools/jina.py
+++ b/libs/agno/agno/tools/jina.py
@@ -53,7 +53,8 @@ class JinaReaderTools(Toolkit):
         """Reads a URL and returns the truncated content using Jina Reader API."""
         full_url = f"{self.config.base_url}{url}"
         try:
-            response = httpx.get(full_url, headers=self._get_headers(), timeout=self.config.timeout)
+            request_kwargs = {"timeout": self.config.timeout} if self.config.timeout is not None else {}
+            response = httpx.get(full_url, headers=self._get_headers(), **request_kwargs)
             response.raise_for_status()
             content = response.json()
             return self._truncate_content(str(content))
@@ -71,7 +72,8 @@ class JinaReaderTools(Toolkit):
 
         body = {"q": query}
         try:
-            response = httpx.post(full_url, headers=headers, json=body, timeout=self.config.timeout)
+            request_kwargs = {"timeout": self.config.timeout} if self.config.timeout is not None else {}
+            response = httpx.post(full_url, headers=headers, json=body, **request_kwargs)
             response.raise_for_status()
             content = response.json()
             return self._truncate_content(str(content))

--- a/libs/agno/agno/tools/jina.py
+++ b/libs/agno/agno/tools/jina.py
@@ -53,8 +53,10 @@ class JinaReaderTools(Toolkit):
         """Reads a URL and returns the truncated content using Jina Reader API."""
         full_url = f"{self.config.base_url}{url}"
         try:
-            request_kwargs = {"timeout": self.config.timeout} if self.config.timeout is not None else {}
-            response = httpx.get(full_url, headers=self._get_headers(), **request_kwargs)
+            if self.config.timeout is None:
+                response = httpx.get(full_url, headers=self._get_headers())
+            else:
+                response = httpx.get(full_url, headers=self._get_headers(), timeout=self.config.timeout)
             response.raise_for_status()
             content = response.json()
             return self._truncate_content(str(content))
@@ -72,8 +74,10 @@ class JinaReaderTools(Toolkit):
 
         body = {"q": query}
         try:
-            request_kwargs = {"timeout": self.config.timeout} if self.config.timeout is not None else {}
-            response = httpx.post(full_url, headers=headers, json=body, **request_kwargs)
+            if self.config.timeout is None:
+                response = httpx.post(full_url, headers=headers, json=body)
+            else:
+                response = httpx.post(full_url, headers=headers, json=body, timeout=self.config.timeout)
             response.raise_for_status()
             content = response.json()
             return self._truncate_content(str(content))

--- a/libs/agno/agno/tools/jina.py
+++ b/libs/agno/agno/tools/jina.py
@@ -53,7 +53,7 @@ class JinaReaderTools(Toolkit):
         """Reads a URL and returns the truncated content using Jina Reader API."""
         full_url = f"{self.config.base_url}{url}"
         try:
-            response = httpx.get(full_url, headers=self._get_headers())
+            response = httpx.get(full_url, headers=self._get_headers(), timeout=self.config.timeout)
             response.raise_for_status()
             content = response.json()
             return self._truncate_content(str(content))
@@ -71,7 +71,7 @@ class JinaReaderTools(Toolkit):
 
         body = {"q": query}
         try:
-            response = httpx.post(full_url, headers=headers, json=body)
+            response = httpx.post(full_url, headers=headers, json=body, timeout=self.config.timeout)
             response.raise_for_status()
             content = response.json()
             return self._truncate_content(str(content))

--- a/libs/agno/tests/unit/tools/test_jina.py
+++ b/libs/agno/tests/unit/tools/test_jina.py
@@ -157,7 +157,7 @@ def test_read_url_successful(mock_httpx_get, sample_read_url_response):
 
     # Verify the call
     expected_url = f"{tools.config.base_url}https://example.com"
-    mock_httpx_get.assert_called_once_with(expected_url, headers=tools._get_headers(), timeout=None)
+    mock_httpx_get.assert_called_once_with(expected_url, headers=tools._get_headers())
 
     # Verify result contains the response data
     assert str(sample_read_url_response) in result
@@ -242,9 +242,7 @@ def test_search_query_successful(mock_httpx_post, sample_search_query_response):
         expected_headers["X-Respond-With"] = "no-content"  # to avoid returning full content in search results
 
     expected_body = {"q": "test query"}
-    mock_httpx_post.assert_called_once_with(
-        str(tools.config.search_url), headers=expected_headers, json=expected_body, timeout=None
-    )
+    mock_httpx_post.assert_called_once_with(str(tools.config.search_url), headers=expected_headers, json=expected_body)
 
     # Verify result contains the response data
     assert str(sample_search_query_response) in result

--- a/libs/agno/tests/unit/tools/test_jina.py
+++ b/libs/agno/tests/unit/tools/test_jina.py
@@ -157,9 +157,25 @@ def test_read_url_successful(mock_httpx_get, sample_read_url_response):
 
     # Verify the call
     expected_url = f"{tools.config.base_url}https://example.com"
-    mock_httpx_get.assert_called_once_with(expected_url, headers=tools._get_headers())
+    mock_httpx_get.assert_called_once_with(expected_url, headers=tools._get_headers(), timeout=None)
 
     # Verify result contains the response data
+    assert str(sample_read_url_response) in result
+
+
+@patch("agno.tools.jina.httpx.get")
+def test_read_url_passes_configured_timeout(mock_httpx_get, sample_read_url_response):
+    """Test read_url passes the configured timeout to the HTTP client"""
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = sample_read_url_response
+    mock_httpx_get.return_value = mock_response
+
+    tools = JinaReaderTools(api_key="test_key", timeout=12)
+    result = tools.read_url("https://example.com")
+
+    expected_url = f"{tools.config.base_url}https://example.com"
+    mock_httpx_get.assert_called_once_with(expected_url, headers=tools._get_headers(), timeout=12)
     assert str(sample_read_url_response) in result
 
 
@@ -226,9 +242,30 @@ def test_search_query_successful(mock_httpx_post, sample_search_query_response):
         expected_headers["X-Respond-With"] = "no-content"  # to avoid returning full content in search results
 
     expected_body = {"q": "test query"}
-    mock_httpx_post.assert_called_once_with(str(tools.config.search_url), headers=expected_headers, json=expected_body)
+    mock_httpx_post.assert_called_once_with(
+        str(tools.config.search_url), headers=expected_headers, json=expected_body, timeout=None
+    )
 
     # Verify result contains the response data
+    assert str(sample_search_query_response) in result
+
+
+@patch("agno.tools.jina.httpx.post")
+def test_search_query_passes_configured_timeout(mock_httpx_post, sample_search_query_response):
+    """Test search_query passes the configured timeout to the HTTP client"""
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = sample_search_query_response
+    mock_httpx_post.return_value = mock_response
+
+    tools = JinaReaderTools(api_key="test_key", enable_search_query=True, timeout=12)
+    result = tools.search_query("test query")
+
+    expected_headers = tools._get_headers()
+    expected_body = {"q": "test query"}
+    mock_httpx_post.assert_called_once_with(
+        str(tools.config.search_url), headers=expected_headers, json=expected_body, timeout=12
+    )
     assert str(sample_search_query_response) in result
 
 


### PR DESCRIPTION
Closes #9464

## Problem

`JinaReaderTools` exposes a `timeout` option and forwards it to Jina through the `X-Timeout` header, but the underlying `httpx.get()` and `httpx.post()` calls did not receive that configured client timeout.

## Before / after

Before:
- `timeout=...` only affected the Jina API header.
- The local `httpx` request did not use the configured tool timeout.

After:
- `read_url()` passes `self.config.timeout` to `httpx.get()` when a timeout is configured.
- `search_query()` passes `self.config.timeout` to `httpx.post()` when a timeout is configured.
- When no timeout is configured, the timeout keyword is omitted so httpx's default timeout behavior is preserved.

## Verification

- `python -m pytest libs/agno/tests/unit/tools/test_jina.py` - 19 passed
- `python -m ruff check libs/agno/agno/tools/jina.py libs/agno/tests/unit/tools/test_jina.py`
- `python -m ruff format --check libs/agno/agno/tools/jina.py libs/agno/tests/unit/tools/test_jina.py`
- `git diff --check`