### PR TITLE
[fix] Avoid collisions in scoped Valkey document ids

### DIFF
--- a/libs/agno/agno/vectordb/valkey/valkeydb.py
+++ b/libs/agno/agno/vectordb/valkey/valkeydb.py
@@ -296,7 +296,10 @@ class ValkeyDB(VectorDb):
         """
         if user_id is None:
             return base_id
-        return hash_string_sha256(f"{base_id}_{user_id}")
+        # Length-prefix each part so delimiters in either value cannot make two
+        # distinct (base_id, user_id) pairs produce the same preimage.
+        key = "|".join(f"{len(part)}:{part}" for part in (base_id, user_id))
+        return hash_string_sha256(key)
 
     def _parse_hash(self, doc: Document, user_id: Optional[str] = None) -> Dict[str, Any]:
         """Create a dict serializable into a Valkey HASH structure.

--- a/libs/agno/tests/unit/vectordb/test_valkeydb.py
+++ b/libs/agno/tests/unit/vectordb/test_valkeydb.py
@@ -291,6 +291,21 @@ def test_filter_query_escapes_tag_values_without_changing_stored_metadata(valkey
     assert db._build_filter_expression({"category": "north america"}) == r"@category:{north\ america}"
 
 
+def test_scoped_doc_id_keeps_delimiter_values_distinct(valkey_db):
+    db = valkey_db[0]
+
+    first = db._scoped_doc_id("doc_a", "u")
+    second = db._scoped_doc_id("doc", "a_u")
+
+    assert first != second
+
+
+def test_unscoped_doc_id_keeps_legacy_value(valkey_db):
+    db = valkey_db[0]
+
+    assert db._scoped_doc_id("doc_a", None) == "doc_a"
+
+
 def test_embedding_dimension_mismatch_raises(valkey_db):
     db = valkey_db[0]
     doc = Document(content="Doc A", name="doc_a", embedding=[0.1] * 4)


### PR DESCRIPTION
## Summary

Fixes #9412.

`ValkeyDB._scoped_doc_id` previously hashed `f{base_id}_{user_id}`. That encoding is ambiguous: `(base_id=doc_a, user_id=u)` and `(base_id=doc, user_id=a_u)` produced the same Valkey document id.

This change length-prefixes each part before hashing, so the pair remains unambiguous even when either value contains the delimiter. Unscoped documents still return their existing `base_id` unchanged.

The new scoped ids are intentionally different from the old derivation, so existing user-scoped records need to be re-indexed as part of deployment. Any data already overwritten because of a collision cannot be recovered by this code change alone.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (not applicable; no public API change)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
- [x] Tested in clean environment

### Duplicate and AI-Generated PR Check

- [x] I searched the existing open pull requests and confirmed that no other PR addresses #9412.
- [ ] If a similar PR exists, I have explained below why this PR is a better approach.
- [x] This change was prepared with AI assistance (Codex) and reviewed against the issue, source, and test results. I am responsible for the submitted changes.

## Validation

- `libs/agno/tests/unit/vectordb/test_valkeydb.py`: 18 passed
- `./libs/agno/scripts/format.bat`: passed
- `./libs/agno/scripts/validate.bat`: passed (ruff and mypy, 955 source files)
- `git diff --check`: passed

## Additional Notes

The regression test fails on the current `main` because the two delimiter-ambiguous pairs produce the same digest, and passes with this change.