### PR TITLE
[fix] Skip empty team content events

### DIFF
--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1397,7 +1397,7 @@ def _handle_model_response_chunk(
 
             should_yield = False
             # Process content
-            if model_response_event.content:
+            if model_response_event.content is not None and model_response_event.content != "":
                 if parse_structured_output:
                     full_model_response.content = model_response_event.content
                     _convert_response_to_structured_format(team, full_model_response, run_context=run_context)

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1396,9 +1396,9 @@ def _handle_model_response_chunk(
             content_type = "str"
 
             should_yield = False
-            # Process content. Empty values are provider stop/metadata chunks.
+            # Process content. Empty strings are provider stop/metadata chunks.
             content = model_response_event.content
-            if content:
+            if content is not None and content != "":
                 if parse_structured_output:
                     full_model_response.content = content
                     _convert_response_to_structured_format(team, full_model_response, run_context=run_context)
@@ -1415,8 +1415,8 @@ def _handle_model_response_chunk(
                         else team._member_response_model.__name__
                     )  # type: ignore
                     run_response.content_type = content_type
-                elif isinstance(model_response_event.content, str):
-                    full_model_response.content = (full_model_response.content or "") + model_response_event.content
+                elif isinstance(content, str):
+                    full_model_response.content = (full_model_response.content or "") + content
                     run_response.content = full_model_response.content
                 should_yield = True
 

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1396,10 +1396,9 @@ def _handle_model_response_chunk(
             content_type = "str"
 
             should_yield = False
-            # Process content. Empty strings are provider stop/metadata chunks,
-            # but other falsy values can be valid structured responses.
+            # Process content. Empty values are provider stop/metadata chunks.
             content = model_response_event.content
-            if content is not None and content != "":
+            if content:
                 if parse_structured_output:
                     full_model_response.content = content
                     _convert_response_to_structured_format(team, full_model_response, run_context=run_context)

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1397,7 +1397,7 @@ def _handle_model_response_chunk(
 
             should_yield = False
             # Process content
-            if model_response_event.content is not None and model_response_event.content != "":
+            if model_response_event.content:
                 if parse_structured_output:
                     full_model_response.content = model_response_event.content
                     _convert_response_to_structured_format(team, full_model_response, run_context=run_context)

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1396,17 +1396,19 @@ def _handle_model_response_chunk(
             content_type = "str"
 
             should_yield = False
-            # Process content
-            if model_response_event.content:
+            # Process content. Empty strings are provider stop/metadata chunks,
+            # but other falsy values can be valid structured responses.
+            content = model_response_event.content
+            if content is not None and content != "":
                 if parse_structured_output:
-                    full_model_response.content = model_response_event.content
+                    full_model_response.content = content
                     _convert_response_to_structured_format(team, full_model_response, run_context=run_context)
                     # Get output_schema from run_context
                     output_schema = run_context.output_schema if run_context else None
                     content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__  # type: ignore
                     run_response.content_type = content_type
                 elif team._member_response_model is not None:
-                    full_model_response.content = model_response_event.content
+                    full_model_response.content = content
                     _convert_response_to_structured_format(team, full_model_response, run_context=run_context)
                     content_type = (
                         "dict"

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1397,7 +1397,7 @@ def _handle_model_response_chunk(
 
             should_yield = False
             # Process content
-            if model_response_event.content is not None:
+            if model_response_event.content:
                 if parse_structured_output:
                     full_model_response.content = model_response_event.content
                     _convert_response_to_structured_format(team, full_model_response, run_context=run_context)

--- a/libs/agno/tests/unit/team/test_empty_content_events.py
+++ b/libs/agno/tests/unit/team/test_empty_content_events.py
@@ -1,4 +1,5 @@
 from agno.agent import Agent
+from agno.models.message import Citations
 from agno.models.response import ModelResponse, ModelResponseEvent
 from agno.run.team import TeamRunEvent, TeamRunOutput
 from agno.session import TeamSession
@@ -43,3 +44,31 @@ def test_team_stream_skips_empty_model_content_and_preserves_accumulated_content
     assert empty_events == []
     assert full_model_response.content == "Hello"
     assert run_response.content == "Hello"
+
+
+def test_team_stream_preserves_metadata_on_empty_model_content():
+    team = Team(members=[Agent(name="Agent1")])
+    session = TeamSession(session_id="session_1")
+    run_response = TeamRunOutput(run_id="run_1", team_id="team_1", team_name="Team")
+    full_model_response = ModelResponse()
+    citations = Citations(raw={"source": "provider"})
+    provider_data = {"response_id": "response-1"}
+
+    events = list(
+        team._handle_model_response_chunk(
+            session=session,
+            run_response=run_response,
+            full_model_response=full_model_response,
+            model_response_event=ModelResponse(
+                event=ModelResponseEvent.assistant_response.value,
+                content="",
+                citations=citations,
+                provider_data=provider_data,
+            ),
+            stream_events=True,
+        )
+    )
+
+    assert events == []
+    assert run_response.citations == citations
+    assert run_response.model_provider_data == provider_data

--- a/libs/agno/tests/unit/team/test_empty_content_events.py
+++ b/libs/agno/tests/unit/team/test_empty_content_events.py
@@ -1,0 +1,45 @@
+from agno.agent import Agent
+from agno.models.response import ModelResponse, ModelResponseEvent
+from agno.run.team import TeamRunEvent, TeamRunOutput
+from agno.session import TeamSession
+from agno.team import Team
+
+
+def test_team_stream_skips_empty_model_content_and_preserves_accumulated_content():
+    team = Team(members=[Agent(name="Agent1")])
+    session = TeamSession(session_id="session_1")
+    run_response = TeamRunOutput(run_id="run_1", team_id="team_1", team_name="Team")
+    full_model_response = ModelResponse()
+
+    first_events = list(
+        team._handle_model_response_chunk(
+            session=session,
+            run_response=run_response,
+            full_model_response=full_model_response,
+            model_response_event=ModelResponse(
+                event=ModelResponseEvent.assistant_response.value,
+                content="Hello",
+            ),
+            stream_events=True,
+        )
+    )
+
+    empty_events = list(
+        team._handle_model_response_chunk(
+            session=session,
+            run_response=run_response,
+            full_model_response=full_model_response,
+            model_response_event=ModelResponse(
+                event=ModelResponseEvent.assistant_response.value,
+                content="",
+            ),
+            stream_events=True,
+        )
+    )
+
+    assert len(first_events) == 1
+    assert first_events[0].event == TeamRunEvent.run_content.value
+    assert first_events[0].content == "Hello"
+    assert empty_events == []
+    assert full_model_response.content == "Hello"
+    assert run_response.content == "Hello"

--- a/libs/agno/tests/unit/team/test_empty_content_events.py
+++ b/libs/agno/tests/unit/team/test_empty_content_events.py
@@ -95,8 +95,8 @@ def test_team_stream_preserves_metadata_on_empty_model_content():
     assert run_response.model_provider_data == provider_data
 
 
-@pytest.mark.parametrize("empty_content", [False, 0, [], {}])
-def test_team_stream_skips_other_empty_model_content(empty_content):
+@pytest.mark.parametrize("falsy_content", [False, 0, [], {}])
+def test_team_stream_preserves_other_falsy_model_content(falsy_content):
     team = Team(members=[Agent(name="Agent1")])
     session = TeamSession(session_id="session_1")
     run_response = TeamRunOutput(run_id="run_1", team_id="team_1", team_name="Team")
@@ -109,12 +109,14 @@ def test_team_stream_skips_other_empty_model_content(empty_content):
             full_model_response=full_model_response,
             model_response_event=ModelResponse(
                 event=ModelResponseEvent.assistant_response.value,
-                content=empty_content,
+                content=falsy_content,
             ),
             stream_events=True,
         )
     )
 
-    assert events == []
+    assert len(events) == 1
+    assert events[0].event == TeamRunEvent.run_content.value
+    assert events[0].content == falsy_content
     assert full_model_response.content is None
     assert run_response.content is None

--- a/libs/agno/tests/unit/team/test_empty_content_events.py
+++ b/libs/agno/tests/unit/team/test_empty_content_events.py
@@ -1,3 +1,5 @@
+import pytest
+
 from agno.agent import Agent
 from agno.models.message import Citations
 from agno.models.response import ModelResponse, ModelResponseEvent
@@ -45,6 +47,25 @@ def test_team_stream_skips_empty_model_content_and_preserves_accumulated_content
     assert full_model_response.content == "Hello"
     assert run_response.content == "Hello"
 
+    followup_events = list(
+        team._handle_model_response_chunk(
+            session=session,
+            run_response=run_response,
+            full_model_response=full_model_response,
+            model_response_event=ModelResponse(
+                event=ModelResponseEvent.assistant_response.value,
+                content=" world",
+            ),
+            stream_events=True,
+        )
+    )
+
+    assert len(followup_events) == 1
+    assert followup_events[0].event == TeamRunEvent.run_content.value
+    assert followup_events[0].content == " world"
+    assert full_model_response.content == "Hello world"
+    assert run_response.content == "Hello world"
+
 
 def test_team_stream_preserves_metadata_on_empty_model_content():
     team = Team(members=[Agent(name="Agent1")])
@@ -72,3 +93,28 @@ def test_team_stream_preserves_metadata_on_empty_model_content():
     assert events == []
     assert run_response.citations == citations
     assert run_response.model_provider_data == provider_data
+
+
+@pytest.mark.parametrize("empty_content", [False, 0, [], {}])
+def test_team_stream_skips_other_falsy_model_content(empty_content):
+    team = Team(members=[Agent(name="Agent1")])
+    session = TeamSession(session_id="session_1")
+    run_response = TeamRunOutput(run_id="run_1", team_id="team_1", team_name="Team")
+    full_model_response = ModelResponse()
+
+    events = list(
+        team._handle_model_response_chunk(
+            session=session,
+            run_response=run_response,
+            full_model_response=full_model_response,
+            model_response_event=ModelResponse(
+                event=ModelResponseEvent.assistant_response.value,
+                content=empty_content,
+            ),
+            stream_events=True,
+        )
+    )
+
+    assert events == []
+    assert full_model_response.content is None
+    assert run_response.content is None

--- a/libs/agno/tests/unit/team/test_empty_content_events.py
+++ b/libs/agno/tests/unit/team/test_empty_content_events.py
@@ -95,8 +95,8 @@ def test_team_stream_preserves_metadata_on_empty_model_content():
     assert run_response.model_provider_data == provider_data
 
 
-@pytest.mark.parametrize("falsy_content", [False, 0, [], {}])
-def test_team_stream_preserves_other_falsy_model_content(falsy_content):
+@pytest.mark.parametrize("empty_content", [False, 0, [], {}])
+def test_team_stream_skips_other_empty_model_content(empty_content):
     team = Team(members=[Agent(name="Agent1")])
     session = TeamSession(session_id="session_1")
     run_response = TeamRunOutput(run_id="run_1", team_id="team_1", team_name="Team")
@@ -109,14 +109,12 @@ def test_team_stream_preserves_other_falsy_model_content(falsy_content):
             full_model_response=full_model_response,
             model_response_event=ModelResponse(
                 event=ModelResponseEvent.assistant_response.value,
-                content=falsy_content,
+                content=empty_content,
             ),
             stream_events=True,
         )
     )
 
-    assert len(events) == 1
-    assert events[0].event == TeamRunEvent.run_content.value
-    assert events[0].content == falsy_content
+    assert events == []
     assert full_model_response.content is None
     assert run_response.content is None

--- a/libs/agno/tests/unit/team/test_empty_content_events.py
+++ b/libs/agno/tests/unit/team/test_empty_content_events.py
@@ -95,8 +95,8 @@ def test_team_stream_preserves_metadata_on_empty_model_content():
     assert run_response.model_provider_data == provider_data
 
 
-@pytest.mark.parametrize("empty_content", [False, 0, [], {}])
-def test_team_stream_skips_other_falsy_model_content(empty_content):
+@pytest.mark.parametrize("falsy_content", [False, 0, [], {}])
+def test_team_stream_preserves_other_falsy_model_content(falsy_content):
     team = Team(members=[Agent(name="Agent1")])
     session = TeamSession(session_id="session_1")
     run_response = TeamRunOutput(run_id="run_1", team_id="team_1", team_name="Team")
@@ -109,12 +109,14 @@ def test_team_stream_skips_other_falsy_model_content(empty_content):
             full_model_response=full_model_response,
             model_response_event=ModelResponse(
                 event=ModelResponseEvent.assistant_response.value,
-                content=empty_content,
+                content=falsy_content,
             ),
             stream_events=True,
         )
     )
 
-    assert events == []
+    assert len(events) == 1
+    assert events[0].event == TeamRunEvent.run_content.value
+    assert events[0].content == falsy_content
     assert full_model_response.content is None
     assert run_response.content is None


### PR DESCRIPTION
## Summary

Fixes #9491 by suppressing team content events for empty model-response chunks.

Anthropic stop/metadata chunks can carry an empty string so citations and provider metadata can pass through without duplicating streamed text. The team response handler now skips only empty string content while continuing to pass metadata, citations, and other non-None content values through the existing handling path.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (./scripts/format.sh and ./scripts/validate.sh) - targeted Ruff and mypy checks passed; repository-wide validation remains blocked by unrelated dependency/API typing errors outside the changed files
- [x] Self-review completed
- [x] Documentation updated (not applicable; no public API change)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] This PR was created with AI assistance (Codex); I reviewed and understand the changes, and the patch is intentionally limited to the reported behavior.

---

## Additional Notes

Targeted validation in an isolated Python environment:

- python -m pytest libs/agno/tests/unit/team/test_empty_content_events.py libs/agno/tests/unit/team/test_team_paused_content.py -q - **20 passed**
- ruff check libs/agno/agno/team/_response.py libs/agno/tests/unit/team/test_empty_content_events.py - passed
- ruff format --check libs/agno/agno/team/_response.py libs/agno/tests/unit/team/test_empty_content_events.py - passed
- Targeted mypy for libs/agno/agno/team/_response.py with the repository configuration and --follow-imports=skip - passed
- Python bytecode compilation for the changed source and test files - passed
- git diff --check - passed

Repository-wide checks were attempted in the Windows environment. The repository-wide unit entrypoint collected 9,340 tests but reported 83 collection errors and unrelated platform/provider failures. The repository-wide mypy run reported 59 errors in unrelated AWS, Google, Anthropic, Mistral, and other dependency-backed modules; no changed file was among those errors.