### PR TITLE
fix: restore per-user RAG isolation on the agent/ team path and close a SurrealDB filter key leak

### DIFF
--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/README.md
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/README.md
@@ -7,6 +7,15 @@ plus the shared ones. `user_id=None` drops the scope - the admin view.
 
 Every example runs the same scenario against a different vector backend.
 
+Each one then repeats the check through an **agent**, which is how an
+application actually retrieves: `Agent(user_id="alice")` puts the owner on the
+run context, and it has to survive the hop into `search_knowledge_base` and
+down to the vector DB. That last hop is worth exercising explicitly - a
+dropped `user_id` becomes `None`, which is the admin view, so a broken handoff
+returns every user's chunks instead of raising. The agent section asserts on
+the documents retrieval returned (`RunOutput.references`) rather than on the
+model's prose, so the isolation check stays deterministic.
+
 ## Prerequisites
 
 1. Set `OPENAI_API_KEY`

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/cassandra_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/cassandra_db.py
@@ -22,9 +22,11 @@ import asyncio
 from typing import List
 
 import cassio
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.embedder.openai import OpenAIEmbedder
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.cassandra import Cassandra
 from cassandra.cluster import Cluster
 
@@ -147,6 +149,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
         cluster.shutdown()
 

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/cassandra_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/cassandra_db.py
@@ -183,6 +183,10 @@ if __name__ == "__main__":
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
         )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
+        )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
             "dropped between the run context and the vector DB, so retrieval ran "

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/chroma_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/chroma_db.py
@@ -21,8 +21,10 @@ Requirements:
 import asyncio
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.chroma import ChromaDb
 
 # ---------------------------------------------------------------------------
@@ -127,6 +129,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
     asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/chroma_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/chroma_db.py
@@ -163,6 +163,10 @@ if __name__ == "__main__":
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
         )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
+        )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
             "dropped between the run context and the vector DB, so retrieval ran "

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/clickhouse_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/clickhouse_db.py
@@ -21,8 +21,10 @@ Requirements:
 import asyncio
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.clickhouse import Clickhouse
 
 # ---------------------------------------------------------------------------
@@ -135,6 +137,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
         if vector_db.async_client is not None:
             await vector_db.async_client.close()

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/clickhouse_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/clickhouse_db.py
@@ -62,8 +62,8 @@ vector_db = Clickhouse(
     password=CLICKHOUSE_PASSWORD,
 )
 
-# Start clean: a legacy table without the user_id column would make every row
-# look like shared content.
+# Start clean, so the table is created with the owner column. Scoped reads
+# against a pre-isolation table name a column that is not there.
 if vector_db.exists():
     vector_db.drop()
 vector_db.create()
@@ -170,6 +170,10 @@ if __name__ == "__main__":
             for ref in (response.references or [])
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
+        )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
         )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/couchbase_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/couchbase_db.py
@@ -23,8 +23,10 @@ import asyncio
 from os import getenv
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.couchbase import CouchbaseSearch
 from couchbase.auth import PasswordAuthenticator
 from couchbase.management.search import SearchIndex
@@ -232,6 +234,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
     asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/couchbase_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/couchbase_db.py
@@ -268,6 +268,10 @@ if __name__ == "__main__":
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
         )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
+        )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
             "dropped between the run context and the vector DB, so retrieval ran "

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/lance_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/lance_db.py
@@ -162,6 +162,10 @@ if __name__ == "__main__":
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
         )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
+        )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
             "dropped between the run context and the vector DB, so retrieval ran "

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/lance_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/lance_db.py
@@ -21,8 +21,10 @@ Requirements:
 import asyncio
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.lancedb import LanceDb
 
 # ---------------------------------------------------------------------------
@@ -126,6 +128,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
     asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/milvus_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/milvus_db.py
@@ -168,6 +168,10 @@ if __name__ == "__main__":
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
         )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
+        )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
             "dropped between the run context and the vector DB, so retrieval ran "

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/milvus_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/milvus_db.py
@@ -26,8 +26,10 @@ Requirements:
 import asyncio
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.milvus import Milvus
 
 # ---------------------------------------------------------------------------
@@ -132,6 +134,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
     asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/mongo_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/mongo_db.py
@@ -176,6 +176,10 @@ if __name__ == "__main__":
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
         )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
+        )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
             "dropped between the run context and the vector DB, so retrieval ran "

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/mongo_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/mongo_db.py
@@ -23,8 +23,10 @@ Requirements:
 import asyncio
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.mongodb import MongoDb
 
 # ---------------------------------------------------------------------------
@@ -140,6 +142,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
     asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/opensearch_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/opensearch_db.py
@@ -23,8 +23,10 @@ Requirements:
 import asyncio
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.opensearch import OpenSearch
 
 # ---------------------------------------------------------------------------
@@ -128,6 +130,51 @@ if __name__ == "__main__":
         )
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
+
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
 
         print("\nDone.")
 

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/pgvector_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/pgvector_db.py
@@ -52,8 +52,9 @@ def show(label: str, results: List[Document]) -> None:
 
 vector_db = PgVector(table_name=TABLE_NAME, db_url=db_url)
 
-# Start clean: a legacy table without the user_id column would make every row
-# look like shared content.
+# Start clean, so the table is created with the owner column. Scoped reads against
+# a pre-isolation table name a column that is not there, and Knowledge.search turns
+# that error into an empty result.
 if vector_db.exists():
     vector_db.drop()
 vector_db.create()
@@ -161,6 +162,10 @@ if __name__ == "__main__":
             for ref in (response.references or [])
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
+        )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
         )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/pgvector_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/pgvector_db.py
@@ -20,8 +20,10 @@ Requirements:
 import asyncio
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.pgvector import PgVector
 
 # ---------------------------------------------------------------------------
@@ -126,6 +128,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
     asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/pinecone_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/pinecone_db.py
@@ -25,8 +25,10 @@ import asyncio
 from os import getenv
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.pineconedb import PineconeDb
 
 # ---------------------------------------------------------------------------
@@ -138,6 +140,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
     asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/pinecone_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/pinecone_db.py
@@ -174,6 +174,10 @@ if __name__ == "__main__":
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
         )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
+        )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
             "dropped between the run context and the vector DB, so retrieval ran "

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/qdrant_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/qdrant_db.py
@@ -22,8 +22,10 @@ Requirements:
 import asyncio
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.qdrant import Qdrant
 
 # ---------------------------------------------------------------------------
@@ -133,6 +135,46 @@ if __name__ == "__main__":
         # close it once the run is over.
         await vector_db.async_close()
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
     asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/qdrant_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/qdrant_db.py
@@ -131,10 +131,6 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
-        # The in-memory async client holds the demo's only copy of the data, so
-        # close it once the run is over.
-        await vector_db.async_close()
-
         print("\n" + "=" * 60)
         print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
         print("=" * 60 + "\n")
@@ -169,12 +165,21 @@ if __name__ == "__main__":
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
         )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
+        )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
             "dropped between the run context and the vector DB, so retrieval ran "
             "unscoped (user_id=None, the admin view)."
         )
         print("\nisolation holds: Bob's salary never reached Alice's agent")
+
+        # Close once the run is over. Closing earlier leaks: async_client is a lazy
+        # property that rebuilds itself, and the replacement is never closed.
+        await vector_db.async_close()
+
         print("\nDone.")
 
     asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/redis_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/redis_db.py
@@ -23,8 +23,10 @@ Requirements:
 import asyncio
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.redis import RedisDB
 from agno.vectordb.search import SearchType
 
@@ -134,6 +136,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
     asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/redis_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/redis_db.py
@@ -170,6 +170,10 @@ if __name__ == "__main__":
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
         )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
+        )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
             "dropped between the run context and the vector DB, so retrieval ran "

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/singlestore_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/singlestore_db.py
@@ -69,8 +69,8 @@ vector_db = SingleStore(
     db_engine=get_engine(),
 )
 
-# Start clean: a legacy table without the user_id column would make every row
-# look like shared content.
+# Start clean, so the table is created with the owner column. Scoped reads
+# against a pre-isolation table name a column that is not there.
 if vector_db.exists():
     vector_db.drop()
 vector_db.create()
@@ -178,6 +178,10 @@ if __name__ == "__main__":
             for ref in (response.references or [])
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
+        )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
         )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/singlestore_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/singlestore_db.py
@@ -23,8 +23,10 @@ import asyncio
 from os import getenv
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.singlestore import SingleStore
 from sqlalchemy.engine import create_engine
 
@@ -143,6 +145,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
     asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/surreal_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/surreal_db.py
@@ -184,6 +184,10 @@ if __name__ == "__main__":
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
         )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
+        )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
             "dropped between the run context and the vector DB, so retrieval ran "

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/surreal_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/surreal_db.py
@@ -22,8 +22,10 @@ Requirements:
 import asyncio
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.surrealdb import SurrealDb
 from surrealdb import AsyncSurreal, Surreal
 
@@ -148,6 +150,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
     asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/upstash_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/upstash_db.py
@@ -7,7 +7,8 @@ without one are shared with everyone.
 
 Upstash stores the owner in each vector's metadata; shared chunks omit the
 field and scoped reads filter user_id = X OR HAS NOT FIELD user_id. The Upstash
-wrapper has no async lifecycle methods, so this demo runs the sync path.
+wrapper raises NotImplementedError from async_search, so Knowledge.asearch falls
+back to the sync call with the owner intact.
 
 - Search as Alice: her chunks plus shared content, never Bob's
 - Search as Bob: his chunks plus shared content, never Alice's
@@ -21,6 +22,7 @@ Requirements:
 - OPENAI_API_KEY
 """
 
+import asyncio
 import time
 from os import getenv
 from typing import List
@@ -76,32 +78,32 @@ knowledge = Knowledge(
 
 if __name__ == "__main__":
 
-    def main() -> None:
+    async def main() -> None:
         # Alice and Bob upload private docs; the last upload has no user_id,
         # which makes it shared / org-wide content.
-        knowledge.insert(
+        await knowledge.ainsert(
             name="alice_salary",
             text_content=ALICE_SALARY,
             user_id="alice",
         )
-        knowledge.insert(
+        await knowledge.ainsert(
             name="bob_salary",
             text_content=BOB_SALARY,
             user_id="bob",
         )
-        knowledge.insert(
+        await knowledge.ainsert(
             name="company_holidays",
             text_content=HOLIDAYS,
         )
 
         # Upstash upserts are eventually consistent; let them settle.
-        time.sleep(5)
+        await asyncio.sleep(5)
 
         print("\n" + "=" * 60)
         print("SCOPED SEARCH: three callers, one corpus")
         print("=" * 60 + "\n")
 
-        alice_view = knowledge.search(query="salary", user_id="alice")
+        alice_view = await knowledge.asearch(query="salary", user_id="alice")
         show("Alice (user_id='alice')", alice_view)
         alice_text = " ".join(d.content for d in alice_view)
         assert "180,000" in alice_text, "Alice cannot retrieve her own document"
@@ -112,7 +114,7 @@ if __name__ == "__main__":
             "Isolation broken: Alice's scoped view leaked Bob's salary"
         )
 
-        bob_view = knowledge.search(query="salary", user_id="bob")
+        bob_view = await knowledge.asearch(query="salary", user_id="bob")
         show("Bob (user_id='bob')", bob_view)
         bob_text = " ".join(d.content for d in bob_view)
         assert "215,000" in bob_text, "Bob cannot retrieve his own document"
@@ -123,7 +125,7 @@ if __name__ == "__main__":
             "Isolation broken: Bob's scoped view leaked Alice's salary"
         )
 
-        admin_view = knowledge.search(query="salary", user_id=None)
+        admin_view = await knowledge.asearch(query="salary", user_id=None)
         show("Admin (user_id=None)", admin_view)
         admin_text = " ".join(d.content for d in admin_view)
         for expected in ("180,000", "215,000", "January 1"):
@@ -158,7 +160,7 @@ if __name__ == "__main__":
             markdown=True,
         )
 
-        response = alice_agent.run("What is Bob's salary?")
+        response = await alice_agent.arun("What is Bob's salary?")
         print("Alice's agent on 'What is Bob's salary?':")
         print(response.content)
 
@@ -170,6 +172,10 @@ if __name__ == "__main__":
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
         )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
+        )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
             "dropped between the run context and the vector DB, so retrieval ran "
@@ -178,4 +184,4 @@ if __name__ == "__main__":
         print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
-    main()
+    asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/upstash_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/upstash_db.py
@@ -25,9 +25,11 @@ import time
 from os import getenv
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.embedder.openai import OpenAIEmbedder
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.upstashdb import UpstashVectorDb
 
 # ---------------------------------------------------------------------------
@@ -134,6 +136,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = alice_agent.run("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
     main()

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/valkey_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/valkey_db.py
@@ -13,6 +13,9 @@ get a __shared__ sentinel tag and scoped reads match caller OR sentinel.
 - Search with user_id=None: admin view, sees everything
 
 Redis and Valkey both bind port 6379, so run only one of them at a time.
+Use the valkey-bundle image; plain valkey/valkey ships no search module. Redis
+Stack answers the same FT.* commands, so pointing this at a running Redis fails
+on the writes rather than on the connection.
 
 Requirements:
 - ./cookbook/scripts/run_valkey.sh
@@ -23,8 +26,10 @@ Requirements:
 import asyncio
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.search import SearchType
 from agno.vectordb.valkey import ValkeyDB
 
@@ -103,7 +108,10 @@ if __name__ == "__main__":
         alice_view = await knowledge.asearch(query="salary", user_id="alice")
         show("Alice (user_id='alice')", alice_view)
         alice_text = " ".join(d.content for d in alice_view)
-        assert "180,000" in alice_text, "Alice cannot retrieve her own document"
+        assert "180,000" in alice_text, (
+            "Alice cannot retrieve her own document. If every write also failed, "
+            "check that VALKEY_PORT points at a Valkey with the search module."
+        )
         assert "January 1" in alice_text, (
             "Shared content is unreachable from Alice's scoped view"
         )
@@ -134,6 +142,51 @@ if __name__ == "__main__":
         )
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
+
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
 
         print("\nDone.")
 

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/weaviate_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/weaviate_db.py
@@ -21,8 +21,10 @@ Requirements:
 import asyncio
 from typing import List
 
+from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIResponses
 from agno.vectordb.weaviate import Distance, VectorIndex, Weaviate
 
 # ---------------------------------------------------------------------------
@@ -130,6 +132,46 @@ if __name__ == "__main__":
         print("Alice and Bob each see their own chunk plus the shared one.")
         print("Admin sees the whole corpus.")
 
+        print("\n" + "=" * 60)
+        print("AGENT-MEDIATED RETRIEVAL: the owner has to survive the handoff")
+        print("=" * 60 + "\n")
+
+        # Everything above calls Knowledge directly. An application does not -
+        # it runs an agent, and the owner has to travel from the run context
+        # through the search tool into the vector DB. A dropped user_id becomes
+        # None, which is the admin view, so a broken handoff leaks silently
+        # instead of raising.
+        alice_agent = Agent(
+            name="Alice's Assistant",
+            model=OpenAIResponses(id="gpt-5.5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+            user_id="alice",
+            instructions=[
+                "Answer questions using ONLY the knowledge you can retrieve.",
+                "If you don't know, say so - do not invent salary figures.",
+            ],
+            markdown=True,
+        )
+
+        response = await alice_agent.arun("What is Bob's salary?")
+        print("Alice's agent on 'What is Bob's salary?':")
+        print(response.content)
+
+        # Assert on what retrieval actually returned, not on the model's prose:
+        # the references are the deterministic record of the isolation boundary.
+        retrieved = " ".join(
+            item["content"]
+            for ref in (response.references or [])
+            for item in (ref.references or [])
+            if isinstance(item, dict) and item.get("content")
+        )
+        assert "215,000" not in retrieved, (
+            "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "
+            "dropped between the run context and the vector DB, so retrieval ran "
+            "unscoped (user_id=None, the admin view)."
+        )
+        print("\nisolation holds: Bob's salary never reached Alice's agent")
         print("\nDone.")
 
     asyncio.run(main())

--- a/cookbook/07_knowledge/04_advanced/07_per_user_isolation/weaviate_db.py
+++ b/cookbook/07_knowledge/04_advanced/07_per_user_isolation/weaviate_db.py
@@ -57,8 +57,8 @@ vector_db = Weaviate(
     local=True,
 )
 
-# Start clean: a legacy collection without the user_id property would make
-# every object look like shared content.
+# Start clean, so the collection is created with the owner property. Scoped reads
+# against a pre-isolation collection go blank, and the property cannot be added in place.
 if vector_db.exists():
     vector_db.drop()
 vector_db.create()
@@ -165,6 +165,10 @@ if __name__ == "__main__":
             for ref in (response.references or [])
             for item in (ref.references or [])
             if isinstance(item, dict) and item.get("content")
+        )
+        # Guard against a vacuous pass: empty references mean the agent never searched
+        assert retrieved, (
+            "Retrieval returned no documents, so the isolation check below would pass on nothing"
         )
         assert "215,000" not in retrieved, (
             "Isolation broken: Alice's agent retrieved Bob's salary. The owner was "

--- a/cookbook/07_knowledge/TEST_LOG.md
+++ b/cookbook/07_knowledge/TEST_LOG.md
@@ -102,9 +102,9 @@ No tests recorded yet.
 
 **Status:** PASS
 
-**Description:** OpenSearch on localhost:9200. `user_id` keyword field scoped with `term` OR `must_not exists`.
+**Description:** OpenSearch on localhost:9200, index `per_user_isolation_demo`. `user_id` keyword field scoped with `term` OR `must_not exists`.
 
-**Result:** Alice 2 results, Bob 2, admin 3. All assertions passed; the agent did not state Bob's salary.
+**Result:** Alice 2 results, Bob 2, admin 3. All assertions passed. Alice's agent called `search_knowledge_base` and got back her own chunk plus the shared one; Bob's salary was absent from the references, excluded by the scoped read rather than by an empty result.
 
 ---
 
@@ -172,9 +172,9 @@ No tests recorded yet.
 
 **Status:** PASS
 
-**Description:** Upstash Vector over `UPSTASH_VECTOR_REST_URL` / `_TOKEN`, index at 1536 dimensions. `user_id` in metadata scoped with `user_id = X OR HAS NOT FIELD user_id`. Includes waits for eventual consistency.
+**Description:** Upstash Vector over `UPSTASH_VECTOR_REST_URL` / `_TOKEN`, index at 1536 dimensions, cosine. `user_id` in metadata scoped with `user_id = X OR HAS NOT FIELD user_id`. Waits for eventual consistency: 2s after the index reset, 5s after the upserts.
 
-**Result:** Alice 2 results, Bob 2, admin 3. All assertions passed; the agent did not state Bob's salary.
+**Result:** Alice 2 results, Bob 2, admin 3, identical across three consecutive runs. All assertions passed. Alice's agent called `search_knowledge_base` and got back her own chunk plus the shared one; Bob's salary was absent from the references.
 
 ---
 
@@ -182,9 +182,9 @@ No tests recorded yet.
 
 **Status:** PASS
 
-**Description:** Valkey on localhost:6379, `user_id` TAG field with a `__shared__` sentinel tag.
+**Description:** Valkey on localhost:6379, index `per_user_isolation_valkey`. `user_id` TAG field with a `__shared__` sentinel tag. Needs the valkey-bundle image; plain `valkey/valkey` ships no search module, and Redis Stack answers the same FT.* commands, so a stray Redis on 6379 fails on the writes rather than on the connection.
 
-**Result:** Alice 2 results, Bob 2, admin 3. All assertions passed; the agent did not state Bob's salary.
+**Result:** Alice 2 results, Bob 2, admin 3. All assertions passed. Alice's agent called `search_knowledge_base` and got back her own chunk plus the shared one; Bob's salary was absent from the references. ValkeyDB logs nothing during search, so the non-vacuity guard is what distinguishes a scoped read from an agent that never searched.
 
 ---
 

--- a/libs/agno/agno/agent/_default_tools.py
+++ b/libs/agno/agno/agent/_default_tools.py
@@ -26,7 +26,7 @@ from agno.run import RunContext
 from agno.run.agent import RunOutput
 from agno.session import AgentSession
 from agno.tools.function import Function
-from agno.utils.knowledge import get_agentic_or_user_search_filters
+from agno.utils.knowledge import get_agentic_or_user_search_filters, get_user_id_kwarg
 from agno.utils.log import (
     log_debug,
     log_info,
@@ -380,12 +380,13 @@ def make_update_session_state_entrypoint(agent: Agent) -> Callable:
     return _entrypoint
 
 
-def add_to_knowledge(agent: Agent, query: str, result: str) -> str:
+def add_to_knowledge(agent: Agent, query: str, result: str, user_id: Optional[str] = None) -> str:
     """Use this function to add information to the knowledge base for future use.
 
     Args:
         query (str): The query or topic to add.
         result (str): The actual content or information to store.
