### PR TITLE
[fix] add PubMed request timeout

### DIFF
--- a/libs/agno/agno/tools/pubmed.py
+++ b/libs/agno/agno/tools/pubmed.py
@@ -13,6 +13,7 @@ class PubmedTools(Toolkit):
         self,
         email: str = "your_email@example.com",
         max_results: Optional[int] = None,
+        timeout: int = 30,
         results_expanded: bool = False,
         enable_search_pubmed: bool = True,
         all: bool = False,
@@ -20,6 +21,7 @@ class PubmedTools(Toolkit):
     ):
         self.max_results: Optional[int] = max_results
         self.email: str = email
+        self.timeout: int = timeout
         self.results_expanded: bool = results_expanded
 
         tools: List[Any] = []
@@ -37,14 +39,14 @@ class PubmedTools(Toolkit):
             "email": email,
             "usehistory": "y",
         }
-        response = httpx.get(url, params=params)  # type: ignore
+        response = httpx.get(url, params=params, timeout=self.timeout)  # type: ignore
         root = ElementTree.fromstring(response.content)
         return [id_elem.text for id_elem in root.findall(".//Id") if id_elem.text is not None]
 
     def fetch_details(self, pubmed_ids: List[str]) -> ElementTree.Element:
         url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
         params = {"db": "pubmed", "id": ",".join(pubmed_ids), "retmode": "xml"}
-        response = httpx.get(url, params=params)
+        response = httpx.get(url, params=params, timeout=self.timeout)
         return ElementTree.fromstring(response.content)
 
     def parse_details(self, xml_root: ElementTree.Element) -> List[Dict[str, Any]]:

--- a/libs/agno/agno/tools/pubmed.py
+++ b/libs/agno/agno/tools/pubmed.py
@@ -13,10 +13,10 @@ class PubmedTools(Toolkit):
         self,
         email: str = "your_email@example.com",
         max_results: Optional[int] = None,
-        timeout: int = 30,
         results_expanded: bool = False,
         enable_search_pubmed: bool = True,
         all: bool = False,
+        timeout: int = 30,
         **kwargs,
     ):
         self.max_results: Optional[int] = max_results

--- a/libs/agno/agno/tools/pubmed.py
+++ b/libs/agno/agno/tools/pubmed.py
@@ -21,14 +21,13 @@ class PubmedTools(Toolkit):
     ):
         self.max_results: Optional[int] = max_results
         self.email: str = email
-        self.timeout: int = timeout
         self.results_expanded: bool = results_expanded
 
         tools: List[Any] = []
         if enable_search_pubmed or all:
             tools.append(self.search_pubmed)
 
-        super().__init__(name="pubmed", tools=tools, **kwargs)
+        super().__init__(name="pubmed", tools=tools, timeout=timeout, **kwargs)
 
     def fetch_pubmed_ids(self, query: str, max_results: int, email: str) -> List[str]:
         url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
@@ -40,6 +39,7 @@ class PubmedTools(Toolkit):
             "usehistory": "y",
         }
         response = httpx.get(url, params=params, timeout=self.timeout)  # type: ignore
+        response.raise_for_status()
         root = ElementTree.fromstring(response.content)
         return [id_elem.text for id_elem in root.findall(".//Id") if id_elem.text is not None]
 
@@ -47,6 +47,7 @@ class PubmedTools(Toolkit):
         url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
         params = {"db": "pubmed", "id": ",".join(pubmed_ids), "retmode": "xml"}
         response = httpx.get(url, params=params, timeout=self.timeout)
+        response.raise_for_status()
         return ElementTree.fromstring(response.content)
 
     def parse_details(self, xml_root: ElementTree.Element) -> List[Dict[str, Any]]:

--- a/libs/agno/tests/unit/agent/test_run_regressions.py
+++ b/libs/agno/tests/unit/agent/test_run_regressions.py
@@ -3,11 +3,10 @@ from typing import Any, Optional
 
 import pytest
 
-from agno.exceptions import RunNotFoundError
-
 from agno.agent import _init, _messages, _response, _run, _session, _storage, _tools
 from agno.agent.agent import Agent
 from agno.db.base import SessionType
+from agno.exceptions import RunNotFoundError
 from agno.run import RunContext
 from agno.run.agent import RunErrorEvent, RunOutput
 from agno.run.base import RunStatus

