### PR TITLE
cookbook: make the at-most-once default discoverable where testers hit it

### DIFF
--- a/cookbook/05_agent_os/background_tasks/durable_queue.py
+++ b/cookbook/05_agent_os/background_tasks/durable_queue.py
@@ -2,9 +2,11 @@
 
 With QueueConfig(durable=True), a background run (background=True) is
 accepted as a committed row in the job queue table. Whichever replica's worker
-claims the job executes it - across process restarts and deploys. A crashed
-run is never silently re-executed (max_attempts=1 by default): it is failed
-visibly, and an operator can requeue it.
+claims the job executes it - across process restarts and deploys. What
+happens to a run whose worker CRASHES is a choice: with the default
+max_attempts=1 it fails visibly and is never silently re-executed (its side
+effects may already have happened); with max_attempts=2+ a live replica
+reclaims and re-executes it automatically. See "Try it" step 3.
 
 Try it:
 1. Start this app and submit a background run:
@@ -13,8 +15,20 @@ Try it:
         -F "stream=false"
    -> 202 with run_id and session_id; the run row is committed before the response.
 2. Poll GET /agents/durable-agent/runs/{run_id}?session_id={session_id} for the result.
-3. Kill the server mid-run and restart it: the job is reclaimed or failed
-   visibly - never lost, never stuck at RUNNING forever.
+3. Kill the server mid-run and restart it. What happens next is the most
+   important knob in this cookbook:
+   - max_attempts=1 (the default, at-most-once): the run is NOT re-executed.
+     After lock_grace_seconds the sweeper fails it visibly - the poll shows
+     ERROR with the reason, /queue/jobs lists it as failed, and an operator
+     can requeue it. This is the right default for runs with side effects
+     (emails, payments): a killed run may have already acted, and silent
+     re-execution would act twice.
+   - max_attempts=2 or higher (at-least-once): the restarted worker (or any
+     other replica) reclaims the stale job and re-executes it automatically -
+     kill the server mid-run and watch the run complete anyway. Retries are
+     safe: a still-alive "dead" worker is fenced from corrupting the retry's
+     run row or event stream.
+   Either way the run is never lost and never stuck at RUNNING forever.
 4. Operations surface:
    GET  /queue/stats                 - counts by status, oldest queued age
    GET  /queue/jobs?status=failed    - the dead-letter list
@@ -70,6 +84,11 @@ agent_os = AgentOS(
         durable=True,  # queue table lives in the Postgres above
         max_concurrency=8,  # per replica
         max_queue_depth=1000,  # global bound -> 429 beyond it
+        # At-most-once by default: a run killed mid-flight FAILS VISIBLY and
+        # is never silently re-executed (its side effects may already have
+        # happened). Set 2+ to have a crashed run reclaimed and re-executed
+        # automatically by any live replica - see "Try it" step 3.
+        max_attempts=1,
     ),
 )
 app = agent_os.get_app()

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -448,7 +448,15 @@ class QueueWorker:
                 # Lost to a live heartbeat or another sweeper - and the run
                 # row was never touched, which is the point of acquiring first
                 continue
-            error = "Worker lost and attempt budget exhausted; run was not re-executed"
+            # The message is the operator surface (it lands on job.error and
+            # the polled run's content): it must answer the next question -
+            # "why did my durable run not re-execute?" - not just state facts
+            error = (
+                "Worker lost and attempt budget exhausted; run was not re-executed. "
+                "Crashed runs fail visibly instead of silently re-executing (at-most-once, "
+                "max_attempts=1 by default): set QueueConfig(max_attempts=2) or higher to allow "
+                "automatic re-execution, or grant one attempt via POST /queue/jobs/{id}/requeue."
+            )
             if not await self._persist_run_error(job, error):
                 # The run row could not be terminalized (component missing
                 # after a deploy, session store fault). Failing the ticket now


### PR DESCRIPTION
## Summary

Two field testers independently killed a replica mid-run, watched the run fail with "attempt budget exhausted", and reported it as a durability bug. It is the documented at-most-once default (`max_attempts=1`) doing exactly its job - but the only places that said so were a docstring headline and the design docs, and the failure message answered "what happened" without "what do I do next".

- The sweeper's failure message (which lands on `job.error` and the polled run's content - the operator surface) now explains the at-most-once default and names both remedies: `QueueConfig(max_attempts=2)` or higher for automatic re-execution by any live replica, or `POST /queue/jobs/{id}/requeue` for a one-shot grant.
- `cookbook/05_agent_os/background_tasks/durable_queue.py`: the "kill the server mid-run" step now walks both modes explicitly - why at-most-once is the side-effect-safe default (a killed run may already have acted; silent re-execution would act twice), and what `max_attempts=2+` does (reclaim and re-execute automatically, safely fenced against the presumed-dead worker). The `QueueConfig` in the code carries an explicit `max_attempts=1` with the trade-off in a comment, so the knob is visible exactly where people experiment.

No behavior changes - message text and cookbook documentation only. Existing tests pin the message by substring ("worker lost") and pass unchanged.

## Type of change

- [x] Documentation update

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Follow-up from field testing of the durable queue (replica-kill scenarios). The workflow-replica variant of the same report is still under diagnosis separately (ticket max_attempts vs heartbeat starvation); this PR addresses the discoverability gap common to all three repros.
