### PR TITLE
fix: inline continue terminal sync survives client disconnect

### DIFF
--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - "*release*" # Run on release-* format
       - "release/*" # Run on release/1.2.3 branch format
-      - "claude/agentos-request-queue-621b2a"
       - "feat/v3.0"
   workflow_dispatch: # Allows manual triggering
     inputs:

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -286,8 +286,23 @@ async def agent_continue_response_streamer(
                 # Stream close + paused-ticket settle as one cancellation-
                 # proof unit: a client disconnect cancels this generator,
                 # and an interrupted finalizer abandoned the stream view as
-                # RUNNING with no producer and left the ticket paused
-                await afinalize_continue_stream(agent, run_id, session_id, queue_worker=queue_worker)
+                # RUNNING with no producer and left the ticket paused.
+                # Under cancellation the final status is KNOWN (the core
+                # cancels the inline run and persists cancelled from its own
+                # detached task) - passing it avoids racing that persist
+                # with a fresh session read, which could stamp a stale
+                # paused/running row's status onto the stream and ticket.
+                import sys
+
+                _exc = sys.exc_info()[0]
+                _cancelled = _exc is not None and issubclass(_exc, (asyncio.CancelledError, GeneratorExit))
+                await afinalize_continue_stream(
+                    agent,
+                    run_id,
+                    session_id,
+                    queue_worker=queue_worker,
+                    final_status=RunStatus.cancelled if _cancelled else None,
+                )
     except (InputCheckError, OutputCheckError) as e:
         error_response = RunErrorEvent(
             content=str(e),

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -38,7 +38,6 @@ from agno.os.job_queue import (
     acontinue_via_queue,
     aprepare_accepted_or_abort,
     araise_if_ticket_owns_continue,
-    asettle_paused_ticket,
     aticket_poll_fallback,
     normalize_idempotency_key,
     payload_is_queueable,
@@ -62,7 +61,7 @@ from agno.os.schema import (
 )
 from agno.os.settings import AgnoAPISettings
 from agno.os.utils import (
-    acomplete_continue_stream,
+    afinalize_continue_stream,
     amark_continue_stream_running,
     classify_upload_file,
     find_factory_by_id,
@@ -284,13 +283,11 @@ async def agent_continue_response_streamer(
                 yield format_sse_event(run_response_chunk)  # type: ignore
         finally:
             if _sync_stream:
-                _final = await acomplete_continue_stream(agent, run_id, session_id)
-                # Inline continue of a DURABLE paused run: terminalize the
-                # queue ticket too (paused tickets are retention-exempt and
-                # would otherwise say paused forever). CAS no-op for runs
-                # that never rode the queue or whose continuation is owned
-                # by a worker.
-                await asettle_paused_ticket(queue_worker, run_id, _final)
+                # Stream close + paused-ticket settle as one cancellation-
+                # proof unit: a client disconnect cancels this generator,
+                # and an interrupted finalizer abandoned the stream view as
+                # RUNNING with no producer and left the ticket paused
+                await afinalize_continue_stream(agent, run_id, session_id, queue_worker=queue_worker)
     except (InputCheckError, OutputCheckError) as e:
         error_response = RunErrorEvent(
             content=str(e),
@@ -1520,20 +1517,15 @@ def get_agent_router(
                 # runs alone. Skipped for remote agents and fork/regenerate
                 # (they mint a NEW run_id).
                 if not isinstance(agent, RemoteAgent) and not fork and not regenerate:
-                    await acomplete_continue_stream(
+                    # Stream close + paused-ticket settle as one
+                    # cancellation-proof unit (see the streaming twin)
+                    await afinalize_continue_stream(
                         agent,
                         run_id,
                         session_id,
+                        queue_worker=getattr(request.app.state, "queue_worker", None),
                         only_if_tracked=True,
                         final_status=getattr(run_response_obj, "status", None),
-                    )
-                    # Inline continue of a DURABLE paused run: terminalize
-                    # the queue ticket too (paused is retention-exempt; the
-                    # CAS no-ops for never-queued or worker-owned runs)
-                    await asettle_paused_ticket(
-                        getattr(request.app.state, "queue_worker", None),
-                        run_id,
-                        getattr(run_response_obj, "status", None),
                     )
                 return run_response_obj.to_dict()
 

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -446,8 +446,19 @@ async def team_continue_response_streamer(
         finally:
             if _sync_stream:
                 # Stream close + paused-ticket settle as one cancellation-
-                # proof unit (see the agents twin for the disconnect hazard)
-                await afinalize_continue_stream(team, run_id, session_id, queue_worker=queue_worker)
+                # proof unit; under cancellation the final status is KNOWN -
+                # see the agents twin for both hazards
+                import sys
+
+                _exc = sys.exc_info()[0]
+                _cancelled = _exc is not None and issubclass(_exc, (asyncio.CancelledError, GeneratorExit))
+                await afinalize_continue_stream(
+                    team,
+                    run_id,
+                    session_id,
+                    queue_worker=queue_worker,
+                    final_status=RunStatus.cancelled if _cancelled else None,
+                )
     except (InputCheckError, OutputCheckError) as e:
         error_response = TeamRunErrorEvent(
             content=str(e),

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -34,7 +34,6 @@ from agno.os.job_queue import (
     acontinue_via_queue,
     aprepare_accepted_or_abort,
     araise_if_ticket_owns_continue,
-    asettle_paused_ticket,
     aticket_poll_fallback,
     normalize_idempotency_key,
     payload_is_queueable,
@@ -58,7 +57,7 @@ from agno.os.schema import (
 )
 from agno.os.settings import AgnoAPISettings
 from agno.os.utils import (
-    acomplete_continue_stream,
+    afinalize_continue_stream,
     amark_continue_stream_running,
     classify_upload_file,
     find_factory_by_id,
@@ -446,13 +445,9 @@ async def team_continue_response_streamer(
                 yield format_sse_event(run_response_chunk)  # type: ignore
         finally:
             if _sync_stream:
-                _final = await acomplete_continue_stream(team, run_id, session_id)
-                # Inline continue of a DURABLE paused run: terminalize the
-                # queue ticket too (paused tickets are retention-exempt and
-                # would otherwise say paused forever). CAS no-op for runs
-                # that never rode the queue or whose continuation is owned
-                # by a worker.
-                await asettle_paused_ticket(queue_worker, run_id, _final)
+                # Stream close + paused-ticket settle as one cancellation-
+                # proof unit (see the agents twin for the disconnect hazard)
+                await afinalize_continue_stream(team, run_id, session_id, queue_worker=queue_worker)
     except (InputCheckError, OutputCheckError) as e:
         error_response = TeamRunErrorEvent(
             content=str(e),
@@ -1486,20 +1481,15 @@ def get_team_router(
                 # runs alone. Skipped for remote teams and fork/regenerate
                 # (they mint a NEW run_id).
                 if not isinstance(team, RemoteTeam) and not fork and not regenerate:
-                    await acomplete_continue_stream(
+                    # Stream close + paused-ticket settle as one
+                    # cancellation-proof unit (see the streaming twin)
+                    await afinalize_continue_stream(
                         team,
                         run_id,
                         session_id,
+                        queue_worker=getattr(request.app.state, "queue_worker", None),
                         only_if_tracked=True,
                         final_status=getattr(run_response_obj, "status", None),
-                    )
-                    # Inline continue of a DURABLE paused run: terminalize
-                    # the queue ticket too (paused is retention-exempt; the
-                    # CAS no-ops for never-queued or worker-owned runs)
-                    await asettle_paused_ticket(
-                        getattr(request.app.state, "queue_worker", None),
-                        run_id,
-                        getattr(run_response_obj, "status", None),
                     )
                 return run_response_obj.to_dict()
 

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1035,9 +1035,20 @@ async def workflow_continue_response_streamer(
                 yield format_sse_event(run_response_chunk)  # type: ignore
         finally:
             # Stream close + paused-ticket settle as one cancellation-proof
-            # unit (see the agents twin for the disconnect hazard). Final
-            # status resolves from THIS run's row, never session.runs[-1]
-            await afinalize_continue_stream(workflow, run_id, session_id, queue_worker=queue_worker)
+            # unit; under cancellation the final status is KNOWN - see the
+            # agents twin for both hazards. Otherwise it resolves from THIS
+            # run's row, never session.runs[-1]
+            import sys
+
+            _exc = sys.exc_info()[0]
+            _cancelled = _exc is not None and issubclass(_exc, (asyncio.CancelledError, GeneratorExit))
+            await afinalize_continue_stream(
+                workflow,
+                run_id,
+                session_id,
+                queue_worker=queue_worker,
+                final_status=RunStatus.cancelled if _cancelled else None,
+            )
 
         # If the workflow re-paused, yield WorkflowPausedEvent as the new clean
         # snapshot event. Also yield the legacy "WorkflowRunOutput" event for

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -33,7 +33,6 @@ from agno.os.job_queue import (
     acontinue_via_queue,
     aprepare_accepted_or_abort,
     araise_if_ticket_owns_continue,
-    asettle_paused_ticket,
     aticket_poll_fallback,
     normalize_idempotency_key,
     payload_is_queueable,
@@ -60,7 +59,7 @@ from agno.os.schema import (
 )
 from agno.os.settings import AgnoAPISettings
 from agno.os.utils import (
-    acomplete_continue_stream,
+    afinalize_continue_stream,
     amark_continue_stream_running,
     find_factory_by_id,
     format_sse_event,
@@ -1035,14 +1034,10 @@ async def workflow_continue_response_streamer(
                     await workflow._apublish_stream_event(run_response_chunk, run_id)
                 yield format_sse_event(run_response_chunk)  # type: ignore
         finally:
-            # Final status from THIS run's row (never session.runs[-1]: an
-            # interleaved run on the same session would be a different run)
-            _final = await acomplete_continue_stream(workflow, run_id, session_id)
-            # Inline continue of a DURABLE paused run: terminalize the queue
-            # ticket too (paused tickets are retention-exempt and would
-            # otherwise say paused forever). CAS no-op for runs that never
-            # rode the queue or whose continuation is owned by a worker.
-            await asettle_paused_ticket(queue_worker, run_id, _final)
+            # Stream close + paused-ticket settle as one cancellation-proof
+            # unit (see the agents twin for the disconnect hazard). Final
+            # status resolves from THIS run's row, never session.runs[-1]
+            await afinalize_continue_stream(workflow, run_id, session_id, queue_worker=queue_worker)
 
         # If the workflow re-paused, yield WorkflowPausedEvent as the new clean
         # snapshot event. Also yield the legacy "WorkflowRunOutput" event for
@@ -2011,20 +2006,15 @@ def get_workflow_router(
                 # streamed run's stream view must stop saying PAUSED once the
                 # continue settles - only_if_tracked leaves never-streamed
                 # runs alone.
-                await acomplete_continue_stream(
+                # Stream close + paused-ticket settle as one
+                # cancellation-proof unit (see the streaming twin)
+                await afinalize_continue_stream(
                     workflow,
                     run_id,
                     session_id,
+                    queue_worker=getattr(request.app.state, "queue_worker", None),
                     only_if_tracked=True,
                     final_status=getattr(run_response, "status", None),
-                )
-                # Inline continue of a DURABLE paused run: terminalize the
-                # queue ticket too (paused is retention-exempt; the CAS
-                # no-ops for never-queued or worker-owned runs)
-                await asettle_paused_ticket(
-                    getattr(request.app.state, "queue_worker", None),
-                    run_id,
-                    getattr(run_response, "status", None),
                 )
                 return run_response.to_dict()
             except InputCheckError as e:

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -527,6 +527,51 @@ async def acomplete_continue_stream(
     return final_status
 
 
+async def afinalize_continue_stream(
+    component: Any,
+    run_id: str,
+    session_id: Optional[str],
+    queue_worker: Any = None,
+    only_if_tracked: bool = False,
+    final_status: Any = None,
+) -> Optional[Any]:
+    """The inline continue's terminal-sync obligation as ONE unit that
+    survives client-disconnect cancellation: resolve the run's final status,
+    close the stream view (acomplete_continue_stream), settle a paused
+    ticket (asettle_paused_ticket).
+
+    A disconnecting client cancels the response task, and the first
+    unshielded await in this sequence used to leak that cancellation
+    (contextlib.suppress(Exception) does not catch CancelledError) -
+    abandoning the stream view as RUNNING with no producer (immortal on
+    Redis, whose TTL refresher had enrolled the run, so /resume tails spun
+    on keepalives forever) and skipping the ticket settle entirely. The
+    obligation now runs in its OWN task: the caller's cancellation
+    re-raises here, but the task completes on the loop regardless.
+    """
+    import asyncio
+
+    async def _obligation() -> Optional[Any]:
+        final = await acomplete_continue_stream(
+            component, run_id, session_id, only_if_tracked=only_if_tracked, final_status=final_status
+        )
+        if queue_worker is not None:
+            from agno.os.job_queue import asettle_paused_ticket
+
+            await asettle_paused_ticket(queue_worker, run_id, final)
+        return final
+
+    task = asyncio.ensure_future(_obligation())
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        # The obligation finishes in the background; retrieve its eventual
+        # result so it never warns, and let the cancellation propagate so
+        # the response task still ends as cancelled
+        task.add_done_callback(lambda t: t.cancelled() or t.exception())
+        raise
+
+
 def replayed_payload_to_sse(payload: Any, event_index: int, run_id: str) -> str:
     """Convert an event-stream replay payload to an SSE string.
 

--- a/libs/agno/tests/unit/os/test_continue_disconnect_finalize.py
+++ b/libs/agno/tests/unit/os/test_continue_disconnect_finalize.py
@@ -9,7 +9,9 @@ so both were skipped: the stream view stayed RUNNING with no producer
 (immortal on Redis, whose TTL refresher had enrolled the run - /resume
 tails heartbeat forever) and the retention-exempt paused ticket said paused
 forever. The obligation now runs as one shielded unit that completes even
-while the response task is being cancelled.
+while the response task is being cancelled - and under cancellation it
+stamps the KNOWN cancelled status rather than racing the core's own
+detached cancelled-row persist with a fresh session read.
 
 These tests drive the REAL agents continue streamer with a continuation
 that blocks mid-stream, then cancel the consumer exactly like a disconnect.
@@ -29,8 +31,6 @@ from agno.run.base import RunStatus
 
 RUN_ID = "r-disc"
 SESSION_ID = "s-disc"
-
-_TERMINAL = (RunStatus.completed, RunStatus.paused, RunStatus.error, RunStatus.cancelled)
 
 
 @pytest.fixture()
@@ -127,11 +127,13 @@ async def test_disconnect_mid_stream_still_closes_stream_and_settles_ticket(stre
     await asyncio.sleep(0.3)  # the shielded obligation completes in the background
 
     status = await stream_harness.get_run_status(RUN_ID)
-    assert status in _TERMINAL, (
-        f"stream view abandoned as {status} with no producer - a /resume tail would heartbeat forever"
+    assert status == RunStatus.cancelled, (
+        f"stream view finalized as {status} - a disconnect cancels the inline continue, and the "
+        "finalizer must stamp that KNOWN status instead of racing the core's own cancelled-row "
+        "persist with a session read (which can observe the stale paused/running row)"
     )
     job = await store.get_job(RUN_ID)
-    assert job["status"] != "paused", f"the paused ticket never settled: {job['status']}"
+    assert job["status"] == "cancelled", f"the paused ticket must settle as cancelled: {job['status']}"
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/os/test_continue_disconnect_finalize.py
+++ b/libs/agno/tests/unit/os/test_continue_disconnect_finalize.py
@@ -1,0 +1,154 @@
+"""A client disconnect mid-inline-continue-stream must not abandon the
+terminal-sync obligation.
+
+The disconnecting client cancels the response task. The streamer's finally
+then owed two writes - close the stream view with the run's real final
+status, and settle a paused durable ticket - but its first unshielded await
+leaked the cancellation (suppress(Exception) does not catch CancelledError),
+so both were skipped: the stream view stayed RUNNING with no producer
+(immortal on Redis, whose TTL refresher had enrolled the run - /resume
+tails heartbeat forever) and the retention-exempt paused ticket said paused
+forever. The obligation now runs as one shielded unit that completes even
+while the response task is being cancelled.
+
+These tests drive the REAL agents continue streamer with a continuation
+that blocks mid-stream, then cancel the consumer exactly like a disconnect.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import agno.os.event_streams as es_mod
+from agno.db.schemas.jobs import QueuedJob
+from agno.job_queue.store import InMemoryQueueStore
+from agno.os.event_streams import InMemoryEventStream, set_event_stream
+from agno.os.managers import EventsBuffer, SSESubscriberManager
+from agno.run.base import RunStatus
+
+RUN_ID = "r-disc"
+SESSION_ID = "s-disc"
+
+_TERMINAL = (RunStatus.completed, RunStatus.paused, RunStatus.error, RunStatus.cancelled)
+
+
+@pytest.fixture()
+def stream_harness():
+    original = es_mod._event_stream
+    stream = InMemoryEventStream(events_buffer=EventsBuffer(), subscriber_manager=SSESubscriberManager())
+    set_event_stream(stream)
+    yield stream
+    es_mod._event_stream = original
+
+
+class ContinueFakeAgent:
+    """Yields chunks like a real continuation; optionally blocks after the
+    first chunk (the long tool call whose client walks away). The session
+    read reports the run COMPLETED - the durable truth the finalizer must
+    propagate to the stream and ticket."""
+
+    id = "agent-1"
+
+    def __init__(self, hang: bool = True):
+        self.hang = hang
+        self._never = asyncio.Event()
+
+    def acontinue_run(self, **kwargs):
+        def make_chunk():
+            # format_sse_event needs to_json; a bare namespace would error
+            # out of the streamer's try and finalize BEFORE any disconnect,
+            # making the whole test vacuous
+            chunk = SimpleNamespace(event="chunk", content="hello")
+            chunk.to_dict = lambda: {"event": "chunk", "content": "hello"}
+            chunk.to_json = lambda **kw: '{"event": "chunk", "content": "hello"}'
+            return chunk
+
+        async def gen():
+            yield make_chunk()
+            if self.hang:
+                await self._never.wait()
+
+        return gen()
+
+    async def aget_session(self, session_id=None, **kwargs):
+        # Slow enough that a level-based cancellation lands mid-read
+        await asyncio.sleep(0.05)
+        run = SimpleNamespace(status=RunStatus.completed, events=None)
+        return SimpleNamespace(get_run=lambda rid: run)
+
+
+async def seed_paused_ticket(store: InMemoryQueueStore) -> None:
+    job = QueuedJob(
+        id=RUN_ID,
+        component_type="agent",
+        component_id="agent-1",
+        session_id=SESSION_ID,
+        payload={"input": "hi", "kwargs": {}},
+    ).to_dict()
+    await store.enqueue_job(job)
+    claimed = await store.claim_job("w1")
+    assert await store.complete_job(RUN_ID, "w1", claimed["attempt"], "paused")
+
+
+@pytest.mark.asyncio
+async def test_disconnect_mid_stream_still_closes_stream_and_settles_ticket(stream_harness):
+    from agno.os.routers.agents.router import agent_continue_response_streamer
+
+    store = InMemoryQueueStore()
+    await seed_paused_ticket(store)
+    agent = ContinueFakeAgent(hang=True)
+    gen = agent_continue_response_streamer(
+        agent, RUN_ID, session_id=SESSION_ID, queue_worker=SimpleNamespace(store=store)
+    )
+
+    consumed: list = []
+
+    async def consume():
+        async for frame in gen:
+            consumed.append(frame)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.2)
+    assert consumed, "the stream must have produced its first frame before the disconnect"
+
+    # The client walks away. Starlette's disconnect cancellation is
+    # LEVEL-based (anyio cancel scopes re-raise at every await until the
+    # scope exits), not a single edge - simulate that by re-cancelling
+    # until the response task actually ends. This is exactly what defeats
+    # an unshielded finally: each await inside it takes the cancellation
+    # again.
+    for _ in range(50):
+        if task.done():
+            break
+        task.cancel()
+        await asyncio.sleep(0.01)
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0.3)  # the shielded obligation completes in the background
+
+    status = await stream_harness.get_run_status(RUN_ID)
+    assert status in _TERMINAL, (
+        f"stream view abandoned as {status} with no producer - a /resume tail would heartbeat forever"
+    )
+    job = await store.get_job(RUN_ID)
+    assert job["status"] != "paused", f"the paused ticket never settled: {job['status']}"
+
+
+@pytest.mark.asyncio
+async def test_clean_completion_still_finalizes(stream_harness):
+    """The non-disconnect path must be unchanged: stream closed with the
+    run's final status, ticket settled."""
+    from agno.os.routers.agents.router import agent_continue_response_streamer
+
+    store = InMemoryQueueStore()
+    await seed_paused_ticket(store)
+    agent = ContinueFakeAgent(hang=False)
+    gen = agent_continue_response_streamer(
+        agent, RUN_ID, session_id=SESSION_ID, queue_worker=SimpleNamespace(store=store)
+    )
+
+    frames = [frame async for frame in gen]
+    assert frames
+
+    assert await stream_harness.get_run_status(RUN_ID) == RunStatus.completed
+    assert (await store.get_job(RUN_ID))["status"] == "completed"

--- a/libs/agno/tests/unit/run/test_queue_store_logging.py
+++ b/libs/agno/tests/unit/run/test_queue_store_logging.py
@@ -12,7 +12,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from agno.db.postgres import AsyncPostgresDb
+pytest.importorskip("psycopg", reason="postgres extras required for the adapter under test")
+
+from agno.db.postgres import AsyncPostgresDb  # noqa: E402
 
 DEAD_URL = "postgresql+psycopg://ai:ai@localhost:59999/ai"
 


### PR DESCRIPTION
## Summary

The route-matrix review's top finding (F1), verified and fixed: a client disconnect during an inline continue with streaming abandoned the terminal-sync obligation, leaving the run's event-stream view RUNNING forever with no producer and the paused durable ticket never settled.

Mechanism (reproduced against the real streamer): Starlette's disconnect cancellation is level-based (anyio) - CancelledError re-raises at every await until the scope exits. The streamer's `finally` owed two writes (close the stream view with the run's real final status; settle the paused ticket), and its first unshielded await took the cancellation - `contextlib.suppress(Exception)` does not catch `CancelledError` - skipping both. On Redis the abandoned RUNNING status had enrolled the run in the TTL refresher, so `/resume` tails heartbeat forever; in-memory cleanup only reaps terminal statuses, so the view leaks permanently. The trigger is a client closing a tab mid-SSE.

- New `afinalize_continue_stream` bundles status resolution + stream close + ticket settle into ONE obligation running in its own task, shielded from the caller's cancellation: the response task still ends as cancelled, but the obligation completes regardless.
- All six call-site pairs (streaming finally + non-stream inline, across agents/teams/workflows) collapse onto the bundled helper - the pair could never be made cancellation-safe as two separate calls, since a cancellation between them skips the second.
- Rides along (review F17): the unit-tier queue-store logging suite now `importorskip`s psycopg instead of collection-erroring in environments without the postgres extras.

Tests drive the REAL agents streamer with a continuation blocked mid-stream and cancel level-style (a single edge cancel does not reproduce the leak - an early version of the test was vacuous for exactly that reason, which is documented in the fake). On the unfixed code the test observes the reported end-state (stream RUNNING, ticket paused); a clean-completion twin pins the normal path unchanged.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Regression sweep: continue seam, acceptance truthfulness, unified-continue gate, and queue-store logging suites green (71 tests) plus the two new disconnect tests. Validation carries the two known ambient marks only. Sync/async: the helper is async-only by nature (it exists to survive async cancellation); the sync non-stream paths cannot be cancelled mid-request the same way.
