### PR TITLE
[fix] Default to descending sort order in SurrealDB

### DIFF
--- a/libs/agno/agno/db/surrealdb/queries.py
+++ b/libs/agno/agno/db/surrealdb/queries.py
@@ -48,13 +48,13 @@ def order_limit_start(
     limit: Optional[int] = None,
     page: Optional[int] = None,
 ) -> str:
-    if sort_order is not None:
-        if "desc" in sort_order.lower():
-            sort_order = "DESC"
-        else:
-            sort_order = "ASC"
+    # An omitted sort_order means descending, as it does in every other backend.
+    if sort_order is not None and "desc" not in sort_order.lower():
+        sort_order = "ASC"
+    else:
+        sort_order = "DESC"
 
-    order_clause = f"ORDER BY {sort_by} {sort_order or ''}" if sort_by is not None else ""
+    order_clause = f"ORDER BY {sort_by} {sort_order}" if sort_by is not None else ""
 
     if limit is not None:
         limit_clause = f"LIMIT {limit}"

--- a/libs/agno/tests/unit/db/test_surrealdb_order_clause.py
+++ b/libs/agno/tests/unit/db/test_surrealdb_order_clause.py
@@ -1,0 +1,51 @@
+"""An omitted sort_order must mean descending, as it does in every other backend.
+
+`order_limit_start` builds the ORDER BY / LIMIT / START tail of every SurrealDB
+listing query. When sort_order was omitted it emitted a bare `ORDER BY {field}`,
+and SurrealDB parses a direction-less ORDER BY as ascending, so listings that
+every other backend returns newest first came back oldest first here.
+
+These are pure string assertions: `order_limit_start` builds SurrealQL and never
+touches a connection, matching how test_surrealdb_models.py covers this backend.
+"""
+
+from agno.db.surrealdb.queries import order_limit_start
+
+
+def test_omitted_sort_order_is_descending():
+    """The case that was wrong: no direction at all, which SurrealDB read as ascending."""
+    assert order_limit_start(sort_by="created_at") == "ORDER BY created_at DESC"
+
+
+def test_explicit_sort_order_is_unchanged():
+    """The explicit directions keep working; only the omitted case moves."""
+    assert order_limit_start(sort_by="created_at", sort_order="desc") == "ORDER BY created_at DESC"
+    assert order_limit_start(sort_by="created_at", sort_order="asc") == "ORDER BY created_at ASC"
+
+
+def test_sort_order_matching_is_case_insensitive():
+    """Callers pass both cases; three call sites in surrealdb.py pass "DESC"."""
+    assert order_limit_start(sort_by="created_at", sort_order="DESC") == "ORDER BY created_at DESC"
+    assert order_limit_start(sort_by="created_at", sort_order="ASC") == "ORDER BY created_at ASC"
+
+
+def test_unrecognized_sort_order_is_still_ascending():
+    """Anything that is not "desc" stayed ascending before and stays ascending now."""
+    assert order_limit_start(sort_by="created_at", sort_order="") == "ORDER BY created_at ASC"
+    assert order_limit_start(sort_by="created_at", sort_order="oldest") == "ORDER BY created_at ASC"
+
+
+def test_no_sort_by_emits_no_order_clause():
+    """Without a field to sort on there is no ORDER BY to give a direction to."""
+    assert order_limit_start() == ""
+    assert order_limit_start(sort_order="desc") == ""
+    assert order_limit_start(sort_order=None, limit=10) == "LIMIT 10"
+
+
+def test_limit_and_start_clauses_are_unchanged():
+    """The rest of the clause builder is untouched by this change."""
+    assert order_limit_start(sort_by="created_at", limit=10) == "ORDER BY created_at DESC LIMIT 10"
+    assert order_limit_start(sort_by="created_at", sort_order="asc", limit=10, page=3) == (
+        "ORDER BY created_at ASC LIMIT 10 START 20"
+    )
+    assert order_limit_start(limit=10, page=1) == "LIMIT 10 START 0"


### PR DESCRIPTION
## Summary

`SurrealDb.get_sessions()` and its siblings return **oldest first** when `sort_order` is omitted, while every other backend returns newest first. A "recent sessions" list built on SurrealDB shows the oldest rows, and with `limit` set the newest ones never appear at all.

`order_limit_start` only appends a direction when the caller passes one:

```python
# libs/agno/agno/db/surrealdb/queries.py
order_clause = f"ORDER BY {sort_by} {sort_order or ''}" if sort_by is not None else ""
```

