### PR TITLE
[fix] prevent path traversal in VisualizationTools chart filenames

### DIFF
--- a/libs/agno/agno/tools/visualization.py
+++ b/libs/agno/agno/tools/visualization.py
@@ -2,8 +2,10 @@ import json
 import os
 from typing import Any, Dict, List, Optional, Union
 
+from agno.exceptions import PathSecurityError
 from agno.tools import Toolkit
 from agno.utils.log import log_info, logger
+from agno.utils.path_safety import safe_join_filename
 
 
 class VisualizationTools(Toolkit):
@@ -144,7 +146,9 @@ class VisualizationTools(Toolkit):
             if filename is None:
                 filename = f"bar_chart_{len(os.listdir(self.output_dir)) + 1}.png"
 
-            file_path = os.path.join(self.output_dir, filename)
+            # filename is a model-supplied tool argument: contain it within output_dir
+            # (rejects path traversal and absolute paths). See safe_join_filename.
+            file_path = str(safe_join_filename(self.output_dir, filename))
             plt.savefig(file_path, dpi=300, bbox_inches="tight")
             plt.close()
 
@@ -160,6 +164,9 @@ class VisualizationTools(Toolkit):
                 }
             )
 
+        except PathSecurityError as e:
+            # Unsafe model-supplied filename — a routine rejection, not an internal error.
+            return json.dumps({"chart_type": "bar_chart", "error": str(e), "status": "error"})
         except Exception as e:
             logger.exception("Error creating bar chart")
             return json.dumps({"chart_type": "bar_chart", "error": str(e), "status": "error"})
@@ -217,7 +224,9 @@ class VisualizationTools(Toolkit):
             if filename is None:
                 filename = f"line_chart_{len(os.listdir(self.output_dir)) + 1}.png"
 
-            file_path = os.path.join(self.output_dir, filename)
+            # filename is a model-supplied tool argument: contain it within output_dir
+            # (rejects path traversal and absolute paths). See safe_join_filename.
+            file_path = str(safe_join_filename(self.output_dir, filename))
             plt.savefig(file_path, dpi=300, bbox_inches="tight")
             plt.close()
 
@@ -233,6 +242,9 @@ class VisualizationTools(Toolkit):
                 }
             )
 
+        except PathSecurityError as e:
+            # Unsafe model-supplied filename — a routine rejection, not an internal error.
+            return json.dumps({"chart_type": "line_chart", "error": str(e), "status": "error"})
         except Exception as e:
             logger.exception("Error creating line chart")
             return json.dumps({"chart_type": "line_chart", "error": str(e), "status": "error"})
@@ -282,7 +294,9 @@ class VisualizationTools(Toolkit):
             if filename is None:
                 filename = f"pie_chart_{len(os.listdir(self.output_dir)) + 1}.png"
 
-            file_path = os.path.join(self.output_dir, filename)
+            # filename is a model-supplied tool argument: contain it within output_dir
+            # (rejects path traversal and absolute paths). See safe_join_filename.
+            file_path = str(safe_join_filename(self.output_dir, filename))
             plt.savefig(file_path, dpi=300, bbox_inches="tight")
             plt.close()
 
@@ -298,6 +312,9 @@ class VisualizationTools(Toolkit):
                 }
             )
 
+        except PathSecurityError as e:
+            # Unsafe model-supplied filename — a routine rejection, not an internal error.
+            return json.dumps({"chart_type": "pie_chart", "error": str(e), "status": "error"})
         except Exception as e:
             logger.exception("Error creating pie chart")
             return json.dumps({"chart_type": "pie_chart", "error": str(e), "status": "error"})
@@ -371,7 +388,9 @@ class VisualizationTools(Toolkit):
             if filename is None:
                 filename = f"scatter_plot_{len(os.listdir(self.output_dir)) + 1}.png"
 
