### PR TITLE
[fix] surface async member routing failures

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -6223,7 +6223,7 @@ async def _aroute_requirements_to_members(
             # the team run without the approved tool.
             raise r
         if isinstance(r, BaseException):
-            log_warning(f"Member continue_run failed: {r}")
+            raise r
         elif isinstance(r, str):
             member_results.append(r)
     return member_results

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -8781,9 +8781,10 @@ async def _acontinue_run(
                             session=team_session,
                             run_context=run_context,
                         )
-                    except Exception:
+                    except (Exception, asyncio.CancelledError):
                         # Routing failed mid-flight; put the team-level requirements
-                        # back so the caller's run object stays complete for a retry.
+                        # back so the caller's run object stays complete for a retry,
+                        # including when the client disconnects during cancellation.
                         run_response.requirements = team_level_reqs + (run_response.requirements or [])
                         raise
                     # Merge: keep team-level reqs + any newly propagated member reqs (chained HITL)

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -914,6 +914,58 @@ class TestContinueRunApprovalResolution:
 
         asyncio.run(_exercise())
 
+    def test_acontinue_run_restores_team_requirements_on_member_cancellation(self):
+        from agno.team._run import _acontinue_run
+
+        team = MagicMock()
+        team.retries = 0
+        team.events_to_skip = []
+        team.store_events = False
+        team.db = MagicMock()
+        team.model = MagicMock()
+
+        team_requirement = _make_requirement(requires_confirmation=True)
+        team_requirement.confirm()
+        member_requirement = _make_requirement(requires_confirmation=True)
+        member_requirement.confirm()
+        member_requirement.member_agent_id = "member-id-1"
+        member_requirement.member_run_id = "member-run-1"
+
+        run_response = TeamRunOutput(
+            run_id="run-1",
+            session_id="session-1",
+            requirements=[team_requirement, member_requirement],
+        )
+        team_session = MagicMock()
+        team_session.runs = [run_response]
+        run_context = MagicMock()
+
+        async def _exercise():
+            with (
+                patch("agno.team._run._asetup_session", new=AsyncMock(return_value=team_session)),
+                patch("agno.team._run.aregister_run", new=AsyncMock()),
+                patch("agno.team._run.acleanup_run", new=AsyncMock()),
+                patch("agno.team._init._disconnect_connectable_tools"),
+                patch("agno.team._init._disconnect_mcp_tools", new=AsyncMock()),
+                patch("agno.team._run._reclaim_own_requirements", side_effect=lambda _, reqs, __: reqs),
+                patch(
+                    "agno.team._run._aroute_requirements_to_members",
+                    new=AsyncMock(side_effect=asyncio.CancelledError()),
+                ),
+                patch("agno.team._run._persist_cancelled_team_run_in_background"),
+            ):
+                with pytest.raises(asyncio.CancelledError):
+                    await _acontinue_run(
+                        team,
+                        session_id="session-1",
+                        run_context=run_context,
+                        run_response=run_response,
+                    )
+
+        asyncio.run(_exercise())
+
+        assert run_response.requirements == [team_requirement, member_requirement]
+
     def test_acontinue_run_stream_uses_run_id_for_empty_requirements(self):
         from agno.team._run import _acontinue_run_stream
 

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -4,6 +4,8 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from agno.models.response import ToolExecution
 from agno.run import RunStatus
 from agno.run.requirement import RunRequirement
@@ -629,45 +631,7 @@ class TestUnresolvedTeamLevelRequirements:
 
 
 # ===========================================================================
-# 11. asyncio.gather error handling in _aroute_requirements_to_members
-# ===========================================================================
-
-
-class TestAsyncGatherErrorHandling:
-    """Verify that _aroute_requirements_to_members handles member failures gracefully."""
-
-    def test_gather_filters_exceptions(self):
-        """When asyncio.gather returns exceptions, they should be filtered out."""
-        # Simulate the post-gather filtering logic
-        results = ["[Agent A]: Success", Exception("Agent B failed"), None, "[Agent C]: Done"]
-
-        member_results = []
-        for r in results:
-            if isinstance(r, Exception):
-                pass  # logged as warning
-            elif r is not None:
-                member_results.append(r)
-
-        assert len(member_results) == 2
-        assert member_results[0] == "[Agent A]: Success"
-        assert member_results[1] == "[Agent C]: Done"
-
-    def test_all_exceptions_yields_empty_results(self):
-        """When all members fail, result list should be empty."""
-        results = [Exception("fail 1"), Exception("fail 2")]
-
-        member_results = []
-        for r in results:
-            if isinstance(r, Exception):
-                pass
-            elif r is not None:
-                member_results.append(r)
-
-        assert len(member_results) == 0
-
-
-# ===========================================================================
-# 12. _tool_result_requires_human_input
+# 11. _tool_result_requires_human_input
 # ===========================================================================
 
 
@@ -1170,6 +1134,27 @@ class TestRoutingForwardsRunContextToMembers:
         assert kwargs["dependencies"] == {"user_token": "Bearer abc"}
         assert kwargs["metadata"] == {"trace": "id"}
         assert kwargs["knowledge_filters"] == {"tag": "v"}
+
+    def test_async_routing_surfaces_member_failures(self):
+        from agno.team._run import _aroute_requirements_to_members
+
+        run_response, session, _ = self._make_run_response_with_member_req()
+        run_context = self._make_run_context()
+
+        member = MagicMock()
+        member.name = "Member 1"
+        member.acontinue_run = AsyncMock(side_effect=RuntimeError("member continue_run failed"))
+
+        team = MagicMock()
+
+        async def _exercise():
+            with patch("agno.team._tools._find_member_route_by_id", return_value=(0, member)):
+                with pytest.raises(RuntimeError, match="member continue_run failed"):
+                    await _aroute_requirements_to_members(
+                        team, run_response=run_response, session=session, run_context=run_context
+                    )
+
+        asyncio.run(_exercise())
 
     def test_async_streaming_routing_forwards_dependencies(self):
         from agno.team._run import _aroute_requirements_to_members_stream


### PR DESCRIPTION
## Summary

Fixes #9421.

Async member continuation failures were being converted into warnings after asyncio.gather(..., return_exceptions=True), so the team could finish with an incomplete result. The async routing helper now re-raises member exceptions after the concurrent calls complete, matching the existing failure semantics for non-continuable runs.

The cancellation path also restores team-level requirements before propagating asyncio.CancelledError, keeping the paused run complete if a client disconnects during member routing.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (./scripts/format.sh and ./scripts/validate.sh)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation:
- tests/unit/team/test_continue_run_requirements.py: 58 passed
- tests/unit/team/test_paused_member_persistence.py targeted async routing/retry cases: 5 passed, 137 deselected
- ./scripts/format.sh: passed
- ./scripts/validate.sh: passed

AI assistance was used during analysis and implementation. The patch was reviewed locally, and the targeted tests plus repository validation scripts were run.