### PR TITLE
fix: RBAC filtering covers DB-loaded teams and workflows on list endpoints

### DIFF
--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -1696,9 +1696,15 @@ def get_team_router(
             # Exclude teams whose IDs are owned by the registry
             exclude_ids = registry.get_team_ids() if registry else None
             db_teams = get_teams(db=os.db, registry=registry, exclude_component_ids=exclude_ids or None)
-            for db_team in db_teams:
-                team_response = await TeamResponse.from_team(team=db_team, is_component=True)
-                teams.append(team_response)
+            if db_teams:
+                # Apply the same RBAC filtering to DB-loaded teams: without
+                # it, a caller whose scope excludes a team still saw its
+                # config here (the agents endpoint already filters)
+                if getattr(request.state, "authorization_enabled", False):
+                    db_teams = filter_resources_by_access(request, db_teams, "teams")
+                for db_team in db_teams:
+                    team_response = await TeamResponse.from_team(team=db_team, is_component=True)
+                    teams.append(team_response)
 
         return teams
 

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1344,7 +1344,15 @@ def get_workflow_router(
         if os.db and isinstance(os.db, BaseDb):
             from agno.workflow.workflow import get_workflows
 
-            for db_workflow in get_workflows(db=os.db, registry=os.registry):
+            db_workflows = get_workflows(db=os.db, registry=os.registry)
+            if db_workflows:
+                # Apply the same RBAC filtering to DB-loaded workflows:
+                # without it, a caller whose scope excludes a workflow
+                # still saw its config here (the agents endpoint already
+                # filters)
+                if getattr(request.state, "authorization_enabled", False):
+                    db_workflows = filter_resources_by_access(request, db_workflows, "workflows")
+            for db_workflow in db_workflows or []:
                 try:
                     workflows.append(WorkflowSummaryResponse.from_workflow(workflow=db_workflow, is_component=True))
                 except Exception:

--- a/libs/agno/tests/unit/os/test_list_endpoints_rbac.py
+++ b/libs/agno/tests/unit/os/test_list_endpoints_rbac.py
@@ -1,0 +1,82 @@
+"""RBAC filtering covers DB-loaded components on the list endpoints.
+
+The list endpoints filter REGISTRY components through
+filter_resources_by_access when authorization is enabled - but the
+DB-loaded components appended below that check bypassed the filter on
+teams and workflows (agents already filtered): a caller whose scope
+excluded a team or workflow still received its full config from
+GET /teams and GET /workflows. These tests scope a caller to registry
+components only and assert DB-loaded ones stay invisible, with agents
+pinned as the reference behavior.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.os import AgentOS
+from agno.team import Team
+from agno.workflow import Workflow
+
+
+@pytest.fixture()
+def harness(tmp_path, monkeypatch):
+    db = SqliteDb(db_file=str(tmp_path / "t.db"))
+    agent = Agent(id="reg-agent", name="Reg Agent", db=db)
+    team = Team(id="reg-team", name="Reg Team", members=[], db=db)
+    workflow = Workflow(id="reg-wf", name="Reg WF", db=db, steps=[])
+    app = AgentOS(agents=[agent], teams=[team], workflows=[workflow], db=db, telemetry=False).get_app()
+
+    # Authorization enabled for every request (the middleware the real
+    # deployment installs sets this from the JWT/scopes config)
+    @app.middleware("http")
+    async def _enable_authz(request, call_next):
+        request.state.authorization_enabled = True
+        return await call_next(request)
+
+    # The caller's scope: registry components visible, db-* components not
+    def scoped_filter(request, resources, resource_type):
+        return [r for r in resources if not str(getattr(r, "id", "")).startswith("db-")]
+
+    monkeypatch.setattr("agno.os.auth.filter_resources_by_access", scoped_filter)
+    monkeypatch.setattr("agno.os.auth.get_accessible_resources", lambda request, kind: {"reg"})
+
+    # The DB hands back one out-of-scope component per type
+    monkeypatch.setattr(
+        "agno.agent.agent.get_agents",
+        lambda db, registry=None, exclude_component_ids=None: [Agent(id="db-agent", name="DB Agent")],
+    )
+    monkeypatch.setattr(
+        "agno.team.team.get_teams",
+        lambda db, registry=None, exclude_component_ids=None: [Team(id="db-team", name="DB Team", members=[])],
+    )
+    monkeypatch.setattr(
+        "agno.workflow.workflow.get_workflows", lambda db, registry=None: [Workflow(id="db-wf", name="DB WF", steps=[])]
+    )
+    return SimpleNamespace(client=TestClient(app, raise_server_exceptions=False))
+
+
+def ids_of(response):
+    assert response.status_code == 200, response.text[:300]
+    return {item.get("id") or item.get("workflow_id") for item in response.json()}
+
+
+class TestDbLoadedComponentsAreScoped:
+    def test_teams_list_filters_db_loaded_teams(self, harness):
+        ids = ids_of(harness.client.get("/teams"))
+        assert "reg-team" in ids
+        assert "db-team" not in ids, "an out-of-scope DB-loaded team leaked through GET /teams"
+
+    def test_workflows_list_filters_db_loaded_workflows(self, harness):
+        ids = ids_of(harness.client.get("/workflows"))
+        assert "reg-wf" in ids
+        assert "db-wf" not in ids, "an out-of-scope DB-loaded workflow leaked through GET /workflows"
+
+    def test_agents_list_keeps_filtering_db_loaded_agents(self, harness):
+        """The reference behavior teams/workflows now mirror."""
+        ids = ids_of(harness.client.get("/agents"))
+        assert "reg-agent" in ids
+        assert "db-agent" not in ids


### PR DESCRIPTION
## Summary

Authorization gap from the route-matrix review (F19, pre-existing on base): `GET /teams` and `GET /workflows` filter REGISTRY components through `filter_resources_by_access` when authorization is enabled, then append DB-loaded components below that check with **no access filtering** - a caller whose RBAC scope excludes a team or workflow still received its full config. `GET /agents` already filters its DB-loaded batch; teams and workflows now mirror it exactly (same flag check, same filter, applied before conversion).

- Scope: information disclosure of component configurations to under-scoped callers on two list endpoints. No write paths involved; the per-resource endpoints (`GET /teams/{id}` etc.) have their own dependency-based access checks and are unaffected.
- Endpoint tests scope a caller to registry components and assert DB-loaded ones stay invisible on all three lists. Teams and workflows fail on the unfixed code; agents pins the reference behavior both ways.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Worth a look from whoever owns the RBAC surface: the fix mirrors the agents endpoint's existing pattern rather than introducing new policy, but the reviewer should confirm the intended semantics for DB-loaded components under scoped callers (filter, as implemented here, vs. hide-all).