With `sort_order=None` that emits a bare `ORDER BY created_at`, and SurrealDB parses a direction-less `ORDER BY` as **ascending** — from its own parser, where a missing keyword falls through to `true` and `direction` is documented as *"true if the direction is ascending"*:

```rust
// surrealdb/core/src/syn/parser/stmt/select.rs
let direction = match self.peek_kind() {
    t!("ASCENDING")  => { self.pop_peek(); true }
    t!("DESCENDING") => { self.pop_peek(); false }
    _ => true,
};
```

This is a follow-on to #9290, which fixed the same default in Redis, Valkey, DynamoDB and Firestore. It is deliberately a **separate PR** because the mechanism is different — those four resolve direction in a Python comparison, this one omits a keyword from generated SurrealQL — and it touches no file that PR touches, so the two can land in either order.

**Why descending is the intended default**, stated in three places this backend already agrees with elsewhere:

- `tests/unit/os/routers/test_sort_order_default.py` says in its own docstring *"Validates that `sort_order` query parameter defaults to `SortOrder.DESC`"*, and asserts it across all four routers.
- The SQL backends resolve `None` to descending (`if sort_order and sort_order == "asc"`), and Mongo does the same (`1 if sort_order == "asc" else -1`).
- **`surrealdb.py` itself passes `"DESC"` explicitly at three call sites** (`get_user_memories`' last-updated ordering, and the traces paths at `start_time` / `last_trace_at`). When this backend picks a direction for itself it picks descending; it just never applied that to the caller-omitted case.

Affected public methods, all of which forward a caller's `sort_order` straight through: `get_sessions`, `get_user_memories`, `get_knowledge_contents`, `get_eval_runs`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

The only related PR is my own #9290, covered above: different backends, different mechanism, no shared files.

---

## Additional Notes

**What changed.** Only the omitted case. `"desc"`, `"DESC"`, `"asc"`, `"ASC"`, `""` and unrecognized strings all keep their current behaviour — the case-insensitive `"desc" in ...` match is preserved verbatim, and the `sort_by is None` path still emits no `ORDER BY` at all.

**Verification.**

- **Fail-first.** The new tests against unpatched code: **2 failed, 4 passed**, the two being the omitted-direction cases (`- ORDER BY created_at DESC LIMIT 10` / `+ ORDER BY created_at  LIMIT 10`). **6 passed** after.
- **Full `libs/agno/tests/unit/db` suite, like for like.** `main`: **3 failed, 301 passed, 1 skipped, 7 errors**. This branch: **3 failed, 307 passed, 1 skipped, 7 errors** — `diff` on the two sorted FAILED/ERROR line sets is **empty**, and +6 is exactly the six tests added. (`test_clickhouse.py` excluded from both runs — it fails collection locally on `clickhouse-connect`, unrelated to this change.)
- **`./scripts/format.sh`** clean, **`./scripts/validate.sh`**: `ruff check` passes; `mypy` reports 5 errors in 3 files (`vectordb/valkey/valkeydb.py`, `tools/google/bigquery.py`, `db/firestore/firestore.py`) — **identical on clean `main`**, verified by re-running validate against a stashed tree, so none are introduced here.

**Tests.** Six, in a new `tests/unit/db/test_surrealdb_order_clause.py`, matching how `test_surrealdb_models.py` covers this backend: pure string assertions against `order_limit_start`, no connection and no `surrealdb` server. Two of the six (`test_no_sort_by_emits_no_order_clause`, `test_unrecognized_sort_order_is_still_ascending`) pass both before and after by design — they hold the paths that did *not* change.

**Scope — what I left out.** `metrics.py:92` passes `sort_order="asc"` explicitly and `surrealdb.py:1103` hardcodes `ORDER BY date ASC`; both are deliberate and untouched. I also did not add a `sort_by` default the way `dynamo/utils.py` substitutes `created_at`, so a SurrealDB call with no `sort_by` still returns rows unordered — that is a second behaviour and belongs in its own PR if you want the parity.

**One honest limitation.** I could not run a live SurrealDB locally, so the ascending-default claim is argued from SurrealDB's parser source quoted above rather than from an observed query result. If you would rather see it reproduced against a real instance before merging, say so and I will find a way to run one.

---

*Disclosure per contributing guideline 5: this PR was prepared with the assistance of an AI coding agent. The target and scope were mine, and the verification above was run locally and reviewed by me.*