+        user_id (Optional[str]): The owner to store the document under. None writes to the shared bucket.
     Returns:
         str: A string indicating the status of the addition.
     """
@@ -404,8 +405,39 @@ def add_to_knowledge(agent: Agent, query: str, result: str) -> str:
     log_info(f"Adding document to Knowledge: {document_name}: {document_content}")
     from agno.knowledge.reader.text_reader import TextReader
 
-    insert_fn(name=document_name, text_content=document_content, reader=TextReader())
+    # Probe like the retrieval path: a custom Knowledge whose insert predates isolation raises on the kwarg
+    insert_kwargs: Dict[str, Any] = {
+        "name": document_name,
+        "text_content": document_content,
+        "reader": TextReader(),
+    }
+    insert_kwargs.update(get_user_id_kwarg(insert_fn, user_id))
+    insert_fn(**insert_kwargs)
     return "Successfully added to knowledge base"
+
+
+def create_add_to_knowledge_tool(agent: Agent, run_context: Optional[RunContext] = None) -> Function:
+    """Create a closure that binds the run's owner to the add_to_knowledge tool."""
+
+    def add_to_knowledge_base(query: str, result: str) -> str:
+        """Use this function to add information to the knowledge base for future use.
+
+        Args:
+            query (str): The query or topic to add.
+            result (str): The actual content or information to store.
+
+        Returns:
+            str: A string indicating the status of the addition.
+        """
+        try:
+            return add_to_knowledge(
+                agent, query=query, result=result, user_id=run_context.user_id if run_context else agent.user_id
+            )
+        except Exception as e:
+            log_warning(f"Adding to knowledge base failed: {str(e)}")
+            return f"Error adding to knowledge base: {type(e).__name__}"
+
+    return Function.from_callable(add_to_knowledge_base, name="add_to_knowledge")
 
 
 def _get_message_text(msg: Message) -> Optional[str]:

--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -1874,7 +1874,27 @@ def get_relevant_docs_from_knowledge(
             num_documents = getattr(resolved_knowledge, "max_results", 10)
 
         log_debug(f"Retrieving from knowledge base with filters: {filters}")
-        relevant_docs: List[Document] = retrieve_fn(query=query, max_results=num_documents, filters=filters)
+        # Owner scope flows from the run context (which carries the JWT sub
+        # for routed runs, or whatever ``Agent.user_id`` was set to). When
+        # None, retrieval is unscoped — see Knowledge.search docstring.
+        # Probe the retrieve signature so a custom Knowledge subclass that
+        # doesn't accept user_id keeps working — passing the kwarg would
+        # blow up.
+        retrieve_kwargs: Dict[str, Any] = {
+            "query": query,
+            "max_results": num_documents,
+            "filters": filters,
+        }
+        from inspect import signature as _sig
+
+        try:
+            if "user_id" in _sig(retrieve_fn).parameters:
+                retrieve_kwargs["user_id"] = run_context.user_id if run_context is not None else None
+        except (TypeError, ValueError):
+            # Some callables (builtins, C-extensions) don't have inspectable
+            # signatures. Skip user_id rather than crash.
+            pass
+        relevant_docs: List[Document] = retrieve_fn(**retrieve_kwargs)
 
         if not relevant_docs or len(relevant_docs) == 0:
             log_debug("No relevant documents found for query")
@@ -1968,10 +1988,25 @@ async def aget_relevant_docs_from_knowledge(
 
         log_debug(f"Retrieving from knowledge base with filters: {filters}")
 
+        # Probe the retrieve signatures and only pass user_id if the
+        # underlying method accepts it (see sync variant for rationale).
+        from inspect import signature as _sig
+
+        scope_user_id = run_context.user_id if run_context is not None else None
+
+        def _maybe_with_user_id(fn: Any) -> Dict[str, Any]:
+            base: Dict[str, Any] = {"query": query, "max_results": num_documents, "filters": filters}
+            try:
+                if "user_id" in _sig(fn).parameters:
+                    base["user_id"] = scope_user_id
+            except (TypeError, ValueError):
+                pass
+            return base
+
         if callable(aretrieve_fn):
-            relevant_docs: List[Document] = await aretrieve_fn(query=query, max_results=num_documents, filters=filters)
+            relevant_docs: List[Document] = await aretrieve_fn(**_maybe_with_user_id(aretrieve_fn))
         elif callable(retrieve_fn):
-            relevant_docs = retrieve_fn(query=query, max_results=num_documents, filters=filters)
+            relevant_docs = retrieve_fn(**_maybe_with_user_id(retrieve_fn))
         else:
             return None
 

--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -1885,15 +1885,10 @@ def get_relevant_docs_from_knowledge(
             "max_results": num_documents,
             "filters": filters,
         }
-        from inspect import signature as _sig
+        from agno.utils.knowledge import accepts_user_id
 
-        try:
-            if "user_id" in _sig(retrieve_fn).parameters:
-                retrieve_kwargs["user_id"] = run_context.user_id if run_context is not None else None
-        except (TypeError, ValueError):
-            # Some callables (builtins, C-extensions) don't have inspectable
-            # signatures. Skip user_id rather than crash.
-            pass
+        if accepts_user_id(retrieve_fn):
+            retrieve_kwargs["user_id"] = run_context.user_id if run_context is not None else None
         relevant_docs: List[Document] = retrieve_fn(**retrieve_kwargs)
 
         if not relevant_docs or len(relevant_docs) == 0:
@@ -1990,17 +1985,14 @@ async def aget_relevant_docs_from_knowledge(
 
         # Probe the retrieve signatures and only pass user_id if the
         # underlying method accepts it (see sync variant for rationale).
-        from inspect import signature as _sig
+        from agno.utils.knowledge import accepts_user_id
 
         scope_user_id = run_context.user_id if run_context is not None else None
 
         def _maybe_with_user_id(fn: Any) -> Dict[str, Any]:
             base: Dict[str, Any] = {"query": query, "max_results": num_documents, "filters": filters}
-            try:
-                if "user_id" in _sig(fn).parameters:
-                    base["user_id"] = scope_user_id
-            except (TypeError, ValueError):
-                pass
+            if accepts_user_id(fn):
+                base["user_id"] = scope_user_id
             return base
 
         if callable(aretrieve_fn):

--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -35,6 +35,7 @@ from agno.utils.agent import (
     execute_system_message,
 )
 from agno.utils.common import is_typed_dict
+from agno.utils.knowledge import get_user_id_kwarg
 from agno.utils.log import log_debug, log_warning
 from agno.utils.message import filter_tool_calls, get_text_from_message
 from agno.utils.prompts import get_json_output_prompt, get_response_model_format_prompt
@@ -450,9 +451,12 @@ def get_system_message(
     if _resolved_knowledge is not None and agent.search_knowledge and agent.add_search_knowledge_instructions:
         build_context_fn = getattr(_resolved_knowledge, "build_context", None)
         if callable(build_context_fn):
-            knowledge_context = build_context_fn(
-                enable_agentic_filters=agent.enable_agentic_knowledge_filters,
+            # The filter keys rendered into the prompt come from stored content, so scope them like retrieval
+            build_context_kwargs: Dict[str, Any] = {"enable_agentic_filters": agent.enable_agentic_knowledge_filters}
+            build_context_kwargs.update(
+                get_user_id_kwarg(build_context_fn, run_context.user_id if run_context else agent.user_id)
             )
+            knowledge_context = build_context_fn(**build_context_kwargs)
             if knowledge_context is not None:
                 system_message_content += knowledge_context + "\n"
 
@@ -810,16 +814,17 @@ async def aget_system_message(
         # Prefer async version if available for async databases
         abuild_context_fn = getattr(_resolved_knowledge, "abuild_context", None)
         build_context_fn = getattr(_resolved_knowledge, "build_context", None)
+        scope_uid = run_context.user_id if run_context else agent.user_id
         if callable(abuild_context_fn):
-            knowledge_context = await abuild_context_fn(
-                enable_agentic_filters=agent.enable_agentic_knowledge_filters,
-            )
+            abuild_context_kwargs: Dict[str, Any] = {"enable_agentic_filters": agent.enable_agentic_knowledge_filters}
+            abuild_context_kwargs.update(get_user_id_kwarg(abuild_context_fn, scope_uid))
+            knowledge_context = await abuild_context_fn(**abuild_context_kwargs)
             if knowledge_context is not None:
                 system_message_content += knowledge_context + "\n"
         elif callable(build_context_fn):
-            knowledge_context = build_context_fn(
-                enable_agentic_filters=agent.enable_agentic_knowledge_filters,
-            )
+            build_context_kwargs: Dict[str, Any] = {"enable_agentic_filters": agent.enable_agentic_knowledge_filters}
+            build_context_kwargs.update(get_user_id_kwarg(build_context_fn, scope_uid))
+            knowledge_context = build_context_fn(**build_context_kwargs)
             if knowledge_context is not None:
                 system_message_content += knowledge_context + "\n"
 
@@ -1822,7 +1827,13 @@ def get_relevant_docs_from_knowledge(
     # Validate the filters against known valid filter keys
     if resolved_knowledge is not None and filters is not None:
         if validate_filters:
-            valid_filters, invalid_keys = resolved_knowledge.validate_filters(filters)  # type: ignore
+            validate_kwargs: Dict[str, Any] = {}
+            validate_kwargs.update(
+                get_user_id_kwarg(
+                    resolved_knowledge.validate_filters, run_context.user_id if run_context else agent.user_id
+                )  # type: ignore
+            )
+            valid_filters, invalid_keys = resolved_knowledge.validate_filters(filters, **validate_kwargs)  # type: ignore
 
             # Warn about invalid filter keys
             if invalid_keys:
@@ -1854,6 +1865,13 @@ def get_relevant_docs_from_knowledge(
                 # Backward compatibility: support dependencies parameter
                 knowledge_retriever_kwargs["dependencies"] = dependencies
             knowledge_retriever_kwargs.update({"query": query, "num_documents": num_documents, **kwargs})
+            # Applied after the **kwargs merge: the owner comes from the run context, so caller kwargs must not win
+            knowledge_retriever_kwargs.update(
+                get_user_id_kwarg(
+                    agent.knowledge_retriever,
+                    run_context.user_id if run_context else agent.user_id,
+                )
+            )
             return agent.knowledge_retriever(**knowledge_retriever_kwargs)
         except Exception as e:
             log_warning(f"Knowledge retriever failed: {str(e)}")
@@ -1874,21 +1892,13 @@ def get_relevant_docs_from_knowledge(
             num_documents = getattr(resolved_knowledge, "max_results", 10)
 
         log_debug(f"Retrieving from knowledge base with filters: {filters}")
-        # Owner scope flows from the run context (which carries the JWT sub
-        # for routed runs, or whatever ``Agent.user_id`` was set to). When
-        # None, retrieval is unscoped — see Knowledge.search docstring.
-        # Probe the retrieve signature so a custom Knowledge subclass that
-        # doesn't accept user_id keeps working — passing the kwarg would
-        # blow up.
+        # Owner scope comes from the run context; None is unscoped, see the Knowledge.search docstring
         retrieve_kwargs: Dict[str, Any] = {
             "query": query,
             "max_results": num_documents,
             "filters": filters,
         }
-        from agno.utils.knowledge import accepts_user_id
-
-        if accepts_user_id(retrieve_fn):
-            retrieve_kwargs["user_id"] = run_context.user_id if run_context is not None else None
+        retrieve_kwargs.update(get_user_id_kwarg(retrieve_fn, run_context.user_id if run_context else agent.user_id))
         relevant_docs: List[Document] = retrieve_fn(**retrieve_kwargs)
 
         if not relevant_docs or len(relevant_docs) == 0:
@@ -1924,7 +1934,13 @@ async def aget_relevant_docs_from_knowledge(
     # Validate the filters against known valid filter keys
     if resolved_knowledge is not None and filters is not None:
         if validate_filters:
-            valid_filters, invalid_keys = await resolved_knowledge.avalidate_filters(filters)  # type: ignore
+            avalidate_kwargs: Dict[str, Any] = {}
+            avalidate_kwargs.update(
+                get_user_id_kwarg(
+                    resolved_knowledge.avalidate_filters, run_context.user_id if run_context else agent.user_id
+                )  # type: ignore
+            )
+            valid_filters, invalid_keys = await resolved_knowledge.avalidate_filters(filters, **avalidate_kwargs)  # type: ignore
 
             # Warn about invalid filter keys
             if invalid_keys:  # type: ignore
@@ -1955,6 +1971,13 @@ async def aget_relevant_docs_from_knowledge(
                 # Backward compatibility: support dependencies parameter
                 knowledge_retriever_kwargs["dependencies"] = dependencies
             knowledge_retriever_kwargs.update({"query": query, "num_documents": num_documents, **kwargs})
+            # Applied after the **kwargs merge: the owner comes from the run context, so caller kwargs must not win
+            knowledge_retriever_kwargs.update(
+                get_user_id_kwarg(
+                    agent.knowledge_retriever,
+                    run_context.user_id if run_context else agent.user_id,
+                )
+            )
             result = agent.knowledge_retriever(**knowledge_retriever_kwargs)
 
             if isawaitable(result):
@@ -1983,22 +2006,20 @@ async def aget_relevant_docs_from_knowledge(
 
         log_debug(f"Retrieving from knowledge base with filters: {filters}")
 
-        # Probe the retrieve signatures and only pass user_id if the
-        # underlying method accepts it (see sync variant for rationale).
-        from agno.utils.knowledge import accepts_user_id
-
-        scope_user_id = run_context.user_id if run_context is not None else None
-
-        def _maybe_with_user_id(fn: Any) -> Dict[str, Any]:
-            base: Dict[str, Any] = {"query": query, "max_results": num_documents, "filters": filters}
-            if accepts_user_id(fn):
-                base["user_id"] = scope_user_id
-            return base
+        # See the sync variant above
+        scope_user_id = run_context.user_id if run_context else agent.user_id
+        retrieve_kwargs: Dict[str, Any] = {
+            "query": query,
+            "max_results": num_documents,
+            "filters": filters,
+        }
 
         if callable(aretrieve_fn):
-            relevant_docs: List[Document] = await aretrieve_fn(**_maybe_with_user_id(aretrieve_fn))
+            retrieve_kwargs.update(get_user_id_kwarg(aretrieve_fn, scope_user_id))
+            relevant_docs: List[Document] = await aretrieve_fn(**retrieve_kwargs)
         elif callable(retrieve_fn):
-            relevant_docs = retrieve_fn(**_maybe_with_user_id(retrieve_fn))
+            retrieve_kwargs.update(get_user_id_kwarg(retrieve_fn, scope_user_id))
+            relevant_docs = retrieve_fn(**retrieve_kwargs)
         else:
             return None
 

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -1413,6 +1413,7 @@ def run_dispatch(
         dependencies_provided=dependencies is not None,
         knowledge_filters_provided=knowledge_filters is not None,
         metadata_provided=metadata is not None,
+        user_id=user_id,
     )
 
     # Prepare arguments for the model (must be after run_context is fully initialized)
@@ -2950,6 +2951,7 @@ def arun_dispatch(  # type: ignore
         dependencies_provided=dependencies is not None,
         knowledge_filters_provided=knowledge_filters is not None,
         metadata_provided=metadata is not None,
+        user_id=user_id,
     )
 
     # Prepare arguments for the model (must be after run_context is fully initialized)
@@ -3248,6 +3250,26 @@ def _resolve_continue_from(
     raise ValueError("`continue_from` must be an integer message index, 'end', or 'last_user'.")
 
 
+def _resolve_continue_owner(
+    run_response: Optional[RunOutput],
+    *,
+    run_id: Optional[str],
+    session: Optional[AgentSession],
+) -> Optional[str]:
+    """Owner stored on the run being continued.
+
+    A resume rarely carries the owner: the caller replays the paused run, or
+    only its id, and a routed Agent has no ``user_id`` of its own to fall back
+    on. Losing it resumes with ``user_id=None`` — the unscoped admin view over
+    every tenant — so the paused run is the last place the owner survives.
+    """
+    if run_response is not None:
+        return run_response.user_id
+    if session is not None:
+        return next((run.user_id for run in session.runs or [] if run.run_id == run_id), None)
+    return None
+
+
 def _normalize_regenerate_params(
     run_response: Optional[RunOutput],
     *,
@@ -3419,6 +3441,11 @@ def continue_run_dispatch(
     agent_session = read_or_create_session(agent, session_id=session_id, user_id=user_id)
     update_metadata(agent, session=agent_session)
 
+    # Fall back to the owner the run paused with, so the resumed half retrieves
+    # under the same scope as the first half
+    if user_id is None:
+        user_id = _resolve_continue_owner(run_response, run_id=run_id, session=agent_session)
+
     # Initialize session state. Get it from DB if relevant.
     session_state = load_session_state(agent, session=agent_session, session_state={})
 
@@ -3449,6 +3476,7 @@ def continue_run_dispatch(
         dependencies_provided=dependencies is not None,
         knowledge_filters_provided=knowledge_filters is not None,
         metadata_provided=metadata is not None,
+        user_id=user_id,
     )
 
     # Resolve dependencies
@@ -4268,12 +4296,19 @@ def acontinue_run_dispatch(  # type: ignore
     from agno.agent._init import has_async_db
 
     _session_state: Dict[str, Any] = {}
+    _pre_session: Optional[AgentSession] = None
     if not has_async_db(agent):
         from agno.agent._storage import load_session_state, read_or_create_session, update_metadata
 
         _pre_session = read_or_create_session(agent, session_id=session_id, user_id=user_id)
         update_metadata(agent, session=_pre_session)
         _session_state = load_session_state(agent, session=_pre_session, session_state={})
+
+    # Fall back to the owner the run paused with, so the resumed half retrieves
+    # under the same scope as the first half. With an async DB no session is read
+    # here, so a run_id-only resume has nothing to fall back to.
+    if user_id is None:
+        user_id = _resolve_continue_owner(run_response, run_id=run_id, session=_pre_session)
 
     # Resolve all run options centrally
     opts = resolve_run_options(
@@ -4305,6 +4340,7 @@ def acontinue_run_dispatch(  # type: ignore
         dependencies_provided=dependencies is not None,
         knowledge_filters_provided=knowledge_filters is not None,
         metadata_provided=metadata is not None,
+        user_id=user_id,
     )
 
     response_format = get_response_format(agent, run_context=run_context) if agent.parser_model is None else None

--- a/libs/agno/agno/agent/_run_options.py
+++ b/libs/agno/agno/agent/_run_options.py
@@ -42,9 +42,18 @@ class ResolvedRunOptions:
         dependencies_provided: bool = False,
         knowledge_filters_provided: bool = False,
         metadata_provided: bool = False,
+        user_id: Optional[str] = None,
     ) -> None:
         """Apply resolved options to run_context with precedence:
-        explicit args > existing run_context > resolved defaults."""
+        explicit args > existing run_context > resolved defaults.
+
+        ``user_id`` inverts this: an owner already on the run_context wins, so a
+        workflow step cannot re-own a run that arrived scoped to someone else.
+        """
+        # Fill the owner only when the run_context has none, so a caller-supplied owner still wins
+        if user_id is not None and run_context.user_id is None:
+            run_context.user_id = user_id
+
         if dependencies_provided:
             run_context.dependencies = self.dependencies
         elif run_context.dependencies is None:

--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -208,7 +208,7 @@ def get_tools(
         )
 
     if resolved_knowledge is not None and agent.update_knowledge:
-        agent_tools.append(agent.add_to_knowledge)
+        agent_tools.append(_default_tools.create_add_to_knowledge_tool(agent, run_context=run_context))
 
     # Add tools for accessing skills
     if agent.skills is not None:
@@ -341,7 +341,7 @@ async def aget_tools(
         )
 
     if resolved_knowledge is not None and agent.update_knowledge:
-        agent_tools.append(agent.add_to_knowledge)
+        agent_tools.append(_default_tools.create_add_to_knowledge_tool(agent, run_context=run_context))
 
     # Add tools for accessing skills
     if agent.skills is not None:

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -1143,7 +1143,7 @@ class Agent:
         )
 
     def add_to_knowledge(self, query: str, result: str) -> str:
-        return _default_tools.add_to_knowledge(self, query=query, result=result)
+        return _default_tools.add_to_knowledge(self, query=query, result=result, user_id=self.user_id)
 
     # ---------------------------------------------------------------
     # _cli module delegates

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -913,11 +913,12 @@ class Knowledge(RemoteKnowledge):
     # PUBLIC API - FILTER METHODS
     # ==========================================
 
-    def get_valid_filters(self) -> Set[str]:
+    def get_valid_filters(self, user_id: Optional[str] = None) -> Set[str]:
+        # Filter key names are content, so only return keys from documents the caller can retrieve
         if self.contents_db is None:
             log_info("No contents db configured; returning an empty filter validation key set.")
             return set()
-        contents, _ = self.get_content()
+        contents, _ = self.get_content(user_id=user_id)
         valid_filters: Set[str] = set()
         for content in contents:
             if content.metadata:
@@ -925,11 +926,12 @@ class Knowledge(RemoteKnowledge):
 
         return valid_filters
 
-    async def aget_valid_filters(self) -> Set[str]:
+    async def aget_valid_filters(self, user_id: Optional[str] = None) -> Set[str]:
+        """Async version of get_valid_filters."""
         if self.contents_db is None:
             log_info("No contents db configured; returning an empty filter validation key set.")
             return set()
-        contents, _ = await self.aget_content()
+        contents, _ = await self.aget_content(user_id=user_id)
         valid_filters: Set[str] = set()
         for content in contents:
             if content.metadata:
@@ -938,27 +940,27 @@ class Knowledge(RemoteKnowledge):
         return valid_filters
 
     def validate_filters(
-        self, filters: Union[Dict[str, Any], List[FilterExpr]]
+        self, filters: Union[Dict[str, Any], List[FilterExpr]], user_id: Optional[str] = None
     ) -> Tuple[Union[Dict[str, Any], List[FilterExpr]], List[str]]:
         if self.contents_db is None:
             log_info("No contents db configured; skipping filter key validation and preserving filters.")
             return filters, []
 
-        valid_filters_from_db = self.get_valid_filters()
+        valid_filters_from_db = self.get_valid_filters(user_id=user_id)
 
         valid_filters, invalid_keys = self._validate_filters(filters, valid_filters_from_db)
 
         return valid_filters, invalid_keys
 
     async def avalidate_filters(
-        self, filters: Union[Dict[str, Any], List[FilterExpr]]
+        self, filters: Union[Dict[str, Any], List[FilterExpr]], user_id: Optional[str] = None
     ) -> Tuple[Union[Dict[str, Any], List[FilterExpr]], List[str]]:
         """Return a tuple containing a dict with all valid filters and a list of invalid filter keys"""
         if self.contents_db is None:
             log_info("No contents db configured; skipping filter key validation and preserving filters.")
             return filters, []
 
-        valid_filters_from_db = await self.aget_valid_filters()
+        valid_filters_from_db = await self.aget_valid_filters(user_id=user_id)
 
         valid_filters, invalid_keys = self._validate_filters(filters, valid_filters_from_db)
 
@@ -3223,6 +3225,7 @@ Make sure to pass the filters as [Dict[str: Any]] to the tool. FOLLOW THIS STRUC
     def build_context(
         self,
         enable_agentic_filters: bool = False,
+        user_id: Optional[str] = None,
         **kwargs,
     ) -> str:
         """Build context string for the agent's system prompt.
@@ -3241,7 +3244,7 @@ Make sure to pass the filters as [Dict[str: Any]] to the tool. FOLLOW THIS STRUC
 
         # Add filter instructions if agentic filters are enabled
         if enable_agentic_filters:
-            valid_filters = self.get_valid_filters()
+            valid_filters = self.get_valid_filters(user_id=user_id)
             if valid_filters:
                 context_parts.append(self._get_agentic_filter_instructions(valid_filters))
 
@@ -3250,6 +3253,7 @@ Make sure to pass the filters as [Dict[str: Any]] to the tool. FOLLOW THIS STRUC
     async def abuild_context(
         self,
         enable_agentic_filters: bool = False,
+        user_id: Optional[str] = None,
         **kwargs,
     ) -> str:
         """Async version of build_context.
@@ -3268,7 +3272,7 @@ Make sure to pass the filters as [Dict[str: Any]] to the tool. FOLLOW THIS STRUC
 
         # Add filter instructions if agentic filters are enabled
         if enable_agentic_filters:
-            valid_filters = await self.aget_valid_filters()
+            valid_filters = await self.aget_valid_filters(user_id=user_id)
             if valid_filters:
                 context_parts.append(self._get_agentic_filter_instructions(valid_filters))
 
@@ -3340,6 +3344,7 @@ Make sure to pass the filters as [Dict[str: Any]] to the tool. FOLLOW THIS STRUC
             **kwargs,
         )
 
+    # The tools these factories build carry the run's owner, like the agent/team search tool does
     def _create_search_tool(
         self,
         run_response: Optional[Any] = None,
@@ -3370,7 +3375,9 @@ Make sure to pass the filters as [Dict[str: Any]] to the tool. FOLLOW THIS STRUC
             retrieval_timer.start()
 
             try:
-                docs = self.search(query=query, filters=knowledge_filters)
+                docs = self.search(
+                    query=query, filters=knowledge_filters, user_id=getattr(run_context, "user_id", None)
+                )
             except Exception as e:
                 retrieval_timer.stop()
                 log_warning(f"Knowledge search failed: {str(e)}")
@@ -3407,7 +3414,9 @@ Make sure to pass the filters as [Dict[str: Any]] to the tool. FOLLOW THIS STRUC
             retrieval_timer.start()
 
             try:
-                docs = await self.asearch(query=query, filters=knowledge_filters)
+                docs = await self.asearch(
+                    query=query, filters=knowledge_filters, user_id=getattr(run_context, "user_id", None)
+                )
             except Exception as e:
                 retrieval_timer.stop()
                 log_warning(f"Knowledge search failed: {str(e)}")
@@ -3494,7 +3503,7 @@ Make sure to pass the filters as [Dict[str: Any]] to the tool. FOLLOW THIS STRUC
             retrieval_timer.start()
 
             try:
-                docs = self.search(query=query, filters=search_filters)
+                docs = self.search(query=query, filters=search_filters, user_id=getattr(run_context, "user_id", None))
             except Exception as e:
                 retrieval_timer.stop()
                 log_warning(f"Knowledge search failed: {str(e)}")
@@ -3553,7 +3562,9 @@ Make sure to pass the filters as [Dict[str: Any]] to the tool. FOLLOW THIS STRUC
             retrieval_timer.start()
 
             try:
-                docs = await self.asearch(query=query, filters=search_filters)
+                docs = await self.asearch(
+                    query=query, filters=search_filters, user_id=getattr(run_context, "user_id", None)
+                )
             except Exception as e:
                 retrieval_timer.stop()
                 log_warning(f"Knowledge search failed: {str(e)}")

--- a/libs/agno/agno/os/routers/knowledge/knowledge.py
+++ b/libs/agno/agno/os/routers/knowledge/knowledge.py
@@ -1329,7 +1329,8 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
                     search_types=search_types,
                 )
             )
-        filters = await knowledge.aget_valid_filters()
+        # Filter key names are content, so scope them with the same gate the other routes use
+        filters = await knowledge.aget_valid_filters(user_id=get_scoped_user_id(request))
 
         # Get remote content sources if available
         remote_content_sources = None

--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -1714,20 +1714,15 @@ def get_relevant_docs_from_knowledge(
         # agno.agent._messages. When None, retrieval is unscoped — see the
         # Knowledge.search docstring. Probe the retrieve signature so a custom
         # Knowledge subclass that doesn't accept user_id keeps working.
-        from inspect import signature as _sig
+        from agno.utils.knowledge import accepts_user_id
 
         retrieve_kwargs: Dict[str, Any] = {
             "query": query,
             "max_results": num_documents,
             "filters": filters,
         }
-        try:
-            if "user_id" in _sig(retrieve_fn).parameters:
-                retrieve_kwargs["user_id"] = run_context.user_id if run_context is not None else None
-        except (TypeError, ValueError):
-            # Some callables (builtins, C-extensions) don't have inspectable
-            # signatures. Skip user_id rather than crash.
-            pass
+        if accepts_user_id(retrieve_fn):
+            retrieve_kwargs["user_id"] = run_context.user_id if run_context is not None else None
         relevant_docs: List[Document] = retrieve_fn(**retrieve_kwargs)
 
         if not relevant_docs or len(relevant_docs) == 0:
@@ -1827,17 +1822,14 @@ async def aget_relevant_docs_from_knowledge(
 
         # Probe the retrieve signatures and only pass user_id if the
         # underlying method accepts it (see sync variant for rationale).
-        from inspect import signature as _sig
+        from agno.utils.knowledge import accepts_user_id
 
         scope_user_id = run_context.user_id if run_context is not None else None
 
         def _maybe_with_user_id(fn: Any) -> Dict[str, Any]:
             base: Dict[str, Any] = {"query": query, "max_results": num_documents, "filters": filters}
-            try:
-                if "user_id" in _sig(fn).parameters:
-                    base["user_id"] = scope_user_id
-            except (TypeError, ValueError):
-                pass
+            if accepts_user_id(fn):
+                base["user_id"] = scope_user_id
             return base
 
         if callable(aretrieve_fn):

--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -1710,7 +1710,25 @@ def get_relevant_docs_from_knowledge(
             num_documents = getattr(knowledge, "max_results", 10)
 
         log_debug(f"Retrieving from knowledge base with filters: {filters}")
-        relevant_docs: List[Document] = retrieve_fn(query=query, max_results=num_documents, filters=filters)
+        # Owner scope flows from the run context, mirroring the agent path in
+        # agno.agent._messages. When None, retrieval is unscoped — see the
+        # Knowledge.search docstring. Probe the retrieve signature so a custom
+        # Knowledge subclass that doesn't accept user_id keeps working.
+        from inspect import signature as _sig
+
+        retrieve_kwargs: Dict[str, Any] = {
+            "query": query,
+            "max_results": num_documents,
+            "filters": filters,
+        }
+        try:
+            if "user_id" in _sig(retrieve_fn).parameters:
+                retrieve_kwargs["user_id"] = run_context.user_id if run_context is not None else None
+        except (TypeError, ValueError):
+            # Some callables (builtins, C-extensions) don't have inspectable
+            # signatures. Skip user_id rather than crash.
+            pass
+        relevant_docs: List[Document] = retrieve_fn(**retrieve_kwargs)
 
         if not relevant_docs or len(relevant_docs) == 0:
             log_debug("No relevant documents found for query")
@@ -1807,10 +1825,25 @@ async def aget_relevant_docs_from_knowledge(
 
         log_debug(f"Retrieving from knowledge base with filters: {filters}")
 
+        # Probe the retrieve signatures and only pass user_id if the
+        # underlying method accepts it (see sync variant for rationale).
+        from inspect import signature as _sig
+
+        scope_user_id = run_context.user_id if run_context is not None else None
+
+        def _maybe_with_user_id(fn: Any) -> Dict[str, Any]:
+            base: Dict[str, Any] = {"query": query, "max_results": num_documents, "filters": filters}
+            try:
+                if "user_id" in _sig(fn).parameters:
+                    base["user_id"] = scope_user_id
+            except (TypeError, ValueError):
+                pass
+            return base
+
         if callable(aretrieve_fn):
-            relevant_docs: List[Document] = await aretrieve_fn(query=query, max_results=num_documents, filters=filters)
+            relevant_docs: List[Document] = await aretrieve_fn(**_maybe_with_user_id(aretrieve_fn))
         elif callable(retrieve_fn):
-            relevant_docs = retrieve_fn(query=query, max_results=num_documents, filters=filters)
+            relevant_docs = retrieve_fn(**_maybe_with_user_id(retrieve_fn))
         else:
             return None
 

--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -69,7 +69,7 @@ from agno.run.team import (
 )
 from agno.session import TeamSession
 from agno.tools.function import Function
-from agno.utils.knowledge import get_agentic_or_user_search_filters
+from agno.utils.knowledge import get_agentic_or_user_search_filters, get_user_id_kwarg
 from agno.utils.log import (
     log_debug,
     log_info,
@@ -1433,12 +1433,13 @@ def _get_delegate_task_function(
     return delegate_func
 
 
-def add_to_knowledge(team: "Team", query: str, result: str) -> str:
+def add_to_knowledge(team: "Team", query: str, result: str, user_id: Optional[str] = None) -> str:
     """Use this function to add information to the knowledge base for future use.
 
     Args:
         query (str): The query or topic to add.
         result (str): The actual content or information to store.
+        user_id (Optional[str]): The owner to store the document under. None writes to the shared bucket.
 
     Returns:
         str: A string indicating the status of the addition.
@@ -1460,8 +1461,39 @@ def add_to_knowledge(team: "Team", query: str, result: str) -> str:
     log_info(f"Adding document to Knowledge: {document_name}: {document_content}")
     from agno.knowledge.reader.text_reader import TextReader
 
-    insert_method(name=document_name, text_content=document_content, reader=TextReader())
+    # See the matching comment in agno.agent._default_tools.
+    insert_kwargs: Dict[str, Any] = {
+        "name": document_name,
+        "text_content": document_content,
+        "reader": TextReader(),
+    }
+    insert_kwargs.update(get_user_id_kwarg(insert_method, user_id))
+    insert_method(**insert_kwargs)
     return "Successfully added to knowledge base"
+
+
+def create_add_to_knowledge_tool(team: "Team", run_context: Optional[RunContext] = None) -> Function:
+    """Create a closure that binds the run's owner to the add_to_knowledge tool."""
+
+    def add_to_knowledge_base(query: str, result: str) -> str:
+        """Use this function to add information to the knowledge base for future use.
+
+        Args:
+            query (str): The query or topic to add.
+            result (str): The actual content or information to store.
+
+        Returns:
+            str: A string indicating the status of the addition.
+        """
+        try:
+            return add_to_knowledge(
+                team, query=query, result=result, user_id=run_context.user_id if run_context else team.user_id
+            )
+        except Exception as e:
+            log_warning(f"Adding to knowledge base failed: {str(e)}")
+            return f"Error adding to knowledge base: {type(e).__name__}"
+
+    return Function.from_callable(add_to_knowledge_base, name="add_to_knowledge")
 
 
 def create_knowledge_search_tool(
@@ -1691,6 +1723,13 @@ def get_relevant_docs_from_knowledge(
                 # Backward compatibility: support dependencies parameter
                 knowledge_retriever_kwargs["dependencies"] = dependencies
             knowledge_retriever_kwargs.update({"query": query, "num_documents": num_documents, **kwargs})
+            # Applied after the **kwargs merge: the owner comes from the run context, so caller kwargs must not win
+            knowledge_retriever_kwargs.update(
+                get_user_id_kwarg(
+                    team.knowledge_retriever,
+                    run_context.user_id if run_context else team.user_id,
+                )
+            )
             return team.knowledge_retriever(**knowledge_retriever_kwargs)
         except Exception as e:
             log_warning(f"Knowledge retriever failed: {str(e)}")
@@ -1710,19 +1749,13 @@ def get_relevant_docs_from_knowledge(
             num_documents = getattr(knowledge, "max_results", 10)
 
         log_debug(f"Retrieving from knowledge base with filters: {filters}")
-        # Owner scope flows from the run context, mirroring the agent path in
-        # agno.agent._messages. When None, retrieval is unscoped — see the
-        # Knowledge.search docstring. Probe the retrieve signature so a custom
-        # Knowledge subclass that doesn't accept user_id keeps working.
-        from agno.utils.knowledge import accepts_user_id
-
+        # Owner scope comes from the run context; None is unscoped, see the Knowledge.search docstring
         retrieve_kwargs: Dict[str, Any] = {
             "query": query,
             "max_results": num_documents,
             "filters": filters,
         }
-        if accepts_user_id(retrieve_fn):
-            retrieve_kwargs["user_id"] = run_context.user_id if run_context is not None else None
+        retrieve_kwargs.update(get_user_id_kwarg(retrieve_fn, run_context.user_id if run_context else team.user_id))
         relevant_docs: List[Document] = retrieve_fn(**retrieve_kwargs)
 
         if not relevant_docs or len(relevant_docs) == 0:
@@ -1791,6 +1824,13 @@ async def aget_relevant_docs_from_knowledge(
                 # Backward compatibility: support dependencies parameter
                 knowledge_retriever_kwargs["dependencies"] = dependencies
             knowledge_retriever_kwargs.update({"query": query, "num_documents": num_documents, **kwargs})
+            # Applied after the **kwargs merge: the owner comes from the run context, so caller kwargs must not win
+            knowledge_retriever_kwargs.update(
+                get_user_id_kwarg(
+                    team.knowledge_retriever,
+                    run_context.user_id if run_context else team.user_id,
+                )
+            )
 
             result = team.knowledge_retriever(**knowledge_retriever_kwargs)
 
@@ -1820,22 +1860,20 @@ async def aget_relevant_docs_from_knowledge(
 
         log_debug(f"Retrieving from knowledge base with filters: {filters}")
 
-        # Probe the retrieve signatures and only pass user_id if the
-        # underlying method accepts it (see sync variant for rationale).
-        from agno.utils.knowledge import accepts_user_id
-
-        scope_user_id = run_context.user_id if run_context is not None else None
-
-        def _maybe_with_user_id(fn: Any) -> Dict[str, Any]:
-            base: Dict[str, Any] = {"query": query, "max_results": num_documents, "filters": filters}
-            if accepts_user_id(fn):
-                base["user_id"] = scope_user_id
-            return base
+        # See the sync variant above
+        scope_user_id = run_context.user_id if run_context else team.user_id
+        retrieve_kwargs: Dict[str, Any] = {
+            "query": query,
+            "max_results": num_documents,
+            "filters": filters,
+        }
 
         if callable(aretrieve_fn):
-            relevant_docs: List[Document] = await aretrieve_fn(**_maybe_with_user_id(aretrieve_fn))
+            retrieve_kwargs.update(get_user_id_kwarg(aretrieve_fn, scope_user_id))
+            relevant_docs: List[Document] = await aretrieve_fn(**retrieve_kwargs)
         elif callable(retrieve_fn):
-            relevant_docs = retrieve_fn(**_maybe_with_user_id(retrieve_fn))
+            retrieve_kwargs.update(get_user_id_kwarg(retrieve_fn, scope_user_id))
+            relevant_docs = retrieve_fn(**retrieve_kwargs)
         else:
             return None
 

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -41,6 +41,7 @@ from agno.utils.agent import (
     execute_system_message,
 )
 from agno.utils.common import is_typed_dict
+from agno.utils.knowledge import get_user_id_kwarg
 from agno.utils.log import (
     log_debug,
     log_warning,
@@ -514,9 +515,12 @@ def get_system_message(
     if team.knowledge is not None and team.search_knowledge and team.add_search_knowledge_instructions:
         build_context_fn = getattr(team.knowledge, "build_context", None)
         if callable(build_context_fn):
-            knowledge_context = build_context_fn(
-                enable_agentic_filters=team.enable_agentic_knowledge_filters,
+            # See the matching comment in agno.agent._messages.
+            build_context_kwargs: Dict[str, Any] = {"enable_agentic_filters": team.enable_agentic_knowledge_filters}
+            build_context_kwargs.update(
+                get_user_id_kwarg(build_context_fn, run_context.user_id if run_context else team.user_id)
             )
+            knowledge_context = build_context_fn(**build_context_kwargs)
             if knowledge_context:
                 system_message_content += knowledge_context + "\n"
 
@@ -753,11 +757,20 @@ async def aget_system_message(
 
     # 2.4 Knowledge base instructions
     if team.knowledge is not None and team.search_knowledge and team.add_search_knowledge_instructions:
+        # Prefer the async builder: the sync one reads through get_content(), which raises on an async database
+        abuild_context_fn = getattr(team.knowledge, "abuild_context", None)
         build_context_fn = getattr(team.knowledge, "build_context", None)
-        if callable(build_context_fn):
-            knowledge_context = build_context_fn(
-                enable_agentic_filters=team.enable_agentic_knowledge_filters,
-            )
+        scope_uid = run_context.user_id if run_context else team.user_id
+        if callable(abuild_context_fn):
+            abuild_context_kwargs: Dict[str, Any] = {"enable_agentic_filters": team.enable_agentic_knowledge_filters}
+            abuild_context_kwargs.update(get_user_id_kwarg(abuild_context_fn, scope_uid))
+            knowledge_context = await abuild_context_fn(**abuild_context_kwargs)
+            if knowledge_context:
+                system_message_content += knowledge_context + "\n"
+        elif callable(build_context_fn):
+            build_context_kwargs: Dict[str, Any] = {"enable_agentic_filters": team.enable_agentic_knowledge_filters}
+            build_context_kwargs.update(get_user_id_kwarg(build_context_fn, scope_uid))
+            knowledge_context = build_context_fn(**build_context_kwargs)
             if knowledge_context:
                 system_message_content += knowledge_context + "\n"
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -1992,6 +1992,7 @@ def run_dispatch(
             dependencies_provided=dependencies_provided,
             knowledge_filters_provided=knowledge_filters_provided,
             metadata_provided=metadata_provided,
+            user_id=user_id,
         )
 
         # Resolve callable dependencies once before retry loop
@@ -4290,6 +4291,7 @@ def arun_dispatch(  # type: ignore
         dependencies_provided=dependencies_provided,
         knowledge_filters_provided=knowledge_filters_provided,
         metadata_provided=metadata_provided,
+        user_id=user_id,
     )
 
     # Configure the model for runs
@@ -5598,6 +5600,8 @@ def _member_continue_kwargs_from_run_context(run_context: Optional[RunContext]) 
         return {}
 
     kwargs: Dict[str, Any] = {}
+    if run_context.user_id is not None:
+        kwargs["user_id"] = run_context.user_id
     if run_context.dependencies is not None:
         kwargs["dependencies"] = run_context.dependencies
     if run_context.metadata is not None:
@@ -6416,6 +6420,20 @@ def _resolve_continue_from_team(
     raise ValueError("`continue_from` must be an integer message index, 'end', or 'last_user'.")
 
 
+def _resolve_continue_owner_team(
+    run_response: Optional["TeamRunOutput"],
+    *,
+    run_id: Optional[str],
+    session: Optional[TeamSession],
+) -> Optional[str]:
+    """Owner stored on the team run being continued."""
+    if run_response is not None:
+        return run_response.user_id
+    if session is not None:
+        return next((run.user_id for run in session.runs or [] if run.run_id == run_id), None)
+    return None
+
+
 def _normalize_regenerate_params_team(
     run_response: Optional["TeamRunOutput"],
     *,
@@ -6727,6 +6745,11 @@ def continue_run_dispatch(
     team_session = _read_or_create_session(team, session_id=session_id, user_id=user_id)
     _update_metadata(team, session=team_session)
 
+    # Fall back to the owner the run paused with, so the resumed half retrieves
+    # under the same scope as the first half
+    if user_id is None:
+        user_id = _resolve_continue_owner_team(run_response, run_id=run_id_resolved, session=team_session)
+
     # Load session state
     session_state = _load_session_state(team, session=team_session, session_state={})
 
@@ -6751,6 +6774,8 @@ def continue_run_dispatch(
         knowledge_filters=opts.knowledge_filters,
         metadata=opts.metadata,
     )
+    if user_id is not None and run_context.user_id is None:
+        run_context.user_id = user_id
     if dependencies is not None:
         run_context.dependencies = opts.dependencies
     elif run_context.dependencies is None:
@@ -8166,6 +8191,12 @@ def acontinue_run_dispatch(  # type: ignore
 
     session_id_resolved, user_id = _initialize_session(team, session_id=session_id_resolved, user_id=user_id)
 
+    # Fall back to the owner the run paused with, so the resumed half retrieves
+    # under the same scope as the first half. This dispatch reads no session, so
+    # a run_id-only resume has nothing to fall back to.
+    if user_id is None:
+        user_id = _resolve_continue_owner_team(run_response, run_id=run_id_resolved, session=None)
+
     # Initialize the Team
     team.initialize_team(debug_mode=debug_mode)
 
@@ -8190,6 +8221,8 @@ def acontinue_run_dispatch(  # type: ignore
         knowledge_filters=opts.knowledge_filters,
         metadata=opts.metadata,
     )
+    if user_id is not None and run_context.user_id is None:
+        run_context.user_id = user_id
     if dependencies is not None:
         run_context.dependencies = opts.dependencies
     elif run_context.dependencies is None:

--- a/libs/agno/agno/team/_run_options.py
+++ b/libs/agno/agno/team/_run_options.py
@@ -42,9 +42,18 @@ class ResolvedRunOptions:
         dependencies_provided: bool = False,
         knowledge_filters_provided: bool = False,
         metadata_provided: bool = False,
+        user_id: Optional[str] = None,
     ) -> None:
         """Apply resolved options to run_context with precedence:
-        explicit args > existing run_context > resolved defaults."""
+        explicit args > existing run_context > resolved defaults.
+
+        ``user_id`` inverts this: an owner already on the run_context wins, so a
+        workflow step cannot re-own a run that arrived scoped to someone else.
+        """
+        # Fill the owner only when the run_context has none, so a caller-supplied owner still wins
+        if user_id is not None and run_context.user_id is None:
+            run_context.user_id = user_id
+
         if dependencies_provided:
             run_context.dependencies = self.dependencies
         elif run_context.dependencies is None:

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -144,6 +144,7 @@ def _determine_tools_for_model(
         _read_past_session_function,
         _search_past_sessions_function,
         _update_session_state_tool,
+        create_add_to_knowledge_tool,
         create_knowledge_search_tool,
     )
     from agno.team._init import _connect_connectable_tools
@@ -247,7 +248,7 @@ def _determine_tools_for_model(
         )
 
     if resolved_knowledge is not None and team.update_knowledge:
-        _tools.append(team.add_to_knowledge)
+        _tools.append(create_add_to_knowledge_tool(team, run_context=run_context))
 
     # Add tools for accessing skills
     if team.skills is not None:
@@ -268,7 +269,8 @@ def _determine_tools_for_model(
             run_context=run_context,
             session=session,
             team_run_context=team_run_context,
-            user_id=user_id,
+            # Members must run as the owner the team itself resolved, not a stale caller argument
+            user_id=run_context.user_id if run_context else user_id,
             stream=stream or False,
             stream_events=stream_events or False,
             async_mode=async_mode,
@@ -307,7 +309,8 @@ def _determine_tools_for_model(
             session=session,
             team_run_context=team_run_context,
             input=user_message_content,
-            user_id=user_id,
+            # Members must run as the owner the team itself resolved, not a stale caller argument
+            user_id=run_context.user_id if run_context else user_id,
             stream=stream or False,
             stream_events=stream_events or False,
             async_mode=async_mode,

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -1740,7 +1740,7 @@ class Team:
     ###########################################################################
 
     def add_to_knowledge(self, query: str, result: str) -> str:
-        return _default_tools.add_to_knowledge(self, query=query, result=result)
+        return _default_tools.add_to_knowledge(self, query=query, result=result, user_id=self.user_id)
 
     def get_relevant_docs_from_knowledge(
         self,

--- a/libs/agno/agno/utils/knowledge.py
+++ b/libs/agno/agno/utils/knowledge.py
@@ -34,3 +34,29 @@ def get_agentic_or_user_search_filters(
 
     log_info(f"Filters used by Agent: {search_filters}")
     return search_filters or {}
+
+
+def accepts_user_id(retrieve_fn: Any) -> bool:
+    """Whether ``retrieve_fn`` can receive the per-user isolation owner.
+
+    True when the callable declares a literal ``user_id`` parameter OR accepts
+    ``**kwargs``. The ``**kwargs`` case matters: ``KnowledgeProtocol`` documents
+    retrieval as ``retrieve(self, query, **kwargs)``, so a protocol-conforming
+    implementation never names ``user_id`` explicitly. Probing for the literal
+    name alone would drop the owner for every such class, and because ``None``
+    means "no owner filter" (the admin view), the drop is silent - retrieval
+    widens to every owner's chunks instead of raising.
+
+    Falls back to False when the signature can't be inspected (builtins and
+    C-extensions raise here), which keeps the legacy no-``user_id`` contract
+    working rather than crashing on an unexpected kwarg.
+    """
+    from inspect import Parameter, signature
+
+    try:
+        params = signature(retrieve_fn).parameters
+    except (TypeError, ValueError):
+        return False
+    if "user_id" in params:
+        return True
+    return any(p.kind == Parameter.VAR_KEYWORD for p in params.values())

--- a/libs/agno/agno/utils/knowledge.py
+++ b/libs/agno/agno/utils/knowledge.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 from agno.filters import FilterExpr
-from agno.utils.log import log_info
+from agno.utils.log import log_info, log_warning
 
 
 def get_agentic_or_user_search_filters(
@@ -36,27 +36,30 @@ def get_agentic_or_user_search_filters(
     return search_filters or {}
 
 
-def accepts_user_id(retrieve_fn: Any) -> bool:
-    """Whether ``retrieve_fn`` can receive the per-user isolation owner.
+def get_user_id_kwarg(fn: Any, user_id: Optional[str]) -> Dict[str, Any]:
+    """``{"user_id": ...}`` only when the callee accepts it.
 
-    True when the callable declares a literal ``user_id`` parameter OR accepts
-    ``**kwargs``. The ``**kwargs`` case matters: ``KnowledgeProtocol`` documents
-    retrieval as ``retrieve(self, query, **kwargs)``, so a protocol-conforming
-    implementation never names ``user_id`` explicitly. Probing for the literal
-    name alone would drop the owner for every such class, and because ``None``
-    means "no owner filter" (the admin view), the drop is silent - retrieval
-    widens to every owner's chunks instead of raising.
+    ``KnowledgeProtocol`` documents retrieval as ``retrieve(self, query, **kwargs)``,
+    so ``**kwargs`` counts as accepting it. Dropping the owner is not an error, it
+    widens the call to every owner's documents, so it warns.
 
-    Falls back to False when the signature can't be inspected (builtins and
-    C-extensions raise here), which keeps the legacy no-``user_id`` contract
-    working rather than crashing on an unexpected kwarg.
+    Args:
+        fn: The callable the kwarg will be passed to.
+        user_id: The owner to scope the call to.
+
+    Returns:
+        Dict[str, Any]: {"user_id": user_id} when the callee accepts it, empty otherwise.
     """
-    from inspect import Parameter, signature
+    import inspect
 
     try:
-        params = signature(retrieve_fn).parameters
+        parameters = inspect.signature(fn).parameters
     except (TypeError, ValueError):
-        return False
-    if "user_id" in params:
-        return True
-    return any(p.kind == Parameter.VAR_KEYWORD for p in params.values())
+        parameters = {}  # type: ignore[assignment]
+    if "user_id" in parameters or any(p.kind == p.VAR_KEYWORD for p in parameters.values()):
+        return {"user_id": user_id}
+    if user_id is not None:
+        log_warning(
+            f"{getattr(fn, '__qualname__', fn)} does not accept user_id, so this call is not scoped to a single owner."
+        )
+    return {}

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -63,7 +63,6 @@ class PgVector(VectorDb):
         vector_score_weight: float = 0.5,
         content_language: str = "english",
         schema_version: int = 1,
-        auto_upgrade_schema: bool = False,
         reranker: Optional[Reranker] = None,
         create_schema: bool = True,
         similarity_threshold: Optional[float] = None,
@@ -86,7 +85,6 @@ class PgVector(VectorDb):
             vector_score_weight (float): Weight for vector similarity in hybrid search.
             content_language (str): Language for full-text search.
             schema_version (int): Version of the database schema.
-            auto_upgrade_schema (bool): Automatically upgrade schema if True.
             reranker (Optional[Reranker]): Reranker instance for reranking search results.
             create_schema (bool): Whether to automatically create the database schema if it doesn't exist.
                 Set to False if schema is managed externally (e.g., via migrations). Defaults to True.
@@ -150,8 +148,6 @@ class PgVector(VectorDb):
 
         # Table schema version
         self.schema_version: int = schema_version
-        # Automatically upgrade schema if True
-        self.auto_upgrade_schema: bool = auto_upgrade_schema
 
         # Reranker instance
         self.reranker: Optional[Reranker] = reranker

--- a/libs/agno/agno/vectordb/pineconedb/pineconedb.py
+++ b/libs/agno/agno/vectordb/pineconedb/pineconedb.py
@@ -296,6 +296,8 @@ class PineconeDb(VectorDb):
 
             metadata["content_hash"] = content_hash
             # Stamp the owner; user_id=None writes to the shared bucket (no field).
+            # Drop any inherited owner key first: metadata and filters are caller data, not the owner
+            metadata.pop(self.USER_ID_KEY, None)
             if user_id is not None:
                 metadata[self.USER_ID_KEY] = user_id
 
@@ -424,6 +426,8 @@ class PineconeDb(VectorDb):
 
             metadata["content_hash"] = content_hash
             # Stamp the owner; user_id=None writes to the shared bucket (no field).
+            # Drop any inherited owner key first: metadata and filters are caller data, not the owner
+            metadata.pop(self.USER_ID_KEY, None)
             if user_id is not None:
                 metadata[self.USER_ID_KEY] = user_id
 

--- a/libs/agno/agno/vectordb/surrealdb/surrealdb.py
+++ b/libs/agno/agno/vectordb/surrealdb/surrealdb.py
@@ -225,23 +225,20 @@ class SurrealDb(VectorDb):
         """
         if not filters:
             return ""
-        # Bind both halves. Interpolating the key builds the path out of caller
-        # data: a key carrying SurrealQL (``name OR true``) becomes part of the
-        # WHERE logic, and because OR binds looser than AND it disjoins the
-        # owner scope away - one crafted filter key returns every owner's rows.
-        # A key with a '.' is the accidental version of the same bug: it splits
-        # into an unbound variable whose NONE = NONE comparison is true for
-        # every row. ``delete_by_metadata`` binds keys for exactly this reason.
-        conditions = [f"meta_data[$filter_key_{i}] = $filter_value_{i}" for i in range(len(filters))]
+        # Bind the key as well as the value: an interpolated key is caller data in the WHERE clause
+        # Walk items() like _build_filter_params, so the two cannot produce different counts
+        conditions = [f"meta_data[$filter_key_{i}] = $filter_value_{i}" for i, _ in enumerate(filters.items())]
         return "AND " + " AND ".join(conditions)
 
     @staticmethod
     def _build_filter_params(filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        """Bound parameters matching the placeholders ``_build_filter_condition`` emits.
+        """Build the bound parameters for the placeholders ``_build_filter_condition`` emits.
 
-        Kept alongside the condition builder so the two never drift: the query
-        references ``$filter_key_i``/``$filter_value_i`` and nothing else, so a
-        caller's key can no longer reach the query text.
+        Args:
+            filters: A dictionary of filters to apply to the query.
+
+        Returns:
+            Dict[str, Any]: The $filter_key_i / $filter_value_i bindings.
         """
         if not filters:
             return {}
@@ -661,7 +658,7 @@ class SurrealDb(VectorDb):
             # data: a key carrying a '.' splits into an unbound variable and a field
             # walk, and NONE = NONE is true for every row - one ordinary dotted key
             # deletes the whole collection.
-            conditions = [f"meta_data[$key_{i}] = $value_{i}" for i in range(len(metadata))]
+            conditions = [f"meta_data[$key_{i}] = $value_{i}" for i, _ in enumerate(metadata.items())]
             params: Dict[str, Any] = {}
             for i, (key, value) in enumerate(metadata.items()):
                 params[f"key_{i}"] = key

--- a/libs/agno/agno/vectordb/surrealdb/surrealdb.py
+++ b/libs/agno/agno/vectordb/surrealdb/surrealdb.py
@@ -217,8 +217,31 @@ class SurrealDb(VectorDb):
         """
         if not filters:
             return ""
-        conditions = [f"meta_data.{key} = ${key}" for key in filters]
+        # Bind both halves. Interpolating the key builds the path out of caller
+        # data: a key carrying SurrealQL (``name OR true``) becomes part of the
+        # WHERE logic, and because OR binds looser than AND it disjoins the
+        # owner scope away - one crafted filter key returns every owner's rows.
+        # A key with a '.' is the accidental version of the same bug: it splits
+        # into an unbound variable whose NONE = NONE comparison is true for
+        # every row. ``delete_by_metadata`` binds keys for exactly this reason.
+        conditions = [f"meta_data[$filter_key_{i}] = $filter_value_{i}" for i in range(len(filters))]
         return "AND " + " AND ".join(conditions)
+
+    @staticmethod
+    def _build_filter_params(filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Bound parameters matching the placeholders ``_build_filter_condition`` emits.
+
+        Kept alongside the condition builder so the two never drift: the query
+        references ``$filter_key_i``/``$filter_value_i`` and nothing else, so a
+        caller's key can no longer reach the query text.
+        """
+        if not filters:
+            return {}
+        params: Dict[str, Any] = {}
+        for i, (key, value) in enumerate(filters.items()):
+            params[f"filter_key_{i}"] = key
+            params[f"filter_value_{i}"] = value
+        return params
 
     @staticmethod
     def _user_scope_condition(user_id: Optional[str]) -> str:
@@ -470,7 +493,7 @@ class SurrealDb(VectorDb):
         log_debug(f"Search query: {search_query}")
         search_params: Dict[str, Any] = {"query_embedding": query_embedding}
         if filters:
-            search_params.update(filters)
+            search_params.update(self._build_filter_params(filters))
         if user_id is not None:
             search_params["scope_user_id"] = user_id
         response: Any = self.client.query(search_query, search_params)
@@ -881,7 +904,7 @@ class SurrealDb(VectorDb):
         )
         search_params: Dict[str, Any] = {"query_embedding": query_embedding}
         if filters:
-            search_params.update(filters)
+            search_params.update(self._build_filter_params(filters))
         if user_id is not None:
             search_params["scope_user_id"] = user_id
         response: Any = await self.async_client.query(search_query, search_params)

--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextvars
 import inspect
-from copy import deepcopy
+from copy import copy, deepcopy
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, AsyncIterator, Awaitable, Callable, Dict, Iterator, List, Optional, Union, cast
 from uuid import uuid4
@@ -666,6 +666,9 @@ class Step:
         """Execute the step with StepInput, returning final StepOutput (non-streaming)"""
         log_debug(f"Executing step: {self.name}")
 
+        # Give this step its own run context, so options resolved here do not persist into the next step
+        run_context = copy(run_context) if run_context is not None else None
+
         if step_input.previous_step_outputs:
             step_input.previous_step_content = step_input.get_last_step_content()
 
@@ -831,7 +834,8 @@ class Step:
                             audio=audios,
                             files=step_input.files,
                             session_id=session_id,
-                            user_id=user_id,
+                            # The executor passes this owner down to its own members, so send the resolved one
+                            user_id=run_context.user_id if run_context is not None else user_id,
                             session_state=session_state_copy,  # Send a copy to the executor
                             run_context=run_context,
                             run_id=executor_run_id,
@@ -862,7 +866,8 @@ class Step:
                         response = self._execute_nested_workflow(
                             step_input=step_input,
                             session_id=session_id,
-                            user_id=user_id,
+                            # Workflow.run takes no run_context, so the resolved owner travels as an argument
+                            user_id=run_context.user_id if run_context is not None else user_id,
                             workflow_run_response=workflow_run_response,
                             session_state=session_state_copy,
                             store_executor_outputs=store_executor_outputs,
@@ -988,6 +993,9 @@ class Step:
         add_session_state_to_context: Optional[bool] = None,
     ) -> Iterator[Union[WorkflowRunOutputEvent, StepOutput]]:
         """Execute the step with event-driven streaming support"""
+
+        # Give this step its own run context, so options resolved here do not persist into the next step
+        run_context = copy(run_context) if run_context is not None else None
 
         if step_input.previous_step_outputs:
             step_input.previous_step_content = step_input.get_last_step_content()
@@ -1166,7 +1174,8 @@ class Step:
                             audio=audios,
                             files=step_input.files,
                             session_id=session_id,
-                            user_id=user_id,
+                            # The executor passes this owner down to its own members, so send the resolved one
+                            user_id=run_context.user_id if run_context is not None else user_id,
                             session_state=session_state_copy,  # Send a copy to the executor
                             stream=True,
                             stream_events=stream_events,
@@ -1218,7 +1227,8 @@ class Step:
                         for event in self._execute_nested_workflow_stream(
                             step_input=step_input,
                             session_id=session_id,
-                            user_id=user_id,
+                            # Workflow.run takes no run_context, so the resolved owner travels as an argument
+                            user_id=run_context.user_id if run_context is not None else user_id,
                             workflow_run_response=workflow_run_response,
                             session_state=session_state_copy,
                             store_executor_outputs=store_executor_outputs,
@@ -1309,6 +1319,9 @@ class Step:
         """Execute the step with StepInput, returning final StepOutput (non-streaming)"""
         logger.info(f"Executing async step (non-streaming): {self.name}")
         log_debug(f"Executor type: {self._executor_type}")
+
+        # Give this step its own run context, so options resolved here do not persist into the next step
+        run_context = copy(run_context) if run_context is not None else None
 
         if step_input.previous_step_outputs:
             step_input.previous_step_content = step_input.get_last_step_content()
@@ -1505,7 +1518,8 @@ class Step:
                             audio=audios,
                             files=step_input.files,
                             session_id=session_id,
-                            user_id=user_id,
+                            # The executor passes this owner down to its own members, so send the resolved one
+                            user_id=run_context.user_id if run_context is not None else user_id,
                             session_state=session_state_copy,
                             run_context=run_context,
                             run_id=executor_run_id,
@@ -1536,7 +1550,8 @@ class Step:
                         response = await self._aexecute_nested_workflow(
                             step_input=step_input,
                             session_id=session_id,
-                            user_id=user_id,
+                            # Workflow.run takes no run_context, so the resolved owner travels as an argument
+                            user_id=run_context.user_id if run_context is not None else user_id,
                             workflow_run_response=workflow_run_response,
                             session_state=session_state_copy,
                             store_executor_outputs=store_executor_outputs,
@@ -1592,6 +1607,9 @@ class Step:
         add_session_state_to_context: Optional[bool] = None,
     ) -> AsyncIterator[Union[WorkflowRunOutputEvent, StepOutput]]:
         """Execute the step with event-driven streaming support"""
+
+        # Give this step its own run context, so options resolved here do not persist into the next step
+        run_context = copy(run_context) if run_context is not None else None
 
         if step_input.previous_step_outputs:
             step_input.previous_step_content = step_input.get_last_step_content()
@@ -1814,7 +1832,8 @@ class Step:
                             audio=audios,
                             files=step_input.files,
                             session_id=session_id,
-                            user_id=user_id,
+                            # The executor passes this owner down to its own members, so send the resolved one
+                            user_id=run_context.user_id if run_context is not None else user_id,
                             session_state=session_state_copy,
                             stream=True,
                             stream_events=stream_events,
@@ -1866,7 +1885,8 @@ class Step:
                         async for event in self._aexecute_nested_workflow_stream(
                             step_input=step_input,
                             session_id=session_id,
-                            user_id=user_id,
+                            # Workflow.run takes no run_context, so the resolved owner travels as an argument
+                            user_id=run_context.user_id if run_context is not None else user_id,
                             workflow_run_response=workflow_run_response,
                             session_state=session_state_copy,
                             store_executor_outputs=store_executor_outputs,

--- a/libs/agno/tests/unit/agent/test_agent_knowledge_user_isolation.py
+++ b/libs/agno/tests/unit/agent/test_agent_knowledge_user_isolation.py
@@ -229,3 +229,121 @@ class TestLegacyKnowledgeStillWorks:
 
         assert legacy.calls == 1
         assert docs
+
+
+class ProtocolKnowledge:
+    """A ``KnowledgeProtocol``-shaped implementation: ``retrieve(query, **kwargs)``.
+
+    ``agno/knowledge/protocol.py`` documents retrieval with ``**kwargs`` rather
+    than named parameters, so a conforming class never declares ``user_id``
+    explicitly. Probing only for the literal name would drop the owner here -
+    and since ``None`` is the admin view, the drop widens retrieval to every
+    owner instead of raising.
+    """
+
+    def __init__(self) -> None:
+        self.max_results = 5
+        self.vector_db = None
+        self.seen_user_ids: List[Any] = []
+
+    def validate_filters(self, filters):
+        return filters or {}, []
+
+    async def avalidate_filters(self, filters):
+        return filters or {}, []
+
+    def retrieve(self, query: str, **kwargs) -> List[Document]:
+        self.seen_user_ids.append(kwargs.get("user_id", "<absent>"))
+        return [Document(content="chunk")]
+
+    async def aretrieve(self, query: str, **kwargs) -> List[Document]:
+        self.seen_user_ids.append(kwargs.get("user_id", "<absent>"))
+        return [Document(content="chunk")]
+
+
+class TestVariadicKnowledgeStillGetsOwner:
+    """``**kwargs`` retrieval must receive the owner, not silently fall back to admin."""
+
+    def test_sync_agent_forwards_owner_through_kwargs(self, run_context):
+        from agno.agent import _messages
+
+        kb = ProtocolKnowledge()
+        _messages.get_relevant_docs_from_knowledge(
+            SpyOwner(kb),  # type: ignore[arg-type]
+            query="what is my salary",
+            run_context=run_context,
+        )
+
+        assert kb.seen_user_ids == [ALICE], (
+            "A **kwargs Knowledge lost the owner, so retrieval ran unscoped "
+            "(user_id=None) and would return every owner's chunks."
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_agent_forwards_owner_through_kwargs(self, run_context):
+        from agno.agent import _messages
+
+        kb = ProtocolKnowledge()
+        await _messages.aget_relevant_docs_from_knowledge(
+            SpyOwner(kb),  # type: ignore[arg-type]
+            query="what is my salary",
+            run_context=run_context,
+        )
+
+        assert kb.seen_user_ids == [ALICE]
+
+    def test_sync_team_forwards_owner_through_kwargs(self, run_context):
+        from agno.team import _default_tools as team_tools
+
+        kb = ProtocolKnowledge()
+        team_tools.get_relevant_docs_from_knowledge(
+            SpyOwner(kb),  # type: ignore[arg-type]
+            query="what is my salary",
+            run_context=run_context,
+        )
+
+        assert kb.seen_user_ids == [ALICE]
+
+    @pytest.mark.asyncio
+    async def test_async_team_forwards_owner_through_kwargs(self, run_context):
+        from agno.team import _default_tools as team_tools
+
+        kb = ProtocolKnowledge()
+        await team_tools.aget_relevant_docs_from_knowledge(
+            SpyOwner(kb),  # type: ignore[arg-type]
+            query="what is my salary",
+            run_context=run_context,
+        )
+
+        assert kb.seen_user_ids == [ALICE]
+
+
+class TestAcceptsUserIdHelper:
+    """The shared probe all four retrieval sites depend on."""
+
+    def test_explicit_user_id_parameter(self):
+        from agno.utils.knowledge import accepts_user_id
+
+        def fn(query, max_results=None, filters=None, user_id=None): ...
+
+        assert accepts_user_id(fn) is True
+
+    def test_var_keyword_parameter(self):
+        from agno.utils.knowledge import accepts_user_id
+
+        def fn(query, **kwargs): ...
+
+        assert accepts_user_id(fn) is True
+
+    def test_legacy_signature_without_either(self):
+        from agno.utils.knowledge import accepts_user_id
+
+        def fn(query, max_results=None, filters=None): ...
+
+        assert accepts_user_id(fn) is False
+
+    def test_uninspectable_callable_is_false(self):
+        """Builtins raise on signature() - fall back to the legacy contract."""
+        from agno.utils.knowledge import accepts_user_id
+
+        assert accepts_user_id(len) is False

--- a/libs/agno/tests/unit/agent/test_agent_knowledge_user_isolation.py
+++ b/libs/agno/tests/unit/agent/test_agent_knowledge_user_isolation.py
@@ -1,0 +1,231 @@
+"""Per-user RAG isolation must survive the agent/team -> knowledge handoff."""
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from agno.knowledge.document import Document
+from agno.run.base import RunContext
+
+ALICE = "alice"
+
+
+class SpyKnowledge:
+    """Records the owner each retrieval was scoped to.
+
+    ``retrieve``/``aretrieve`` accept ``user_id``, so the signature probe in the
+    retrieval helpers is expected to find the parameter and pass the owner.
+    """
+
+    def __init__(self) -> None:
+        self.max_results = 5
+        self.vector_db = None
+        self.seen_user_ids: List[Optional[str]] = []
+
+    def validate_filters(self, filters):
+        return filters or {}, []
+
+    async def avalidate_filters(self, filters):
+        return filters or {}, []
+
+    def retrieve(
+        self,
+        query: str,
+        max_results: Optional[int] = None,
+        filters: Optional[Dict[str, Any]] = None,
+        user_id: Optional[str] = None,
+        **kwargs,
+    ) -> List[Document]:
+        self.seen_user_ids.append(user_id)
+        return [Document(content="owned chunk")]
+
+    async def aretrieve(
+        self,
+        query: str,
+        max_results: Optional[int] = None,
+        filters: Optional[Dict[str, Any]] = None,
+        user_id: Optional[str] = None,
+        **kwargs,
+    ) -> List[Document]:
+        self.seen_user_ids.append(user_id)
+        return [Document(content="owned chunk")]
+
+
+class LegacyKnowledge:
+    """A pre-isolation Knowledge whose ``retrieve`` has no ``user_id`` parameter.
+
+    Passing the kwarg unconditionally would raise ``TypeError``, so the helpers
+    probe the signature first. This guards that probe.
+    """
+
+    def __init__(self) -> None:
+        self.max_results = 5
+        self.vector_db = None
+        self.calls = 0
+
+    def validate_filters(self, filters):
+        return filters or {}, []
+
+    async def avalidate_filters(self, filters):
+        return filters or {}, []
+
+    def retrieve(self, query, max_results=None, filters=None, **kwargs) -> List[Document]:
+        self.calls += 1
+        return [Document(content="legacy chunk")]
+
+
+class SpyOwner:
+    """The attribute surface the agent/team retrieval helpers read."""
+
+    def __init__(self, knowledge: Any) -> None:
+        self.knowledge = knowledge
+        self.knowledge_retriever = None
+        self.knowledge_filters = None
+        self.enable_agentic_knowledge_filters = False
+        self.references_format = "json"
+
+
+@pytest.fixture
+def knowledge() -> SpyKnowledge:
+    return SpyKnowledge()
+
+
+@pytest.fixture
+def run_context() -> RunContext:
+    return RunContext(run_id="run-1", user_id=ALICE, session_id="session-1")
+
+
+class TestAgentRetrievalScopesToOwner:
+    def test_sync_helper_forwards_owner(self, knowledge, run_context):
+        from agno.agent import _messages
+
+        _messages.get_relevant_docs_from_knowledge(
+            SpyOwner(knowledge),  # type: ignore[arg-type]
+            query="what is my salary",
+            run_context=run_context,
+        )
+
+        assert knowledge.seen_user_ids == [ALICE], (
+            "Agent retrieval dropped the owner; the vector DB would be queried "
+            "with user_id=None, which is the admin view over every owner."
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_helper_forwards_owner(self, knowledge, run_context):
+        from agno.agent import _messages
+
+        await _messages.aget_relevant_docs_from_knowledge(
+            SpyOwner(knowledge),  # type: ignore[arg-type]
+            query="what is my salary",
+            run_context=run_context,
+        )
+
+        assert knowledge.seen_user_ids == [ALICE]
+
+    def test_unscoped_run_stays_unscoped(self, knowledge):
+        """No owner on the run context is the admin view - None must stay None."""
+        from agno.agent import _messages
+
+        _messages.get_relevant_docs_from_knowledge(
+            SpyOwner(knowledge),  # type: ignore[arg-type]
+            query="anything",
+            run_context=RunContext(run_id="run-2", user_id=None, session_id="session-2"),
+        )
+
+        assert knowledge.seen_user_ids == [None]
+
+    def test_missing_run_context_is_unscoped(self, knowledge):
+        from agno.agent import _messages
+
+        _messages.get_relevant_docs_from_knowledge(
+            SpyOwner(knowledge),  # type: ignore[arg-type]
+            query="anything",
+        )
+
+        assert knowledge.seen_user_ids == [None]
+
+
+class TestDefaultSearchToolScopesToOwner:
+    """The tool ``search_knowledge=True`` installs is the primary RAG path."""
+
+    def test_sync_tool_forwards_owner(self, knowledge, run_context):
+        from agno.agent import _default_tools
+
+        tool = _default_tools.create_knowledge_search_tool(
+            SpyOwner(knowledge),  # type: ignore[arg-type]
+            run_context=run_context,
+        )
+        tool.entrypoint(query="what is my salary")
+
+        assert knowledge.seen_user_ids == [ALICE]
+
+    @pytest.mark.asyncio
+    async def test_async_tool_forwards_owner(self, knowledge, run_context):
+        from agno.agent import _default_tools
+
+        tool = _default_tools.create_knowledge_search_tool(
+            SpyOwner(knowledge),  # type: ignore[arg-type]
+            run_context=run_context,
+            async_mode=True,
+        )
+        await tool.entrypoint(query="what is my salary")
+
+        assert knowledge.seen_user_ids == [ALICE]
+
+
+class TestTeamRetrievalScopesToOwner:
+    """Teams share the knowledge path and need the same guarantee."""
+
+    def test_sync_helper_forwards_owner(self, knowledge, run_context):
+        from agno.team import _default_tools as team_tools
+
+        team_tools.get_relevant_docs_from_knowledge(
+            SpyOwner(knowledge),  # type: ignore[arg-type]
+            query="what is my salary",
+            run_context=run_context,
+        )
+
+        assert knowledge.seen_user_ids == [ALICE]
+
+    @pytest.mark.asyncio
+    async def test_async_helper_forwards_owner(self, knowledge, run_context):
+        from agno.team import _default_tools as team_tools
+
+        await team_tools.aget_relevant_docs_from_knowledge(
+            SpyOwner(knowledge),  # type: ignore[arg-type]
+            query="what is my salary",
+            run_context=run_context,
+        )
+
+        assert knowledge.seen_user_ids == [ALICE]
+
+
+class TestLegacyKnowledgeStillWorks:
+    """A custom Knowledge predating isolation must not start raising TypeError."""
+
+    def test_sync_retrieve_without_user_id_is_tolerated(self, run_context):
+        from agno.agent import _messages
+
+        legacy = LegacyKnowledge()
+        docs = _messages.get_relevant_docs_from_knowledge(
+            SpyOwner(legacy),  # type: ignore[arg-type]
+            query="q",
+            run_context=run_context,
+        )
+
+        assert legacy.calls == 1
+        assert docs
+
+    @pytest.mark.asyncio
+    async def test_async_retrieve_without_user_id_is_tolerated(self, run_context):
+        from agno.agent import _messages
+
+        legacy = LegacyKnowledge()
+        docs = await _messages.aget_relevant_docs_from_knowledge(
+            SpyOwner(legacy),  # type: ignore[arg-type]
+            query="q",
+            run_context=run_context,
+        )
+
+        assert legacy.calls == 1
+        assert docs

--- a/libs/agno/tests/unit/agent/test_agent_knowledge_user_isolation.py
+++ b/libs/agno/tests/unit/agent/test_agent_knowledge_user_isolation.py
@@ -54,8 +54,8 @@ class SpyKnowledge:
 class LegacyKnowledge:
     """A pre-isolation Knowledge whose ``retrieve`` has no ``user_id`` parameter.
 
-    Passing the kwarg unconditionally would raise ``TypeError``, so the helpers
-    probe the signature first. This guards that probe.
+    No ``**kwargs`` either, so the signature probe answers False. Passing the kwarg
+    unconditionally would raise ``TypeError``.
     """
 
     def __init__(self) -> None:
@@ -69,7 +69,11 @@ class LegacyKnowledge:
     async def avalidate_filters(self, filters):
         return filters or {}, []
 
-    def retrieve(self, query, max_results=None, filters=None, **kwargs) -> List[Document]:
+    def retrieve(self, query, max_results=None, filters=None) -> List[Document]:
+        self.calls += 1
+        return [Document(content="legacy chunk")]
+
+    async def aretrieve(self, query, max_results=None, filters=None) -> List[Document]:
         self.calls += 1
         return [Document(content="legacy chunk")]
 
@@ -77,12 +81,14 @@ class LegacyKnowledge:
 class SpyOwner:
     """The attribute surface the agent/team retrieval helpers read."""
 
-    def __init__(self, knowledge: Any) -> None:
+    def __init__(self, knowledge: Any, user_id: Optional[str] = None) -> None:
         self.knowledge = knowledge
         self.knowledge_retriever = None
         self.knowledge_filters = None
         self.enable_agentic_knowledge_filters = False
         self.references_format = "json"
+        # Read when no run_context is supplied, i.e. the public Agent.get_relevant_docs_from_knowledge() call
+        self.user_id = user_id
 
 
 @pytest.fixture
@@ -230,6 +236,143 @@ class TestLegacyKnowledgeStillWorks:
         assert legacy.calls == 1
         assert docs
 
+    def test_dropping_the_owner_warns(self, run_context, monkeypatch):
+        """A dropped owner is tolerated, but it has to warn: retrieval runs unscoped."""
+        from agno.agent import _messages
+        from agno.utils import knowledge as knowledge_utils
+
+        warnings: List[str] = []
+        monkeypatch.setattr(knowledge_utils, "log_warning", lambda msg: warnings.append(msg))
+
+        _messages.get_relevant_docs_from_knowledge(
+            SpyOwner(LegacyKnowledge()),  # type: ignore[arg-type]
+            query="q",
+            run_context=run_context,
+        )
+
+        assert len(warnings) == 1
+        assert "does not accept user_id" in warnings[0]
+        assert "LegacyKnowledge.retrieve" in warnings[0]
+
+    def test_unscoped_run_does_not_warn(self, monkeypatch):
+        """An unscoped run has no owner to drop, so it must not warn."""
+        from agno.agent import _messages
+        from agno.utils import knowledge as knowledge_utils
+
+        warnings: List[str] = []
+        monkeypatch.setattr(knowledge_utils, "log_warning", lambda msg: warnings.append(msg))
+
+        _messages.get_relevant_docs_from_knowledge(
+            SpyOwner(LegacyKnowledge()),  # type: ignore[arg-type]
+            query="q",
+            run_context=RunContext(run_id="run-3", user_id=None, session_id="session-3"),
+        )
+
+        assert warnings == []
+
+
+class TestOwnerFallsBackToTheComponent:
+    """``Agent.get_relevant_docs_from_knowledge`` is public and defaults run_context to None."""
+
+    def test_sync_direct_call_uses_agent_user_id(self, knowledge):
+        from agno.agent import _messages
+
+        _messages.get_relevant_docs_from_knowledge(
+            SpyOwner(knowledge, user_id=ALICE),  # type: ignore[arg-type]
+            query="what is my salary",
+        )
+
+        assert knowledge.seen_user_ids == [ALICE], (
+            "A direct call fell back to user_id=None, which is the admin view over every owner."
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_direct_call_uses_agent_user_id(self, knowledge):
+        from agno.agent import _messages
+
+        await _messages.aget_relevant_docs_from_knowledge(
+            SpyOwner(knowledge, user_id=ALICE),  # type: ignore[arg-type]
+            query="what is my salary",
+        )
+
+        assert knowledge.seen_user_ids == [ALICE]
+
+    def test_run_context_owner_still_wins(self, knowledge):
+        """An explicit run owner beats the component default."""
+        from agno.agent import _messages
+
+        _messages.get_relevant_docs_from_knowledge(
+            SpyOwner(knowledge, user_id="bob"),  # type: ignore[arg-type]
+            query="q",
+            run_context=RunContext(run_id="run-4", user_id=ALICE, session_id="session-4"),
+        )
+
+        assert knowledge.seen_user_ids == [ALICE]
+
+
+class TestCustomRetrieverGetsOwner:
+    """``Agent(knowledge_retriever=...)`` is the documented extension point."""
+
+    def test_retriever_declaring_user_id_receives_it(self, run_context):
+        from agno.agent import _messages
+
+        seen: List[Any] = []
+
+        def retriever(query, num_documents=None, user_id=None, **kwargs):
+            seen.append(user_id)
+            return [Document(content="chunk")]
+
+        owner = SpyOwner(SpyKnowledge())
+        owner.knowledge_retriever = retriever  # type: ignore[assignment]
+        _messages.get_relevant_docs_from_knowledge(
+            owner,  # type: ignore[arg-type]
+            query="q",
+            run_context=run_context,
+        )
+
+        assert seen == [ALICE]
+
+    def test_variadic_retriever_also_gets_the_owner(self, run_context):
+        """A retriever declared ``(query, **kwargs)`` still receives the owner."""
+        from agno.agent import _messages
+
+        seen: List[Any] = []
+
+        def retriever(query, num_documents=None, **kwargs):
+            seen.append(kwargs.get("user_id", "<absent>"))
+            return [Document(content="chunk")]
+
+        owner = SpyOwner(SpyKnowledge())
+        owner.knowledge_retriever = retriever  # type: ignore[assignment]
+        _messages.get_relevant_docs_from_knowledge(
+            owner,  # type: ignore[arg-type]
+            query="q",
+            run_context=run_context,
+        )
+
+        assert seen == [ALICE]
+
+    def test_caller_kwargs_cannot_override_the_owner(self, run_context):
+        """The owner comes from the run context, so caller kwargs must not win."""
+        from agno.agent import _messages
+
+        seen: List[Any] = []
+
+        def retriever(query, num_documents=None, user_id=None, **kwargs):
+            seen.append(user_id)
+            return [Document(content="chunk")]
+
+        owner = SpyOwner(SpyKnowledge())
+        owner.knowledge_retriever = retriever  # type: ignore[assignment]
+        _messages.get_relevant_docs_from_knowledge(
+            owner,  # type: ignore[arg-type]
+            query="q",
+            run_context=run_context,
+            user_id="bob",
+        )
+
+        assert seen == [ALICE]
+
 
 class ProtocolKnowledge:
     """A ``KnowledgeProtocol``-shaped implementation: ``retrieve(query, **kwargs)``.
@@ -318,32 +461,169 @@ class TestVariadicKnowledgeStillGetsOwner:
         assert kb.seen_user_ids == [ALICE]
 
 
-class TestAcceptsUserIdHelper:
+class VariadicInsertKnowledge:
+    """A custom Knowledge whose ``insert`` is declared ``insert(self, **kwargs)``.
+
+    The ordinary wrapper shape. The owner has to reach it the same way it reaches a
+    variadic ``retrieve``, because a write that loses it lands in the shared bucket.
+    """
+
+    def __init__(self) -> None:
+        self.stored: List[Dict[str, Any]] = []
+
+    def insert(self, **kwargs) -> None:
+        self.stored.append({"name": kwargs.get("name"), "user_id": kwargs.get("user_id")})
+
+
+class OwnerAwareInsertKnowledge:
+    """A Knowledge that declares ``user_id``, like ``agno.knowledge.Knowledge.insert``."""
+
+    def __init__(self) -> None:
+        self.stored: List[Dict[str, Any]] = []
+
+    def insert(self, name=None, text_content=None, reader=None, user_id=None) -> None:
+        self.stored.append({"name": name, "user_id": user_id})
+
+
+class TestAddToKnowledgeScopesTheWrite:
+    """The owner reaches insert, so what an agent learns stays the caller's."""
+
+    def test_agent_write_reaches_an_owner_aware_insert(self):
+        from agno.agent import _default_tools as agent_tools
+
+        kb = OwnerAwareInsertKnowledge()
+        agent_tools.add_to_knowledge(SpyOwner(kb), query="salary", result="100k", user_id=ALICE)  # type: ignore[arg-type]
+
+        assert kb.stored == [{"name": "salary", "user_id": ALICE}]
+
+    def test_team_write_reaches_an_owner_aware_insert(self):
+        from agno.team import _default_tools as team_tools
+
+        kb = OwnerAwareInsertKnowledge()
+        team_tools.add_to_knowledge(SpyOwner(kb), query="salary", result="100k", user_id=ALICE)  # type: ignore[arg-type]
+
+        assert kb.stored == [{"name": "salary", "user_id": ALICE}]
+
+    def test_agent_write_reaches_a_variadic_insert(self, monkeypatch):
+        """A wrapper that forwards its kwargs is scoped like any other insert."""
+        from agno.agent import _default_tools as agent_tools
+        from agno.utils import knowledge as knowledge_utils
+
+        warnings: List[str] = []
+        monkeypatch.setattr(knowledge_utils, "log_warning", lambda msg: warnings.append(msg))
+
+        kb = VariadicInsertKnowledge()
+        agent_tools.add_to_knowledge(SpyOwner(kb), query="salary", result="100k", user_id=ALICE)  # type: ignore[arg-type]
+
+        assert kb.stored == [{"name": "salary", "user_id": ALICE}]
+        assert warnings == []
+
+    def test_team_write_reaches_a_variadic_insert(self, monkeypatch):
+        from agno.team import _default_tools as team_tools
+        from agno.utils import knowledge as knowledge_utils
+
+        warnings: List[str] = []
+        monkeypatch.setattr(knowledge_utils, "log_warning", lambda msg: warnings.append(msg))
+
+        kb = VariadicInsertKnowledge()
+        team_tools.add_to_knowledge(SpyOwner(kb), query="salary", result="100k", user_id=ALICE)  # type: ignore[arg-type]
+
+        assert kb.stored == [{"name": "salary", "user_id": ALICE}]
+        assert warnings == []
+
+    def test_write_to_an_insert_predating_isolation_is_tolerated(self, monkeypatch):
+        """The kwarg is dropped rather than raised, and the widened write is reported."""
+        from agno.agent import _default_tools as agent_tools
+        from agno.utils import knowledge as knowledge_utils
+
+        warnings: List[str] = []
+        monkeypatch.setattr(knowledge_utils, "log_warning", lambda msg: warnings.append(msg))
+
+        class LegacyInsertKnowledge:
+            def __init__(self) -> None:
+                self.stored: List[Dict[str, Any]] = []
+
+            def insert(self, name=None, text_content=None, reader=None) -> None:
+                self.stored.append({"name": name})
+
+        kb = LegacyInsertKnowledge()
+        agent_tools.add_to_knowledge(SpyOwner(kb), query="salary", result="100k", user_id=ALICE)  # type: ignore[arg-type]
+
+        assert kb.stored == [{"name": "salary"}]
+        assert len(warnings) == 1
+        assert "LegacyInsertKnowledge.insert" in warnings[0]
+
+    def test_unscoped_write_does_not_warn(self, monkeypatch):
+        """No owner to lose, so a variadic insert is not worth reporting."""
+        from agno.agent import _default_tools as agent_tools
+        from agno.utils import knowledge as knowledge_utils
+
+        warnings: List[str] = []
+        monkeypatch.setattr(knowledge_utils, "log_warning", lambda msg: warnings.append(msg))
+
+        agent_tools.add_to_knowledge(SpyOwner(VariadicInsertKnowledge()), query="salary", result="100k")  # type: ignore[arg-type]
+
+        assert warnings == []
+
+
+class TestGetUserIdKwarg:
     """The shared probe all four retrieval sites depend on."""
 
     def test_explicit_user_id_parameter(self):
-        from agno.utils.knowledge import accepts_user_id
+        from agno.utils.knowledge import get_user_id_kwarg
 
         def fn(query, max_results=None, filters=None, user_id=None): ...
 
-        assert accepts_user_id(fn) is True
+        assert get_user_id_kwarg(fn, ALICE) == {"user_id": ALICE}
 
     def test_var_keyword_parameter(self):
-        from agno.utils.knowledge import accepts_user_id
+        from agno.utils.knowledge import get_user_id_kwarg
 
         def fn(query, **kwargs): ...
 
-        assert accepts_user_id(fn) is True
+        assert get_user_id_kwarg(fn, ALICE) == {"user_id": ALICE}
+
+    def test_insert_signature_parameter(self):
+        """The write path reads the same probe as the four read sites."""
+        from agno.utils.knowledge import get_user_id_kwarg
+
+        def fn(name=None, text_content=None, reader=None, user_id=None): ...
+
+        assert get_user_id_kwarg(fn, ALICE) == {"user_id": ALICE}
+
+    def test_var_keyword_does_not_warn(self, monkeypatch):
+        """``KnowledgeProtocol`` documents ``retrieve(query, **kwargs)``, so this is correct."""
+        from agno.utils import knowledge as knowledge_utils
+
+        warnings: List[str] = []
+        monkeypatch.setattr(knowledge_utils, "log_warning", lambda msg: warnings.append(msg))
+
+        def fn(query, **kwargs): ...
+
+        assert knowledge_utils.get_user_id_kwarg(fn, ALICE) == {"user_id": ALICE}
+        assert warnings == []
 
     def test_legacy_signature_without_either(self):
-        from agno.utils.knowledge import accepts_user_id
+        from agno.utils.knowledge import get_user_id_kwarg
 
         def fn(query, max_results=None, filters=None): ...
 
-        assert accepts_user_id(fn) is False
+        assert get_user_id_kwarg(fn, ALICE) == {}
 
-    def test_uninspectable_callable_is_false(self):
+    def test_uninspectable_callable_is_skipped(self):
         """Builtins raise on signature() - fall back to the legacy contract."""
-        from agno.utils.knowledge import accepts_user_id
+        from agno.utils.knowledge import get_user_id_kwarg
 
-        assert accepts_user_id(len) is False
+        assert get_user_id_kwarg(len, ALICE) == {}
+
+    def test_unscoped_run_does_not_warn(self, monkeypatch):
+        """No owner to lose, so nothing to report."""
+        from agno.utils import knowledge as knowledge_utils
+
+        warnings: List[str] = []
+        monkeypatch.setattr(knowledge_utils, "log_warning", lambda msg: warnings.append(msg))
+
+        def fn(query, max_results=None, filters=None): ...
+
+        assert knowledge_utils.get_user_id_kwarg(fn, None) == {}
+        assert warnings == []

--- a/libs/agno/tests/unit/agent/test_continue_run_owner.py
+++ b/libs/agno/tests/unit/agent/test_continue_run_owner.py
@@ -1,0 +1,46 @@
+"""Tests for the owner fallback used when a paused run is resumed.
+
+A resume rarely carries the owner — the caller replays the paused run, or only
+its id — and a routed Agent has no ``user_id`` of its own. Losing it resumes
+with ``user_id=None``, which is the unscoped admin view over every tenant.
+"""
+
+from agno.agent._run import _resolve_continue_owner
+from agno.run.agent import RunOutput
+from agno.session import AgentSession
+
+
+def _session(*runs: RunOutput) -> AgentSession:
+    return AgentSession(session_id="s", runs=list(runs))
+
+
+class TestResolveContinueOwner:
+    def test_run_response_carries_the_owner(self):
+        run = RunOutput(run_id="r1", session_id="s", user_id="alice")
+
+        assert _resolve_continue_owner(run, run_id="r1", session=None) == "alice"
+
+    def test_persisted_run_carries_the_owner_when_only_a_run_id_is_given(self):
+        session = _session(
+            RunOutput(run_id="other", session_id="s", user_id="bob"),
+            RunOutput(run_id="r1", session_id="s", user_id="alice"),
+        )
+
+        assert _resolve_continue_owner(None, run_id="r1", session=session) == "alice"
+
+    def test_unknown_run_id_resolves_to_no_owner(self):
+        session = _session(RunOutput(run_id="r1", session_id="s", user_id="alice"))
+
+        assert _resolve_continue_owner(None, run_id="missing", session=session) is None
+
+    def test_run_without_an_owner_stays_unscoped(self):
+        # No owner anywhere is the admin view — an owner must never be invented.
+        run = RunOutput(run_id="r1", session_id="s")
+
+        assert _resolve_continue_owner(run, run_id="r1", session=None) is None
+
+    def test_run_response_wins_over_the_persisted_run(self):
+        session = _session(RunOutput(run_id="r1", session_id="s", user_id="bob"))
+        run = RunOutput(run_id="r1", session_id="s", user_id="alice")
+
+        assert _resolve_continue_owner(run, run_id="r1", session=session) == "alice"

--- a/libs/agno/tests/unit/knowledge/test_knowledge_topic_loading.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_topic_loading.py
@@ -31,7 +31,6 @@ def mock_reader():
 
 
 def test_load_from_topics_continues_after_skip(knowledge, mock_reader):
-
     skip_pattern = [True, False, False]
     skip_index = [0]
 

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -1013,6 +1013,39 @@ class TestContinueRunApprovalResolution:
 # ===========================================================================
 
 
+class TestResolveContinueOwnerTeam:
+    """The owner a paused team run is resumed under."""
+
+    def test_run_response_carries_the_owner(self):
+        from agno.team._run import _resolve_continue_owner_team
+
+        run = TeamRunOutput(run_id="r1", session_id="s", user_id="alice")
+
+        assert _resolve_continue_owner_team(run, run_id="r1", session=None) == "alice"
+
+    def test_persisted_run_carries_the_owner_when_only_a_run_id_is_given(self):
+        from agno.session import TeamSession
+        from agno.team._run import _resolve_continue_owner_team
+
+        session = TeamSession(
+            session_id="s",
+            runs=[
+                TeamRunOutput(run_id="other", session_id="s", user_id="bob"),
+                TeamRunOutput(run_id="r1", session_id="s", user_id="alice"),
+            ],
+        )
+
+        assert _resolve_continue_owner_team(None, run_id="r1", session=session) == "alice"
+
+    def test_run_without_an_owner_stays_unscoped(self):
+        from agno.team._run import _resolve_continue_owner_team
+
+        # No owner anywhere is the admin view — an owner must never be invented.
+        run = TeamRunOutput(run_id="r1", session_id="s")
+
+        assert _resolve_continue_owner_team(run, run_id="r1", session=None) is None
+
+
 class TestMemberContinueKwargsFromRunContext:
     """Verify the helper that builds kwargs forwarded to member continue_run calls."""
 
@@ -1043,6 +1076,16 @@ class TestMemberContinueKwargsFromRunContext:
         # or it would be silently swallowed by **kwargs and confuse callers.
         assert "session_state" not in kwargs
 
+    def test_forwards_owner(self):
+        from agno.run import RunContext
+        from agno.team._run import _member_continue_kwargs_from_run_context
+
+        rc = RunContext(run_id="r", session_id="s", user_id="alice")
+
+        # A member Agent has no user_id of its own, so without this the member
+        # half of a resumed run retrieves unscoped — the admin view.
+        assert _member_continue_kwargs_from_run_context(rc)["user_id"] == "alice"
+
     def test_only_forwards_set_fields(self):
         from agno.run import RunContext
         from agno.team._run import _member_continue_kwargs_from_run_context
@@ -1050,7 +1093,7 @@ class TestMemberContinueKwargsFromRunContext:
         rc = RunContext(
             run_id="r",
             session_id="s",
-            user_id="u",
+            user_id=None,
             session_state=None,
             dependencies=None,
             metadata=None,

--- a/libs/agno/tests/unit/vectordb/test_milvus_user_isolation.py
+++ b/libs/agno/tests/unit/vectordb/test_milvus_user_isolation.py
@@ -131,6 +131,14 @@ class TestWriteStampsOwner:
 class TestScopeExpressionBuilder:
     """The scope-expression builder is small enough to unit-test directly, without spinning the DB at all."""
 
+    def test_user_id_field_constant_is_user_id(self):
+        # The field name is baked into every persisted row and into the scope
+        # expression. If it drifts, retrieval silently stops matching what was
+        # written - and an unmatched scope reads as "no rows", not as an error.
+        from agno.vectordb.milvus.milvus import USER_ID_FIELD
+
+        assert USER_ID_FIELD == "user_id"
+
     def test_none_user_id_applies_no_scope(self, milvus_db):
         # user_id=None is the admin view: the metadata filter passes through unchanged.
         assert milvus_db._scoped_filter_expr(None, None) is None

--- a/libs/agno/tests/unit/vectordb/test_surrealdb.py
+++ b/libs/agno/tests/unit/vectordb/test_surrealdb.py
@@ -104,11 +104,24 @@ def test_build_filter_condition(surrealdb_vector):
     result = surrealdb_vector._build_filter_condition(None)
     assert result == ""
 
-    # Test with filters
+    # Test with filters. Keys are BOUND, not interpolated: splicing a caller's
+    # key into the query text lets ``{"name OR true": ...}`` disjoin the owner
+    # scope away and return every owner's rows. See
+    # test_surrealdb_user_isolation.TestFilterKeyCannotEscapeTheOwnerScope.
     filters = {"cuisine": "Thai", "type": "soup"}
     result = surrealdb_vector._build_filter_condition(filters)
-    assert "AND meta_data.cuisine = $cuisine" in result
-    assert "AND meta_data.type = $type" in result
+    assert "AND meta_data[$filter_key_0] = $filter_value_0" in result
+    assert "AND meta_data[$filter_key_1] = $filter_value_1" in result
+    assert "cuisine" not in result
+    assert "type" not in result
+
+    params = surrealdb_vector._build_filter_params(filters)
+    assert params == {
+        "filter_key_0": "cuisine",
+        "filter_value_0": "Thai",
+        "filter_key_1": "type",
+        "filter_value_1": "soup",
+    }
 
 
 def test_create(surrealdb_vector, mock_surrealdb_client):

--- a/libs/agno/tests/unit/vectordb/test_surrealdb_user_isolation.py
+++ b/libs/agno/tests/unit/vectordb/test_surrealdb_user_isolation.py
@@ -208,11 +208,14 @@ class TestSearchScope:
     def test_scoped_search_ands_scope_onto_caller_filter(self, surreal_db):
         surreal_db.search("salary", limit=10, filters={"topic": "hr"}, user_id="alice")
         sql, params = _last_query(surreal_db.client)
-        # Both the caller's own metadata filter AND the owner scope apply.
-        assert "meta_data.topic = $topic" in sql
+        # Both the caller's own metadata filter AND the owner scope apply. The
+        # filter key is bound, not spliced, so it cannot reach the query text.
+        assert "meta_data[$filter_key_0] = $filter_value_0" in sql
         assert self.OWN_OR_SHARED in sql
         assert params["scope_user_id"] == "alice"
-        assert params["topic"] == "hr"
+        assert params["filter_key_0"] == "topic"
+        assert params["filter_value_0"] == "hr"
+        assert "topic" not in sql
 
     def test_scope_condition_helper_matches(self):
         # Guards the exact predicate the two search methods share.
@@ -383,3 +386,69 @@ class TestAsyncIsolation:
         assert alice_rid == f"{shared_id}:alice"
         assert bob_rid == f"{shared_id}:bob"
         assert alice_rid != bob_rid
+
+
+class TestFilterKeyCannotEscapeTheOwnerScope:
+    """A caller's filter KEY must never reach the query text.
+
+    Interpolating the key builds the WHERE clause out of caller data. Because
+    SurrealQL's OR binds looser than AND, a key carrying ``OR true`` disjoins
+    the sibling owner scope away and the search returns every owner's rows -
+    verified against a live SurrealDB before the fix. A key containing '.' is
+    the accidental version: it splits into an unbound variable whose
+    ``NONE = NONE`` comparison is true for every row.
+
+    ``delete_by_metadata`` has always bound its keys for this reason; these
+    tests hold the search path to the same rule.
+    """
+
+    # Payloads that leaked (or errored) against a real server pre-fix.
+    INJECTION_KEYS = [
+        "name OR true",
+        "name OR user_id",
+        "name OR user_id != NONE",
+        "a.b",
+    ]
+
+    @pytest.mark.parametrize("evil_key", INJECTION_KEYS)
+    def test_injected_key_never_reaches_sql(self, surreal_db, evil_key):
+        surreal_db.search("salary", limit=10, filters={evil_key: "x"}, user_id="alice")
+        sql, params = _last_query(surreal_db.client)
+        assert evil_key not in sql, f"filter key {evil_key!r} was spliced into the query text"
+        assert "OR true" not in sql
+        assert params["filter_key_0"] == evil_key
+        # The owner scope survives intact alongside the bound filter.
+        assert TestSearchScope.OWN_OR_SHARED in sql
+        assert params["scope_user_id"] == "alice"
+
+    @pytest.mark.parametrize("evil_key", INJECTION_KEYS)
+    @pytest.mark.asyncio
+    async def test_injected_key_never_reaches_sql_async(self, async_surreal_db, evil_key):
+        await async_surreal_db.async_search("salary", limit=10, filters={evil_key: "x"}, user_id="alice")
+        sql, params = _last_query(async_surreal_db.async_client)
+        assert evil_key not in sql
+        assert "OR true" not in sql
+        assert params["filter_key_0"] == evil_key
+        assert TestSearchScope.OWN_OR_SHARED in sql
+        assert params["scope_user_id"] == "alice"
+
+    def test_multiple_filters_each_bound_separately(self, surreal_db):
+        surreal_db.search("q", limit=5, filters={"topic": "hr", "year": 2026}, user_id="alice")
+        sql, params = _last_query(surreal_db.client)
+        assert "meta_data[$filter_key_0] = $filter_value_0" in sql
+        assert "meta_data[$filter_key_1] = $filter_value_1" in sql
+        assert {params["filter_key_0"], params["filter_key_1"]} == {"topic", "year"}
+        assert {params["filter_value_0"], params["filter_value_1"]} == {"hr", 2026}
+
+    def test_condition_and_params_stay_in_step(self):
+        """The builders are a pair - every placeholder must have a bound value."""
+        filters = {"a": 1, "b OR true": 2}
+        condition = SurrealDb._build_filter_condition(filters)
+        params = SurrealDb._build_filter_params(filters)
+        for i in range(len(filters)):
+            assert f"$filter_key_{i}" in condition
+            assert f"$filter_value_{i}" in condition
+            assert f"filter_key_{i}" in params
+            assert f"filter_value_{i}" in params
+        assert SurrealDb._build_filter_condition(None) == ""
+        assert SurrealDb._build_filter_params(None) == {}

--- a/libs/agno/tests/unit/workflow/test_step_executor_owner.py
+++ b/libs/agno/tests/unit/workflow/test_step_executor_owner.py
@@ -1,0 +1,123 @@
+"""
+Unit tests for the owner a workflow step hands to its agent/team executor.
+
+A Workflow carries the per-run owner on the RunContext, while ``Workflow.user_id``
+is only the instance-level default. A Team passes the ``user_id`` argument it was
+called with down to its members, so a step that forwards the stale instance
+default makes every member run unscoped (admin view over all tenants) or under
+the wrong owner.
+"""
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from agno.agent import Agent
+from agno.run.team import TeamRunOutput
+from agno.team import Team
+from agno.workflow.step import Step
+from agno.workflow.workflow import Workflow
+
+
+@pytest.fixture
+def team():
+    return Team(name="Test Team", members=[Agent(name="Test Agent")])
+
+
+def _team_output() -> TeamRunOutput:
+    return TeamRunOutput(run_id="team-run-id", content="done")
+
+
+def _spy_team(captured: List[Optional[str]], monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace Team.run/arun so the step's dispatch is observed without a model."""
+
+    def spy_run(self_team, *args, **kwargs):
+        captured.append(kwargs.get("user_id"))
+        if kwargs.get("stream"):
+            return iter([_team_output()])
+        return _team_output()
+
+    def spy_arun(self_team, *args, **kwargs):
+        captured.append(kwargs.get("user_id"))
+        if kwargs.get("stream"):
+
+            async def stream_output():
+                yield _team_output()
+
+            return stream_output()
+
+        async def output():
+            return _team_output()
+
+        return output()
+
+    monkeypatch.setattr(Team, "run", spy_run)
+    monkeypatch.setattr(Team, "arun", spy_arun)
+
+
+def _drain(workflow: Workflow, mode: str, run_kwargs: Dict[str, Any]) -> None:
+    if mode == "run":
+        workflow.run(input="hello", **run_kwargs)
+    elif mode == "run_stream":
+        list(workflow.run(input="hello", stream=True, **run_kwargs))
+    elif mode == "arun":
+        asyncio.run(workflow.arun(input="hello", **run_kwargs))
+    else:
+
+        async def consume():
+            async for _ in workflow.arun(input="hello", stream=True, **run_kwargs):
+                pass
+
+        asyncio.run(consume())
+
+
+ALL_MODES = ["run", "run_stream", "arun", "arun_stream"]
+
+
+class TestStepExecutorOwner:
+    """The step must hand its executor the run-scoped owner, not Workflow.user_id."""
+
+    @pytest.mark.parametrize("mode", ALL_MODES)
+    def test_run_owner_reaches_team_executor(self, team, monkeypatch, mode):
+        """The owner passed to workflow.run() reaches the team executor."""
+        captured: List[Optional[str]] = []
+        _spy_team(captured, monkeypatch)
+
+        workflow = Workflow(name="Owner Test", steps=[Step(name="step1", team=team)])
+        _drain(workflow, mode, {"user_id": "alice"})
+
+        assert captured == ["alice"]
+
+    @pytest.mark.parametrize("mode", ALL_MODES)
+    def test_run_owner_wins_over_workflow_default(self, team, monkeypatch, mode):
+        """A per-run owner beats the workflow's instance-level default."""
+        captured: List[Optional[str]] = []
+        _spy_team(captured, monkeypatch)
+
+        workflow = Workflow(name="Owner Test", user_id="carol", steps=[Step(name="step1", team=team)])
+        _drain(workflow, mode, {"user_id": "alice"})
+
+        assert captured == ["alice"]
+
+    @pytest.mark.parametrize("mode", ALL_MODES)
+    def test_workflow_default_owner_used_when_run_has_none(self, team, monkeypatch, mode):
+        """With no per-run owner, the workflow's default still applies."""
+        captured: List[Optional[str]] = []
+        _spy_team(captured, monkeypatch)
+
+        workflow = Workflow(name="Owner Test", user_id="carol", steps=[Step(name="step1", team=team)])
+        _drain(workflow, mode, {})
+
+        assert captured == ["carol"]
+
+    @pytest.mark.parametrize("mode", ALL_MODES)
+    def test_no_owner_stays_unscoped(self, team, monkeypatch, mode):
+        """No owner anywhere stays unscoped, so shared content is not invented an owner."""
+        captured: List[Optional[str]] = []
+        _spy_team(captured, monkeypatch)
+
+        workflow = Workflow(name="Owner Test", steps=[Step(name="step1", team=team)])
+        _drain(workflow, mode, {})
+
+        assert captured == [None]

--- a/libs/agno/tests/unit/workflow/test_workflow_run_params.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_run_params.py
@@ -749,13 +749,10 @@ class TestWorkflowRunE2EDependencies:
         finally:
             Agent.run = original_run  # type: ignore
 
-        # Agent1 sets its deps on the shared run_context
+        # Each step resolves onto its own copy of the run context, so what step 1
+        # resolved does not persist into step 2
         assert captured_per_step["Agent1"]["deps_after"] == {"agent1_key": "a1-val"}
-
-        # Agent2: run_context already has Agent1's deps (not None),
-        # so Agent2's deps are NOT applied — this is the shared RunContext behavior.
-        # Agent1's deps persist into Step 2.
-        assert captured_per_step["Agent2"]["deps_after"] == {"agent1_key": "a1-val"}
+        assert captured_per_step["Agent2"]["deps_after"] == {"agent2_key": "a2-val"}
 
     def test_add_dependencies_flag_propagated_e2e(self):
         """add_dependencies_to_context flag propagates from workflow to agent.run()."""


### PR DESCRIPTION
## Summary

Carries the run's owner (`user_id`) from the caller through to the vector database on every retrieval path — agent, team, workflow step and resumed run — and binds SurrealDB filter keys as query parameters.

**The contract this upholds.** Every vector row carries an owner. Reads are *inclusive*: the caller's own rows plus unowned/shared rows. A `user_id` of `None` applies no filter at all, which is the unscoped view over every tenant. An owner dropped anywhere along the call path therefore widens the result set **silently** and never raises. That is why the changes below are about keeping the owner attached at each hop rather than about adding a check at the end.

### 1. The default knowledge search carries the owner, for agents and teams

The default `search_knowledge_base` tool resolves the owner from the run context and passes it to `Knowledge.retrieve` / `aretrieve`, on both the `Agent` path (`agent/_messages.py`) and the `Team` path (`team/_default_tools.py`). The search tools built by `Knowledge._create_search_tool` pass it too, so a `Knowledge` used as a toolkit scopes the same way.

### 2. SurrealDB binds filter keys as query parameters

`_build_filter_condition` emits `meta_data[$filter_key_i] = $filter_value_i` and `_build_filter_params` supplies both halves as bindings, so a caller's filter key never reaches the query text.

Without this, an interpolated key is caller data sitting inside the `WHERE` clause:

```
filters = {"name OR true": "x"}   ->   ... AND meta_data.name OR true = $...
```

SurrealQL's `OR` binds looser than `AND`, so that disjoins the sibling owner-scope condition away and the query returns every owner's rows. A key containing an ordinary `.` reaches the same place by accident: it splits into an unbound variable whose `NONE = NONE` comparison is true for every row.

### 3. `RunContext` retains the `user_id` argument

`RunOptions.apply_to_context` (agent and team) takes `user_id` and fills it in when the context has no owner. A caller who supplies their own `RunContext` with an owner already on it keeps that owner, so an inner caller cannot re-own a run that arrived scoped to someone else.

### 4. Workflow steps hand their executor the owner resolved for the run

`Step` passes `run_context.user_id` — the owner resolved for *this run* — to its agent, team or nested-workflow executor, rather than the `Workflow` instance's own `user_id` attribute. This matters because the executor passes the owner it receives down to its own members.

Each step also runs against its own `copy(run_context)`, so an option resolved in one step does not persist into the next: `user_id`, `dependencies` and `output_schema` are isolated per step, while `session_state` stays shared by reference, per the existing contract.

| run | owner reaching the executor |
|---|---|
| `wf.run(user_id="alice")` | `alice` |
| `Workflow(user_id="carol").run(…, user_id="alice")` | `alice` |
| `Workflow(user_id="carol").run(…)` | `carol` |
| no owner anywhere | `None` (unscoped) |

### 5. Resumed runs recover the owner from the run being continued

A resume is a second, separate call, and it often carries no owner: the caller replays the paused run or passes only its id, and a routed `Agent` has no `user_id` of its own. `continue_run` / `acontinue_run` (agent and team) now read the owner off the run being continued — from the paused run object, or from the persisted run in the session — and use it only when the caller supplied none. An explicitly passed owner always wins.

The team-to-member hand-off on resume (`_member_continue_kwargs_from_run_context`) forwards the owner alongside the dependencies, metadata and knowledge filters it forwards, so a member resumes under the same scope as the leader.

### 6. Pinecone metadata cannot set ownership

`metadata` is caller data, so the `user_id` key is dropped from it before the row's owner is stamped, on both the sync and the async insert. Ownership comes only from the `user_id` argument.

### 7. Custom `Knowledge` and custom retrievers

A shared probe, `agno/utils/knowledge.py:get_user_id_kwarg`, passes the owner to a callee that accepts it and warns rather than raising when it does not. `KnowledgeProtocol` documents retrieval as `retrieve(self, query, **kwargs)`, so `**kwargs` counts as accepting it — a protocol-conforming implementation that never names `user_id` still gets scoped.

It is applied to:

- the custom-retriever path, **after** the caller-kwargs merge, so caller kwargs cannot override the owner;
- `validate_filters` / `avalidate_filters`;
- the `add_to_knowledge` write path, which now binds the run's owner through a per-run tool closure (`create_add_to_knowledge_tool`) for both agents and teams.

### 8. Prompt-time knowledge scoping

`build_context` / `abuild_context` and `get_valid_filters` / `aget_valid_filters` take the owner, because the filter keys rendered into the system prompt come from stored content. The knowledge config route scopes through `get_scoped_user_id`, the same gate its sibling routes use.

The team path prefers the async context builder where one is available. The sync builder reads through `get_content()`, which raises `ValueError: get_content() is not supported for async databases`; without the async preference, a `Team` on an async DB with `enable_agentic_knowledge_filters=True` cannot complete a run.

### Admin behaviour

Retrieval is user-isolated for **everyone**, including admins. An admin retrieving through an agent sees shared/unowned content plus their own, not other users' content. This is deliberate and agreed: an admin bypass is not part of this PR. A configurable option — whether an admin retrieves across all owners or has isolation enforced — is a documented follow-up.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Tests.** `3341 passed, 16 skipped` across `unit/agent`, `unit/team`, `unit/workflow`, `unit/knowledge` and `unit/vectordb` on this branch's current base.

New coverage:

- `tests/unit/workflow/test_step_executor_owner.py` — 16 cases, four scenarios across the four execution modes (`run`, `run` streaming, `arun`, `arun` streaming).
- `tests/unit/agent/test_continue_run_owner.py` — owner resolution for a resumed run, including "no owner anywhere stays unscoped".
- Additions to `tests/unit/agent/test_agent_knowledge_user_isolation.py` and `tests/unit/team/test_continue_run_requirements.py`.

**Cookbooks.** All 17 per-user isolation cookbooks under `cookbook/07_knowledge/04_advanced/07_per_user_isolation/` were run against real backends.

- `opensearch_db.py` and `valkey_db.py` gain an agent section, so all 17 now exercise agent-mediated retrieval as well as direct `Knowledge` calls. OpenSearch verified on `localhost:9200`; Valkey requires the `valkey/valkey-bundle` image, as plain `valkey/valkey` ships no search module (documented in the cookbook and the test log).
- `upstash_db.py` uses `await asyncio.sleep` inside its async `main()`.
- All 17 carry a non-vacuity guard, so a run in which the agent never searched cannot report success. On Valkey, which logs nothing during search, that guard is the only in-cookbook evidence a search occurred.
- The agent sections assert on `RunOutput.references` rather than on the model's prose, which keeps the isolation check deterministic.
- `cookbook/07_knowledge/TEST_LOG.md` entries for opensearch, valkey and upstash are written from captured run output.

**Known limits, marked in-code.** A resume that supplies only a run id and no owner cannot recover one in two places: `team/_run.py` `acontinue_run_dispatch` reads no session, and `agent/_run.py` `acontinue_run_dispatch` on an async DB reads its session after the owner is needed. Closing either means relocating the session read inside a large dispatcher. Neither is reachable over HTTP: the agent and team routes pass the owner, and the workflow routes pass the paused run.

**Security note.** None of these are authentication bypasses. `get_scoped_user_id` reads only `request.state.user_id`, which auth middleware sets from the token; nothing in a request body, query string or form reaches it.

**Scripts.** `./scripts/format.sh` is clean. `./scripts/validate.sh` reports ruff clean; the mypy errors it reports are all in files this PR does not touch — verified by intersecting the mypy error file list with this PR's changed file list, which is empty.