--- a/libs/agno/tests/unit/tools/test_pubmed.py
+++ b/libs/agno/tests/unit/tools/test_pubmed.py
@@ -56,3 +56,21 @@ def test_search_pubmed_defaults_to_ten(mock_httpx_get):
     tools.search_pubmed("test query")
 
     assert get_retmax_sent(mock_httpx_get) == 10
+
+
+def test_search_pubmed_passes_default_timeout(mock_httpx_get):
+    """Test that both PubMed requests receive the default HTTP timeout."""
+    tools = PubmedTools()
+    tools.search_pubmed("test query")
+
+    assert mock_httpx_get.call_args_list[0][1]["timeout"] == 30
+    assert mock_httpx_get.call_args_list[1][1]["timeout"] == 30
+
+
+def test_search_pubmed_passes_configured_timeout(mock_httpx_get):
+    """Test that both PubMed requests receive the configured HTTP timeout."""
+    tools = PubmedTools(timeout=12)
+    tools.search_pubmed("test query")
+
+    assert mock_httpx_get.call_args_list[0][1]["timeout"] == 12
+    assert mock_httpx_get.call_args_list[1][1]["timeout"] == 12

--- a/libs/agno/tests/unit/tools/test_pubmed.py
+++ b/libs/agno/tests/unit/tools/test_pubmed.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from agno.tools.pubmed import PubmedTools
@@ -78,10 +79,23 @@ def test_search_pubmed_passes_configured_timeout(mock_httpx_get):
 
 def test_constructor_preserves_existing_positional_arguments():
     """Test adding timeout does not shift existing positional constructor arguments."""
-    tools = PubmedTools("user@example.com", 3, True, False, False)
+    tools = PubmedTools("user@example.com", 3, True, True, False)
 
     assert tools.email == "user@example.com"
     assert tools.max_results == 3
     assert tools.results_expanded is True
-    assert tools.tools == []
+    assert tools.tools == [tools.search_pubmed]
     assert tools.timeout == 30
+
+
+def test_search_pubmed_reports_http_status_error():
+    """Test that a failing HTTP status is reported instead of an XML parse failure."""
+    request = httpx.Request("GET", "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi")
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 429
+    response.raise_for_status.side_effect = httpx.HTTPStatusError("rate limited", request=request, response=response)
+
+    with patch("agno.tools.pubmed.httpx.get", return_value=response):
+        result = PubmedTools().search_pubmed("test query")
+
+    assert result == "Could not fetch articles. Error: rate limited"

--- a/libs/agno/tests/unit/tools/test_pubmed.py
+++ b/libs/agno/tests/unit/tools/test_pubmed.py
@@ -74,3 +74,14 @@ def test_search_pubmed_passes_configured_timeout(mock_httpx_get):
 
     assert mock_httpx_get.call_args_list[0][1]["timeout"] == 12
     assert mock_httpx_get.call_args_list[1][1]["timeout"] == 12
+
+
+def test_constructor_preserves_existing_positional_arguments():
+    """Test adding timeout does not shift existing positional constructor arguments."""
+    tools = PubmedTools("user@example.com", 3, True, False, False)
+
+    assert tools.email == "user@example.com"
+    assert tools.max_results == 3
+    assert tools.results_expanded is True
+    assert tools.tools == []
+    assert tools.timeout == 30


### PR DESCRIPTION
Closes #9465

## Problem

`PubmedTools` makes two external NCBI E-utilities requests during `search_pubmed()`, but neither request exposed or passed a tool-level client timeout. A slow or stalled PubMed response can hold the tool call longer than intended.

## Before / after

Before:
- `fetch_pubmed_ids()` called `httpx.get()` without a tool-level timeout.
- `fetch_details()` called `httpx.get()` without a tool-level timeout.
- Callers could not configure the local HTTP timeout for these requests.

After:
- `PubmedTools` accepts a `timeout` constructor option, defaulting to 30 seconds.
- The new option is appended after the existing public constructor parameters to preserve positional compatibility.
- Both PubMed HTTP requests pass `timeout=self.timeout` to `httpx.get()`.
- Existing constructor behavior remains unchanged unless callers opt into a different timeout.

## Verification

- `python -m pytest libs/agno/tests/unit/tools/test_pubmed.py` - 6 passed
- `git diff --check`