### PR TITLE
[fix] gate workflow continue on required admin approvals

### DIFF
--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -521,15 +521,19 @@ async def handle_workflow_continue_via_websocket(
             return
 
         # Mirror HTTP continue: nested executor approvals must be resolved first.
-        # WebSocketAuthContext has no scopes list; admins bypass via is_admin.
+        # Scope the scan to *currently paused* executors so a historical pending
+        # approval on an earlier executor does not block the active resume. Admins
+        # bypass via is_admin (WebSocketAuthContext has no granular scope list).
         if ws_auth is not None and not ws_auth.is_admin:
             for executor_run in getattr(existing_run, "step_executor_runs", None) or []:
+                if not getattr(executor_run, "is_paused", False):
+                    continue
                 executor_run_id = getattr(executor_run, "run_id", None)
                 reason = await run_continuation_blocked_reason(
                     os.db,
                     executor_run_id,
                     authorization_enabled=bool(ws_auth.jwt_enabled),
-                    user_scopes=[],
+                    user_scopes=["approvals:write"] if ws_auth.is_admin else [],
                 )
                 if reason:
                     await websocket.send_text(json.dumps({"event": "error", "error": reason}))
@@ -1437,7 +1441,11 @@ def get_workflow_router(
         # Approvals are stored under nested executor run_ids, not the workflow run_id.
         # require_approval_resolved above covers the workflow id; also block when any
         # paused executor still has a pending approval_type='required' record.
+        # Scan only currently paused executors so a historical pending approval does
+        # not block a later, already-resolved pause.
         for executor_run in getattr(existing_run, "step_executor_runs", None) or []:
+            if not getattr(executor_run, "is_paused", False):
+                continue
             executor_run_id = getattr(executor_run, "run_id", None)
             reason = await run_continuation_blocked_reason(
                 os.db,

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -23,7 +23,9 @@ from agno.factory import FactoryContextRequired
 from agno.os.auth import (
     get_auth_token_from_request,
     get_authentication_dependency,
+    require_approval_resolved,
     require_resource_access,
+    run_continuation_blocked_reason,
 )
 from agno.os.managers import event_buffer, websocket_manager
 from agno.os.middleware.user_scope import (
@@ -517,6 +519,21 @@ async def handle_workflow_continue_via_websocket(
                 )
             )
             return
+
+        # Mirror HTTP continue: nested executor approvals must be resolved first.
+        # WebSocketAuthContext has no scopes list; admins bypass via is_admin.
+        if ws_auth is not None and not ws_auth.is_admin:
+            for executor_run in getattr(existing_run, "step_executor_runs", None) or []:
+                executor_run_id = getattr(executor_run, "run_id", None)
+                reason = await run_continuation_blocked_reason(
+                    os.db,
+                    executor_run_id,
+                    authorization_enabled=bool(ws_auth.jwt_enabled),
+                    user_scopes=[],
+                )
+                if reason:
+                    await websocket.send_text(json.dumps({"event": "error", "error": reason}))
+                    return
 
         # Apply step requirements if provided
         if step_requirements_data:
@@ -1331,11 +1348,15 @@ def get_workflow_router(
             },
             400: {"description": "Invalid JSON in requirements field", "model": BadRequestResponse},
             404: {"description": "Workflow not found", "model": NotFoundResponse},
+            403: {"description": "Run has a pending admin approval and cannot be continued by the user yet."},
             409: {
                 "description": "Run is not paused. Only PAUSED runs can be continued.",
             },
         },
-        dependencies=[Depends(require_resource_access("workflows", "run", "workflow_id"))],
+        dependencies=[
+            Depends(require_resource_access("workflows", "run", "workflow_id")),
+            Depends(require_approval_resolved(os.db)),
+        ],
     )
     async def continue_workflow_run(
         workflow_id: str,
@@ -1413,6 +1434,20 @@ def get_workflow_router(
             )
             raise HTTPException(status_code=409, detail=detail)
 
+        # Approvals are stored under nested executor run_ids, not the workflow run_id.
+        # require_approval_resolved above covers the workflow id; also block when any
+        # paused executor still has a pending approval_type='required' record.
+        for executor_run in getattr(existing_run, "step_executor_runs", None) or []:
+            executor_run_id = getattr(executor_run, "run_id", None)
+            reason = await run_continuation_blocked_reason(
+                os.db,
+                executor_run_id,
+                authorization_enabled=getattr(request.state, "authorization_enabled", False),
+                user_scopes=getattr(request.state, "scopes", []) or [],
+            )
+            if reason:
+                raise HTTPException(status_code=403, detail=reason)
+
         # Convert step requirements dicts to StepRequirement objects
         from agno.workflow.types import StepRequirement
 
@@ -1455,6 +1490,11 @@ def get_workflow_router(
                 return run_response.to_dict()
             except InputCheckError as e:
                 raise HTTPException(status_code=400, detail=str(e))
+            except RuntimeError as e:
+                # Pending / missing admin approval from executor continue path.
+                if "approval" in str(e).lower():
+                    raise HTTPException(status_code=403, detail=str(e))
+                raise HTTPException(status_code=500, detail=f"Error continuing workflow run: {str(e)}")
             except Exception as e:
                 raise HTTPException(status_code=500, detail=f"Error continuing workflow run: {str(e)}")
 

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -295,6 +295,34 @@ def _apply_requirements_to_run_response(run_response: Any, requirements: list) -
         run_response.tools = updated_tools
 
 
+
+def _ensure_executor_approval_resolved(executor: Any, paused_run_response: Any, executor_run_id: Optional[str]) -> None:
+    """Block workflow continuation while a required admin approval is still pending.
+
+    Must run *before* ``_apply_requirements_to_run_response``: clients can submit
+    ``confirmed=true`` HITL payloads that would otherwise resume the executor
+    without an admin approval record being resolved.
+    """
+    from agno.run.approval import check_and_apply_approval_resolution
+
+    rid = executor_run_id or getattr(paused_run_response, "run_id", None)
+    if not rid:
+        return
+    check_and_apply_approval_resolution(getattr(executor, "db", None), rid, paused_run_response)
+
+
+async def _aensure_executor_approval_resolved(
+    executor: Any, paused_run_response: Any, executor_run_id: Optional[str]
+) -> None:
+    """Async variant of ``_ensure_executor_approval_resolved``."""
+    from agno.run.approval import acheck_and_apply_approval_resolution
+
+    rid = executor_run_id or getattr(paused_run_response, "run_id", None)
+    if not rid:
+        return
+    await acheck_and_apply_approval_resolution(getattr(executor, "db", None), rid, paused_run_response)
+
+
 def _create_skipped_step_output(
     step_name: str,
     step_id: str,
@@ -6511,6 +6539,9 @@ class Workflow:
                 else:
                     requirements.append(req_data)
 
+        # Admin-required approvals must be resolved before client HITL payloads apply.
+        _ensure_executor_approval_resolved(executor, paused_run_response, step_req.executor_run_id)
+
         # Apply resolved requirements to the paused run_response (update tool states)
         _apply_requirements_to_run_response(paused_run_response, requirements)
 
@@ -6571,6 +6602,7 @@ class Workflow:
 
         # Find the paused executor run and apply resolved requirements
         paused_run_response = _find_paused_executor_run(workflow_run_response, step_req.executor_run_id)
+        _ensure_executor_approval_resolved(executor, paused_run_response, step_req.executor_run_id)
         _apply_requirements_to_run_response(paused_run_response, requirements)
 
         # Call executor's continue_run with the stored run_response (streaming).
@@ -6659,6 +6691,7 @@ class Workflow:
 
         # Find the paused executor run and apply resolved requirements
         paused_run_response = _find_paused_executor_run(workflow_run_response, step_req.executor_run_id)
+        await _aensure_executor_approval_resolved(executor, paused_run_response, step_req.executor_run_id)
         _apply_requirements_to_run_response(paused_run_response, requirements)
 
         # Call executor's acontinue_run with the stored run_response (streaming).
@@ -6743,6 +6776,7 @@ class Workflow:
 
         # Find the paused executor run and apply resolved requirements
         paused_run_response = _find_paused_executor_run(workflow_run_response, step_req.executor_run_id)
+        await _aensure_executor_approval_resolved(executor, paused_run_response, step_req.executor_run_id)
         _apply_requirements_to_run_response(paused_run_response, requirements)
 
         # Call executor's acontinue_run with the stored run_response

--- a/libs/agno/tests/integration/os/test_workflow_runs.py
+++ b/libs/agno/tests/integration/os/test_workflow_runs.py
@@ -494,3 +494,17 @@ async def test_aget_workflow_nonexistent_version_returns_404(versioned_workflow_
     async with httpx.AsyncClient(transport=ASGITransport(app=versioned_workflow_app), base_url="http://test") as client:
         response = await client.get("/workflows/versioned-wf", params={"version": 999})
         assert response.status_code == 404
+
+
+def test_continue_workflow_run_route_requires_approval_resolution_dependency(test_os_client):
+    """Workflow continue must share the agent/team admin-approval gate."""
+    from agno.os.utils import flatten_routes
+
+    route = next(
+        route
+        for route in flatten_routes(test_os_client.app.routes)
+        if getattr(route, "path", None) == "/workflows/{workflow_id}/runs/{run_id}/continue"
+    )
+
+    dependency_qualnames = [getattr(dep.call, "__qualname__", "") for dep in route.dependant.dependencies]
+    assert any("require_approval_resolved" in qualname for qualname in dependency_qualnames)

--- a/libs/agno/tests/unit/workflow/test_executor_approval_gate.py
+++ b/libs/agno/tests/unit/workflow/test_executor_approval_gate.py
@@ -1,0 +1,29 @@
+"""Workflow continue must honor @approval(type='required') before applying client HITL."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.workflow.workflow import _ensure_executor_approval_resolved
+
+
+def test_ensure_executor_approval_resolved_runs_before_client_can_confirm():
+    executor = SimpleNamespace(db=object())
+    paused = SimpleNamespace(run_id="executor-run-1", tools=[], requirements=[])
+
+    with patch(
+        "agno.run.approval.check_and_apply_approval_resolution",
+        side_effect=RuntimeError("Approval is still pending. Resolve the approval before continuing this run."),
+    ) as mock_check:
+        with pytest.raises(RuntimeError, match="still pending"):
+            _ensure_executor_approval_resolved(executor, paused, "executor-run-1")
+        mock_check.assert_called_once_with(executor.db, "executor-run-1", paused)
+
+
+def test_ensure_executor_approval_resolved_noops_without_run_id():
+    executor = SimpleNamespace(db=object())
+    paused = SimpleNamespace(run_id=None)
+    with patch("agno.run.approval.check_and_apply_approval_resolution") as mock_check:
+        _ensure_executor_approval_resolved(executor, paused, None)
+        mock_check.assert_not_called()


### PR DESCRIPTION
## Summary
- Workflow `POST /workflows/{id}/runs/{run_id}/continue` (and the WebSocket continue path) did not enforce `@approval(type='required')`, unlike agent/team continue.
- Nested executor continue applied client-supplied HITL `confirmed=true` payloads without calling `check_and_apply_approval_resolution`, which disarmed the executor-level gate.
- Fix: call the approval resolution gate on nested executor runs **before** applying client requirements; add `Depends(require_approval_resolved)` plus an executor-run_id scan on the HTTP route; mirror the scan on WebSocket continue; map approval `RuntimeError` to HTTP 403.

## Type of change
- [x] Bug fix

## Checklist
- [x] Self-review completed
- [x] Tests added/updated
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

### Duplicate and AI-Generated PR Check
- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] This PR was developed with AI assistance (Cursor). I reviewed the change, tip-verified the gap against `d28d580`, and added regression coverage for the route dependency and the executor approval helper.

## Test plan
- [ ] `tests/unit/workflow/test_executor_approval_gate.py` passes
- [ ] `test_continue_workflow_run_route_requires_approval_resolution_dependency` passes
- [ ] With authorization enabled: pause a workflow step on `@approval(type='required')`, then `POST .../continue` with `confirmed=true` as a non-admin → 403 until an admin resolves the approval
- [ ] Existing HITL continue suite in `test_workflow_continue.py` still passes (confirmation-only steps without admin approval)


Made with [Cursor](https://cursor.com)