-            file_path = os.path.join(self.output_dir, filename)
+            # filename is a model-supplied tool argument: contain it within output_dir
+            # (rejects path traversal and absolute paths). See safe_join_filename.
+            file_path = str(safe_join_filename(self.output_dir, filename))
             plt.savefig(file_path, dpi=300, bbox_inches="tight")
             plt.close()
 
@@ -387,6 +406,9 @@ class VisualizationTools(Toolkit):
                 }
             )
 
+        except PathSecurityError as e:
+            # Unsafe model-supplied filename — a routine rejection, not an internal error.
+            return json.dumps({"chart_type": "scatter_plot", "error": str(e), "status": "error"})
         except Exception as e:
             logger.exception("Error creating scatter plot")
             return json.dumps({"chart_type": "scatter_plot", "error": str(e), "status": "error"})
@@ -445,7 +467,9 @@ class VisualizationTools(Toolkit):
             if filename is None:
                 filename = f"histogram_{len(os.listdir(self.output_dir)) + 1}.png"
 
-            file_path = os.path.join(self.output_dir, filename)
+            # filename is a model-supplied tool argument: contain it within output_dir
+            # (rejects path traversal and absolute paths). See safe_join_filename.
+            file_path = str(safe_join_filename(self.output_dir, filename))
             plt.savefig(file_path, dpi=300, bbox_inches="tight")
             plt.close()
 
@@ -462,6 +486,9 @@ class VisualizationTools(Toolkit):
                 }
             )
 
+        except PathSecurityError as e:
+            # Unsafe model-supplied filename — a routine rejection, not an internal error.
+            return json.dumps({"chart_type": "histogram", "error": str(e), "status": "error"})
         except Exception as e:
             logger.exception("Error creating histogram")
             return json.dumps({"chart_type": "histogram", "error": str(e), "status": "error"})

--- a/libs/agno/tests/unit/tools/test_visualization.py
+++ b/libs/agno/tests/unit/tools/test_visualization.py
@@ -3,6 +3,7 @@
 import json
 import os
 import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -482,3 +483,62 @@ def test_create_bar_chart_with_json_string(viz_tools):
         assert result_dict["status"] == "success"
         assert result_dict["chart_type"] == "bar_chart"
         assert result_dict["data_points"] == 3
+
+
+# -- path-safety: filename is a model-supplied tool argument -------------------
+
+# Every chart method takes the same model-controlled ``filename`` and must keep the
+# written file inside ``output_dir``. Parametrizing over all five guards against the
+# fix being applied to only some of the identical sinks. Each entry carries the method's
+# own data kwargs (signatures differ — scatter takes x_data/y_data).
+_CHART_CALLS = [
+    ("create_bar_chart", {"data": {"A": 1, "B": 2}}),
+    ("create_line_chart", {"data": {"A": 1, "B": 2}}),
+    ("create_pie_chart", {"data": {"A": 1, "B": 2}}),
+    ("create_scatter_plot", {"x_data": [1, 2, 3], "y_data": [4, 5, 6]}),
+    ("create_histogram", {"data": [1, 2, 3, 4, 5]}),
+]
+
+
+def _assert_contained(result_json: str, outside: Path, output_dir: str) -> None:
+    """The write never landed at ``outside``; anything written stayed under output_dir."""
+    result = json.loads(result_json)
+    assert not outside.exists(), f"wrote outside output_dir to {outside}"
+    if result.get("status") == "success":
+        written = Path(result["file_path"]).resolve()
+        assert written.is_relative_to(Path(output_dir).resolve()), f"escaped to {written}"
+
+
+@pytest.mark.parametrize("method_name,kwargs", _CHART_CALLS)
+def test_chart_traversal_filename_stays_inside_output_dir(viz_tools, temp_output_dir, tmp_path, method_name, kwargs):
+    """A ``../`` filename must not write outside output_dir (path components stripped)."""
+    outside = tmp_path / "escaped.png"
+    rel = os.path.relpath(str(outside), temp_output_dir)  # ../../.../escaped.png
+    assert ".." in rel
+
+    _assert_contained(getattr(viz_tools, method_name)(filename=rel, **kwargs), outside, temp_output_dir)
+
+
+@pytest.mark.parametrize("method_name,kwargs", _CHART_CALLS)
+def test_chart_absolute_filename_stays_inside_output_dir(viz_tools, temp_output_dir, tmp_path, method_name, kwargs):
+    """An absolute filename must not escape output_dir (os.path.join drops the base)."""
+    outside = tmp_path / "abs.png"
+
+    _assert_contained(getattr(viz_tools, method_name)(filename=str(outside), **kwargs), outside, temp_output_dir)
+
+
+@pytest.mark.parametrize("method_name,kwargs", _CHART_CALLS)
+def test_chart_rejects_unsafe_filename(viz_tools, method_name, kwargs):
+    """A structurally invalid filename (reserved device name) is refused, not written."""
+    result = json.loads(getattr(viz_tools, method_name)(filename="CON", **kwargs))
+
+    assert result["status"] == "error"
+
+
+@pytest.mark.parametrize("method_name,kwargs", _CHART_CALLS)
+def test_chart_accepts_plain_filename(viz_tools, temp_output_dir, method_name, kwargs):
+    """A plain filename still works and lands inside output_dir."""
+    result = json.loads(getattr(viz_tools, method_name)(filename="chart.png", **kwargs))
+
+    assert result["status"] == "success"
+    assert (Path(temp_output_dir) / "chart.png").exists()


