### PR TITLE
fix: add ensure_ascii=False to json.dumps for human/LLM-readable outputs

### DIFF
--- a/libs/agno/agno/agent/_default_tools.py
+++ b/libs/agno/agno/agent/_default_tools.py
@@ -306,7 +306,7 @@ def get_chat_history_function(agent: Agent, session: AgentSession) -> Callable:
         all_chats = session.get_messages()
 
         if len(all_chats) == 0:
-            return json.dumps([])
+            return json.dumps([], ensure_ascii=False)
 
         for chat in all_chats:  # type: ignore
             history.append(chat.to_dict())  # type: ignore
@@ -338,7 +338,7 @@ def get_tool_call_history_function(agent: Agent, session: AgentSession) -> Calla
 
         tool_calls = session.get_tool_calls(num_calls=num_calls)
         if len(tool_calls) == 0:
-            return json.dumps([])
+            return json.dumps([], ensure_ascii=False)
         return json.dumps(tool_calls, ensure_ascii=False)
 
     return get_tool_call_history
@@ -478,7 +478,7 @@ def get_search_past_sessions_function(
         import json
 
         if agent.db is None:
-            return json.dumps([])
+            return json.dumps([], ensure_ascii=False)
 
         agent.db = cast(BaseDb, agent.db)
         selected_sessions = agent.db.get_sessions(
@@ -525,7 +525,7 @@ async def aget_search_past_sessions_function(
         import json
 
         if agent.db is None:
-            return json.dumps([])
+            return json.dumps([], ensure_ascii=False)
 
         if _init.has_async_db(agent):
             selected_sessions = await agent.db.get_sessions(  # type: ignore

--- a/libs/agno/agno/agent/_utils.py
+++ b/libs/agno/agno/agent/_utils.py
@@ -91,7 +91,7 @@ def convert_dependencies_to_string(agent: Agent, context: Dict[str, Any]) -> str
         for key, value in context.items():
             try:
                 # Try to serialize each value individually
-                json.dumps({key: value}, default=str)
+                json.dumps({key: value}, default=str, ensure_ascii=False)
                 sanitized_context[key] = value
             except Exception:
                 # If serialization fails, convert to string representation

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -487,7 +487,7 @@ class BaseExternalAgent:
                     "type": "function",
                     "function": {
                         "name": tool.tool_name or "",
-                        "arguments": json.dumps(tool.tool_args or {}),
+                        "arguments": json.dumps(tool.tool_args or {}, ensure_ascii=False),
                     },
                 }
                 messages.append(

--- a/libs/agno/agno/client/os.py
+++ b/libs/agno/agno/client/os.py
@@ -581,20 +581,20 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps([img.to_dict() for img in images])
+            data["images"] = json.dumps([img.to_dict() for img in images], ensure_ascii=False)
         if audio:
-            data["audio"] = json.dumps([a.to_dict() for a in audio])
+            data["audio"] = json.dumps([a.to_dict() for a in audio], ensure_ascii=False)
         if videos:
-            data["videos"] = json.dumps([v.to_dict() for v in videos])
+            data["videos"] = json.dumps([v.to_dict() for v in videos], ensure_ascii=False)
         if files:
             # Sent as "input_files" because the run endpoints already use the "files"
             # field for multipart uploads (List[UploadFile]).
-            data["input_files"] = json.dumps([f.to_dict() for f in files])
+            data["input_files"] = json.dumps([f.to_dict() for f in files], ensure_ascii=False)
 
         # Add kwargs to data, serializing dicts as JSON
         for key, value in kwargs.items():
             if isinstance(value, dict):
-                data[key] = json.dumps(value)
+                data[key] = json.dumps(value, ensure_ascii=False)
             else:
                 data[key] = value
 
@@ -643,19 +643,19 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps([img.to_dict() for img in images])
+            data["images"] = json.dumps([img.to_dict() for img in images], ensure_ascii=False)
         if audio:
-            data["audio"] = json.dumps([a.to_dict() for a in audio])
+            data["audio"] = json.dumps([a.to_dict() for a in audio], ensure_ascii=False)
         if videos:
-            data["videos"] = json.dumps([v.to_dict() for v in videos])
+            data["videos"] = json.dumps([v.to_dict() for v in videos], ensure_ascii=False)
         if files:
             # Sent as "input_files" because the run endpoints already use the "files"
             # field for multipart uploads (List[UploadFile]).
-            data["input_files"] = json.dumps([f.to_dict() for f in files])
+            data["input_files"] = json.dumps([f.to_dict() for f in files], ensure_ascii=False)
 
         for key, value in kwargs.items():
             if isinstance(value, dict):
-                data[key] = json.dumps(value)
+                data[key] = json.dumps(value, ensure_ascii=False)
             else:
                 data[key] = value
 
@@ -694,7 +694,10 @@ class AgentOSClient:
             HTTPStatusError: On HTTP errors
         """
         endpoint = f"/agents/{agent_id}/runs/{run_id}/continue"
-        data: Dict[str, Any] = {"tools": json.dumps([tool.to_dict() for tool in tools]), "stream": "false"}
+        data: Dict[str, Any] = {
+            "tools": json.dumps([tool.to_dict() for tool in tools], ensure_ascii=False),
+            "stream": "false",
+        }
         if session_id is not None:
             data["session_id"] = session_id
         if user_id is not None:
@@ -702,7 +705,7 @@ class AgentOSClient:
 
         for key, value in kwargs.items():
             if isinstance(value, dict):
-                data[key] = json.dumps(value)
+                data[key] = json.dumps(value, ensure_ascii=False)
             else:
                 data[key] = value
 
@@ -736,7 +739,10 @@ class AgentOSClient:
             HTTPStatusError: On HTTP errors
         """
         endpoint = f"/agents/{agent_id}/runs/{run_id}/continue"
-        data: Dict[str, Any] = {"tools": json.dumps([tool.to_dict() for tool in tools]), "stream": "true"}
+        data: Dict[str, Any] = {
+            "tools": json.dumps([tool.to_dict() for tool in tools], ensure_ascii=False),
+            "stream": "true",
+        }
         if session_id is not None:
             data["session_id"] = session_id
         if user_id is not None:
@@ -744,7 +750,7 @@ class AgentOSClient:
 
         for key, value in kwargs.items():
             if isinstance(value, dict):
-                data[key] = json.dumps(value)
+                data[key] = json.dumps(value, ensure_ascii=False)
             else:
                 data[key] = value
 
@@ -857,20 +863,20 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps([img.to_dict() for img in images])
+            data["images"] = json.dumps([img.to_dict() for img in images], ensure_ascii=False)
         if audio:
-            data["audio"] = json.dumps([a.to_dict() for a in audio])
+            data["audio"] = json.dumps([a.to_dict() for a in audio], ensure_ascii=False)
         if videos:
-            data["videos"] = json.dumps([v.to_dict() for v in videos])
+            data["videos"] = json.dumps([v.to_dict() for v in videos], ensure_ascii=False)
         if files:
             # Sent as "input_files" because the run endpoints already use the "files"
             # field for multipart uploads (List[UploadFile]).
-            data["input_files"] = json.dumps([f.to_dict() for f in files])
+            data["input_files"] = json.dumps([f.to_dict() for f in files], ensure_ascii=False)
 
         # Add kwargs to data, serializing dicts as JSON
         for key, value in kwargs.items():
             if isinstance(value, dict):
-                data[key] = json.dumps(value)
+                data[key] = json.dumps(value, ensure_ascii=False)
             else:
                 data[key] = value
 
@@ -919,20 +925,20 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps([img.to_dict() for img in images])
+            data["images"] = json.dumps([img.to_dict() for img in images], ensure_ascii=False)
         if audio:
-            data["audio"] = json.dumps([a.to_dict() for a in audio])
+            data["audio"] = json.dumps([a.to_dict() for a in audio], ensure_ascii=False)
         if videos:
-            data["videos"] = json.dumps([v.to_dict() for v in videos])
+            data["videos"] = json.dumps([v.to_dict() for v in videos], ensure_ascii=False)
         if files:
             # Sent as "input_files" because the run endpoints already use the "files"
             # field for multipart uploads (List[UploadFile]).
-            data["input_files"] = json.dumps([f.to_dict() for f in files])
+            data["input_files"] = json.dumps([f.to_dict() for f in files], ensure_ascii=False)
 
         # Add kwargs to data, serializing dicts as JSON
         for key, value in kwargs.items():
             if isinstance(value, dict):
-                data[key] = json.dumps(value)
+                data[key] = json.dumps(value, ensure_ascii=False)
             else:
                 data[key] = value
 
@@ -995,7 +1001,10 @@ class AgentOSClient:
             else:
                 serialized_requirements.append(req)
 
-        data: Dict[str, Any] = {"requirements": json.dumps(serialized_requirements), "stream": "false"}
+        data: Dict[str, Any] = {
+            "requirements": json.dumps(serialized_requirements, ensure_ascii=False),
+            "stream": "false",
+        }
         if session_id is not None:
             data["session_id"] = session_id
         if user_id is not None:
@@ -1003,7 +1012,7 @@ class AgentOSClient:
 
         for key, value in kwargs.items():
             if isinstance(value, dict):
-                data[key] = json.dumps(value)
+                data[key] = json.dumps(value, ensure_ascii=False)
             else:
                 data[key] = value
 
@@ -1049,7 +1058,10 @@ class AgentOSClient:
             else:
                 serialized_requirements.append(req)
 
-        data: Dict[str, Any] = {"requirements": json.dumps(serialized_requirements), "stream": "true"}
+        data: Dict[str, Any] = {
+            "requirements": json.dumps(serialized_requirements, ensure_ascii=False),
+            "stream": "true",
+        }
         if session_id is not None:
             data["session_id"] = session_id
         if user_id is not None:
@@ -1057,7 +1069,7 @@ class AgentOSClient:
 
         for key, value in kwargs.items():
             if isinstance(value, dict):
-                data[key] = json.dumps(value)
+                data[key] = json.dumps(value, ensure_ascii=False)
             else:
                 data[key] = value
 
@@ -1165,20 +1177,20 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps([img.to_dict() for img in images])
+            data["images"] = json.dumps([img.to_dict() for img in images], ensure_ascii=False)
         if audio:
-            data["audio"] = json.dumps([a.to_dict() for a in audio])
+            data["audio"] = json.dumps([a.to_dict() for a in audio], ensure_ascii=False)
         if videos:
-            data["videos"] = json.dumps([v.to_dict() for v in videos])
+            data["videos"] = json.dumps([v.to_dict() for v in videos], ensure_ascii=False)
         if files:
             # Sent as "input_files" because the run endpoints already use the "files"
             # field for multipart uploads (List[UploadFile]).
-            data["input_files"] = json.dumps([f.to_dict() for f in files])
+            data["input_files"] = json.dumps([f.to_dict() for f in files], ensure_ascii=False)
 
         # Add kwargs to data, serializing dicts as JSON
         for key, value in kwargs.items():
             if isinstance(value, dict):
-                data[key] = json.dumps(value)
+                data[key] = json.dumps(value, ensure_ascii=False)
             else:
                 data[key] = value
 
@@ -1227,20 +1239,20 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps([img.to_dict() for img in images])
+            data["images"] = json.dumps([img.to_dict() for img in images], ensure_ascii=False)
         if audio:
-            data["audio"] = json.dumps([a.to_dict() for a in audio])
+            data["audio"] = json.dumps([a.to_dict() for a in audio], ensure_ascii=False)
         if videos:
-            data["videos"] = json.dumps([v.to_dict() for v in videos])
+            data["videos"] = json.dumps([v.to_dict() for v in videos], ensure_ascii=False)
         if files:
             # Sent as "input_files" because the run endpoints already use the "files"
             # field for multipart uploads (List[UploadFile]).
-            data["input_files"] = json.dumps([f.to_dict() for f in files])
+            data["input_files"] = json.dumps([f.to_dict() for f in files], ensure_ascii=False)
 
         # Add kwargs to data, serializing dicts as JSON
         for key, value in kwargs.items():
             if isinstance(value, dict):
-                data[key] = json.dumps(value)
+                data[key] = json.dumps(value, ensure_ascii=False)
             else:
                 data[key] = value
 
@@ -1286,7 +1298,7 @@ class AgentOSClient:
                 serialized.append(req)
             else:
                 serialized.append(req)
-        data: Dict[str, Any] = {"step_requirements": json.dumps(serialized), "stream": "false"}
+        data: Dict[str, Any] = {"step_requirements": json.dumps(serialized, ensure_ascii=False), "stream": "false"}
         if session_id is not None:
             data["session_id"] = session_id
         if user_id is not None:
@@ -1294,7 +1306,7 @@ class AgentOSClient:
 
         for key, value in kwargs.items():
             if isinstance(value, dict):
-                data[key] = json.dumps(value)
+                data[key] = json.dumps(value, ensure_ascii=False)
             else:
                 data[key] = value
 
@@ -1336,7 +1348,7 @@ class AgentOSClient:
                 serialized.append(req)
             else:
                 serialized.append(req)
-        data: Dict[str, Any] = {"step_requirements": json.dumps(serialized), "stream": "true"}
+        data: Dict[str, Any] = {"step_requirements": json.dumps(serialized, ensure_ascii=False), "stream": "true"}
         if session_id is not None:
             data["session_id"] = session_id
         if user_id is not None:
@@ -1344,7 +1356,7 @@ class AgentOSClient:
 
         for key, value in kwargs.items():
             if isinstance(value, dict):
-                data[key] = json.dumps(value)
+                data[key] = json.dumps(value, ensure_ascii=False)
             else:
                 data[key] = value
 
@@ -2429,7 +2441,7 @@ class AgentOSClient:
         if url:
             form_data["url"] = url
         if metadata:
-            form_data["metadata"] = json.dumps(metadata)
+            form_data["metadata"] = json.dumps(metadata, ensure_ascii=False)
         if text_content:
             form_data["text_content"] = text_content
         if reader_id:
@@ -2493,7 +2505,7 @@ class AgentOSClient:
         if description:
             form_data["description"] = description
         if metadata:
-            form_data["metadata"] = json.dumps(metadata)
+            form_data["metadata"] = json.dumps(metadata, ensure_ascii=False)
         if reader_id:
             form_data["reader_id"] = reader_id
 

--- a/libs/agno/agno/context/provider.py
+++ b/libs/agno/agno/context/provider.py
@@ -269,26 +269,26 @@ class ContextProvider(ABC):
             try:
                 agent = await provider._aget_query_agent(run_context)
             except Exception as exc:
-                yield json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+                yield json.dumps({"error": f"{type(exc).__name__}: {exc}"}, ensure_ascii=False)
                 return
 
             if agent is None:
                 try:
                     answer = await provider.aquery(question, run_context=run_context)
                 except Exception as exc:
-                    yield json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+                    yield json.dumps({"error": f"{type(exc).__name__}: {exc}"}, ensure_ascii=False)
                     return
-                yield json.dumps(serialize_answer(answer))
+                yield json.dumps(serialize_answer(answer), ensure_ascii=False)
                 return
 
             try:
                 async for chunk in provider._stream_from_agent(agent, question, run_context):
                     if isinstance(chunk, Answer):
-                        yield json.dumps(serialize_answer(chunk))
+                        yield json.dumps(serialize_answer(chunk), ensure_ascii=False)
                     else:
                         yield chunk
             except Exception as exc:
-                yield json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+                yield json.dumps({"error": f"{type(exc).__name__}: {exc}"}, ensure_ascii=False)
 
         return _query
 
@@ -300,32 +300,32 @@ class ContextProvider(ABC):
             try:
                 agent = await provider._aget_update_agent(run_context)
             except NotImplementedError:
-                yield json.dumps({"error": f"{provider.name} is read-only"})
+                yield json.dumps({"error": f"{provider.name} is read-only"}, ensure_ascii=False)
                 return
             except Exception as exc:
-                yield json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+                yield json.dumps({"error": f"{type(exc).__name__}: {exc}"}, ensure_ascii=False)
                 return
 
             if agent is None:
                 try:
                     answer = await provider.aupdate(instruction, run_context=run_context)
                 except NotImplementedError:
-                    yield json.dumps({"error": f"{provider.name} is read-only"})
+                    yield json.dumps({"error": f"{provider.name} is read-only"}, ensure_ascii=False)
                     return
                 except Exception as exc:
-                    yield json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+                    yield json.dumps({"error": f"{type(exc).__name__}: {exc}"}, ensure_ascii=False)
                     return
-                yield json.dumps(serialize_answer(answer))
+                yield json.dumps(serialize_answer(answer), ensure_ascii=False)
                 return
 
             try:
                 async for chunk in provider._stream_from_agent(agent, instruction, run_context):
                     if isinstance(chunk, Answer):
-                        yield json.dumps(serialize_answer(chunk))
+                        yield json.dumps(serialize_answer(chunk), ensure_ascii=False)
                     else:
                         yield chunk
             except Exception as exc:
-                yield json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+                yield json.dumps({"error": f"{type(exc).__name__}: {exc}"}, ensure_ascii=False)
 
         return _update
 

--- a/libs/agno/agno/context/web/exa.py
+++ b/libs/agno/agno/context/web/exa.py
@@ -60,12 +60,12 @@ class ExaBackend(ContextBackend):
                 JSON with `results: [{url, title, excerpt}, ...]`.
             """
             if not backend.api_key:
-                return json.dumps({"error": "EXA_API_KEY not configured"})
+                return json.dumps({"error": "EXA_API_KEY not configured"}, ensure_ascii=False)
             try:
                 out = await backend._get_client().search_and_contents(query, num_results=max_results, text=True)
             except Exception as exc:
                 log_error(f"web_search failed: {exc}")
-                return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+                return json.dumps({"error": f"{type(exc).__name__}: {exc}"}, ensure_ascii=False)
             results = []
             for r in (getattr(out, "results", None) or [])[:max_results]:
                 results.append(
@@ -75,7 +75,7 @@ class ExaBackend(ContextBackend):
                         "excerpt": (getattr(r, "text", "") or "")[:500],
                     }
                 )
-            return json.dumps({"results": results})
+            return json.dumps({"results": results}, ensure_ascii=False)
 
         @tool(name="web_extract")
         async def web_extract(url: str) -> str:
@@ -88,16 +88,16 @@ class ExaBackend(ContextBackend):
                 JSON with `{url, content}` or `{error}`.
             """
             if not backend.api_key:
-                return json.dumps({"error": "EXA_API_KEY not configured"})
+                return json.dumps({"error": "EXA_API_KEY not configured"}, ensure_ascii=False)
             try:
                 out = await backend._get_client().get_contents([url], text=True)
             except Exception as exc:
                 log_error(f"web_extract failed for {url}: {exc}")
-                return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+                return json.dumps({"error": f"{type(exc).__name__}: {exc}"}, ensure_ascii=False)
             results = getattr(out, "results", None) or []
             if not results:
-                return json.dumps({"url": url, "content": ""})
+                return json.dumps({"url": url, "content": ""}, ensure_ascii=False)
             body = getattr(results[0], "text", "") or ""
-            return json.dumps({"url": url, "content": body[:_MAX_EXTRACT_CHARS]})
+            return json.dumps({"url": url, "content": body[:_MAX_EXTRACT_CHARS]}, ensure_ascii=False)
 
         return [web_search, web_extract]

--- a/libs/agno/agno/context/web/parallel.py
+++ b/libs/agno/agno/context/web/parallel.py
@@ -65,7 +65,7 @@ class ParallelBackend(ContextBackend):
                 JSON with `results: [{url, title, excerpts: [...]}, ...]`.
             """
             if not backend.api_key:
-                return json.dumps({"error": "PARALLEL_API_KEY not configured"})
+                return json.dumps({"error": "PARALLEL_API_KEY not configured"}, ensure_ascii=False)
             try:
                 out = await backend._get_client().search(
                     search_queries=[objective],
@@ -74,7 +74,7 @@ class ParallelBackend(ContextBackend):
                 )
             except Exception as exc:
                 log_error(f"web_search failed: {exc}")
-                return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+                return json.dumps({"error": f"{type(exc).__name__}: {exc}"}, ensure_ascii=False)
             results = []
             for r in (out.results or [])[:max_results]:
                 results.append(
@@ -84,7 +84,7 @@ class ParallelBackend(ContextBackend):
                         "excerpts": [e for e in (getattr(r, "excerpts", None) or [])][:5],
                     }
                 )
-            return json.dumps({"results": results})
+            return json.dumps({"results": results}, ensure_ascii=False)
 
         @tool(name="web_extract")
         async def web_extract(url: str) -> str:
@@ -97,7 +97,7 @@ class ParallelBackend(ContextBackend):
                 JSON with `{url, content}` or `{error}`.
             """
             if not backend.api_key:
-                return json.dumps({"error": "PARALLEL_API_KEY not configured"})
+                return json.dumps({"error": "PARALLEL_API_KEY not configured"}, ensure_ascii=False)
             try:
                 result = await backend._get_client().extract(
                     urls=[url],
@@ -105,10 +105,10 @@ class ParallelBackend(ContextBackend):
                 )
             except Exception as exc:
                 log_error(f"web_extract failed for {url}: {exc}")
-                return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+                return json.dumps({"error": f"{type(exc).__name__}: {exc}"}, ensure_ascii=False)
             if not result or not result.results:
-                return json.dumps({"url": url, "content": ""})
+                return json.dumps({"url": url, "content": ""}, ensure_ascii=False)
             body = result.results[0].full_content or ""
-            return json.dumps({"url": url, "content": body[:_MAX_EXTRACT_CHARS]})
+            return json.dumps({"url": url, "content": body[:_MAX_EXTRACT_CHARS]}, ensure_ascii=False)
 
         return [web_search, web_extract]

--- a/libs/agno/agno/context/wiki/notion_ops.py
+++ b/libs/agno/agno/context/wiki/notion_ops.py
@@ -69,7 +69,7 @@ class Manifest:
 
     def save(self, path: Path) -> None:
         path.write_text(
-            json.dumps({"entries": self.entries}, indent=2, sort_keys=True),
+            json.dumps({"entries": self.entries}, indent=2, sort_keys=True, ensure_ascii=False),
             encoding="utf-8",
         )
 

--- a/libs/agno/agno/context/wiki/provider.py
+++ b/libs/agno/agno/context/wiki/provider.py
@@ -241,12 +241,12 @@ class WikiContextProvider(ContextProvider):
                         answer = Answer(results=answer.results, text=(answer.text or "") + note)
 
                 if answer is not None:
-                    yield json.dumps(serialize_answer(answer))
+                    yield json.dumps(serialize_answer(answer), ensure_ascii=False)
                 else:
-                    yield json.dumps({})
+                    yield json.dumps({}, ensure_ascii=False)
 
             except Exception as exc:
-                yield json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+                yield json.dumps({"error": f"{type(exc).__name__}: {exc}"}, ensure_ascii=False)
 
         return _update
 

--- a/libs/agno/agno/knowledge/embedder/aws_bedrock.py
+++ b/libs/agno/agno/knowledge/embedder/aws_bedrock.py
@@ -231,7 +231,7 @@ class AwsBedrockEmbedder(Embedder):
         if self.request_params:
             request_body.update(self.request_params)
 
-        return json.dumps(request_body)
+        return json.dumps(request_body, ensure_ascii=False)
 
     def _format_multimodal_request_body(
         self,
@@ -288,7 +288,7 @@ class AwsBedrockEmbedder(Embedder):
         if self.request_params:
             request_body.update(self.request_params)
 
-        return json.dumps(request_body)
+        return json.dumps(request_body, ensure_ascii=False)
 
     def _extract_embeddings(self, response_body: Dict[str, Any]) -> List[float]:
         """

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -2232,7 +2232,7 @@ class Knowledge(RemoteKnowledge):
         if content.description:
             hash_parts.append(content.description)
         if content.metadata:
-            hash_parts.append(json.dumps(content.metadata, sort_keys=True, default=str))
+            hash_parts.append(json.dumps(content.metadata, sort_keys=True, default=str, ensure_ascii=False))
 
         remote_identity = self._build_remote_content_identity(content.remote_content)
         if remote_identity:
@@ -2301,7 +2301,7 @@ class Knowledge(RemoteKnowledge):
         if content.description:
             hash_parts.append(content.description)
         if content.metadata:
-            hash_parts.append(json.dumps(content.metadata, sort_keys=True, default=str))
+            hash_parts.append(json.dumps(content.metadata, sort_keys=True, default=str, ensure_ascii=False))
 
         # Use document's own URL if available (set by WebsiteReader)
         doc_url = document.meta_data.get("url") if document.meta_data else None

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -1040,7 +1040,7 @@ class Claude(Model):
 
                     function_def = {"name": tool_name}
                     if tool_input:
-                        function_def["arguments"] = json.dumps(tool_input)
+                        function_def["arguments"] = json.dumps(tool_input, ensure_ascii=False)
 
                     model_response.extra = model_response.extra or {}
 
@@ -1143,7 +1143,7 @@ class Claude(Model):
 
                 function_def = {"name": tool_name}
                 if tool_input:
-                    function_def["arguments"] = json.dumps(tool_input)
+                    function_def["arguments"] = json.dumps(tool_input, ensure_ascii=False)
 
                 model_response.extra = model_response.extra or {}
 

--- a/libs/agno/agno/models/aws/bedrock.py
+++ b/libs/agno/agno/models/aws/bedrock.py
@@ -754,7 +754,7 @@ class AwsBedrock(Model):
                                 "type": "function",
                                 "function": {
                                     "name": tool["toolUse"]["name"],
-                                    "arguments": json.dumps(tool["toolUse"]["input"]),
+                                    "arguments": json.dumps(tool["toolUse"]["input"], ensure_ascii=False),
                                 },
                             }
                         )

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -475,7 +475,7 @@ class Model(ABC):
                 return obj.model_dump()
             raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
-        cache_str = json.dumps(cache_data, sort_keys=True, default=_cache_default)
+        cache_str = json.dumps(cache_data, sort_keys=True, default=_cache_default, ensure_ascii=False)
         return md5(cache_str.encode()).hexdigest()
 
     def _get_model_cache_file_path(self, cache_key: str) -> Path:

--- a/libs/agno/agno/models/cerebras/cerebras.py
+++ b/libs/agno/agno/models/cerebras/cerebras.py
@@ -421,7 +421,7 @@ class Cerebras(Model):
                     "type": tool_call["type"],
                     "function": {
                         "name": tool_call["function"]["name"],
-                        "arguments": json.dumps(tool_call["function"]["arguments"])
+                        "arguments": json.dumps(tool_call["function"]["arguments"], ensure_ascii=False)
                         if isinstance(tool_call["function"]["arguments"], (dict, list))
                         else tool_call["function"]["arguments"],
                     },

--- a/libs/agno/agno/models/cerebras/cerebras_openai.py
+++ b/libs/agno/agno/models/cerebras/cerebras_openai.py
@@ -108,7 +108,7 @@ class CerebrasOpenAI(OpenAILike):
                     "type": tool_call["type"],
                     "function": {
                         "name": tool_call["function"]["name"],
-                        "arguments": json.dumps(tool_call["function"]["arguments"])
+                        "arguments": json.dumps(tool_call["function"]["arguments"], ensure_ascii=False)
                         if isinstance(tool_call["function"]["arguments"], (dict, list))
                         else tool_call["function"]["arguments"],
                     },

--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -1224,7 +1224,7 @@ class Gemini(Model):
                         "type": "function",
                         "function": {
                             "name": part.function_call.name,
-                            "arguments": json.dumps(part.function_call.args)
+                            "arguments": json.dumps(part.function_call.args, ensure_ascii=False)
                             if part.function_call.args is not None
                             else "",
                         },
@@ -1375,7 +1375,7 @@ class Gemini(Model):
                             "type": "function",
                             "function": {
                                 "name": part.function_call.name,
-                                "arguments": json.dumps(part.function_call.args)
+                                "arguments": json.dumps(part.function_call.args, ensure_ascii=False)
                                 if part.function_call.args is not None
                                 else "",
                             },

--- a/libs/agno/agno/models/google/gemini_interactions.py
+++ b/libs/agno/agno/models/google/gemini_interactions.py
@@ -708,14 +708,14 @@ class GeminiInteractions(Model):
                             model_response.images = []
                         model_response.images.append(image)
                 elif hasattr(item, "model_dump"):
-                    text_parts.append(json.dumps(item.model_dump(exclude_none=True)))
+                    text_parts.append(json.dumps(item.model_dump(exclude_none=True), ensure_ascii=False))
                 else:
                     text_parts.append(str(item))
             return ("\n".join(text_parts) if text_parts else None), is_error
         if hasattr(raw, "model_dump"):
-            return json.dumps(raw.model_dump(exclude_none=True)), is_error
+            return json.dumps(raw.model_dump(exclude_none=True), ensure_ascii=False), is_error
         try:
-            return json.dumps(raw), is_error
+            return json.dumps(raw, ensure_ascii=False), is_error
         except (TypeError, ValueError):
             return str(raw), is_error
 
@@ -765,12 +765,14 @@ class GeminiInteractions(Model):
                             model_response.images = []
                         model_response.images.append(image)
                 elif hasattr(item, "model_dump"):
-                    pending_result["text_parts"].append(json.dumps(item.model_dump(exclude_none=True)))
+                    pending_result["text_parts"].append(
+                        json.dumps(item.model_dump(exclude_none=True), ensure_ascii=False)
+                    )
                 else:
                     pending_result["text_parts"].append(str(item))
             return
         if hasattr(raw, "model_dump"):
-            pending_result["text_parts"].append(json.dumps(raw.model_dump(exclude_none=True)))
+            pending_result["text_parts"].append(json.dumps(raw.model_dump(exclude_none=True), ensure_ascii=False))
         else:
             pending_result["text_parts"].append(str(raw))
 
@@ -902,13 +904,15 @@ class GeminiInteractions(Model):
                             tool_call_error=bool(is_error) if is_error is not None else None,
                         )
                     )
-                    log_info(f"Server-side tool call: {tool_name}({json.dumps(tool_args) if tool_args else ''})")
+                    log_info(
+                        f"Server-side tool call: {tool_name}({json.dumps(tool_args, ensure_ascii=False) if tool_args else ''})"
+                    )
                     continue
 
             if isinstance(step, FunctionCallStep):
                 args = step.arguments
                 if isinstance(args, dict):
-                    args_str = json.dumps(args)
+                    args_str = json.dumps(args, ensure_ascii=False)
                 elif args is not None:
                     args_str = str(args)
                 else:
@@ -1100,7 +1104,7 @@ class GeminiInteractions(Model):
                 if step_signature:
                     tool_call["thought_signature"] = step_signature
                 args = step.arguments
-                args_buffer = json.dumps(args) if isinstance(args, dict) and args else ""
+                args_buffer = json.dumps(args, ensure_ascii=False) if isinstance(args, dict) and args else ""
                 stream_state["pending_calls"][idx] = {"tool_call": tool_call, "args_buffer": args_buffer}
 
         elif isinstance(stream_event, interaction_types.StepStop):
@@ -1154,7 +1158,9 @@ class GeminiInteractions(Model):
                     # agent/_response.py routes tool_executions into
                     # run_response.tools and emits the UI tool-call event.
                     model_response.event = ModelResponseEvent.tool_call_completed.value
-                    args_repr = json.dumps(pending_call["tool_args"]) if pending_call["tool_args"] else ""
+                    args_repr = (
+                        json.dumps(pending_call["tool_args"], ensure_ascii=False) if pending_call["tool_args"] else ""
+                    )
                     log_info(f"Server-side tool call: {pending_call['tool_name']}({args_repr})")
 
         elif isinstance(stream_event, interaction_types.InteractionCompletedEvent):
@@ -1168,7 +1174,7 @@ class GeminiInteractions(Model):
             for call_id, info in list(pending_agent_calls.items()):
                 if not info.get("is_function_call"):
                     continue
-                args_str = json.dumps(info["tool_args"]) if info["tool_args"] else "{}"
+                args_str = json.dumps(info["tool_args"], ensure_ascii=False) if info["tool_args"] else "{}"
                 tool_call = {
                     "id": call_id,
                     "type": "function",

--- a/libs/agno/agno/models/huggingface/huggingface.py
+++ b/libs/agno/agno/models/huggingface/huggingface.py
@@ -430,7 +430,9 @@ class HuggingFace(Model):
             model_response.tool_calls = [asdict(t) for t in response_message.tool_calls]
             for tool_call in model_response.tool_calls:
                 if isinstance(tool_call["function"]["arguments"], dict):
-                    tool_call["function"]["arguments"] = json.dumps(tool_call["function"]["arguments"])
+                    tool_call["function"]["arguments"] = json.dumps(
+                        tool_call["function"]["arguments"], ensure_ascii=False
+                    )
 
         try:
             if (

--- a/libs/agno/agno/models/litellm/chat.py
+++ b/libs/agno/agno/models/litellm/chat.py
@@ -507,12 +507,12 @@ class LiteLLM(Model):
                         parsed = json.loads(args)
                         # If it's not a dict, convert to a JSON string of a dict
                         if not isinstance(parsed, dict):
-                            tc_copy["function"]["arguments"] = json.dumps({"value": parsed})
+                            tc_copy["function"]["arguments"] = json.dumps({"value": parsed}, ensure_ascii=False)
                         else:
                             tc_copy["function"]["arguments"] = args
                     except json.JSONDecodeError:
                         # If not valid JSON, make it a JSON dict
-                        tc_copy["function"]["arguments"] = json.dumps({"text": args})
+                        tc_copy["function"]["arguments"] = json.dumps({"text": args}, ensure_ascii=False)
 
             result.append(tc_copy)
 

--- a/libs/agno/agno/models/ollama/chat.py
+++ b/libs/agno/agno/models/ollama/chat.py
@@ -383,7 +383,7 @@ class Ollama(Model):
 
                 function_def = {
                     "name": tool_name,
-                    "arguments": (json.dumps(tool_args) if tool_args is not None else None),
+                    "arguments": (json.dumps(tool_args, ensure_ascii=False) if tool_args is not None else None),
                 }
                 model_response.tool_calls.append({"type": "function", "function": function_def})
 
@@ -423,7 +423,7 @@ class Ollama(Model):
                     tool_args = tc.get("arguments")
                     function_def = {
                         "name": tool_name,
-                        "arguments": json.dumps(tool_args) if tool_args is not None else None,
+                        "arguments": json.dumps(tool_args, ensure_ascii=False) if tool_args is not None else None,
                     }
                     model_response.tool_calls.append({"type": "function", "function": function_def})
 

--- a/libs/agno/agno/os/interfaces/a2a/utils.py
+++ b/libs/agno/agno/os/interfaces/a2a/utils.py
@@ -164,7 +164,7 @@ async def map_a2a_request_to_run_input(request_body: dict, stream: bool = True) 
         elif isinstance(part.root, DataPart):
             import json
 
-            text_parts.append(json.dumps(part.root.data))
+            text_parts.append(json.dumps(part.root.data, ensure_ascii=False))
 
     # 3. Build and return RunInput
     complete_input_content = "\n".join(text_parts) if text_parts else ""
@@ -342,7 +342,7 @@ async def stream_a2a_response(
                 final=False,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         # 2. Send all content and secondary events
 
@@ -368,7 +368,7 @@ async def stream_a2a_response(
                 metadata={"agno_content_category": "content"},
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=message)
-            yield f"event: Message\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: Message\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         # Send tool call events
         elif isinstance(event, (ToolCallStartedEvent, TeamToolCallStartedEvent)):
@@ -378,7 +378,7 @@ async def stream_a2a_response(
                 if hasattr(event.tool, "tool_call_id") and event.tool.tool_call_id:
                     metadata["tool_call_id"] = event.tool.tool_call_id
                 if hasattr(event.tool, "tool_args") and event.tool.tool_args:
-                    metadata["tool_args"] = json.dumps(event.tool.tool_args)
+                    metadata["tool_args"] = json.dumps(event.tool.tool_args, ensure_ascii=False)
 
             status_event = TaskStatusUpdateEvent(
                 task_id=task_id,
@@ -388,7 +388,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         elif isinstance(event, (ToolCallCompletedEvent, TeamToolCallCompletedEvent)):
             metadata = {"agno_event_type": "tool_call_completed"}
@@ -397,7 +397,7 @@ async def stream_a2a_response(
                 if hasattr(event.tool, "tool_call_id") and event.tool.tool_call_id:
                     metadata["tool_call_id"] = event.tool.tool_call_id
                 if hasattr(event.tool, "tool_args") and event.tool.tool_args:
-                    metadata["tool_args"] = json.dumps(event.tool.tool_args)
+                    metadata["tool_args"] = json.dumps(event.tool.tool_args, ensure_ascii=False)
 
             status_event = TaskStatusUpdateEvent(
                 task_id=task_id,
@@ -407,7 +407,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         # Send reasoning events
         elif isinstance(event, (ReasoningStartedEvent, TeamReasoningStartedEvent)):
@@ -419,7 +419,7 @@ async def stream_a2a_response(
                 metadata={"agno_event_type": "reasoning_started"},
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         elif isinstance(event, (ReasoningStepEvent, TeamReasoningStepEvent)):
             if event.reasoning_content:
@@ -442,7 +442,7 @@ async def stream_a2a_response(
                     metadata={"agno_content_category": "reasoning", "agno_event_type": "reasoning_step"},
                 )
                 response = SendStreamingMessageSuccessResponse(id=request_id, result=reasoning_message)
-                yield f"event: Message\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+                yield f"event: Message\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         elif isinstance(event, (ReasoningCompletedEvent, TeamReasoningCompletedEvent)):
             status_event = TaskStatusUpdateEvent(
@@ -453,7 +453,7 @@ async def stream_a2a_response(
                 metadata={"agno_event_type": "reasoning_completed"},
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         # Send memory update events
         elif isinstance(event, (MemoryUpdateStartedEvent, TeamMemoryUpdateStartedEvent)):
@@ -465,7 +465,7 @@ async def stream_a2a_response(
                 metadata={"agno_event_type": "memory_update_started"},
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         elif isinstance(event, (MemoryUpdateCompletedEvent, TeamMemoryUpdateCompletedEvent)):
             status_event = TaskStatusUpdateEvent(
@@ -476,7 +476,7 @@ async def stream_a2a_response(
                 metadata={"agno_event_type": "memory_update_completed"},
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         # Send workflow events
         elif isinstance(event, WorkflowStepStartedEvent):
@@ -492,7 +492,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         elif isinstance(event, WorkflowStepCompletedEvent):
             metadata = {"agno_event_type": "workflow_step_completed"}
@@ -507,7 +507,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         elif isinstance(event, WorkflowStepErrorEvent):
             metadata = {"agno_event_type": "workflow_step_error"}
@@ -524,7 +524,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         # Send loop events
         elif isinstance(event, LoopExecutionStartedEvent):
@@ -542,7 +542,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         elif isinstance(event, LoopIterationStartedEvent):
             metadata = {"agno_event_type": "loop_iteration_started"}
@@ -561,7 +561,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         elif isinstance(event, LoopIterationCompletedEvent):
             metadata = {"agno_event_type": "loop_iteration_completed"}
@@ -580,7 +580,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         elif isinstance(event, LoopExecutionCompletedEvent):
             metadata = {"agno_event_type": "loop_execution_completed"}
@@ -597,7 +597,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         # Send parallel events
         elif isinstance(event, ParallelExecutionStartedEvent):
@@ -615,7 +615,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         elif isinstance(event, ParallelExecutionCompletedEvent):
             metadata = {"agno_event_type": "parallel_execution_completed"}
@@ -632,7 +632,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         # Send condition events
         elif isinstance(event, ConditionExecutionStartedEvent):
@@ -650,7 +650,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         elif isinstance(event, ConditionExecutionCompletedEvent):
             metadata = {"agno_event_type": "condition_execution_completed"}
@@ -669,7 +669,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         # Send router events
         elif isinstance(event, RouterExecutionStartedEvent):
@@ -687,7 +687,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         elif isinstance(event, RouterExecutionCompletedEvent):
             metadata = {"agno_event_type": "router_execution_completed"}
@@ -706,7 +706,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         # Send steps events
         elif isinstance(event, StepsExecutionStartedEvent):
@@ -724,7 +724,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         elif isinstance(event, StepsExecutionCompletedEvent):
             metadata = {"agno_event_type": "steps_execution_completed"}
@@ -743,7 +743,7 @@ async def stream_a2a_response(
                 metadata=metadata,
             )
             response = SendStreamingMessageSuccessResponse(id=request_id, result=status_event)
-            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+            yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         # Capture completion event for final task construction
         elif isinstance(event, (RunCompletedEvent, TeamRunCompletedEvent, WorkflowCompletedEvent)):
@@ -775,7 +775,7 @@ async def stream_a2a_response(
             final=True,
         )
     response = SendStreamingMessageSuccessResponse(id=request_id, result=final_status_event)
-    yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+    yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
     # 4. Send final task
     # Handle cancelled case
@@ -805,7 +805,7 @@ async def stream_a2a_response(
             history=[final_message],
         )
         response = SendStreamingMessageSuccessResponse(id=request_id, result=task)
-        yield f"event: Task\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+        yield f"event: Task\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
         return
 
     # Build from completion_event if available, otherwise use accumulated content
@@ -907,7 +907,7 @@ async def stream_a2a_response(
         artifacts=artifacts if artifacts else None,
     )
     response = SendStreamingMessageSuccessResponse(id=request_id, result=task)
-    yield f"event: Task\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+    yield f"event: Task\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
 
 async def stream_a2a_response_with_error_handling(
@@ -931,7 +931,7 @@ async def stream_a2a_response_with_error_handling(
             final=True,
         )
         response = SendStreamingMessageSuccessResponse(id=request_id, result=failed_status_event)
-        yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+        yield f"event: TaskStatusUpdateEvent\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"
 
         # Send failed Task
         error_message = A2AMessage(
@@ -948,4 +948,4 @@ async def stream_a2a_response_with_error_handling(
         )
 
         response = SendStreamingMessageSuccessResponse(id=request_id, result=failed_task)
-        yield f"event: Task\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+        yield f"event: Task\ndata: {json.dumps(response.model_dump(exclude_none=True), ensure_ascii=False)}\n\n"

--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -173,7 +173,7 @@ def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[
         ToolCallArgsEvent(
             type=EventType.TOOL_CALL_ARGS,
             tool_call_id=tool.tool_call_id,
-            delta=json.dumps(tool.tool_args),
+            delta=json.dumps(tool.tool_args, ensure_ascii=False),
         )
     )
 
@@ -394,7 +394,7 @@ def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
                 ToolCallArgsEvent(
                     type=EventType.TOOL_CALL_ARGS,
                     tool_call_id=tool.tool_call_id,
-                    delta=json.dumps(tool.tool_args),
+                    delta=json.dumps(tool.tool_args, ensure_ascii=False),
                 )
             )
 

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -21,9 +21,9 @@ def to_json_str(value: Optional[str]) -> str:
     # Handles: "{'a': 1}" → {"a": 1}, "True" → true, "None" → null
     try:
         obj = ast.literal_eval(value)
-        return json.dumps(obj)
+        return json.dumps(obj, ensure_ascii=False)
     except (ValueError, SyntaxError):
         pass
 
     # 3. Plain string — wrap as JSON string literal
-    return json.dumps(value)
+    return json.dumps(value, ensure_ascii=False)

--- a/libs/agno/agno/os/interfaces/slack/builders.py
+++ b/libs/agno/agno/os/interfaces/slack/builders.py
@@ -55,7 +55,7 @@ def render_arg_value(value: Any) -> str:
     if isinstance(value, str):
         return value
     try:
-        return json.dumps(value, default=json_serializer)
+        return json.dumps(value, default=json_serializer, ensure_ascii=False)
     except (TypeError, ValueError):
         return str(value)
 
@@ -91,7 +91,9 @@ def _build_text_input(name: str, field_type: Any, initial_raw: Any) -> PlainText
     multiline = type_name in ("list", "dict")
     initial_value: Optional[str] = None
     if initial_raw is not None:
-        initial_value = initial_raw if isinstance(initial_raw, str) else json.dumps(initial_raw, default=str)
+        initial_value = (
+            initial_raw if isinstance(initial_raw, str) else json.dumps(initial_raw, default=str, ensure_ascii=False)
+        )
     return PlainTextInputElement(
         action_id=user_input_action_id(name),
         placeholder=PlainTextObject(text=f"Enter {name}"),

--- a/libs/agno/agno/os/managers.py
+++ b/libs/agno/agno/os/managers.py
@@ -80,7 +80,9 @@ class WebSocketHandler:
             if run_id and "run_id" not in data:
                 data["run_id"] = run_id
 
-            await self.websocket.send_text(self.format_sse_event(json.dumps(data, default=json_serializer)))
+            await self.websocket.send_text(
+                self.format_sse_event(json.dumps(data, default=json_serializer, ensure_ascii=False))
+            )
 
         except RuntimeError as e:
             if "websocket.close" in str(e).lower() or "already completed" in str(e).lower():
@@ -127,7 +129,8 @@ class WebSocketManager:
                         else "Connected to AgentOS."
                     ),
                     "requires_auth": requires_auth,
-                }
+                },
+                ensure_ascii=False,
             )
         )
 
@@ -142,7 +145,8 @@ class WebSocketManager:
                 {
                     "event": "authenticated",
                     "message": "Authentication successful. You can now send commands.",
-                }
+                },
+                ensure_ascii=False,
             )
         )
 

--- a/libs/agno/agno/os/mcp_auth_builtin.py
+++ b/libs/agno/agno/os/mcp_auth_builtin.py
@@ -565,7 +565,7 @@ class AgentOSBuiltinAuth(OAuthProvider):
         self._require_db().store_mcp_oauth_transaction(
             txn_id=txn_id,
             client_id=client_id,
-            params=json.dumps(payload),
+            params=json.dumps(payload, ensure_ascii=False),
             expires_at=now + DEFAULT_TRANSACTION_TTL,
             now=now,
             max_pending=self._max_pending_transactions,
@@ -712,7 +712,7 @@ class AgentOSBuiltinAuth(OAuthProvider):
                 )
             body["token_endpoint_auth_method"] = "none"
 
-        raw = json.dumps(body).encode()
+        raw = json.dumps(body, ensure_ascii=False).encode()
 
         async def receive() -> Dict[str, Any]:
             return {"type": "http.request", "body": raw, "more_body": False}
@@ -918,7 +918,10 @@ button {{ padding: .5rem 1.25rem; border-radius: 6px; border: 0; cursor: pointer
             "scopes": self._grant_scopes,
         }
         self._require_db().store_mcp_oauth_code(
-            code_hash=_hash(code), payload=json.dumps(payload), expires_at=now + self._auth_code_ttl, now=now
+            code_hash=_hash(code),
+            payload=json.dumps(payload, ensure_ascii=False),
+            expires_at=now + self._auth_code_ttl,
+            now=now,
         )
 
     async def load_authorization_code(
@@ -994,7 +997,7 @@ button {{ padding: .5rem 1.25rem; border-radius: 6px; border: 0; cursor: pointer
         self._require_db().store_mcp_oauth_refresh(
             token_hash=_hash(refresh_token),
             client_id=client_id,
-            scopes=json.dumps(scopes),
+            scopes=json.dumps(scopes, ensure_ascii=False),
             expires_at=now + self._refresh_token_ttl,
             now=now,
             family_id=family_id,

--- a/libs/agno/agno/os/mcp_results.py
+++ b/libs/agno/agno/os/mcp_results.py
@@ -95,7 +95,7 @@ def _paused_requirements(run_output: AnyRunOutput) -> Optional[List[Dict[str, An
 
 def _json_safe(data: Dict[str, Any]) -> Dict[str, Any]:
     """Force a dict through JSON so enum/datetime leftovers cannot break the transport."""
-    return json.loads(json.dumps(data, default=json_serializer))
+    return json.loads(json.dumps(data, default=json_serializer, ensure_ascii=False))
 
 
 def trimmed_structured_content(run_output: AnyRunOutput) -> Dict[str, Any]:

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -374,7 +374,9 @@ def get_websocket_router(
                 if action == "authenticate":
                     token = message.get("token")
                     if not token:
-                        await websocket.send_text(json.dumps({"event": "auth_error", "error": "Token is required"}))
+                        await websocket.send_text(
+                            json.dumps({"event": "auth_error", "error": "Token is required"}, ensure_ascii=False)
+                        )
                         continue
 
                     if token.startswith(SERVICE_ACCOUNT_TOKEN_PREFIX):
@@ -399,7 +401,8 @@ def get_websocket_router(
                                         "event": "authenticated",
                                         "message": "Service account authentication successful.",
                                         "user_id": account.principal,
-                                    }
+                                    },
+                                    ensure_ascii=False,
                                 )
                             )
                         else:
@@ -408,7 +411,9 @@ def get_websocket_router(
                                 error_msg = "Too many failed authentication attempts"
                             elif verification is not None and verification.status == VerificationStatus.UNAVAILABLE:
                                 error_msg = "Authentication is temporarily unavailable"
-                            await websocket.send_text(json.dumps({"event": "auth_error", "error": error_msg}))
+                            await websocket.send_text(
+                                json.dumps({"event": "auth_error", "error": error_msg}, ensure_ascii=False)
+                            )
                         continue
 
                     if jwt_auth_required and not jwt_auth_enabled:
@@ -421,7 +426,8 @@ def get_websocket_router(
                                     "event": "auth_error",
                                     "error": "JWT authentication is misconfigured on the server",
                                     "error_type": "server_error",
-                                }
+                                },
+                                ensure_ascii=False,
                             )
                         )
                         continue
@@ -448,7 +454,8 @@ def get_websocket_router(
                                             "event": "auth_error",
                                             "error": "Invalid token subject",
                                             "error_type": "invalid_token",
-                                        }
+                                        },
+                                        ensure_ascii=False,
                                     )
                                 )
                                 continue
@@ -466,21 +473,27 @@ def get_websocket_router(
                                         "event": "authenticated",
                                         "message": "JWT authentication successful.",
                                         "user_id": claims["user_id"],
-                                    }
+                                    },
+                                    ensure_ascii=False,
                                 )
                             )
                         except Exception as e:
                             error_msg = str(e) if str(e) else "Invalid token"
                             error_type = "expired" if "expired" in error_msg.lower() else "invalid_token"
                             await websocket.send_text(
-                                json.dumps({"event": "auth_error", "error": error_msg, "error_type": error_type})
+                                json.dumps(
+                                    {"event": "auth_error", "error": error_msg, "error_type": error_type},
+                                    ensure_ascii=False,
+                                )
                             )
                         continue
                     elif validate_websocket_token(token, settings):
                         # Legacy os_security_key authentication
                         await websocket_manager.authenticate_websocket(websocket)
                     else:
-                        await websocket.send_text(json.dumps({"event": "auth_error", "error": "Invalid token"}))
+                        await websocket.send_text(
+                            json.dumps({"event": "auth_error", "error": "Invalid token"}, ensure_ascii=False)
+                        )
                     continue
 
                 # Check authentication for all other actions (only when required)
@@ -491,14 +504,15 @@ def get_websocket_router(
                             {
                                 "event": "auth_required",
                                 "error": f"Authentication required. Send authenticate action with valid {auth_type}.",
-                            }
+                            },
+                            ensure_ascii=False,
                         )
                     )
                     continue
 
                 # Handle authenticated actions
                 elif action == "ping":
-                    await websocket.send_text(json.dumps({"event": "pong"}))
+                    await websocket.send_text(json.dumps({"event": "pong"}, ensure_ascii=False))
 
                 elif action == "start-workflow":
                     # Enforce workflow-level RBAC whenever scope enforcement is
@@ -519,7 +533,10 @@ def get_websocket_router(
                             admin_scope=ws_admin_scope,
                         ):
                             await websocket.send_text(
-                                json.dumps({"event": "error", "error": "Insufficient permissions to run this workflow"})
+                                json.dumps(
+                                    {"event": "error", "error": "Insufficient permissions to run this workflow"},
+                                    ensure_ascii=False,
+                                )
                             )
                             continue
 
@@ -565,7 +582,8 @@ def get_websocket_router(
                                     {
                                         "event": "error",
                                         "error": WORKFLOW_ID_REQUIRED_RECONNECT,
-                                    }
+                                    },
+                                    ensure_ascii=False,
                                 )
                             )
                             continue
@@ -583,7 +601,8 @@ def get_websocket_router(
                                     {
                                         "event": "error",
                                         "error": INSUFFICIENT_PERMISSIONS_WS_RECONNECT,
-                                    }
+                                    },
+                                    ensure_ascii=False,
                                 )
                             )
                             continue
@@ -611,7 +630,8 @@ def get_websocket_router(
                         ):
                             await websocket.send_text(
                                 json.dumps(
-                                    {"event": "error", "error": "Insufficient permissions to continue this workflow"}
+                                    {"event": "error", "error": "Insufficient permissions to continue this workflow"},
+                                    ensure_ascii=False,
                                 )
                             )
                             continue
@@ -636,7 +656,9 @@ def get_websocket_router(
                     await handle_workflow_continue_via_websocket(websocket, message, os, ws_auth=ws_auth)
 
                 else:
-                    await websocket.send_text(json.dumps({"event": "error", "error": f"Unknown action: {action}"}))
+                    await websocket.send_text(
+                        json.dumps({"event": "error", "error": f"Unknown action: {action}"}, ensure_ascii=False)
+                    )
 
         except Exception as e:
             if "1012" not in str(e) and "1001" not in str(e):

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -368,7 +368,7 @@ async def _resume_stream_generator(
                 run_output = await agent.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)
             except Exception as e:
                 error = {"event": "error", "error": f"Failed to fetch run from database: {str(e)}"}
-                yield f"event: error\ndata: {json.dumps(error)}\n\n"
+                yield f"event: error\ndata: {json.dumps(error, ensure_ascii=False)}\n\n"
                 return
             if run_output and run_output.events:
                 meta: dict = {
@@ -378,7 +378,7 @@ async def _resume_stream_generator(
                     "total_events": len(run_output.events),
                     "message": "Run completed. Replaying all events from database.",
                 }
-                yield f"event: replay\ndata: {json.dumps(meta)}\n\n"
+                yield f"event: replay\ndata: {json.dumps(meta, ensure_ascii=False)}\n\n"
 
                 for idx, event in enumerate(run_output.events):
                     event_dict = event.to_dict()
@@ -396,12 +396,12 @@ async def _resume_stream_generator(
                     "total_events": 0,
                     "message": "Run completed but no events stored.",
                 }
-                yield f"event: replay\ndata: {json.dumps(meta)}\n\n"
+                yield f"event: replay\ndata: {json.dumps(meta, ensure_ascii=False)}\n\n"
                 return
 
         # Run not found anywhere
         error = {"event": "error", "error": f"Run {run_id} not found in buffer or database"}
-        yield f"event: error\ndata: {json.dumps(error)}\n\n"
+        yield f"event: error\ndata: {json.dumps(error, ensure_ascii=False)}\n\n"
         return
 
     if buffer_status in (RunStatus.completed, RunStatus.error, RunStatus.cancelled, RunStatus.paused):
@@ -423,7 +423,7 @@ async def _resume_stream_generator(
             "last_event_index_requested": last_event_index if last_event_index is not None else -1,
             "message": f"Run {buffer_status.value}. Replaying {len(missed_events)} missed events (of {total_buffered} total).",
         }
-        yield f"event: replay\ndata: {json.dumps(meta)}\n\n"
+        yield f"event: replay\ndata: {json.dumps(meta, ensure_ascii=False)}\n\n"
 
         for ev_index, buffered_event in missed_events:
             event_dict = buffered_event.to_dict()
@@ -453,7 +453,7 @@ async def _resume_stream_generator(
                 "current_event_count": current_count,
                 "message": f"Catching up on {len(missed_events)} missed events.",
             }
-            yield f"event: catch_up\ndata: {json.dumps(meta)}\n\n"
+            yield f"event: catch_up\ndata: {json.dumps(meta, ensure_ascii=False)}\n\n"
 
             for ev_index, buffered_event in missed_events:
                 event_dict = buffered_event.to_dict()
@@ -490,7 +490,7 @@ async def _resume_stream_generator(
             "current_event_count": current_count,
             "message": "Subscribed to agent run. Receiving live events.",
         }
-        yield f"event: subscribed\ndata: {json.dumps(subscribed)}\n\n"
+        yield f"event: subscribed\ndata: {json.dumps(subscribed, ensure_ascii=False)}\n\n"
 
         log_debug(f"SSE client subscribed to agent run {run_id} (last_event_index: {last_event_index})")
 

--- a/libs/agno/agno/os/routers/memory/schemas.py
+++ b/libs/agno/agno/os/routers/memory/schemas.py
@@ -34,7 +34,7 @@ class UserMemorySchema(BaseModel):
                 memory = str(memory_dict["memory"]["memory"])
             else:
                 try:
-                    memory = json.dumps(memory_dict["memory"])
+                    memory = json.dumps(memory_dict["memory"], ensure_ascii=False)
                 except json.JSONDecodeError:
                     memory = str(memory_dict["memory"])
         else:

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -238,7 +238,7 @@ async def _resume_stream_generator(
                 run_output = await team.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)
             except Exception as e:
                 error = {"event": "error", "error": f"Failed to fetch run from database: {str(e)}"}
-                yield f"event: error\ndata: {json.dumps(error)}\n\n"
+                yield f"event: error\ndata: {json.dumps(error, ensure_ascii=False)}\n\n"
                 return
             if run_output and run_output.events:
                 meta: dict = {
@@ -248,7 +248,7 @@ async def _resume_stream_generator(
                     "total_events": len(run_output.events),
                     "message": "Run completed. Replaying all events from database.",
                 }
-                yield f"event: replay\ndata: {json.dumps(meta)}\n\n"
+                yield f"event: replay\ndata: {json.dumps(meta, ensure_ascii=False)}\n\n"
 
                 for idx, event in enumerate(run_output.events):
                     event_dict = event.to_dict()
@@ -266,12 +266,12 @@ async def _resume_stream_generator(
                     "total_events": 0,
                     "message": "Run completed but no events stored.",
                 }
-                yield f"event: replay\ndata: {json.dumps(meta)}\n\n"
+                yield f"event: replay\ndata: {json.dumps(meta, ensure_ascii=False)}\n\n"
                 return
 
         # Run not found anywhere
         error = {"event": "error", "error": f"Run {run_id} not found in buffer or database"}
-        yield f"event: error\ndata: {json.dumps(error)}\n\n"
+        yield f"event: error\ndata: {json.dumps(error, ensure_ascii=False)}\n\n"
         return
 
     if buffer_status in (RunStatus.completed, RunStatus.error, RunStatus.cancelled, RunStatus.paused):
@@ -293,7 +293,7 @@ async def _resume_stream_generator(
             "last_event_index_requested": last_event_index if last_event_index is not None else -1,
             "message": f"Run {buffer_status.value}. Replaying {len(missed_events)} missed events (of {total_buffered} total).",
         }
-        yield f"event: replay\ndata: {json.dumps(meta)}\n\n"
+        yield f"event: replay\ndata: {json.dumps(meta, ensure_ascii=False)}\n\n"
 
         for ev_index, buffered_event in missed_events:
             event_dict = buffered_event.to_dict()
@@ -323,7 +323,7 @@ async def _resume_stream_generator(
                 "current_event_count": current_count,
                 "message": f"Catching up on {len(missed_events)} missed events.",
             }
-            yield f"event: catch_up\ndata: {json.dumps(meta)}\n\n"
+            yield f"event: catch_up\ndata: {json.dumps(meta, ensure_ascii=False)}\n\n"
 
             for ev_index, buffered_event in missed_events:
                 event_dict = buffered_event.to_dict()
@@ -360,7 +360,7 @@ async def _resume_stream_generator(
             "current_event_count": current_count,
             "message": "Subscribed to team run. Receiving live events.",
         }
-        yield f"event: subscribed\ndata: {json.dumps(subscribed)}\n\n"
+        yield f"event: subscribed\ndata: {json.dumps(subscribed, ensure_ascii=False)}\n\n"
 
         log_debug(f"SSE client subscribed to team run {run_id} (last_event_index: {last_event_index})")
 

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -95,7 +95,9 @@ async def handle_workflow_via_websocket(
                     user_id = jwt_user_id
 
         if not workflow_id:
-            await websocket.send_text(json.dumps({"event": "error", "error": "workflow_id is required"}))
+            await websocket.send_text(
+                json.dumps({"event": "error", "error": "workflow_id is required"}, ensure_ascii=False)
+            )
             return
 
         # Get workflow from OS — supports both static and factory components
@@ -130,7 +132,9 @@ async def handle_workflow_via_websocket(
                     ctx=ctx,
                 )
             except Exception as e:
-                await websocket.send_text(json.dumps({"event": "error", "error": f"Factory error: {e}"}))
+                await websocket.send_text(
+                    json.dumps({"event": "error", "error": f"Factory error: {e}"}, ensure_ascii=False)
+                )
                 return
         else:
             try:
@@ -138,15 +142,21 @@ async def handle_workflow_via_websocket(
                     workflow_id=workflow_id, workflows=os.workflows, db=os.db, registry=os.registry, create_fresh=True
                 )
             except Exception as e:
-                await websocket.send_text(json.dumps({"event": "error", "error": f"Error resolving workflow: {e}"}))
+                await websocket.send_text(
+                    json.dumps({"event": "error", "error": f"Error resolving workflow: {e}"}, ensure_ascii=False)
+                )
                 return
         if not workflow:
-            await websocket.send_text(json.dumps({"event": "error", "error": f"Workflow {workflow_id} not found"}))
+            await websocket.send_text(
+                json.dumps({"event": "error", "error": f"Workflow {workflow_id} not found"}, ensure_ascii=False)
+            )
             return
 
         if isinstance(workflow, RemoteWorkflow):
             await websocket.send_text(
-                json.dumps({"event": "error", "error": "Remote workflows are not supported via WebSocket"})
+                json.dumps(
+                    {"event": "error", "error": "Remote workflows are not supported via WebSocket"}, ensure_ascii=False
+                )
             )
             return
 
@@ -183,7 +193,8 @@ async def handle_workflow_via_websocket(
                     "error_type": e.type,
                     "error_id": e.error_id,
                     "additional_data": e.additional_data,
-                }
+                },
+                ensure_ascii=False,
             )
         )
     except Exception as e:
@@ -195,7 +206,7 @@ async def handle_workflow_via_websocket(
             "error_id": e.error_id if hasattr(e, "error_id") else None,
         }
         error_payload = {k: v for k, v in error_payload.items() if v is not None}
-        await websocket.send_text(json.dumps(error_payload))
+        await websocket.send_text(json.dumps(error_payload, ensure_ascii=False))
 
 
 @dataclass
@@ -239,7 +250,9 @@ async def handle_workflow_subscription(
         user_isolation_enabled = ctx.user_isolation_enabled
 
         if not run_id:
-            await websocket.send_text(json.dumps({"event": "error", "error": "run_id is required for subscription"}))
+            await websocket.send_text(
+                json.dumps({"event": "error", "error": "run_id is required for subscription"}, ensure_ascii=False)
+            )
             return
 
         # Non-admin JWT callers must prove session ownership before any replay or
@@ -255,7 +268,8 @@ async def handle_workflow_subscription(
                         {
                             "event": "error",
                             "error": SESSION_ID_REQUIRED_RECONNECT,
-                        }
+                        },
+                        ensure_ascii=False,
                     )
                 )
                 return
@@ -270,7 +284,8 @@ async def handle_workflow_subscription(
                         {
                             "event": "error",
                             "error": WORKFLOW_ID_REQUIRED_RECONNECT,
-                        }
+                        },
+                        ensure_ascii=False,
                     )
                 )
                 return
@@ -286,7 +301,9 @@ async def handle_workflow_subscription(
                 )
             except HTTPException:
                 # Mask existence of another user's run.
-                await websocket.send_text(json.dumps({"event": "error", "error": f"Run {run_id} not found"}))
+                await websocket.send_text(
+                    json.dumps({"event": "error", "error": f"Run {run_id} not found"}, ensure_ascii=False)
+                )
                 return
 
         # Check if run exists in event buffer
@@ -319,7 +336,8 @@ async def handle_workflow_subscription(
                                         "status": workflow_run.status.value if workflow_run.status else "unknown",
                                         "total_events": len(workflow_run.events),
                                         "message": "Run completed. Replaying all events from database.",
-                                    }
+                                    },
+                                    ensure_ascii=False,
                                 )
                             )
 
@@ -331,7 +349,9 @@ async def handle_workflow_subscription(
                                 if "run_id" not in event_dict:
                                     event_dict["run_id"] = run_id
 
-                                await websocket.send_text(json.dumps(event_dict, default=json_serializer))
+                                await websocket.send_text(
+                                    json.dumps(event_dict, default=json_serializer, ensure_ascii=False)
+                                )
                         else:
                             await websocket.send_text(
                                 json.dumps(
@@ -341,14 +361,17 @@ async def handle_workflow_subscription(
                                         "status": workflow_run.status.value if workflow_run.status else "unknown",
                                         "total_events": 0,
                                         "message": "Run completed but no events stored.",
-                                    }
+                                    },
+                                    ensure_ascii=False,
                                 )
                             )
                         return
 
             # Run not found anywhere
             await websocket.send_text(
-                json.dumps({"event": "error", "error": f"Run {run_id} not found in buffer or database"})
+                json.dumps(
+                    {"event": "error", "error": f"Run {run_id} not found in buffer or database"}, ensure_ascii=False
+                )
             )
             return
 
@@ -365,7 +388,8 @@ async def handle_workflow_subscription(
                         "status": buffer_status.value,
                         "total_events": len(all_events),
                         "message": f"Run {buffer_status.value}. Replaying all events.",
-                    }
+                    },
+                    ensure_ascii=False,
                 )
             )
 
@@ -379,7 +403,7 @@ async def handle_workflow_subscription(
                 if "run_id" not in event_dict:
                     event_dict["run_id"] = run_id
 
-                await websocket.send_text(json.dumps(event_dict))
+                await websocket.send_text(json.dumps(event_dict, ensure_ascii=False))
             return
 
         # Run is still active - send missed events and subscribe to new ones
@@ -397,7 +421,8 @@ async def handle_workflow_subscription(
                         "missed_events": len(missed_events),
                         "current_event_count": current_event_count,
                         "message": f"Catching up on {len(missed_events)} missed events.",
-                    }
+                    },
+                    ensure_ascii=False,
                 )
             )
 
@@ -411,7 +436,7 @@ async def handle_workflow_subscription(
                 if "run_id" not in event_dict:
                     event_dict["run_id"] = run_id
 
-                await websocket.send_text(json.dumps(event_dict))
+                await websocket.send_text(json.dumps(event_dict, ensure_ascii=False))
 
         # Register websocket for future events
         await websocket_manager.register_websocket(run_id, websocket)
@@ -425,7 +450,8 @@ async def handle_workflow_subscription(
                     "status": "running",
                     "current_event_count": current_event_count,
                     "message": "Subscribed to workflow run. You will receive new events as they occur.",
-                }
+                },
+                ensure_ascii=False,
             )
         )
 
@@ -438,7 +464,8 @@ async def handle_workflow_subscription(
                 {
                     "event": "error",
                     "error": f"Subscription failed: {str(e)}",
-                }
+                },
+                ensure_ascii=False,
             )
         )
 
@@ -458,10 +485,12 @@ async def handle_workflow_continue_via_websocket(
         step_requirements_data = message.get("step_requirements")
 
         if not workflow_id:
-            await websocket.send_text(json.dumps({"event": "error", "error": "workflow_id is required"}))
+            await websocket.send_text(
+                json.dumps({"event": "error", "error": "workflow_id is required"}, ensure_ascii=False)
+            )
             return
         if not run_id:
-            await websocket.send_text(json.dumps({"event": "error", "error": "run_id is required"}))
+            await websocket.send_text(json.dumps({"event": "error", "error": "run_id is required"}, ensure_ascii=False))
             return
 
         # Enforce ownership for non-admin callers when user isolation is enabled.
@@ -469,7 +498,9 @@ async def handle_workflow_continue_via_websocket(
         # both the session and the run before we even fetch the paused state.
         if ws_auth and ws_auth.jwt_enabled and ws_auth.user_isolation_enabled and not ws_auth.is_admin and user_id:
             if not session_id:
-                await websocket.send_text(json.dumps({"event": "error", "error": SESSION_ID_REQUIRED}))
+                await websocket.send_text(
+                    json.dumps({"event": "error", "error": SESSION_ID_REQUIRED}, ensure_ascii=False)
+                )
                 return
             # Prefer the factory's db when this workflow_id is a factory entry;
             # only fall back to os.db when no factory-specific db is configured.
@@ -486,25 +517,34 @@ async def handle_workflow_continue_via_websocket(
                     component_id=workflow_id,
                 )
             except HTTPException:
-                await websocket.send_text(json.dumps({"event": "error", "error": f"Run {run_id} not found"}))
+                await websocket.send_text(
+                    json.dumps({"event": "error", "error": f"Run {run_id} not found"}, ensure_ascii=False)
+                )
                 return
 
         workflow = get_workflow_by_id(
             workflow_id=workflow_id, workflows=os.workflows, db=os.db, registry=os.registry, create_fresh=True
         )
         if not workflow:
-            await websocket.send_text(json.dumps({"event": "error", "error": f"Workflow {workflow_id} not found"}))
+            await websocket.send_text(
+                json.dumps({"event": "error", "error": f"Workflow {workflow_id} not found"}, ensure_ascii=False)
+            )
             return
         if isinstance(workflow, RemoteWorkflow):
             await websocket.send_text(
-                json.dumps({"event": "error", "error": "Continue is not supported for remote workflows via WebSocket"})
+                json.dumps(
+                    {"event": "error", "error": "Continue is not supported for remote workflows via WebSocket"},
+                    ensure_ascii=False,
+                )
             )
             return
 
         # Load the paused run
         existing_run = await workflow.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)
         if existing_run is None:
-            await websocket.send_text(json.dumps({"event": "error", "error": f"Run {run_id} not found"}))
+            await websocket.send_text(
+                json.dumps({"event": "error", "error": f"Run {run_id} not found"}, ensure_ascii=False)
+            )
             return
         if not getattr(existing_run, "is_paused", False):
             status = getattr(existing_run, "status", None)
@@ -513,7 +553,8 @@ async def handle_workflow_continue_via_websocket(
                     {
                         "event": "error",
                         "error": f"Run is not paused (status={getattr(status, 'value', status)})",
-                    }
+                    },
+                    ensure_ascii=False,
                 )
             )
             return
@@ -527,7 +568,7 @@ async def handle_workflow_continue_via_websocket(
                 existing_run.step_requirements = parsed_requirements
             except Exception as e:
                 await websocket.send_text(
-                    json.dumps({"event": "error", "error": f"Invalid step_requirements: {str(e)}"})
+                    json.dumps({"event": "error", "error": f"Invalid step_requirements: {str(e)}"}, ensure_ascii=False)
                 )
                 return
 
@@ -553,7 +594,8 @@ async def handle_workflow_continue_via_websocket(
                     "error_type": e.type,
                     "error_id": e.error_id,
                     "additional_data": e.additional_data,
-                }
+                },
+                ensure_ascii=False,
             )
         )
     except Exception as e:
@@ -565,7 +607,7 @@ async def handle_workflow_continue_via_websocket(
             "error_id": e.error_id if hasattr(e, "error_id") else None,
         }
         error_payload = {k: v for k, v in error_payload.items() if v is not None}
-        await websocket.send_text(json.dumps(error_payload))
+        await websocket.send_text(json.dumps(error_payload, ensure_ascii=False))
 
 
 async def workflow_response_streamer(
@@ -633,7 +675,7 @@ async def workflow_response_streamer(
 
                 # Legacy WorkflowRunOutput event for backwards compatibility
                 run_dict = _last_run.to_dict()
-                run_json = json.dumps(run_dict, default=json_serializer, separators=(",", ":"))
+                run_json = json.dumps(run_dict, default=json_serializer, separators=(",", ":"), ensure_ascii=False)
                 yield f"event: WorkflowRunOutput\ndata: {run_json}\n\n"
 
     except (InputCheckError, OutputCheckError) as e:
@@ -776,7 +818,7 @@ async def workflow_continue_response_streamer(
 
                 # Legacy WorkflowRunOutput event for backwards compatibility
                 run_dict = _last_run.to_dict()
-                run_json = json.dumps(run_dict, default=json_serializer, separators=(",", ":"))
+                run_json = json.dumps(run_dict, default=json_serializer, separators=(",", ":"), ensure_ascii=False)
                 yield f"event: WorkflowRunOutput\ndata: {run_json}\n\n"
 
     except (InputCheckError, OutputCheckError) as e:
@@ -827,7 +869,7 @@ async def _resume_stream_generator(
                 run_output = await workflow.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)
             except Exception as e:
                 error = {"event": "error", "error": f"Failed to fetch run from database: {str(e)}"}
-                yield f"event: error\ndata: {json.dumps(error)}\n\n"
+                yield f"event: error\ndata: {json.dumps(error, ensure_ascii=False)}\n\n"
                 return
             if run_output and run_output.events:
                 meta: dict = {
@@ -837,7 +879,7 @@ async def _resume_stream_generator(
                     "total_events": len(run_output.events),
                     "message": "Run completed. Replaying all events from database.",
                 }
-                yield f"event: replay\ndata: {json.dumps(meta)}\n\n"
+                yield f"event: replay\ndata: {json.dumps(meta, ensure_ascii=False)}\n\n"
 
                 for idx, event in enumerate(run_output.events):
                     event_dict = event.to_dict()
@@ -855,12 +897,12 @@ async def _resume_stream_generator(
                     "total_events": 0,
                     "message": "Run completed but no events stored.",
                 }
-                yield f"event: replay\ndata: {json.dumps(meta)}\n\n"
+                yield f"event: replay\ndata: {json.dumps(meta, ensure_ascii=False)}\n\n"
                 return
 
         # Run not found anywhere
         error = {"event": "error", "error": f"Run {run_id} not found in buffer or database"}
-        yield f"event: error\ndata: {json.dumps(error)}\n\n"
+        yield f"event: error\ndata: {json.dumps(error, ensure_ascii=False)}\n\n"
         return
 
     if buffer_status in (RunStatus.completed, RunStatus.error, RunStatus.cancelled, RunStatus.paused):
@@ -882,7 +924,7 @@ async def _resume_stream_generator(
             "last_event_index_requested": last_event_index if last_event_index is not None else -1,
             "message": f"Run {buffer_status.value}. Replaying {len(missed_events)} missed events (of {total_buffered} total).",
         }
-        yield f"event: replay\ndata: {json.dumps(meta)}\n\n"
+        yield f"event: replay\ndata: {json.dumps(meta, ensure_ascii=False)}\n\n"
 
         for ev_index, buffered_event in missed_events:
             event_dict = buffered_event.to_dict()
@@ -912,7 +954,7 @@ async def _resume_stream_generator(
                 "current_event_count": current_count,
                 "message": f"Catching up on {len(missed_events)} missed events.",
             }
-            yield f"event: catch_up\ndata: {json.dumps(meta)}\n\n"
+            yield f"event: catch_up\ndata: {json.dumps(meta, ensure_ascii=False)}\n\n"
 
             for ev_index, buffered_event in missed_events:
                 event_dict = buffered_event.to_dict()

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -490,7 +490,7 @@ def get_session_name(session: Dict[str, Any]) -> str:
             return workflow_input
         elif isinstance(workflow_input, dict):
             try:
-                return json.dumps(workflow_input)
+                return json.dumps(workflow_input, ensure_ascii=False)
             except (TypeError, ValueError):
                 pass
         workflow_name = session.get("workflow_data", {}).get("name")
@@ -1947,14 +1947,14 @@ def stringify_input_content(input_content: Union[str, Dict[str, Any], List[Any],
     if isinstance(input_content, str):
         return input_content
     elif isinstance(input_content, Message):
-        return json.dumps(input_content.to_dict())
+        return json.dumps(input_content.to_dict(), ensure_ascii=False)
     elif isinstance(input_content, dict):
-        return json.dumps(input_content, indent=2, default=str)
+        return json.dumps(input_content, indent=2, default=str, ensure_ascii=False)
     elif isinstance(input_content, list):
         if input_content:
             # Handle live Message objects
             if isinstance(input_content[0], Message):
-                return json.dumps([m.to_dict() for m in input_content])
+                return json.dumps([m.to_dict() for m in input_content], ensure_ascii=False)
             # Handle serialized Message dicts
             elif isinstance(input_content[0], dict) and input_content[0].get("role") == "user":
                 return input_content[0].get("content", str(input_content))

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -842,9 +842,9 @@ class RunOutput:
             raise
 
         if indent is None:
-            return json.dumps(_dict, separators=separators)
+            return json.dumps(_dict, separators=separators, ensure_ascii=False)
         else:
-            return json.dumps(_dict, indent=indent, separators=separators)
+            return json.dumps(_dict, indent=indent, separators=separators, ensure_ascii=False)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "RunOutput":
@@ -954,4 +954,4 @@ class RunOutput:
             return self.content.model_dump_json(exclude_none=True, **kwargs)
         else:
             kwargs.setdefault("ensure_ascii", False)
-            return json.dumps(self.content, **kwargs)
+            return json.dumps(self.content, **kwargs, ensure_ascii=False)

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -941,9 +941,9 @@ class TeamRunOutput:
             raise
 
         if indent is None:
-            return json.dumps(_dict, separators=separators)
+            return json.dumps(_dict, separators=separators, ensure_ascii=False)
         else:
-            return json.dumps(_dict, indent=indent, separators=separators)
+            return json.dumps(_dict, indent=indent, separators=separators, ensure_ascii=False)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "TeamRunOutput":
@@ -1053,7 +1053,7 @@ class TeamRunOutput:
             return self.content.model_dump_json(exclude_none=True, **kwargs)
         else:
             kwargs.setdefault("ensure_ascii", False)
-            return json.dumps(self.content, **kwargs)
+            return json.dumps(self.content, **kwargs, ensure_ascii=False)
 
     def add_member_run(self, run_response: Union["TeamRunOutput", RunOutput]) -> None:
         self.member_responses.append(run_response)

--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -1077,7 +1077,7 @@ class WorkflowRunOutput:
             return self.content.model_dump_json(exclude_none=True, **kwargs)
         else:
             kwargs.setdefault("ensure_ascii", False)
-            return json.dumps(self.content, **kwargs)
+            return json.dumps(self.content, **kwargs, ensure_ascii=False)
 
     def has_completed(self) -> bool:
         """Check if the workflow run is completed (either successfully or with error)"""

--- a/libs/agno/agno/skills/agent_skills.py
+++ b/libs/agno/agno/skills/agent_skills.py
@@ -200,7 +200,8 @@ class Skills:
                 {
                     "error": f"Skill '{skill_name}' not found",
                     "available_skills": available,
-                }
+                },
+                ensure_ascii=False,
             )
 
         return json.dumps(
@@ -210,7 +211,8 @@ class Skills:
                 "instructions": skill.instructions,
                 "available_scripts": skill.scripts,
                 "available_references": skill.references,
-            }
+            },
+            ensure_ascii=False,
         )
 
     def _get_skill_reference(self, skill_name: str, reference_path: Optional[str] = None) -> str:
@@ -230,7 +232,8 @@ class Skills:
                 {
                     "error": f"Skill '{skill_name}' not found",
                     "available_skills": available,
-                }
+                },
+                ensure_ascii=False,
             )
 
         if not reference_path:
@@ -239,7 +242,8 @@ class Skills:
                     "error": f"A reference_path is required to read a reference from skill '{skill_name}'",
                     "skill_name": skill_name,
                     "available_references": skill.references,
-                }
+                },
+                ensure_ascii=False,
             )
 
         if reference_path not in skill.references:
@@ -247,7 +251,8 @@ class Skills:
                 {
                     "error": f"Reference '{reference_path}' not found in skill '{skill_name}'",
                     "available_references": skill.references,
-                }
+                },
+                ensure_ascii=False,
             )
 
         # Validate and resolve path to prevent path traversal attacks
@@ -259,7 +264,8 @@ class Skills:
                 {
                     "error": f"Invalid reference path: '{reference_path}'",
                     "skill_name": skill_name,
-                }
+                },
+                ensure_ascii=False,
             )
         try:
             content = read_file_safe(ref_file)
@@ -268,7 +274,8 @@ class Skills:
                     "skill_name": skill_name,
                     "reference_path": reference_path,
                     "content": content,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             return json.dumps(
@@ -276,7 +283,8 @@ class Skills:
                     "error": f"Error reading reference file: {e}",
                     "skill_name": skill_name,
                     "reference_path": reference_path,
-                }
+                },
+                ensure_ascii=False,
             )
 
     def _get_skill_script(
@@ -306,7 +314,8 @@ class Skills:
                 {
                     "error": f"Skill '{skill_name}' not found",
                     "available_skills": available,
-                }
+                },
+                ensure_ascii=False,
             )
 
         if not script_path:
@@ -315,7 +324,8 @@ class Skills:
                     "error": f"A script_path is required to read a script from skill '{skill_name}'",
                     "skill_name": skill_name,
                     "available_scripts": skill.scripts,
-                }
+                },
+                ensure_ascii=False,
             )
 
         if script_path not in skill.scripts:
@@ -323,7 +333,8 @@ class Skills:
                 {
                     "error": f"Script '{script_path}' not found in skill '{skill_name}'",
                     "available_scripts": skill.scripts,
-                }
+                },
+                ensure_ascii=False,
             )
 
         # Validate and resolve path to prevent path traversal attacks
@@ -335,7 +346,8 @@ class Skills:
                 {
                     "error": f"Invalid script path: '{script_path}'",
                     "skill_name": skill_name,
-                }
+                },
+                ensure_ascii=False,
             )
 
         if not execute:
@@ -347,7 +359,8 @@ class Skills:
                         "skill_name": skill_name,
                         "script_path": script_path,
                         "content": content,
-                    }
+                    },
+                    ensure_ascii=False,
                 )
             except Exception as e:
                 return json.dumps(
@@ -355,7 +368,8 @@ class Skills:
                         "error": f"Error reading script file: {e}",
                         "skill_name": skill_name,
                         "script_path": script_path,
-                    }
+                    },
+                    ensure_ascii=False,
                 )
 
         # Execute mode: run the script
@@ -373,7 +387,8 @@ class Skills:
                     "stdout": result.stdout,
                     "stderr": result.stderr,
                     "returncode": result.returncode,
-                }
+                },
+                ensure_ascii=False,
             )
         except subprocess.TimeoutExpired:
             return json.dumps(
@@ -381,7 +396,8 @@ class Skills:
                     "error": f"Script execution timed out after {timeout} seconds",
                     "skill_name": skill_name,
                     "script_path": script_path,
-                }
+                },
+                ensure_ascii=False,
             )
         except FileNotFoundError as e:
             return json.dumps(
@@ -389,7 +405,8 @@ class Skills:
                     "error": f"Interpreter or script not found: {e}",
                     "skill_name": skill_name,
                     "script_path": script_path,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             return json.dumps(
@@ -397,5 +414,6 @@ class Skills:
                     "error": f"Error executing script: {e}",
                     "skill_name": skill_name,
                     "script_path": script_path,
-                }
+                },
+                ensure_ascii=False,
             )

--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -268,7 +268,7 @@ def _search_past_sessions_function(
             str: JSON list of session previews with session_id, created_at, and runs (user/assistant pairs).
         """
         if team.db is None:
-            return json.dumps([])
+            return json.dumps([], ensure_ascii=False)
 
         team.db = cast(BaseDb, team.db)
         selected_sessions = team.db.get_sessions(
@@ -297,7 +297,7 @@ def _search_past_sessions_function(
             str: JSON list of session previews with session_id, created_at, and runs (user/assistant pairs).
         """
         if team.db is None:
-            return json.dumps([])
+            return json.dumps([], ensure_ascii=False)
 
         if _has_async_db(team):
             selected_sessions = await cast(AsyncBaseDb, team.db).get_sessions(  # type: ignore

--- a/libs/agno/agno/team/_utils.py
+++ b/libs/agno/agno/team/_utils.py
@@ -89,7 +89,7 @@ def _convert_dependencies_to_string(team: Team, context: Dict[str, Any]) -> str:
         for key, value in context.items():
             try:
                 # Try to serialize each value individually
-                json.dumps({key: value}, default=str)
+                json.dumps({key: value}, default=str, ensure_ascii=False)
                 sanitized_context[key] = value
             except Exception as e:
                 log_error(f"Failed to serialize to JSON: {str(e)}")

--- a/libs/agno/agno/tools/agentos.py
+++ b/libs/agno/agno/tools/agentos.py
@@ -254,7 +254,9 @@ class AgentOSTools(Toolkit):
             _, window_total = self._sync_db().get_traces(limit=1, filter_expr=_created_after_expr(start_time))
             return _format_run_activity(groupings, window_total, days)
         except NotImplementedError as e:
-            return json.dumps({"error": f"Component-grouped trace stats are not supported by this database: {e}"})
+            return json.dumps(
+                {"error": f"Component-grouped trace stats are not supported by this database: {e}"}, ensure_ascii=False
+            )
         except Exception:
             logger.exception("Failed to get run activity")
             return _tool_error("Failed to get run activity")
@@ -283,7 +285,9 @@ class AgentOSTools(Toolkit):
             _, window_total = await self._async_db().get_traces(limit=1, filter_expr=_created_after_expr(start_time))
             return _format_run_activity(groupings, window_total, days)
         except NotImplementedError as e:
-            return json.dumps({"error": f"Component-grouped trace stats are not supported by this database: {e}"})
+            return json.dumps(
+                {"error": f"Component-grouped trace stats are not supported by this database: {e}"}, ensure_ascii=False
+            )
         except Exception:
             logger.exception("Failed to get run activity")
             return _tool_error("Failed to get run activity")
@@ -320,7 +324,7 @@ class AgentOSTools(Toolkit):
             )
             return _format_tool_activity(tools_most_used, tools_slowest, tools_total, model_calls, models_total, days)
         except NotImplementedError:
-            return json.dumps({"error": "Span statistics are not supported by this database"})
+            return json.dumps({"error": "Span statistics are not supported by this database"}, ensure_ascii=False)
         except Exception:
             logger.exception("Failed to get tool activity")
             return _tool_error("Failed to get tool activity")
@@ -353,7 +357,7 @@ class AgentOSTools(Toolkit):
             )
             return _format_tool_activity(tools_most_used, tools_slowest, tools_total, model_calls, models_total, days)
         except NotImplementedError:
-            return json.dumps({"error": "Span statistics are not supported by this database"})
+            return json.dumps({"error": "Span statistics are not supported by this database"}, ensure_ascii=False)
         except Exception:
             logger.exception("Failed to get tool activity")
             return _tool_error("Failed to get tool activity")
@@ -431,7 +435,7 @@ class AgentOSTools(Toolkit):
                 last_runs[schedule["id"]] = runs[0] if runs else None
             return _format_schedules(schedules, total, last_runs)
         except NotImplementedError:
-            return json.dumps({"error": "The scheduler is not supported by this database"})
+            return json.dumps({"error": "The scheduler is not supported by this database"}, ensure_ascii=False)
         except Exception:
             logger.exception("Failed to list schedules")
             return _tool_error("Failed to list schedules")
@@ -457,7 +461,7 @@ class AgentOSTools(Toolkit):
                 last_runs[schedule["id"]] = runs[0] if runs else None
             return _format_schedules(schedules, total, last_runs)
         except NotImplementedError:
-            return json.dumps({"error": "The scheduler is not supported by this database"})
+            return json.dumps({"error": "The scheduler is not supported by this database"}, ensure_ascii=False)
         except Exception:
             logger.exception("Failed to list schedules")
             return _tool_error("Failed to list schedules")
@@ -482,7 +486,7 @@ class AgentOSTools(Toolkit):
             runs, total = self._sync_db().get_schedule_runs(schedule_id, limit=_clamp(limit, 1, 100))
             return _format_schedule_history(schedule_id, runs, total)
         except NotImplementedError:
-            return json.dumps({"error": "The scheduler is not supported by this database"})
+            return json.dumps({"error": "The scheduler is not supported by this database"}, ensure_ascii=False)
         except Exception:
             logger.exception("Failed to get schedule history")
             return _tool_error("Failed to get schedule history")
@@ -507,7 +511,7 @@ class AgentOSTools(Toolkit):
             runs, total = await self._async_db().get_schedule_runs(schedule_id, limit=_clamp(limit, 1, 100))
             return _format_schedule_history(schedule_id, runs, total)
         except NotImplementedError:
-            return json.dumps({"error": "The scheduler is not supported by this database"})
+            return json.dumps({"error": "The scheduler is not supported by this database"}, ensure_ascii=False)
         except Exception:
             logger.exception("Failed to get schedule history")
             return _tool_error("Failed to get schedule history")
@@ -527,12 +531,12 @@ class AgentOSTools(Toolkit):
                 type, name, description and current version.
         """
         if self._db_is_async:
-            return json.dumps({"error": "Component listing is not supported by async databases"})
+            return json.dumps({"error": "Component listing is not supported by async databases"}, ensure_ascii=False)
         try:
             components, total = self._sync_db().list_components(limit=_clamp(limit, 1, 100))
             return _format_components(components, total)
         except NotImplementedError:
-            return json.dumps({"error": "Component listing is not supported by this database"})
+            return json.dumps({"error": "Component listing is not supported by this database"}, ensure_ascii=False)
         except Exception:
             logger.exception("Failed to list platform components")
             return _tool_error("Failed to list platform components")
@@ -548,7 +552,7 @@ class AgentOSTools(Toolkit):
                 type, name, description and current version.
         """
         if self._db_is_async:
-            return json.dumps({"error": "Component listing is not supported by async databases"})
+            return json.dumps({"error": "Component listing is not supported by async databases"}, ensure_ascii=False)
         return await _run_sync(self.list_platform_components, limit)
 
     # ------------------------------------------------------------------
@@ -571,7 +575,7 @@ class AgentOSTools(Toolkit):
             approvals, total = self._sync_db().get_approvals(status="pending", limit=_APPROVAL_LIMIT)
             return _format_pending_approvals(approvals, total)
         except NotImplementedError:
-            return json.dumps({"error": "Approvals are not supported by this database"})
+            return json.dumps({"error": "Approvals are not supported by this database"}, ensure_ascii=False)
         except Exception:
             logger.exception("Failed to list pending approvals")
             return _tool_error("Failed to list pending approvals")
@@ -592,7 +596,7 @@ class AgentOSTools(Toolkit):
             approvals, total = await self._async_db().get_approvals(status="pending", limit=_APPROVAL_LIMIT)
             return _format_pending_approvals(approvals, total)
         except NotImplementedError:
-            return json.dumps({"error": "Approvals are not supported by this database"})
+            return json.dumps({"error": "Approvals are not supported by this database"}, ensure_ascii=False)
         except Exception:
             logger.exception("Failed to list pending approvals")
             return _tool_error("Failed to list pending approvals")
@@ -654,7 +658,8 @@ def _async_db_error() -> str:
         {
             "error": "This toolkit is configured with an async database. Run the agent through the "
             "async execution path (arun / AgentOS server) so the async tool variants are used."
-        }
+        },
+        ensure_ascii=False,
     )
 
 
@@ -666,7 +671,7 @@ def _tool_error(context: str) -> str:
     text -- SQL fragments, table or column names -- must not reach whoever talks
     to the agent.
     """
-    return json.dumps({"error": f"{context}. The error has been logged."})
+    return json.dumps({"error": f"{context}. The error has been logged."}, ensure_ascii=False)
 
 
 def _clamp(value: int, low: int, high: int) -> int:
@@ -747,7 +752,7 @@ def _format_platform_metrics(rows: List[Any], days: int, start_date: date, end_d
     }
     if not daily:
         payload["notes"].append("no metrics recorded for this window; the platform may have had no sessions")
-    return json.dumps(payload, default=str)
+    return json.dumps(payload, default=str, ensure_ascii=False)
 
 
 def _created_after_expr(start_time: datetime) -> Dict[str, Any]:
@@ -775,7 +780,7 @@ def _format_run_activity(groupings: Dict[str, Tuple[List[Dict[str, Any]], int]],
         "component appears under each, so the tables may not sum to total_traces"
     )
     payload["notes"] = notes
-    return json.dumps(payload, default=str)
+    return json.dumps(payload, default=str, ensure_ascii=False)
 
 
 def _format_tool_activity(
@@ -801,7 +806,7 @@ def _format_tool_activity(
         "model_calls": model_calls,
         "notes": notes,
     }
-    return json.dumps(payload, default=str)
+    return json.dumps(payload, default=str, ensure_ascii=False)
 
 
 def _normalize_eval_run(record: Dict[str, Any]) -> Dict[str, Any]:
@@ -864,7 +869,7 @@ def _format_eval_history(rows: List[Any], total: int) -> str:
     payload: Dict[str, Any] = {"eval_runs": eval_runs, "count": len(eval_runs), "total": total}
     if total > len(eval_runs):
         payload["notes"] = [f"only the {len(eval_runs)} most recent of {total} eval runs are shown"]
-    return json.dumps(payload, default=str)
+    return json.dumps(payload, default=str, ensure_ascii=False)
 
 
 def _summarize_run_error(run: Dict[str, Any]) -> Optional[str]:
@@ -919,7 +924,7 @@ def _format_schedules(
     payload: Dict[str, Any] = {"schedules": rows, "count": len(rows), "total": total}
     if total > len(rows):
         payload["notes"] = [f"only {len(rows)} of {total} schedules are shown"]
-    return json.dumps(payload, default=str)
+    return json.dumps(payload, default=str, ensure_ascii=False)
 
 
 def _format_schedule_history(schedule_id: str, runs: List[Dict[str, Any]], total: int) -> str:
@@ -943,7 +948,7 @@ def _format_schedule_history(schedule_id: str, runs: List[Dict[str, Any]], total
             f"only the {len(runs)} most recent of {total} runs are shown",
             f"page_summary covers only these {len(runs)} runs; older runs may hold failures it does not reflect",
         ]
-    return json.dumps(payload, default=str)
+    return json.dumps(payload, default=str, ensure_ascii=False)
 
 
 def _format_components(components: List[Dict[str, Any]], total: int) -> str:
@@ -962,7 +967,7 @@ def _format_components(components: List[Dict[str, Any]], total: int) -> str:
     payload: Dict[str, Any] = {"components": rows, "count": len(rows), "total": total}
     if total > len(rows):
         payload["notes"] = [f"only {len(rows)} of {total} components are shown"]
-    return json.dumps(payload, default=str)
+    return json.dumps(payload, default=str, ensure_ascii=False)
 
 
 def _format_pending_approvals(approvals: List[Dict[str, Any]], total: int) -> str:
@@ -988,4 +993,4 @@ def _format_pending_approvals(approvals: List[Dict[str, Any]], total: int) -> st
     payload: Dict[str, Any] = {"approvals": rows, "count": len(rows), "total": total}
     if total > len(rows):
         payload["notes"] = [f"only {len(rows)} of {total} pending approvals are shown"]
-    return json.dumps(payload, default=str)
+    return json.dumps(payload, default=str, ensure_ascii=False)

--- a/libs/agno/agno/tools/antigravity.py
+++ b/libs/agno/agno/tools/antigravity.py
@@ -341,10 +341,10 @@ class AntigravityTools(Toolkit):
                 return text
             # No model_output text block found. Surface the raw payload so the
             # calling model has something to work with rather than retrying blindly.
-            return json.dumps(data)
+            return json.dumps(data, ensure_ascii=False)
         except Exception as e:
             log_error(f"Antigravity run_antigravity_task failed: {e}")
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def run_custom_antigravity_agent(self, agent: Union[Agent, Team], custom_agent_name: str, task: str) -> str:
         """Invoke a named custom Antigravity agent (created via /agents) and return its response.
@@ -386,10 +386,10 @@ class AntigravityTools(Toolkit):
                 if data.get("id"):
                     state[prev_key] = data["id"]
 
-            return self._extract_final_text(data) or json.dumps(data)
+            return self._extract_final_text(data) or json.dumps(data, ensure_ascii=False)
         except Exception as e:
             log_error(f"Antigravity run_custom_antigravity_agent failed: {e}")
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def create_custom_antigravity_agent(
         self,
@@ -428,10 +428,10 @@ class AntigravityTools(Toolkit):
             elif sources:
                 body["base_environment"] = {"type": "remote", "sources": sources}
             data = self._post("/agents", body)
-            return json.dumps(data)
+            return json.dumps(data, ensure_ascii=False)
         except Exception as e:
             log_error(f"Antigravity create_custom_antigravity_agent failed: {e}")
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def update_custom_antigravity_agent(
         self,
@@ -456,44 +456,44 @@ class AntigravityTools(Toolkit):
             if description is not None:
                 body["description"] = description
             if not body:
-                return json.dumps({"status": "error", "message": "no fields to update"})
-            return json.dumps(self._patch(f"/agents/{name}", body))
+                return json.dumps({"status": "error", "message": "no fields to update"}, ensure_ascii=False)
+            return json.dumps(self._patch(f"/agents/{name}", body), ensure_ascii=False)
         except Exception as e:
             log_error(f"Antigravity update_custom_antigravity_agent failed: {e}")
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def get_custom_antigravity_agent(self, name: str) -> str:
         """Fetch a single custom Antigravity agent by name via GET /agents/{name}."""
         try:
-            return json.dumps(self._get(f"/agents/{name}"))
+            return json.dumps(self._get(f"/agents/{name}"), ensure_ascii=False)
         except Exception as e:
             log_error(f"Antigravity get_custom_antigravity_agent failed: {e}")
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def list_antigravity_agents(self) -> str:
         """List all custom Antigravity agents owned by the API key."""
         try:
-            return json.dumps(self._get("/agents"))
+            return json.dumps(self._get("/agents"), ensure_ascii=False)
         except Exception as e:
             log_error(f"Antigravity list_antigravity_agents failed: {e}")
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def list_antigravity_agent_versions(self, name: str) -> str:
         """List versions of a custom Antigravity agent via GET /agents/{name}/versions."""
         try:
-            return json.dumps(self._get(f"/agents/{name}/versions"))
+            return json.dumps(self._get(f"/agents/{name}/versions"), ensure_ascii=False)
         except Exception as e:
             log_error(f"Antigravity list_antigravity_agent_versions failed: {e}")
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def delete_antigravity_agent(self, name: str) -> str:
         """Delete a custom Antigravity agent by name."""
         try:
             self._delete(f"/agents/{name}")
-            return json.dumps({"status": "ok", "deleted": name})
+            return json.dumps({"status": "ok", "deleted": name}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Antigravity delete_antigravity_agent failed: {e}")
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def download_antigravity_environment_snapshot(
         self, environment_id: str, output_path: str, agent: Optional[Union[Agent, Team]] = None
@@ -520,7 +520,8 @@ class AntigravityTools(Toolkit):
                 state = self._session_state(agent)
                 if not state or not state.get("antigravity_env_id"):
                     return json.dumps(
-                        {"status": "error", "message": "no cached env id; run a task first or pass an explicit id"}
+                        {"status": "error", "message": "no cached env id; run a task first or pass an explicit id"},
+                        ensure_ascii=False,
                     )
                 env_id = state["antigravity_env_id"]
 
@@ -536,7 +537,9 @@ class AntigravityTools(Toolkit):
                             fh.write(chunk)
                             written += len(chunk)
             log_debug(f"Antigravity: wrote snapshot ({written} bytes) for env {env_id} to {output_path}")
-            return json.dumps({"status": "ok", "path": output_path, "bytes": written, "environment_id": env_id})
+            return json.dumps(
+                {"status": "ok", "path": output_path, "bytes": written, "environment_id": env_id}, ensure_ascii=False
+            )
         except Exception as e:
             log_error(f"Antigravity download_antigravity_environment_snapshot failed: {e}")
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/api.py
+++ b/libs/agno/agno/tools/api.py
@@ -114,13 +114,13 @@ class CustomApiTools(Toolkit):
                 log_error(f"Request failed with status {response.status_code}: {response.text}")
                 result["error"] = "Request failed"
 
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         except requests.exceptions.RequestException as e:
             error_message = f"Request failed: {str(e)}"
             log_error(error_message)
-            return json.dumps({"error": error_message}, indent=2)
+            return json.dumps({"error": error_message}, indent=2, ensure_ascii=False)
         except Exception as e:
             error_message = f"Unexpected error: {str(e)}"
             log_error(error_message)
-            return json.dumps({"error": error_message}, indent=2)
+            return json.dumps({"error": error_message}, indent=2, ensure_ascii=False)

--- a/libs/agno/agno/tools/apify.py
+++ b/libs/agno/agno/tools/apify.py
@@ -90,12 +90,12 @@ class ApifyTools(Toolkit):
                     run = self.client.run(run_id=run_id)
                     results = run.dataset().list_items(clean=True).items
 
-                    return json.dumps(results)
+                    return json.dumps(results, ensure_ascii=False)
 
                 except Exception as e:
                     error_msg = f"Error running Apify Actor {actor_id}: {str(e)}"
                     log_error(error_msg)
-                    return json.dumps([{"error": error_msg}])
+                    return json.dumps([{"error": error_msg}], ensure_ascii=False)
 
             docstring = f"{actor_description}\n\nArgs:\n"
 

--- a/libs/agno/agno/tools/arxiv.py
+++ b/libs/agno/agno/tools/arxiv.py
@@ -73,7 +73,7 @@ class ArxivTools(Toolkit):
                 articles.append(article)
             except Exception:
                 logger.exception("Error processing article")
-        return json.dumps(articles, indent=4)
+        return json.dumps(articles, indent=4, ensure_ascii=False)
 
     def read_arxiv_papers(self, id_list: List[str], pages_to_read: Optional[int] = None) -> str:
         """Use this function to read a list of arxiv papers and return the content.
@@ -124,4 +124,4 @@ class ArxivTools(Toolkit):
                 articles.append(article)
             except Exception:
                 logger.exception("Error processing article")
-        return json.dumps(articles, indent=4)
+        return json.dumps(articles, indent=4, ensure_ascii=False)

--- a/libs/agno/agno/tools/baidusearch.py
+++ b/libs/agno/agno/tools/baidusearch.py
@@ -86,4 +86,4 @@ class BaiduSearchTools(Toolkit):
                     "rank": str(idx),
                 }
             )
-        return json.dumps(res, indent=2)
+        return json.dumps(res, indent=2, ensure_ascii=False)

--- a/libs/agno/agno/tools/bitbucket.py
+++ b/libs/agno/agno/tools/bitbucket.py
@@ -106,10 +106,10 @@ class BitbucketTools(Toolkit):
 
             repo = self._make_request("GET", f"/repositories/{self.workspace}", params=params)
 
-            return json.dumps(repo, indent=2)
+            return json.dumps(repo, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error retrieving repository list for workspace {self.workspace}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_repository_details(self) -> str:
         """
@@ -121,10 +121,10 @@ class BitbucketTools(Toolkit):
         """
         try:
             repo = self._make_request("GET", f"/repositories/{self.workspace}/{self.repo_slug}")
-            return json.dumps(repo, indent=2)
+            return json.dumps(repo, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error retrieving repository information for {self.repo_slug}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def create_repository(
         self,
@@ -164,10 +164,10 @@ class BitbucketTools(Toolkit):
             if project:
                 payload["project"] = {"key": project}
             repo = self._make_request("POST", f"/repositories/{self.workspace}/{self.repo_slug}", data=payload)
-            return json.dumps(repo, indent=2)
+            return json.dumps(repo, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error creating repository {self.repo_slug} for {self.workspace}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_repository_commits(self, count: int = 10) -> str:
         """
@@ -202,10 +202,10 @@ class BitbucketTools(Toolkit):
                 if isinstance(commits, dict):
                     commits["values"] = collected_commits[:count]
 
-            return json.dumps(commits, indent=2)
+            return json.dumps(commits, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error retrieving commits for {self.repo_slug}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_all_pull_requests(self, state: str = "OPEN") -> str:
         """
@@ -228,10 +228,10 @@ class BitbucketTools(Toolkit):
                 "GET", f"/repositories/{self.workspace}/{self.repo_slug}/pullrequests", params=params
             )
 
-            return json.dumps(pull_requests, indent=2)
+            return json.dumps(pull_requests, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error retrieving pull requests for {self.repo_slug}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_pull_request_details(self, pull_request_id: int) -> str:
         """
@@ -246,10 +246,10 @@ class BitbucketTools(Toolkit):
             pull_request = self._make_request(
                 "GET", f"/repositories/{self.workspace}/{self.repo_slug}/pullrequests/{pull_request_id}"
             )
-            return json.dumps(pull_request, indent=2)
+            return json.dumps(pull_request, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error retrieving pull requests for {self.repo_slug}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_pull_request_changes(self, pull_request_id: int) -> str:
         """
@@ -266,11 +266,11 @@ class BitbucketTools(Toolkit):
                 "GET", f"/repositories/{self.workspace}/{self.repo_slug}/pullrequests/{pull_request_id}/diff"
             )
             if isinstance(diff, dict):
-                return json.dumps(diff, indent=2)
+                return json.dumps(diff, indent=2, ensure_ascii=False)
             return diff
         except Exception as e:
             logger.exception(f"Error retrieving changes for pull request {pull_request_id} in {self.repo_slug}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_issues(self, count: int = 10) -> str:
         """
@@ -288,7 +288,7 @@ class BitbucketTools(Toolkit):
 
             issues = self._make_request("GET", f"/repositories/{self.workspace}/{self.repo_slug}/issues", params=params)
 
-            return json.dumps(issues, indent=2)
+            return json.dumps(issues, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error retrieving issues for {self.repo_slug}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/bravesearch.py
+++ b/libs/agno/agno/tools/bravesearch.py
@@ -71,7 +71,7 @@ class BraveSearchTools(Toolkit):
         final_search_lang = self.fixed_language if self.fixed_language is not None else search_lang
 
         if not query:
-            return json.dumps({"error": "Please provide a query to search for"})
+            return json.dumps({"error": "Please provide a query to search for"}, ensure_ascii=False)
 
         log_info(f"Searching Brave for: {query}")
 
@@ -103,4 +103,4 @@ class BraveSearchTools(Toolkit):
             filtered_results["web_results"] = web_results
             filtered_results["total_results"] = len(web_results)
 
-        return json.dumps(filtered_results, indent=2)
+        return json.dumps(filtered_results, indent=2, ensure_ascii=False)

--- a/libs/agno/agno/tools/brightdata.py
+++ b/libs/agno/agno/tools/brightdata.py
@@ -82,7 +82,7 @@ class BrightDataTools(Toolkit):
                 log_info(f"[Bright Data] Request: {payload['url']}")
 
             response = requests.post(
-                self.endpoint, headers=self.headers, data=json.dumps(payload), timeout=self.timeout
+                self.endpoint, headers=self.headers, data=json.dumps(payload, ensure_ascii=False), timeout=self.timeout
             )
 
             if response.status_code != 200:
@@ -149,7 +149,7 @@ class BrightDataTools(Toolkit):
             }
 
             response = requests.post(
-                self.endpoint, headers=self.headers, data=json.dumps(payload), timeout=self.timeout
+                self.endpoint, headers=self.headers, data=json.dumps(payload, ensure_ascii=False), timeout=self.timeout
             )
 
             if response.status_code != 200:
@@ -361,7 +361,7 @@ class BrightDataTools(Toolkit):
                         time.sleep(1)
                         continue
 
-                    return json.dumps(snapshot_data)
+                    return json.dumps(snapshot_data, ensure_ascii=False)
 
                 except Exception:
                     attempts += 1

--- a/libs/agno/agno/tools/browserbase.py
+++ b/libs/agno/agno/tools/browserbase.py
@@ -176,7 +176,7 @@ class BrowserbaseTools(Toolkit):
             if self._page:
                 self._page.goto(url, wait_until="networkidle")
             result = {"status": "complete", "title": self._page.title() if self._page else "", "url": url}
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
         except Exception as e:
             self._cleanup()
             raise e
@@ -196,7 +196,7 @@ class BrowserbaseTools(Toolkit):
             self._initialize_browser(connect_url)
             if self._page:
                 self._page.screenshot(path=path, full_page=full_page)
-            return json.dumps({"status": "success", "path": path})
+            return json.dumps({"status": "success", "path": path}, ensure_ascii=False)
         except Exception as e:
             self._cleanup()
             raise e
@@ -287,10 +287,13 @@ class BrowserbaseTools(Toolkit):
                 {
                     "status": "closed",
                     "message": "Browser resources cleaned up. Session will auto-close if not already closed.",
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
-            return json.dumps({"status": "warning", "message": f"Cleanup completed with warning: {str(e)}"})
+            return json.dumps(
+                {"status": "warning", "message": f"Cleanup completed with warning: {str(e)}"}, ensure_ascii=False
+            )
 
     async def _ainitialize_browser(self, connect_url: Optional[str] = None):
         """
@@ -343,7 +346,7 @@ class BrowserbaseTools(Toolkit):
                 await self._async_page.goto(url, wait_until="networkidle")
             title = await self._async_page.title() if self._async_page else ""
             result = {"status": "complete", "title": title, "url": url}
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
         except Exception as e:
             await self._acleanup()
             raise e
@@ -363,7 +366,7 @@ class BrowserbaseTools(Toolkit):
             await self._ainitialize_browser(connect_url)
             if self._async_page:
                 await self._async_page.screenshot(path=path, full_page=full_page)
-            return json.dumps({"status": "success", "path": path})
+            return json.dumps({"status": "success", "path": path}, ensure_ascii=False)
         except Exception as e:
             await self._acleanup()
             raise e
@@ -412,7 +415,10 @@ class BrowserbaseTools(Toolkit):
                 {
                     "status": "closed",
                     "message": "Browser resources cleaned up. Session will auto-close if not already closed.",
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
-            return json.dumps({"status": "warning", "message": f"Cleanup completed with warning: {str(e)}"})
+            return json.dumps(
+                {"status": "warning", "message": f"Cleanup completed with warning: {str(e)}"}, ensure_ascii=False
+            )

--- a/libs/agno/agno/tools/calculator.py
+++ b/libs/agno/agno/tools/calculator.py
@@ -37,7 +37,7 @@ class CalculatorTools(Toolkit):
         """
         result = a + b
         log_debug(f"Adding {a} and {b} to get {result}")
-        return json.dumps({"operation": "addition", "result": result})
+        return json.dumps({"operation": "addition", "result": result}, ensure_ascii=False)
 
     def subtract(self, a: float, b: float) -> str:
         """Subtract second number from first and return the result.
@@ -51,7 +51,7 @@ class CalculatorTools(Toolkit):
         """
         result = a - b
         log_debug(f"Subtracting {b} from {a} to get {result}")
-        return json.dumps({"operation": "subtraction", "result": result})
+        return json.dumps({"operation": "subtraction", "result": result}, ensure_ascii=False)
 
     def multiply(self, a: float, b: float) -> str:
         """Multiply two numbers and return the result.
@@ -65,7 +65,7 @@ class CalculatorTools(Toolkit):
         """
         result = a * b
         log_debug(f"Multiplying {a} and {b} to get {result}")
-        return json.dumps({"operation": "multiplication", "result": result})
+        return json.dumps({"operation": "multiplication", "result": result}, ensure_ascii=False)
 
     def divide(self, a: float, b: float) -> str:
         """Divide first number by second and return the result.
@@ -79,13 +79,13 @@ class CalculatorTools(Toolkit):
         """
         if b == 0:
             log_error("Attempt to divide by zero")
-            return json.dumps({"operation": "division", "error": "Division by zero is undefined"})
+            return json.dumps({"operation": "division", "error": "Division by zero is undefined"}, ensure_ascii=False)
         try:
             result = a / b
         except Exception as e:
-            return json.dumps({"operation": "division", "error": str(e), "result": "Error"})
+            return json.dumps({"operation": "division", "error": str(e), "result": "Error"}, ensure_ascii=False)
         log_debug(f"Dividing {a} by {b} to get {result}")
-        return json.dumps({"operation": "division", "result": result})
+        return json.dumps({"operation": "division", "result": result}, ensure_ascii=False)
 
     def exponentiate(self, a: float, b: float) -> str:
         """Raise first number to the power of the second number and return the result.
@@ -99,7 +99,7 @@ class CalculatorTools(Toolkit):
         """
         result = math.pow(a, b)
         log_debug(f"Raising {a} to the power of {b} to get {result}")
-        return json.dumps({"operation": "exponentiation", "result": result})
+        return json.dumps({"operation": "exponentiation", "result": result}, ensure_ascii=False)
 
     def factorial(self, n: int) -> str:
         """Calculate the factorial of a number and return the result.
@@ -112,10 +112,12 @@ class CalculatorTools(Toolkit):
         """
         if n < 0:
             log_error("Attempt to calculate factorial of a negative number")
-            return json.dumps({"operation": "factorial", "error": "Factorial of a negative number is undefined"})
+            return json.dumps(
+                {"operation": "factorial", "error": "Factorial of a negative number is undefined"}, ensure_ascii=False
+            )
         result = math.factorial(n)
         log_debug(f"Calculating factorial of {n} to get {result}")
-        return json.dumps({"operation": "factorial", "result": result})
+        return json.dumps({"operation": "factorial", "result": result}, ensure_ascii=False)
 
     def is_prime(self, n: int) -> str:
         """Check if a number is prime and return the result.
@@ -127,11 +129,11 @@ class CalculatorTools(Toolkit):
             str: JSON string of the result.
         """
         if n <= 1:
-            return json.dumps({"operation": "prime_check", "result": False})
+            return json.dumps({"operation": "prime_check", "result": False}, ensure_ascii=False)
         for i in range(2, int(math.sqrt(n)) + 1):
             if n % i == 0:
-                return json.dumps({"operation": "prime_check", "result": False})
-        return json.dumps({"operation": "prime_check", "result": True})
+                return json.dumps({"operation": "prime_check", "result": False}, ensure_ascii=False)
+        return json.dumps({"operation": "prime_check", "result": True}, ensure_ascii=False)
 
     def square_root(self, n: float) -> str:
         """Calculate the square root of a number and return the result.
@@ -144,8 +146,11 @@ class CalculatorTools(Toolkit):
         """
         if n < 0:
             log_error("Attempt to calculate square root of a negative number")
-            return json.dumps({"operation": "square_root", "error": "Square root of a negative number is undefined"})
+            return json.dumps(
+                {"operation": "square_root", "error": "Square root of a negative number is undefined"},
+                ensure_ascii=False,
+            )
 
         result = math.sqrt(n)
         log_debug(f"Calculating square root of {n} to get {result}")
-        return json.dumps({"operation": "square_root", "result": result})
+        return json.dumps({"operation": "square_root", "result": result}, ensure_ascii=False)

--- a/libs/agno/agno/tools/cartesia.py
+++ b/libs/agno/agno/tools/cartesia.py
@@ -81,10 +81,12 @@ class CartesiaTools(Toolkit):
                         log_error(f"Unexpected error processing voice. Voice data: {voice}: {str(e)}")
                         continue
 
-            return json.dumps(filtered_result, indent=4)
+            return json.dumps(filtered_result, indent=4, ensure_ascii=False)
         except Exception as e:
             log_error(f"Error listing voices from Cartesia: {str(e)}")
-            return json.dumps({"error": str(e), "detail": "Error occurred in list_voices function."})
+            return json.dumps(
+                {"error": str(e), "detail": "Error occurred in list_voices function."}, ensure_ascii=False
+            )
 
     def localize_voice(
         self,
@@ -119,13 +121,13 @@ class CartesiaTools(Toolkit):
             )
 
             if isinstance(result, dict):
-                return json.dumps(result, indent=4)
+                return json.dumps(result, indent=4, ensure_ascii=False)
             else:
                 return result.model_dump_json(indent=4)
 
         except Exception as e:
             log_error(f"Error localizing voice with Cartesia: {str(e)}")
-            return json.dumps({"error": str(e), "type": type(e).__name__})
+            return json.dumps({"error": str(e), "type": type(e).__name__}, ensure_ascii=False)
 
     def text_to_speech(
         self,

--- a/libs/agno/agno/tools/clickup.py
+++ b/libs/agno/agno/tools/clickup.py
@@ -131,13 +131,13 @@ class ClickUpTools(Toolkit):
         # Get space
         space = self._get_space(space_name)
         if "error" in space:
-            return json.dumps(space, indent=2)
+            return json.dumps(space, indent=2, ensure_ascii=False)
 
         # Get lists
         lists = self._make_request("GET", f"space/{space['id']}/list")
         lists_data = lists.get("lists", [])
         if not lists_data:
-            return json.dumps({"error": f"No lists found in space '{space_name}'"}, indent=2)
+            return json.dumps({"error": f"No lists found in space '{space_name}'"}, indent=2, ensure_ascii=False)
 
         # Get tasks from all lists
         all_tasks = []
@@ -147,7 +147,7 @@ class ClickUpTools(Toolkit):
                 task["list_name"] = list_info["name"]  # Add list name for context
             all_tasks.extend(tasks)
 
-        return json.dumps({"tasks": all_tasks}, indent=2)
+        return json.dumps({"tasks": all_tasks}, indent=2, ensure_ascii=False)
 
     def create_task(self, space_name: str, task_name: str, task_description: str) -> str:
         """Create a new task in a space.
@@ -163,14 +163,14 @@ class ClickUpTools(Toolkit):
         # Get space
         space = self._get_space(space_name)
         if "error" in space:
-            return json.dumps(space, indent=2)
+            return json.dumps(space, indent=2, ensure_ascii=False)
 
         # Get first list in space
         response = self._make_request("GET", f"space/{space['id']}/list")
         log_debug(f"Lists: {response}")
         lists_data = response.get("lists", [])
         if not lists_data:
-            return json.dumps({"error": f"No lists found in space '{space_name}'"}, indent=2)
+            return json.dumps({"error": f"No lists found in space '{space_name}'"}, indent=2, ensure_ascii=False)
 
         list_info = lists_data[0]  # Use first list
 
@@ -178,7 +178,7 @@ class ClickUpTools(Toolkit):
         data = {"name": task_name, "description": task_description}
 
         task = self._make_request("POST", f"list/{list_info['id']}/task", data=data)
-        return json.dumps(task, indent=2)
+        return json.dumps(task, indent=2, ensure_ascii=False)
 
     def list_spaces(self) -> str:
         """List all spaces in the workspace.
@@ -187,7 +187,7 @@ class ClickUpTools(Toolkit):
             str: JSON string containing list of spaces
         """
         spaces = self._make_request("GET", f"team/{self.master_space_id}/space")
-        return json.dumps(spaces, indent=2)
+        return json.dumps(spaces, indent=2, ensure_ascii=False)
 
     def list_lists(self, space_name: str) -> str:
         """List all lists in a space.
@@ -201,11 +201,11 @@ class ClickUpTools(Toolkit):
         # Get space
         space = self._get_space(space_name)
         if "error" in space:
-            return json.dumps(space, indent=2)
+            return json.dumps(space, indent=2, ensure_ascii=False)
 
         # Get lists
         lists = self._make_request("GET", f"space/{space['id']}/list")
-        return json.dumps(lists, indent=2)
+        return json.dumps(lists, indent=2, ensure_ascii=False)
 
     def get_task(self, task_id: str) -> str:
         """Get details of a specific task.
@@ -217,7 +217,7 @@ class ClickUpTools(Toolkit):
             str: JSON string containing task details
         """
         task = self._make_request("GET", f"task/{task_id}")
-        return json.dumps(task, indent=2)
+        return json.dumps(task, indent=2, ensure_ascii=False)
 
     def update_task(self, task_id: str, **kwargs) -> str:
         """Update a specific task.
@@ -230,7 +230,7 @@ class ClickUpTools(Toolkit):
             str: JSON string containing updated task details
         """
         task = self._make_request("PUT", f"task/{task_id}", data=kwargs)
-        return json.dumps(task, indent=2)
+        return json.dumps(task, indent=2, ensure_ascii=False)
 
     def delete_task(self, task_id: str) -> str:
         """Delete a specific task.
@@ -244,4 +244,4 @@ class ClickUpTools(Toolkit):
         result = self._make_request("DELETE", f"task/{task_id}")
         if "error" not in result:
             result = {"success": True, "message": f"Task {task_id} deleted successfully"}
-        return json.dumps(result, indent=2)
+        return json.dumps(result, indent=2, ensure_ascii=False)

--- a/libs/agno/agno/tools/confluence.py
+++ b/libs/agno/agno/tools/confluence.py
@@ -98,19 +98,19 @@ class ConfluenceTools(Toolkit):
             log_info(f"Retrieving page content from space '{space_name}'")
             key = self.get_space_key(space_name=space_name)
             if key == "No space found":
-                return json.dumps({"error": f"Space '{space_name}' not found"})
+                return json.dumps({"error": f"Space '{space_name}' not found"}, ensure_ascii=False)
 
             page = self.confluence.get_page_by_title(key, page_title, expand=expand)
             if page:
                 log_info(f"Successfully retrieved page '{page_title}' from space '{space_name}'")
-                return json.dumps(page)
+                return json.dumps(page, ensure_ascii=False)
 
             logger.warning(f"Page '{page_title}' not found in space '{space_name}'")
-            return json.dumps({"error": f"Page '{page_title}' not found in space '{space_name}'"})
+            return json.dumps({"error": f"Page '{page_title}' not found in space '{space_name}'"}, ensure_ascii=False)
 
         except Exception as e:
             logger.exception(f"Error retrieving page '{page_title}'")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_all_space_detail(self):
         """Retrieve details about all Confluence spaces.
@@ -184,14 +184,14 @@ class ConfluenceTools(Toolkit):
         space_key = self.get_space_key(space_name)
 
         if space_key == "No space found":
-            return json.dumps({"error": f"Space '{space_name}' not found"})
+            return json.dumps({"error": f"Space '{space_name}' not found"}, ensure_ascii=False)
 
         page_details = self.confluence.get_all_pages_from_space(
             space_key, status=None, expand=None, content_type="page"
         )
 
         if not page_details:
-            return json.dumps({"error": f"No pages found in space '{space_name}'"})
+            return json.dumps({"error": f"No pages found in space '{space_name}'"}, ensure_ascii=False)
 
         page_details = str([{"id": page["id"], "title": page["title"]} for page in page_details])
         return page_details
@@ -211,14 +211,14 @@ class ConfluenceTools(Toolkit):
         try:
             space_key = self.get_space_key(space_name=space_name)
             if space_key == "No space found":
-                return json.dumps({"error": f"Space '{space_name}' not found"})
+                return json.dumps({"error": f"Space '{space_name}' not found"}, ensure_ascii=False)
 
             page = self.confluence.create_page(space_key, title, body, parent_id=parent_id)
             log_info(f"Page created: {title} with ID {page['id']}")
-            return json.dumps({"id": page["id"], "title": title})
+            return json.dumps({"id": page["id"], "title": title}, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error creating page '{title}'")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def update_page(self, page_id: str, title: str, body: str) -> str:
         """Update an existing Confluence page.
@@ -234,7 +234,7 @@ class ConfluenceTools(Toolkit):
         try:
             updated_page = self.confluence.update_page(page_id, title, body)
             log_info(f"Page updated: {title} with ID {updated_page['id']}")
-            return json.dumps({"status": "success", "id": updated_page["id"]})
+            return json.dumps({"status": "success", "id": updated_page["id"]}, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error updating page '{title}'")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/csv_toolkit.py
+++ b/libs/agno/agno/tools/csv_toolkit.py
@@ -57,7 +57,7 @@ class CsvTools(Toolkit):
         Returns:
             str: List of available csv files
         """
-        return json.dumps([_csv.stem for _csv in self.csvs])
+        return json.dumps([_csv.stem for _csv in self.csvs], ensure_ascii=False)
 
     def read_csv_file(self, csv_name: str, row_limit: Optional[int] = None) -> str:
         """Use this function to read the contents of a csv file `name` without the extension.
@@ -85,7 +85,7 @@ class CsvTools(Toolkit):
                     csv_data = [row for row in reader][:_row_limit]
                 else:
                     csv_data = [row for row in reader]
-            return json.dumps(csv_data)
+            return json.dumps(csv_data, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error reading csv")
             return f"Error reading csv: {e}"
@@ -111,7 +111,7 @@ class CsvTools(Toolkit):
                 reader = csv.DictReader(csvfile)
                 columns = reader.fieldnames
 
-            return json.dumps(columns)
+            return json.dumps(columns, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error getting columns")
             return f"Error getting columns: {e}"

--- a/libs/agno/agno/tools/daytona.py
+++ b/libs/agno/agno/tools/daytona.py
@@ -266,7 +266,7 @@ class DaytonaTools(Toolkit):
             self.result = response.result
             return self.result
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error executing code: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error executing code: {str(e)}"}, ensure_ascii=False)
 
     def run_shell_command(self, agent: Union[Agent, Team], command: str) -> str:
         """Execute a shell command in the sandbox.
@@ -313,7 +313,7 @@ class DaytonaTools(Toolkit):
             response = current_sandbox.process.exec(command, cwd=cwd)
             return response.result
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error executing command: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error executing command: {str(e)}"}, ensure_ascii=False)
 
     def create_file(self, agent: Union[Agent, Team], file_path: str, content: str) -> str:
         """Create or update a file in the sandbox.
@@ -343,7 +343,10 @@ class DaytonaTools(Toolkit):
             if parent_dir and parent_dir != "/":
                 result = current_sandbox.process.exec(f"mkdir -p {shlex.quote(parent_dir)}")
                 if result.exit_code != 0:
-                    return json.dumps({"status": "error", "message": f"Failed to create directory: {result.result}"})
+                    return json.dumps(
+                        {"status": "error", "message": f"Failed to create directory: {result.result}"},
+                        ensure_ascii=False,
+                    )
 
             # Write the file using shell command
             # Use cat with heredoc for better handling of special characters
@@ -352,11 +355,13 @@ class DaytonaTools(Toolkit):
             result = current_sandbox.process.exec(command)
 
             if result.exit_code != 0:
-                return json.dumps({"status": "error", "message": f"Failed to create file: {result.result}"})
+                return json.dumps(
+                    {"status": "error", "message": f"Failed to create file: {result.result}"}, ensure_ascii=False
+                )
 
             return f"File created/updated: {path_str}"
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error creating file: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error creating file: {str(e)}"}, ensure_ascii=False)
 
     def read_file(self, agent: Union[Agent, Team], file_path: str) -> str:
         """Read a file from the sandbox.
@@ -383,11 +388,13 @@ class DaytonaTools(Toolkit):
             result = current_sandbox.process.exec(f"cat {shlex.quote(path_str)}")
 
             if result.exit_code != 0:
-                return json.dumps({"status": "error", "message": f"Error reading file: {result.result}"})
+                return json.dumps(
+                    {"status": "error", "message": f"Error reading file: {result.result}"}, ensure_ascii=False
+                )
 
             return result.result
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error reading file: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error reading file: {str(e)}"}, ensure_ascii=False)
 
     def list_files(self, agent: Union[Agent, Team], directory: Optional[str] = None) -> str:
         """List files in a directory.
@@ -416,11 +423,13 @@ class DaytonaTools(Toolkit):
             result = current_sandbox.process.exec(f"ls -la {shlex.quote(path_str)}")
 
             if result.exit_code != 0:
-                return json.dumps({"status": "error", "message": f"Error listing directory: {result.result}"})
+                return json.dumps(
+                    {"status": "error", "message": f"Error listing directory: {result.result}"}, ensure_ascii=False
+                )
 
             return f"Contents of {path_str}:\n{result.result}"
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error listing files: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error listing files: {str(e)}"}, ensure_ascii=False)
 
     def delete_file(self, agent: Union[Agent, Team], file_path: str) -> str:
         """Delete a file or directory from the sandbox.
@@ -456,11 +465,13 @@ class DaytonaTools(Toolkit):
                 result = current_sandbox.process.exec(f"rm -f {shlex.quote(path_str)}")
 
             if result.exit_code != 0:
-                return json.dumps({"status": "error", "message": f"Failed to delete: {result.result}"})
+                return json.dumps(
+                    {"status": "error", "message": f"Failed to delete: {result.result}"}, ensure_ascii=False
+                )
 
             return f"Deleted: {path_str}"
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error deleting file: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error deleting file: {str(e)}"}, ensure_ascii=False)
 
     def change_directory(self, agent: Union[Agent, Team], directory: str) -> str:
         """Change the current working directory.
@@ -474,4 +485,4 @@ class DaytonaTools(Toolkit):
         try:
             return self.run_shell_command(agent, f"cd {directory}")
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error changing directory: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error changing directory: {str(e)}"}, ensure_ascii=False)

--- a/libs/agno/agno/tools/discord.py
+++ b/libs/agno/agno/tools/discord.py
@@ -85,7 +85,7 @@ class DiscordTools(Toolkit):
         """
         try:
             response = self._make_request("GET", f"/channels/{channel_id}")
-            return json.dumps(response, indent=2)
+            return json.dumps(response, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error getting channel info")
             return f"Error getting channel info: {str(e)}"
@@ -102,7 +102,7 @@ class DiscordTools(Toolkit):
         """
         try:
             response = self._make_request("GET", f"/guilds/{guild_id}/channels")
-            return json.dumps(response, indent=2)
+            return json.dumps(response, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error listing channels")
             return f"Error listing channels: {str(e)}"
@@ -120,7 +120,7 @@ class DiscordTools(Toolkit):
         """
         try:
             response = self._make_request("GET", f"/channels/{channel_id}/messages?limit={limit}")
-            return json.dumps(response, indent=2)
+            return json.dumps(response, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error getting messages")
             return f"Error getting messages: {str(e)}"

--- a/libs/agno/agno/tools/docker.py
+++ b/libs/agno/agno/tools/docker.py
@@ -172,7 +172,7 @@ class DockerTools(Toolkit):
                     }
                 )
 
-            return json.dumps(container_list, indent=2)
+            return json.dumps(container_list, indent=2, ensure_ascii=False)
         except DockerException as e:
             error_msg = f"Error listing containers: {str(e)}"
             log_error(error_msg)
@@ -276,7 +276,7 @@ class DockerTools(Toolkit):
         """
         try:
             container = self.client.containers.get(container_id)
-            return json.dumps(container.attrs, indent=2)
+            return json.dumps(container.attrs, indent=2, ensure_ascii=False)
         except DockerException as e:
             error_msg = f"Error inspecting container: {str(e)}"
             log_error(error_msg)
@@ -386,7 +386,7 @@ class DockerTools(Toolkit):
                     }
                 )
 
-            return json.dumps(image_list, indent=2)
+            return json.dumps(image_list, indent=2, ensure_ascii=False)
         except DockerException as e:
             error_msg = f"Error listing images: {str(e)}"
             log_error(error_msg)
@@ -493,7 +493,7 @@ class DockerTools(Toolkit):
         """
         try:
             image = self.client.images.get(image_id)
-            return json.dumps(image.attrs, indent=2)
+            return json.dumps(image.attrs, indent=2, ensure_ascii=False)
         except DockerException as e:
             error_msg = f"Error inspecting image: {str(e)}"
             log_error(error_msg)
@@ -521,7 +521,7 @@ class DockerTools(Toolkit):
                     }
                 )
 
-            return json.dumps(volume_list, indent=2)
+            return json.dumps(volume_list, indent=2, ensure_ascii=False)
         except DockerException as e:
             error_msg = f"Error listing volumes: {str(e)}"
             log_error(error_msg)
@@ -579,7 +579,7 @@ class DockerTools(Toolkit):
         """
         try:
             volume = self.client.volumes.get(volume_name)
-            return json.dumps(volume.attrs, indent=2)
+            return json.dumps(volume.attrs, indent=2, ensure_ascii=False)
         except DockerException as e:
             error_msg = f"Error inspecting volume: {str(e)}"
             log_error(error_msg)
@@ -609,7 +609,7 @@ class DockerTools(Toolkit):
                     }
                 )
 
-            return json.dumps(network_list, indent=2)
+            return json.dumps(network_list, indent=2, ensure_ascii=False)
         except DockerException as e:
             error_msg = f"Error listing networks: {str(e)}"
             log_error(error_msg)
@@ -669,7 +669,7 @@ class DockerTools(Toolkit):
         """
         try:
             network = self.client.networks.get(network_name)
-            return json.dumps(network.attrs, indent=2)
+            return json.dumps(network.attrs, indent=2, ensure_ascii=False)
         except DockerException as e:
             error_msg = f"Error inspecting network: {str(e)}"
             log_error(error_msg)

--- a/libs/agno/agno/tools/docling.py
+++ b/libs/agno/agno/tools/docling.py
@@ -392,7 +392,7 @@ class DoclingTools(Toolkit):
             "supported_input_parsers": all_supported,
             "active_allowed_parsers": active_formats,
         }
-        return json.dumps(payload, indent=2)
+        return json.dumps(payload, indent=2, ensure_ascii=False)
 
     def _convert_and_export(
         self,
@@ -435,7 +435,7 @@ class DoclingTools(Toolkit):
         if export_format == "html_split_page":
             return document.export_to_html(split_page_view=True)
         if export_format == "json":
-            return json.dumps(document.export_to_dict(), indent=2)
+            return json.dumps(document.export_to_dict(), indent=2, ensure_ascii=False)
         if export_format == "yaml":
             import yaml
 
@@ -644,7 +644,7 @@ class DoclingTools(Toolkit):
                     "max_chars": self.max_chars,
                     "content": content[: self.max_chars] + "...",
                 }
-                return json.dumps(truncated_payload, indent=2)
+                return json.dumps(truncated_payload, indent=2, ensure_ascii=False)
             if export_format == "yaml":
                 import yaml
 

--- a/libs/agno/agno/tools/e2b.py
+++ b/libs/agno/agno/tools/e2b.py
@@ -127,10 +127,10 @@ class E2BTools(Toolkit):
                 else:
                     results.append(f"Result {i + 1}: Output available")
 
-            return json.dumps(results) if results else "Code executed successfully with no output."
+            return json.dumps(results, ensure_ascii=False) if results else "Code executed successfully with no output."
 
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error executing code: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error executing code: {str(e)}"}, ensure_ascii=False)
 
     #  File Upload/Download Functions
     def upload_file(self, file_path: str, sandbox_path: Optional[str] = None) -> str:
@@ -155,7 +155,7 @@ class E2BTools(Toolkit):
 
             return file_in_sandbox.path
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error uploading file: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error uploading file: {str(e)}"}, ensure_ascii=False)
 
     def download_png_result(
         self, agent: Union[Agent, Team], result_index: int = 0, output_path: Optional[str] = None
@@ -332,7 +332,7 @@ class E2BTools(Toolkit):
 
             return local_path
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error downloading file: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error downloading file: {str(e)}"}, ensure_ascii=False)
 
     # Command Execution Functions
     def run_command(
@@ -379,10 +379,10 @@ class E2BTools(Toolkit):
             if hasattr(result, "stderr") and result.stderr:
                 output.append(f"STDERR:\n{result.stderr}")
 
-            return json.dumps(output) if output else "Command executed successfully with no output."
+            return json.dumps(output, ensure_ascii=False) if output else "Command executed successfully with no output."
 
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error executing command: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error executing command: {str(e)}"}, ensure_ascii=False)
 
     def stream_command(self, command: str) -> str:
         """
@@ -406,9 +406,9 @@ class E2BTools(Toolkit):
 
         try:
             self.run_command(command, on_stdout=stdout_callback, on_stderr=stderr_callback)
-            return json.dumps(outputs) if outputs else "Command completed with no output."
+            return json.dumps(outputs, ensure_ascii=False) if outputs else "Command completed with no output."
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error streaming command: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error streaming command: {str(e)}"}, ensure_ascii=False)
 
     def run_background_command(self, command: str) -> Any:
         """
@@ -425,7 +425,9 @@ class E2BTools(Toolkit):
             command_obj = self.sandbox.commands.run(command, background=True)
             return command_obj
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error starting background command: {str(e)}"})
+            return json.dumps(
+                {"status": "error", "message": f"Error starting background command: {str(e)}"}, ensure_ascii=False
+            )
 
     def kill_background_command(self, command_obj: Any) -> str:
         """
@@ -444,7 +446,9 @@ class E2BTools(Toolkit):
             command_obj.kill()
             return "Background command terminated successfully."
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error killing background command: {str(e)}"})
+            return json.dumps(
+                {"status": "error", "message": f"Error killing background command: {str(e)}"}, ensure_ascii=False
+            )
 
     # Filesystem Operations
     def list_files(self, directory_path: str = "/") -> str:
@@ -470,7 +474,7 @@ class E2BTools(Toolkit):
 
             return result
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error listing files: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error listing files: {str(e)}"}, ensure_ascii=False)
 
     def read_file_content(self, file_path: str, encoding: str = "utf-8") -> str:
         """
@@ -501,7 +505,7 @@ class E2BTools(Toolkit):
                 return f"Unexpected content type: {type(content)}. Expected str or bytes."
 
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error reading file: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error reading file: {str(e)}"}, ensure_ascii=False)
 
     def write_file_content(self, file_path: str, content: str) -> str:
         """
@@ -523,7 +527,7 @@ class E2BTools(Toolkit):
 
             return file_info.path
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error writing file: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error writing file: {str(e)}"}, ensure_ascii=False)
 
     def watch_directory(self, directory_path: str, duration_seconds: int = 5) -> str:
         """
@@ -558,18 +562,20 @@ class E2BTools(Toolkit):
                         "status": "success",
                         "message": f"Changes detected in {directory_path} over {duration_seconds} seconds:\n"
                         + "\n".join(changes),
-                    }
+                    },
+                    ensure_ascii=False,
                 )
             else:
                 return json.dumps(
                     {
                         "status": "success",
                         "message": f"No changes detected in {directory_path} over {duration_seconds} seconds",
-                    }
+                    },
+                    ensure_ascii=False,
                 )
 
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error watching directory: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error watching directory: {str(e)}"}, ensure_ascii=False)
 
     # Internet Access Functions
     def get_public_url(self, port: int) -> str:
@@ -587,7 +593,7 @@ class E2BTools(Toolkit):
 
             return f"http://{host}"
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error getting public URL: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error getting public URL: {str(e)}"}, ensure_ascii=False)
 
     def run_server(self, command: str, port: int) -> str:
         """
@@ -613,7 +619,7 @@ class E2BTools(Toolkit):
 
             return url
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error starting server: {str(e)}"})
+            return json.dumps({"status": "error", "message": f"Error starting server: {str(e)}"}, ensure_ascii=False)
 
     # Sandbox Management Functions
     def set_sandbox_timeout(self, timeout: int) -> str:
@@ -636,7 +642,9 @@ class E2BTools(Toolkit):
 
             return str(timeout)  # Convert int to str before returning
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error updating sandbox timeout: {str(e)}"})
+            return json.dumps(
+                {"status": "error", "message": f"Error updating sandbox timeout: {str(e)}"}, ensure_ascii=False
+            )
 
     def get_sandbox_status(self) -> str:
         """
@@ -652,7 +660,9 @@ class E2BTools(Toolkit):
             return sandbox_id
 
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error getting sandbox status: {str(e)}"})
+            return json.dumps(
+                {"status": "error", "message": f"Error getting sandbox status: {str(e)}"}, ensure_ascii=False
+            )
 
     def shutdown_sandbox(self) -> str:
         """
@@ -663,9 +673,13 @@ class E2BTools(Toolkit):
         """
         try:
             cont = self.sandbox.kill()
-            return json.dumps({"status": "success", "message": "Sandbox shut down successfully", "content": cont})
+            return json.dumps(
+                {"status": "success", "message": "Sandbox shut down successfully", "content": cont}, ensure_ascii=False
+            )
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error shutting down sandbox: {str(e)}"})
+            return json.dumps(
+                {"status": "error", "message": f"Error shutting down sandbox: {str(e)}"}, ensure_ascii=False
+            )
 
     def list_running_sandboxes(self) -> str:
         """
@@ -678,7 +692,9 @@ class E2BTools(Toolkit):
             running_sandboxes = self.sandbox.list()
 
             if not running_sandboxes:
-                return json.dumps({"status": "success", "message": "No running sandboxes found", "sandboxes": []})
+                return json.dumps(
+                    {"status": "success", "message": "No running sandboxes found", "sandboxes": []}, ensure_ascii=False
+                )
 
             sandboxes_info = []
             for sandbox in running_sandboxes:
@@ -697,7 +713,10 @@ class E2BTools(Toolkit):
                     "sandboxes": sandboxes_info,
                 },
                 indent=2,
+                ensure_ascii=False,
             )
 
         except Exception as e:
-            return json.dumps({"status": "error", "message": f"Error listing running sandboxes: {str(e)}"})
+            return json.dumps(
+                {"status": "error", "message": f"Error listing running sandboxes: {str(e)}"}, ensure_ascii=False
+            )

--- a/libs/agno/agno/tools/exa.py
+++ b/libs/agno/agno/tools/exa.py
@@ -303,9 +303,9 @@ class ExaTools(Toolkit):
                 ],
             }
             if self.show_results:
-                log_info(json.dumps(result))
+                log_info(json.dumps(result, ensure_ascii=False))
 
-            return json.dumps(result, indent=4)
+            return json.dumps(result, indent=4, ensure_ascii=False)
 
         except TimeoutError as e:
             log_error(f"Answer generation timed out after {self.timeout} seconds: {str(e)}")
@@ -363,13 +363,13 @@ class ExaTools(Toolkit):
             if self.show_results:
                 log_info("Research completed successfully")
 
-            return json.dumps(result, indent=4)
+            return json.dumps(result, indent=4, ensure_ascii=False)
 
         except TimeoutError:
             error_msg = "Research task timed out"
             log_error(error_msg)
-            return json.dumps({"error": error_msg}, indent=4)
+            return json.dumps({"error": error_msg}, indent=4, ensure_ascii=False)
         except Exception as e:
             error_msg = f"Research failed: {str(e)}"
             log_error(error_msg)
-            return json.dumps({"error": error_msg}, indent=4)
+            return json.dumps({"error": error_msg}, indent=4, ensure_ascii=False)

--- a/libs/agno/agno/tools/file.py
+++ b/libs/agno/agno/tools/file.py
@@ -291,7 +291,7 @@ class FileTools(Toolkit):
                 if self._is_excluded(file_path):
                     continue
                 files.append(rel_path)
-            return json.dumps(files, indent=4)
+            return json.dumps(files, indent=4, ensure_ascii=False)
         except Exception as e:
             log_error(f"Error reading files: {str(e)}")
             return f"Error reading files: {e}"
@@ -333,7 +333,7 @@ class FileTools(Toolkit):
                     "files": file_paths,
                 }
             log_debug(f"Found {len(file_paths)} files matching pattern {pattern}")
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         except Exception as e:
             error_msg = f"Error searching files with pattern '{pattern}': {e}"
@@ -416,7 +416,7 @@ class FileTools(Toolkit):
                 "files": matches,
             }
             log_debug(f"Found {len(matches)} files containing '{query}'")
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         except Exception as e:
             error_msg = f"Error searching content for '{query}': {e}"

--- a/libs/agno/agno/tools/file_generation.py
+++ b/libs/agno/agno/tools/file_generation.py
@@ -237,7 +237,7 @@ class FileGenerationTools(Toolkit):
                     json_content = data  # Use the original string if it's valid JSON
                 except json.JSONDecodeError:
                     # If it's not valid JSON, treat as plain text and wrap it
-                    json_content = json.dumps({"content": data}, indent=2)
+                    json_content = json.dumps({"content": data}, indent=2, ensure_ascii=False)
             else:
                 json_content = json.dumps(data, indent=2, ensure_ascii=False)
 

--- a/libs/agno/agno/tools/firecrawl.py
+++ b/libs/agno/agno/tools/firecrawl.py
@@ -88,7 +88,7 @@ class FirecrawlTools(Toolkit):
             params["formats"] = self.formats
 
         scrape_result = self.app.scrape(url, **params)
-        return json.dumps(scrape_result.model_dump(), cls=CustomJSONEncoder)
+        return json.dumps(scrape_result.model_dump(), cls=CustomJSONEncoder, ensure_ascii=False)
 
     def crawl_website(self, url: str, limit: Optional[int] = None) -> str:
         """Use this function to Crawls a website using Firecrawl.
@@ -111,7 +111,7 @@ class FirecrawlTools(Toolkit):
         params["poll_interval"] = self.poll_interval
 
         crawl_result = self.app.crawl(url, **params)
-        return json.dumps(crawl_result.model_dump(), cls=CustomJSONEncoder)
+        return json.dumps(crawl_result.model_dump(), cls=CustomJSONEncoder, ensure_ascii=False)
 
     def map_website(self, url: str) -> str:
         """Use this function to Map a website using Firecrawl.
@@ -121,7 +121,7 @@ class FirecrawlTools(Toolkit):
 
         """
         map_result = self.app.map(url)
-        return json.dumps(map_result.model_dump(), cls=CustomJSONEncoder)
+        return json.dumps(map_result.model_dump(), cls=CustomJSONEncoder, ensure_ascii=False)
 
     def search_web(self, query: str, limit: Optional[int] = None):
         """Use this function to search for the web using Firecrawl.
@@ -145,8 +145,8 @@ class FirecrawlTools(Toolkit):
 
         if hasattr(search_result, "success"):
             if search_result.success:
-                return json.dumps(search_result.data, cls=CustomJSONEncoder)
+                return json.dumps(search_result.data, cls=CustomJSONEncoder, ensure_ascii=False)
             else:
                 return f"Error searching with the Firecrawl tool: {search_result.error}"
         else:
-            return json.dumps(search_result.model_dump(), cls=CustomJSONEncoder)
+            return json.dumps(search_result.model_dump(), cls=CustomJSONEncoder, ensure_ascii=False)

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -801,7 +801,7 @@ class Function(BaseModel):
         if "files" in copy_entrypoint_args:
             del copy_entrypoint_args["files"]
         # Use json.dumps with sort_keys=True to ensure consistent ordering regardless of dict key order
-        args_str = json.dumps(copy_entrypoint_args, sort_keys=True, default=str)
+        args_str = json.dumps(copy_entrypoint_args, sort_keys=True, default=str, ensure_ascii=False)
 
         kwargs_str = str(sorted((call_args or {}).items()))
         key_str = f"{self.name}:{args_str}:{kwargs_str}"

--- a/libs/agno/agno/tools/github.py
+++ b/libs/agno/agno/tools/github.py
@@ -126,11 +126,11 @@ class GithubTools(Toolkit):
                 if len(repo_list) >= per_page:
                     break
 
-            return json.dumps(repo_list, indent=2)
+            return json.dumps(repo_list, indent=2, ensure_ascii=False)
 
         except GithubException as e:
             logger.exception("Error searching repositories")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_repositories(self) -> str:
         """List all repositories for the authenticated user.
@@ -142,10 +142,10 @@ class GithubTools(Toolkit):
         try:
             repos = self.g.get_user().get_repos()
             repo_names = [repo.full_name for repo in repos]
-            return json.dumps(repo_names, indent=2)
+            return json.dumps(repo_names, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error listing repositories")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def create_repository(
         self,
@@ -194,10 +194,10 @@ class GithubTools(Toolkit):
                 "private": repo.private,
                 "description": repo.description,
             }
-            return json.dumps(repo_info, indent=2)
+            return json.dumps(repo_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error creating repository")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_repository(self, repo_name: str) -> str:
         """Get details of a specific repository.
@@ -222,10 +222,10 @@ class GithubTools(Toolkit):
                 "license": repo.license.name if repo.license else None,
                 "default_branch": repo.default_branch,
             }
-            return json.dumps(repo_info, indent=2)
+            return json.dumps(repo_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error getting repository")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_repository_languages(self, repo_name: str) -> str:
         """Get the languages used in a repository.
@@ -240,10 +240,10 @@ class GithubTools(Toolkit):
         try:
             repo = self.g.get_repo(repo_name)
             languages = repo.get_languages()
-            return json.dumps(languages, indent=2)
+            return json.dumps(languages, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error getting repository languages")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_pull_request_count(
         self,
@@ -280,10 +280,10 @@ class GithubTools(Toolkit):
             else:
                 count = pulls.totalCount
 
-            return json.dumps({"count": count}, indent=2)
+            return json.dumps({"count": count}, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error counting pull requests")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_pull_request(self, repo_name: str, pr_number: int) -> str:
         """Get details of a specific pull request.
@@ -312,10 +312,10 @@ class GithubTools(Toolkit):
                 "mergeable": pr.mergeable,
                 "url": pr.html_url,
             }
-            return json.dumps(pr_info, indent=2)
+            return json.dumps(pr_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error getting pull request")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_pull_request_changes(self, repo_name: str, pr_number: int) -> str:
         """Get the changes (files modified) in a pull request.
@@ -345,10 +345,10 @@ class GithubTools(Toolkit):
                     "patch": file.patch,
                 }
                 changes.append(file_info)
-            return json.dumps(changes, indent=2)
+            return json.dumps(changes, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error getting pull request changes")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def create_issue(self, repo_name: str, title: str, body: Optional[str] = None) -> str:
         """Create an issue in a repository.
@@ -375,10 +375,10 @@ class GithubTools(Toolkit):
                 "created_at": issue.created_at.isoformat(),
                 "user": issue.user.login,
             }
-            return json.dumps(issue_info, indent=2)
+            return json.dumps(issue_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error creating issue")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_issues(self, repo_name: str, state: str = "open", page: int = 1, per_page: int = 20) -> str:
         """List issues for a repository with pagination.
@@ -436,10 +436,10 @@ class GithubTools(Toolkit):
 
             response = {"data": issue_list, "meta": meta}
 
-            return json.dumps(response, indent=2)
+            return json.dumps(response, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error listing issues")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_issue(self, repo_name: str, issue_number: int) -> str:
         """Get details of a specific issue.
@@ -467,10 +467,10 @@ class GithubTools(Toolkit):
                 "assignees": [assignee.login for assignee in issue.assignees],
                 "labels": [label.name for label in issue.labels],
             }
-            return json.dumps(issue_info, indent=2)
+            return json.dumps(issue_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error getting issue")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def comment_on_issue(self, repo_name: str, issue_number: int, comment_body: str) -> str:
         """Add a comment to an issue.
@@ -495,10 +495,10 @@ class GithubTools(Toolkit):
                 "created_at": comment.created_at.isoformat(),
                 "url": comment.html_url,
             }
-            return json.dumps(comment_info, indent=2)
+            return json.dumps(comment_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error commenting on issue")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def close_issue(self, repo_name: str, issue_number: int) -> str:
         """Close an issue.
@@ -515,10 +515,10 @@ class GithubTools(Toolkit):
             repo = self.g.get_repo(repo_name)
             issue = repo.get_issue(number=issue_number)
             issue.edit(state="closed")
-            return json.dumps({"message": f"Issue #{issue_number} closed."}, indent=2)
+            return json.dumps({"message": f"Issue #{issue_number} closed."}, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error closing issue")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def reopen_issue(self, repo_name: str, issue_number: int) -> str:
         """Reopen a closed issue.
@@ -535,10 +535,10 @@ class GithubTools(Toolkit):
             repo = self.g.get_repo(repo_name)
             issue = repo.get_issue(number=issue_number)
             issue.edit(state="open")
-            return json.dumps({"message": f"Issue #{issue_number} reopened."}, indent=2)
+            return json.dumps({"message": f"Issue #{issue_number} reopened."}, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error reopening issue")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def assign_issue(self, repo_name: str, issue_number: int, assignees: List[str]) -> str:
         """Assign users to an issue.
@@ -556,10 +556,12 @@ class GithubTools(Toolkit):
             repo = self.g.get_repo(repo_name)
             issue = repo.get_issue(number=issue_number)
             issue.edit(assignees=assignees)
-            return json.dumps({"message": f"Issue #{issue_number} assigned to {assignees}."}, indent=2)
+            return json.dumps(
+                {"message": f"Issue #{issue_number} assigned to {assignees}."}, indent=2, ensure_ascii=False
+            )
         except GithubException as e:
             logger.exception("Error assigning issue")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def label_issue(self, repo_name: str, issue_number: int, labels: List[str]) -> str:
         """Add labels to an issue.
@@ -580,10 +582,11 @@ class GithubTools(Toolkit):
             return json.dumps(
                 {"message": f"Labels {labels} added to issue #{issue_number}."},
                 indent=2,
+                ensure_ascii=False,
             )
         except GithubException as e:
             logger.exception("Error labeling issue")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_issue_comments(self, repo_name: str, issue_number: int) -> str:
         """List comments on an issue.
@@ -610,10 +613,10 @@ class GithubTools(Toolkit):
                     "url": comment.html_url,
                 }
                 comment_list.append(comment_info)
-            return json.dumps(comment_list, indent=2)
+            return json.dumps(comment_list, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error listing issue comments")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def edit_issue(
         self,
@@ -638,10 +641,10 @@ class GithubTools(Toolkit):
             repo = self.g.get_repo(repo_name)
             issue = repo.get_issue(number=issue_number)
             issue.edit(title=title, body=body)  # type: ignore
-            return json.dumps({"message": f"Issue #{issue_number} updated."}, indent=2)
+            return json.dumps({"message": f"Issue #{issue_number} updated."}, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error editing issue")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def delete_repository(self, repo_name: str) -> str:
         """Delete a repository (requires admin permissions).
@@ -656,10 +659,10 @@ class GithubTools(Toolkit):
         try:
             repo = self.g.get_repo(repo_name)
             repo.delete()
-            return json.dumps({"message": f"Repository {repo_name} deleted successfully"}, indent=2)
+            return json.dumps({"message": f"Repository {repo_name} deleted successfully"}, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error deleting repository")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_branches(self, repo_name: str) -> str:
         """List all branches in a repository.
@@ -673,10 +676,10 @@ class GithubTools(Toolkit):
         try:
             repo = self.g.get_repo(repo_name)
             branches = [branch.name for branch in repo.get_branches()]
-            return json.dumps(branches, indent=2)
+            return json.dumps(branches, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error listing branches")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_repository_stars(self, repo_name: str) -> str:
         """Get the number of stars for a repository.
@@ -690,10 +693,10 @@ class GithubTools(Toolkit):
         log_debug(f"Getting star count for repository: {repo_name}")
         try:
             repo = self.g.get_repo(repo_name)
-            return json.dumps({"stars": repo.stargazers_count}, indent=2)
+            return json.dumps({"stars": repo.stargazers_count}, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error getting repository stars")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_pull_requests(
         self,
@@ -735,10 +738,10 @@ class GithubTools(Toolkit):
                 if len(pr_list) >= limit:
                     break
 
-            return json.dumps(pr_list, indent=2)
+            return json.dumps(pr_list, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error getting pull requests by query")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_pull_request_comments(self, repo_name: str, pr_number: int, include_issue_comments: bool = True) -> str:
         """Get all comments on a pull request.
@@ -793,10 +796,10 @@ class GithubTools(Toolkit):
             # Sort all comments by creation date
             comment_list.sort(key=lambda x: x["created_at"], reverse=True)
 
-            return json.dumps(comment_list, indent=2)
+            return json.dumps(comment_list, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error getting pull request comments")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def create_pull_request_comment(
         self,
@@ -838,10 +841,10 @@ class GithubTools(Toolkit):
                 "url": comment.html_url,
             }
 
-            return json.dumps(comment_info, indent=2)
+            return json.dumps(comment_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error creating pull request comment")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def edit_pull_request_comment(self, repo_name: str, comment_id: int, body: str) -> str:
         """Edit an existing pull request comment.
@@ -877,10 +880,10 @@ class GithubTools(Toolkit):
                 "url": comment.html_url,
             }
 
-            return json.dumps(comment_info, indent=2)
+            return json.dumps(comment_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error editing pull request comment")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_pull_request_with_details(self, repo_name: str, pr_number: int) -> str:
         """Get comprehensive details of a pull request including comments, labels, and metadata.
@@ -985,10 +988,10 @@ class GithubTools(Toolkit):
                 "files_changed": files_changed,
             }
 
-            return json.dumps(pr_info, indent=2)
+            return json.dumps(pr_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error getting pull request details")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_repository_with_stats(self, repo_name: str) -> str:
         """Get comprehensive repository information including statistics.
@@ -1148,10 +1151,10 @@ class GithubTools(Toolkit):
                 log_debug(f"Error getting contributors: {e}")
                 repo_info["contributors"] = []
 
-            return json.dumps(repo_info, indent=2)
+            return json.dumps(repo_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error getting repository stats")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def create_pull_request(
         self,
@@ -1202,10 +1205,10 @@ class GithubTools(Toolkit):
                 "mergeable": pr.mergeable,
             }
 
-            return json.dumps(pr_info, indent=2)
+            return json.dumps(pr_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error creating pull request")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def create_review_request(
         self,
@@ -1238,10 +1241,11 @@ class GithubTools(Toolkit):
                     "requested_team_reviewers": team_reviewers or [],
                 },
                 indent=2,
+                ensure_ascii=False,
             )
         except GithubException as e:
             logger.exception("Error creating review request")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def create_file(
         self,
@@ -1287,10 +1291,10 @@ class GithubTools(Toolkit):
                 },
             }
 
-            return json.dumps(file_info, indent=2)
+            return json.dumps(file_info, indent=2, ensure_ascii=False)
         except (GithubException, AssertionError) as e:
             logger.exception("Error creating file")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_file_content(self, repo_name: str, path: str, ref: Optional[str] = None) -> str:
         """Get the content of a file in a repository.
@@ -1315,7 +1319,7 @@ class GithubTools(Toolkit):
 
             # If it's a list (directory), raise an error
             if isinstance(file_content, list):
-                return json.dumps({"error": f"{path} is a directory, not a file"})
+                return json.dumps({"error": f"{path} is a directory, not a file"}, ensure_ascii=False)
 
             # Decode content
             try:
@@ -1343,10 +1347,10 @@ class GithubTools(Toolkit):
                 "content": decoded_content,
             }
 
-            return json.dumps(content_info, indent=2)
+            return json.dumps(content_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error getting file content")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def update_file(
         self,
@@ -1398,10 +1402,10 @@ class GithubTools(Toolkit):
                 },
             }
 
-            return json.dumps(file_info, indent=2)
+            return json.dumps(file_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error updating file")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def delete_file(
         self,
@@ -1440,10 +1444,10 @@ class GithubTools(Toolkit):
                 },
             }
 
-            return json.dumps(commit_info, indent=2)
+            return json.dumps(commit_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error deleting file")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_directory_content(self, repo_name: str, path: str, ref: Optional[str] = None) -> str:
         """Get the contents of a directory in a repository.
@@ -1468,7 +1472,7 @@ class GithubTools(Toolkit):
 
             # If it's not a list, it's a file not a directory
             if not isinstance(contents, list):
-                return json.dumps({"error": f"{path} is a file, not a directory"})
+                return json.dumps({"error": f"{path} is a file, not a directory"}, ensure_ascii=False)
 
             # Process directory contents
             items = []
@@ -1487,10 +1491,10 @@ class GithubTools(Toolkit):
             # Sort by type (directories first) and then by name
             items.sort(key=lambda x: (x["type"] != "dir", x["name"].lower()))
 
-            return json.dumps(items, indent=2)
+            return json.dumps(items, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error getting directory contents")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_branch_content(self, repo_name: str, branch: str = "main") -> str:
         """Get the root directory content of a specific branch.
@@ -1508,7 +1512,7 @@ class GithubTools(Toolkit):
             return self.get_directory_content(repo_name=repo_name, path="", ref=branch)
         except GithubException as e:
             logger.exception("Error getting branch contents")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def create_branch(self, repo_name: str, branch_name: str, source_branch: Optional[str] = None) -> str:
         """Create a new branch in a repository.
@@ -1542,10 +1546,10 @@ class GithubTools(Toolkit):
                 "url": new_branch.url.replace("api.github.com/repos", "github.com").replace("git/refs/heads", "tree"),
             }
 
-            return json.dumps(branch_info, indent=2)
+            return json.dumps(branch_info, indent=2, ensure_ascii=False)
         except GithubException as e:
             logger.exception("Error creating branch")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def set_default_branch(self, repo_name: str, branch_name: str) -> str:
         """Set the default branch for a repository.
@@ -1564,7 +1568,7 @@ class GithubTools(Toolkit):
             # Check if the branch exists by looking at all branches
             branches = [branch.name for branch in repo.get_branches()]
             if branch_name not in branches:
-                return json.dumps({"error": f"Branch '{branch_name}' does not exist"})
+                return json.dumps({"error": f"Branch '{branch_name}' does not exist"}, ensure_ascii=False)
 
             # Set the default branch
             repo.edit(default_branch=branch_name)
@@ -1576,10 +1580,11 @@ class GithubTools(Toolkit):
                     "default_branch": branch_name,
                 },
                 indent=2,
+                ensure_ascii=False,
             )
         except GithubException as e:
             logger.exception("Error setting default branch")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def search_code(
         self,
@@ -1659,10 +1664,11 @@ class GithubTools(Toolkit):
                     "results": results,
                 },
                 indent=2,
+                ensure_ascii=False,
             )
         except GithubException as e:
             logger.exception("Error searching code")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def search_issues_and_prs(
         self,
@@ -1757,7 +1763,8 @@ class GithubTools(Toolkit):
                     "results": results,
                 },
                 indent=2,
+                ensure_ascii=False,
             )
         except GithubException as e:
             logger.exception("Error searching issues and PRs")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/gitlab.py
+++ b/libs/agno/agno/tools/gitlab.py
@@ -82,7 +82,7 @@ class GitlabTools(Toolkit):
         return {"current_page": page, "per_page": per_page, "returned_items": returned_items}
 
     def _json_error(self, message: str) -> str:
-        return json.dumps({"error": message})
+        return json.dumps({"error": message}, ensure_ascii=False)
 
     def _build_headers(self) -> Dict[str, str]:
         if self.access_token:
@@ -105,11 +105,11 @@ class GitlabTools(Toolkit):
                 message = payload.get("message") or payload.get("error")
                 if message is not None:
                     if isinstance(message, (dict, list)):
-                        detail = json.dumps(message)
+                        detail = json.dumps(message, ensure_ascii=False)
                     else:
                         detail = str(message)
             elif isinstance(payload, list):
-                detail = json.dumps(payload)
+                detail = json.dumps(payload, ensure_ascii=False)
         except Exception:
             detail = None
 
@@ -221,7 +221,9 @@ class GitlabTools(Toolkit):
             log_debug(f"Listing GitLab projects with params: {params}")
             projects = self.client.projects.list(**params)
             data = [self._serialize_project(project) for project in projects]
-            return json.dumps({"data": data, "meta": self._build_meta(page, per_page, len(data))}, indent=2)
+            return json.dumps(
+                {"data": data, "meta": self._build_meta(page, per_page, len(data))}, indent=2, ensure_ascii=False
+            )
         except (GitlabAuthenticationError, GitlabError) as e:
             logger.exception("GitLab API error while listing projects")
             return self._json_error(str(e))
@@ -259,7 +261,9 @@ class GitlabTools(Toolkit):
             log_debug(f"Listing GitLab projects with params: {params}")
             projects = await self._aget("/projects", params=params)
             data = [self._serialize_project(project) for project in projects]
-            return json.dumps({"data": data, "meta": self._build_meta(page, per_page, len(data))}, indent=2)
+            return json.dumps(
+                {"data": data, "meta": self._build_meta(page, per_page, len(data))}, indent=2, ensure_ascii=False
+            )
         except httpx.HTTPStatusError as e:
             message = self._http_error_message(e.response)
             log_error(f"GitLab API error while listing projects: {message}: {str(e)}")
@@ -284,7 +288,7 @@ class GitlabTools(Toolkit):
         try:
             log_debug(f"Getting GitLab project: {project_id_or_path}")
             project = self._get_project(project_id_or_path)
-            return json.dumps(self._serialize_project(project), indent=2)
+            return json.dumps(self._serialize_project(project), indent=2, ensure_ascii=False)
         except (GitlabAuthenticationError, GitlabError) as e:
             logger.exception(f"GitLab API error while getting project {project_id_or_path}")
             return self._json_error(str(e))
@@ -306,7 +310,7 @@ class GitlabTools(Toolkit):
             project_ref = self._encode_project_ref(project_id_or_path)
             log_debug(f"Getting GitLab project: {project_id_or_path}")
             project = await self._aget(f"/projects/{project_ref}")
-            return json.dumps(self._serialize_project(project), indent=2)
+            return json.dumps(self._serialize_project(project), indent=2, ensure_ascii=False)
         except httpx.HTTPStatusError as e:
             message = self._http_error_message(e.response)
             log_error(f"GitLab API error while getting project {project_id_or_path}: {message}: {str(e)}")
@@ -357,7 +361,9 @@ class GitlabTools(Toolkit):
             log_debug(f"Listing merge requests for project {project_id_or_path} with params: {params}")
             merge_requests = project.mergerequests.list(**params)
             data = [self._serialize_merge_request(mr) for mr in merge_requests]
-            return json.dumps({"data": data, "meta": self._build_meta(page, per_page, len(data))}, indent=2)
+            return json.dumps(
+                {"data": data, "meta": self._build_meta(page, per_page, len(data))}, indent=2, ensure_ascii=False
+            )
         except (GitlabAuthenticationError, GitlabError) as e:
             logger.exception(f"GitLab API error while listing merge requests for project {project_id_or_path}")
             return self._json_error(str(e))
@@ -404,7 +410,9 @@ class GitlabTools(Toolkit):
             log_debug(f"Listing merge requests for project {project_id_or_path} with params: {params}")
             merge_requests = await self._aget(f"/projects/{project_ref}/merge_requests", params=params)
             data = [self._serialize_merge_request(mr) for mr in merge_requests]
-            return json.dumps({"data": data, "meta": self._build_meta(page, per_page, len(data))}, indent=2)
+            return json.dumps(
+                {"data": data, "meta": self._build_meta(page, per_page, len(data))}, indent=2, ensure_ascii=False
+            )
         except httpx.HTTPStatusError as e:
             message = self._http_error_message(e.response)
             log_error(
@@ -433,7 +441,7 @@ class GitlabTools(Toolkit):
             project = self._get_project(project_id_or_path)
             log_debug(f"Getting merge request {merge_request_iid} from project {project_id_or_path}")
             merge_request = project.mergerequests.get(merge_request_iid)
-            return json.dumps(self._serialize_merge_request(merge_request), indent=2)
+            return json.dumps(self._serialize_merge_request(merge_request), indent=2, ensure_ascii=False)
         except (GitlabAuthenticationError, GitlabError) as e:
             logger.exception(f"GitLab API error while getting merge request {merge_request_iid}")
             return self._json_error(str(e))
@@ -456,7 +464,7 @@ class GitlabTools(Toolkit):
             project_ref = self._encode_project_ref(project_id_or_path)
             log_debug(f"Getting merge request {merge_request_iid} from project {project_id_or_path}")
             merge_request = await self._aget(f"/projects/{project_ref}/merge_requests/{merge_request_iid}")
-            return json.dumps(self._serialize_merge_request(merge_request), indent=2)
+            return json.dumps(self._serialize_merge_request(merge_request), indent=2, ensure_ascii=False)
         except httpx.HTTPStatusError as e:
             message = self._http_error_message(e.response)
             log_error(f"GitLab API error while getting merge request {merge_request_iid}: {message}: {str(e)}")
@@ -511,7 +519,9 @@ class GitlabTools(Toolkit):
             log_debug(f"Listing issues for project {project_id_or_path} with params: {params}")
             issues = project.issues.list(**params)
             data = [self._serialize_issue(issue) for issue in issues]
-            return json.dumps({"data": data, "meta": self._build_meta(page, per_page, len(data))}, indent=2)
+            return json.dumps(
+                {"data": data, "meta": self._build_meta(page, per_page, len(data))}, indent=2, ensure_ascii=False
+            )
         except (GitlabAuthenticationError, GitlabError) as e:
             logger.exception(f"GitLab API error while listing issues for project {project_id_or_path}")
             return self._json_error(str(e))
@@ -562,7 +572,9 @@ class GitlabTools(Toolkit):
             log_debug(f"Listing issues for project {project_id_or_path} with params: {params}")
             issues = await self._aget(f"/projects/{project_ref}/issues", params=params)
             data = [self._serialize_issue(issue) for issue in issues]
-            return json.dumps({"data": data, "meta": self._build_meta(page, per_page, len(data))}, indent=2)
+            return json.dumps(
+                {"data": data, "meta": self._build_meta(page, per_page, len(data))}, indent=2, ensure_ascii=False
+            )
         except httpx.HTTPStatusError as e:
             message = self._http_error_message(e.response)
             log_error(f"GitLab API error while listing issues for project {project_id_or_path}: {message}: {str(e)}")

--- a/libs/agno/agno/tools/google/auth/decorator.py
+++ b/libs/agno/agno/tools/google/auth/decorator.py
@@ -25,13 +25,17 @@ def google_authenticate(service_name: str):
                     self.creds = self._resolve_creds()
                 except Exception as e:
                     log_error(f"{service_name.title()} authentication failed: {e}")
-                    return json.dumps({"error": f"{service_name.title()} authentication failed: {e}"})
+                    return json.dumps(
+                        {"error": f"{service_name.title()} authentication failed: {e}"}, ensure_ascii=False
+                    )
             if not self._service:
                 try:
                     self._service = self._build_service(self.creds)
                 except Exception as e:
                     log_error(f"{service_name.title()} service initialization failed: {e}")
-                    return json.dumps({"error": f"{service_name.title()} service initialization failed: {e}"})
+                    return json.dumps(
+                        {"error": f"{service_name.title()} service initialization failed: {e}"}, ensure_ascii=False
+                    )
             return func(self, *args, **kwargs)
 
         return wrapper

--- a/libs/agno/agno/tools/google/auth/toolkit.py
+++ b/libs/agno/agno/tools/google/auth/toolkit.py
@@ -47,7 +47,9 @@ class GoogleAuth(Toolkit):
             if service in self._services:
                 scopes.update(self._services[service])
         if not scopes:
-            return json.dumps({"error": f"Unknown services. Available: {', '.join(self._services)}"})
+            return json.dumps(
+                {"error": f"Unknown services. Available: {', '.join(self._services)}"}, ensure_ascii=False
+            )
         params = {
             "client_id": self.client_id,
             "redirect_uri": self.redirect_uri,
@@ -58,4 +60,4 @@ class GoogleAuth(Toolkit):
             "include_granted_scopes": "true",
         }
         url = f"https://accounts.google.com/o/oauth2/v2/auth?{urlencode(params)}"
-        return json.dumps({"message": f"Connect {', '.join(services)}", "url": url})
+        return json.dumps({"message": f"Connect {', '.join(services)}", "url": url}, ensure_ascii=False)

--- a/libs/agno/agno/tools/google/bigquery.py
+++ b/libs/agno/agno/tools/google/bigquery.py
@@ -94,7 +94,7 @@ class GoogleBigQueryTools(Toolkit):
             table_api_repr = api_response.to_api_repr()
             desc = str(table_api_repr.get("description", ""))
             col_names = str([column["name"] for column in table_api_repr["schema"]["fields"]])  # Columns in a table
-            result = json.dumps({"table_description": desc, "columns": col_names})
+            result = json.dumps({"table_description": desc, "columns": col_names}, ensure_ascii=False)
             return result
         except Exception as e:
             logger.exception("Error getting table schema")
@@ -110,7 +110,7 @@ class GoogleBigQueryTools(Toolkit):
             - The result may be empty if the query does not return any data.
         """
         try:
-            return json.dumps(self._run_sql(sql=query), default=str)
+            return json.dumps(self._run_sql(sql=query), default=str, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error running query")
             return f"Error running query: {e}"

--- a/libs/agno/agno/tools/google/calendar.py
+++ b/libs/agno/agno/tools/google/calendar.py
@@ -223,7 +223,8 @@ class GoogleCalendarTools(GoogleToolkit):
                 start_date = start_dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
             except ValueError:
                 return json.dumps(
-                    {"error": f"Invalid date format: {start_date}. Use ISO format (YYYY-MM-DDTHH:MM:SS)."}
+                    {"error": f"Invalid date format: {start_date}. Use ISO format (YYYY-MM-DDTHH:MM:SS)."},
+                    ensure_ascii=False,
                 )
 
         try:
@@ -244,7 +245,9 @@ class GoogleCalendarTools(GoogleToolkit):
                         dt = dt.replace(tzinfo=datetime.timezone.utc)
                     params["timeMax"] = dt.isoformat()
                 except ValueError:
-                    return json.dumps({"error": f"Invalid end_date format: {end_date}. Use ISO format."})
+                    return json.dumps(
+                        {"error": f"Invalid end_date format: {end_date}. Use ISO format."}, ensure_ascii=False
+                    )
             if page_token:
                 params["pageToken"] = page_token
 
@@ -256,10 +259,10 @@ class GoogleCalendarTools(GoogleToolkit):
                 result["nextPageToken"] = events_result["nextPageToken"]
             if not events and not page_token:
                 result["message"] = "No upcoming events found."
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
         except HttpError as error:
             log_error(f"An error occurred: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)
 
     @authenticate
     def create_event(
@@ -306,7 +309,9 @@ class GoogleCalendarTools(GoogleToolkit):
                 else:
                     end_time = end_dt.isoformat()
             except ValueError:
-                return json.dumps({"error": "Invalid datetime format. Use ISO format (YYYY-MM-DDTHH:MM:SS)."})
+                return json.dumps(
+                    {"error": "Invalid datetime format. Use ISO format (YYYY-MM-DDTHH:MM:SS)."}, ensure_ascii=False
+                )
 
             event: Dict[str, Any] = {
                 "summary": title,
@@ -339,10 +344,10 @@ class GoogleCalendarTools(GoogleToolkit):
                 .execute()
             )
             log_debug(f"Event created successfully in calendar {self.calendar_id}. Event ID: {event_result['id']}")
-            return json.dumps(event_result)
+            return json.dumps(event_result, ensure_ascii=False)
         except HttpError as error:
             log_error(f"An error occurred: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)
 
     @authenticate
     def update_event(
@@ -398,7 +403,9 @@ class GoogleCalendarTools(GoogleToolkit):
                     if timezone:
                         event["start"]["timeZone"] = timezone
                 except ValueError:
-                    return json.dumps({"error": f"Invalid start datetime format: {start_date}. Use ISO format."})
+                    return json.dumps(
+                        {"error": f"Invalid start datetime format: {start_date}. Use ISO format."}, ensure_ascii=False
+                    )
 
             if end_date:
                 try:
@@ -411,7 +418,9 @@ class GoogleCalendarTools(GoogleToolkit):
                     if timezone:
                         event["end"]["timeZone"] = timezone
                 except ValueError:
-                    return json.dumps({"error": f"Invalid end datetime format: {end_date}. Use ISO format."})
+                    return json.dumps(
+                        {"error": f"Invalid end datetime format: {end_date}. Use ISO format."}, ensure_ascii=False
+                    )
 
             send_updates = "all" if notify_attendees and attendees else "none"
 
@@ -422,10 +431,10 @@ class GoogleCalendarTools(GoogleToolkit):
             )
 
             log_debug(f"Event {event_id} updated successfully.")
-            return json.dumps(updated_event)
+            return json.dumps(updated_event, ensure_ascii=False)
         except HttpError as error:
             log_error(f"An error occurred while updating event: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)
 
     @authenticate
     def delete_event(self, event_id: str = "", notify_attendees: Optional[bool] = True) -> str:
@@ -444,10 +453,12 @@ class GoogleCalendarTools(GoogleToolkit):
             service = cast(Resource, self.service)
             service.events().delete(calendarId=self.calendar_id, eventId=event_id, sendUpdates=send_updates).execute()
             log_debug(f"Event {event_id} deleted successfully.")
-            return json.dumps({"success": True, "message": f"Event {event_id} deleted successfully."})
+            return json.dumps(
+                {"success": True, "message": f"Event {event_id} deleted successfully."}, ensure_ascii=False
+            )
         except HttpError as error:
             log_error(f"An error occurred while deleting event: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)
 
     @authenticate
     def fetch_all_events(
@@ -519,11 +530,11 @@ class GoogleCalendarTools(GoogleToolkit):
             log_debug(f"Fetched {len(all_events)} events from calendar: {self.calendar_id}")
 
             if not all_events:
-                return json.dumps({"message": "No events found."})
-            return json.dumps(all_events)
+                return json.dumps({"message": "No events found."}, ensure_ascii=False)
+            return json.dumps(all_events, ensure_ascii=False)
         except HttpError as error:
             log_error(f"An error occurred while fetching events: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)
 
     @authenticate
     def find_available_slots(
@@ -573,7 +584,7 @@ class GoogleCalendarTools(GoogleToolkit):
             events_data = json.loads(events_json)
 
             if isinstance(events_data, dict) and "error" in events_data:
-                return json.dumps({"error": events_data["error"]})
+                return json.dumps({"error": events_data["error"]}, ensure_ascii=False)
 
             events = events_data if isinstance(events_data, list) else events_data.get("items", [])
 
@@ -630,11 +641,11 @@ class GoogleCalendarTools(GoogleToolkit):
             }
 
             log_debug(f"Found {len(available_slots)} available slots")
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
 
         except Exception as e:
             log_error(f"An error occurred while finding available slots: {str(e)}")
-            return json.dumps({"error": f"An error occurred: {str(e)}"})
+            return json.dumps({"error": f"An error occurred: {str(e)}"}, ensure_ascii=False)
 
     def _get_working_hours(self) -> str:
         """Get working hours based on user's calendar settings and locale.
@@ -674,12 +685,13 @@ class GoogleCalendarTools(GoogleToolkit):
                     "locale": locale,
                     "week_start": week_start,
                     "hide_weekends": hide_weekends,
-                }
+                },
+                ensure_ascii=False,
             )
 
         except HttpError as error:
             log_error(f"An error occurred while getting working hours: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)
 
     @authenticate
     def list_calendars(self, page_token: Optional[str] = None) -> str:
@@ -718,11 +730,11 @@ class GoogleCalendarTools(GoogleToolkit):
             }
             if calendar_list.get("nextPageToken"):
                 result["nextPageToken"] = calendar_list["nextPageToken"]
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
 
         except HttpError as error:
             log_error(f"An error occurred while listing calendars: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)
 
     @authenticate
     def get_event(self, event_id: str = "") -> str:
@@ -738,10 +750,10 @@ class GoogleCalendarTools(GoogleToolkit):
         try:
             service = cast(Resource, self.service)
             event = service.events().get(calendarId=self.calendar_id, eventId=event_id).execute()
-            return json.dumps(event)
+            return json.dumps(event, ensure_ascii=False)
         except HttpError as error:
             log_error(f"An error occurred while getting event: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)
 
     @authenticate
     def quick_add_event(self, text: str = "") -> str:
@@ -759,10 +771,10 @@ class GoogleCalendarTools(GoogleToolkit):
             service = cast(Resource, self.service)
             event = service.events().quickAdd(calendarId=self.calendar_id, text=text).execute()
             log_debug(f"Quick add event created: {event.get('id')}")
-            return json.dumps(event)
+            return json.dumps(event, ensure_ascii=False)
         except HttpError as error:
             log_error(f"An error occurred while quick-adding event: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)
 
     @authenticate
     def check_availability(
@@ -798,7 +810,9 @@ class GoogleCalendarTools(GoogleToolkit):
                 if end_dt.tzinfo is None:
                     end_dt = end_dt.replace(tzinfo=datetime.timezone.utc)
             except ValueError:
-                return json.dumps({"error": "Invalid date format. Use ISO format (YYYY-MM-DDTHH:MM:SS)."})
+                return json.dumps(
+                    {"error": "Invalid date format. Use ISO format (YYYY-MM-DDTHH:MM:SS)."}, ensure_ascii=False
+                )
 
             body = {
                 "timeMin": start_dt.isoformat(),
@@ -831,11 +845,12 @@ class GoogleCalendarTools(GoogleToolkit):
                     "availability": availability,
                     "time_window": {"start": start_dt.isoformat(), "end": end_dt.isoformat()},
                     "timezone": timezone or "UTC",
-                }
+                },
+                ensure_ascii=False,
             )
         except HttpError as error:
             log_error(f"An error occurred while checking availability: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)
 
     @authenticate
     def search_events(
@@ -904,10 +919,10 @@ class GoogleCalendarTools(GoogleToolkit):
                 result["message"] = f"No events found matching '{query}'."
 
             log_debug(f"Found {len(events)} events matching '{query}'")
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
         except HttpError as error:
             log_error(f"An error occurred while searching events: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)
 
     @authenticate
     def move_event(
@@ -941,10 +956,10 @@ class GoogleCalendarTools(GoogleToolkit):
                 .execute()
             )
             log_debug(f"Event {event_id} moved to calendar {destination_calendar_id}")
-            return json.dumps(moved_event)
+            return json.dumps(moved_event, ensure_ascii=False)
         except HttpError as error:
             log_error(f"An error occurred while moving event: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)
 
     @authenticate
     def get_event_attendees(self, event_id: str = "") -> str:
@@ -981,11 +996,12 @@ class GoogleCalendarTools(GoogleToolkit):
                     "event_summary": event.get("summary", ""),
                     "attendees": attendee_list,
                     "total": len(attendee_list),
-                }
+                },
+                ensure_ascii=False,
             )
         except HttpError as error:
             log_error(f"An error occurred while getting attendees: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)
 
     @authenticate
     def respond_to_event(self, event_id: str = "", response: str = "") -> str:
@@ -1001,7 +1017,10 @@ class GoogleCalendarTools(GoogleToolkit):
         """
         valid_responses = {"accepted", "declined", "tentative"}
         if response not in valid_responses:
-            return json.dumps({"error": f"Invalid response '{response}'. Must be one of: {', '.join(valid_responses)}"})
+            return json.dumps(
+                {"error": f"Invalid response '{response}'. Must be one of: {', '.join(valid_responses)}"},
+                ensure_ascii=False,
+            )
 
         try:
             service = cast(Resource, self.service)
@@ -1038,7 +1057,7 @@ class GoogleCalendarTools(GoogleToolkit):
             )
 
             log_debug(f"Responded '{response}' to event {event_id}")
-            return json.dumps(updated_event)
+            return json.dumps(updated_event, ensure_ascii=False)
         except HttpError as error:
             log_error(f"An error occurred while responding to event: {error}")
-            return json.dumps({"error": f"An error occurred: {error}"})
+            return json.dumps({"error": f"An error occurred: {error}"}, ensure_ascii=False)

--- a/libs/agno/agno/tools/google/drive.py
+++ b/libs/agno/agno/tools/google/drive.py
@@ -468,7 +468,7 @@ class GoogleDriveTools(GoogleToolkit):
             str: JSON string containing matching files and metadata or error message
         """
         if max_results < 1:
-            return json.dumps({"error": "max_results must be greater than 0"})
+            return json.dumps({"error": "max_results must be greater than 0"}, ensure_ascii=False)
 
         try:
             service = cast(Resource, self.service)
@@ -507,13 +507,14 @@ class GoogleDriveTools(GoogleToolkit):
                     "count": len(files),
                     "nextPageToken": results.get("nextPageToken"),
                     "incompleteSearch": incomplete,
-                }
+                },
+                ensure_ascii=False,
             )
         except HttpError as e:
-            return json.dumps({"error": f"Google Drive API error: {e}"})
+            return json.dumps({"error": f"Google Drive API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Could not search Google Drive files: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     async def asearch_files(
         self,
@@ -556,7 +557,8 @@ class GoogleDriveTools(GoogleToolkit):
             elif mime_type.startswith(WorkspaceType.WORKSPACE_PREFIX):
                 # Drawings, Vids, etc. have no text export — get_media() would crash
                 return json.dumps(
-                    {"error": f"Cannot read {mime_type} as text. Use download_file instead.", "file": metadata}
+                    {"error": f"Cannot read {mime_type} as text. Use download_file instead.", "file": metadata},
+                    ensure_ascii=False,
                 )
             elif mime_type in OFFICE_MIME_TYPES:
                 file_size = int(metadata.get("size", 0))
@@ -568,7 +570,8 @@ class GoogleDriveTools(GoogleToolkit):
                                 f"({self.max_read_size}). Use download_file instead."
                             ),
                             "file": metadata,
-                        }
+                        },
+                        ensure_ascii=False,
                     )
                 request = service.files().get_media(fileId=file_id, supportsAllDrives=self.supports_all_drives)
                 content_bytes = self._download_bytes(request)
@@ -590,14 +593,16 @@ class GoogleDriveTools(GoogleToolkit):
                             "content": content,
                             "contentLength": len(content),
                             "extractedFrom": fmt,
-                        }
+                        },
+                        ensure_ascii=False,
                     )
                 except ImportError:
                     return json.dumps(
                         {
                             "error": f"Cannot read .{fmt} file: {pkg} not installed. Install with: pip install {pkg}",
                             "file": metadata,
-                        }
+                        },
+                        ensure_ascii=False,
                     )
             elif _is_binary_mime(mime_type):
                 file_ext = metadata.get("name", "").rsplit(".", 1)[-1].lower()
@@ -612,7 +617,8 @@ class GoogleDriveTools(GoogleToolkit):
                     {
                         "error": f"Cannot read binary file ({mime_type}) as text.{hint}",
                         "file": metadata,
-                    }
+                    },
+                    ensure_ascii=False,
                 )
             else:
                 export_mime = None
@@ -629,7 +635,8 @@ class GoogleDriveTools(GoogleToolkit):
                         {
                             "error": f"File is {file_size} bytes, exceeds max_read_size ({self.max_read_size}). Use download_file instead.",
                             "file": metadata,
-                        }
+                        },
+                        ensure_ascii=False,
                     )
                 request = service.files().get_media(fileId=file_id, supportsAllDrives=self.supports_all_drives)
                 content_bytes = self._download_bytes(request)
@@ -641,13 +648,14 @@ class GoogleDriveTools(GoogleToolkit):
                     "content": content,
                     "contentLength": len(content),
                     "exportMimeType": export_mime,
-                }
+                },
+                ensure_ascii=False,
             )
         except HttpError as e:
-            return json.dumps({"error": f"Google Drive API error: {e}"})
+            return json.dumps({"error": f"Google Drive API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Could not read Google Drive file {file_id}: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     async def aread_file(self, file_id: str = "") -> str:
         """
@@ -674,7 +682,7 @@ class GoogleDriveTools(GoogleToolkit):
         """
         path = Path(file_path)
         if not path.exists() or not path.is_file():
-            return json.dumps({"error": f"The file '{path}' does not exist or is not a file."})
+            return json.dumps({"error": f"The file '{path}' does not exist or is not a file."}, ensure_ascii=False)
 
         resolved_mime_type, _ = mimetypes.guess_type(path.as_posix())
         if resolved_mime_type is None:
@@ -691,12 +699,12 @@ class GoogleDriveTools(GoogleToolkit):
                 )
                 .execute()
             )
-            return json.dumps(uploaded_file)
+            return json.dumps(uploaded_file, ensure_ascii=False)
         except HttpError as e:
-            return json.dumps({"error": f"Google Drive API error: {e}"})
+            return json.dumps({"error": f"Google Drive API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Could not upload file '{path}': {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     async def aupload_file(self, file_path: Union[str, Path] = "") -> str:
         """
@@ -729,7 +737,9 @@ class GoogleDriveTools(GoogleToolkit):
             try:
                 path = safe_join_filename(self.download_dir, metadata.get("name", file_id))
             except PathSecurityError as e:
-                return json.dumps({"error": f"Invalid file name from Google Drive: {e}", "file": metadata})
+                return json.dumps(
+                    {"error": f"Invalid file name from Google Drive: {e}", "file": metadata}, ensure_ascii=False
+                )
 
             # Resolve export target — user override > auto-detect > None for regular files
             if export_format:
@@ -739,7 +749,9 @@ class GoogleDriveTools(GoogleToolkit):
                 target_mime, ext = self.DOWNLOAD_EXPORT_TYPES[mime_type]
             elif mime_type.startswith(WorkspaceType.WORKSPACE_PREFIX):
                 # Future-proofing: catch new Workspace types Google may add
-                return json.dumps({"error": f"Unsupported Workspace file type for download: {mime_type}"})
+                return json.dumps(
+                    {"error": f"Unsupported Workspace file type for download: {mime_type}"}, ensure_ascii=False
+                )
             else:
                 target_mime = None
                 ext = ""
@@ -759,7 +771,8 @@ class GoogleDriveTools(GoogleToolkit):
                         "status": "exported",
                         "exportMimeType": target_mime,
                         "originalMimeType": mime_type,
-                    }
+                    },
+                    ensure_ascii=False,
                 )
 
             # Regular file — direct download
@@ -769,12 +782,12 @@ class GoogleDriveTools(GoogleToolkit):
                 done = False
                 while not done:
                     _, done = downloader.next_chunk()
-            return json.dumps({"fileId": file_id, "path": str(path), "status": "downloaded"})
+            return json.dumps({"fileId": file_id, "path": str(path), "status": "downloaded"}, ensure_ascii=False)
         except HttpError as e:
-            return json.dumps({"error": f"Google Drive API error: {e}"})
+            return json.dumps({"error": f"Google Drive API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Could not download file '{file_id}': {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     async def adownload_file(self, file_id: str = "", export_format: Optional[str] = None) -> str:
         """

--- a/libs/agno/agno/tools/google/gmail.py
+++ b/libs/agno/agno/tools/google/gmail.py
@@ -418,11 +418,11 @@ class GmailTools(GoogleToolkit):
                 response["totalEstimate"] = results["resultSizeEstimate"]
             if results.get("nextPageToken"):
                 response["nextPageToken"] = results["nextPageToken"]
-            return json.dumps(response)
+            return json.dumps(response, ensure_ascii=False)
         except HttpError as error:
-            return json.dumps({"error": f"Error retrieving latest emails: {error}"})
+            return json.dumps({"error": f"Error retrieving latest emails: {error}"}, ensure_ascii=False)
         except Exception as error:
-            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"})
+            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"}, ensure_ascii=False)
 
     @authenticate
     def get_emails_from_user(self, user: str = "", count: int = 10, page_token: Optional[str] = None) -> str:
@@ -452,11 +452,11 @@ class GmailTools(GoogleToolkit):
                 response["totalEstimate"] = results["resultSizeEstimate"]
             if results.get("nextPageToken"):
                 response["nextPageToken"] = results["nextPageToken"]
-            return json.dumps(response)
+            return json.dumps(response, ensure_ascii=False)
         except HttpError as error:
-            return json.dumps({"error": f"Error retrieving emails from {user}: {error}"})
+            return json.dumps({"error": f"Error retrieving emails from {user}: {error}"}, ensure_ascii=False)
         except Exception as error:
-            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"})
+            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"}, ensure_ascii=False)
 
     @authenticate
     def get_unread_emails(self, count: int = 10, page_token: Optional[str] = None) -> str:
@@ -484,11 +484,11 @@ class GmailTools(GoogleToolkit):
                 response["totalEstimate"] = results["resultSizeEstimate"]
             if results.get("nextPageToken"):
                 response["nextPageToken"] = results["nextPageToken"]
-            return json.dumps(response)
+            return json.dumps(response, ensure_ascii=False)
         except HttpError as error:
-            return json.dumps({"error": f"Error retrieving unread emails: {error}"})
+            return json.dumps({"error": f"Error retrieving unread emails: {error}"}, ensure_ascii=False)
         except Exception as error:
-            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"})
+            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"}, ensure_ascii=False)
 
     @authenticate
     def get_emails_by_thread(self, thread_id: str = "") -> str:
@@ -537,11 +537,11 @@ class GmailTools(GoogleToolkit):
                 response["totalEstimate"] = results["resultSizeEstimate"]
             if results.get("nextPageToken"):
                 response["nextPageToken"] = results["nextPageToken"]
-            return json.dumps(response)
+            return json.dumps(response, ensure_ascii=False)
         except HttpError as error:
-            return json.dumps({"error": f"Error retrieving starred emails: {error}"})
+            return json.dumps({"error": f"Error retrieving starred emails: {error}"}, ensure_ascii=False)
         except Exception as error:
-            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"})
+            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"}, ensure_ascii=False)
 
     @authenticate
     def get_emails_by_context(self, context: str = "", count: int = 10, page_token: Optional[str] = None) -> str:
@@ -570,11 +570,11 @@ class GmailTools(GoogleToolkit):
                 response["totalEstimate"] = results["resultSizeEstimate"]
             if results.get("nextPageToken"):
                 response["nextPageToken"] = results["nextPageToken"]
-            return json.dumps(response)
+            return json.dumps(response, ensure_ascii=False)
         except HttpError as error:
-            return json.dumps({"error": f"Error retrieving emails by context '{context}': {error}"})
+            return json.dumps({"error": f"Error retrieving emails by context '{context}': {error}"}, ensure_ascii=False)
         except Exception as error:
-            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"})
+            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"}, ensure_ascii=False)
 
     @authenticate
     def get_emails_by_date(
@@ -617,11 +617,11 @@ class GmailTools(GoogleToolkit):
                 response["totalEstimate"] = results["resultSizeEstimate"]
             if results.get("nextPageToken"):
                 response["nextPageToken"] = results["nextPageToken"]
-            return json.dumps(response)
+            return json.dumps(response, ensure_ascii=False)
         except HttpError as error:
-            return json.dumps({"error": f"Error retrieving emails by date: {error}"})
+            return json.dumps({"error": f"Error retrieving emails by date: {error}"}, ensure_ascii=False)
         except Exception as error:
-            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"})
+            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"}, ensure_ascii=False)
 
     @authenticate
     def create_draft_email(
@@ -682,7 +682,7 @@ class GmailTools(GoogleToolkit):
             )
             draft = {"message": message}
             draft = self.service.users().drafts().create(userId="me", body=draft).execute()  # type: ignore
-            return json.dumps(draft)
+            return json.dumps(draft, ensure_ascii=False)
         except HttpError as error:
             return f"HTTP Error creating draft: {error}"
         except Exception as error:
@@ -746,7 +746,7 @@ class GmailTools(GoogleToolkit):
                 attachments=attachment_files,
             )
             message = self.service.users().messages().send(userId="me", body=message).execute()  # type: ignore
-            return json.dumps(message)
+            return json.dumps(message, ensure_ascii=False)
         except HttpError as error:
             return f"HTTP Error sending email: {error}"
         except Exception as error:
@@ -806,7 +806,7 @@ class GmailTools(GoogleToolkit):
                 attachments=attachment_files,
             )
             message = self.service.users().messages().send(userId="me", body=message).execute()  # type: ignore
-            return json.dumps(message)
+            return json.dumps(message, ensure_ascii=False)
         except HttpError as error:
             return f"HTTP Error sending reply: {error}"
         except Exception as error:
@@ -840,11 +840,11 @@ class GmailTools(GoogleToolkit):
                 response["totalEstimate"] = results["resultSizeEstimate"]
             if results.get("nextPageToken"):
                 response["nextPageToken"] = results["nextPageToken"]
-            return json.dumps(response)
+            return json.dumps(response, ensure_ascii=False)
         except HttpError as error:
-            return json.dumps({"error": f"Error retrieving emails with query '{query}': {error}"})
+            return json.dumps({"error": f"Error retrieving emails with query '{query}': {error}"}, ensure_ascii=False)
         except Exception as error:
-            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"})
+            return json.dumps({"error": f"Unexpected error: {type(error).__name__}: {error}"}, ensure_ascii=False)
 
     @authenticate
     def mark_email_as_read(self, message_id: str = "") -> str:
@@ -1456,13 +1456,13 @@ class GmailTools(GoogleToolkit):
                         att["localPath"] = self._download_attachment_file(
                             message_id, att["attachmentId"], att["filename"]
                         )
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
         except HttpError as e:
             log_error(f"Failed to get message {message_id}: {str(e)}")
-            return json.dumps({"error": f"Gmail API error: {e}"})
+            return json.dumps({"error": f"Gmail API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Unexpected error: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     @authenticate
     def get_thread(self, thread_id: str = "") -> str:
@@ -1483,14 +1483,15 @@ class GmailTools(GoogleToolkit):
                     "threadId": thread_id,
                     "messages": messages,
                     "messageCount": len(messages),
-                }
+                },
+                ensure_ascii=False,
             )
         except HttpError as e:
             log_error(f"Failed to get thread {thread_id}: {str(e)}")
-            return json.dumps({"error": f"Gmail API error: {e}"})
+            return json.dumps({"error": f"Gmail API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Unexpected error: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     @authenticate
     def search_threads(self, query: str = "", count: int = 10, page_token: Optional[str] = None) -> str:
@@ -1520,13 +1521,13 @@ class GmailTools(GoogleToolkit):
                 response["requested"] = count
             if results.get("nextPageToken"):
                 response["nextPageToken"] = results["nextPageToken"]
-            return json.dumps(response)
+            return json.dumps(response, ensure_ascii=False)
         except HttpError as e:
             log_error(f"Thread search failed: {str(e)}")
-            return json.dumps({"error": f"Gmail API error: {e}"})
+            return json.dumps({"error": f"Gmail API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Unexpected error: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     @authenticate
     def modify_thread_labels(
@@ -1555,17 +1556,17 @@ class GmailTools(GoogleToolkit):
                 body["removeLabelIds"] = self._resolve_label_ids(names)
 
             if not body:
-                return json.dumps({"error": "Must specify add_labels or remove_labels"})
+                return json.dumps({"error": "Must specify add_labels or remove_labels"}, ensure_ascii=False)
 
             service = self.service
             result = service.users().threads().modify(userId="me", id=thread_id, body=body).execute()  # type: ignore
-            return json.dumps({"threadId": result["id"], "labelIds": result.get("labelIds", [])})
+            return json.dumps({"threadId": result["id"], "labelIds": result.get("labelIds", [])}, ensure_ascii=False)
         except HttpError as e:
             log_error(f"Failed to modify labels on thread {thread_id}: {str(e)}")
-            return json.dumps({"error": f"Gmail API error: {e}"})
+            return json.dumps({"error": f"Gmail API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Unexpected error: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     @authenticate
     def trash_thread(self, thread_id: str = "") -> str:
@@ -1580,13 +1581,13 @@ class GmailTools(GoogleToolkit):
         try:
             service = self.service
             service.users().threads().trash(userId="me", id=thread_id).execute()  # type: ignore
-            return json.dumps({"threadId": thread_id, "action": "trashed"})
+            return json.dumps({"threadId": thread_id, "action": "trashed"}, ensure_ascii=False)
         except HttpError as e:
             log_error(f"Failed to trash thread {thread_id}: {str(e)}")
-            return json.dumps({"error": f"Gmail API error: {e}"})
+            return json.dumps({"error": f"Gmail API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Unexpected error: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     @authenticate
     def get_draft(self, draft_id: str = "") -> str:
@@ -1606,14 +1607,15 @@ class GmailTools(GoogleToolkit):
                 {
                     "draftId": draft["id"],
                     "message": self._format_message(msg_data) if msg_data else {},
-                }
+                },
+                ensure_ascii=False,
             )
         except HttpError as e:
             log_error(f"Failed to get draft {draft_id}: {str(e)}")
-            return json.dumps({"error": f"Gmail API error: {e}"})
+            return json.dumps({"error": f"Gmail API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Unexpected error: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     @authenticate
     def list_drafts(self, count: int = 10, page_token: Optional[str] = None) -> str:
@@ -1642,13 +1644,13 @@ class GmailTools(GoogleToolkit):
                 response["requested"] = count
             if results.get("nextPageToken"):
                 response["nextPageToken"] = results["nextPageToken"]
-            return json.dumps(response)
+            return json.dumps(response, ensure_ascii=False)
         except HttpError as e:
             log_error(f"Failed to list drafts: {str(e)}")
-            return json.dumps({"error": f"Gmail API error: {e}"})
+            return json.dumps({"error": f"Gmail API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Unexpected error: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     @authenticate
     def send_draft(self, draft_id: str = "") -> str:
@@ -1668,14 +1670,15 @@ class GmailTools(GoogleToolkit):
                     "id": result.get("id"),
                     "threadId": result.get("threadId"),
                     "labelIds": result.get("labelIds", []),
-                }
+                },
+                ensure_ascii=False,
             )
         except HttpError as e:
             log_error(f"Failed to send draft {draft_id}: {str(e)}")
-            return json.dumps({"error": f"Gmail API error: {e}"})
+            return json.dumps({"error": f"Gmail API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Unexpected error: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     @authenticate
     def update_draft(
@@ -1736,13 +1739,13 @@ class GmailTools(GoogleToolkit):
 
             service = self.service
             result = service.users().drafts().update(userId="me", id=draft_id, body={"message": mime}).execute()  # type: ignore
-            return json.dumps({"draftId": result["id"]})
+            return json.dumps({"draftId": result["id"]}, ensure_ascii=False)
         except HttpError as e:
             log_error(f"Failed to update draft {draft_id}: {str(e)}")
-            return json.dumps({"error": f"Gmail API error: {e}"})
+            return json.dumps({"error": f"Gmail API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Failed to update draft {draft_id}: {str(e)}")
-            return json.dumps({"error": f"{type(e).__name__}: {e}"})
+            return json.dumps({"error": f"{type(e).__name__}: {e}"}, ensure_ascii=False)
 
     @authenticate
     def list_labels(self) -> str:
@@ -1773,13 +1776,13 @@ class GmailTools(GoogleToolkit):
                         "threadsUnread": detail.get("threadsUnread", 0),
                     }
                 )
-            return json.dumps({"labels": formatted, "count": len(formatted)})
+            return json.dumps({"labels": formatted, "count": len(formatted)}, ensure_ascii=False)
         except HttpError as e:
             log_error(f"Failed to list labels: {str(e)}")
-            return json.dumps({"error": f"Gmail API error: {e}"})
+            return json.dumps({"error": f"Gmail API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Unexpected error: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     @authenticate
     def modify_message_labels(
@@ -1809,17 +1812,17 @@ class GmailTools(GoogleToolkit):
                 body["removeLabelIds"] = self._resolve_label_ids(names)
 
             if not body:
-                return json.dumps({"error": "Must specify add_labels or remove_labels"})
+                return json.dumps({"error": "Must specify add_labels or remove_labels"}, ensure_ascii=False)
 
             service = self.service
             result = service.users().messages().modify(userId="me", id=message_id, body=body).execute()  # type: ignore
-            return json.dumps({"id": result["id"], "labelIds": result.get("labelIds", [])})
+            return json.dumps({"id": result["id"], "labelIds": result.get("labelIds", [])}, ensure_ascii=False)
         except HttpError as e:
             log_error(f"Failed to modify labels on message {message_id}: {str(e)}")
-            return json.dumps({"error": f"Gmail API error: {e}"})
+            return json.dumps({"error": f"Gmail API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Unexpected error: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     @authenticate
     def trash_message(self, message_id: str = "", undo: bool = False) -> str:
@@ -1836,17 +1839,17 @@ class GmailTools(GoogleToolkit):
             service = self.service
             if undo:
                 service.users().messages().untrash(userId="me", id=message_id).execute()  # type: ignore
-                return json.dumps({"id": message_id, "action": "untrashed"})
+                return json.dumps({"id": message_id, "action": "untrashed"}, ensure_ascii=False)
             else:
                 service.users().messages().trash(userId="me", id=message_id).execute()  # type: ignore
-                return json.dumps({"id": message_id, "action": "trashed"})
+                return json.dumps({"id": message_id, "action": "trashed"}, ensure_ascii=False)
         except HttpError as e:
             action_name = "untrash" if undo else "trash"
             log_error(f"Failed to {action_name} message {message_id}: {str(e)}")
-            return json.dumps({"error": f"Gmail API error: {e}"})
+            return json.dumps({"error": f"Gmail API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Unexpected error: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)
 
     @authenticate
     def download_attachment(
@@ -1867,10 +1870,12 @@ class GmailTools(GoogleToolkit):
         """
         try:
             local_path = self._download_attachment_file(message_id, attachment_id, filename)
-            return json.dumps({"localPath": local_path, "filename": filename, "messageId": message_id})
+            return json.dumps(
+                {"localPath": local_path, "filename": filename, "messageId": message_id}, ensure_ascii=False
+            )
         except HttpError as e:
             log_error(f"Failed to download attachment from {message_id}: {str(e)}")
-            return json.dumps({"error": f"Gmail API error: {e}"})
+            return json.dumps({"error": f"Gmail API error: {e}"}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Unexpected error: {str(e)}")
-            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"})
+            return json.dumps({"error": f"Unexpected error: {type(e).__name__}: {e}"}, ensure_ascii=False)

--- a/libs/agno/agno/tools/google/maps.py
+++ b/libs/agno/agno/tools/google/maps.py
@@ -99,7 +99,7 @@ class GoogleMapTools(Toolkit):
 
                 places.append(place_info)
 
-            return json.dumps(places)
+            return json.dumps(places, ensure_ascii=False)
 
         except Exception as e:
             print(f"Error searching Google Maps: {str(e)}")

--- a/libs/agno/agno/tools/google/sheets.py
+++ b/libs/agno/agno/tools/google/sheets.py
@@ -209,7 +209,7 @@ class GoogleSheetsTools(GoogleToolkit):
 
         try:
             result = self.service.spreadsheets().values().get(spreadsheetId=sheet_id, range=sheet_range).execute()  # type: ignore
-            return json.dumps(result.get("values", []))
+            return json.dumps(result.get("values", []), ensure_ascii=False)
 
         except Exception as e:
             return f"Error reading Google Sheet: {e}"

--- a/libs/agno/agno/tools/google/slides.py
+++ b/libs/agno/agno/tools/google/slides.py
@@ -288,7 +288,7 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not title.strip():
-                return json.dumps({"error": "title cannot be empty."})
+                return json.dumps({"error": "title cannot be empty."}, ensure_ascii=False)
             result = self.slides_service.presentations().create(body={"title": title}).execute()
             pres_id = result["presentationId"]
             return json.dumps(
@@ -296,10 +296,11 @@ class GoogleSlidesTools(GoogleToolkit):
                     "presentation_id": pres_id,
                     "url": f"https://docs.google.com/presentation/d/{pres_id}",
                     "title": title,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def get_presentation(self, presentation_id: str, fields: Optional[str] = None) -> str:
@@ -315,12 +316,12 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
 
             result = self.slides_service.presentations().get(presentationId=presentation_id, fields=fields).execute()
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def list_presentations(self, page_size: int = 20, page_token: Optional[str] = None) -> str:
@@ -336,7 +337,7 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if page_size <= 0:
-                return json.dumps({"error": "page_size must be a positive integer."})
+                return json.dumps({"error": "page_size must be a positive integer."}, ensure_ascii=False)
             effective_size = min(page_size, self.max_results)
             response = (
                 self.drive_service.files()
@@ -349,9 +350,11 @@ class GoogleSlidesTools(GoogleToolkit):
                 .execute()
             )
             files = response.get("files", [])
-            return json.dumps({"presentations": files, "nextPageToken": response.get("nextPageToken")})
+            return json.dumps(
+                {"presentations": files, "nextPageToken": response.get("nextPageToken")}, ensure_ascii=False
+            )
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def delete_presentation(self, presentation_id: str) -> str:
@@ -366,12 +369,12 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
 
             self.drive_service.files().delete(fileId=presentation_id).execute()
-            return json.dumps({"deleted": presentation_id})
+            return json.dumps({"deleted": presentation_id}, ensure_ascii=False)
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def add_slide(
@@ -401,10 +404,10 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
 
             if insertion_index is not None and insertion_index < 0:
-                return json.dumps({"error": "insertion_index must be >= 0."})
+                return json.dumps({"error": "insertion_index must be >= 0."}, ensure_ascii=False)
 
             valid_layouts = {
                 "BLANK",
@@ -421,7 +424,8 @@ class GoogleSlidesTools(GoogleToolkit):
             }
             if layout not in valid_layouts:
                 return json.dumps(
-                    {"error": f"Invalid layout '{layout}'. Must be one of: {', '.join(sorted(valid_layouts))}"}
+                    {"error": f"Invalid layout '{layout}'. Must be one of: {', '.join(sorted(valid_layouts))}"},
+                    ensure_ascii=False,
                 )
 
             slide_id = self._generate_id("slide")
@@ -498,10 +502,11 @@ class GoogleSlidesTools(GoogleToolkit):
                     "body": body,
                     "body_2": body_2,
                     "warnings": insert_errors if insert_errors else None,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def delete_slide(self, presentation_id: str, slide_id: str) -> str:
@@ -517,14 +522,14 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
             if not slide_id.strip():
-                return json.dumps({"error": "object_id cannot be empty."})
+                return json.dumps({"error": "object_id cannot be empty."}, ensure_ascii=False)
 
             self._batch_update(presentation_id, [{"deleteObject": {"objectId": slide_id}}])
-            return json.dumps({"deleted_slide": slide_id})
+            return json.dumps({"deleted_slide": slide_id}, ensure_ascii=False)
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def duplicate_slide(self, presentation_id: str, slide_id: str) -> str:
@@ -540,14 +545,14 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
             if not slide_id.strip():
-                return json.dumps({"error": "object_id cannot be empty."})
+                return json.dumps({"error": "object_id cannot be empty."}, ensure_ascii=False)
 
             result = self._batch_update(presentation_id, [{"duplicateObject": {"objectId": slide_id}}])
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def move_slides(
@@ -569,12 +574,12 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
 
             if not slide_ids:
-                return json.dumps({"error": "slide_ids list cannot be empty."})
+                return json.dumps({"error": "slide_ids list cannot be empty."}, ensure_ascii=False)
             if insertion_index < 0:
-                return json.dumps({"error": "insertion_index must be >= 0."})
+                return json.dumps({"error": "insertion_index must be >= 0."}, ensure_ascii=False)
 
             self._batch_update(
                 presentation_id,
@@ -587,9 +592,9 @@ class GoogleSlidesTools(GoogleToolkit):
                     }
                 ],
             )
-            return json.dumps({"moved": slide_ids, "to_index": insertion_index})
+            return json.dumps({"moved": slide_ids, "to_index": insertion_index}, ensure_ascii=False)
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def add_text_box(
@@ -619,14 +624,14 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
             if not slide_id.strip():
-                return json.dumps({"error": "object_id cannot be empty."})
+                return json.dumps({"error": "object_id cannot be empty."}, ensure_ascii=False)
 
             if not text or not text.strip():
-                return json.dumps({"error": "text cannot be empty."})
+                return json.dumps({"error": "text cannot be empty."}, ensure_ascii=False)
             if width <= 0 or height <= 0:
-                return json.dumps({"error": "Width and height must be positive."})
+                return json.dumps({"error": "Width and height must be positive."}, ensure_ascii=False)
 
             box_id = self._generate_id("textbox")
             emu_x, emu_y = self._to_emu(x), self._to_emu(y)
@@ -656,9 +661,9 @@ class GoogleSlidesTools(GoogleToolkit):
                 {"insertText": {"objectId": box_id, "text": text, "insertionIndex": 0}},
             ]
             self._batch_update(presentation_id, requests)
-            return json.dumps({"text_box_id": box_id, "slide_id": slide_id})
+            return json.dumps({"text_box_id": box_id, "slide_id": slide_id}, ensure_ascii=False)
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def add_table(
@@ -684,15 +689,15 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
             if not slide_id.strip():
-                return json.dumps({"error": "object_id cannot be empty."})
+                return json.dumps({"error": "object_id cannot be empty."}, ensure_ascii=False)
 
             if rows <= 0 or columns <= 0:
-                return json.dumps({"error": "Rows and columns must be positive integers."})
+                return json.dumps({"error": "Rows and columns must be positive integers."}, ensure_ascii=False)
 
             if content and (len(content) > rows or any(len(r) > columns for r in content)):
-                return json.dumps({"error": "Content dimensions exceed table dimensions."})
+                return json.dumps({"error": "Content dimensions exceed table dimensions."}, ensure_ascii=False)
 
             table_id = self._generate_id("table")
             requests: List[Dict[str, Any]] = [
@@ -720,9 +725,9 @@ class GoogleSlidesTools(GoogleToolkit):
                                 }
                             )
             self._batch_update(presentation_id, requests)
-            return json.dumps({"table_id": table_id, "rows": rows, "columns": columns})
+            return json.dumps({"table_id": table_id, "rows": rows, "columns": columns}, ensure_ascii=False)
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def set_background_image(
@@ -744,16 +749,16 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
             if not slide_id.strip():
-                return json.dumps({"error": "object_id cannot be empty."})
+                return json.dumps({"error": "object_id cannot be empty."}, ensure_ascii=False)
 
             if not image_url or not image_url.strip():
-                return json.dumps({"error": "image_url cannot be empty."})
+                return json.dumps({"error": "image_url cannot be empty."}, ensure_ascii=False)
 
             parsed = urlparse(image_url)
             if parsed.scheme not in ("http", "https") or not parsed.netloc:
-                return json.dumps({"error": "image_url must be a valid http or https URL."})
+                return json.dumps({"error": "image_url must be a valid http or https URL."}, ensure_ascii=False)
 
             self._batch_update(
                 presentation_id,
@@ -769,9 +774,9 @@ class GoogleSlidesTools(GoogleToolkit):
                     }
                 ],
             )
-            return json.dumps({"background_set": True, "slide_id": slide_id})
+            return json.dumps({"background_set": True, "slide_id": slide_id}, ensure_ascii=False)
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def read_all_text(self, presentation_id: str) -> str:
@@ -786,7 +791,7 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
 
             fields = (
                 "slides(objectId,pageElements("
@@ -804,9 +809,9 @@ class GoogleSlidesTools(GoogleToolkit):
                 for el in slide.get("pageElements", []):
                     lines.extend(self._extract_text_recursive(el))
                 result[sid] = lines
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def get_slide_thumbnail(self, presentation_id: str, slide_id: str) -> str:
@@ -822,9 +827,9 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
             if not slide_id.strip():
-                return json.dumps({"error": "object_id cannot be empty."})
+                return json.dumps({"error": "object_id cannot be empty."}, ensure_ascii=False)
 
             response = (
                 self.slides_service.presentations()
@@ -834,10 +839,10 @@ class GoogleSlidesTools(GoogleToolkit):
             )
             url = response.get("contentUrl")
             if not url:
-                return json.dumps({"error": f"No thumbnail URL found for slide {slide_id}"})
-            return json.dumps({"thumbnail_url": url})
+                return json.dumps({"error": f"No thumbnail URL found for slide {slide_id}"}, ensure_ascii=False)
+            return json.dumps({"thumbnail_url": url}, ensure_ascii=False)
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def get_presentation_metadata(self, presentation_id: str) -> str:
@@ -852,7 +857,7 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
 
             result = (
                 self.slides_service.presentations()
@@ -906,10 +911,11 @@ class GoogleSlidesTools(GoogleToolkit):
                     "page_width_inches": round(width_emu / 914400, 2),
                     "page_height_inches": round(height_emu / 914400, 2),
                     "slides": slides_info,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def get_page(self, presentation_id: str, page_object_id: str) -> str:
@@ -925,9 +931,9 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
             if not page_object_id.strip():
-                return json.dumps({"error": "object_id cannot be empty."})
+                return json.dumps({"error": "object_id cannot be empty."}, ensure_ascii=False)
 
             result = (
                 self.slides_service.presentations()
@@ -935,9 +941,9 @@ class GoogleSlidesTools(GoogleToolkit):
                 .get(presentationId=presentation_id, pageObjectId=page_object_id)
                 .execute()
             )
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def get_slide_text(self, presentation_id: str, page_object_id: str) -> str:
@@ -953,9 +959,9 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
             if not page_object_id.strip():
-                return json.dumps({"error": "object_id cannot be empty."})
+                return json.dumps({"error": "object_id cannot be empty."}, ensure_ascii=False)
 
             page = (
                 self.slides_service.presentations()
@@ -966,9 +972,9 @@ class GoogleSlidesTools(GoogleToolkit):
             lines = []
             for el in page.get("pageElements", []):
                 lines.extend(self._extract_text_recursive(el))
-            return json.dumps({"slide_id": page_object_id, "text": lines})
+            return json.dumps({"slide_id": page_object_id, "text": lines}, ensure_ascii=False)
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def insert_youtube_video(
@@ -998,14 +1004,14 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
             if not slide_id.strip():
-                return json.dumps({"error": "object_id cannot be empty."})
+                return json.dumps({"error": "object_id cannot be empty."}, ensure_ascii=False)
 
             if not video_id or not video_id.strip():
-                return json.dumps({"error": "video_id cannot be empty."})
+                return json.dumps({"error": "video_id cannot be empty."}, ensure_ascii=False)
             if width <= 0 or height <= 0:
-                return json.dumps({"error": "Width and height must be positive."})
+                return json.dumps({"error": "Width and height must be positive."}, ensure_ascii=False)
 
             emu_x, emu_y = self._to_emu(x), self._to_emu(y)
             emu_width, emu_height = self._to_emu(width), self._to_emu(height)
@@ -1021,9 +1027,12 @@ class GoogleSlidesTools(GoogleToolkit):
                 height=emu_height,
                 id_alias="video_yt",
             )
-            return json.dumps({"video_object_id": video_obj_id, "slide_id": slide_id, "youtube_video_id": video_id})
+            return json.dumps(
+                {"video_object_id": video_obj_id, "slide_id": slide_id, "youtube_video_id": video_id},
+                ensure_ascii=False,
+            )
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     @authenticate
     def insert_drive_video(
@@ -1053,14 +1062,14 @@ class GoogleSlidesTools(GoogleToolkit):
         """
         try:
             if not presentation_id.strip():
-                return json.dumps({"error": "presentation_id cannot be empty."})
+                return json.dumps({"error": "presentation_id cannot be empty."}, ensure_ascii=False)
             if not slide_id.strip():
-                return json.dumps({"error": "object_id cannot be empty."})
+                return json.dumps({"error": "object_id cannot be empty."}, ensure_ascii=False)
 
             if not file_id or not file_id.strip():
-                return json.dumps({"error": "file_id cannot be empty."})
+                return json.dumps({"error": "file_id cannot be empty."}, ensure_ascii=False)
             if width <= 0 or height <= 0:
-                return json.dumps({"error": "Width and height must be positive."})
+                return json.dumps({"error": "Width and height must be positive."}, ensure_ascii=False)
 
             emu_x, emu_y = self._to_emu(x), self._to_emu(y)
             emu_width, emu_height = self._to_emu(width), self._to_emu(height)
@@ -1076,6 +1085,8 @@ class GoogleSlidesTools(GoogleToolkit):
                 height=emu_height,
                 id_alias="video_drive",
             )
-            return json.dumps({"video_object_id": video_obj_id, "slide_id": slide_id, "drive_file_id": file_id})
+            return json.dumps(
+                {"video_object_id": video_obj_id, "slide_id": slide_id, "drive_file_id": file_id}, ensure_ascii=False
+            )
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/hackernews.py
+++ b/libs/agno/agno/tools/hackernews.py
@@ -64,7 +64,7 @@ class HackerNewsTools(Toolkit):
                     continue
                 story["username"] = story.get("by", "unknown")
                 stories.append(story)
-            return json.dumps(stories)
+            return json.dumps(stories, ensure_ascii=False)
         except Exception as e:
             logger.exception(e)
             return f"Error fetching stories: {e}"
@@ -93,7 +93,7 @@ class HackerNewsTools(Toolkit):
                 "about": user.get("about"),
                 "total_items_submitted": len(user.get("submitted", [])),
             }
-            return json.dumps(user_details)
+            return json.dumps(user_details, ensure_ascii=False)
         except Exception as e:
             logger.exception(e)
             return f"Error getting user details: {e}"

--- a/libs/agno/agno/tools/jira.py
+++ b/libs/agno/agno/tools/jira.py
@@ -80,10 +80,10 @@ class JiraTools(Toolkit):
                 "description": issue.fields.description or "",
             }
             log_debug(f"Issue details retrieved for {issue_key}: {issue_details}")
-            return json.dumps(issue_details)
+            return json.dumps(issue_details, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error retrieving issue {issue_key}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def create_issue(self, project_key: str, summary: str, description: str, issuetype: str = "Task") -> str:
         """
@@ -105,10 +105,10 @@ class JiraTools(Toolkit):
             new_issue = self.jira.create_issue(fields=issue_dict)
             issue_url = f"{self.server_url}/browse/{new_issue.key}"
             log_debug(f"Issue created with key: {new_issue.key}")
-            return json.dumps({"key": new_issue.key, "url": issue_url})
+            return json.dumps({"key": new_issue.key, "url": issue_url}, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error creating issue in project {project_key}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def search_issues(self, jql_str: str, max_results: int = 50) -> str:
         """
@@ -131,10 +131,10 @@ class JiraTools(Toolkit):
                 }
                 results.append(issue_details)
             log_debug(f"Found {len(results)} issues for JQL '{jql_str}'")
-            return json.dumps(results)
+            return json.dumps(results, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error searching issues with JQL '{jql_str}'")
-            return json.dumps([{"error": str(e)}])
+            return json.dumps([{"error": str(e)}], ensure_ascii=False)
 
     def add_comment(self, issue_key: str, comment: str) -> str:
         """
@@ -147,10 +147,10 @@ class JiraTools(Toolkit):
         try:
             self.jira.add_comment(issue_key, comment)
             log_debug(f"Comment added to issue {issue_key}")
-            return json.dumps({"status": "success", "issue_key": issue_key})
+            return json.dumps({"status": "success", "issue_key": issue_key}, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error adding comment to issue {issue_key}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def add_worklog(self, issue_key: str, time_spent: str, comment: Optional[str] = None) -> str:
         """
@@ -164,7 +164,9 @@ class JiraTools(Toolkit):
         try:
             self.jira.add_worklog(issue=issue_key, timeSpent=time_spent, comment=comment)
             log_debug(f"Worklog of '{time_spent}' added to issue {issue_key}")
-            return json.dumps({"status": "success", "issue_key": issue_key, "time_spent": time_spent})
+            return json.dumps(
+                {"status": "success", "issue_key": issue_key, "time_spent": time_spent}, ensure_ascii=False
+            )
         except Exception as e:
             logger.exception(f"Error adding worklog to issue {issue_key}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/knowledge.py
+++ b/libs/agno/agno/tools/knowledge.py
@@ -109,7 +109,7 @@ class KnowledgeTools(Toolkit):
             relevant_docs: List[Document] = self.knowledge.search(query=query)
             if len(relevant_docs) == 0:
                 return "No documents found"
-            return json.dumps([doc.to_dict() for doc in relevant_docs])
+            return json.dumps([doc.to_dict() for doc in relevant_docs], ensure_ascii=False)
         except Exception as e:
             log_error(f"Error searching knowledge base: {str(e)}")
             return f"Error searching knowledge base: {e}"

--- a/libs/agno/agno/tools/llms_txt.py
+++ b/libs/agno/agno/tools/llms_txt.py
@@ -61,7 +61,8 @@ class LLMsTxtTools(Toolkit):
                     for e in entries
                 ],
                 "total_pages": len(entries),
-            }
+            },
+            ensure_ascii=False,
         )
 
     # Tools

--- a/libs/agno/agno/tools/mem0.py
+++ b/libs/agno/agno/tools/mem0.py
@@ -105,7 +105,7 @@ class Mem0Tools(Toolkit):
         try:
             if isinstance(content, dict):
                 log_debug("Wrapping dict message into content string")
-                content = json.dumps(content)
+                content = json.dumps(content, ensure_ascii=False)
             elif not isinstance(content, str):
                 content = str(content)
             messages_list = [{"role": "user", "content": content}]
@@ -115,7 +115,7 @@ class Mem0Tools(Toolkit):
                 user_id=resolved_user_id,
                 infer=self.infer,
             )
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
         except Exception as e:
             log_error(f"Error adding memory: {str(e)}")
             return f"Error adding memory: {e}"
@@ -144,7 +144,7 @@ class Mem0Tools(Toolkit):
                 log_warning(f"Unexpected return type from mem0.search: {type(results)}. Returning empty list.")
                 search_results_list = []
 
-            return json.dumps(search_results_list)
+            return json.dumps(search_results_list, ensure_ascii=False)
         except ValueError as ve:
             log_error(str(ve))
             return str(ve)
@@ -170,7 +170,7 @@ class Mem0Tools(Toolkit):
             else:
                 log_warning(f"Unexpected return type from mem0.get_all: {type(results)}. Returning empty list.")
                 memories_list = []
-            return json.dumps(memories_list)
+            return json.dumps(memories_list, ensure_ascii=False)
         except ValueError as ve:
             log_error(str(ve))
             return str(ve)

--- a/libs/agno/agno/tools/memory.py
+++ b/libs/agno/agno/tools/memory.py
@@ -118,10 +118,10 @@ class MemoryTools(Toolkit):
             }
             run_context.session_state["memory_operations"].append(operation_result)
 
-            return json.dumps([memory.to_dict() for memory in memories], indent=2)  # type: ignore
+            return json.dumps([memory.to_dict() for memory in memories], indent=2, ensure_ascii=False)  # type: ignore
         except Exception as e:
             log_error(f"Error getting memories: {str(e)}")
-            return json.dumps({"error": str(e)}, indent=2)
+            return json.dumps({"error": str(e)}, indent=2, ensure_ascii=False)
 
     def add_memory(
         self,
@@ -172,15 +172,21 @@ class MemoryTools(Toolkit):
             run_context.session_state["memory_operations"].append(operation_result)
 
             if created_memory:
-                return json.dumps({"success": True, "operation": "add_memory", "memory": memory_dict}, indent=2)
+                return json.dumps(
+                    {"success": True, "operation": "add_memory", "memory": memory_dict}, indent=2, ensure_ascii=False
+                )
             else:
                 return json.dumps(
-                    {"success": False, "operation": "add_memory", "error": "Failed to create memory"}, indent=2
+                    {"success": False, "operation": "add_memory", "error": "Failed to create memory"},
+                    indent=2,
+                    ensure_ascii=False,
                 )
 
         except Exception as e:
             log_error(f"Error adding memory: {str(e)}")
-            return json.dumps({"success": False, "operation": "add_memory", "error": str(e)}, indent=2)
+            return json.dumps(
+                {"success": False, "operation": "add_memory", "error": str(e)}, indent=2, ensure_ascii=False
+            )
 
     def update_memory(
         self,
@@ -208,6 +214,7 @@ class MemoryTools(Toolkit):
                 return json.dumps(
                     {"success": False, "operation": "update_memory", "error": f"Memory with ID {memory_id} not found"},
                     indent=2,
+                    ensure_ascii=False,
                 )
 
             # Update fields if provided
@@ -238,15 +245,21 @@ class MemoryTools(Toolkit):
             run_context.session_state["memory_operations"].append(operation_result)
 
             if updated_result:
-                return json.dumps({"success": True, "operation": "update_memory", "memory": memory_dict}, indent=2)
+                return json.dumps(
+                    {"success": True, "operation": "update_memory", "memory": memory_dict}, indent=2, ensure_ascii=False
+                )
             else:
                 return json.dumps(
-                    {"success": False, "operation": "update_memory", "error": "Failed to update memory"}, indent=2
+                    {"success": False, "operation": "update_memory", "error": "Failed to update memory"},
+                    indent=2,
+                    ensure_ascii=False,
                 )
 
         except Exception as e:
             log_error(f"Error updating memory: {str(e)}")
-            return json.dumps({"success": False, "operation": "update_memory", "error": str(e)}, indent=2)
+            return json.dumps(
+                {"success": False, "operation": "update_memory", "error": str(e)}, indent=2, ensure_ascii=False
+            )
 
     def delete_memory(
         self,
@@ -270,6 +283,7 @@ class MemoryTools(Toolkit):
                 return json.dumps(
                     {"success": False, "operation": "delete_memory", "error": f"Memory with ID {memory_id} not found"},
                     indent=2,
+                    ensure_ascii=False,
                 )
 
             # Delete from database
@@ -300,11 +314,14 @@ class MemoryTools(Toolkit):
                     "deleted_memory": memory_dict,
                 },
                 indent=2,
+                ensure_ascii=False,
             )
 
         except Exception as e:
             log_error(f"Error deleting memory: {str(e)}")
-            return json.dumps({"success": False, "operation": "delete_memory", "error": str(e)}, indent=2)
+            return json.dumps(
+                {"success": False, "operation": "delete_memory", "error": str(e)}, indent=2, ensure_ascii=False
+            )
 
     def analyze(self, run_context: RunContext, analysis: str) -> str:
         """Use this tool to evaluate whether the memory operations results are correct and sufficient.

--- a/libs/agno/agno/tools/mlx_transcribe.py
+++ b/libs/agno/agno/tools/mlx_transcribe.py
@@ -136,7 +136,7 @@ class MLXTranscribeTools(Toolkit):
         """
         try:
             log_info(f"Reading files in : {self.base_dir}")
-            return json.dumps([str(file_name) for file_name in self.base_dir.iterdir()], indent=4)
+            return json.dumps([str(file_name) for file_name in self.base_dir.iterdir()], indent=4, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error reading files")
             return f"Error reading files: {e}"

--- a/libs/agno/agno/tools/models_labs.py
+++ b/libs/agno/agno/tools/models_labs.py
@@ -167,7 +167,7 @@ class ModelsLabTools(Toolkit):
             return ToolResult(content="Please set the MODELS_LAB_API_KEY")
 
         try:
-            payload = json.dumps(self._create_payload(prompt))
+            payload = json.dumps(self._create_payload(prompt), ensure_ascii=False)
             headers = {"Content-Type": "application/json"}
 
             log_debug(f"Generating {self.file_type.value} for prompt: {prompt}")

--- a/libs/agno/agno/tools/newspaper4k.py
+++ b/libs/agno/agno/tools/newspaper4k.py
@@ -88,6 +88,6 @@ class Newspaper4kTools(Toolkit):
             if self.article_length and "text" in article_data:
                 article_data["text"] = article_data["text"][: self.article_length]
 
-            return json.dumps(article_data, indent=2)
+            return json.dumps(article_data, indent=2, ensure_ascii=False)
         except Exception as e:
             return f"Error reading article from {url}: {e}"

--- a/libs/agno/agno/tools/notion.py
+++ b/libs/agno/agno/tools/notion.py
@@ -89,11 +89,11 @@ class NotionTools(Toolkit):
             )
 
             result = {"success": True, "page_id": new_page["id"], "url": new_page["url"], "title": title, "tag": tag}
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         except Exception as e:
             logger.exception(e)
-            return json.dumps({"success": False, "error": str(e)})
+            return json.dumps({"success": False, "error": str(e)}, ensure_ascii=False)
 
     def update_page(self, page_id: str, content: str) -> str:
         """Add content to an existing Notion page.
@@ -121,11 +121,11 @@ class NotionTools(Toolkit):
             )
 
             result = {"success": True, "page_id": page_id, "message": "Content added successfully"}
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         except Exception as e:
             logger.exception(e)
-            return json.dumps({"success": False, "error": str(e)})
+            return json.dumps({"success": False, "error": str(e)}, ensure_ascii=False)
 
     def search_pages(self, tag: str) -> str:
         """Search for pages in the database by tag.
@@ -163,7 +163,8 @@ class NotionTools(Toolkit):
                         "success": False,
                         "error": f"API request failed with status {response.status_code}",
                         "message": response.text,
-                    }
+                    },
+                    ensure_ascii=False,
                 )
 
             data = response.json()
@@ -191,7 +192,7 @@ class NotionTools(Toolkit):
                     continue
 
             result = {"success": True, "count": len(pages), "pages": pages}
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         except Exception as e:
             logger.exception(e)
@@ -200,5 +201,6 @@ class NotionTools(Toolkit):
                     "success": False,
                     "error": str(e),
                     "message": "Failed to search pages. Make sure the database is shared with the integration and has a 'Tag' property.",
-                }
+                },
+                ensure_ascii=False,
             )

--- a/libs/agno/agno/tools/openbb.py
+++ b/libs/agno/agno/tools/openbb.py
@@ -79,7 +79,7 @@ class OpenBBTools(Toolkit):
                         "ma_200d": row.get("ma_200d"),
                     }
                 )
-            return json.dumps(clean_results, indent=2, default=str)
+            return json.dumps(clean_results, indent=2, default=str, ensure_ascii=False)
         except Exception as e:
             return f"Error fetching current price for {symbol}: {e}"
 
@@ -100,7 +100,7 @@ class OpenBBTools(Toolkit):
             for row in result.to_dicts():
                 clean_results.append({"symbol": row.get("symbol"), "name": row.get("name")})
 
-        return json.dumps(clean_results, indent=2, default=str)
+        return json.dumps(clean_results, indent=2, default=str, ensure_ascii=False)
 
     def get_price_targets(self, symbol: str) -> str:
         """Use this function to get consensus price target and recommendations for a stock symbol or list of symbols.
@@ -115,7 +115,7 @@ class OpenBBTools(Toolkit):
         try:
             log_debug(f"Fetching price targets for {symbol}")
             result = self.obb.equity.estimates.consensus(symbol=symbol, provider=self.provider).to_polars()  # type: ignore
-            return json.dumps(result.to_dicts(), indent=2, default=str)
+            return json.dumps(result.to_dicts(), indent=2, default=str, ensure_ascii=False)
         except Exception as e:
             return f"Error fetching company news for {symbol}: {e}"
 
@@ -138,7 +138,7 @@ class OpenBBTools(Toolkit):
                 for row in result.to_dicts():
                     row.pop("images")
                     clean_results.append(row)
-            return json.dumps(clean_results[:num_stories], indent=2, default=str)
+            return json.dumps(clean_results[:num_stories], indent=2, default=str, ensure_ascii=False)
         except Exception as e:
             return f"Error fetching company news for {symbol}: {e}"
 
@@ -155,6 +155,6 @@ class OpenBBTools(Toolkit):
         try:
             log_debug(f"Fetching company profile for {symbol}")
             result = self.obb.equity.profile(symbol=symbol, provider=self.provider).to_polars()  # type: ignore
-            return json.dumps(result.to_dicts(), indent=2, default=str)
+            return json.dumps(result.to_dicts(), indent=2, default=str, ensure_ascii=False)
         except Exception as e:
             return f"Error fetching company profile for {symbol}: {e}"

--- a/libs/agno/agno/tools/openweather.py
+++ b/libs/agno/agno/tools/openweather.py
@@ -97,15 +97,15 @@ class OpenWeatherTools(Toolkit):
             result = self._make_request(url, params)
 
             if "error" in result:
-                return json.dumps(result)
+                return json.dumps(result, ensure_ascii=False)
 
             if not result:
-                return json.dumps({"error": f"No location found for '{location}'"})
+                return json.dumps({"error": f"No location found for '{location}'"}, ensure_ascii=False)
 
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error geocoding location")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_current_weather(self, location: str) -> str:
         """Get current weather data for a location.
@@ -122,10 +122,10 @@ class OpenWeatherTools(Toolkit):
             # First geocode the location to get coordinates
             geocode_result = json.loads(self.geocode_location(location))
             if "error" in geocode_result:
-                return json.dumps(geocode_result)
+                return json.dumps(geocode_result, ensure_ascii=False)
 
             if not geocode_result:
-                return json.dumps({"error": f"No location found for '{location}'"})
+                return json.dumps({"error": f"No location found for '{location}'"}, ensure_ascii=False)
 
             # Get the first location result
             loc_data = geocode_result[0]
@@ -142,10 +142,10 @@ class OpenWeatherTools(Toolkit):
                 result["location_name"] = loc_data.get("name", location)
                 result["country"] = loc_data.get("country", "")
 
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error getting current weather")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_forecast(self, location: str, days: int = 5) -> str:
         """Get weather forecast for a location.
@@ -163,10 +163,10 @@ class OpenWeatherTools(Toolkit):
             # First geocode the location to get coordinates
             geocode_result = json.loads(self.geocode_location(location))
             if "error" in geocode_result:
-                return json.dumps(geocode_result)
+                return json.dumps(geocode_result, ensure_ascii=False)
 
             if not geocode_result:
-                return json.dumps({"error": f"No location found for '{location}'"})
+                return json.dumps({"error": f"No location found for '{location}'"}, ensure_ascii=False)
 
             # Get the first location result
             loc_data = geocode_result[0]
@@ -189,10 +189,10 @@ class OpenWeatherTools(Toolkit):
                 result["location_name"] = loc_data.get("name", location)
                 result["country"] = loc_data.get("country", "")
 
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error getting forecast")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_air_pollution(self, location: str) -> str:
         """Get current air pollution data for a location.
@@ -209,10 +209,10 @@ class OpenWeatherTools(Toolkit):
             # First geocode the location to get coordinates
             geocode_result = json.loads(self.geocode_location(location))
             if "error" in geocode_result:
-                return json.dumps(geocode_result)
+                return json.dumps(geocode_result, ensure_ascii=False)
 
             if not geocode_result:
-                return json.dumps({"error": f"No location found for '{location}'"})
+                return json.dumps({"error": f"No location found for '{location}'"}, ensure_ascii=False)
 
             # Get the first location result
             loc_data = geocode_result[0]
@@ -229,7 +229,7 @@ class OpenWeatherTools(Toolkit):
                 result["location_name"] = loc_data.get("name", location)
                 result["country"] = loc_data.get("country", "")
 
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error getting air pollution data")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/oxylabs.py
+++ b/libs/agno/agno/tools/oxylabs.py
@@ -156,7 +156,7 @@ class OxylabsTools(Toolkit):
             }
 
             log_info(f"Google search completed. Found {len(search_results)} results")
-            return json.dumps(response_data, indent=2)
+            return json.dumps(response_data, indent=2, ensure_ascii=False)
 
         except Exception as e:
             error_msg = f"Google search failed: {str(e)}"
@@ -253,7 +253,7 @@ class OxylabsTools(Toolkit):
             }
 
             log_info(f"Amazon product lookup completed for ASIN {asin}")
-            return json.dumps(response_data, indent=2)
+            return json.dumps(response_data, indent=2, ensure_ascii=False)
 
         except Exception as e:
             error_msg = f"Amazon product lookup failed: {str(e)}"
@@ -344,7 +344,7 @@ class OxylabsTools(Toolkit):
             }
 
             log_debug(f"Amazon search completed. Found {len(products)} products")
-            return json.dumps(response_data, indent=2)
+            return json.dumps(response_data, indent=2, ensure_ascii=False)
 
         except Exception as e:
             error_msg = f"Amazon search failed: {str(e)}"
@@ -444,7 +444,7 @@ class OxylabsTools(Toolkit):
             }
 
             log_debug(f"Website scraping completed for {url}")
-            return json.dumps(response_data, indent=2)
+            return json.dumps(response_data, indent=2, ensure_ascii=False)
 
         except Exception as e:
             error_msg = f"Website scraping failed: {str(e)}"
@@ -463,4 +463,4 @@ class OxylabsTools(Toolkit):
             str: JSON string with tool name, error message, and context.
         """
         error_data = {"tool": tool_name, "error": error_message, "context": context or {}}
-        return json.dumps(error_data, indent=2)
+        return json.dumps(error_data, indent=2, ensure_ascii=False)

--- a/libs/agno/agno/tools/parallel.py
+++ b/libs/agno/agno/tools/parallel.py
@@ -135,7 +135,11 @@ class ParallelTools(Toolkit):
         """
         try:
             if not objective and not search_queries:
-                return json.dumps({"error": "Please provide at least one of: objective or search_queries"}, indent=2)
+                return json.dumps(
+                    {"error": "Please provide at least one of: objective or search_queries"},
+                    indent=2,
+                    ensure_ascii=False,
+                )
 
             final_max_results = max_results if max_results is not None else self.max_results
 
@@ -181,7 +185,7 @@ class ParallelTools(Toolkit):
             # Prefer SDK's model_dump() for complete response, fall back to manual formatting
             try:
                 if hasattr(search_result, "model_dump"):
-                    return json.dumps(search_result.model_dump(), cls=CustomJSONEncoder)
+                    return json.dumps(search_result.model_dump(), cls=CustomJSONEncoder, ensure_ascii=False)
             except Exception:
                 pass
             formatted_results: Dict[str, Any] = {
@@ -207,11 +211,11 @@ class ParallelTools(Toolkit):
             if hasattr(search_result, "usage"):
                 formatted_results["usage"] = search_result.usage
 
-            return json.dumps(formatted_results, cls=CustomJSONEncoder, indent=2)
+            return json.dumps(formatted_results, cls=CustomJSONEncoder, indent=2, ensure_ascii=False)
 
         except Exception as e:
             log_error(f"Error searching Parallel for objective '{objective}': {str(e)}")
-            return json.dumps({"error": f"Search failed: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"Search failed: {str(e)}"}, indent=2, ensure_ascii=False)
 
     def parallel_extract(
         self,
@@ -237,7 +241,7 @@ class ParallelTools(Toolkit):
         """
         try:
             if not urls:
-                return json.dumps({"error": "Please provide at least one URL to extract"}, indent=2)
+                return json.dumps({"error": "Please provide at least one URL to extract"}, indent=2, ensure_ascii=False)
 
             extract_params: Dict[str, Any] = {"urls": urls}
 
@@ -277,7 +281,7 @@ class ParallelTools(Toolkit):
             # Prefer SDK's model_dump() for complete response, fall back to manual formatting
             try:
                 if hasattr(extract_result, "model_dump"):
-                    return json.dumps(extract_result.model_dump(), cls=CustomJSONEncoder)
+                    return json.dumps(extract_result.model_dump(), cls=CustomJSONEncoder, ensure_ascii=False)
             except Exception:
                 pass
 
@@ -314,11 +318,11 @@ class ParallelTools(Toolkit):
             if hasattr(extract_result, "usage"):
                 formatted_results["usage"] = extract_result.usage
 
-            return json.dumps(formatted_results, cls=CustomJSONEncoder, indent=2)
+            return json.dumps(formatted_results, cls=CustomJSONEncoder, indent=2, ensure_ascii=False)
 
         except Exception as e:
             log_error(f"Error extracting from Parallel: {str(e)}")
-            return json.dumps({"error": f"Extract failed: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"Extract failed: {str(e)}"}, indent=2, ensure_ascii=False)
 
     # -------------------------------------------------------------------------
     # Task API — Deep research with structured output and citations
@@ -379,11 +383,12 @@ class ParallelTools(Toolkit):
                     "is_active": task_run.is_active,
                 },
                 indent=2,
+                ensure_ascii=False,
             )
 
         except Exception as e:
             log_error(f"Error creating task with query '{query[:100]}...': {str(e)}")
-            return json.dumps({"error": f"Create task failed: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"Create task failed: {str(e)}"}, indent=2, ensure_ascii=False)
 
     def get_task_result(self, run_id: str) -> str:
         """
@@ -401,11 +406,11 @@ class ParallelTools(Toolkit):
             )
 
             output_data = self._format_task_output(run_id, task_result)
-            return json.dumps(output_data, cls=CustomJSONEncoder, indent=2)
+            return json.dumps(output_data, cls=CustomJSONEncoder, indent=2, ensure_ascii=False)
 
         except Exception as e:
             log_error(f"Error getting result for task {run_id}: {str(e)}")
-            return json.dumps({"error": f"Get result failed: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"Get result failed: {str(e)}"}, indent=2, ensure_ascii=False)
 
     def get_task_status(self, run_id: str) -> str:
         """
@@ -431,11 +436,12 @@ class ParallelTools(Toolkit):
                 },
                 cls=CustomJSONEncoder,
                 indent=2,
+                ensure_ascii=False,
             )
 
         except Exception as e:
             log_error(f"Error getting status for task {run_id}: {str(e)}")
-            return json.dumps({"error": f"Get status failed: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"Get status failed: {str(e)}"}, indent=2, ensure_ascii=False)
 
     # -------------------------------------------------------------------------
     # Monitor API — Track topics over time and get notified of changes
@@ -477,11 +483,12 @@ class ParallelTools(Toolkit):
                     "last_run_at": monitor.last_run_at,
                 },
                 indent=2,
+                ensure_ascii=False,
             )
 
         except Exception as e:
             log_error(f"Error creating monitor for query '{query}': {str(e)}")
-            return json.dumps({"error": f"Create monitor failed: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"Create monitor failed: {str(e)}"}, indent=2, ensure_ascii=False)
 
     def get_monitor(self, monitor_id: str) -> str:
         """
@@ -508,11 +515,11 @@ class ParallelTools(Toolkit):
             if monitor.type == "event_stream" and hasattr(monitor.settings, "query"):
                 result["query"] = monitor.settings.query
 
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         except Exception as e:
             log_error(f"Error retrieving monitor {monitor_id}: {str(e)}")
-            return json.dumps({"error": f"Get monitor failed: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"Get monitor failed: {str(e)}"}, indent=2, ensure_ascii=False)
 
     def update_monitor(
         self,
@@ -540,7 +547,9 @@ class ParallelTools(Toolkit):
                 update_params["settings"] = {"query": query}
 
             if not update_params:
-                return json.dumps({"error": "At least one of frequency or query must be provided"}, indent=2)
+                return json.dumps(
+                    {"error": "At least one of frequency or query must be provided"}, indent=2, ensure_ascii=False
+                )
 
             monitor = self.parallel_client.monitor.update(monitor_id, **update_params)
 
@@ -555,11 +564,11 @@ class ParallelTools(Toolkit):
             if monitor.type == "event_stream" and hasattr(monitor.settings, "query"):
                 result["query"] = monitor.settings.query
 
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         except Exception as e:
             log_error(f"Error updating monitor {monitor_id}: {str(e)}")
-            return json.dumps({"error": f"Update monitor failed: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"Update monitor failed: {str(e)}"}, indent=2, ensure_ascii=False)
 
     def list_monitors(
         self,
@@ -602,11 +611,13 @@ class ParallelTools(Toolkit):
                     monitor_info["query"] = m.settings.query
                 monitors.append(monitor_info)
 
-            return json.dumps({"monitors": monitors, "has_more": response.next_cursor is not None}, indent=2)
+            return json.dumps(
+                {"monitors": monitors, "has_more": response.next_cursor is not None}, indent=2, ensure_ascii=False
+            )
 
         except Exception as e:
             log_error(f"Error listing monitors: {str(e)}")
-            return json.dumps({"error": f"List monitors failed: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"List monitors failed: {str(e)}"}, indent=2, ensure_ascii=False)
 
     def cancel_monitor(self, monitor_id: str) -> str:
         """
@@ -628,11 +639,12 @@ class ParallelTools(Toolkit):
                     "cancelled": True,
                 },
                 indent=2,
+                ensure_ascii=False,
             )
 
         except Exception as e:
             log_error(f"Error cancelling monitor {monitor_id}: {str(e)}")
-            return json.dumps({"error": f"Cancel monitor failed: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"Cancel monitor failed: {str(e)}"}, indent=2, ensure_ascii=False)
 
     def get_monitor_events(
         self,
@@ -683,8 +695,10 @@ class ParallelTools(Toolkit):
                         ]
                 events.append(event_data)
 
-            return json.dumps({"events": events, "has_more": response.next_cursor is not None}, indent=2)
+            return json.dumps(
+                {"events": events, "has_more": response.next_cursor is not None}, indent=2, ensure_ascii=False
+            )
 
         except Exception as e:
             log_error(f"Error getting events for monitor {monitor_id}: {str(e)}")
-            return json.dumps({"error": f"Get events failed: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"Get events failed: {str(e)}"}, indent=2, ensure_ascii=False)

--- a/libs/agno/agno/tools/perplexity.py
+++ b/libs/agno/agno/tools/perplexity.py
@@ -114,7 +114,7 @@ class PerplexitySearch(Toolkit):
 
         except Exception as e:
             logger.exception("Perplexity search failed")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     async def asearch(self, query: str, max_results: Optional[int] = None) -> str:
         """Use this function to search the web using the Perplexity Search API.
@@ -174,4 +174,4 @@ class PerplexitySearch(Toolkit):
 
         except Exception as e:
             logger.exception("Perplexity search failed")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/pubmed.py
+++ b/libs/agno/agno/tools/pubmed.py
@@ -183,6 +183,6 @@ class PubmedTools(Toolkit):
                     )
                 results.append(article_text)
 
-            return json.dumps(results)
+            return json.dumps(results, ensure_ascii=False)
         except Exception as e:
             return f"Could not fetch articles. Error: {e}"

--- a/libs/agno/agno/tools/reddit.py
+++ b/libs/agno/agno/tools/reddit.py
@@ -129,7 +129,7 @@ class RedditTools(Toolkit):
                 "created_utc": user.created_utc,
             }
 
-            return json.dumps(info)
+            return json.dumps(info, ensure_ascii=False)
 
         except Exception as e:
             return f"Error getting user info: {e}"
@@ -165,7 +165,7 @@ class RedditTools(Toolkit):
                 }
                 for post in posts
             ]
-            return json.dumps({"top_posts": top_posts})
+            return json.dumps({"top_posts": top_posts}, ensure_ascii=False)
         except Exception as e:
             return f"Error getting top posts: {e}"
 
@@ -197,7 +197,7 @@ class RedditTools(Toolkit):
                 "url": subreddit.url,
             }
 
-            return json.dumps(info)
+            return json.dumps(info, ensure_ascii=False)
 
         except Exception as e:
             return f"Error getting subreddit info: {e}"
@@ -211,7 +211,7 @@ class RedditTools(Toolkit):
             log_debug("Getting trending subreddits")
             popular_subreddits = self.reddit.subreddits.popular(limit=5)
             trending: List[str] = [subreddit.display_name for subreddit in popular_subreddits]
-            return json.dumps({"trending_subreddits": trending})
+            return json.dumps({"trending_subreddits": trending}, ensure_ascii=False)
         except Exception as e:
             return f"Error getting trending subreddits: {e}"
 
@@ -238,7 +238,7 @@ class RedditTools(Toolkit):
                 "over18": sub.over18,
                 "public_description": sub.public_description,
             }
-            return json.dumps({"subreddit_stats": stats})
+            return json.dumps({"subreddit_stats": stats}, ensure_ascii=False)
         except Exception as e:
             return f"Error getting subreddit stats: {e}"
 
@@ -306,7 +306,7 @@ class RedditTools(Toolkit):
                 "flair": submission.link_flair_text,
             }
 
-            return json.dumps({"post": post_info})
+            return json.dumps({"post": post_info}, ensure_ascii=False)
 
         except Exception as e:
             return f"Error creating post: {e}"
@@ -384,7 +384,7 @@ class RedditTools(Toolkit):
             }
 
             log_debug(f"Reply created successfully: {reply.permalink}")
-            return json.dumps({"reply": reply_info})
+            return json.dumps({"reply": reply_info}, ensure_ascii=False)
 
         except praw.exceptions.RedditAPIException as api_error:
             # Handle specific Reddit API errors
@@ -462,7 +462,7 @@ class RedditTools(Toolkit):
             }
 
             log_debug(f"Reply created successfully: {reply.permalink}")
-            return json.dumps({"reply": reply_info})
+            return json.dumps({"reply": reply_info}, ensure_ascii=False)
 
         except praw.exceptions.RedditAPIException as api_error:
             # Handle specific Reddit API errors

--- a/libs/agno/agno/tools/redmine.py
+++ b/libs/agno/agno/tools/redmine.py
@@ -88,7 +88,9 @@ class RedmineTools(Toolkit):
         mapping = {resource.name.lower(): resource.id for resource in resources}
         resolved = mapping.get(name.lower())
         if resolved is None:
-            return None, json.dumps({"error": f"Unknown {label} '{name}'. Available: {sorted(mapping)}"})
+            return None, json.dumps(
+                {"error": f"Unknown {label} '{name}'. Available: {sorted(mapping)}"}, ensure_ascii=False
+            )
         return resolved, None
 
     def get_issue(self, issue_id: str, include_comments: bool = False) -> str:
@@ -124,10 +126,10 @@ class RedmineTools(Toolkit):
                     journal.notes for journal in issue.journals if getattr(journal, "notes", "")
                 ]
             log_debug(f"Issue details retrieved for {issue_id}")
-            return json.dumps(issue_details)
+            return json.dumps(issue_details, ensure_ascii=False)
         except Exception as e:
             log_error(f"Error retrieving issue {issue_id}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def create_issue(
         self,
@@ -190,10 +192,10 @@ class RedmineTools(Toolkit):
             new_issue = self.redmine.issue.create(**fields)
             issue_url = f"{self.server_url}/issues/{new_issue.id}"
             log_debug(f"Issue created with id: {new_issue.id}")
-            return json.dumps({"id": new_issue.id, "url": issue_url})
+            return json.dumps({"id": new_issue.id, "url": issue_url}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Error creating issue in project {project_id}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def update_issue(
         self,
@@ -271,13 +273,13 @@ class RedmineTools(Toolkit):
             if due_date:
                 fields["due_date"] = due_date
             if not fields:
-                return json.dumps({"error": "No fields provided to update."})
+                return json.dumps({"error": "No fields provided to update."}, ensure_ascii=False)
             self.redmine.issue.update(self._to_int(issue_id), **fields)
             log_debug(f"Issue {issue_id} updated")
-            return json.dumps({"status": "success", "issue_id": issue_id})
+            return json.dumps({"status": "success", "issue_id": issue_id}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Error updating issue {issue_id}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def search_issues(
         self,
@@ -339,10 +341,10 @@ class RedmineTools(Toolkit):
                     }
                 )
             log_debug(f"Found {len(results)} issues")
-            return json.dumps(results)
+            return json.dumps(results, ensure_ascii=False)
         except Exception as e:
             log_error("Error searching issues")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def add_comment(self, issue_id: str, comment: str, private_notes: bool = False) -> str:
         """Add a comment to an issue.
@@ -356,14 +358,14 @@ class RedmineTools(Toolkit):
             str: A JSON string indicating success or containing an error message.
         """
         if not comment or not comment.strip():
-            return json.dumps({"error": "comment cannot be empty"})
+            return json.dumps({"error": "comment cannot be empty"}, ensure_ascii=False)
         try:
             self.redmine.issue.update(self._to_int(issue_id), notes=comment, private_notes=private_notes)
             log_debug(f"Comment added to issue {issue_id}")
-            return json.dumps({"status": "success", "issue_id": issue_id})
+            return json.dumps({"status": "success", "issue_id": issue_id}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Error adding comment to issue {issue_id}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def log_time(
         self,
@@ -386,7 +388,7 @@ class RedmineTools(Toolkit):
             str: A JSON string with the created time entry id, or an error message.
         """
         if hours <= 0:
-            return json.dumps({"error": "hours must be greater than 0"})
+            return json.dumps({"error": "hours must be greater than 0"}, ensure_ascii=False)
         try:
             fields: Dict[str, Any] = {"issue_id": self._to_int(issue_id), "hours": hours}
             activities = self.redmine.enumeration.filter(resource="time_entry_activities")
@@ -400,7 +402,8 @@ class RedmineTools(Toolkit):
                     {
                         "error": "activity is required (this Redmine instance defines no default activity). "
                         f"Available: {sorted(item.name.lower() for item in activities)}"
-                    }
+                    },
+                    ensure_ascii=False,
                 )
             if comment:
                 fields["comments"] = comment
@@ -408,10 +411,10 @@ class RedmineTools(Toolkit):
                 fields["spent_on"] = spent_on
             time_entry = self.redmine.time_entry.create(**fields)
             log_debug(f"Logged {hours}h on issue {issue_id}")
-            return json.dumps({"id": time_entry.id, "issue_id": issue_id, "hours": hours})
+            return json.dumps({"id": time_entry.id, "issue_id": issue_id, "hours": hours}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Error logging time on issue {issue_id}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_projects(self) -> str:
         """List the projects available on the Redmine server.
@@ -425,10 +428,10 @@ class RedmineTools(Toolkit):
                 for project in self.redmine.project.all()
             ]
             log_debug(f"Found {len(projects)} projects")
-            return json.dumps(projects)
+            return json.dumps(projects, ensure_ascii=False)
         except Exception as e:
             log_error("Error listing projects")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_users(self) -> str:
         """List the active users on the Redmine server.
@@ -445,10 +448,10 @@ class RedmineTools(Toolkit):
                 for user in self.redmine.user.all()
             ]
             log_debug(f"Found {len(users)} users")
-            return json.dumps(users)
+            return json.dumps(users, ensure_ascii=False)
         except Exception as e:
             log_error("Error listing users")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_project_members(self, project_id: str) -> str:
         """List the users who are members of a project.
@@ -468,10 +471,10 @@ class RedmineTools(Toolkit):
                 if user:
                     members.append({"id": user.id, "name": str(user)})
             log_debug(f"Found {len(members)} members in project {project_id}")
-            return json.dumps(members)
+            return json.dumps(members, ensure_ascii=False)
         except Exception as e:
             log_error(f"Error listing members of project {project_id}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_versions(self, project_id: str) -> str:
         """List the versions (sprints/milestones) of a project.
@@ -490,7 +493,7 @@ class RedmineTools(Toolkit):
                 for version in self.redmine.version.filter(project_id=project_id)
             ]
             log_debug(f"Found {len(versions)} versions in project {project_id}")
-            return json.dumps(versions)
+            return json.dumps(versions, ensure_ascii=False)
         except Exception as e:
             log_error(f"Error listing versions of project {project_id}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/salesforce.py
+++ b/libs/agno/agno/tools/salesforce.py
@@ -138,10 +138,10 @@ class SalesforceTools(Toolkit):
             if total > self.max_records:
                 objects = objects[: self.max_records]
 
-            return json.dumps({"total": total, "returned": len(objects), "objects": objects})
+            return json.dumps({"total": total, "returned": len(objects), "objects": objects}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error listing Salesforce objects")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def describe_object(self, sobject: str) -> str:
         """
@@ -184,11 +184,12 @@ class SalesforceTools(Toolkit):
                     "totalFields": len(all_fields),
                     "returnedFields": len(fields),
                     "fields": fields,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception(f"Error describing Salesforce object {sobject}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_record(self, sobject: str, record_id: str, fields: str = "") -> str:
         """
@@ -206,14 +207,14 @@ class SalesforceTools(Toolkit):
                 result = self.sf.query(soql)
                 records = result.get("records", [])
                 if not records:
-                    return json.dumps({"error": f"{sobject} record {record_id} not found."})
-                return json.dumps(records[0])
+                    return json.dumps({"error": f"{sobject} record {record_id} not found."}, ensure_ascii=False)
+                return json.dumps(records[0], ensure_ascii=False)
             else:
                 record = getattr(self.sf, sobject).get(record_id)
-                return json.dumps(record)
+                return json.dumps(record, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error getting {sobject} record {record_id}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def create_record(self, sobject: str, record_data: str) -> str:
         """
@@ -226,14 +227,16 @@ class SalesforceTools(Toolkit):
         try:
             data = json.loads(record_data) if isinstance(record_data, str) else record_data
         except json.JSONDecodeError as e:
-            return json.dumps({"error": f"Invalid JSON in record_data: {e}"})
+            return json.dumps({"error": f"Invalid JSON in record_data: {e}"}, ensure_ascii=False)
 
         try:
             result = getattr(self.sf, sobject).create(data)
-            return json.dumps({"id": result.get("id"), "success": result.get("success"), "sobject": sobject})
+            return json.dumps(
+                {"id": result.get("id"), "success": result.get("success"), "sobject": sobject}, ensure_ascii=False
+            )
         except Exception as e:
             logger.exception(f"Error creating {sobject} record")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def update_record(self, sobject: str, record_id: str, record_data: str) -> str:
         """
@@ -247,14 +250,14 @@ class SalesforceTools(Toolkit):
         try:
             data = json.loads(record_data) if isinstance(record_data, str) else record_data
         except json.JSONDecodeError as e:
-            return json.dumps({"error": f"Invalid JSON in record_data: {e}"})
+            return json.dumps({"error": f"Invalid JSON in record_data: {e}"}, ensure_ascii=False)
 
         try:
             getattr(self.sf, sobject).update(record_id, data)
-            return json.dumps({"status": "success", "id": record_id, "sobject": sobject})
+            return json.dumps({"status": "success", "id": record_id, "sobject": sobject}, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error updating {sobject} record {record_id}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def delete_record(self, sobject: str, record_id: str) -> str:
         """
@@ -266,10 +269,10 @@ class SalesforceTools(Toolkit):
         """
         try:
             getattr(self.sf, sobject).delete(record_id)
-            return json.dumps({"status": "success", "id": record_id, "sobject": sobject})
+            return json.dumps({"status": "success", "id": record_id, "sobject": sobject}, ensure_ascii=False)
         except Exception as e:
             logger.exception(f"Error deleting {sobject} record {record_id}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def query(self, soql: str) -> str:
         """
@@ -287,11 +290,12 @@ class SalesforceTools(Toolkit):
                 records = records[: self.max_records]
 
             return json.dumps(
-                {"totalSize": total_size, "returned": len(records), "done": result.get("done"), "records": records}
+                {"totalSize": total_size, "returned": len(records), "done": result.get("done"), "records": records},
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Error executing SOQL query")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def search(self, sosl: str) -> str:
         """
@@ -305,10 +309,10 @@ class SalesforceTools(Toolkit):
             records = result.get("searchRecords", []) if isinstance(result, dict) else []
             if len(records) > self.max_records:
                 result["searchRecords"] = records[: self.max_records]
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error executing SOSL search")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_report(self, report_id: str) -> str:
         """
@@ -320,8 +324,11 @@ class SalesforceTools(Toolkit):
         try:
             response = self.sf.restful(f"analytics/reports/{report_id}", method="GET")
             if not isinstance(response, dict):
-                return json.dumps({"error": "Unexpected report response format."})
-            return json.dumps({"reportMetadata": response.get("reportMetadata"), "factMap": response.get("factMap")})
+                return json.dumps({"error": "Unexpected report response format."}, ensure_ascii=False)
+            return json.dumps(
+                {"reportMetadata": response.get("reportMetadata"), "factMap": response.get("factMap")},
+                ensure_ascii=False,
+            )
         except Exception as e:
             logger.exception(f"Error running report {report_id}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/scavio.py
+++ b/libs/agno/agno/tools/scavio.py
@@ -96,10 +96,10 @@ class ScavioTools(Toolkit):
     def _call(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> str:
         """Run a Scavio SDK call and return its JSON response as a string."""
         try:
-            return json.dumps(fn(*args, **kwargs))
+            return json.dumps(fn(*args, **kwargs), ensure_ascii=False)
         except Exception as e:
             log_error(f"Scavio request failed: {e}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     # ------------------------------------------------------------------ Google
 

--- a/libs/agno/agno/tools/scheduler.py
+++ b/libs/agno/agno/tools/scheduler.py
@@ -133,14 +133,14 @@ class SchedulerTools(Toolkit):
         """
         resolved_endpoint = endpoint or self.default_endpoint
         if not resolved_endpoint:
-            return json.dumps({"error": "No endpoint provided and no default_endpoint configured"})
+            return json.dumps({"error": "No endpoint provided and no default_endpoint configured"}, ensure_ascii=False)
 
         resolved_payload = self.default_payload
         if payload is not None:
             try:
                 resolved_payload = json.loads(payload)
             except json.JSONDecodeError:
-                return json.dumps({"error": "Invalid JSON in payload parameter"})
+                return json.dumps({"error": "Invalid JSON in payload parameter"}, ensure_ascii=False)
 
         # Run endpoints require a "message" field in the payload
         resolved_method = method or self.default_method
@@ -150,7 +150,8 @@ class SchedulerTools(Toolkit):
                     {
                         "error": "Schedules targeting run endpoints require a 'message' field in the payload. "
                         'Provide payload with at least: {"message": "your prompt here"}'
-                    }
+                    },
+                    ensure_ascii=False,
                 )
 
         try:
@@ -175,11 +176,12 @@ class SchedulerTools(Toolkit):
                     "timezone": schedule.timezone,
                     "enabled": schedule.enabled,
                     "description": schedule.description,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to create schedule")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_schedules(self, enabled_only: bool = False) -> str:
         """List all existing schedules.
@@ -205,10 +207,10 @@ class SchedulerTools(Toolkit):
                 }
                 for s in schedules
             ]
-            return json.dumps({"schedules": result, "count": len(result)})
+            return json.dumps({"schedules": result, "count": len(result)}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to list schedules")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_schedule(self, schedule_id: str) -> str:
         """Get details of a specific schedule by its ID.
@@ -222,7 +224,7 @@ class SchedulerTools(Toolkit):
         try:
             schedule = self.manager.get(schedule_id)
             if schedule is None:
-                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"}, ensure_ascii=False)
             return json.dumps(
                 {
                     "id": schedule.id,
@@ -234,11 +236,12 @@ class SchedulerTools(Toolkit):
                     "enabled": schedule.enabled,
                     "description": schedule.description,
                     "payload": schedule.payload,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to get schedule")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def delete_schedule(self, schedule_id: str) -> str:
         """Delete a schedule by its ID. This permanently removes the schedule.
@@ -252,11 +255,13 @@ class SchedulerTools(Toolkit):
         try:
             deleted = self.manager.delete(schedule_id)
             if deleted:
-                return json.dumps({"status": "deleted", "id": schedule_id})
-            return json.dumps({"error": f"Schedule not found or could not be deleted: {schedule_id}"})
+                return json.dumps({"status": "deleted", "id": schedule_id}, ensure_ascii=False)
+            return json.dumps(
+                {"error": f"Schedule not found or could not be deleted: {schedule_id}"}, ensure_ascii=False
+            )
         except Exception as e:
             logger.exception("Failed to delete schedule")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def enable_schedule(self, schedule_id: str) -> str:
         """Enable a disabled schedule so it starts running again.
@@ -270,18 +275,19 @@ class SchedulerTools(Toolkit):
         try:
             schedule = self.manager.enable(schedule_id)
             if schedule is None:
-                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"}, ensure_ascii=False)
             return json.dumps(
                 {
                     "status": "enabled",
                     "id": schedule.id,
                     "name": schedule.name,
                     "enabled": schedule.enabled,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to enable schedule")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def disable_schedule(self, schedule_id: str) -> str:
         """Disable a schedule so it stops running. Can be re-enabled later.
@@ -295,18 +301,19 @@ class SchedulerTools(Toolkit):
         try:
             schedule = self.manager.disable(schedule_id)
             if schedule is None:
-                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"}, ensure_ascii=False)
             return json.dumps(
                 {
                     "status": "disabled",
                     "id": schedule.id,
                     "name": schedule.name,
                     "enabled": schedule.enabled,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to disable schedule")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def trigger_schedule(self, schedule_id: str) -> str:
         """Queue an enabled schedule to run now.
@@ -324,10 +331,11 @@ class SchedulerTools(Toolkit):
         try:
             schedule = self.manager.get(schedule_id)
             if schedule is None:
-                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"}, ensure_ascii=False)
             if not schedule.enabled:
                 return json.dumps(
-                    {"error": f"Schedule is disabled: {schedule_id}. Call enable_schedule first, then trigger it."}
+                    {"error": f"Schedule is disabled: {schedule_id}. Call enable_schedule first, then trigger it."},
+                    ensure_ascii=False,
                 )
             self.manager.update(schedule_id, next_run_at=int(time.time()))
             return json.dumps(
@@ -335,11 +343,12 @@ class SchedulerTools(Toolkit):
                     "status": "triggered",
                     "id": schedule_id,
                     "note": "The scheduler poller will execute it within one poll interval.",
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to trigger schedule")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_schedule_runs(self, schedule_id: str, limit: int = 10) -> str:
         """Get the run history for a schedule.
@@ -363,10 +372,10 @@ class SchedulerTools(Toolkit):
                 }
                 for r in runs
             ]
-            return json.dumps({"runs": result, "count": len(result)})
+            return json.dumps({"runs": result, "count": len(result)}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to get schedule runs")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     # ------------------------------------------------------------------
     # Async tools
@@ -398,14 +407,14 @@ class SchedulerTools(Toolkit):
         """
         resolved_endpoint = endpoint or self.default_endpoint
         if not resolved_endpoint:
-            return json.dumps({"error": "No endpoint provided and no default_endpoint configured"})
+            return json.dumps({"error": "No endpoint provided and no default_endpoint configured"}, ensure_ascii=False)
 
         resolved_payload = self.default_payload
         if payload is not None:
             try:
                 resolved_payload = json.loads(payload)
             except json.JSONDecodeError:
-                return json.dumps({"error": "Invalid JSON in payload parameter"})
+                return json.dumps({"error": "Invalid JSON in payload parameter"}, ensure_ascii=False)
 
         # Run endpoints require a "message" field in the payload
         resolved_method = method or self.default_method
@@ -415,7 +424,8 @@ class SchedulerTools(Toolkit):
                     {
                         "error": "Schedules targeting run endpoints require a 'message' field in the payload. "
                         'Provide payload with at least: {"message": "your prompt here"}'
-                    }
+                    },
+                    ensure_ascii=False,
                 )
 
         try:
@@ -440,11 +450,12 @@ class SchedulerTools(Toolkit):
                     "timezone": schedule.timezone,
                     "enabled": schedule.enabled,
                     "description": schedule.description,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to create schedule")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     async def alist_schedules(self, enabled_only: bool = False) -> str:
         """List all existing schedules.
@@ -470,10 +481,10 @@ class SchedulerTools(Toolkit):
                 }
                 for s in schedules
             ]
-            return json.dumps({"schedules": result, "count": len(result)})
+            return json.dumps({"schedules": result, "count": len(result)}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to list schedules")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     async def aget_schedule(self, schedule_id: str) -> str:
         """Get details of a specific schedule by its ID.
@@ -487,7 +498,7 @@ class SchedulerTools(Toolkit):
         try:
             schedule = await self.manager.aget(schedule_id)
             if schedule is None:
-                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"}, ensure_ascii=False)
             return json.dumps(
                 {
                     "id": schedule.id,
@@ -499,11 +510,12 @@ class SchedulerTools(Toolkit):
                     "enabled": schedule.enabled,
                     "description": schedule.description,
                     "payload": schedule.payload,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to get schedule")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     async def adelete_schedule(self, schedule_id: str) -> str:
         """Delete a schedule by its ID. This permanently removes the schedule.
@@ -517,11 +529,13 @@ class SchedulerTools(Toolkit):
         try:
             deleted = await self.manager.adelete(schedule_id)
             if deleted:
-                return json.dumps({"status": "deleted", "id": schedule_id})
-            return json.dumps({"error": f"Schedule not found or could not be deleted: {schedule_id}"})
+                return json.dumps({"status": "deleted", "id": schedule_id}, ensure_ascii=False)
+            return json.dumps(
+                {"error": f"Schedule not found or could not be deleted: {schedule_id}"}, ensure_ascii=False
+            )
         except Exception as e:
             logger.exception("Failed to delete schedule")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     async def aenable_schedule(self, schedule_id: str) -> str:
         """Enable a disabled schedule so it starts running again.
@@ -535,18 +549,19 @@ class SchedulerTools(Toolkit):
         try:
             schedule = await self.manager.aenable(schedule_id)
             if schedule is None:
-                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"}, ensure_ascii=False)
             return json.dumps(
                 {
                     "status": "enabled",
                     "id": schedule.id,
                     "name": schedule.name,
                     "enabled": schedule.enabled,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to enable schedule")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     async def adisable_schedule(self, schedule_id: str) -> str:
         """Disable a schedule so it stops running. Can be re-enabled later.
@@ -560,18 +575,19 @@ class SchedulerTools(Toolkit):
         try:
             schedule = await self.manager.adisable(schedule_id)
             if schedule is None:
-                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"}, ensure_ascii=False)
             return json.dumps(
                 {
                     "status": "disabled",
                     "id": schedule.id,
                     "name": schedule.name,
                     "enabled": schedule.enabled,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to disable schedule")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     async def atrigger_schedule(self, schedule_id: str) -> str:
         """Queue an enabled schedule to run now.
@@ -589,10 +605,11 @@ class SchedulerTools(Toolkit):
         try:
             schedule = await self.manager.aget(schedule_id)
             if schedule is None:
-                return json.dumps({"error": f"Schedule not found: {schedule_id}"})
+                return json.dumps({"error": f"Schedule not found: {schedule_id}"}, ensure_ascii=False)
             if not schedule.enabled:
                 return json.dumps(
-                    {"error": f"Schedule is disabled: {schedule_id}. Call enable_schedule first, then trigger it."}
+                    {"error": f"Schedule is disabled: {schedule_id}. Call enable_schedule first, then trigger it."},
+                    ensure_ascii=False,
                 )
             await self.manager.aupdate(schedule_id, next_run_at=int(time.time()))
             return json.dumps(
@@ -600,11 +617,12 @@ class SchedulerTools(Toolkit):
                     "status": "triggered",
                     "id": schedule_id,
                     "note": "The scheduler poller will execute it within one poll interval.",
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to trigger schedule")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     async def aget_schedule_runs(self, schedule_id: str, limit: int = 10) -> str:
         """Get the run history for a schedule.
@@ -628,7 +646,7 @@ class SchedulerTools(Toolkit):
                 }
                 for r in runs
             ]
-            return json.dumps({"runs": result, "count": len(result)})
+            return json.dumps({"runs": result, "count": len(result)}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to get schedule runs")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/scrapegraph.py
+++ b/libs/agno/agno/tools/scrapegraph.py
@@ -113,7 +113,7 @@ class ScrapeGraphTools(Toolkit):
             if response.status != "success" or response.data is None:
                 return f"Error extracting from {url}: {response.error or 'unknown error'}"
             payload = response.data.json_data if response.data.json_data is not None else response.data.raw
-            return json.dumps(payload)
+            return json.dumps(payload, ensure_ascii=False)
         except Exception as error:
             return f"Error extracting from {url}: {type(error).__name__}: {error}"
 

--- a/libs/agno/agno/tools/searchapi.py
+++ b/libs/agno/agno/tools/searchapi.py
@@ -109,7 +109,7 @@ class SearchApiTools(Toolkit):
             str: JSON string containing organic results, knowledge graph, and related questions.
         """
         if not query:
-            return json.dumps({"error": "Please provide a query to search for"})
+            return json.dumps({"error": "Please provide a query to search for"}, ensure_ascii=False)
 
         log_debug(f"Searching Google for: {query}")
 
@@ -126,7 +126,7 @@ class SearchApiTools(Toolkit):
         data = self._make_request(params)
 
         if "error" in data:
-            return json.dumps({"error": data["error"]})
+            return json.dumps({"error": data["error"]}, ensure_ascii=False)
 
         result = {
             "organic_results": [
@@ -146,7 +146,7 @@ class SearchApiTools(Toolkit):
             "search_information": data.get("search_information"),
         }
 
-        return json.dumps(result, indent=2)
+        return json.dumps(result, indent=2, ensure_ascii=False)
 
     def search_news(
         self,
@@ -168,7 +168,7 @@ class SearchApiTools(Toolkit):
             str: JSON string containing news articles with title, link, source, and date.
         """
         if not query:
-            return json.dumps({"error": "Please provide a query to search for"})
+            return json.dumps({"error": "Please provide a query to search for"}, ensure_ascii=False)
 
         log_debug(f"Searching Google News for: {query}")
 
@@ -185,7 +185,7 @@ class SearchApiTools(Toolkit):
         data = self._make_request(params)
 
         if "error" in data:
-            return json.dumps({"error": data["error"]})
+            return json.dumps({"error": data["error"]}, ensure_ascii=False)
 
         result = {
             "news_results": [
@@ -202,7 +202,7 @@ class SearchApiTools(Toolkit):
             ]
         }
 
-        return json.dumps(result, indent=2)
+        return json.dumps(result, indent=2, ensure_ascii=False)
 
     def search_images(
         self,
@@ -222,7 +222,7 @@ class SearchApiTools(Toolkit):
             str: JSON string containing image results with title, link, and thumbnail.
         """
         if not query:
-            return json.dumps({"error": "Please provide a query to search for"})
+            return json.dumps({"error": "Please provide a query to search for"}, ensure_ascii=False)
 
         log_debug(f"Searching Google Images for: {query}")
 
@@ -237,7 +237,7 @@ class SearchApiTools(Toolkit):
         data = self._make_request(params)
 
         if "error" in data:
-            return json.dumps({"error": data["error"]})
+            return json.dumps({"error": data["error"]}, ensure_ascii=False)
 
         result = {
             "image_results": [
@@ -253,7 +253,7 @@ class SearchApiTools(Toolkit):
             ]
         }
 
-        return json.dumps(result, indent=2)
+        return json.dumps(result, indent=2, ensure_ascii=False)
 
     def search_youtube(
         self,
@@ -274,7 +274,7 @@ class SearchApiTools(Toolkit):
                 published_time, description, and thumbnail.
         """
         if not query:
-            return json.dumps({"error": "Please provide a query to search for"})
+            return json.dumps({"error": "Please provide a query to search for"}, ensure_ascii=False)
 
         log_debug(f"Searching YouTube for: {query}")
 
@@ -286,7 +286,7 @@ class SearchApiTools(Toolkit):
         data = self._make_request(params)
 
         if "error" in data:
-            return json.dumps({"error": data["error"]})
+            return json.dumps({"error": data["error"]}, ensure_ascii=False)
 
         limit = num_results or self.num_results
         videos = data.get("videos", []) or []
@@ -312,4 +312,4 @@ class SearchApiTools(Toolkit):
             ]
         }
 
-        return json.dumps(result, indent=2)
+        return json.dumps(result, indent=2, ensure_ascii=False)

--- a/libs/agno/agno/tools/searxng.py
+++ b/libs/agno/agno/tools/searxng.py
@@ -146,7 +146,7 @@ class Searxng(Toolkit):
             resp = response.json()
             results = self.fixed_max_results or max_results
             resp["results"] = resp["results"][:results]
-            return json.dumps(resp)
+            return json.dumps(resp, ensure_ascii=False)
         except Exception as e:
             return f"Error fetching results from searxng: {e}"
 

--- a/libs/agno/agno/tools/serpapi.py
+++ b/libs/agno/agno/tools/serpapi.py
@@ -71,7 +71,7 @@ class SerpApiTools(Toolkit):
                 "related_questions": results.get("related_questions", ""),
             }
 
-            return json.dumps(filtered_results)
+            return json.dumps(filtered_results, ensure_ascii=False)
 
         except Exception as e:
             return f"Error searching for the query {query}: {e}"
@@ -110,7 +110,7 @@ class SerpApiTools(Toolkit):
                 "channel_results": results.get("channel_results", ""),
             }
 
-            return json.dumps(filtered_results)
+            return json.dumps(filtered_results, ensure_ascii=False)
 
         except Exception as e:
             return f"Error searching for the query {query}: {e}"

--- a/libs/agno/agno/tools/serper.py
+++ b/libs/agno/agno/tools/serper.py
@@ -87,7 +87,7 @@ class SerperTools(Toolkit):
             if self.language:
                 params["hl"] = self.language
 
-            payload = json.dumps(params)
+            payload = json.dumps(params, ensure_ascii=False)
 
             log_debug(f"Making request to {url} with params: {params}")
             response = requests.request("POST", url, headers=headers, data=payload, timeout=self.timeout)
@@ -116,7 +116,7 @@ class SerperTools(Toolkit):
         """
         try:
             if not query:
-                return json.dumps({"error": "Please provide a query to search for"}, indent=2)
+                return json.dumps({"error": "Please provide a query to search for"}, indent=2, ensure_ascii=False)
 
             log_debug(f"Searching Google for: {query}")
 
@@ -132,11 +132,11 @@ class SerperTools(Toolkit):
                 return result["raw_response"]
             else:
                 log_error(f"Error searching Google for query {query}: {result['error']}")
-                return json.dumps({"error": result["error"]}, indent=2)
+                return json.dumps({"error": result["error"]}, indent=2, ensure_ascii=False)
 
         except Exception as e:
             log_error(f"Unexpected error searching Google for query {query}: {str(e)}")
-            return json.dumps({"error": f"An unexpected error occurred: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"An unexpected error occurred: {str(e)}"}, indent=2, ensure_ascii=False)
 
     def search_news(
         self,
@@ -155,7 +155,7 @@ class SerperTools(Toolkit):
         """
         try:
             if not query:
-                return json.dumps({"error": "Please provide a query to search for news"}, indent=2)
+                return json.dumps({"error": "Please provide a query to search for news"}, indent=2, ensure_ascii=False)
 
             log_debug(f"Searching news for: {query}")
 
@@ -171,11 +171,11 @@ class SerperTools(Toolkit):
                 return result["raw_response"]
             else:
                 log_error(f"Error searching news for query {query}: {result['error']}")
-                return json.dumps({"error": result["error"]}, indent=2)
+                return json.dumps({"error": result["error"]}, indent=2, ensure_ascii=False)
 
         except Exception as e:
             log_error(f"Unexpected error searching news for query {query}: {str(e)}")
-            return json.dumps({"error": f"An unexpected error occurred: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"An unexpected error occurred: {str(e)}"}, indent=2, ensure_ascii=False)
 
     def search_scholar(
         self,
@@ -194,7 +194,9 @@ class SerperTools(Toolkit):
         """
         try:
             if not query:
-                return json.dumps({"error": "Please provide a query to search for academic papers"}, indent=2)
+                return json.dumps(
+                    {"error": "Please provide a query to search for academic papers"}, indent=2, ensure_ascii=False
+                )
 
             log_debug(f"Searching scholar for: {query}")
 
@@ -210,11 +212,11 @@ class SerperTools(Toolkit):
                 return result["raw_response"]
             else:
                 log_error(f"Error searching scholar for query {query}: {result['error']}")
-                return json.dumps({"error": result["error"]}, indent=2)
+                return json.dumps({"error": result["error"]}, indent=2, ensure_ascii=False)
 
         except Exception as e:
             log_error(f"Unexpected error searching scholar for query {query}: {str(e)}")
-            return json.dumps({"error": f"An unexpected error occurred: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"An unexpected error occurred: {str(e)}"}, indent=2, ensure_ascii=False)
 
     def scrape_webpage(
         self,
@@ -234,7 +236,7 @@ class SerperTools(Toolkit):
         try:
             if not url:
                 log_warning("No URL provided to scrape")
-                return json.dumps({"error": "Please provide a URL to scrape"}, indent=2)
+                return json.dumps({"error": "Please provide a URL to scrape"}, indent=2, ensure_ascii=False)
 
             log_debug(f"Scraping webpage: {url}")
 
@@ -250,8 +252,8 @@ class SerperTools(Toolkit):
                 return result["raw_response"]
             else:
                 log_error(f"Error scraping webpage {url}: {result['error']}")
-                return json.dumps({"error": result["error"]}, indent=2)
+                return json.dumps({"error": result["error"]}, indent=2, ensure_ascii=False)
 
         except Exception as e:
             log_error(f"Unexpected error scraping webpage {url}: {str(e)}")
-            return json.dumps({"error": f"An unexpected error occurred: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"An unexpected error occurred: {str(e)}"}, indent=2, ensure_ascii=False)

--- a/libs/agno/agno/tools/shopify.py
+++ b/libs/agno/agno/tools/shopify.py
@@ -125,9 +125,9 @@ class ShopifyTools(Toolkit):
         result = self._make_graphql_request(query)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
-        return json.dumps(result.get("shop", {}), indent=2)
+        return json.dumps(result.get("shop", {}), indent=2, ensure_ascii=False)
 
     def get_products(
         self,
@@ -190,7 +190,7 @@ class ShopifyTools(Toolkit):
         result = self._make_graphql_request(query)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         products = []
         for edge in result.get("products", {}).get("edges", []):
@@ -220,7 +220,7 @@ class ShopifyTools(Toolkit):
                 }
             )
 
-        return json.dumps(products, indent=2)
+        return json.dumps(products, indent=2, ensure_ascii=False)
 
     def get_orders(
         self,
@@ -309,7 +309,7 @@ class ShopifyTools(Toolkit):
         result = self._make_graphql_request(query)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         orders = []
         for edge in result.get("orders", {}).get("edges", []):
@@ -348,7 +348,7 @@ class ShopifyTools(Toolkit):
                 }
             )
 
-        return json.dumps(orders, indent=2)
+        return json.dumps(orders, indent=2, ensure_ascii=False)
 
     def get_top_selling_products(
         self,
@@ -413,7 +413,7 @@ class ShopifyTools(Toolkit):
         result = self._make_graphql_request(query)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         # Aggregate sales by product
         product_sales: Dict[str, Dict[str, Any]] = {}
@@ -451,7 +451,7 @@ class ShopifyTools(Toolkit):
             product["rank"] = i + 1
             product["total_revenue"] = round(product["total_revenue"], 2)
 
-        return json.dumps(sorted_products, indent=2)
+        return json.dumps(sorted_products, indent=2, ensure_ascii=False)
 
     def get_products_bought_together(
         self,
@@ -509,7 +509,7 @@ class ShopifyTools(Toolkit):
         result = self._make_graphql_request(query)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         # Count co-occurrences
         pair_counter: Counter = Counter()
@@ -548,7 +548,7 @@ class ShopifyTools(Toolkit):
             if count >= min_occurrences
         ]
 
-        return json.dumps(frequent_pairs, indent=2)
+        return json.dumps(frequent_pairs, indent=2, ensure_ascii=False)
 
     def get_sales_by_date_range(
         self,
@@ -594,7 +594,7 @@ class ShopifyTools(Toolkit):
         result = self._make_graphql_request(query)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         # Aggregate data
         total_revenue = 0.0
@@ -636,7 +636,7 @@ class ShopifyTools(Toolkit):
             "daily_breakdown": sorted_daily,
         }
 
-        return json.dumps(summary, indent=2)
+        return json.dumps(summary, indent=2, ensure_ascii=False)
 
     def get_order_analytics(
         self,
@@ -709,12 +709,12 @@ class ShopifyTools(Toolkit):
         result = self._make_graphql_request(query)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         orders = result.get("orders", {}).get("edges", [])
 
         if not orders:
-            return json.dumps({"message": "No orders found in the specified period"}, indent=2)
+            return json.dumps({"message": "No orders found in the specified period"}, indent=2, ensure_ascii=False)
 
         # Calculate metrics
         total_orders = len(orders)
@@ -771,7 +771,7 @@ class ShopifyTools(Toolkit):
             "fulfillment_status_breakdown": dict(fulfillment_status_counts),
         }
 
-        return json.dumps(analytics, indent=2)
+        return json.dumps(analytics, indent=2, ensure_ascii=False)
 
     def get_product_sales_breakdown(
         self,
@@ -840,7 +840,7 @@ class ShopifyTools(Toolkit):
         result = self._make_graphql_request(query)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         # Filter for specific product and aggregate
         product_title = None
@@ -896,7 +896,9 @@ class ShopifyTools(Toolkit):
                 order_count += 1
 
         if product_title is None:
-            return json.dumps({"error": "Product not found in any orders during this period"}, indent=2)
+            return json.dumps(
+                {"error": "Product not found in any orders during this period"}, indent=2, ensure_ascii=False
+            )
 
         # Format variants and daily data
         for v in variant_breakdown.values():
@@ -922,7 +924,7 @@ class ShopifyTools(Toolkit):
             "daily_sales": sorted_daily,
         }
 
-        return json.dumps(breakdown, indent=2)
+        return json.dumps(breakdown, indent=2, ensure_ascii=False)
 
     def get_customer_order_history(
         self,
@@ -983,12 +985,12 @@ class ShopifyTools(Toolkit):
         result = self._make_graphql_request(query)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         orders = result.get("orders", {}).get("edges", [])
 
         if not orders:
-            return json.dumps({"message": f"No orders found for {customer_email}"}, indent=2)
+            return json.dumps({"message": f"No orders found for {customer_email}"}, indent=2, ensure_ascii=False)
 
         # Get customer info from first order
         first_customer = orders[0]["node"].get("customer", {}) if orders else {}
@@ -1025,7 +1027,7 @@ class ShopifyTools(Toolkit):
             "orders": order_list,
         }
 
-        return json.dumps(response, indent=2)
+        return json.dumps(response, indent=2, ensure_ascii=False)
 
     def get_inventory_levels(
         self,
@@ -1070,7 +1072,7 @@ class ShopifyTools(Toolkit):
         result = self._make_graphql_request(query)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         products = []
         for edge in result.get("products", {}).get("edges", []):
@@ -1094,7 +1096,7 @@ class ShopifyTools(Toolkit):
                 }
             )
 
-        return json.dumps(products, indent=2)
+        return json.dumps(products, indent=2, ensure_ascii=False)
 
     def get_low_stock_products(
         self,
@@ -1139,7 +1141,7 @@ class ShopifyTools(Toolkit):
         result = self._make_graphql_request(query)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         low_stock = []
         for edge in result.get("products", {}).get("edges", []):
@@ -1171,7 +1173,7 @@ class ShopifyTools(Toolkit):
         # Sort by total inventory (lowest first)
         low_stock.sort(key=lambda x: x["total_inventory"])
 
-        return json.dumps(low_stock[:max_results], indent=2)
+        return json.dumps(low_stock[:max_results], indent=2, ensure_ascii=False)
 
     def get_sales_trends(
         self,
@@ -1262,7 +1264,7 @@ class ShopifyTools(Toolkit):
 
         current_data = fetch_period_data(current_start, current_end)
         if "error" in current_data:
-            return json.dumps(current_data, indent=2)
+            return json.dumps(current_data, indent=2, ensure_ascii=False)
 
         result = {
             "current_period": {
@@ -1304,7 +1306,7 @@ class ShopifyTools(Toolkit):
                     "orders_trend": "up" if orders_change > 0 else ("down" if orders_change < 0 else "flat"),
                 }
 
-        return json.dumps(result, indent=2)
+        return json.dumps(result, indent=2, ensure_ascii=False)
 
     def get_average_order_value(
         self,
@@ -1354,12 +1356,12 @@ class ShopifyTools(Toolkit):
         result = self._make_graphql_request(query)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         orders = result.get("orders", {}).get("edges", [])
 
         if not orders:
-            return json.dumps({"message": "No orders found in the specified period"}, indent=2)
+            return json.dumps({"message": "No orders found in the specified period"}, indent=2, ensure_ascii=False)
 
         # Group orders
         grouped: Dict[str, List[float]] = {}
@@ -1408,7 +1410,7 @@ class ShopifyTools(Toolkit):
             "breakdown": aov_data,
         }
 
-        return json.dumps(response, indent=2)
+        return json.dumps(response, indent=2, ensure_ascii=False)
 
     def get_repeat_customers(
         self,
@@ -1469,7 +1471,7 @@ class ShopifyTools(Toolkit):
         result = self._make_graphql_request(query)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         # Aggregate by customer
         customer_data: Dict[str, Dict[str, Any]] = {}
@@ -1516,4 +1518,4 @@ class ShopifyTools(Toolkit):
             "customers": repeat_customers[:limit],
         }
 
-        return json.dumps(response, indent=2)
+        return json.dumps(response, indent=2, ensure_ascii=False)

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -532,10 +532,10 @@ class SlackTools(Toolkit):
         """
         try:
             response = self.client.chat_postMessage(channel=channel, text=text, mrkdwn=self.markdown)
-            return json.dumps(response.data)
+            return json.dumps(response.data, ensure_ascii=False)
         except SlackApiError as e:
             logger.exception("Error sending message")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def send_message_thread(self, channel: str, text: str, thread_ts: str) -> str:
         """Reply to a message thread in a Slack channel.
@@ -552,10 +552,10 @@ class SlackTools(Toolkit):
             response = self.client.chat_postMessage(
                 channel=channel, text=text, thread_ts=thread_ts, mrkdwn=self.markdown
             )
-            return json.dumps(response.data)
+            return json.dumps(response.data, ensure_ascii=False)
         except SlackApiError as e:
             logger.exception("Error sending message")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_channels(self, include_private: bool = False) -> str:
         """List all channels in the Slack workspace.
@@ -593,9 +593,9 @@ class SlackTools(Toolkit):
                 cursor = (response.get("response_metadata") or {}).get("next_cursor")
                 if not cursor:
                     break
-            return json.dumps(channels)
+            return json.dumps(channels, ensure_ascii=False)
         except SlackApiError as e:
-            return json.dumps(self._slack_error_payload(e, operation="conversations.list"))
+            return json.dumps(self._slack_error_payload(e, operation="conversations.list"), ensure_ascii=False)
 
     def get_channel_history(self, channel: str, limit: int = 100) -> str:
         """Get the message history of a Slack channel.
@@ -609,7 +609,7 @@ class SlackTools(Toolkit):
         """
         resolved, error = self._resolve_channel(channel)
         if error:
-            return json.dumps(error)
+            return json.dumps(error, ensure_ascii=False)
         assert resolved is not None
 
         try:
@@ -628,7 +628,7 @@ class SlackTools(Toolkit):
                     entry["thread_ts"] = thread_ts
                     entry["reply_count"] = msg.get("reply_count", 0)
                 messages.append(entry)
-            return json.dumps(messages)
+            return json.dumps(messages, ensure_ascii=False)
         except SlackApiError as e:
             return json.dumps(
                 self._slack_error_payload(
@@ -636,7 +636,8 @@ class SlackTools(Toolkit):
                     operation="conversations.history",
                     channel=channel,
                     hint="Invite the bot to the channel, or pass a channel ID the bot can read.",
-                )
+                ),
+                ensure_ascii=False,
             )
 
     def upload_file(
@@ -671,13 +672,14 @@ class SlackTools(Toolkit):
                 limit_mb = self.max_file_size / (1024 * 1024)
                 actual_mb = len(content_bytes) / (1024 * 1024)
                 return json.dumps(
-                    {"error": f"File {filename} ({actual_mb:.1f}MB) exceeds {limit_mb:.0f}MB upload limit"}
+                    {"error": f"File {filename} ({actual_mb:.1f}MB) exceeds {limit_mb:.0f}MB upload limit"},
+                    ensure_ascii=False,
                 )
 
             try:
                 file_name = sanitize_filename(filename)
             except PathSecurityError as e:
-                return json.dumps({"error": f"Invalid filename: {e}"})
+                return json.dumps({"error": f"Invalid filename: {e}"}, ensure_ascii=False)
 
             response = self.client.files_upload_v2(
                 channel=channel,
@@ -688,10 +690,10 @@ class SlackTools(Toolkit):
                 thread_ts=thread_ts,
             )
 
-            return json.dumps(dict(cast(Dict[str, Any], response.data)))
+            return json.dumps(dict(cast(Dict[str, Any], response.data)), ensure_ascii=False)
         except SlackApiError as e:
             logger.exception("Error uploading file")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def download_file(self, file_id: str, dest_path: Optional[str] = None) -> str:
         """Download a file from Slack by its file ID.
@@ -709,7 +711,7 @@ class SlackTools(Toolkit):
 
             url_private = file_info.get("url_private")
             if not url_private:
-                return json.dumps({"error": "File URL not available"})
+                return json.dumps({"error": "File URL not available"}, ensure_ascii=False)
 
             filename = file_info.get("name", f"file_{file_id}")
             file_size = file_info.get("size", 0)
@@ -718,7 +720,8 @@ class SlackTools(Toolkit):
                 limit_mb = self.max_file_size / (1024 * 1024)
                 actual_mb = file_size / (1024 * 1024)
                 return json.dumps(
-                    {"error": f"File {filename} ({actual_mb:.1f}MB) exceeds {limit_mb:.0f}MB download limit"}
+                    {"error": f"File {filename} ({actual_mb:.1f}MB) exceeds {limit_mb:.0f}MB download limit"},
+                    ensure_ascii=False,
                 )
 
             headers = {"Authorization": f"Bearer {self.token}"}
@@ -743,14 +746,14 @@ class SlackTools(Toolkit):
             else:
                 result["content_base64"] = base64.b64encode(content).decode("utf-8")
 
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
 
         except SlackApiError as e:
             logger.exception("Error downloading file")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
         except httpx.HTTPError as e:
             logger.exception("Error downloading file content")
-            return json.dumps({"error": f"HTTP error: {str(e)}"})
+            return json.dumps({"error": f"HTTP error: {str(e)}"}, ensure_ascii=False)
 
     def download_file_bytes(self, file_id: str) -> Optional[bytes]:
         """Download file content as raw bytes. For internal use by interfaces."""
@@ -804,10 +807,10 @@ class SlackTools(Toolkit):
                 }
                 for msg in matches
             ]
-            return json.dumps({"count": len(messages), "messages": messages})
+            return json.dumps({"count": len(messages), "messages": messages}, ensure_ascii=False)
         except SlackApiError as e:
             logger.exception("Error searching messages")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def search_workspace(
         self,
@@ -837,7 +840,8 @@ class SlackTools(Toolkit):
         action_token = (run_context.metadata or {}).get("action_token") if run_context else None
         if not action_token:
             return json.dumps(
-                {"error": "No action_token available. This tool only works when invoked through the Slack interface."}
+                {"error": "No action_token available. This tool only works when invoked through the Slack interface."},
+                ensure_ascii=False,
             )
 
         try:
@@ -856,12 +860,14 @@ class SlackTools(Toolkit):
             if not response.get("ok"):
                 error = response.get("error", "unknown_error")
                 log_error(f"assistant.search.context failed: {error}")
-                return json.dumps({"error": error})
+                return json.dumps({"error": error}, ensure_ascii=False)
 
-            return json.dumps(self._format_search_results(response.get("results", {}), include_context_messages))
+            return json.dumps(
+                self._format_search_results(response.get("results", {}), include_context_messages), ensure_ascii=False
+            )
         except SlackApiError as e:
             logger.exception("Error in search_workspace")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_thread(self, channel: str, thread_ts: str, limit: int = 20) -> str:
         """Get all messages in a thread by the parent message's timestamp.
@@ -876,7 +882,7 @@ class SlackTools(Toolkit):
         """
         resolved, error = self._resolve_channel(channel)
         if error:
-            return json.dumps(error)
+            return json.dumps(error, ensure_ascii=False)
         assert resolved is not None
 
         try:
@@ -899,7 +905,8 @@ class SlackTools(Toolkit):
                     "thread_ts": thread_ts,
                     "reply_count": len(messages) - 1,
                     "messages": messages,
-                }
+                },
+                ensure_ascii=False,
             )
         except SlackApiError as e:
             return json.dumps(
@@ -908,7 +915,8 @@ class SlackTools(Toolkit):
                     operation="conversations.replies",
                     channel=channel,
                     hint="Invite the bot to the channel, or pass a channel ID the bot can read.",
-                )
+                ),
+                ensure_ascii=False,
             )
 
     def list_users(self, limit: int = 100) -> str:
@@ -934,10 +942,10 @@ class SlackTools(Toolkit):
                 for member in members
                 if not member.get("deleted", False)
             ]
-            return json.dumps({"count": len(users), "users": users})
+            return json.dumps({"count": len(users), "users": users}, ensure_ascii=False)
         except SlackApiError as e:
             logger.exception("Error listing users")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_user_info(self, user_id: str) -> str:
         """Get detailed information about a Slack user by their user ID.
@@ -961,11 +969,12 @@ class SlackTools(Toolkit):
                     "title": profile.get("title", ""),
                     "tz": user.get("tz", ""),
                     "is_bot": user.get("is_bot", False),
-                }
+                },
+                ensure_ascii=False,
             )
         except SlackApiError as e:
             logger.exception("Error getting user info")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_channel_info(self, channel: str) -> str:
         """Get detailed information about a Slack channel by its ID or name.
@@ -978,7 +987,7 @@ class SlackTools(Toolkit):
         """
         resolved, error = self._resolve_channel(channel)
         if error:
-            return json.dumps(error)
+            return json.dumps(error, ensure_ascii=False)
         assert resolved is not None
 
         try:
@@ -997,7 +1006,8 @@ class SlackTools(Toolkit):
                     "is_archived": ch.get("is_archived", False),
                     "created": ch.get("created", 0),
                     "creator": ch.get("creator", ""),
-                }
+                },
+                ensure_ascii=False,
             )
         except SlackApiError as e:
             return json.dumps(
@@ -1006,5 +1016,6 @@ class SlackTools(Toolkit):
                     operation="conversations.info",
                     channel=channel,
                     hint="Invite the bot to the channel, or pass a channel ID the bot can read.",
-                )
+                ),
+                ensure_ascii=False,
             )

--- a/libs/agno/agno/tools/smallest.py
+++ b/libs/agno/agno/tools/smallest.py
@@ -131,9 +131,9 @@ class SmallestTools(Toolkit):
                             "languages": tags.get("language") or voice.get("languages"),
                         }
                     )
-                return json.dumps(result)
+                return json.dumps(result, ensure_ascii=False)
 
-            return json.dumps(voices)
+            return json.dumps(voices, ensure_ascii=False)
         except Exception as e:
             log_error(f"Failed to fetch voices: {str(e)}")
             return f"Error: {e}"

--- a/libs/agno/agno/tools/sofya.py
+++ b/libs/agno/agno/tools/sofya.py
@@ -101,9 +101,9 @@ class SofyaTools(Toolkit):
             str: Search results as markdown or a JSON string.
         """
         if not self.api_key:
-            return json.dumps({"error": "Please provide a Sofya API key"})
+            return json.dumps({"error": "Please provide a Sofya API key"}, ensure_ascii=False)
         if not query or not query.strip():
-            return json.dumps({"error": "Please provide a query to search for"})
+            return json.dumps({"error": "Please provide a query to search for"}, ensure_ascii=False)
 
         payload = {
             "query": query.strip(),
@@ -116,7 +116,7 @@ class SofyaTools(Toolkit):
             data = self._post("search", payload)
         except Exception as e:
             log_error(f"Sofya search failed: {e}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
         clean: Dict[str, Any] = {"query": query}
         if data.get("answer"):
@@ -132,7 +132,7 @@ class SofyaTools(Toolkit):
         ]
 
         if self.format == "json":
-            return json.dumps(clean)
+            return json.dumps(clean, ensure_ascii=False)
 
         markdown = f"# {query}\n\n"
         if "answer" in clean:
@@ -158,11 +158,11 @@ class SofyaTools(Toolkit):
             str: Extracted content as markdown, with one section per URL.
         """
         if not self.api_key:
-            return json.dumps({"error": "Please provide a Sofya API key"})
+            return json.dumps({"error": "Please provide a Sofya API key"}, ensure_ascii=False)
 
         url_list = [u.strip() for u in urls.split(",") if u.strip()]
         if not url_list:
-            return json.dumps({"error": "No valid URLs provided"})
+            return json.dumps({"error": "No valid URLs provided"}, ensure_ascii=False)
         if len(url_list) > FETCH_MAX_URLS:
             log_debug(f"Sofya fetch capped at {FETCH_MAX_URLS} URLs; dropping {len(url_list) - FETCH_MAX_URLS}")
             url_list = url_list[:FETCH_MAX_URLS]
@@ -171,7 +171,7 @@ class SofyaTools(Toolkit):
             data = self._post("fetch", {"urls": url_list})
         except Exception as e:
             log_error(f"Sofya extract failed: {e}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
         results = data.get("results", [])
         if not results:
@@ -202,18 +202,18 @@ class SofyaTools(Toolkit):
             str: The research report as markdown, or a JSON string.
         """
         if not self.api_key:
-            return json.dumps({"error": "Please provide a Sofya API key"})
+            return json.dumps({"error": "Please provide a Sofya API key"}, ensure_ascii=False)
         if not query or not query.strip():
-            return json.dumps({"error": "Please provide a query to research"})
+            return json.dumps({"error": "Please provide a query to research"}, ensure_ascii=False)
 
         try:
             data = self._post("research", {"query": query.strip()})
         except Exception as e:
             log_error(f"Sofya research failed: {e}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
         if self.format == "json":
-            return json.dumps(data)
+            return json.dumps(data, ensure_ascii=False)
 
         report = data.get("report", "")
         markdown = f"# {query}\n\n{report}\n\n"

--- a/libs/agno/agno/tools/spider.py
+++ b/libs/agno/agno/tools/spider.py
@@ -88,7 +88,7 @@ class SpiderTools(Toolkit):
                 options["num"] = max_results
             log_info(f"Fetching results from spider for query: {query} with max_results: {options['num']}")
             results = app.search(query, options)
-            return json.dumps(results)
+            return json.dumps(results, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error fetching results from spider")
             return f"Error fetching results from spider: {e}"
@@ -99,7 +99,7 @@ class SpiderTools(Toolkit):
         try:
             options = {"return_format": "markdown", **self.optional_params}
             results = app.scrape_url(url, options)
-            return json.dumps(results)
+            return json.dumps(results, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error fetching content from spider")
             return f"Error fetching content from spider: {e}"
@@ -113,7 +113,7 @@ class SpiderTools(Toolkit):
             if limit is not None:
                 options["limit"] = limit
             results = app.crawl_url(url, options)
-            return json.dumps(results)
+            return json.dumps(results, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error fetching content from spider")
             return f"Error fetching content from spider: {e}"

--- a/libs/agno/agno/tools/spotify.py
+++ b/libs/agno/agno/tools/spotify.py
@@ -103,7 +103,7 @@ class SpotifyTools(Toolkit):
         """
         log_debug("Fetching current Spotify user profile")
         result = self._make_request("me")
-        return json.dumps(result, indent=2)
+        return json.dumps(result, indent=2, ensure_ascii=False)
 
     def get_my_top_tracks(
         self,
@@ -134,7 +134,7 @@ class SpotifyTools(Toolkit):
         result = self._make_request("me/top/tracks", params=params)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         tracks = result.get("items", [])
         simplified_tracks = [
@@ -150,7 +150,7 @@ class SpotifyTools(Toolkit):
             for i, track in enumerate(tracks)
         ]
 
-        return json.dumps(simplified_tracks, indent=2)
+        return json.dumps(simplified_tracks, indent=2, ensure_ascii=False)
 
     def get_my_top_artists(
         self,
@@ -181,7 +181,7 @@ class SpotifyTools(Toolkit):
         result = self._make_request("me/top/artists", params=params)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         artists = result.get("items", [])
         simplified_artists = [
@@ -197,7 +197,7 @@ class SpotifyTools(Toolkit):
             for i, artist in enumerate(artists)
         ]
 
-        return json.dumps(simplified_artists, indent=2)
+        return json.dumps(simplified_artists, indent=2, ensure_ascii=False)
 
     def search_playlists(
         self,
@@ -227,7 +227,7 @@ class SpotifyTools(Toolkit):
         result = self._make_request("search", params=params)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         playlists = result.get("playlists", {}).get("items", [])
         simplified_playlists = [
@@ -244,7 +244,7 @@ class SpotifyTools(Toolkit):
             if playlist is not None
         ]
 
-        return json.dumps(simplified_playlists, indent=2)
+        return json.dumps(simplified_playlists, indent=2, ensure_ascii=False)
 
     def get_user_playlists(
         self,
@@ -270,7 +270,7 @@ class SpotifyTools(Toolkit):
         result = self._make_request("me/playlists", params=params)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         playlists = result.get("items", [])
         simplified_playlists = [
@@ -287,7 +287,7 @@ class SpotifyTools(Toolkit):
             if playlist is not None
         ]
 
-        return json.dumps(simplified_playlists, indent=2)
+        return json.dumps(simplified_playlists, indent=2, ensure_ascii=False)
 
     def search_artists(
         self,
@@ -316,7 +316,7 @@ class SpotifyTools(Toolkit):
         result = self._make_request("search", params=params)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         artists = result.get("artists", {}).get("items", [])
         simplified_artists = [
@@ -331,7 +331,7 @@ class SpotifyTools(Toolkit):
             for artist in artists
         ]
 
-        return json.dumps(simplified_artists, indent=2)
+        return json.dumps(simplified_artists, indent=2, ensure_ascii=False)
 
     def search_albums(
         self,
@@ -363,7 +363,7 @@ class SpotifyTools(Toolkit):
         result = self._make_request("search", params=params)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         albums = result.get("albums", {}).get("items", [])
         simplified_albums = [
@@ -379,7 +379,7 @@ class SpotifyTools(Toolkit):
             for album in albums
         ]
 
-        return json.dumps(simplified_albums, indent=2)
+        return json.dumps(simplified_albums, indent=2, ensure_ascii=False)
 
     def get_album_tracks(
         self,
@@ -404,7 +404,7 @@ class SpotifyTools(Toolkit):
         album_result = self._make_request(f"albums/{album_id}", params={"market": market or self.default_market})
 
         if "error" in album_result:
-            return json.dumps(album_result, indent=2)
+            return json.dumps(album_result, indent=2, ensure_ascii=False)
 
         tracks = album_result.get("tracks", {}).get("items", [])
         simplified_tracks = [
@@ -431,7 +431,7 @@ class SpotifyTools(Toolkit):
             "tracks": simplified_tracks,
         }
 
-        return json.dumps(response, indent=2)
+        return json.dumps(response, indent=2, ensure_ascii=False)
 
     def get_artist_top_tracks(
         self,
@@ -458,7 +458,7 @@ class SpotifyTools(Toolkit):
         result = self._make_request(f"artists/{artist_id}/top-tracks", params=params)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         tracks = result.get("tracks", [])
         simplified_tracks = [
@@ -474,7 +474,7 @@ class SpotifyTools(Toolkit):
             for track in tracks
         ]
 
-        return json.dumps(simplified_tracks, indent=2)
+        return json.dumps(simplified_tracks, indent=2, ensure_ascii=False)
 
     def get_track_recommendations(
         self,
@@ -535,12 +535,14 @@ class SpotifyTools(Toolkit):
 
         # Validate at least one seed
         if not any([seed_tracks, seed_artists, seed_genres]):
-            return json.dumps({"error": "At least one seed (tracks, artists, or genres) is required"}, indent=2)
+            return json.dumps(
+                {"error": "At least one seed (tracks, artists, or genres) is required"}, indent=2, ensure_ascii=False
+            )
 
         result = self._make_request("recommendations", params=params)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         tracks = result.get("tracks", [])
         simplified_tracks = [
@@ -556,7 +558,7 @@ class SpotifyTools(Toolkit):
             for track in tracks
         ]
 
-        return json.dumps(simplified_tracks, indent=2)
+        return json.dumps(simplified_tracks, indent=2, ensure_ascii=False)
 
     def play_track(
         self,
@@ -600,7 +602,7 @@ class SpotifyTools(Toolkit):
         )
 
         if result.get("success") or not result.get("error"):
-            return json.dumps({"success": True, "message": "Playback started"}, indent=2)
+            return json.dumps({"success": True, "message": "Playback started"}, indent=2, ensure_ascii=False)
 
         # Common error: no active device
         if result.get("error", {}).get("reason") == "NO_ACTIVE_DEVICE":
@@ -610,9 +612,10 @@ class SpotifyTools(Toolkit):
                     "reason": "NO_ACTIVE_DEVICE",
                 },
                 indent=2,
+                ensure_ascii=False,
             )
 
-        return json.dumps(result, indent=2)
+        return json.dumps(result, indent=2, ensure_ascii=False)
 
     def get_currently_playing(self) -> str:
         """Get information about the user's current playback state.
@@ -625,10 +628,10 @@ class SpotifyTools(Toolkit):
         result = self._make_request("me/player/currently-playing")
 
         if not result or result.get("success"):
-            return json.dumps({"message": "Nothing currently playing"}, indent=2)
+            return json.dumps({"message": "Nothing currently playing"}, indent=2, ensure_ascii=False)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         track = result.get("item", {})
         response = {
@@ -647,7 +650,7 @@ class SpotifyTools(Toolkit):
             "device": result.get("device", {}).get("name"),
         }
 
-        return json.dumps(response, indent=2)
+        return json.dumps(response, indent=2, ensure_ascii=False)
 
     def search_tracks(
         self,
@@ -680,7 +683,7 @@ class SpotifyTools(Toolkit):
         result = self._make_request("search", params=params)
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         tracks = result.get("tracks", {}).get("items", [])
         simplified_tracks = [
@@ -696,7 +699,7 @@ class SpotifyTools(Toolkit):
             for track in tracks
         ]
 
-        return json.dumps(simplified_tracks, indent=2)
+        return json.dumps(simplified_tracks, indent=2, ensure_ascii=False)
 
     def create_playlist(
         self,
@@ -722,7 +725,7 @@ class SpotifyTools(Toolkit):
         # First get the current user's ID
         user_response = self._make_request("me")
         if "error" in user_response:
-            return json.dumps(user_response, indent=2)
+            return json.dumps(user_response, indent=2, ensure_ascii=False)
 
         user_id = user_response["id"]
 
@@ -736,7 +739,7 @@ class SpotifyTools(Toolkit):
         playlist = self._make_request(f"users/{user_id}/playlists", method="POST", body=body)
 
         if "error" in playlist:
-            return json.dumps(playlist, indent=2)
+            return json.dumps(playlist, indent=2, ensure_ascii=False)
 
         # Add tracks if provided
         if track_uris and len(track_uris) > 0:
@@ -760,7 +763,7 @@ class SpotifyTools(Toolkit):
             "tracks_added": playlist.get("tracks_added", 0),
         }
 
-        return json.dumps(result, indent=2)
+        return json.dumps(result, indent=2, ensure_ascii=False)
 
     def add_tracks_to_playlist(
         self,
@@ -795,9 +798,10 @@ class SpotifyTools(Toolkit):
                     "snapshot_id": result["snapshot_id"],
                 },
                 indent=2,
+                ensure_ascii=False,
             )
 
-        return json.dumps(result, indent=2)
+        return json.dumps(result, indent=2, ensure_ascii=False)
 
     def remove_tracks_from_playlist(
         self,
@@ -828,9 +832,10 @@ class SpotifyTools(Toolkit):
                     "snapshot_id": result["snapshot_id"],
                 },
                 indent=2,
+                ensure_ascii=False,
             )
 
-        return json.dumps(result, indent=2)
+        return json.dumps(result, indent=2, ensure_ascii=False)
 
     def get_playlist(
         self,
@@ -855,7 +860,7 @@ class SpotifyTools(Toolkit):
         result = self._make_request(f"playlists/{playlist_id}", params={"fields": fields})
 
         if "error" in result:
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         playlist_info = {
             "id": result["id"],
@@ -878,7 +883,7 @@ class SpotifyTools(Toolkit):
                 if item.get("track")
             ]
 
-        return json.dumps(playlist_info, indent=2)
+        return json.dumps(playlist_info, indent=2, ensure_ascii=False)
 
     def update_playlist_details(
         self,
@@ -909,11 +914,11 @@ class SpotifyTools(Toolkit):
             body["public"] = public
 
         if not body:
-            return json.dumps({"error": "No updates provided"}, indent=2)
+            return json.dumps({"error": "No updates provided"}, indent=2, ensure_ascii=False)
 
         result = self._make_request(f"playlists/{playlist_id}", method="PUT", body=body)
 
         if result.get("success") or "error" not in result:
-            return json.dumps({"success": True, "updated_fields": list(body.keys())}, indent=2)
+            return json.dumps({"success": True, "updated_fields": list(body.keys())}, indent=2, ensure_ascii=False)
 
-        return json.dumps(result, indent=2)
+        return json.dumps(result, indent=2, ensure_ascii=False)

--- a/libs/agno/agno/tools/sql.py
+++ b/libs/agno/agno/tools/sql.py
@@ -70,7 +70,7 @@ class SQLTools(Toolkit):
             str: list of tables in the database.
         """
         if self.tables is not None:
-            return json.dumps(self.tables)
+            return json.dumps(self.tables, ensure_ascii=False)
 
         try:
             log_debug("listing tables in the database")
@@ -80,7 +80,7 @@ class SQLTools(Toolkit):
             else:
                 table_names = inspector.get_table_names()
             log_debug(f"table_names: {table_names}")
-            return json.dumps(table_names)
+            return json.dumps(table_names, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error getting tables")
             return f"Error getting tables: {e}"
@@ -108,7 +108,8 @@ class SQLTools(Toolkit):
                         "default": column.get("default"),
                     }
                     for column in table_schema
-                ]
+                ],
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Error getting table schema")
@@ -127,7 +128,7 @@ class SQLTools(Toolkit):
         """
 
         try:
-            return json.dumps(self.run_sql(sql=query, limit=limit), default=str)
+            return json.dumps(self.run_sql(sql=query, limit=limit), default=str, ensure_ascii=False)
         except Exception as e:
             logger.exception("Error running query")
             return f"Error running query: {e}"

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -606,10 +606,10 @@ class StudioTools(Toolkit):
         """
         try:
             models = [{"id": getattr(m, "id", None), "provider": type(m).__name__} for m in self.registry.models]
-            return json.dumps({"models": models, "count": len(models)})
+            return json.dumps({"models": models, "count": len(models)}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to list models")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_tools(self) -> str:
         """List toolkits and functions available in the registry.
@@ -627,10 +627,10 @@ class StudioTools(Toolkit):
                     result.append({"name": tool.name, "kind": "function"})
                 elif callable(tool):
                     result.append({"name": getattr(tool, "__name__", repr(tool)), "kind": "callable"})
-            return json.dumps({"tools": result, "count": len(result)})
+            return json.dumps({"tools": result, "count": len(result)}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to list tools")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_functions(self) -> str:
         """List raw functions available in the registry for workflow steps.
@@ -656,10 +656,10 @@ class StudioTools(Toolkit):
                         "signature": signature,
                     }
                 )
-            return json.dumps({"functions": result, "count": len(result)})
+            return json.dumps({"functions": result, "count": len(result)}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to list functions")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_dbs(self) -> str:
         """List databases available in the registry.
@@ -669,10 +669,10 @@ class StudioTools(Toolkit):
         """
         try:
             dbs = [{"id": getattr(d, "id", None), "class": type(d).__name__} for d in self.registry.dbs]
-            return json.dumps({"dbs": dbs, "count": len(dbs)})
+            return json.dumps({"dbs": dbs, "count": len(dbs)}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to list dbs")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_agents(self) -> str:
         """List all known agents: code-defined (registry / agents_list) plus DB components.
@@ -704,10 +704,10 @@ class StudioTools(Toolkit):
                 if row["id"] in seen or row["name"] in seen:
                     continue
                 result.append({**row, "source": "db"})
-            return json.dumps({"agents": result, "count": len(result)})
+            return json.dumps({"agents": result, "count": len(result)}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to list agents")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_teams(self) -> str:
         """List all known teams: code-defined plus DB components.
@@ -740,10 +740,10 @@ class StudioTools(Toolkit):
                 if row["id"] in seen or row["name"] in seen:
                     continue
                 result.append({**row, "source": "db"})
-            return json.dumps({"teams": result, "count": len(result)})
+            return json.dumps({"teams": result, "count": len(result)}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to list teams")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_workflows(self) -> str:
         """List all known workflows: code-defined plus DB components.
@@ -775,10 +775,10 @@ class StudioTools(Toolkit):
                 if row["id"] in seen or row["name"] in seen:
                     continue
                 result.append({**row, "source": "db"})
-            return json.dumps({"workflows": result, "count": len(result)})
+            return json.dumps({"workflows": result, "count": len(result)}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to list workflows")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def _list_db_components(self, component_type: str) -> List[Dict[str, Any]]:
         """Return a thin summary of DB components of a given type: [{id, name, description}]."""
@@ -810,7 +810,7 @@ class StudioTools(Toolkit):
         """
         agent = self._find_agent(agent_id)
         if agent is None:
-            return json.dumps({"error": f"Agent not found: {agent_id}"})
+            return json.dumps({"error": f"Agent not found: {agent_id}"}, ensure_ascii=False)
         return json.dumps(
             {
                 "id": getattr(agent, "id", None),
@@ -824,6 +824,7 @@ class StudioTools(Toolkit):
                 "add_datetime_to_context": getattr(agent, "add_datetime_to_context", None),
             },
             default=str,
+            ensure_ascii=False,
         )
 
     def get_team(self, team_id: str) -> str:
@@ -836,7 +837,7 @@ class StudioTools(Toolkit):
         """
         team = self._find_team(team_id)
         if team is None:
-            return json.dumps({"error": f"Team not found: {team_id}"})
+            return json.dumps({"error": f"Team not found: {team_id}"}, ensure_ascii=False)
         members = getattr(team, "members", None) or []
         return json.dumps(
             {
@@ -851,6 +852,7 @@ class StudioTools(Toolkit):
                 "add_datetime_to_context": getattr(team, "add_datetime_to_context", None),
             },
             default=str,
+            ensure_ascii=False,
         )
 
     def get_workflow(self, workflow_id: str) -> str:
@@ -863,7 +865,7 @@ class StudioTools(Toolkit):
         """
         wf = self._find_workflow(workflow_id)
         if wf is None:
-            return json.dumps({"error": f"Workflow not found: {workflow_id}"})
+            return json.dumps({"error": f"Workflow not found: {workflow_id}"}, ensure_ascii=False)
         steps = getattr(wf, "steps", None) or []
         step_summaries: List[Dict[str, Any]] = []
         for step in steps if isinstance(steps, list) else []:
@@ -887,6 +889,7 @@ class StudioTools(Toolkit):
                 "steps": step_summaries,
             },
             default=str,
+            ensure_ascii=False,
         )
 
     # ------------------------------------------------------------------
@@ -933,12 +936,12 @@ class StudioTools(Toolkit):
         try:
             model = self._find_model(model_id)
             if model is None:
-                return json.dumps({"error": f"Model not found: {model_id or 'default'}"})
+                return json.dumps({"error": f"Model not found: {model_id or 'default'}"}, ensure_ascii=False)
             tools = self._resolve_tools(tool_names)
             db = self._find_db(db_id)
             if db is None:
                 message = f"Db not found: {db_id}" if db_id is not None else "StudioTools has no db configured."
-                return json.dumps({"error": message})
+                return json.dumps({"error": message}, ensure_ascii=False)
 
             agent_id = self._unique_component_id(name, db)
             agent = Agent(
@@ -966,11 +969,12 @@ class StudioTools(Toolkit):
                     "add_history_to_context": add_history_to_context,
                     "add_datetime_to_context": add_datetime_to_context,
                     "db_version": version,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to create agent")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def create_team(
         self,
@@ -1011,18 +1015,18 @@ class StudioTools(Toolkit):
         try:
             model = self._find_model(model_id)
             if model is None:
-                return json.dumps({"error": f"Model not found: {model_id or 'default'}"})
+                return json.dumps({"error": f"Model not found: {model_id or 'default'}"}, ensure_ascii=False)
 
             members, missing = self._resolve_members(member_ids)
             if missing:
-                return json.dumps({"error": f"Members not found: {missing}"})
+                return json.dumps({"error": f"Members not found: {missing}"}, ensure_ascii=False)
             if not members:
-                return json.dumps({"error": "A team must have at least one member"})
+                return json.dumps({"error": "A team must have at least one member"}, ensure_ascii=False)
 
             db = self._find_db(db_id)
             if db is None:
                 message = f"Db not found: {db_id}" if db_id is not None else "StudioTools has no db configured."
-                return json.dumps({"error": message})
+                return json.dumps({"error": message}, ensure_ascii=False)
             team_id = self._unique_component_id(name, db)
             team = Team(
                 id=team_id,
@@ -1049,11 +1053,12 @@ class StudioTools(Toolkit):
                     "add_history_to_context": add_history_to_context,
                     "add_datetime_to_context": add_datetime_to_context,
                     "db_version": version,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to create team")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def create_workflow(
         self,
@@ -1079,12 +1084,12 @@ class StudioTools(Toolkit):
         try:
             steps, err = self._build_steps(step_specs)
             if err is not None:
-                return json.dumps({"error": err})
+                return json.dumps({"error": err}, ensure_ascii=False)
 
             db = self._find_db(db_id)
             if db is None:
                 message = f"Db not found: {db_id}" if db_id is not None else "StudioTools has no db configured."
-                return json.dumps({"error": message})
+                return json.dumps({"error": message}, ensure_ascii=False)
             workflow_id = self._unique_component_id(name, db)
             workflow = Workflow(
                 id=workflow_id,
@@ -1104,11 +1109,12 @@ class StudioTools(Toolkit):
                     "description": description,
                     "steps": [s.name for s in steps],
                     "db_version": version,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to create workflow")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     # ------------------------------------------------------------------
     # Edit (produces a draft version)
@@ -1145,14 +1151,17 @@ class StudioTools(Toolkit):
                 current date and time. Omit to keep.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured; cannot edit components."})
+            return json.dumps(
+                {"error": "StudioTools has no db configured; cannot edit components."}, ensure_ascii=False
+            )
         if self._is_code_defined(agent_id, self._iter_agents()):
             return json.dumps(
-                {"error": f"Cannot edit code-defined agent: {agent_id}. Only Studio-created components are editable."}
+                {"error": f"Cannot edit code-defined agent: {agent_id}. Only Studio-created components are editable."},
+                ensure_ascii=False,
             )
         agent = self._find_agent_for_edit(agent_id)
         if agent is None:
-            return json.dumps({"error": f"Agent not found: {agent_id}"})
+            return json.dumps({"error": f"Agent not found: {agent_id}"}, ensure_ascii=False)
 
         try:
             agent = agent.deep_copy()
@@ -1166,7 +1175,7 @@ class StudioTools(Toolkit):
             if model_id is not None:
                 model = self._find_model(model_id)
                 if model is None:
-                    return json.dumps({"error": f"Model not found: {model_id}"})
+                    return json.dumps({"error": f"Model not found: {model_id}"}, ensure_ascii=False)
                 agent.model = model
             if tool_names is not None:
                 agent.tools = self._resolve_tools(tool_names) or None
@@ -1182,10 +1191,10 @@ class StudioTools(Toolkit):
 
             result = self._save_edit(agent)
             log_debug(f"StudioTools edited agent id={agent_id} result={result}")
-            return json.dumps({"status": "edited", "id": agent_id, **result})
+            return json.dumps({"status": "edited", "id": agent_id, **result}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to edit agent")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def edit_team(
         self,
@@ -1218,14 +1227,17 @@ class StudioTools(Toolkit):
                 current date and time. Omit to keep.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured; cannot edit components."})
+            return json.dumps(
+                {"error": "StudioTools has no db configured; cannot edit components."}, ensure_ascii=False
+            )
         if self._is_code_defined(team_id, self._iter_teams()):
             return json.dumps(
-                {"error": f"Cannot edit code-defined team: {team_id}. Only Studio-created components are editable."}
+                {"error": f"Cannot edit code-defined team: {team_id}. Only Studio-created components are editable."},
+                ensure_ascii=False,
             )
         team = self._find_team_for_edit(team_id)
         if team is None:
-            return json.dumps({"error": f"Team not found: {team_id}"})
+            return json.dumps({"error": f"Team not found: {team_id}"}, ensure_ascii=False)
 
         try:
             team = team.deep_copy()
@@ -1239,14 +1251,14 @@ class StudioTools(Toolkit):
             if model_id is not None:
                 model = self._find_model(model_id)
                 if model is None:
-                    return json.dumps({"error": f"Model not found: {model_id}"})
+                    return json.dumps({"error": f"Model not found: {model_id}"}, ensure_ascii=False)
                 team.model = model
             if member_ids is not None:
                 members, missing = self._resolve_members(member_ids)
                 if missing:
-                    return json.dumps({"error": f"Members not found: {missing}"})
+                    return json.dumps({"error": f"Members not found: {missing}"}, ensure_ascii=False)
                 if not members:
-                    return json.dumps({"error": "A team must have at least one member"})
+                    return json.dumps({"error": "A team must have at least one member"}, ensure_ascii=False)
                 team.members = members
             if add_history_to_context is not None:
                 team.add_history_to_context = add_history_to_context
@@ -1260,10 +1272,10 @@ class StudioTools(Toolkit):
 
             result = self._save_edit(team)
             log_debug(f"StudioTools edited team id={team_id} result={result}")
-            return json.dumps({"status": "edited", "id": team_id, **result})
+            return json.dumps({"status": "edited", "id": team_id, **result}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to edit team")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def edit_workflow(
         self,
@@ -1285,16 +1297,19 @@ class StudioTools(Toolkit):
                 Same shape as create_workflow.step_specs.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured; cannot edit components."})
+            return json.dumps(
+                {"error": "StudioTools has no db configured; cannot edit components."}, ensure_ascii=False
+            )
         if self._is_code_defined(workflow_id, self._iter_workflows()):
             return json.dumps(
                 {
                     "error": f"Cannot edit code-defined workflow: {workflow_id}. Only Studio-created components are editable."
-                }
+                },
+                ensure_ascii=False,
             )
         wf = self._find_workflow_for_edit(workflow_id)
         if wf is None:
-            return json.dumps({"error": f"Workflow not found: {workflow_id}"})
+            return json.dumps({"error": f"Workflow not found: {workflow_id}"}, ensure_ascii=False)
 
         try:
             wf = wf.deep_copy()
@@ -1306,15 +1321,15 @@ class StudioTools(Toolkit):
             if step_specs is not None:
                 steps, err = self._build_steps(step_specs)
                 if err is not None:
-                    return json.dumps({"error": err})
+                    return json.dumps({"error": err}, ensure_ascii=False)
                 wf.steps = steps
 
             result = self._save_edit(wf)
             log_debug(f"StudioTools edited workflow id={workflow_id} result={result}")
-            return json.dumps({"status": "edited", "id": workflow_id, **result})
+            return json.dumps({"status": "edited", "id": workflow_id, **result}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to edit workflow")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     # ------------------------------------------------------------------
     # Versioning / configs
@@ -1327,7 +1342,7 @@ class StudioTools(Toolkit):
             component_id (str): The component id.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured."})
+            return json.dumps({"error": "StudioTools has no db configured."}, ensure_ascii=False)
         try:
             component = self.db.get_component(component_id) or {}
             current_version = component.get("current_version")
@@ -1342,10 +1357,12 @@ class StudioTools(Toolkit):
                 }
                 for c in configs
             ]
-            return json.dumps({"component_id": component_id, "versions": versions, "count": len(versions)})
+            return json.dumps(
+                {"component_id": component_id, "versions": versions, "count": len(versions)}, ensure_ascii=False
+            )
         except Exception as e:
             logger.exception("Failed to list versions")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_version(self, component_id: str, version: Optional[int] = None) -> str:
         """Get a specific config version. If version is omitted, returns the current version.
@@ -1355,15 +1372,17 @@ class StudioTools(Toolkit):
             version (Optional[int]): Version number, or omit for the current version.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured."})
+            return json.dumps({"error": "StudioTools has no db configured."}, ensure_ascii=False)
         try:
             config = self.db.get_config(component_id=component_id, version=version)
             if config is None:
-                return json.dumps({"error": f"Version not found: component_id={component_id} version={version}"})
-            return json.dumps(config, default=str)
+                return json.dumps(
+                    {"error": f"Version not found: component_id={component_id} version={version}"}, ensure_ascii=False
+                )
+            return json.dumps(config, default=str, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to get version")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def publish_component(self, component_id: str, version: Optional[int] = None) -> str:
         """Promote a draft to published (and make it the current version).
@@ -1375,23 +1394,25 @@ class StudioTools(Toolkit):
                 returns status "already_published".
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured."})
+            return json.dumps({"error": "StudioTools has no db configured."}, ensure_ascii=False)
         try:
             configs = self.db.list_configs(component_id, include_config=False)
             target = version
             if target is None:
                 drafts = [c for c in configs if c.get("stage") == "draft"]
                 if not drafts:
-                    return json.dumps({"error": "No draft version to publish."})
+                    return json.dumps({"error": "No draft version to publish."}, ensure_ascii=False)
                 target = max(d.get("version", 0) for d in drafts)
             else:
                 # Explicit version: validate it exists and is not already published.
                 match = next((c for c in configs if c.get("version") == target), None)
                 if match is None:
-                    return json.dumps({"error": f"Version not found: {component_id} v{target}"})
+                    return json.dumps({"error": f"Version not found: {component_id} v{target}"}, ensure_ascii=False)
                 if match.get("stage") == "published":
                     self._sync_component_row(component_id, target)
-                    return json.dumps({"status": "already_published", "id": component_id, "version": target})
+                    return json.dumps(
+                        {"status": "already_published", "id": component_id, "version": target}, ensure_ascii=False
+                    )
 
             result = self.db.upsert_config(component_id=component_id, version=target, stage="published")
             published_version = result.get("version", target)
@@ -1401,11 +1422,12 @@ class StudioTools(Toolkit):
                     "status": "published",
                     "id": component_id,
                     "version": published_version,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to publish component")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def set_current_version(self, component_id: str, version: int) -> str:
         """Roll back to a previously published version (make it current).
@@ -1415,15 +1437,17 @@ class StudioTools(Toolkit):
             version (int): A published version to set as current.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured."})
+            return json.dumps({"error": "StudioTools has no db configured."}, ensure_ascii=False)
         try:
             ok = self.db.set_current_version(component_id, version=version)
             if not ok:
-                return json.dumps({"error": f"Component or version not found: {component_id} v{version}"})
-            return json.dumps({"status": "set_current", "id": component_id, "version": version})
+                return json.dumps(
+                    {"error": f"Component or version not found: {component_id} v{version}"}, ensure_ascii=False
+                )
+            return json.dumps({"status": "set_current", "id": component_id, "version": version}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to set current version")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def delete_version(self, component_id: str, version: int) -> str:
         """Delete a draft config version. Published and current versions cannot be deleted.
@@ -1433,15 +1457,15 @@ class StudioTools(Toolkit):
             version (int): The draft version to delete.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured."})
+            return json.dumps({"error": "StudioTools has no db configured."}, ensure_ascii=False)
         try:
             deleted = self.db.delete_config(component_id, version=version)
             if not deleted:
-                return json.dumps({"error": f"Version not found: {component_id} v{version}"})
-            return json.dumps({"status": "deleted", "id": component_id, "version": version})
+                return json.dumps({"error": f"Version not found: {component_id} v{version}"}, ensure_ascii=False)
+            return json.dumps({"status": "deleted", "id": component_id, "version": version}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to delete version")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     # ------------------------------------------------------------------
     # Delete
@@ -1454,20 +1478,22 @@ class StudioTools(Toolkit):
             agent_id (str): The id of the agent to delete.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured; cannot delete components."})
+            return json.dumps(
+                {"error": "StudioTools has no db configured; cannot delete components."}, ensure_ascii=False
+            )
         try:
             from agno.db.base import ComponentType
 
             component = self.db.get_component(agent_id, component_type=ComponentType.AGENT)
             if component is None:
-                return json.dumps({"error": f"Agent not found: {agent_id}"})
+                return json.dumps({"error": f"Agent not found: {agent_id}"}, ensure_ascii=False)
             deleted = self.db.delete_component(agent_id, hard_delete=True)
             if not deleted:
-                return json.dumps({"error": f"Agent not found: {agent_id}"})
-            return json.dumps({"status": "deleted", "id": agent_id})
+                return json.dumps({"error": f"Agent not found: {agent_id}"}, ensure_ascii=False)
+            return json.dumps({"status": "deleted", "id": agent_id}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to delete agent")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def delete_team(self, team_id: str) -> str:
         """Hard-delete a team component.
@@ -1476,20 +1502,22 @@ class StudioTools(Toolkit):
             team_id (str): The id of the team to delete.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured; cannot delete components."})
+            return json.dumps(
+                {"error": "StudioTools has no db configured; cannot delete components."}, ensure_ascii=False
+            )
         try:
             from agno.db.base import ComponentType
 
             component = self.db.get_component(team_id, component_type=ComponentType.TEAM)
             if component is None:
-                return json.dumps({"error": f"Team not found: {team_id}"})
+                return json.dumps({"error": f"Team not found: {team_id}"}, ensure_ascii=False)
             deleted = self.db.delete_component(team_id, hard_delete=True)
             if not deleted:
-                return json.dumps({"error": f"Team not found: {team_id}"})
-            return json.dumps({"status": "deleted", "id": team_id})
+                return json.dumps({"error": f"Team not found: {team_id}"}, ensure_ascii=False)
+            return json.dumps({"status": "deleted", "id": team_id}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to delete team")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def delete_workflow(self, workflow_id: str) -> str:
         """Hard-delete a workflow component.
@@ -1498,20 +1526,22 @@ class StudioTools(Toolkit):
             workflow_id (str): The id of the workflow to delete.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTools has no db configured; cannot delete components."})
+            return json.dumps(
+                {"error": "StudioTools has no db configured; cannot delete components."}, ensure_ascii=False
+            )
         try:
             from agno.db.base import ComponentType
 
             component = self.db.get_component(workflow_id, component_type=ComponentType.WORKFLOW)
             if component is None:
-                return json.dumps({"error": f"Workflow not found: {workflow_id}"})
+                return json.dumps({"error": f"Workflow not found: {workflow_id}"}, ensure_ascii=False)
             deleted = self.db.delete_component(workflow_id, hard_delete=True)
             if not deleted:
-                return json.dumps({"error": f"Workflow not found: {workflow_id}"})
-            return json.dumps({"status": "deleted", "id": workflow_id})
+                return json.dumps({"error": f"Workflow not found: {workflow_id}"}, ensure_ascii=False)
+            return json.dumps({"status": "deleted", "id": workflow_id}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to delete workflow")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     # ------------------------------------------------------------------
     # Execute
@@ -1526,13 +1556,15 @@ class StudioTools(Toolkit):
         """
         agent = self._find_agent(agent_id)
         if agent is None:
-            return json.dumps({"error": f"Agent not found: {agent_id}"})
+            return json.dumps({"error": f"Agent not found: {agent_id}"}, ensure_ascii=False)
         try:
             response = agent.run(message)
-            return json.dumps({"id": agent_id, "content": getattr(response, "content", None)}, default=str)
+            return json.dumps(
+                {"id": agent_id, "content": getattr(response, "content", None)}, default=str, ensure_ascii=False
+            )
         except Exception as e:
             logger.exception("Failed to run agent")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def run_team(self, team_id: str, message: str) -> str:
         """Run a team and return its response content.
@@ -1543,13 +1575,15 @@ class StudioTools(Toolkit):
         """
         team = self._find_team(team_id)
         if team is None:
-            return json.dumps({"error": f"Team not found: {team_id}"})
+            return json.dumps({"error": f"Team not found: {team_id}"}, ensure_ascii=False)
         try:
             response = team.run(message)
-            return json.dumps({"id": team_id, "content": getattr(response, "content", None)}, default=str)
+            return json.dumps(
+                {"id": team_id, "content": getattr(response, "content", None)}, default=str, ensure_ascii=False
+            )
         except Exception as e:
             logger.exception("Failed to run team")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def run_workflow(self, workflow_id: str, message: str) -> str:
         """Run a workflow and return its final content.
@@ -1560,13 +1594,15 @@ class StudioTools(Toolkit):
         """
         wf = self._find_workflow(workflow_id)
         if wf is None:
-            return json.dumps({"error": f"Workflow not found: {workflow_id}"})
+            return json.dumps({"error": f"Workflow not found: {workflow_id}"}, ensure_ascii=False)
         try:
             response = wf.run(input=message)
-            return json.dumps({"id": workflow_id, "content": getattr(response, "content", None)}, default=str)
+            return json.dumps(
+                {"id": workflow_id, "content": getattr(response, "content", None)}, default=str, ensure_ascii=False
+            )
         except Exception as e:
             logger.exception("Failed to run workflow")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     # ------------------------------------------------------------------
     # Schedules (component-aware)
@@ -1603,13 +1639,14 @@ class StudioTools(Toolkit):
         try:
             component_id, target_error = self._resolve_schedule_target(target_type, target_id)
             if target_error is not None:
-                return json.dumps({"error": target_error})
+                return json.dumps({"error": target_error}, ensure_ascii=False)
             if not message or not message.strip():
                 return json.dumps(
                     {
                         "error": "message must be a non-empty string; it is the prompt "
                         "sent to the component on every scheduled run."
-                    }
+                    },
+                    ensure_ascii=False,
                 )
             manager = self._get_schedule_manager()
             schedule = manager.create(
@@ -1635,11 +1672,12 @@ class StudioTools(Toolkit):
                     "timezone": schedule.timezone,
                     "enabled": schedule.enabled,
                     "next_run_at": schedule.next_run_at,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             logger.exception("Failed to create schedule")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     # ------------------------------------------------------------------
     # Async tools
@@ -1856,13 +1894,15 @@ class StudioTools(Toolkit):
         """
         agent = self._find_agent(agent_id)
         if agent is None:
-            return json.dumps({"error": f"Agent not found: {agent_id}"})
+            return json.dumps({"error": f"Agent not found: {agent_id}"}, ensure_ascii=False)
         try:
             response = await agent.arun(message)
-            return json.dumps({"id": agent_id, "content": getattr(response, "content", None)}, default=str)
+            return json.dumps(
+                {"id": agent_id, "content": getattr(response, "content", None)}, default=str, ensure_ascii=False
+            )
         except Exception as e:
             logger.exception("Failed to run agent")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     async def arun_team(self, team_id: str, message: str) -> str:
         """Async variant of run_team.
@@ -1873,13 +1913,15 @@ class StudioTools(Toolkit):
         """
         team = self._find_team(team_id)
         if team is None:
-            return json.dumps({"error": f"Team not found: {team_id}"})
+            return json.dumps({"error": f"Team not found: {team_id}"}, ensure_ascii=False)
         try:
             response = await team.arun(message)
-            return json.dumps({"id": team_id, "content": getattr(response, "content", None)}, default=str)
+            return json.dumps(
+                {"id": team_id, "content": getattr(response, "content", None)}, default=str, ensure_ascii=False
+            )
         except Exception as e:
             logger.exception("Failed to run team")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     async def arun_workflow(self, workflow_id: str, message: str) -> str:
         """Async variant of run_workflow.
@@ -1890,13 +1932,15 @@ class StudioTools(Toolkit):
         """
         wf = self._find_workflow(workflow_id)
         if wf is None:
-            return json.dumps({"error": f"Workflow not found: {workflow_id}"})
+            return json.dumps({"error": f"Workflow not found: {workflow_id}"}, ensure_ascii=False)
         try:
             response = await wf.arun(input=message)
-            return json.dumps({"id": workflow_id, "content": getattr(response, "content", None)}, default=str)
+            return json.dumps(
+                {"id": workflow_id, "content": getattr(response, "content", None)}, default=str, ensure_ascii=False
+            )
         except Exception as e:
             logger.exception("Failed to run workflow")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     async def acreate_schedule(
         self,

--- a/libs/agno/agno/tools/superserve.py
+++ b/libs/agno/agno/tools/superserve.py
@@ -306,7 +306,7 @@ class SuperserveTools(Toolkit):
     # ------------------------------------------------------------------
     @staticmethod
     def _error(message: str, error: Union[str, Exception]) -> str:
-        return json.dumps({"status": "error", "message": f"{message}: {str(error)}"})
+        return json.dumps({"status": "error", "message": f"{message}: {str(error)}"}, ensure_ascii=False)
 
     @staticmethod
     def _format_result(stdout: str, stderr: str, exit_code: int) -> str:
@@ -454,7 +454,8 @@ class SuperserveTools(Toolkit):
             sandbox = self._get_sandbox(agent)
             info = sandbox.get_info()
             return json.dumps(
-                {"id": info.id, "name": info.name, "status": info.status.value, "metadata": info.metadata}
+                {"id": info.id, "name": info.name, "status": info.status.value, "metadata": info.metadata},
+                ensure_ascii=False,
             )
         except Exception as e:
             return self._error("Error getting sandbox info", e)
@@ -467,7 +468,9 @@ class SuperserveTools(Toolkit):
         """
         try:
             sandboxes = Sandbox.list(api_key=self.api_key, base_url=self.base_url)
-            return json.dumps([{"id": s.id, "name": s.name, "status": s.status.value} for s in sandboxes])
+            return json.dumps(
+                [{"id": s.id, "name": s.name, "status": s.status.value} for s in sandboxes], ensure_ascii=False
+            )
         except Exception as e:
             return self._error("Error listing sandboxes", e)
 
@@ -677,7 +680,8 @@ class SuperserveTools(Toolkit):
             sandbox = await self._aget_sandbox(agent)
             info = await sandbox.get_info()
             return json.dumps(
-                {"id": info.id, "name": info.name, "status": info.status.value, "metadata": info.metadata}
+                {"id": info.id, "name": info.name, "status": info.status.value, "metadata": info.metadata},
+                ensure_ascii=False,
             )
         except Exception as e:
             return self._error("Error getting sandbox info", e)
@@ -686,7 +690,9 @@ class SuperserveTools(Toolkit):
         """Async variant of list_sandboxes."""
         try:
             sandboxes = await AsyncSandbox.list(api_key=self.api_key, base_url=self.base_url)
-            return json.dumps([{"id": s.id, "name": s.name, "status": s.status.value} for s in sandboxes])
+            return json.dumps(
+                [{"id": s.id, "name": s.name, "status": s.status.value} for s in sandboxes], ensure_ascii=False
+            )
         except Exception as e:
             return self._error("Error listing sandboxes", e)
 

--- a/libs/agno/agno/tools/tavily.py
+++ b/libs/agno/agno/tools/tavily.py
@@ -154,7 +154,7 @@ class TavilyTools(Toolkit):
             clean_response["answer"] = response["answer"]
 
         clean_results = []
-        current_token_count = len(json.dumps(clean_response))
+        current_token_count = len(json.dumps(clean_response, ensure_ascii=False))
         for result in response.get("results", []):
             _result = {
                 "title": result["title"],
@@ -162,14 +162,14 @@ class TavilyTools(Toolkit):
                 "content": result["content"],
                 "score": result["score"],
             }
-            current_token_count += len(json.dumps(_result))
+            current_token_count += len(json.dumps(_result, ensure_ascii=False))
             if current_token_count > self.max_tokens:
                 break
             clean_results.append(_result)
         clean_response["results"] = clean_results
 
         if self.format == "json":
-            return json.dumps(clean_response) if clean_response else "No results found."
+            return json.dumps(clean_response, ensure_ascii=False) if clean_response else "No results found."
         elif self.format == "markdown":
             _markdown = ""
             _markdown += f"# {query}\n\n"
@@ -246,7 +246,7 @@ class TavilyTools(Toolkit):
                 return self._format_extract_text(results)
             else:
                 # Fallback to JSON if format is unrecognized
-                return json.dumps(results, indent=2)
+                return json.dumps(results, indent=2, ensure_ascii=False)
 
         except Exception as e:
             logger.exception("Error extracting content from URLs")

--- a/libs/agno/agno/tools/telegram.py
+++ b/libs/agno/agno/tools/telegram.py
@@ -127,9 +127,9 @@ class TelegramTools(Toolkit):
         log_debug(f"Sending telegram message: {message}")
         try:
             result = self.bot.send_message(self._chat_id, message)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id}, ensure_ascii=False)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def send_photo(self, photo: bytes, caption: Optional[str] = None) -> str:
         """Send a photo to a Telegram chat.
@@ -143,9 +143,9 @@ class TelegramTools(Toolkit):
         """
         try:
             result = self.bot.send_photo(self._chat_id, photo, caption=caption)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id}, ensure_ascii=False)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def send_document(self, document: bytes, filename: str, caption: Optional[str] = None) -> str:
         """Send a document to a Telegram chat.
@@ -160,9 +160,9 @@ class TelegramTools(Toolkit):
         """
         try:
             result = self.bot.send_document(self._chat_id, (filename, document), caption=caption)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id}, ensure_ascii=False)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def send_video(self, video: bytes, caption: Optional[str] = None) -> str:
         """Send a video to a Telegram chat.
@@ -176,9 +176,9 @@ class TelegramTools(Toolkit):
         """
         try:
             result = self.bot.send_video(self._chat_id, video, caption=caption)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id}, ensure_ascii=False)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def send_audio(self, audio: bytes, caption: Optional[str] = None, title: Optional[str] = None) -> str:
         """Send an audio file to a Telegram chat.
@@ -193,9 +193,9 @@ class TelegramTools(Toolkit):
         """
         try:
             result = self.bot.send_audio(self._chat_id, audio, caption=caption, title=title)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id}, ensure_ascii=False)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def send_animation(self, animation: bytes, caption: Optional[str] = None) -> str:
         """Send an animation (GIF) to a Telegram chat.
@@ -209,9 +209,9 @@ class TelegramTools(Toolkit):
         """
         try:
             result = self.bot.send_animation(self._chat_id, animation, caption=caption)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id}, ensure_ascii=False)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def send_sticker(self, sticker: bytes) -> str:
         """Send a sticker to a Telegram chat.
@@ -224,9 +224,9 @@ class TelegramTools(Toolkit):
         """
         try:
             result = self.bot.send_sticker(self._chat_id, sticker)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id}, ensure_ascii=False)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def edit_message(self, text: str, message_id: int) -> str:
         """Edit a previously sent message in a Telegram chat.
@@ -241,9 +241,9 @@ class TelegramTools(Toolkit):
         try:
             result = self.bot.edit_message_text(text, chat_id=self._chat_id, message_id=message_id)
             msg_id = result.message_id if hasattr(result, "message_id") else message_id
-            return json.dumps({"status": "success", "message_id": msg_id})
+            return json.dumps({"status": "success", "message_id": msg_id}, ensure_ascii=False)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def delete_message(self, message_id: int) -> str:
         """Delete a message from a Telegram chat.
@@ -256,9 +256,9 @@ class TelegramTools(Toolkit):
         """
         try:
             self.bot.delete_message(self._chat_id, message_id)
-            return json.dumps({"status": "success", "deleted": True})
+            return json.dumps({"status": "success", "deleted": True}, ensure_ascii=False)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def react_with_emoji(self, message_id: int, emoji: str) -> str:
         """React to a message with an emoji.
@@ -276,9 +276,9 @@ class TelegramTools(Toolkit):
                 message_id=message_id,
                 reaction=[ReactionTypeEmoji(emoji=emoji)],
             )
-            return json.dumps({"status": "success", "message_id": message_id, "emoji": emoji})
+            return json.dumps({"status": "success", "message_id": message_id, "emoji": emoji}, ensure_ascii=False)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def pin_message(self, message_id: int, disable_notification: bool = False) -> str:
         """Pin a message in the chat.
@@ -292,9 +292,9 @@ class TelegramTools(Toolkit):
         """
         try:
             self.bot.pin_chat_message(self._chat_id, message_id, disable_notification=disable_notification)
-            return json.dumps({"status": "success", "pinned": True, "message_id": message_id})
+            return json.dumps({"status": "success", "pinned": True, "message_id": message_id}, ensure_ascii=False)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def get_chat(self) -> str:
         """Get information about the current chat.
@@ -314,10 +314,11 @@ class TelegramTools(Toolkit):
                     "first_name": getattr(chat, "first_name", None),
                     "last_name": getattr(chat, "last_name", None),
                     "description": getattr(chat, "description", None),
-                }
+                },
+                ensure_ascii=False,
             )
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
     def get_file(self, file_id: str) -> str:
         """Download a file by its file_id. Returns path if save_downloads=True, else base64.
@@ -333,7 +334,7 @@ class TelegramTools(Toolkit):
         try:
             file_info = self.bot.get_file(file_id)
             if not file_info.file_path:
-                return json.dumps({"status": "error", "message": "File path not available"})
+                return json.dumps({"status": "error", "message": "File path not available"}, ensure_ascii=False)
             file_content = self.bot.download_file(file_info.file_path)
 
             result: dict[str, Any] = {
@@ -350,6 +351,6 @@ class TelegramTools(Toolkit):
             else:
                 result["content_base64"] = base64.b64encode(file_content).decode("utf-8")
 
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/todoist.py
+++ b/libs/agno/agno/tools/todoist.py
@@ -97,20 +97,20 @@ class TodoistTools(Toolkit):
             )
             # Convert task to a dictionary and handle the Due object
             task_dict = self._task_to_dict(task)
-            return json.dumps(task_dict, default=str)
+            return json.dumps(task_dict, default=str, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to create task")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_task(self, task_id: str) -> str:
         """Get a specific task by ID."""
         try:
             task = self.api.get_task(task_id)
             task_dict = self._task_to_dict(task)
-            return json.dumps(task_dict, default=str)
+            return json.dumps(task_dict, default=str, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to get task")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def update_task(
         self,
@@ -170,29 +170,29 @@ class TodoistTools(Toolkit):
                 updates["section_id"] = section_id
 
             success = self.api.update_task(task_id=task_id, **updates)
-            return json.dumps({"success": success})
+            return json.dumps({"success": success}, ensure_ascii=False)
         except Exception as e:
             error_msg = str(e)
             log_error(f"Failed to update task: {error_msg}")
-            return json.dumps({"error": error_msg})
+            return json.dumps({"error": error_msg}, ensure_ascii=False)
 
     def close_task(self, task_id: str) -> str:
         """Mark a task as completed."""
         try:
             success = self.api.complete_task(task_id)
-            return json.dumps({"success": success})
+            return json.dumps({"success": success}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to close task")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def delete_task(self, task_id: str) -> str:
         """Delete a task."""
         try:
             success = self.api.delete_task(task_id)
-            return json.dumps({"success": success})
+            return json.dumps({"success": success}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to delete task")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_active_tasks(self) -> str:
         """Get all active (not completed) tasks."""
@@ -203,16 +203,16 @@ class TodoistTools(Toolkit):
             for task in tasks:
                 task_dict = self._task_to_dict(task)
                 tasks_list.append(task_dict)
-            return json.dumps(tasks_list, default=str)
+            return json.dumps(tasks_list, default=str, ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to get active tasks")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_projects(self) -> str:
         """Get all projects."""
         try:
             projects = self.api.get_projects()
-            return json.dumps([project.__dict__ for project in projects])
+            return json.dumps([project.__dict__ for project in projects], ensure_ascii=False)
         except Exception as e:
             logger.exception("Failed to get projects")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/trafilatura.py
+++ b/libs/agno/agno/tools/trafilatura.py
@@ -221,7 +221,7 @@ class TrafilaturaTools(Toolkit):
             reset_caches()
 
             if as_json:
-                return json.dumps(metadata_dict, indent=2, default=str)
+                return json.dumps(metadata_dict, indent=2, default=str, ensure_ascii=False)
             else:
                 return "\n".join(f"{key}: {value}" for key, value in metadata_dict.items())
 
@@ -298,7 +298,7 @@ class TrafilaturaTools(Toolkit):
             # Reset caches
             reset_caches()
 
-            return json.dumps(crawl_results, indent=2, default=str)
+            return json.dumps(crawl_results, indent=2, default=str, ensure_ascii=False)
 
         except Exception as e:
             log_warning(f"Error crawling website {homepage_url}: {str(e)}")
@@ -382,7 +382,7 @@ class TrafilaturaTools(Toolkit):
                 "failed_urls": failed_urls,
             }
 
-            return json.dumps(batch_results, indent=2, default=str)
+            return json.dumps(batch_results, indent=2, default=str, ensure_ascii=False)
 
         except Exception as e:
             log_warning(f"Error in batch extraction: {str(e)}")

--- a/libs/agno/agno/tools/trello.py
+++ b/libs/agno/agno/tools/trello.py
@@ -76,7 +76,9 @@ class TrelloTools(Toolkit):
 
             card = target_list.add_card(name=card_title, desc=description)
 
-            return json.dumps({"id": card.id, "name": card.name, "url": card.url, "list": list_name})
+            return json.dumps(
+                {"id": card.id, "name": card.name, "url": card.url, "list": list_name}, ensure_ascii=False
+            )
 
         except Exception as e:
             return f"Error creating card: {e}"
@@ -102,7 +104,7 @@ class TrelloTools(Toolkit):
 
             lists_info = [{"id": lst.id, "name": lst.name, "cards_count": len(lst.list_cards())} for lst in lists]
 
-            return json.dumps({"lists": lists_info})
+            return json.dumps({"lists": lists_info}, ensure_ascii=False)
 
         except Exception as e:
             return f"Error getting board lists: {e}"
@@ -127,7 +129,7 @@ class TrelloTools(Toolkit):
             card = self.client.get_card(card_id)
             card.change_list(list_id)
 
-            return json.dumps({"success": True, "card_id": card_id, "new_list_id": list_id})
+            return json.dumps({"success": True, "card_id": card_id, "new_list_id": list_id}, ensure_ascii=False)
 
         except Exception as e:
             return f"Error moving card: {e}"
@@ -162,7 +164,7 @@ class TrelloTools(Toolkit):
                 for card in cards
             ]
 
-            return json.dumps({"cards": cards_info})
+            return json.dumps({"cards": cards_info}, ensure_ascii=False)
 
         except Exception as e:
             return f"Error getting cards: {e}"
@@ -191,7 +193,8 @@ class TrelloTools(Toolkit):
                     "id": board.id,
                     "name": board.name,
                     "url": board.url,
-                }
+                },
+                ensure_ascii=False,
             )
 
         except Exception as e:
@@ -224,7 +227,8 @@ class TrelloTools(Toolkit):
                     "name": new_list.name,
                     "pos": new_list.pos,
                     "board_id": board_id,
-                }
+                },
+                ensure_ascii=False,
             )
 
         except Exception as e:
@@ -267,7 +271,8 @@ class TrelloTools(Toolkit):
                     "filter_used": board_filter,
                     "total_boards": len(boards_list),
                     "boards": boards_list,
-                }
+                },
+                ensure_ascii=False,
             )
 
         except Exception as e:

--- a/libs/agno/agno/tools/twelvelabs.py
+++ b/libs/agno/agno/tools/twelvelabs.py
@@ -142,7 +142,9 @@ class TwelveLabsTools(Toolkit):
             vector = response.text_embedding.segments[0].float_
             if not vector:
                 return "No embedding returned"
-            return json.dumps({"model": self.embed_model, "dimensions": len(vector), "embedding": vector})
+            return json.dumps(
+                {"model": self.embed_model, "dimensions": len(vector), "embedding": vector}, ensure_ascii=False
+            )
         except Exception as e:
             log_error(f"Error embedding text: {e}")
             return f"Error embedding text: {e}"
@@ -222,7 +224,8 @@ class TwelveLabsTools(Toolkit):
                     "dimensions": dimensions,
                     "num_segments": len(segments),
                     "segments": segments,
-                }
+                },
+                ensure_ascii=False,
             )
         except Exception as e:
             log_error(f"Error embedding video {video_url}: {e}")

--- a/libs/agno/agno/tools/unsplash.py
+++ b/libs/agno/agno/tools/unsplash.py
@@ -209,7 +209,7 @@ class UnsplashTools(Toolkit):
                 "photos": [self._format_photo(photo) for photo in response.get("results", [])],
             }
 
-            return json.dumps(results, indent=2)
+            return json.dumps(results, indent=2, ensure_ascii=False)
 
         except Exception as e:
             return f"Error searching Unsplash: {e}"
@@ -258,7 +258,7 @@ class UnsplashTools(Toolkit):
             result["views"] = photo.get("views")
             result["downloads"] = photo.get("downloads")
 
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         except Exception as e:
             return f"Error getting photo: {e}"
@@ -303,7 +303,7 @@ class UnsplashTools(Toolkit):
             else:
                 photos = [self._format_photo(response)]
 
-            return json.dumps({"photos": photos}, indent=2)
+            return json.dumps({"photos": photos}, indent=2, ensure_ascii=False)
 
         except Exception as e:
             return f"Error getting random photo: {e}"
@@ -337,6 +337,7 @@ class UnsplashTools(Toolkit):
                     "download_url": response.get("url"),
                 },
                 indent=2,
+                ensure_ascii=False,
             )
 
         except Exception as e:

--- a/libs/agno/agno/tools/valyu.py
+++ b/libs/agno/agno/tools/valyu.py
@@ -106,7 +106,7 @@ class ValyuTools(Toolkit):
 
             parsed_results.append(result_dict)
 
-        return json.dumps(parsed_results, indent=2)
+        return json.dumps(parsed_results, indent=2, ensure_ascii=False)
 
     def _valyu_search(
         self,

--- a/libs/agno/agno/tools/visualization.py
+++ b/libs/agno/agno/tools/visualization.py
@@ -157,12 +157,13 @@ class VisualizationTools(Toolkit):
                     "file_path": file_path,
                     "data_points": len(normalized_data),
                     "status": "success",
-                }
+                },
+                ensure_ascii=False,
             )
 
         except Exception as e:
             logger.exception("Error creating bar chart")
-            return json.dumps({"chart_type": "bar_chart", "error": str(e), "status": "error"})
+            return json.dumps({"chart_type": "bar_chart", "error": str(e), "status": "error"}, ensure_ascii=False)
 
     def create_line_chart(
         self,
@@ -230,12 +231,13 @@ class VisualizationTools(Toolkit):
                     "file_path": file_path,
                     "data_points": len(normalized_data),
                     "status": "success",
-                }
+                },
+                ensure_ascii=False,
             )
 
         except Exception as e:
             logger.exception("Error creating line chart")
-            return json.dumps({"chart_type": "line_chart", "error": str(e), "status": "error"})
+            return json.dumps({"chart_type": "line_chart", "error": str(e), "status": "error"}, ensure_ascii=False)
 
     def create_pie_chart(
         self,
@@ -295,12 +297,13 @@ class VisualizationTools(Toolkit):
                     "file_path": file_path,
                     "data_points": len(normalized_data),
                     "status": "success",
-                }
+                },
+                ensure_ascii=False,
             )
 
         except Exception as e:
             logger.exception("Error creating pie chart")
-            return json.dumps({"chart_type": "pie_chart", "error": str(e), "status": "error"})
+            return json.dumps({"chart_type": "pie_chart", "error": str(e), "status": "error"}, ensure_ascii=False)
 
     def create_scatter_plot(
         self,
@@ -384,12 +387,13 @@ class VisualizationTools(Toolkit):
                     "file_path": file_path,
                     "data_points": len(x_data),
                     "status": "success",
-                }
+                },
+                ensure_ascii=False,
             )
 
         except Exception as e:
             logger.exception("Error creating scatter plot")
-            return json.dumps({"chart_type": "scatter_plot", "error": str(e), "status": "error"})
+            return json.dumps({"chart_type": "scatter_plot", "error": str(e), "status": "error"}, ensure_ascii=False)
 
     def create_histogram(
         self,
@@ -459,9 +463,10 @@ class VisualizationTools(Toolkit):
                     "data_points": len(numeric_data),
                     "bins": bins,
                     "status": "success",
-                }
+                },
+                ensure_ascii=False,
             )
 
         except Exception as e:
             logger.exception("Error creating histogram")
-            return json.dumps({"chart_type": "histogram", "error": str(e), "status": "error"})
+            return json.dumps({"chart_type": "histogram", "error": str(e), "status": "error"}, ensure_ascii=False)

--- a/libs/agno/agno/tools/webex.py
+++ b/libs/agno/agno/tools/webex.py
@@ -48,10 +48,10 @@ class WebexTools(Toolkit):
         """
         try:
             response = self.client.messages.create(roomId=room_id, text=text)
-            return json.dumps(response.json_data)
+            return json.dumps(response.json_data, ensure_ascii=False)
         except ApiError as e:
             logger.exception(f"Error sending message in room: {room_id}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_rooms(self) -> str:
         """
@@ -72,7 +72,7 @@ class WebexTools(Toolkit):
                 for room in response
             ]
 
-            return json.dumps({"rooms": rooms_list}, indent=4)
+            return json.dumps({"rooms": rooms_list}, indent=4, ensure_ascii=False)
         except ApiError as e:
             logger.exception("Error listing rooms")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/website.py
+++ b/libs/agno/agno/tools/website.py
@@ -51,4 +51,4 @@ class WebsiteTools(Toolkit):
 
         log_debug(f"Reading website: {url}")
         relevant_docs: List[Document] = website.read(url=url)
-        return json.dumps([doc.to_dict() for doc in relevant_docs])
+        return json.dumps([doc.to_dict() for doc in relevant_docs], ensure_ascii=False)

--- a/libs/agno/agno/tools/whatsapp.py
+++ b/libs/agno/agno/tools/whatsapp.py
@@ -135,7 +135,7 @@ class WhatsAppTools(Toolkit):
         try:
             to = self._resolve_recipient(recipient)
             if not to:
-                return json.dumps({"error": "No recipient provided and no default recipient set"})
+                return json.dumps({"error": "No recipient provided and no default recipient set"}, ensure_ascii=False)
 
             data = {
                 "messaging_product": "whatsapp",
@@ -146,7 +146,7 @@ class WhatsAppTools(Toolkit):
             }
             response = self._send_message(data)
             message_id = response.get("messages", [{}])[0].get("id", "unknown")
-            return json.dumps({"ok": True, "message_id": message_id})
+            return json.dumps({"ok": True, "message_id": message_id}, ensure_ascii=False)
         except Exception:
             logger.exception("Error sending text message")
             raise
@@ -172,7 +172,7 @@ class WhatsAppTools(Toolkit):
         try:
             to = self._resolve_recipient(recipient)
             if not to:
-                return json.dumps({"error": "No recipient provided and no default recipient set"})
+                return json.dumps({"error": "No recipient provided and no default recipient set"}, ensure_ascii=False)
 
             template: Dict[str, Any] = {"name": template_name, "language": {"code": language_code}}
             if components:
@@ -186,7 +186,7 @@ class WhatsAppTools(Toolkit):
             }
             response = self._send_message(data)
             message_id = response.get("messages", [{}])[0].get("id", "unknown")
-            return json.dumps({"ok": True, "message_id": message_id})
+            return json.dumps({"ok": True, "message_id": message_id}, ensure_ascii=False)
         except Exception:
             logger.exception("Error sending template message")
             raise
@@ -214,10 +214,10 @@ class WhatsAppTools(Toolkit):
         try:
             to = self._resolve_recipient(recipient)
             if not to:
-                return json.dumps({"error": "No recipient provided and no default recipient set"})
+                return json.dumps({"error": "No recipient provided and no default recipient set"}, ensure_ascii=False)
 
             if not buttons or len(buttons) > 3:
-                return json.dumps({"error": "WhatsApp requires 1-3 reply buttons"})
+                return json.dumps({"error": "WhatsApp requires 1-3 reply buttons"}, ensure_ascii=False)
 
             action_buttons = [{"type": "reply", "reply": {"id": btn.id, "title": btn.title[:20]}} for btn in buttons]
 
@@ -239,7 +239,7 @@ class WhatsAppTools(Toolkit):
             }
             response = self._send_message(data)
             message_id = response.get("messages", [{}])[0].get("id", "unknown")
-            return json.dumps({"ok": True, "message_id": message_id})
+            return json.dumps({"ok": True, "message_id": message_id}, ensure_ascii=False)
         except Exception:
             logger.exception("Error sending reply buttons")
             raise
@@ -269,17 +269,18 @@ class WhatsAppTools(Toolkit):
         try:
             to = self._resolve_recipient(recipient)
             if not to:
-                return json.dumps({"error": "No recipient provided and no default recipient set"})
+                return json.dumps({"error": "No recipient provided and no default recipient set"}, ensure_ascii=False)
 
             if not sections or len(sections) > 10:
-                return json.dumps({"error": "WhatsApp requires 1-10 sections"})
+                return json.dumps({"error": "WhatsApp requires 1-10 sections"}, ensure_ascii=False)
 
             total_rows = sum(len(s.rows) for s in sections)
             if total_rows > 10:
                 return json.dumps(
                     {
                         "error": f"WhatsApp allows a maximum of 10 rows total across all sections (got {total_rows}). Reduce the number of rows."
-                    }
+                    },
+                    ensure_ascii=False,
                 )
 
             # Build payload with truncation without mutating caller's models
@@ -314,7 +315,7 @@ class WhatsAppTools(Toolkit):
             }
             response = self._send_message(data)
             message_id = response.get("messages", [{}])[0].get("id", "unknown")
-            return json.dumps({"ok": True, "message_id": message_id})
+            return json.dumps({"ok": True, "message_id": message_id}, ensure_ascii=False)
         except Exception:
             logger.exception("Error sending list message")
             raise
@@ -340,10 +341,10 @@ class WhatsAppTools(Toolkit):
         try:
             to = self._resolve_recipient(recipient)
             if not to:
-                return json.dumps({"error": "No recipient provided and no default recipient set"})
+                return json.dumps({"error": "No recipient provided and no default recipient set"}, ensure_ascii=False)
 
             if not image_url and not media_id:
-                return json.dumps({"error": "Either image_url or media_id must be provided"})
+                return json.dumps({"error": "Either image_url or media_id must be provided"}, ensure_ascii=False)
 
             image: Dict[str, Any] = {}
             if media_id:
@@ -361,7 +362,7 @@ class WhatsAppTools(Toolkit):
             }
             response = self._send_message(data)
             message_id = response.get("messages", [{}])[0].get("id", "unknown")
-            return json.dumps({"ok": True, "message_id": message_id})
+            return json.dumps({"ok": True, "message_id": message_id}, ensure_ascii=False)
         except Exception:
             logger.exception("Error sending image")
             raise
@@ -389,10 +390,10 @@ class WhatsAppTools(Toolkit):
         try:
             to = self._resolve_recipient(recipient)
             if not to:
-                return json.dumps({"error": "No recipient provided and no default recipient set"})
+                return json.dumps({"error": "No recipient provided and no default recipient set"}, ensure_ascii=False)
 
             if not document_url and not media_id:
-                return json.dumps({"error": "Either document_url or media_id must be provided"})
+                return json.dumps({"error": "Either document_url or media_id must be provided"}, ensure_ascii=False)
 
             document: Dict[str, Any] = {}
             if media_id:
@@ -412,7 +413,7 @@ class WhatsAppTools(Toolkit):
             }
             response = self._send_message(data)
             message_id = response.get("messages", [{}])[0].get("id", "unknown")
-            return json.dumps({"ok": True, "message_id": message_id})
+            return json.dumps({"ok": True, "message_id": message_id}, ensure_ascii=False)
         except Exception:
             logger.exception("Error sending document")
             raise
@@ -440,7 +441,7 @@ class WhatsAppTools(Toolkit):
         try:
             to = self._resolve_recipient(recipient)
             if not to:
-                return json.dumps({"error": "No recipient provided and no default recipient set"})
+                return json.dumps({"error": "No recipient provided and no default recipient set"}, ensure_ascii=False)
 
             location: Dict[str, Any] = {
                 "latitude": latitude,
@@ -459,7 +460,7 @@ class WhatsAppTools(Toolkit):
             }
             response = self._send_message(data)
             message_id = response.get("messages", [{}])[0].get("id", "unknown")
-            return json.dumps({"ok": True, "message_id": message_id})
+            return json.dumps({"ok": True, "message_id": message_id}, ensure_ascii=False)
         except Exception:
             logger.exception("Error sending location")
             raise
@@ -483,7 +484,7 @@ class WhatsAppTools(Toolkit):
         try:
             to = self._resolve_recipient(recipient)
             if not to:
-                return json.dumps({"error": "No recipient provided and no default recipient set"})
+                return json.dumps({"error": "No recipient provided and no default recipient set"}, ensure_ascii=False)
 
             data = {
                 "messaging_product": "whatsapp",
@@ -496,7 +497,7 @@ class WhatsAppTools(Toolkit):
             }
             response = self._send_message(data)
             resp_message_id = response.get("messages", [{}])[0].get("id", "unknown")
-            return json.dumps({"ok": True, "message_id": resp_message_id})
+            return json.dumps({"ok": True, "message_id": resp_message_id}, ensure_ascii=False)
         except Exception:
             logger.exception("Error sending reaction")
             raise

--- a/libs/agno/agno/tools/wikipedia.py
+++ b/libs/agno/agno/tools/wikipedia.py
@@ -52,7 +52,7 @@ class WikipediaTools(Toolkit):
         )
         log_debug(f"Searching knowledge: {topic}")
         relevant_docs: List[Document] = self.knowledge.search(query=topic)
-        return json.dumps([doc.to_dict() for doc in relevant_docs])
+        return json.dumps([doc.to_dict() for doc in relevant_docs], ensure_ascii=False)
 
     def search_wikipedia(self, query: str) -> str:
         """Searches Wikipedia for a query.
@@ -63,9 +63,9 @@ class WikipediaTools(Toolkit):
         log_info(f"Searching wikipedia for: {query}")
         try:
             content = wikipedia.summary(query, auto_suggest=self.auto_suggest)
-            return json.dumps(Document(name=query, content=content).to_dict())
+            return json.dumps(Document(name=query, content=content).to_dict(), ensure_ascii=False)
         except DisambiguationError as e:
-            return json.dumps({"disambiguation": query, "options": e.options})
+            return json.dumps({"disambiguation": query, "options": e.options}, ensure_ascii=False)
         except Exception as e:
             log_error(f"Error searching Wikipedia for '{query}': {e}")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)

--- a/libs/agno/agno/tools/workflow.py
+++ b/libs/agno/agno/tools/workflow.py
@@ -158,7 +158,7 @@ class WorkflowTools(Toolkit):
 
             run_context.session_state["workflow_results"].append(result.to_dict())
 
-            return json.dumps(result.to_dict(), indent=2)
+            return json.dumps(result.to_dict(), indent=2, ensure_ascii=False)
 
         except Exception as e:
             log_error(f"Error running workflow: {str(e)}")
@@ -198,7 +198,7 @@ class WorkflowTools(Toolkit):
 
             run_context.session_state["workflow_results"].append(result.to_dict())
 
-            return json.dumps(result.to_dict(), indent=2)
+            return json.dumps(result.to_dict(), indent=2, ensure_ascii=False)
 
         except Exception as e:
             log_error(f"Error running workflow: {str(e)}")

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -558,6 +558,7 @@ class Workspace(Toolkit):
                     "files": files,
                 },
                 indent=2,
+                ensure_ascii=False,
             )
         except Exception as e:
             log_error(f"list_files failed: {e}")
@@ -624,7 +625,9 @@ class Workspace(Toolkit):
                                 "snippet": _extract_snippet(content, query),
                             }
                         )
-            return json.dumps({"query": query, "matches_found": len(matches), "files": matches}, indent=2)
+            return json.dumps(
+                {"query": query, "matches_found": len(matches), "files": matches}, indent=2, ensure_ascii=False
+            )
         except Exception as e:
             log_error(f"search_content failed: {e}")
             return f"Error searching content: {e}"

--- a/libs/agno/agno/tools/x.py
+++ b/libs/agno/agno/tools/x.py
@@ -81,10 +81,10 @@ class XTools(Toolkit):
             post_url = f"https://x.com/{user.username}/status/{post_id}"
 
             result = {"message": "Post successfully created!", "url": post_url}
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except tweepy.TweepyException as e:
             logger.exception("Error creating post")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def reply_to_post(self, post_id: str, text: str) -> str:
         """
@@ -105,10 +105,10 @@ class XTools(Toolkit):
             user = self.client.get_me().data
             reply_url = f"https://twitter.com/{user.username}/status/{reply_id}"
             result = {"message": "Reply successfully posted!", "url": reply_url}
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except tweepy.TweepyException as e:
             logger.exception("Error replying to post")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def send_dm(self, recipient: str, text: str) -> str:
         """
@@ -141,7 +141,7 @@ class XTools(Toolkit):
                 "recipient_id": recipient_id,
                 "recipient_username": recipient if not recipient.isdigit() else None,
             }
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except tweepy.TweepyException as e:
             logger.exception("Error from X while sending DM")
             error_message = str(e)
@@ -151,10 +151,10 @@ class XTools(Toolkit):
                 error_message = (
                     f"Unable to send message to '{recipient}'. The user may have restricted who can send them messages."
                 )
-            return json.dumps({"error": error_message}, indent=2)
+            return json.dumps({"error": error_message}, indent=2, ensure_ascii=False)
         except Exception as e:
             logger.exception("Unexpected error sending DM")
-            return json.dumps({"error": f"An unexpected error occurred: {str(e)}"}, indent=2)
+            return json.dumps({"error": f"An unexpected error occurred: {str(e)}"}, indent=2, ensure_ascii=False)
 
     def get_my_info(self) -> str:
         """
@@ -178,10 +178,10 @@ class XTools(Toolkit):
                 "following_count": user_info["public_metrics"]["following_count"],
                 "tweet_count": user_info["public_metrics"]["tweet_count"],
             }
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except tweepy.TweepyException as e:
             logger.exception("Error fetching user info")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_user_info(self, username: str) -> str:
         """
@@ -208,10 +208,10 @@ class XTools(Toolkit):
                 "following_count": user_info["public_metrics"]["following_count"],
                 "tweet_count": user_info["public_metrics"]["tweet_count"],
             }
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except tweepy.TweepyException as e:
             logger.exception("Error fetching user info")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_home_timeline(self, max_results: int = 10) -> str:
         """
@@ -242,10 +242,10 @@ class XTools(Toolkit):
                 )
             log_info(f"Successfully fetched {len(timeline)} tweets")
             result = {"home_timeline": timeline}
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except tweepy.TweepyException as e:
             logger.exception("Error fetching home timeline")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def search_posts(self, query: str, max_results: int = 10) -> str:
         """
@@ -325,11 +325,11 @@ class XTools(Toolkit):
             else:
                 log_info(f"No posts found for query: {query}")
                 result = {}
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
 
         except tweepy.TweepyException as e:
             logger.exception("Error searching posts")
-            return json.dumps({"error": str(e), "query": query})
+            return json.dumps({"error": str(e), "query": query}, ensure_ascii=False)
         except Exception as e:
             logger.exception("Unexpected error searching posts")
-            return json.dumps({"error": f"An unexpected error occurred: {str(e)}", "query": query})
+            return json.dumps({"error": f"An unexpected error occurred: {str(e)}", "query": query}, ensure_ascii=False)

--- a/libs/agno/agno/tools/yfinance.py
+++ b/libs/agno/agno/tools/yfinance.py
@@ -133,7 +133,7 @@ class YFinanceTools(Toolkit):
                 "Gross Margins": company_info_full.get("grossMargins"),
                 "Ebitda Margins": company_info_full.get("ebitdaMargins"),
             }
-            return json.dumps(company_info_cleaned, indent=2)
+            return json.dumps(company_info_cleaned, indent=2, ensure_ascii=False)
         except Exception as e:
             return f"Error fetching company profile for {symbol}: {e}"
 
@@ -199,7 +199,7 @@ class YFinanceTools(Toolkit):
                 "52_week_high": info.get("fiftyTwoWeekHigh", "N/A"),
                 "52_week_low": info.get("fiftyTwoWeekLow", "N/A"),
             }
-            return json.dumps(fundamentals, indent=2)
+            return json.dumps(fundamentals, indent=2, ensure_ascii=False)
         except Exception as e:
             return f"Error getting fundamentals for {symbol}: {e}"
 
@@ -233,7 +233,7 @@ class YFinanceTools(Toolkit):
             log_debug(f"Fetching key financial ratios for {symbol}")
             stock = yf.Ticker(symbol, session=self.session)
             key_ratios = stock.info
-            return json.dumps(key_ratios, indent=2)
+            return json.dumps(key_ratios, indent=2, ensure_ascii=False)
         except Exception as e:
             return f"Error fetching key financial ratios for {symbol}: {e}"
 
@@ -267,7 +267,7 @@ class YFinanceTools(Toolkit):
         try:
             log_debug(f"Fetching company news for {symbol}")
             news = yf.Ticker(symbol, session=self.session).news
-            return json.dumps(news[:num_stories], indent=2)
+            return json.dumps(news[:num_stories], indent=2, ensure_ascii=False)
         except Exception as e:
             return f"Error fetching company news for {symbol}: {e}"
 

--- a/libs/agno/agno/tools/youtube.py
+++ b/libs/agno/agno/tools/youtube.py
@@ -104,7 +104,7 @@ class YouTubeTools(Toolkit):
                     "provider_url": video_data.get("provider_url"),
                     "thumbnail_url": video_data.get("thumbnail_url"),
                 }
-                return json.dumps(clean_data, indent=4)
+                return json.dumps(clean_data, indent=4, ensure_ascii=False)
         except Exception as e:
             return f"Error getting video data: {e}"
 

--- a/libs/agno/agno/tools/zendesk.py
+++ b/libs/agno/agno/tools/zendesk.py
@@ -79,6 +79,6 @@ class ZendeskTools(Toolkit):
             response.raise_for_status()
             clean = re.compile("<.*?>")
             articles = [re.sub(clean, "", article["body"]) for article in response.json()["results"]]
-            return json.dumps(articles)
+            return json.dumps(articles, ensure_ascii=False)
         except requests.RequestException as e:
             raise ConnectionError(f"API request failed: {e}")

--- a/libs/agno/agno/tools/zoom.py
+++ b/libs/agno/agno/tools/zoom.py
@@ -114,7 +114,7 @@ class ZoomTools(Toolkit):
         token = self.get_access_token()
         if not token:
             log_error("Unable to obtain access token.")
-            return json.dumps({"error": "Failed to obtain access token"})
+            return json.dumps({"error": "Failed to obtain access token"}, ensure_ascii=False)
 
         url = "https://api.zoom.us/v2/users/me/meetings"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
@@ -149,10 +149,10 @@ class ZoomTools(Toolkit):
                 "join_url": meeting_info["join_url"],
             }
             log_info(f"Meeting scheduled successfully. ID: {meeting_info['id']}")
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except requests.RequestException as e:
             logger.exception("Error scheduling meeting")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_upcoming_meetings(self, user_id: str = "me") -> str:
         """
@@ -169,7 +169,7 @@ class ZoomTools(Toolkit):
         token = self.get_access_token()
         if not token:
             log_error("Unable to obtain access token.")
-            return json.dumps({"error": "Failed to obtain access token"})
+            return json.dumps({"error": "Failed to obtain access token"}, ensure_ascii=False)
 
         url = f"https://api.zoom.us/v2/users/{user_id}/meetings"
         headers = {"Authorization": f"Bearer {token}"}
@@ -182,10 +182,10 @@ class ZoomTools(Toolkit):
 
             result = {"message": "Upcoming meetings retrieved successfully", "meetings": meetings.get("meetings", [])}
             log_info(f"Retrieved {len(result['meetings'])} upcoming meetings")
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except requests.RequestException as e:
             logger.exception("Error fetching upcoming meetings")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def list_meetings(self, user_id: str = "me", type: str = "scheduled") -> str:
         """
@@ -208,7 +208,7 @@ class ZoomTools(Toolkit):
         token = self.get_access_token()
         if not token:
             log_error("Unable to obtain access token.")
-            return json.dumps({"error": "Failed to obtain access token"})
+            return json.dumps({"error": "Failed to obtain access token"}, ensure_ascii=False)
 
         url = f"https://api.zoom.us/v2/users/{user_id}/meetings"
         headers = {"Authorization": f"Bearer {token}"}
@@ -228,10 +228,10 @@ class ZoomTools(Toolkit):
                 "meetings": meetings.get("meetings", []),
             }
             log_info(f"Retrieved {len(result['meetings'])} meetings")
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except requests.RequestException as e:
             logger.exception("Error fetching meetings")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_meeting_recordings(
         self, meeting_id: str, include_download_token: bool = False, token_ttl: Optional[int] = None
@@ -252,7 +252,7 @@ class ZoomTools(Toolkit):
         token = self.get_access_token()
         if not token:
             log_error("Unable to obtain access token.")
-            return json.dumps({"error": "Failed to obtain access token"})
+            return json.dumps({"error": "Failed to obtain access token"}, ensure_ascii=False)
 
         url = f"https://api.zoom.us/v2/meetings/{meeting_id}/recordings"
         headers = {"Authorization": f"Bearer {token}"}
@@ -286,10 +286,10 @@ class ZoomTools(Toolkit):
             }
 
             log_info(f"Retrieved {result['recording_count']} recording files")
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except requests.RequestException as e:
             logger.exception("Error fetching meeting recordings")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def delete_meeting(self, meeting_id: str, schedule_for_reminder: bool = True) -> str:
         """
@@ -308,7 +308,7 @@ class ZoomTools(Toolkit):
         token = self.get_access_token()
         if not token:
             log_error("Unable to obtain access token.")
-            return json.dumps({"error": "Failed to obtain access token"})
+            return json.dumps({"error": "Failed to obtain access token"}, ensure_ascii=False)
 
         url = f"https://api.zoom.us/v2/meetings/{meeting_id}"
         headers = {"Authorization": f"Bearer {token}"}
@@ -325,10 +325,10 @@ class ZoomTools(Toolkit):
             else:
                 result = response.json()
 
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except requests.RequestException as e:
             logger.exception("Error deleting meeting")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def get_meeting(self, meeting_id: str) -> str:
         """
@@ -345,7 +345,7 @@ class ZoomTools(Toolkit):
         token = self.get_access_token()
         if not token:
             log_error("Unable to obtain access token.")
-            return json.dumps({"error": "Failed to obtain access token"})
+            return json.dumps({"error": "Failed to obtain access token"}, ensure_ascii=False)
 
         url = f"https://api.zoom.us/v2/meetings/{meeting_id}"
         headers = {"Authorization": f"Bearer {token}"}
@@ -369,10 +369,10 @@ class ZoomTools(Toolkit):
             }
 
             log_info(f"Retrieved details for meeting ID: {meeting_id}")
-            return json.dumps(result, indent=2)
+            return json.dumps(result, indent=2, ensure_ascii=False)
         except requests.RequestException as e:
             logger.exception("Error fetching meeting details")
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, ensure_ascii=False)
 
     def instructions(self) -> str:
         """

--- a/libs/agno/agno/utils/encryption.py
+++ b/libs/agno/agno/utils/encryption.py
@@ -47,7 +47,7 @@ def encrypt_dict(data: Dict[str, Any], key: Optional[str] = None) -> Dict[str, s
 
     fernet_key = _validate_fernet_key(secret)
     f = Fernet(fernet_key)
-    plaintext = json.dumps(data).encode("utf-8")
+    plaintext = json.dumps(data, ensure_ascii=False).encode("utf-8")
     ciphertext = f.encrypt(plaintext)
     return {"encrypted": ciphertext.decode("ascii")}
 

--- a/libs/agno/agno/utils/pprint.py
+++ b/libs/agno/agno/utils/pprint.py
@@ -50,7 +50,7 @@ def pprint_run_response(
                 log_warning(f"Failed to convert response to Markdown: {str(e)}")
         else:
             try:
-                single_response_content = JSON(json.dumps(run_response.content), indent=4)
+                single_response_content = JSON(json.dumps(run_response.content, ensure_ascii=False), indent=4)
             except Exception as e:
                 log_warning(f"Failed to convert response to string: {str(e)}")
 
@@ -133,7 +133,7 @@ async def apprint_run_response(
                 log_warning(f"Failed to convert response to Markdown: {str(e)}")
         else:
             try:
-                single_response_content = JSON(json.dumps(run_response.content), indent=4)
+                single_response_content = JSON(json.dumps(run_response.content, ensure_ascii=False), indent=4)
             except Exception as e:
                 log_warning(f"Failed to convert response to string: {str(e)}")
 

--- a/libs/agno/agno/utils/print_response/agent.py
+++ b/libs/agno/agno/utils/print_response/agent.py
@@ -136,12 +136,16 @@ def print_response_stream(
                                 log_warning(f"Failed to convert response to JSON: {str(e)}")
                         elif agent.output_schema is not None and isinstance(response_event.content, dict):
                             try:
-                                response_content_batch = JSON(json.dumps(response_event.content), indent=2)  # type: ignore
+                                response_content_batch = JSON(
+                                    json.dumps(response_event.content, ensure_ascii=False), indent=2
+                                )  # type: ignore
                             except Exception as e:
                                 log_warning(f"Failed to convert response to JSON: {str(e)}")
                         else:
                             try:
-                                response_content_batch = JSON(json.dumps(response_event.content), indent=4)
+                                response_content_batch = JSON(
+                                    json.dumps(response_event.content, ensure_ascii=False), indent=4
+                                )
                             except Exception as e:
                                 log_warning(f"Failed to convert response to JSON: {str(e)}")
                     if hasattr(response_event, "reasoning_content") and response_event.reasoning_content is not None:  # type: ignore
@@ -339,12 +343,12 @@ async def aprint_response_stream(
                             log_warning(f"Failed to convert response to JSON: {str(e)}")
                     elif agent.output_schema is not None and isinstance(resp.content, dict):
                         try:
-                            response_content_batch = JSON(json.dumps(resp.content), indent=2)  # type: ignore
+                            response_content_batch = JSON(json.dumps(resp.content, ensure_ascii=False), indent=2)  # type: ignore
                         except Exception as e:
                             log_warning(f"Failed to convert response to JSON: {str(e)}")
                     else:
                         try:
-                            response_content_batch = JSON(json.dumps(resp.content), indent=4)
+                            response_content_batch = JSON(json.dumps(resp.content, ensure_ascii=False), indent=4)
                         except Exception as e:
                             log_warning(f"Failed to convert response to JSON: {str(e)}")
                     if resp.reasoning_content is not None:  # type: ignore
@@ -878,12 +882,12 @@ def build_panels(
                 log_warning(f"Failed to convert response to JSON: {str(e)}")
         elif output_schema is not None and isinstance(run_response.content, dict):
             try:
-                response_content_batch = JSON(json.dumps(run_response.content), indent=2)
+                response_content_batch = JSON(json.dumps(run_response.content, ensure_ascii=False), indent=2)
             except Exception as e:
                 log_warning(f"Failed to convert response to JSON: {str(e)}")
         else:
             try:
-                response_content_batch = JSON(json.dumps(run_response.content), indent=4)
+                response_content_batch = JSON(json.dumps(run_response.content, ensure_ascii=False), indent=4)
             except Exception as e:
                 log_warning(f"Failed to convert response to JSON: {str(e)}")
 

--- a/libs/agno/agno/utils/print_response/team.py
+++ b/libs/agno/agno/utils/print_response/team.py
@@ -492,7 +492,7 @@ def print_response_stream(
                             log_warning(f"Failed to convert response to JSON: {str(e)}")
                     elif team.output_schema is not None and isinstance(resp.content, dict):
                         try:
-                            _response_content = JSON(json.dumps(resp.content), indent=2)  # type: ignore
+                            _response_content = JSON(json.dumps(resp.content, ensure_ascii=False), indent=2)  # type: ignore
                         except Exception as e:
                             log_warning(f"Failed to convert response to JSON: {str(e)}")
                     if hasattr(resp, "reasoning_content") and resp.reasoning_content is not None:  # type: ignore
@@ -1424,7 +1424,7 @@ async def aprint_response_stream(
                             log_warning(f"Failed to convert response to JSON: {str(e)}")
                     elif team.output_schema is not None and isinstance(resp.content, dict):
                         try:
-                            _response_content = JSON(json.dumps(resp.content), indent=2)  # type: ignore
+                            _response_content = JSON(json.dumps(resp.content, ensure_ascii=False), indent=2)  # type: ignore
                         except Exception as e:
                             log_warning(f"Failed to convert response to JSON: {str(e)}")
                     if hasattr(resp, "reasoning_content") and resp.reasoning_content is not None:  # type: ignore
@@ -1926,6 +1926,6 @@ def _parse_response_content(
         import json
 
         try:
-            return JSON(json.dumps(run_response.content), indent=4)
+            return JSON(json.dumps(run_response.content, ensure_ascii=False), indent=4)
         except Exception as e:
             log_warning(f"Failed to convert response to JSON: {str(e)}")

--- a/libs/agno/agno/utils/print_response/workflow.py
+++ b/libs/agno/agno/utils/print_response/workflow.py
@@ -96,7 +96,7 @@ def print_response(
             elif isinstance(input, (dict, list)):
                 import json
 
-                data_display = json.dumps(input, indent=2, default=str)
+                data_display = json.dumps(input, indent=2, default=str, ensure_ascii=False)
             else:
                 data_display = str(input)
             workflow_info += f"""\n\n**Structured Input:**\n```json\n{data_display}\n```"""
@@ -242,7 +242,7 @@ def print_response_stream(
             elif isinstance(input, (dict, list)):
                 import json
 
-                data_display = json.dumps(input, indent=2, default=str)
+                data_display = json.dumps(input, indent=2, default=str, ensure_ascii=False)
             else:
                 data_display = str(input)
             workflow_info += f"""\n\n**Structured Input:**\n```json\n{data_display}\n```"""
@@ -877,7 +877,7 @@ def format_step_content_for_display(step_output: StepOutput) -> str:
     elif isinstance(actual_content, (dict, list)):
         import json
 
-        return f"**Structured Output:**\n\n```json\n{json.dumps(actual_content, indent=2, default=str)}\n```"
+        return f"**Structured Output:**\n\n```json\n{json.dumps(actual_content, indent=2, default=str, ensure_ascii=False)}\n```"
     else:
         # Fallback to string conversion
         return str(actual_content)
@@ -938,7 +938,7 @@ async def aprint_response(
             elif isinstance(input, (dict, list)):
                 import json
 
-                data_display = json.dumps(input, indent=2, default=str)
+                data_display = json.dumps(input, indent=2, default=str, ensure_ascii=False)
             else:
                 data_display = str(input)
             workflow_info += f"""\n\n**Structured Input:**\n```json\n{data_display}\n```"""
@@ -1084,7 +1084,7 @@ async def aprint_response_stream(
             elif isinstance(input, (dict, list)):
                 import json
 
-                data_display = json.dumps(input, indent=2, default=str)
+                data_display = json.dumps(input, indent=2, default=str, ensure_ascii=False)
             else:
                 data_display = str(input)
             workflow_info += f"""\n\n**Structured Input:**\n```json\n{data_display}\n```"""

--- a/libs/agno/agno/utils/remote.py
+++ b/libs/agno/agno/utils/remote.py
@@ -13,11 +13,11 @@ def serialize_input(
     if isinstance(input, str):
         return input
     elif isinstance(input, dict):
-        return json.dumps(input)
+        return json.dumps(input, ensure_ascii=False)
     elif isinstance(input, list):
         if any(isinstance(item, Message) for item in input):
-            return json.dumps([item.to_dict() for item in input])
+            return json.dumps([item.to_dict() for item in input], ensure_ascii=False)
         else:
-            return json.dumps(input)
+            return json.dumps(input, ensure_ascii=False)
     elif isinstance(input, BaseModel):
         return input.model_dump_json()

--- a/libs/agno/agno/utils/tokens.py
+++ b/libs/agno/agno/utils/tokens.py
@@ -394,7 +394,7 @@ def count_schema_tokens(
         else:
             return 0
 
-        schema_json = json.dumps(schema)
+        schema_json = json.dumps(schema, ensure_ascii=False)
         return count_text_tokens(schema_json, model_id)
     except Exception:
         return 0
@@ -577,7 +577,7 @@ def _count_message_tokens(message: Message, model_id: str = "gpt-4o") -> int:
                         temp_image = Image(url=url, detail=detail)
                         tokens += count_image_tokens(temp_image)
                     else:
-                        text_parts.append(json.dumps(item))
+                        text_parts.append(json.dumps(item, ensure_ascii=False))
         else:
             text_parts.append(str(content))
 

--- a/libs/agno/agno/utils/tools.py
+++ b/libs/agno/agno/utils/tools.py
@@ -93,7 +93,7 @@ def get_function_call_for_tool_execution(
 
     _tool_call_id = tool_execution.tool_call_id
     _tool_call_function_name = tool_execution.tool_name or ""
-    _tool_call_function_arguments_str = json.dumps(tool_execution.tool_args)
+    _tool_call_function_arguments_str = json.dumps(tool_execution.tool_args, ensure_ascii=False)
     return get_function_call(
         name=_tool_call_function_name,
         arguments=_tool_call_function_arguments_str,

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -1789,7 +1789,7 @@ class Workflow:
 
                     asyncio.create_task(
                         websocket_manager.broadcast_to_run(
-                            buffer_run_id, json.dumps(event_dict, default=json_serializer)
+                            buffer_run_id, json.dumps(event_dict, default=json_serializer, ensure_ascii=False)
                         )
                     )
             except Exception as e:

--- a/libs/agno/tests/unit/skills/test_agent_skills.py
+++ b/libs/agno/tests/unit/skills/test_agent_skills.py
@@ -316,6 +316,30 @@ def test_get_skill_instructions_success(mock_loader: MockSkillLoader) -> None:
     assert "available_references" in result
 
 
+def test_get_skill_instructions_preserves_non_ascii_characters(sample_skill: Skill) -> None:
+    """Test that skill instructions preserve Chinese and other non-ASCII characters."""
+    skill_with_chinese = Skill(
+        name="chinese-skill",
+        description="中文技能描述",
+        instructions="# 中文指令\n\n请按照以下步骤操作：\n1. 第一步\n2. 第二步\n3. 完成",
+        source_path="/path/to/chinese-skill",
+        scripts=["脚本.py"],
+        references=["参考文档.md"],
+    )
+    loader = MockSkillLoader([skill_with_chinese])
+    skills = Skills(loaders=[loader])
+    result_json = skills._get_skill_instructions("chinese-skill")
+    result = json.loads(result_json)
+
+    assert result["skill_name"] == "chinese-skill"
+    assert result["instructions"] == "# 中文指令\n\n请按照以下步骤操作：\n1. 第一步\n2. 第二步\n3. 完成"
+    assert result["description"] == "中文技能描述"
+    # Verify raw JSON string contains actual Chinese chars, not \uXXXX escapes
+    assert "中文指令" in result_json
+    assert "中文技能描述" in result_json
+    assert "\\u" not in result_json  # No ASCII escaping
+
+
 def test_get_skill_instructions_not_found(mock_loader: MockSkillLoader) -> None:
     """Test retrieval of non-existent skill instructions."""
     skills = Skills(loaders=[mock_loader])

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1251,3 +1251,39 @@ def test_model_copy_deep_isolates_user_input_schema():
 
     copied.user_input_schema[0].value = "run-scoped answer"
     assert func.user_input_schema[0].value is None
+
+
+def test_function_entrypoint_json_dumps_preserves_chinese():
+    """Test that json.dumps in tool entrypoints preserves Chinese characters.
+
+    This verifies that tools returning Chinese content via json.dumps
+    produce readable output for LLMs and logs, rather than \\uXXXX escapes.
+    """
+    import json
+
+    def chinese_tool(query: str) -> str:
+        """Search with Chinese results."""
+        return json.dumps({
+            "query": query,
+            "results": [
+                {"title": "中文标题", "content": "这是中文内容"},
+                {"title": "你好世界", "content": "包含中文字符"},
+            ]
+        }, ensure_ascii=False)
+
+    func = Function(
+        name="chinese_search",
+        description="Search that returns Chinese content",
+        entrypoint=chinese_tool,
+    )
+    func.process_entrypoint()
+
+    result = func.entrypoint(query="中文搜索")
+    parsed = json.loads(result)
+
+    assert parsed["results"][0]["title"] == "中文标题"
+    assert parsed["results"][0]["content"] == "这是中文内容"
+    assert parsed["results"][1]["title"] == "你好世界"
+    assert "中文标题" in result
+    assert "你好世界" in result
+    assert "\\u" not in result


### PR DESCRIPTION
## Summary

Fix Chinese/non-ASCII character garbling in `json.dumps` outputs read by LLMs, developers, and logs.

fixes #9485 

## Problem

`json.dumps()` defaults to `ensure_ascii=True`, which escapes non-ASCII characters to `\uXXXX`. When tool return values, skill instructions, agent messages, or logs contain Chinese characters, they become unreadable.

Example:
- Before: `{"instructions": "\u4f60\u597d\u4e16\u754c"}`
- After: `{"instructions": "你好世界"}`

## Change

Add `ensure_ascii=False` to all `json.dumps()` calls where the output is consumed by LLMs or humans.

**Scope** (140 files):
- `tools/` — Tool return values sent to LLMs
- `skills/` — Skill instructions for agents
- `agent/`, `team/` — Agent/team messages
- `models/` — Model interaction formatting
- `os/` — API responses, WebSocket messages
- `context/` — Context building for prompts
- `utils/` — Prompt construction, message formatting, logging
- `run/`, `client/` — Run results, client output

**Excluded** (machine-to-machine serialization):
- `db/`, `vectordb/` — Storage serialization (round-trips correctly via `json.loads`)
- `environments/`, `eval/`, `scorer/`, `learn/`, `fs/` — Internal serialization

## Validation

- `ruff format` — All checks passed
- `ruff check` — All checks passed
- `mypy` — 955 files, no issues

## Type

Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)