### PR TITLE
[fix] Ignore empty tool call stream chunks

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1969,7 +1969,7 @@ class Model(ABC):
                     stream_data.response_provider_data[key] = value
 
         # Update stream_data tool calls
-        if model_response_delta.tool_calls is not None:
+        if model_response_delta.tool_calls:
             if stream_data.response_tool_calls is None:
                 stream_data.response_tool_calls = []
             stream_data.response_tool_calls.extend(model_response_delta.tool_calls)

--- a/libs/agno/tests/unit/models/test_stream_data.py
+++ b/libs/agno/tests/unit/models/test_stream_data.py
@@ -1,0 +1,51 @@
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from agno.models.base import MessageData, Model
+from agno.models.response import ModelResponse
+
+
+class _StreamDataModel(Model):
+    def __init__(self) -> None:
+        super().__init__(id="stream-data-test", provider="test")
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        raise NotImplementedError
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        raise NotImplementedError
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        raise NotImplementedError
+        yield  # pragma: no cover
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        raise NotImplementedError
+        yield  # pragma: no cover
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        raise NotImplementedError
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        raise NotImplementedError
+
+
+def test_empty_tool_calls_do_not_yield_a_stream_delta() -> None:
+    model = _StreamDataModel()
+    stream_data = MessageData()
+
+    deltas = list(model._populate_stream_data(stream_data, ModelResponse()))
+
+    assert deltas == []
+    assert stream_data.response_tool_calls == []
+
+
+def test_non_empty_tool_calls_yield_and_accumulate() -> None:
+    model = _StreamDataModel()
+    stream_data = MessageData()
+    response_delta = ModelResponse(tool_calls=[{"id": "call_1", "function": {"name": "search"}}])
+
+    deltas = list(model._populate_stream_data(stream_data, response_delta))
+
+    assert deltas == [response_delta]
+    assert stream_data.response_tool_calls == response_delta.tool_calls


### PR DESCRIPTION
## Summary\n\nFixes #9490 by ignoring empty tool-call lists when deciding whether to yield a streaming model response delta.\n\nModelResponse.tool_calls defaults to an empty list, so checking only for None caused metadata-only chunks to be emitted as empty stream events. Non-empty tool calls are still accumulated and yielded as before.\n\n## Type of change\n\n- [x] Bug fix\n- [ ] New feature\n- [ ] Breaking change\n- [ ] Improvement\n- [ ] Model update\n- [ ] Other:\n\n---\n\n## Checklist\n\n- [x] Code complies with style guidelines\n- [x] Ran the repository format and validation scripts\n- [x] Self-review completed for this task\n- [x] Documentation updated (not applicable; no public API change)\n- [ ] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)\n- [x] Tested in clean environment\n- [x] Tests added/updated\n\n### Duplicate and AI-Generated PR Check\n\n- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue\n- [ ] If a similar PR exists, I have explained below why this PR is a better approach\n- [x] This PR was created with AI assistance (Codex). The implementation was reviewed and validated as part of this task; the account owner should review the changes before merge.\n\n---\n\n## Validation\n\n- pytest tests/unit/models/test_stream_data.py tests/unit/models/test_response.py -q — 12 passed\n- ./scripts/format.sh — passed\n- ./scripts/validate.sh — passed, including mypy for 955 Agno source files\n