### PR DESCRIPTION
## Summary

`VisualizationTools`' five chart tools — `create_bar_chart`, `create_line_chart`, `create_pie_chart`, `create_scatter_plot`, `create_histogram` — take a model-supplied `filename` argument and pass it straight to `os.path.join(self.output_dir, filename)` → `plt.savefig()` with **no containment check**.

`output_dir` is a sandbox directory the class documents and creates, but nothing keeps writes inside it:

```python
>>> os.path.join("charts", "../../../../tmp/pwned.png")  # -> 'charts/../../../../tmp/pwned.png'
>>> os.path.join("charts", "/tmp/pwned.png")             # -> '/tmp/pwned.png'  (base discarded)
```

**Impact.** A prompt-injected page/document/email that the agent reads and charts can emit a tool call with `filename="../../../../home/user/.bashrc"` (or an absolute path), writing an attacker-named file anywhere the process can write — overwriting config/code/data, or planting a file in a watched/served directory. matplotlib honors the extension, so `.svg`/`.pdf`/`.ps` payloads are possible too, and the chart title/labels/data are partly model-controlled content.

This is the same class of bug already fixed in `FileSystemKnowledge.get_file` (#8726) and `AirflowTools` (#8638); `VisualizationTools` is the remaining toolkit that declares an output directory but never enforces it.

**Fix.** Route the filename through `safe_join_filename` — the helper `FileGenerationTools` and `SlackTools` already use for LLM-supplied filenames — which strips path components, rejects absolute/Windows/reserved names, and verifies containment. A structurally invalid name (e.g. `CON`) returns a clean tool error rather than a logged traceback.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff check` + `ruff format` clean on changed files)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue (the two open `VisualizationTools` PRs are feature enhancements, orthogonal to this security fix)
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

> Disclosure: this PR was written with the assistance of Claude Code. The author reviewed and understands the change; it includes tests, passes `ruff`, and the full `test_visualization.py` (43) and `test_path_safety*` (69) suites pass locally.

---

## Additional Notes

**Tests** (`libs/agno/tests/unit/tools/test_visualization.py`, parametrized across all five methods):
- a `../` filename stays inside `output_dir`,
- an absolute filename stays inside `output_dir`,
- a reserved/invalid name is refused with `status: error`,
- a plain filename still works.

Verified they fail on the current code (files land outside `output_dir`) and pass with the fix.

**Security consideration.** No `SECURITY.md` / private advisory channel exists, and the equivalent path-traversal fixes (#8726, #8638) were submitted as public PRs, so this follows the project's established handling for this bug class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)