### PR TITLE
[fix] Handle empty MCP schemas in strict mode

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1164,9 +1164,10 @@ class Function(BaseModel):
         # Apply strict mode to the entire schema
         self.parameters = make_nested_strict(self.parameters)
 
+        properties = self.parameters.get("properties") or {}
         self.parameters["required"] = [
             name
-            for name in self.parameters["properties"]
+            for name in properties
             if name not in ("return", "self")
             and name not in FRAMEWORK_INJECTED_PARAMS
             and name not in AGNO_INJECTED_PARAMS

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -348,6 +348,20 @@ def test_function_process_schema_for_strict():
     assert "param2" in func.parameters["required"]  # All properties should be required in strict mode
 
 
+def test_function_process_entrypoint_with_empty_fixed_schema_in_strict_mode():
+    """Strict mode should accept MCP tools whose object schema has no properties."""
+    func = Function(
+        name="mcp_no_args",
+        parameters={"type": "object"},
+        skip_entrypoint_processing=True,
+    )
+
+    func.process_entrypoint(strict=True)
+
+    assert func.parameters["additionalProperties"] is False
+    assert func.parameters["required"] == []
+
+
 def test_function_cache_key_generation():
     """Test generation of cache keys for function calls."""
     func = Function(name="test_func", cache_results=True, cache_dir="/tmp")


### PR DESCRIPTION
## Summary

Fixes #9409 by making strict schema processing tolerate MCP tools whose object schema omits `properties`.

When an MCP tool has no arguments, its schema may be `{"type": "object"}`. Strict processing now treats the missing properties map as empty while still emitting the strict-mode `additionalProperties: false` and `required: []` fields.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran the repository format/validation checks (`ruff format --check` and `scripts\\validate.bat`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] This PR was developed with AI assistance and reviewed by me

---

## Additional Notes

Validation completed locally:

- `pytest libs/agno/tests/unit/tools/test_functions.py`: 125 passed
- `ruff format --check`: passed for the changed files
- Repository `scripts\\validate.bat`: Ruff and mypy passed for both Agno and Agno Infra
