### PR TITLE
fix: Wave 2 reliability smalls - thirteen review findings, one commit each

### DIFF
--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -5216,8 +5216,21 @@ class AsyncPostgresDb(AsyncBaseDb):
                     "completed_at": None,
                     "updated_at": now,
                 }
-                await sess.execute(update(table).where(table.c.id == job_id).values(**values))
+                # RETURNING resolves the DB-clock stamps to concrete ints: the
+                # timestamp values are SQL expressions (_db_epoch), and copying
+                # them into the returned dict verbatim would hand callers
+                # unserializable Cast objects where Redis/InMemory return ints.
+                stamped = (
+                    await sess.execute(
+                        update(table)
+                        .where(table.c.id == job_id)
+                        .values(**values)
+                        .returning(table.c.available_at, table.c.updated_at)
+                    )
+                ).fetchone()
                 job.update(values)
+                if stamped is not None:
+                    job["available_at"], job["updated_at"] = stamped[0], stamped[1]
                 return {"outcome": "queued", "job": job}
 
     async def queue_stats(self) -> Dict[str, Any]:

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -6558,8 +6558,19 @@ class PostgresDb(BaseDb):
                 "completed_at": None,
                 "updated_at": now,
             }
-            sess.execute(update(table).where(table.c.id == job_id).values(**values))
+            # RETURNING resolves the DB-clock stamps to concrete ints: the
+            # timestamp values are SQL expressions (_db_epoch), and copying
+            # them into the returned dict verbatim would hand callers
+            # unserializable Cast objects where Redis/InMemory return ints.
+            stamped = sess.execute(
+                update(table)
+                .where(table.c.id == job_id)
+                .values(**values)
+                .returning(table.c.available_at, table.c.updated_at)
+            ).fetchone()
             job.update(values)
+            if stamped is not None:
+                job["available_at"], job["updated_at"] = stamped[0], stamped[1]
             return {"outcome": "queued", "job": job}
 
     def queue_stats(self) -> Dict[str, Any]:

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -2610,6 +2610,26 @@ class RedisDb(BaseDb):
     def _q_job_key(self, job_id: str) -> str:
         return self._q_key(f"job:{job_id}")
 
+    def _q_server_now(self) -> int:
+        """Redis server time as an integer epoch, for LEASE math.
+
+        Lease decisions must be anchored to ONE clock (the Postgres store
+        anchors to the database's NOW() for exactly this reason). With
+        worker wall clocks, a replica whose clock runs fast sees healthy
+        leases as expired and sweeps live runs - and since the sweep steals
+        the lock, the victim's own completion is fenced out and its run is
+        reported failed despite having finished; with multi-attempt budgets
+        that skew-triggered false sweep means duplicate side-effect
+        execution. TIME is the Redis server's clock, identical for every
+        worker on the shared store, so claim/heartbeat/sweep all agree.
+
+        Not applied to queue_stats' age arithmetic or the retention
+        cleanup cutoff; those only shift reporting/retention by the skew,
+        never ownership (mirroring the Postgres store's scope).
+        """
+        seconds, _microseconds = self.redis_client.time()
+        return int(seconds)
+
     def _q_idem_key(self, user_id: Optional[str], idempotency_key: str) -> str:
         """Collision-free dedup key for the (user, idempotency-key) tuple.
 
@@ -2720,7 +2740,7 @@ class RedisDb(BaseDb):
         them indefinitely (foreign entries stay queued at the front). Each
         page is pre-filtered with one pipelined MGET; the CAS inside
         _q_try_claim remains the only authority."""
-        now = int(time.time())
+        now = self._q_server_now()
         stale = now - lock_grace_seconds
 
         job = self._q_scan_claim(
@@ -2875,7 +2895,7 @@ class RedisDb(BaseDb):
                     # was status="running" but in NO zset: invisible to reclaim
                     # and sweep alike, a permanent zombie.
                     if job["status"] == "running":
-                        pipe.zadd(self._q_key("running"), {job_id: job.get("locked_at") or int(time.time())})
+                        pipe.zadd(self._q_key("running"), {job_id: job.get("locked_at") or self._q_server_now()})
                     else:
                         pipe.zrem(self._q_key("running"), job_id)
                     if job["status"] == "queued":
@@ -2891,7 +2911,7 @@ class RedisDb(BaseDb):
         from agno.db.schemas.jobs import QueueWriteOutcome
 
         count = 0
-        now = int(time.time())
+        now = self._q_server_now()
         for job_id in job_ids:
             job = self._q_load_job(job_id)
             if job is None:
@@ -2908,7 +2928,7 @@ class RedisDb(BaseDb):
     def complete_job(self, job_id: str, worker_id: str, attempt: int, status: str, error: Optional[str] = None) -> bool:
         from agno.db.schemas.jobs import QueueWriteOutcome
 
-        now = int(time.time())
+        now = self._q_server_now()
 
         def _complete(job: Dict[str, Any]) -> None:
             job.update(status=status, error=error, locked_by=None, locked_at=None, completed_at=now, updated_at=now)
@@ -2921,7 +2941,7 @@ class RedisDb(BaseDb):
     ) -> Optional[str]:
         from agno.db.schemas.jobs import QueueWriteOutcome
 
-        now = int(time.time())
+        now = self._q_server_now()
         outcome_status: Dict[str, str] = {}
 
         def _retry(job: Dict[str, Any]) -> None:
@@ -2954,7 +2974,7 @@ class RedisDb(BaseDb):
         if status not in ("completed", "cancelled", "failed"):
             return False
         job_key = self._q_job_key(job_id)
-        now = int(time.time())
+        now = self._q_server_now()
         try:
             with self.redis_client.pipeline() as pipe:
                 pipe.watch(job_key)
@@ -2982,7 +3002,7 @@ class RedisDb(BaseDb):
         from redis.exceptions import WatchError
 
         job_key = self._q_job_key(job_id)
-        now = int(time.time())
+        now = self._q_server_now()
         try:
             with self.redis_client.pipeline() as pipe:
                 pipe.watch(job_key)
@@ -3004,7 +3024,7 @@ class RedisDb(BaseDb):
             return False
 
     def sweep_exhausted_jobs(self, lock_grace_seconds: int = 60, limit: int = 20) -> List[Dict[str, Any]]:
-        stale = int(time.time()) - lock_grace_seconds
+        stale = self._q_server_now() - lock_grace_seconds
         exhausted: List[Dict[str, Any]] = []
         for raw_id in self.redis_client.zrangebyscore(self._q_key("running"), "-inf", stale, start=0, num=limit * 2):
             job = self._q_load_job(_q_to_str(raw_id))
@@ -3029,7 +3049,7 @@ class RedisDb(BaseDb):
         from redis.exceptions import WatchError
 
         job_key = self._q_job_key(job_id)
-        now = int(time.time())
+        now = self._q_server_now()
         stale = now - lock_grace_seconds
         try:
             with self.redis_client.pipeline() as pipe:
@@ -3067,7 +3087,7 @@ class RedisDb(BaseDb):
         if status not in ("completed", "cancelled", "paused", "failed"):
             return False
         job_key = self._q_job_key(job_id)
-        now = int(time.time())
+        now = self._q_server_now()
         try:
             with self.redis_client.pipeline() as pipe:
                 pipe.watch(job_key)
@@ -3123,7 +3143,7 @@ class RedisDb(BaseDb):
         from redis.exceptions import WatchError
 
         job_key = self._q_job_key(job_id)
-        now = int(time.time())
+        now = self._q_server_now()
         try:
             with self.redis_client.pipeline() as pipe:
                 pipe.watch(job_key)
@@ -3175,7 +3195,7 @@ class RedisDb(BaseDb):
 
         job_key = self._q_job_key(job_id)
         for _ in range(10):
-            now = int(time.time())
+            now = self._q_server_now()
             try:
                 with self.redis_client.pipeline() as pipe:
                     pipe.watch(job_key)

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -2652,11 +2652,16 @@ class RedisDb(BaseDb):
         # attach to another tenant's run) - mirrors the Postgres index
         idem_key = self._q_idem_key(job.get("user_id"), idem) if idem is not None else None
 
+        job_key = self._q_job_key(job["id"])
+
         for _ in range(10):
             with self.redis_client.pipeline() as pipe:
                 try:
+                    # The job key is always WATCHed: the MULTI below SETs it,
+                    # and a racing enqueue of the same id must not silently
+                    # overwrite (see the existence check further down).
                     if idem_key is not None:
-                        pipe.watch(idem_key)
+                        pipe.watch(job_key, idem_key)
                         existing_id = pipe.get(idem_key)
                         if existing_id is not None:
                             existing_id = existing_id if isinstance(existing_id, str) else existing_id.decode()
@@ -2670,13 +2675,24 @@ class RedisDb(BaseDb):
                             # attach hands the caller that job's identifiers
                             # and live event stream) - never attach; fall
                             # through and take the key over inside the MULTI
+                    else:
+                        pipe.watch(job_key)
 
                     if max_depth and max_depth > 0:
                         queued = int(self.redis_client.zcard(self._q_key("queued")))
                         if queued >= max_depth:
-                            if idem_key is not None:
-                                pipe.unwatch()
+                            pipe.unwatch()
                             return {"accepted": False, "reason": "queue_full", "job": None}
+
+                    # Existing document under this id: mirror Postgres, where
+                    # id is the primary key - a collision is a programming
+                    # error (ids are server-minted uuid4), never a client
+                    # dedup. Silently SETting would reset a live ticket to
+                    # queued/attempt-0 - two executors, the first one's
+                    # completion fenced out.
+                    if pipe.exists(job_key):
+                        pipe.unwatch()
+                        raise RuntimeError(f"enqueue_job: job {job['id']} already exists; ids are never reused")
 
                     pipe.multi()
                     if idem_key is not None:

--- a/libs/agno/agno/job_queue/config.py
+++ b/libs/agno/agno/job_queue/config.py
@@ -110,12 +110,22 @@ class QueueConfig:
     # oldest_queued_age_seconds in /queue/stats.
     deployment_id: Optional[str] = None
     # Stale-lock grace before a crashed worker's jobs are reclaimed. The
-    # worker heartbeat refreshes locks, so this can stay small. Caveat: the
+    # worker heartbeat refreshes locks, so this can stay small - but it is
+    # coupled to the drain timeout below: the worker requires
+    # stop_timeout < lock_grace_seconds (a drain that can outlive the lease
+    # guarantees a peer reclaims a still-draining run mid-drain). Caveat: the
     # heartbeat runs on the event loop - a run doing SYNC blocking work (sync
     # model client / sync tool) that starves the loop past this grace will be
     # swept as dead and its eventual completion fenced out (reported failed
     # despite finishing). Keep blocking work in threads, or raise this grace.
     lock_grace_seconds: int = 60
+    # Graceful-shutdown drain window: in-flight runs get this long to finish
+    # before stragglers are cancelled and requeued/failed. Must be strictly
+    # below lock_grace_seconds (validated here, at construction). None = the
+    # worker default (30s), automatically clamped below lock_grace_seconds -
+    # so every lock_grace the validator accepts also boots (values 3-30 used
+    # to pass validation and then crash the app during lifespan startup).
+    stop_timeout_seconds: Optional[int] = None
     poll_interval: float = 1.0
     # Terminal jobs older than this are deleted by the worker's retention
     # sweep; the queue table must not grow unboundedly. PAUSED tickets are
@@ -137,6 +147,15 @@ class QueueConfig:
             # Heartbeats fire every lock_grace/3: below ~3s the worker races
             # its own heartbeat and reclaims its own healthy jobs
             raise ValueError("QueueConfig.lock_grace_seconds must be >= 3 (heartbeats fire at lock_grace/3)")
+        if self.stop_timeout_seconds is not None:
+            if self.stop_timeout_seconds < 1:
+                raise ValueError("QueueConfig.stop_timeout_seconds must be >= 1 second when set")
+            if self.stop_timeout_seconds >= self.lock_grace_seconds:
+                raise ValueError(
+                    f"QueueConfig.stop_timeout_seconds ({self.stop_timeout_seconds}) must be strictly below "
+                    f"lock_grace_seconds ({self.lock_grace_seconds}): a drain that can outlive the lease "
+                    "guarantees a peer reclaims a still-draining run mid-drain"
+                )
         if self.retry_delay_seconds < 0:
             raise ValueError("QueueConfig.retry_delay_seconds must be >= 0 (0 = no backoff)")
         if self.max_queue_depth < 0:

--- a/libs/agno/agno/job_queue/config.py
+++ b/libs/agno/agno/job_queue/config.py
@@ -119,13 +119,6 @@ class QueueConfig:
     # swept as dead and its eventual completion fenced out (reported failed
     # despite finishing). Keep blocking work in threads, or raise this grace.
     lock_grace_seconds: int = 60
-    # Graceful-shutdown drain window: in-flight runs get this long to finish
-    # before stragglers are cancelled and requeued/failed. Must be strictly
-    # below lock_grace_seconds (validated here, at construction). None = the
-    # worker default (30s), automatically clamped below lock_grace_seconds -
-    # so every lock_grace the validator accepts also boots (values 3-30 used
-    # to pass validation and then crash the app during lifespan startup).
-    stop_timeout_seconds: Optional[int] = None
     poll_interval: float = 1.0
     # Terminal jobs older than this are deleted by the worker's retention
     # sweep; the queue table must not grow unboundedly. PAUSED tickets are
@@ -133,6 +126,16 @@ class QueueConfig:
     # must outlive arbitrary human latency. Abandoned paused tickets therefore
     # persist until continued or cancelled - cancel the run to release one.
     retention_seconds: int = 86400
+    # Graceful-shutdown drain window: in-flight runs get this long to finish
+    # before stragglers are cancelled and requeued/failed. Must be strictly
+    # below lock_grace_seconds (validated here, at construction). None = the
+    # worker default (30s), automatically clamped below lock_grace_seconds -
+    # so every lock_grace the validator accepts also boots (values 3-30 used
+    # to pass validation and then crash the app during lifespan startup).
+    # Appended AFTER the pre-existing fields: this is a public dataclass and
+    # is not keyword-only, so inserting mid-list would silently reinterpret
+    # positional constructions of the fields behind it.
+    stop_timeout_seconds: Optional[int] = None
 
     def __post_init__(self) -> None:
         if self.db is not None and not self.durable:

--- a/libs/agno/agno/job_queue/store.py
+++ b/libs/agno/agno/job_queue/store.py
@@ -41,6 +41,13 @@ class InMemoryQueueStore:
                 queued = sum(1 for j in self._jobs.values() if j["status"] == "queued")
                 if queued >= max_depth:
                     return {"accepted": False, "reason": "queue_full", "job": None}
+            # Mirror Postgres, where id is the primary key: a collision is a
+            # programming error (ids are server-minted uuid4), never a client
+            # dedup. Silently overwriting would reset a live ticket to
+            # queued/attempt-0 - two executors, the first one's completion
+            # fenced out.
+            if job["id"] in self._jobs:
+                raise RuntimeError(f"enqueue_job: job {job['id']} already exists; ids are never reused")
             self._jobs[job["id"]] = dict(job)
             return {"accepted": True, "reason": None, "job": dict(job)}
 

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -456,14 +456,16 @@ class AgentOS:
 
         # Queue configuration. None keeps the process defaults (env var or
         # library default for the concurrency cap, in-memory transports).
-        # queue.redis wires the cross-container transports; the explicit
-        # event_stream parameter below is applied after and wins by ordering.
+        # queue.redis wires the cross-container transports over the process
+        # defaults only; the explicit event_stream parameter is applied first
+        # and survives the wiring regardless of its type.
         self.queue = queue
 
-        # Event stream FIRST: the coordination wiring below only fills in-memory
-        # defaults and warns on asymmetric transports - it must see the user's
-        # explicit stream, or the one split-Redis config it exists to catch
-        # (custom stream on Redis A, wired cancellation on Redis B) never warns.
+        # Event stream FIRST: the coordination wiring below only replaces the
+        # never-explicitly-set defaults and warns on asymmetric transports - it
+        # must see the user's explicit stream, or the one split-Redis config it
+        # exists to catch (custom stream on Redis A, wired cancellation on
+        # Redis B) never warns.
         if event_stream is not None:
             set_event_stream(event_stream)
 

--- a/libs/agno/agno/os/event_streams/__init__.py
+++ b/libs/agno/agno/os/event_streams/__init__.py
@@ -13,6 +13,13 @@ from agno.os.event_streams.in_memory import InMemoryEventStream
 from agno.os.event_streams.redis import RedisEventStream
 
 _event_stream: Optional[BaseEventStream] = None
+# True once set_event_stream() has been called. The lazily-created in-memory
+# default does NOT set this - it is what lets queue wiring distinguish "the
+# process default nobody chose" (replaceable) from an explicitly configured
+# stream (never replaced). An isinstance check cannot make that distinction:
+# an explicitly passed InMemoryEventStream, or a subclass such as a test
+# double, is indistinguishable by type from the default.
+_event_stream_explicitly_set: bool = False
 
 
 def get_event_stream() -> BaseEventStream:
@@ -33,13 +40,24 @@ def set_event_stream(stream: BaseEventStream) -> None:
     the other carries events back out. Configure both with the same Redis
     clients.
     """
-    global _event_stream
+    global _event_stream, _event_stream_explicitly_set
     _event_stream = stream
+    _event_stream_explicitly_set = True
+
+
+def event_stream_explicitly_set() -> bool:
+    """Whether a stream was ever installed via ``set_event_stream()``.
+
+    False means the process is running on (or will lazily create) the
+    in-memory default, which coordination wiring may replace.
+    """
+    return _event_stream_explicitly_set
 
 
 __all__ = [
     "BaseEventStream",
     "InMemoryEventStream",
+    "event_stream_explicitly_set",
     "get_event_stream",
     "set_event_stream",
 ]

--- a/libs/agno/agno/os/interfaces/a2a/router.py
+++ b/libs/agno/agno/os/interfaces/a2a/router.py
@@ -313,8 +313,12 @@ def attach_routes(
             )
 
         # cancel_run always stores cancellation intent (even for not-yet-registered runs
-        # in cancel-before-start scenarios), so we always return success.
-        await agent.acancel_run(run_id=task_id)
+        # in cancel-before-start scenarios), so we always return success. The shared
+        # service also tombstones a still-queued durable ticket first (parity with the
+        # REST cancel routes) - intent alone does not stop a job no task is executing yet.
+        from agno.os.services.runs import cancel_component_run
+
+        await cancel_component_run(agent, task_id)
 
         context_id = params.get("contextId", str(uuid4()))
         canceled_task = Task(
@@ -616,8 +620,12 @@ def attach_routes(
             )
 
         # cancel_run always stores cancellation intent (even for not-yet-registered runs
-        # in cancel-before-start scenarios), so we always return success.
-        await team.acancel_run(run_id=task_id)
+        # in cancel-before-start scenarios), so we always return success. The shared
+        # service also tombstones a still-queued durable ticket first (parity with the
+        # REST cancel routes) - intent alone does not stop a job no task is executing yet.
+        from agno.os.services.runs import cancel_component_run
+
+        await cancel_component_run(team, task_id)
 
         context_id = params.get("contextId", str(uuid4()))
         canceled_task = Task(

--- a/libs/agno/agno/os/interfaces/agui/resume.py
+++ b/libs/agno/agno/os/interfaces/agui/resume.py
@@ -149,7 +149,7 @@ async def resume_paused_run(
         component_id=getattr(entity, "id", None),
     )
 
-    return entity.acontinue_run(  # type: ignore
+    inner = entity.acontinue_run(  # type: ignore
         run_id=paused_run.run_id,
         session_id=session_id,
         requirements=requirements,
@@ -158,3 +158,27 @@ async def resume_paused_run(
         run_context=run_context,
         **run_kwargs,
     )
+
+    run_id = paused_run.run_id
+
+    async def _stream_then_sync():
+        # Status-only stream sync after the continue is consumed (parity with
+        # the REST continue doors): a formerly-queued/streamed run's stream
+        # view must stop saying PAUSED once the continue settles - otherwise
+        # every later /resume replays the stale paused snapshot, and on Redis
+        # the pausing replica's TTL refresher keeps those keys alive
+        # indefinitely. only_if_tracked leaves never-streamed runs alone; a
+        # re-paused continue re-parks the stream as PAUSED. Best-effort: a
+        # stream-backend failure must not fail the AG-UI response.
+        import contextlib
+
+        from agno.os.utils import acomplete_continue_stream
+
+        try:
+            async for chunk in inner:
+                yield chunk
+        finally:
+            with contextlib.suppress(Exception):
+                await acomplete_continue_stream(entity, run_id, session_id, only_if_tracked=True)
+
+    return _stream_then_sync()

--- a/libs/agno/agno/os/interfaces/slack/hitl.py
+++ b/libs/agno/agno/os/interfaces/slack/hitl.py
@@ -184,6 +184,20 @@ class HITLHandler:
             log_error(
                 f"[HITL] continuation append failed: run_id={ctx.run_id} slack_error={slack_error_code(exc)!r} | {exc}"
             )
+        # Status-only stream sync (parity with the REST continue doors): a
+        # formerly-queued/streamed run's stream view must stop saying PAUSED
+        # once the continue settles - otherwise every later /resume replays
+        # the stale paused snapshot, and on Redis the pausing replica's TTL
+        # refresher keeps those keys alive indefinitely. only_if_tracked
+        # leaves never-streamed runs alone; a re-paused continue re-parks the
+        # stream as PAUSED. Best-effort: a stream-backend failure must not
+        # eat the Slack response.
+        try:
+            from agno.os.utils import acomplete_continue_stream
+
+            await acomplete_continue_stream(self.entity, ctx.run_id, session_id, only_if_tracked=True)
+        except Exception as exc:
+            log_error(f"[HITL] continue stream sync failed for run={ctx.run_id}: {exc}")
         return state
 
     async def complete_or_repause(

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -165,6 +165,36 @@ def normalize_idempotency_key(raw: Any) -> Any:
     return raw
 
 
+def ensure_duplicate_matches_component(existing: Dict[str, Any], component_type: str, component_id: Any) -> None:
+    """Refuse an Idempotency-Key duplicate that belongs to a different component.
+
+    The dedup namespace is (idempotency_key, user_id) only, so a key reused on
+    another component's submit route would otherwise be answered with the
+    ORIGINAL component's run - a 202 (or live stream attach) whose ids then 404
+    through this route's poll endpoint, because the ticket poll fallback does
+    enforce component identity. Idempotency keys retry the same submission;
+    they never alias a different one.
+
+    The response deliberately omits the original ticket's identity: in
+    unauthenticated deployments the key namespace is shared across clients,
+    and the mismatch detail belongs in server logs, not on the wire.
+    """
+    if existing.get("component_type") == component_type and existing.get("component_id") == component_id:
+        return
+    from fastapi import HTTPException
+
+    log_warning(
+        f"Idempotency-Key reuse across components: key on ticket "
+        f"{existing.get('component_type')}/{existing.get('component_id')} was replayed against "
+        f"{component_type}/{component_id}; refusing with 409"
+    )
+    raise HTTPException(
+        status_code=409,
+        detail="Idempotency-Key was already used by a different component; "
+        "reuse a key only to retry the identical submission",
+    )
+
+
 def payload_is_queueable(payload: Any) -> bool:
     """True when the job payload survives a JSON round-trip as-is.
 

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -2020,6 +2020,8 @@ async def aticket_poll_fallback(
     component_type: str,
     component_id: Optional[str],
     user_id: Optional[str],
+    *,
+    user_scoped: bool,
 ) -> Optional[Dict[str, Any]]:
     """Tenant-authorized ticket view for run polls that found no run row.
 
@@ -2031,10 +2033,19 @@ async def aticket_poll_fallback(
     202-shaped body.
 
     Every identity check fails CLOSED (None = keep the 404): the ticket must
-    be a run, belong to the path component and the queried session, and be
-    visible to the scoped user under the same predicate the session read
-    uses (owner match, or an ownerless ticket). A guessable run_id must not
-    leak another tenant's run existence.
+    be a run, belong to the path component and the queried session, and -
+    when ``user_scoped`` - be visible to the scoped user under the same
+    predicate the session read uses (owner match, or an ownerless ticket).
+    A guessable run_id must not leak another tenant's run existence.
+
+    ``user_scoped`` is the explicit scoping mode (required keyword so no
+    caller can leave it implicit): ``get_scoped_user_id`` returns None for
+    BOTH an admin/unscoped principal (no filtering anywhere - the session
+    read this fallback mirrors applies none) and would be
+    indistinguishable from an anonymous owner value. Pass
+    ``user_scoped=False`` for the former; ``user_id`` is then ignored.
+    Treating None as an owner value here used to 404 accepted user-owned
+    runs for every admin poll inside the ticket-before-run-row window.
     """
     if queue_worker is None:
         return None
@@ -2051,7 +2062,8 @@ async def aticket_poll_fallback(
         return None
     # Same visibility predicate as the session read: (user_id == scoped) OR
     # row user is NULL. A ticket owned by a DIFFERENT user stays a 404.
-    if job.get("user_id") is not None and job.get("user_id") != user_id:
+    # Unscoped mode applies no user filter, exactly like the session read.
+    if user_scoped and job.get("user_id") is not None and job.get("user_id") != user_id:
         return None
     status_map = {
         "queued": "PENDING",

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -168,6 +168,31 @@ def normalize_idempotency_key(raw: Any) -> Any:
     return raw
 
 
+# Ticket statuses -> the API's RunStatus vocabulary. ONE mapping for every
+# surface that answers from a ticket (poll fallback, duplicate-202 bodies):
+# the API has no "FAILED" (RunStatus.error.value is "ERROR") and no "QUEUED",
+# and a client switch on status must never see a value the run endpoints
+# cannot also produce.
+_TICKET_STATUS_TO_API = {
+    "queued": "PENDING",
+    "running": "RUNNING",
+    "paused": "PAUSED",
+    "completed": "COMPLETED",
+    "failed": "ERROR",
+    "cancelled": "CANCELLED",
+}
+
+
+def ticket_status_to_api(ticket_status: str) -> Optional[str]:
+    """Map a queue-ticket status to the API's run-status vocabulary.
+
+    None for unknown statuses - callers decide their own fallback (the poll
+    fallback keeps its 404; the duplicate-202 branches pass the raw value
+    through rather than inventing a mapping for a store bug).
+    """
+    return _TICKET_STATUS_TO_API.get(ticket_status)
+
+
 def ensure_duplicate_matches_component(existing: Dict[str, Any], component_type: str, component_id: Any) -> None:
     """Refuse an Idempotency-Key duplicate that belongs to a different component.
 
@@ -2065,15 +2090,7 @@ async def aticket_poll_fallback(
     # Unscoped mode applies no user filter, exactly like the session read.
     if user_scoped and job.get("user_id") is not None and job.get("user_id") != user_id:
         return None
-    status_map = {
-        "queued": "PENDING",
-        "running": "RUNNING",
-        "paused": "PAUSED",
-        "completed": "COMPLETED",
-        "failed": "ERROR",
-        "cancelled": "CANCELLED",
-    }
-    status = status_map.get(job.get("status", ""))
+    status = ticket_status_to_api(job.get("status", ""))
     if status is None:
         return None
     body: Dict[str, Any] = {"run_id": run_id, "session_id": session_id, "status": status}

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -115,6 +115,21 @@ def _apply_coordination(redis: Union[str, RedisCoordination]) -> None:
 # Default timeout (in seconds) when stopping the worker
 _DEFAULT_STOP_TIMEOUT = 30
 
+
+def resolve_stop_timeout(config: QueueConfig) -> int:
+    """The drain timeout queue_lifespan hands the worker.
+
+    An explicit config.stop_timeout_seconds was already validated strictly
+    below lock_grace_seconds at construction. None means the worker default,
+    clamped below the lease grace - so every lock_grace the config validator
+    accepts also boots (3..30 used to pass validation and then die at
+    lifespan startup on the worker's stop_timeout < lock_grace invariant).
+    """
+    if config.stop_timeout_seconds is not None:
+        return config.stop_timeout_seconds
+    return min(_DEFAULT_STOP_TIMEOUT, max(1, config.lock_grace_seconds - 1))
+
+
 # The replica's active queue worker, set by queue_lifespan. Exists for
 # continue doors that have no Request/app in scope (MCP tools, AG-UI resume,
 # Slack HITL) but still must pass the inline-door admission gate - a durable
@@ -2175,7 +2190,9 @@ async def queue_lifespan(app: Any, agent_os: Any):
                 return resolved
         return None
 
-    worker = QueueWorker(store=store, resolve_component=resolve_component, config=config)
+    worker = QueueWorker(
+        store=store, resolve_component=resolve_component, config=config, stop_timeout=resolve_stop_timeout(config)
+    )
     app.state.queue_worker = worker
     set_active_queue_worker(worker)
     try:

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -22,9 +22,11 @@ def apply_queue_config(config: QueueConfig) -> None:
 
     Sets the background concurrency cap, and - when ``config.redis`` is given -
     wires the cross-container transports (cancellation manager + event stream)
-    from shared Redis clients. Transports are only wired over in-memory
-    defaults: explicitly configured backends are never replaced, so granular
-    configuration always wins.
+    from shared Redis clients. Transports are only wired over the never
+    explicitly-set process defaults: any backend installed via
+    ``set_event_stream``/``set_cancellation_manager`` (including an in-memory
+    one, e.g. a test double) is never replaced, so granular configuration
+    always wins.
     """
     from agno.run.concurrency import set_background_max_concurrency
 
@@ -57,16 +59,18 @@ def _apply_coordination(redis: Union[str, RedisCoordination]) -> None:
         sync_client = SyncRedis.from_url(url)
         async_client = AsyncRedis.from_url(url)
 
-    # Control in: distributed cancellation. Never clobber a custom manager.
-    from agno.run.cancel import get_cancellation_manager, set_cancellation_manager
-    from agno.run.cancellation_management.in_memory_cancellation_manager import InMemoryRunCancellationManager
+    # Control in: distributed cancellation. Never clobber an explicitly
+    # configured manager - the explicit-set flag is the authority, because an
+    # explicitly passed in-memory manager (or subclass, e.g. a test double) is
+    # indistinguishable by type from the default it replaced.
+    from agno.run.cancel import cancellation_manager_explicitly_set, set_cancellation_manager
     from agno.run.cancellation_management.redis_cancellation_manager import RedisRunCancellationManager
 
     cancellation_wired = False
     cancellation_prefix = (
         f"{coordination.key_prefix}:run:cancellation:" if coordination.key_prefix else "agno:run:cancellation:"
     )
-    if isinstance(get_cancellation_manager(), InMemoryRunCancellationManager):
+    if not cancellation_manager_explicitly_set():
         set_cancellation_manager(
             RedisRunCancellationManager(
                 redis_client=sync_client, async_redis_client=async_client, key_prefix=cancellation_prefix
@@ -77,14 +81,13 @@ def _apply_coordination(redis: Union[str, RedisCoordination]) -> None:
     else:
         log_debug("Queue coordination: keeping explicitly configured cancellation manager")
 
-    # Events out: Redis event stream. Never clobber a custom stream; the
-    # explicit AgentOS(event_stream=...) parameter is applied after this and
-    # wins by ordering.
-    from agno.os.event_streams import InMemoryEventStream, RedisEventStream, get_event_stream, set_event_stream
+    # Events out: Redis event stream. Same rule: only the never-explicitly-set
+    # process default is replaced.
+    from agno.os.event_streams import RedisEventStream, event_stream_explicitly_set, set_event_stream
 
     event_stream_wired = False
     stream_prefix = f"{coordination.key_prefix}:os:events:" if coordination.key_prefix else "agno:os:events:"
-    if isinstance(get_event_stream(), InMemoryEventStream):
+    if not event_stream_explicitly_set():
         set_event_stream(RedisEventStream(async_client, key_prefix=stream_prefix))
         event_stream_wired = True
         log_debug("Queue coordination: Redis event stream configured")

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -1502,9 +1502,13 @@ def get_agent_router(
                 # finishes. That is not real background semantics - it does
                 # not survive client disconnect - hence the warning; a
                 # durable queue (QueueConfig(durable=True)) is the real
-                # background door. Workflows differ deliberately: their
-                # continue endpoint never had the param, so the durable door
-                # is its only contract there and refuses instead.
+                # background door. Workflows differ deliberately: their HTTP
+                # continue endpoint's background param arrived with the
+                # durable queue (no pre-queue clients to protect), so it
+                # refuses without a ticket instead of falling through; only
+                # their WebSocket continue door falls back, to detached
+                # execution, because the socket is itself the live event
+                # channel that machinery streams into.
                 log_warning(
                     f"background=true continue for run {run_id} has no durable ticket: executing "
                     "INLINE-BLOCKING on this replica (legacy behavior; does not survive client "

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -943,21 +943,32 @@ def get_agent_router(
                     status_code=202,
                     content={"run_id": queued_run_id, "session_id": queued_session_id, "status": "PENDING"},
                 )
-            elif queue_worker is not None and (
-                not payload_is_queueable(queued_payload)
-                or base64_images
-                or base64_audios
-                or base64_videos
-                or input_files
-            ):
-                # Media-only bypasses were silent: the payload is JSON-clean
-                # but uploads cannot ride the queue yet, and the run silently
-                # lost durability. Same warning either way.
-                log_warning(
-                    "Background run bypasses the durable queue: the submission carries media "
-                    "uploads or values plain JSON cannot store (e.g. output_schema classes). "
-                    "Executing on the accepting replica instead - bounded and observable, but NOT durable."
-                )
+            elif queue_worker is not None:
+                # EVERY bypass reason warns - a client gets its 202 either way
+                # and must never silently believe acceptance was durable.
+                if (
+                    not payload_is_queueable(queued_payload)
+                    or base64_images
+                    or base64_audios
+                    or base64_videos
+                    or input_files
+                ):
+                    log_warning(
+                        "Background run bypasses the durable queue: the submission carries media "
+                        "uploads or values plain JSON cannot store (e.g. output_schema classes). "
+                        "Executing on the accepting replica instead - bounded and observable, but NOT durable."
+                    )
+                else:
+                    # Off-registry, factory-backed, or version-pinned: the
+                    # worker resolves from the registry, so these cannot ride
+                    # the queue - previously this dropped to the non-durable
+                    # path with no log line at all.
+                    log_warning(
+                        "Background run bypasses the durable queue: the agent is not a plain "
+                        "registry instance (remote, factory-backed, db-resolved, or version-pinned "
+                        "resolution differs from the worker's registry instance). Executing on the "
+                        "accepting replica instead - bounded and observable, but NOT durable."
+                    )
 
             run_response = cast(
                 RunOutput,

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -82,6 +82,7 @@ from agno.os.utils import (
     process_image,
     process_video,
     queued_run_tail_streamer,
+    sse_error_frame,
     replayed_payload_to_sse,
     resolve_agent,
 )
@@ -419,7 +420,7 @@ async def _resume_stream_generator(
         # the only honest signal is an SSE error frame (never a silent close,
         # and never a quiet fall-through to the DB path)
         log_error(f"Resume: event stream status probe failed for run {run_id}: {e}")
-        yield f'event: error\ndata: {{"event": "error", "error": "event stream unavailable: {str(e)[:200]}"}}\n\n'
+        yield sse_error_frame(f"event stream unavailable: {str(e)[:200]}")
         return
 
     if buffer_status is None:
@@ -530,9 +531,7 @@ async def _resume_stream_generator(
             # error frame so the client can distinguish and reconnect
             log_error(f"Resume tail failed for run {run_id}: {e}")
             with contextlib.suppress(Exception):
-                await tail_queue.put(
-                    (-1, f'event: error\ndata: {{"event": "error", "error": "stream tail failed: {str(e)[:200]}"}}\n\n')
-                )
+                await tail_queue.put((-1, sse_error_frame(f"stream tail failed: {str(e)[:200]}")))
         finally:
             await tail_queue.put(None)
 

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -46,6 +46,7 @@ from agno.os.job_queue import (
     araise_if_ticket_owns_continue,
     asettle_paused_ticket,
     aticket_poll_fallback,
+    ensure_duplicate_matches_component,
     normalize_idempotency_key,
     payload_is_queueable,
     validate_seam_input,
@@ -792,6 +793,7 @@ def get_agent_router(
                                 status_code=409,
                                 detail="Idempotency-Key was already used but the original run could not be retrieved",
                             )
+                        ensure_duplicate_matches_component(existing, "agent", job["component_id"])
                         if not (existing.get("payload") or {}).get("stream"):
                             # The key was used by a NON-stream submission: its
                             # run never registers in the event stream, so a
@@ -911,6 +913,7 @@ def get_agent_router(
                     raise HTTPException(status_code=429, detail="Job queue is full")
                 if enqueue_result["reason"] == "duplicate" and enqueue_result["job"] is not None:
                     existing = enqueue_result["job"]
+                    ensure_duplicate_matches_component(existing, "agent", job["component_id"])
                     return JSONResponse(
                         status_code=202,
                         content={

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -49,6 +49,7 @@ from agno.os.job_queue import (
     ensure_duplicate_matches_component,
     normalize_idempotency_key,
     payload_is_queueable,
+    ticket_status_to_api,
     validate_seam_input,
 )
 from agno.os.middleware.user_scope import (
@@ -919,9 +920,10 @@ def get_agent_router(
                         content={
                             "run_id": existing["id"],
                             "session_id": existing["session_id"],
-                            "status": "PENDING"
-                            if existing["status"] in ("queued", "running")
-                            else existing["status"].upper(),
+                            # Same vocabulary as the run poll: a duplicate of a
+                            # failed run says ERROR (not an invented "FAILED"),
+                            # and a running one says RUNNING (not PENDING).
+                            "status": ticket_status_to_api(existing["status"]) or existing["status"].upper(),
                         },
                     )
                 if enqueue_result["reason"] == "duplicate":

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -82,9 +82,9 @@ from agno.os.utils import (
     process_image,
     process_video,
     queued_run_tail_streamer,
-    sse_error_frame,
     replayed_payload_to_sse,
     resolve_agent,
+    sse_error_frame,
 )
 from agno.registry import Registry
 from agno.run.agent import RunErrorEvent, RunOutput

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -1841,7 +1841,13 @@ def get_agent_router(
                 # inside that beat reports an accepted run as nonexistent -
                 # answer from the ticket instead, tenant-checked, fail-closed.
                 ticket_view = await aticket_poll_fallback(
-                    getattr(request.app.state, "queue_worker", None), run_id, session_id, "agent", agent_id, user_id
+                    getattr(request.app.state, "queue_worker", None),
+                    run_id,
+                    session_id,
+                    "agent",
+                    agent_id,
+                    user_id,
+                    user_scoped=user_id is not None,
                 )
                 if ticket_view is not None:
                     return ticket_view
@@ -1851,7 +1857,13 @@ def get_agent_router(
         run_output = await agent.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)  # type: ignore[union-attr]
         if run_output is None:
             ticket_view = await aticket_poll_fallback(
-                getattr(request.app.state, "queue_worker", None), run_id, session_id, "agent", agent_id, user_id
+                getattr(request.app.state, "queue_worker", None),
+                run_id,
+                session_id,
+                "agent",
+                agent_id,
+                user_id,
+                user_scoped=user_id is not None,
             )
             if ticket_view is not None:
                 return ticket_view

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -1872,7 +1872,13 @@ def get_team_router(
                 # inside that beat reports an accepted run as nonexistent -
                 # answer from the ticket instead, tenant-checked, fail-closed.
                 ticket_view = await aticket_poll_fallback(
-                    getattr(request.app.state, "queue_worker", None), run_id, session_id, "team", team_id, user_id
+                    getattr(request.app.state, "queue_worker", None),
+                    run_id,
+                    session_id,
+                    "team",
+                    team_id,
+                    user_id,
+                    user_scoped=user_id is not None,
                 )
                 if ticket_view is not None:
                     return ticket_view
@@ -1882,7 +1888,13 @@ def get_team_router(
         run_output = await team.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)  # type: ignore[union-attr]
         if run_output is None:
             ticket_view = await aticket_poll_fallback(
-                getattr(request.app.state, "queue_worker", None), run_id, session_id, "team", team_id, user_id
+                getattr(request.app.state, "queue_worker", None),
+                run_id,
+                session_id,
+                "team",
+                team_id,
+                user_id,
+                user_scoped=user_id is not None,
             )
             if ticket_view is not None:
                 return ticket_view

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -42,6 +42,7 @@ from agno.os.job_queue import (
     araise_if_ticket_owns_continue,
     asettle_paused_ticket,
     aticket_poll_fallback,
+    ensure_duplicate_matches_component,
     normalize_idempotency_key,
     payload_is_queueable,
     validate_seam_input,
@@ -772,6 +773,7 @@ def get_team_router(
                                 status_code=409,
                                 detail="Idempotency-Key was already used but the original run could not be retrieved",
                             )
+                        ensure_duplicate_matches_component(existing, "team", job["component_id"])
                         if not (existing.get("payload") or {}).get("stream"):
                             # The key was used by a NON-stream submission: its
                             # run never registers in the event stream, so a
@@ -884,6 +886,7 @@ def get_team_router(
                     raise HTTPException(status_code=429, detail="Job queue is full")
                 if enqueue_result["reason"] == "duplicate" and enqueue_result["job"] is not None:
                     existing = enqueue_result["job"]
+                    ensure_duplicate_matches_component(existing, "team", job["component_id"])
                     return JSONResponse(
                         status_code=202,
                         content={

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -78,9 +78,9 @@ from agno.os.utils import (
     process_image,
     process_video,
     queued_run_tail_streamer,
-    sse_error_frame,
     replayed_payload_to_sse,
     resolve_team,
+    sse_error_frame,
 )
 from agno.registry import Registry
 from agno.run.agent import RunOutput

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -45,6 +45,7 @@ from agno.os.job_queue import (
     ensure_duplicate_matches_component,
     normalize_idempotency_key,
     payload_is_queueable,
+    ticket_status_to_api,
     validate_seam_input,
 )
 from agno.os.middleware.user_scope import (
@@ -892,9 +893,10 @@ def get_team_router(
                         content={
                             "run_id": existing["id"],
                             "session_id": existing["session_id"],
-                            "status": "PENDING"
-                            if existing["status"] in ("queued", "running")
-                            else existing["status"].upper(),
+                            # Same vocabulary as the run poll: a duplicate of a
+                            # failed run says ERROR (not an invented "FAILED"),
+                            # and a running one says RUNNING (not PENDING).
+                            "status": ticket_status_to_api(existing["status"]) or existing["status"].upper(),
                         },
                     )
                 if enqueue_result["reason"] == "duplicate":

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -78,6 +78,7 @@ from agno.os.utils import (
     process_image,
     process_video,
     queued_run_tail_streamer,
+    sse_error_frame,
     replayed_payload_to_sse,
     resolve_team,
 )
@@ -260,7 +261,7 @@ async def _resume_stream_generator(
         # the only honest signal is an SSE error frame (never a silent close,
         # and never a quiet fall-through to the DB path)
         log_error(f"Resume: event stream status probe failed for run {run_id}: {e}")
-        yield f'event: error\ndata: {{"event": "error", "error": "event stream unavailable: {str(e)[:200]}"}}\n\n'
+        yield sse_error_frame(f"event stream unavailable: {str(e)[:200]}")
         return
 
     if buffer_status is None:
@@ -371,9 +372,7 @@ async def _resume_stream_generator(
             # error frame so the client can distinguish and reconnect
             log_error(f"Resume tail failed for run {run_id}: {e}")
             with contextlib.suppress(Exception):
-                await tail_queue.put(
-                    (-1, f'event: error\ndata: {{"event": "error", "error": "stream tail failed: {str(e)[:200]}"}}\n\n')
-                )
+                await tail_queue.put((-1, sse_error_frame(f"stream tail failed: {str(e)[:200]}")))
         finally:
             await tail_queue.put(None)
 

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -916,21 +916,32 @@ def get_team_router(
                     status_code=202,
                     content={"run_id": queued_run_id, "session_id": queued_session_id, "status": "PENDING"},
                 )
-            elif queue_worker is not None and (
-                not payload_is_queueable(queued_payload)
-                or base64_images
-                or base64_audios
-                or base64_videos
-                or document_files
-            ):
-                # Media-only bypasses were silent: the payload is JSON-clean
-                # but uploads cannot ride the queue yet, and the run silently
-                # lost durability. Same warning either way.
-                log_warning(
-                    "Background run bypasses the durable queue: the submission carries media "
-                    "uploads or values plain JSON cannot store (e.g. output_schema classes). "
-                    "Executing on the accepting replica instead - bounded and observable, but NOT durable."
-                )
+            elif queue_worker is not None:
+                # EVERY bypass reason warns - a client gets its 202 either way
+                # and must never silently believe acceptance was durable.
+                if (
+                    not payload_is_queueable(queued_payload)
+                    or base64_images
+                    or base64_audios
+                    or base64_videos
+                    or document_files
+                ):
+                    log_warning(
+                        "Background run bypasses the durable queue: the submission carries media "
+                        "uploads or values plain JSON cannot store (e.g. output_schema classes). "
+                        "Executing on the accepting replica instead - bounded and observable, but NOT durable."
+                    )
+                else:
+                    # Off-registry, factory-backed, or version-pinned: the
+                    # worker resolves from the registry, so these cannot ride
+                    # the queue - previously this dropped to the non-durable
+                    # path with no log line at all.
+                    log_warning(
+                        "Background run bypasses the durable queue: the team is not a plain "
+                        "registry instance (remote, factory-backed, db-resolved, or version-pinned "
+                        "resolution differs from the worker's registry instance). Executing on the "
+                        "accepting replica instead - bounded and observable, but NOT durable."
+                    )
 
             run_response = await team.arun(  # type: ignore[misc]
                 input=message,

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1725,12 +1725,26 @@ def get_workflow_router(
                     status_code=202,
                     content={"run_id": queued_run_id, "session_id": queued_session_id, "status": "PENDING"},
                 )
-            elif queue_worker is not None and not payload_is_queueable(queued_payload):
-                log_warning(
-                    "Background run bypasses the durable queue: the submission carries values plain "
-                    "JSON cannot store (e.g. output_schema classes or media objects). Executing on the "
-                    "accepting replica instead - bounded and observable, but NOT durable."
-                )
+            elif queue_worker is not None:
+                # EVERY bypass reason warns - a client gets its 202 either way
+                # and must never silently believe acceptance was durable.
+                if not payload_is_queueable(queued_payload):
+                    log_warning(
+                        "Background run bypasses the durable queue: the submission carries values plain "
+                        "JSON cannot store (e.g. output_schema classes or media objects). Executing on the "
+                        "accepting replica instead - bounded and observable, but NOT durable."
+                    )
+                else:
+                    # Off-registry, factory-backed, or version-pinned: the
+                    # worker resolves from the registry, so these cannot ride
+                    # the queue - previously this dropped to the non-durable
+                    # path with no log line at all.
+                    log_warning(
+                        "Background run bypasses the durable queue: the workflow is not a plain "
+                        "registry instance (remote, factory-backed, db-resolved, or version-pinned "
+                        "resolution differs from the worker's registry instance). Executing on the "
+                        "accepting replica instead - bounded and observable, but NOT durable."
+                    )
 
             run_response = await workflow.arun(
                 input=message,

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -781,6 +781,11 @@ async def handle_workflow_continue_via_websocket(
                     _pump_event_stream_to_websocket(websocket, run_id, continue_outcome.get("tail_from"))
                 )
                 return
+            # DELIBERATE transport asymmetry with the HTTP continue door
+            # (which refuses this cell): the socket is itself the live event
+            # channel the detached machinery streams into, so falling back
+            # delivers exactly what the caller attached for - minus
+            # durability, hence the warning.
             log_warning(
                 "WS background continue bypasses the durable queue (no paused ticket for this "
                 "run): executing on the accepting replica instead - bounded and observable, "
@@ -1978,13 +1983,20 @@ def get_workflow_router(
                         content={"run_id": run_id, "session_id": session_id, "status": "PENDING"},
                     )
             # No durable path (no worker, factory/remote workflow, or no
-            # paused ticket): workflows have no detached background-continue
-            # machinery, so serve the regular response below - loudly, since
-            # the caller asked for background semantics that do not exist
-            # here: workflows have no detached background-continue machinery,
-            # so honoring the request is impossible. Refuse honestly instead
-            # of silently serving a replica-bound foreground response (the
-            # background param is NEW in this PR - no back-compat cost).
+            # paused ticket): refuse. The background param on this HTTP
+            # endpoint arrived with the durable queue, so no pre-queue
+            # clients depend on a fallthrough (unlike agents/teams, whose
+            # inline non-stream fallthrough is kept for back-compat), and
+            # HTTP has no workflow detached-continue machinery to serve
+            # instead - a replica-bound foreground response would silently
+            # fake the semantics the caller asked for.
+            #
+            # DELIBERATE transport asymmetry: the workflow WebSocket
+            # continue door falls back to detached execution with a warning
+            # for this same cell, because the socket is itself the live
+            # event channel the detached machinery streams into. HTTP has
+            # no equivalent until workflows grow the resumable-continue
+            # streamer agents/teams have.
             raise HTTPException(
                 status_code=409,
                 detail="background=true continuation is only available for durably-submitted "

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -70,10 +70,10 @@ from agno.os.utils import (
     get_workflow_by_id,
     get_workflow_by_id_async,
     queued_run_tail_streamer,
-    sse_error_frame,
-    stored_event_replay_dicts,
     replayed_payload_to_sse,
     resolve_workflow,
+    sse_error_frame,
+    stored_event_replay_dicts,
 )
 from agno.run.base import RunStatus
 from agno.run.workflow import WorkflowErrorEvent, WorkflowRunOutput

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -35,6 +35,7 @@ from agno.os.job_queue import (
     araise_if_ticket_owns_continue,
     asettle_paused_ticket,
     aticket_poll_fallback,
+    ensure_duplicate_matches_component,
     normalize_idempotency_key,
     payload_is_queueable,
     validate_seam_input,
@@ -1585,6 +1586,7 @@ def get_workflow_router(
                                 status_code=409,
                                 detail="Idempotency-Key was already used but the original run could not be retrieved",
                             )
+                        ensure_duplicate_matches_component(existing, "workflow", job["component_id"])
                         if not (existing.get("payload") or {}).get("stream"):
                             # The key was used by a NON-stream submission: its
                             # run never registers in the event stream, so a
@@ -1693,6 +1695,7 @@ def get_workflow_router(
                     raise HTTPException(status_code=429, detail="Job queue is full")
                 if enqueue_result["reason"] == "duplicate" and enqueue_result["job"] is not None:
                     existing = enqueue_result["job"]
+                    ensure_duplicate_matches_component(existing, "workflow", job["component_id"])
                     return JSONResponse(
                         status_code=202,
                         content={

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -38,6 +38,7 @@ from agno.os.job_queue import (
     ensure_duplicate_matches_component,
     normalize_idempotency_key,
     payload_is_queueable,
+    ticket_status_to_api,
     validate_seam_input,
 )
 from agno.os.middleware.user_scope import (
@@ -1701,9 +1702,10 @@ def get_workflow_router(
                         content={
                             "run_id": existing["id"],
                             "session_id": existing["session_id"],
-                            "status": "PENDING"
-                            if existing["status"] in ("queued", "running")
-                            else existing["status"].upper(),
+                            # Same vocabulary as the run poll: a duplicate of a
+                            # failed run says ERROR (not an invented "FAILED"),
+                            # and a running one says RUNNING (not PENDING).
+                            "status": ticket_status_to_api(existing["status"]) or existing["status"].upper(),
                         },
                     )
                 if enqueue_result["reason"] == "duplicate":

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -2308,6 +2308,7 @@ def get_workflow_router(
                     "workflow",
                     workflow_id,
                     user_id,
+                    user_scoped=user_id is not None,
                 )
                 if ticket_view is not None:
                     return ticket_view
@@ -2317,7 +2318,13 @@ def get_workflow_router(
         run_output = await workflow.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)
         if run_output is None:
             ticket_view = await aticket_poll_fallback(
-                getattr(request.app.state, "queue_worker", None), run_id, session_id, "workflow", workflow_id, user_id
+                getattr(request.app.state, "queue_worker", None),
+                run_id,
+                session_id,
+                "workflow",
+                workflow_id,
+                user_id,
+                user_scoped=user_id is not None,
             )
             if ticket_view is not None:
                 return ticket_view

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -71,6 +71,7 @@ from agno.os.utils import (
     get_workflow_by_id_async,
     queued_run_tail_streamer,
     sse_error_frame,
+    stored_event_replay_dicts,
     replayed_payload_to_sse,
     resolve_workflow,
 )
@@ -491,41 +492,29 @@ async def handle_workflow_subscription(
                     workflow_run = await workflow.aget_run_output(run_id, session_id, user_id=user_id)
 
                     if workflow_run:
-                        # Run exists in DB - send all events from DB
-                        if workflow_run.events:
-                            await websocket.send_text(
-                                json.dumps(
-                                    {
-                                        "event": "replay",
-                                        "run_id": run_id,
-                                        "status": workflow_run.status.value if workflow_run.status else "unknown",
-                                        "total_events": len(workflow_run.events),
-                                        "message": "Run completed. Replaying all events from database.",
-                                    }
-                                )
+                        # Run exists in DB - replay through the shared
+                        # floor-honoring helper (same contract as the SSE
+                        # resume routes): stamped events are filtered under
+                        # the client's last_event_index and keep their REAL
+                        # stream indices - positional renumbering re-sent the
+                        # full history and destroyed index continuity for
+                        # partially-caught-up clients.
+                        replay_dicts = stored_event_replay_dicts(workflow_run, run_id, last_event_index)
+                        await websocket.send_text(
+                            json.dumps(
+                                {
+                                    "event": "replay",
+                                    "run_id": run_id,
+                                    "status": workflow_run.status.value if workflow_run.status else "unknown",
+                                    "total_events": len(replay_dicts),
+                                    "message": "Run completed. Replaying stored events from database."
+                                    if replay_dicts
+                                    else "Run completed but no events stored past the requested index.",
+                                }
                             )
-
-                            # Send events one by one
-                            for idx, event in enumerate(workflow_run.events):
-                                # Convert event to dict and add event_index
-                                event_dict = event.model_dump() if hasattr(event, "model_dump") else event.to_dict()
-                                event_dict["event_index"] = idx
-                                if "run_id" not in event_dict:
-                                    event_dict["run_id"] = run_id
-
-                                await websocket.send_text(json.dumps(event_dict, default=json_serializer))
-                        else:
-                            await websocket.send_text(
-                                json.dumps(
-                                    {
-                                        "event": "replay",
-                                        "run_id": run_id,
-                                        "status": workflow_run.status.value if workflow_run.status else "unknown",
-                                        "total_events": 0,
-                                        "message": "Run completed but no events stored.",
-                                    }
-                                )
-                            )
+                        )
+                        for event_dict in replay_dicts:
+                            await websocket.send_text(json.dumps(event_dict, default=json_serializer))
                         return
 
             # Run not found anywhere

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -70,6 +70,7 @@ from agno.os.utils import (
     get_workflow_by_id,
     get_workflow_by_id_async,
     queued_run_tail_streamer,
+    sse_error_frame,
     replayed_payload_to_sse,
     resolve_workflow,
 )
@@ -1127,7 +1128,7 @@ async def _resume_stream_generator(
         # the only honest signal is an SSE error frame (never a silent close,
         # and never a quiet fall-through to the DB path)
         log_error(f"Resume: event stream status probe failed for run {run_id}: {e}")
-        yield f'event: error\ndata: {{"event": "error", "error": "event stream unavailable: {str(e)[:200]}"}}\n\n'
+        yield sse_error_frame(f"event stream unavailable: {str(e)[:200]}")
         return
 
     if buffer_status is None:
@@ -1238,9 +1239,7 @@ async def _resume_stream_generator(
             # error frame so the client can distinguish and reconnect
             log_error(f"Resume tail failed for run {run_id}: {e}")
             with contextlib.suppress(Exception):
-                await tail_queue.put(
-                    (-1, f'event: error\ndata: {{"event": "error", "error": "stream tail failed: {str(e)[:200]}"}}\n\n')
-                )
+                await tail_queue.put((-1, sse_error_frame(f"stream tail failed: {str(e)[:200]}")))
         finally:
             await tail_queue.put(None)
 

--- a/libs/agno/agno/os/services/runs.py
+++ b/libs/agno/agno/os/services/runs.py
@@ -75,19 +75,37 @@ async def continue_paused_run(
         get_active_queue_worker(), run_id, component_type=component_type, component_id=getattr(component, "id", None)
     )
     if isinstance(component, Workflow):
-        return await component.acontinue_run(
+        result: AnyRunOutput = await component.acontinue_run(
             run_id=run_id,
             session_id=session_id,
             step_requirements=parse_step_requirements(requirements),
             stream=False,
         )
-    return await component.acontinue_run(  # type: ignore[misc, no-any-return]
-        run_id=run_id,
-        session_id=session_id,
-        user_id=user_id,
-        requirements=parse_run_requirements(requirements),
-        stream=False,
+    else:
+        result = await component.acontinue_run(  # type: ignore[misc]
+            run_id=run_id,
+            session_id=session_id,
+            user_id=user_id,
+            requirements=parse_run_requirements(requirements),
+            stream=False,
+        )
+    # Status-only stream sync (parity with the REST non-stream continue
+    # door): a formerly-queued/streamed run's stream view must stop saying
+    # PAUSED once the continue settles - otherwise every later /resume
+    # replays the stale paused snapshot, and on Redis the pausing replica's
+    # TTL refresher keeps those keys alive indefinitely. only_if_tracked
+    # leaves never-streamed runs alone; a re-paused continue re-parks the
+    # stream as PAUSED.
+    from agno.os.utils import acomplete_continue_stream
+
+    await acomplete_continue_stream(
+        component,
+        run_id,
+        session_id,
+        only_if_tracked=True,
+        final_status=getattr(result, "status", None),
     )
+    return result
 
 
 async def cancel_component_run(component: Union[Agent, Team, Workflow], run_id: str) -> None:
@@ -102,6 +120,17 @@ async def cancel_component_run(component: Union[Agent, Team, Workflow], run_id: 
     over HTTP and return False when the call fails; that must surface, not read as
     success.
     """
+    # Tombstone a still-queued durable ticket first (parity with the REST
+    # cancel routes): intent alone does not stop a job no task is executing
+    # yet - without this, a worker claims the waiting ticket, starts the leg,
+    # and the leg only dies at its first cancellation checkpoint, burning an
+    # attempt and stamping a spurious execution start on the run row.
+    # acancel_queued is a no-op for unticketed or already-executing runs.
+    from agno.os.job_queue import get_active_queue_worker
+
+    queue_worker = get_active_queue_worker()
+    if queue_worker is not None:
+        await queue_worker.acancel_queued(run_id)
     cancelled = await component.acancel_run(run_id=run_id)
     if cancelled is False and isinstance(component, BaseRemote):
         raise Exception(f"Cancellation of run {run_id} could not be delivered to the remote component.")

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -476,7 +476,13 @@ async def amark_continue_stream_running(
         # it also clears the pause's completed_at so the reopened run cannot
         # be reaped mid-continuation, and seeds the index counter from the
         # durable floor when the stream's own counter expired.
-        await event_stream.reopen_run(run_id, floor=floor)
+        if not await event_stream.reopen_run(run_id, floor=floor):
+            # Declined: the status already moved past PAUSED (a racing writer
+            # finished or took over the leg). Stamping RUNNING over that
+            # newer state would resurrect a settled stream until the
+            # streamer's finally heals it - honor the reopen contract and
+            # leave the stream alone; the continue itself proceeds.
+            return
         await event_stream.set_run_status(run_id, RunStatus.running)
 
 

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -274,6 +274,16 @@ def format_sse_event_with_index(
         return f"event: message\ndata: {clean_json}\n\n"
 
 
+def sse_error_frame(message: str) -> str:
+    """A wire-safe SSE error frame.
+
+    The payload goes through json.dumps: hand-interpolating exception text
+    into an f-string frame emitted invalid JSON the moment the message
+    contained a quote, backslash, or newline.
+    """
+    return f"event: error\ndata: {json.dumps({'event': 'error', 'error': message})}\n\n"
+
+
 async def queued_run_tail_streamer(run_id: str, from_index: Optional[int] = None) -> Any:
     """SSE response for a durably queued STREAMING run: tail the event stream.
 
@@ -313,9 +323,7 @@ async def queued_run_tail_streamer(run_id: str, from_index: Optional[int] = None
             # error frame so the client can distinguish and reconnect
             log_error(f"Queued stream tail failed for run {run_id}: {e}")
             with contextlib.suppress(Exception):
-                await tail_queue.put(
-                    (-1, f'event: error\ndata: {{"event": "error", "error": "stream tail failed: {str(e)[:200]}"}}\n\n')
-                )
+                await tail_queue.put((-1, sse_error_frame(f"stream tail failed: {str(e)[:200]}")))
         finally:
             await tail_queue.put(None)
 

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -377,25 +377,26 @@ async def queued_run_tail_streamer(run_id: str, from_index: Optional[int] = None
             await pump_task
 
 
-def stored_event_replay_frames(run_output: Any, run_id: str, last_event_index: Optional[int] = None) -> List[str]:
-    """PATH-3 (DB fallback) replay frames, honoring the client's floor.
+def stored_event_replay_dicts(
+    run_output: Any, run_id: str, last_event_index: Optional[int] = None
+) -> List[Dict[str, Any]]:
+    """DB-fallback replay payloads, honoring the client's floor.
 
-    ONE implementation for all three routers - the old triplicated loop
-    ignored last_event_index and renumbered every stored event from zero:
-    duplicates for partially-caught-up clients, and destroyed index
-    continuity (stream indices are NOT gapless - retries and continuation
-    legs leave real gaps that positional renumbering compacted away).
+    ONE implementation for every replay surface (the three SSE resume routes
+    and the workflow WS subscription) - the old per-surface loops ignored
+    last_event_index and renumbered every stored event from zero: duplicates
+    for partially-caught-up clients, and destroyed index continuity (stream
+    indices are NOT gapless - retries and continuation legs leave real gaps
+    that positional renumbering compacted away).
 
     Events stamped at publish carry their real stream index (event_index);
     those are floor-filtered and replayed under their stored index.
     Unstamped legacy events keep the positional fallback and are never
     floor-filtered: a floor from live-stream indices does not speak their
-    numbering. The meta frame's total reflects what is actually replayed.
+    numbering.
     """
-    from agno.utils.serialize import json_serializer
-
     floor = last_event_index if last_event_index is not None else -1
-    frames: List[str] = []
+    dicts: List[Dict[str, Any]] = []
     for position, event in enumerate(getattr(run_output, "events", None) or []):
         event_dict = event.to_dict()
         stored_index = event_dict.get("event_index")
@@ -404,6 +405,17 @@ def stored_event_replay_frames(run_output: Any, run_id: str, last_event_index: O
         event_dict["event_index"] = int(stored_index) if stored_index is not None else position
         if "run_id" not in event_dict:
             event_dict["run_id"] = run_id
+        dicts.append(event_dict)
+    return dicts
+
+
+def stored_event_replay_frames(run_output: Any, run_id: str, last_event_index: Optional[int] = None) -> List[str]:
+    """SSE framing over ``stored_event_replay_dicts`` (the PATH-3 resume
+    routes). The meta frame's total reflects what is actually replayed."""
+    from agno.utils.serialize import json_serializer
+
+    frames: List[str] = []
+    for event_dict in stored_event_replay_dicts(run_output, run_id, last_event_index):
         event_type = event_dict.get("event", "message")
         frames.append(
             f"event: {event_type}\n"

--- a/libs/agno/agno/run/cancel.py
+++ b/libs/agno/agno/run/cancel.py
@@ -9,6 +9,12 @@ from agno.utils.log import logger
 
 # Global cancellation manager instance
 _cancellation_manager: BaseRunCancellationManager = InMemoryRunCancellationManager()
+# True once set_cancellation_manager() has been called. The import-time
+# in-memory default does NOT set this - it is what lets queue wiring
+# distinguish the default nobody chose (replaceable) from an explicitly
+# configured manager (never replaced). An isinstance check cannot make that
+# distinction for in-memory managers and their subclasses.
+_cancellation_manager_explicitly_set: bool = False
 
 # Per team run_id, the async delegate tasks the model spawned. The team's cancel
 # handler awaits these before persisting so each member's post-cancel
@@ -30,14 +36,24 @@ def set_cancellation_manager(manager: BaseRunCancellationManager) -> None:
         set_cancellation_manager(MyCustomManager())
         ```
     """
-    global _cancellation_manager
+    global _cancellation_manager, _cancellation_manager_explicitly_set
     _cancellation_manager = manager
+    _cancellation_manager_explicitly_set = True
     logger.info(f"Cancellation manager set to {type(manager).__name__}")
 
 
 def get_cancellation_manager() -> BaseRunCancellationManager:
     """Get the current cancellation manager instance."""
     return _cancellation_manager
+
+
+def cancellation_manager_explicitly_set() -> bool:
+    """Whether a manager was ever installed via ``set_cancellation_manager()``.
+
+    False means the process is running on the import-time in-memory default,
+    which coordination wiring may replace.
+    """
+    return _cancellation_manager_explicitly_set
 
 
 def register_run(run_id: str) -> None:

--- a/libs/agno/tests/integration/db/test_queue_store_parity.py
+++ b/libs/agno/tests/integration/db/test_queue_store_parity.py
@@ -231,6 +231,15 @@ class TestWaitingLifecycleParity:
         assert job["status"] == "queued"
         assert job["max_attempts"] == job["attempt"] + 1, "continue grants exactly one more execution"
         assert job["payload"]["continue"]["updated_tools"] == [{"tool_call_id": "t1"}]
+        # The returned ticket is a plain data dict on every store: the SQL
+        # adapters stamp timestamps with DB-clock expressions and must
+        # resolve them to concrete ints, not hand back Cast objects.
+        assert isinstance(job["available_at"], int) and isinstance(job["updated_at"], int), (
+            f"timestamp stamps must be ints, got {type(job['available_at'])!r}/{type(job['updated_at'])!r}"
+        )
+        import json
+
+        json.dumps(job)
 
         attach = await store.continue_job("r1", {"updated_tools": []})
         assert attach["outcome"] == "attach"
@@ -401,3 +410,35 @@ class TestSweepSettleParity:
         assert await store.settle_swept_job("r1", "sweeper", "failed", "worker lost")
         job = await store.get_job("r1")
         assert job["status"] == "failed" and job["error"] == "worker lost"
+
+
+@pytest.mark.skipif(not _PG_AVAILABLE, reason="Postgres not available on localhost:5532")
+class TestSyncPostgresContinueJobStamps:
+    """The sync Postgres adapter's continue_job twin: the parity fixture runs
+    the ASYNC adapter, so the sync path's timestamp resolution needs its own
+    pin (both adapters stamp with SQL DB-clock expressions)."""
+
+    def test_returned_job_is_json_serializable(self):
+        import json
+
+        import sqlalchemy
+
+        from agno.db.postgres import PostgresDb
+
+        db = PostgresDb(db_url=PG_URL, job_table=f"parity_sync_{uuid.uuid4().hex[:8]}")
+        try:
+            db.enqueue_job(make_job("r1"))
+            claimed = db.claim_job("w1")
+            assert db.complete_job("r1", "w1", claimed["attempt"], "paused")
+            result = db.continue_job("r1", {"updated_tools": [{"tool_call_id": "t1"}]})
+            assert result["outcome"] == "queued"
+            job = result["job"]
+            assert isinstance(job["available_at"], int) and isinstance(job["updated_at"], int), (
+                f"timestamp stamps must be ints, got {type(job['available_at'])!r}/{type(job['updated_at'])!r}"
+            )
+            json.dumps(job)
+        finally:
+            engine = sqlalchemy.create_engine(PG_URL)
+            with engine.begin() as conn:
+                conn.execute(sqlalchemy.text(f'DROP TABLE IF EXISTS {db.db_schema}."{db.job_table_name}"'))
+            engine.dispose()

--- a/libs/agno/tests/integration/db/test_queue_store_parity.py
+++ b/libs/agno/tests/integration/db/test_queue_store_parity.py
@@ -150,6 +150,27 @@ class TestDedupParity:
         )
 
 
+class TestEnqueueIdCollisionParity:
+    @pytest.mark.asyncio
+    async def test_reenqueue_of_live_id_raises_and_preserves_ticket(self, store):
+        """Job ids are server-minted and never reused: enqueueing an existing
+        id is a programming error and must raise (Postgres: primary key),
+        never silently reset a live ticket to queued/attempt-0 - that would
+        put two executors on one run and fence out the first one's
+        completion."""
+        await store.enqueue_job(make_job("r1"))
+        claimed = await store.claim_job("w1")
+        assert claimed is not None
+
+        with pytest.raises(Exception):
+            await store.enqueue_job(make_job("r1"))
+
+        job = await store.get_job("r1")
+        assert job["status"] == "running" and job["attempt"] == claimed["attempt"], (
+            f"the live ticket must survive untouched, got {job['status']}/{job['attempt']}"
+        )
+
+
 class TestDepthGateParity:
     @pytest.mark.asyncio
     async def test_sequential_depth_gate_shared_contract(self, store):

--- a/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
+++ b/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
@@ -109,12 +109,18 @@ class TestTicketPollFallback:
         body = resp.json()
         assert body["status"] == "ERROR" and body["content"] == "worker lost"
 
-    def test_tenant_mismatch_stays_404(self, harness):
-        """A guessable run_id must not leak another tenant's run existence:
-        a ticket owned by a user is invisible to an unscoped caller."""
+    def test_unscoped_poll_sees_user_owned_ticket(self, harness):
+        """No user-scope middleware means get_scoped_user_id is None: NO
+        filtering, exactly like the session read. A user-owned ticket must
+        answer the poll - treating the None as an anonymous owner value
+        404ed accepted user-owned runs for every admin/unscoped poll inside
+        the ticket-before-run-row window. (Tenant isolation between SCOPED
+        principals is pinned at the helper level: a scoped caller with a
+        different user_id stays 404.)"""
         seed_ticket(harness.store, "r-poll-3", user_id="alice")
         resp = harness.client.get("/agents/qa-agent/runs/r-poll-3", params={"session_id": "s-tkt"})
-        assert resp.status_code == 404
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "PENDING"
 
     def test_session_mismatch_stays_404(self, harness):
         seed_ticket(harness.store, "r-poll-4")
@@ -162,7 +168,7 @@ class TestHelperUnits:
         ).to_dict()
         store._jobs["r1"] = job
         worker = SimpleNamespace(store=store)
-        view = await aticket_poll_fallback(worker, "r1", "s1", "agent", "a1", None)
+        view = await aticket_poll_fallback(worker, "r1", "s1", "agent", "a1", None, user_scoped=False)
         assert view is not None and view["status"] == expected
 
     @pytest.mark.asyncio
@@ -174,8 +180,25 @@ class TestHelperUnits:
             id="r1", component_type="agent", component_id="a1", session_id="s1", payload={}, user_id="alice"
         ).to_dict()
         worker = SimpleNamespace(store=store)
-        assert await aticket_poll_fallback(worker, "r1", "s1", "agent", "a1", "alice") is not None
-        assert await aticket_poll_fallback(worker, "r1", "s1", "agent", "a1", "bob") is None
+        assert await aticket_poll_fallback(worker, "r1", "s1", "agent", "a1", "alice", user_scoped=True) is not None
+        assert await aticket_poll_fallback(worker, "r1", "s1", "agent", "a1", "bob", user_scoped=True) is None
+
+    @pytest.mark.asyncio
+    async def test_unscoped_mode_sees_user_owned_ticket(self):
+        """get_scoped_user_id returns None for admins and unscoped
+        deployments - NO filtering, exactly like the session read this
+        fallback mirrors. Treating that None as an anonymous owner value
+        404ed accepted user-owned runs for every admin poll inside the
+        ticket-before-run-row window."""
+        from agno.os.job_queue import aticket_poll_fallback
+
+        store = InMemoryQueueStore()
+        store._jobs["r1"] = QueuedJob(
+            id="r1", component_type="agent", component_id="a1", session_id="s1", payload={}, user_id="alice"
+        ).to_dict()
+        worker = SimpleNamespace(store=store)
+        view = await aticket_poll_fallback(worker, "r1", "s1", "agent", "a1", None, user_scoped=False)
+        assert view is not None and view["status"] == "PENDING"
 
 
 class TestBackgroundContinueCompatFallthrough:

--- a/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
+++ b/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
@@ -138,6 +138,60 @@ class TestTicketPollFallback:
         assert resp.status_code == 404
 
 
+class TestDurabilityBypassIsLoud:
+    """A worker is present, the client gets its 202/stream - but the run is
+    executing on the accepting replica, not the durable queue. EVERY bypass
+    reason must warn: the payload/media reasons always did, while
+    factory-backed / off-registry / version-pinned submissions dropped to
+    the non-durable path with no log line at all."""
+
+    @pytest.fixture()
+    def factory_harness(self, tmp_path):
+        from agno.agent.factory import AgentFactory
+
+        db = SqliteDb(db_file=str(tmp_path / "f.db"))
+        produced = Agent(id="fx-agent", name="Produced Agent", db=db)
+        factory = AgentFactory(id="fx-agent", db=db, factory=lambda ctx: produced)
+        app = AgentOS(agents=[factory], telemetry=False).get_app()
+        store = InMemoryQueueStore()
+        app.state.queue_worker = SimpleNamespace(store=store, config=QueueConfig(durable=True))
+        client = TestClient(app, raise_server_exceptions=False)
+        return SimpleNamespace(app=app, store=store, client=client)
+
+    def test_factory_backed_submission_warns(self, factory_harness, caplog):
+        with caplog.at_level("WARNING"):
+            factory_harness.client.post(
+                "/agents/fx-agent/runs", data={"message": "hi", "stream": "false", "background": "true"}
+            )
+        assert any("bypasses the durable queue" in r.message for r in caplog.records), (
+            "a factory-backed background submission silently lost durability - it must warn"
+        )
+        assert len(factory_harness.store._jobs) == 0, "the bypass must not have enqueued anything"
+
+    def test_durable_path_does_not_warn(self, harness, monkeypatch):
+        """No false alarms: a queueable registry submission rides the queue
+        and must NOT log the bypass warning."""
+
+        async def ok_prepare(component, component_type, run_id, session_id, user_id, input):
+            return None
+
+        monkeypatch.setattr("agno.os.job_queue.aprepare_queued_run", ok_prepare)
+        import logging
+
+        records = []
+        handler = logging.Handler()
+        handler.emit = lambda record: records.append(record)  # type: ignore[method-assign]
+        logging.getLogger().addHandler(handler)
+        try:
+            resp = harness.client.post(
+                "/agents/qa-agent/runs", data={"message": "hi", "stream": "false", "background": "true"}
+            )
+        finally:
+            logging.getLogger().removeHandler(handler)
+        assert resp.status_code == 202
+        assert not any("bypasses the durable queue" in str(r.getMessage()) for r in records)
+
+
 class TestDuplicate202Vocabulary:
     """The duplicate-202 body speaks the SAME status vocabulary as the run
     poll: no invented "FAILED" (the API's error value is "ERROR"), and a

--- a/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
+++ b/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
@@ -138,6 +138,43 @@ class TestTicketPollFallback:
         assert resp.status_code == 404
 
 
+class TestDuplicate202Vocabulary:
+    """The duplicate-202 body speaks the SAME status vocabulary as the run
+    poll: no invented "FAILED" (the API's error value is "ERROR"), and a
+    currently-RUNNING original answers RUNNING, not PENDING - a client
+    switch on status must never see a value the run endpoints cannot also
+    produce."""
+
+    def _duplicate(self, harness):
+        return harness.client.post(
+            "/agents/qa-agent/runs",
+            data={"message": "hi", "stream": "false", "background": "true"},
+            headers={"Idempotency-Key": "dup-key"},
+        )
+
+    def test_failed_original_answers_error_not_failed(self, harness):
+        seed_ticket(harness.store, "r-dup-1", status="failed", idempotency_key="dup-key")
+        resp = self._duplicate(harness)
+        assert resp.status_code == 202
+        assert resp.json()["status"] == "ERROR", (
+            f"poll vocabulary is ERROR; got {resp.json()['status']!r} (FAILED exists nowhere else in the API)"
+        )
+
+    def test_running_original_answers_running_not_pending(self, harness):
+        seed_ticket(harness.store, "r-dup-2", status="running", idempotency_key="dup-key")
+        resp = self._duplicate(harness)
+        assert resp.status_code == 202
+        assert resp.json()["status"] == "RUNNING", (
+            "a poll of the same run says RUNNING; the duplicate must not flatten it to PENDING"
+        )
+
+    def test_queued_original_still_answers_pending(self, harness):
+        seed_ticket(harness.store, "r-dup-3", status="queued", idempotency_key="dup-key")
+        resp = self._duplicate(harness)
+        assert resp.status_code == 202
+        assert resp.json()["status"] == "PENDING"
+
+
 class TestHelperUnits:
     """Direct unit coverage of aticket_poll_fallback's status mapping (the
     router tests above cover the wiring)."""

--- a/libs/agno/tests/unit/os/test_alternate_door_parity.py
+++ b/libs/agno/tests/unit/os/test_alternate_door_parity.py
@@ -1,0 +1,292 @@
+"""Door parity for the non-REST surfaces (MCP tools, AG-UI, Slack, A2A).
+
+The REST continue/cancel routes carry two obligations the alternate doors
+were missing:
+
+- continue: a status-only event-stream sync once the continue settles. A
+  stream-PAUSED run continued through one of these doors otherwise completes
+  in the DB while its stream view stays PAUSED - and on Redis the pausing
+  replica's TTL refresher keeps those keys alive indefinitely, so every later
+  /resume replays the stale paused snapshot forever.
+- cancel: tombstone a still-queued durable ticket BEFORE registering the
+  cancellation intent. Intent alone does not stop a job no task is executing
+  yet: a worker claims the waiting ticket, starts the leg, and the leg only
+  dies at its first cancellation checkpoint - burning an attempt and stamping
+  a spurious execution start.
+"""
+
+import json
+from types import SimpleNamespace
+from typing import Any, List, Optional
+
+import pytest
+
+import agno.os.event_streams as es_mod
+import agno.os.job_queue as jq
+from agno.os.event_streams import InMemoryEventStream
+from agno.run.base import RunStatus
+
+
+@pytest.fixture()
+def stream():
+    from agno.os.managers import EventsBuffer, SSESubscriberManager
+
+    original = es_mod._event_stream
+    fresh = InMemoryEventStream(events_buffer=EventsBuffer(), subscriber_manager=SSESubscriberManager())
+    es_mod._event_stream = fresh
+    yield fresh
+    es_mod._event_stream = original
+
+
+@pytest.fixture(autouse=True)
+def no_active_worker():
+    """The doors' ticket-admission gate must see no worker unless a test
+    installs one; always restore."""
+    original = jq.get_active_queue_worker()
+    jq.set_active_queue_worker(None)
+    yield
+    jq.set_active_queue_worker(original)
+
+
+async def _park_paused(stream: InMemoryEventStream, run_id: str) -> None:
+    """Simulate the pre-pause history: a streamed run that paused for HITL."""
+    await stream.register_run(run_id, RunStatus.pending)
+    await stream.set_run_status(run_id, RunStatus.running)
+    await stream.complete_run(run_id, RunStatus.paused)
+
+
+class _Session:
+    def __init__(self, runs: List[Any]):
+        self.runs = runs
+
+    def get_run(self, run_id: str):
+        return next((r for r in self.runs if getattr(r, "run_id", None) == run_id), None)
+
+
+class TestMcpContinueDoorSyncsStream:
+    @pytest.mark.asyncio
+    async def test_tracked_paused_stream_reaches_final_status(self, stream):
+        from agno.os.services.runs import continue_paused_run
+
+        await _park_paused(stream, "r-mcp")
+
+        class FakeAgent:
+            id = "a1"
+
+            async def acontinue_run(self, **kwargs):
+                return SimpleNamespace(status=RunStatus.completed, run_id="r-mcp")
+
+        result = await continue_paused_run(FakeAgent(), run_id="r-mcp", session_id="s1")
+
+        assert result.status == RunStatus.completed
+        assert await stream.get_run_status("r-mcp") == RunStatus.completed, (
+            "the MCP continue door must sync a tracked stream off PAUSED"
+        )
+
+    @pytest.mark.asyncio
+    async def test_never_streamed_run_gets_no_fabricated_stream(self, stream):
+        from agno.os.services.runs import continue_paused_run
+
+        class FakeAgent:
+            id = "a1"
+
+            async def acontinue_run(self, **kwargs):
+                return SimpleNamespace(status=RunStatus.completed, run_id="r-inline")
+
+        await continue_paused_run(FakeAgent(), run_id="r-inline", session_id="s1")
+
+        assert await stream.get_run_status("r-inline") is None, (
+            "only_if_tracked: a run that never streamed needs no stream view"
+        )
+
+
+class TestMcpCancelDoorTombstonesTicket:
+    @pytest.mark.asyncio
+    async def test_ticket_tombstoned_before_intent(self):
+        from agno.os.services.runs import cancel_component_run
+
+        order: List[Any] = []
+
+        class FakeWorker:
+            async def acancel_queued(self, run_id):
+                order.append(("tombstone", run_id))
+                return True
+
+        class FakeComponent:
+            async def acancel_run(self, run_id):
+                order.append(("intent", run_id))
+                return True
+
+        jq.set_active_queue_worker(FakeWorker())
+        await cancel_component_run(FakeComponent(), "r-c1")
+
+        assert order == [("tombstone", "r-c1"), ("intent", "r-c1")], (
+            "a queued durable ticket must be tombstoned before the intent - "
+            "intent alone does not stop a job no task is executing yet"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_worker_still_cancels(self):
+        from agno.os.services.runs import cancel_component_run
+
+        calls: List[str] = []
+
+        class FakeComponent:
+            async def acancel_run(self, run_id):
+                calls.append(run_id)
+                return True
+
+        await cancel_component_run(FakeComponent(), "r-c2")
+        assert calls == ["r-c2"]
+
+
+class TestA2ACancelDelegatesToService:
+    """The A2A tasks:cancel handlers must route through the shared cancel
+    service (which owns the ticket tombstone), not call acancel_run direct."""
+
+    @staticmethod
+    def _build_client(monkeypatch, recorded: List[Any]):
+        pytest.importorskip("a2a", reason="a2a-sdk not installed")
+        from fastapi import FastAPI
+        from fastapi.routing import APIRouter
+        from fastapi.testclient import TestClient
+
+        from agno.agent import Agent
+        from agno.os.interfaces.a2a.router import attach_routes
+        from agno.team import Team
+
+        async def recording_cancel(component, run_id):
+            recorded.append((component, run_id))
+
+        monkeypatch.setattr("agno.os.services.runs.cancel_component_run", recording_cancel)
+
+        agent = Agent(id="a2a-agent", name="A2A Agent")
+        team = Team(id="a2a-team", name="A2A Team", members=[agent])
+        app = FastAPI()
+        app.include_router(attach_routes(APIRouter(), agents=[agent], teams=[team]))
+        return TestClient(app)
+
+    def test_agent_cancel_routes_through_service(self, monkeypatch):
+        recorded: List[Any] = []
+        client = self._build_client(monkeypatch, recorded)
+
+        resp = client.post(
+            "/agents/a2a-agent/v1/tasks:cancel",
+            json={"id": "req-1", "params": {"id": "run-42", "contextId": "ctx-1"}},
+        )
+
+        assert resp.status_code == 200
+        assert [(getattr(c, "id", None), r) for c, r in recorded] == [("a2a-agent", "run-42")]
+
+    def test_team_cancel_routes_through_service(self, monkeypatch):
+        recorded: List[Any] = []
+        client = self._build_client(monkeypatch, recorded)
+
+        resp = client.post(
+            "/teams/a2a-team/v1/tasks:cancel",
+            json={"id": "req-2", "params": {"id": "run-43", "contextId": "ctx-2"}},
+        )
+
+        assert resp.status_code == 200
+        assert [(getattr(c, "id", None), r) for c, r in recorded] == [("a2a-team", "run-43")]
+
+
+class TestAguiResumeSyncsStream:
+    @pytest.mark.asyncio
+    async def test_stream_synced_after_consumption(self, stream, monkeypatch):
+        pytest.importorskip("ag_ui", reason="ag_ui not installed")
+        from ag_ui.core.types import ToolMessage as AGUIToolMessage
+
+        from agno.agent import Agent
+        from agno.models.response import ToolExecution
+        from agno.os.interfaces.agui.resume import resume_paused_run
+        from agno.run.agent import RunOutput
+        from agno.run.base import RunContext
+        from agno.run.requirement import RunRequirement
+        from agno.session.agent import AgentSession
+
+        await _park_paused(stream, "r-agui")
+
+        requirement = RunRequirement(
+            tool_execution=ToolExecution(tool_call_id="tc-1", tool_name="t", requires_confirmation=True)
+        )
+        paused_run = RunOutput(
+            run_id="r-agui", session_id="s-agui", status=RunStatus.paused, requirements=[requirement]
+        )
+        session = AgentSession(session_id="s-agui", runs=[paused_run])
+
+        agent = Agent(id="agui-agent", name="AGUI Agent")
+        agent.db = object()  # resume only checks truthiness
+
+        async def fake_aget_session(session_id: Optional[str] = None):
+            return session
+
+        def fake_acontinue_run(**kwargs):
+            async def _gen():
+                # The run row settles as the continue executes: the post-run
+                # session read must see the final status.
+                paused_run.status = RunStatus.completed
+                yield SimpleNamespace(content="post-approval")
+
+            return _gen()
+
+        monkeypatch.setattr(agent, "aget_session", fake_aget_session)
+        monkeypatch.setattr(agent, "acontinue_run", fake_acontinue_run)
+
+        response_stream = await resume_paused_run(
+            entity=agent,
+            session_id="s-agui",
+            tool_messages=[
+                AGUIToolMessage(id="m1", role="tool", content=json.dumps({"accepted": True}), tool_call_id="tc-1")
+            ],
+            run_context=RunContext(run_id="r-agui", session_id="s-agui"),
+            run_kwargs={},
+        )
+        chunks = [c async for c in response_stream]
+
+        assert chunks, "the wrapped stream must still yield the continue's chunks"
+        assert await stream.get_run_status("r-agui") == RunStatus.completed, (
+            "the AG-UI resume door must sync a tracked stream off PAUSED after consumption"
+        )
+
+
+class TestSlackContinueDoorSyncsStream:
+    @pytest.mark.asyncio
+    async def test_stream_synced_after_continuation(self, stream):
+        pytest.importorskip("slack_sdk", reason="slack_sdk not installed")
+        from agno.os.interfaces.slack.hitl import HITLHandler
+
+        await _park_paused(stream, "r-slack")
+
+        final_run = SimpleNamespace(run_id="r-slack", status=RunStatus.completed)
+
+        class FakeEntity:
+            id = "slack-agent"
+
+            def acontinue_run(self, **kwargs):
+                async def _gen():
+                    if False:  # pragma: no cover - empty continue stream
+                        yield None
+
+                return _gen()
+
+            async def aget_session(self, session_id: Optional[str] = None):
+                return _Session([final_run])
+
+        handler = HITLHandler.__new__(HITLHandler)
+        handler.entity = FakeEntity()
+        handler.entity_name = "Slack Agent"
+        handler.entity_type = "agent"
+
+        ctx = SimpleNamespace(run_id="r-slack", channel="C1", thread_ts=None, msg_ts=None)
+
+        async def _append(**kwargs):
+            return None
+
+        await handler.stream_resumed_run(
+            ctx, SimpleNamespace(append=_append), requirements=[], session_id="s-slack", user_id=None
+        )
+
+        assert await stream.get_run_status("r-slack") == RunStatus.completed, (
+            "the Slack continue door must sync a tracked stream off PAUSED"
+        )

--- a/libs/agno/tests/unit/os/test_continue_seam.py
+++ b/libs/agno/tests/unit/os/test_continue_seam.py
@@ -859,6 +859,33 @@ class TestInlineContinueReopensStream:
         )
 
 
+class TestDeclinedReopenLeavesStreamAlone:
+    """reopen_run's contract: False means the status already moved past
+    PAUSED and the caller must NOT overwrite that newer state. The helper
+    used to ignore the result and stamp RUNNING anyway - resurrecting a
+    settled stream until the streamer's finally healed it."""
+
+    @pytest.mark.asyncio
+    async def test_completed_stream_is_not_stamped_running(self, monkeypatch):
+        from agno.os.event_streams.in_memory import InMemoryEventStream
+        from agno.os.managers import EventsBuffer, SSESubscriberManager
+        from agno.os.utils import amark_continue_stream_running
+        from agno.run.base import RunStatus
+
+        stream = InMemoryEventStream(events_buffer=EventsBuffer(), subscriber_manager=SSESubscriberManager())
+        monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: stream)
+
+        # A racing writer already finished the leg: PAUSED -> COMPLETED
+        await stream.register_run("r1", RunStatus.running)
+        await stream.complete_run("r1", RunStatus.completed)
+
+        await amark_continue_stream_running("r1")
+
+        assert await stream.get_run_status("r1") == RunStatus.completed, (
+            "a declined reopen must leave the settled stream alone, not stamp RUNNING over it"
+        )
+
+
 class TestInlineContinueSeedsExpiredCounter:
     """Inline door: an inline continue of a paused run whose
     stream state expired (deploy/restart) must seed the counter from the run

--- a/libs/agno/tests/unit/os/test_idempotency_component_scope.py
+++ b/libs/agno/tests/unit/os/test_idempotency_component_scope.py
@@ -1,0 +1,113 @@
+"""Behavioral tests for Idempotency-Key component scoping.
+
+The dedup namespace is (idempotency_key, user_id): the queue stores cannot
+tell an agent submission from a workflow submission reusing the same key.
+The router duplicate branches must therefore verify that the original ticket
+belongs to the component the duplicate was submitted against - otherwise a
+key reused across components answers with the OTHER component's run (a 202
+or stream attach whose ids then 404 through this route's poll endpoint,
+because the ticket poll fallback does enforce component identity).
+
+These drive the REAL router endpoints via TestClient - no model calls; the
+original ticket is seeded directly in the store and the worker never runs.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.db.schemas.jobs import QueuedJob
+from agno.db.sqlite import SqliteDb
+from agno.job_queue.config import QueueConfig
+from agno.job_queue.store import InMemoryQueueStore
+from agno.os import AgentOS
+from agno.team import Team
+
+
+@pytest.fixture()
+def harness(tmp_path):
+    db = SqliteDb(db_file=str(tmp_path / "t.db"))
+    agent = Agent(id="qa-agent", name="QA Agent", db=db)
+    team = Team(id="qa-team", name="QA Team", members=[agent], db=db)
+    app = AgentOS(agents=[agent], teams=[team], telemetry=False).get_app()
+    store = InMemoryQueueStore()
+    app.state.queue_worker = SimpleNamespace(store=store, config=QueueConfig(durable=True))
+    client = TestClient(app, raise_server_exceptions=False)
+    return SimpleNamespace(app=app, store=store, client=client)
+
+
+def seed_agent_ticket(store: InMemoryQueueStore, run_id: str, **overrides) -> dict:
+    """Insert a ticket directly (sync): the store's asyncio.Lock must only
+    ever be awaited on the TestClient's request loop."""
+    fields = dict(
+        id=run_id,
+        component_type="agent",
+        component_id="qa-agent",
+        session_id="s-tkt",
+        payload={"input": "hi", "kwargs": {}},
+        idempotency_key="shared-key",
+    )
+    fields.update(overrides)
+    job = QueuedJob(**fields).to_dict()
+    store._jobs[run_id] = job
+    return job
+
+
+class TestCrossComponentReuseRefused:
+    def test_non_stream_duplicate_of_other_component_is_409(self, harness):
+        """A key first used on an agent submit, replayed against the team
+        route, must refuse - not 202 with the agent run's ids (which would
+        then 404 through the team poll endpoint)."""
+        seed_agent_ticket(harness.store, "run-agent-1")
+
+        resp = harness.client.post(
+            "/teams/qa-team/runs",
+            data={"message": "hi", "stream": "false", "background": "true"},
+            headers={"Idempotency-Key": "shared-key"},
+        )
+
+        assert resp.status_code == 409, (
+            f"cross-component Idempotency-Key reuse answered {resp.status_code} "
+            f"{resp.json() if resp.status_code == 202 else resp.text!r} - it must refuse"
+        )
+        assert "different component" in resp.json()["detail"]
+        # The refusal must not leak the original ticket's identity on the wire:
+        # the key namespace is shared across clients in unauthenticated deployments.
+        assert "qa-agent" not in resp.json()["detail"]
+        # And it must not have enqueued anything new.
+        assert list(harness.store._jobs) == ["run-agent-1"]
+
+    def test_stream_duplicate_of_other_component_is_409_before_shape_checks(self, harness):
+        """The component check must come before the stream-shape check: a
+        non-streaming agent ticket replayed on the team STREAM seam must say
+        'different component', not 'non-streaming submission' (which would
+        point the caller at polling a run their route cannot see)."""
+        seed_agent_ticket(harness.store, "run-agent-2")
+
+        resp = harness.client.post(
+            "/teams/qa-team/runs",
+            data={"message": "hi", "stream": "true", "background": "true"},
+            headers={"Idempotency-Key": "shared-key"},
+        )
+
+        assert resp.status_code == 409
+        assert "different component" in resp.json()["detail"]
+
+
+class TestSameComponentReuseStillDedups:
+    def test_same_component_duplicate_answers_original_ticket(self, harness):
+        """The guard must not break legitimate dedup: replaying the key on
+        the SAME component keeps returning the original run's ids."""
+        seed_agent_ticket(harness.store, "run-agent-3")
+
+        resp = harness.client.post(
+            "/agents/qa-agent/runs",
+            data={"message": "hi", "stream": "false", "background": "true"},
+            headers={"Idempotency-Key": "shared-key"},
+        )
+
+        assert resp.status_code == 202
+        assert resp.json()["run_id"] == "run-agent-3"
+        assert list(harness.store._jobs) == ["run-agent-3"]

--- a/libs/agno/tests/unit/os/test_queue_wiring.py
+++ b/libs/agno/tests/unit/os/test_queue_wiring.py
@@ -5,6 +5,7 @@ import pytest
 fakeredis = pytest.importorskip("fakeredis", reason="fakeredis not installed")
 
 import agno.os.event_streams as event_streams_module  # noqa: E402
+import agno.run.cancel as cancel_module  # noqa: E402
 from agno.job_queue.config import QueueConfig, RedisCoordination  # noqa: E402
 from agno.os.event_streams import (  # noqa: E402
     InMemoryEventStream,
@@ -23,15 +24,31 @@ from agno.run.concurrency import get_background_max_concurrency, set_background_
 
 @pytest.fixture(autouse=True)
 def reset_globals():
-    original_manager = get_cancellation_manager()
+    """Reset transports to pristine process defaults between tests.
+
+    Deliberately writes the module globals instead of calling the public
+    setters: the setters mark the backend explicitly-set, and these tests
+    exercise exactly the explicit-vs-default distinction.
+    """
+    original_manager = cancel_module._cancellation_manager
     original_stream = event_streams_module._event_stream
-    set_cancellation_manager(InMemoryRunCancellationManager())
+    # getattr with defaults: keeps this fixture importable against source
+    # trees where the explicit-set flags do not exist (module attribute
+    # assignment below is harmless there), so the tests fail behaviorally
+    # rather than erroring at setup.
+    original_manager_explicit = getattr(cancel_module, "_cancellation_manager_explicitly_set", False)
+    original_stream_explicit = getattr(event_streams_module, "_event_stream_explicitly_set", False)
+    cancel_module._cancellation_manager = InMemoryRunCancellationManager()
+    cancel_module._cancellation_manager_explicitly_set = False
     event_streams_module._event_stream = None
+    event_streams_module._event_stream_explicitly_set = False
     try:
         yield
     finally:
-        set_cancellation_manager(original_manager)
+        cancel_module._cancellation_manager = original_manager
+        cancel_module._cancellation_manager_explicitly_set = original_manager_explicit
         event_streams_module._event_stream = original_stream
+        event_streams_module._event_stream_explicitly_set = original_stream_explicit
         set_background_max_concurrency(None)
 
 
@@ -93,6 +110,33 @@ class TestApplyQueueConfig:
         set_event_stream(custom)
         apply_queue_config(QueueConfig(redis=make_coordination()))
         assert get_event_stream() is custom
+
+    def test_explicit_in_memory_stream_not_clobbered(self):
+        """An explicitly set in-memory stream (or subclass, e.g. a test
+        double) is indistinguishable by TYPE from the process default - only
+        the explicit-set flag can protect it from queue.redis wiring."""
+
+        class RecordingStream(InMemoryEventStream):
+            pass
+
+        explicit = RecordingStream()
+        set_event_stream(explicit)
+        apply_queue_config(QueueConfig(redis=make_coordination()))
+        assert get_event_stream() is explicit
+
+    def test_explicit_in_memory_cancellation_manager_not_clobbered(self):
+        explicit = InMemoryRunCancellationManager()
+        set_cancellation_manager(explicit)
+        apply_queue_config(QueueConfig(redis=make_coordination()))
+        assert get_cancellation_manager() is explicit
+
+    def test_lazy_default_stream_is_still_replaced(self):
+        """Touching the stream via get_event_stream() before wiring must not
+        count as explicit configuration - the lazily created default is still
+        the default."""
+        assert isinstance(get_event_stream(), InMemoryEventStream)
+        apply_queue_config(QueueConfig(redis=make_coordination()))
+        assert isinstance(get_event_stream(), RedisEventStream)
 
 
 class TestSyncStoreAdapter:

--- a/libs/agno/tests/unit/os/test_queue_worker.py
+++ b/libs/agno/tests/unit/os/test_queue_worker.py
@@ -1019,6 +1019,49 @@ class TestConfigValidation:
             with pytest.raises(ValueError):
                 QueueConfig(durable=True, **{k: v for k, v in kwargs.items() if k != "durable"})
 
+    def test_stop_timeout_validated_against_lock_grace_at_construction(self):
+        """The worker requires stop_timeout < lock_grace. An explicit config
+        value violating that must fail HERE, at config construction - not as
+        a mysterious crash during lifespan startup."""
+        from agno.job_queue.config import QueueConfig
+
+        with pytest.raises(ValueError, match="strictly below"):
+            QueueConfig(durable=True, lock_grace_seconds=10, stop_timeout_seconds=10)
+        with pytest.raises(ValueError):
+            QueueConfig(durable=True, stop_timeout_seconds=0)
+        assert QueueConfig(durable=True, lock_grace_seconds=10, stop_timeout_seconds=9).stop_timeout_seconds == 9
+
+    @pytest.mark.asyncio
+    async def test_small_lock_grace_boots_the_lifespan(self):
+        """lock_grace_seconds between 3 and 30 passed config validation and
+        then crashed the app at lifespan startup on the worker's fixed
+        default stop_timeout (30). The lifespan now derives a drain timeout
+        strictly below the lease grace, and an explicit
+        stop_timeout_seconds plumbs through to the worker."""
+        from types import SimpleNamespace
+
+        from agno.job_queue.config import QueueConfig
+        from agno.job_queue.store import InMemoryQueueStore
+        from agno.os.job_queue import queue_lifespan
+
+        for config, expected_stop in (
+            (QueueConfig(durable=True, db=InMemoryQueueStore(), lock_grace_seconds=10, poll_interval=0.05), 9),
+            (
+                QueueConfig(
+                    durable=True,
+                    db=InMemoryQueueStore(),
+                    lock_grace_seconds=10,
+                    stop_timeout_seconds=5,
+                    poll_interval=0.05,
+                ),
+                5,
+            ),
+        ):
+            app = SimpleNamespace(state=SimpleNamespace())
+            agent_os = SimpleNamespace(queue=config, db=None, agents=[], teams=[], workflows=[])
+            async with queue_lifespan(app, agent_os):
+                assert app.state.queue_worker.stop_timeout == expected_stop
+
     def test_multi_attempt_is_first_class(self):
         """The interim experimental opt-in is GONE: the save and stream fences closed the
         two-producer races (run-row saves and stream writes), so

--- a/libs/agno/tests/unit/os/test_redis_lease_clock.py
+++ b/libs/agno/tests/unit/os/test_redis_lease_clock.py
@@ -1,0 +1,81 @@
+"""Redis queue-store lease math is anchored to the SERVER clock.
+
+The Postgres store anchors lease decisions to the database's NOW() with a
+loud doctrine comment; the Redis store judged staleness on each worker's
+wall clock. A replica whose clock runs fast beyond the grace saw healthy
+leases as expired and swept live runs - the sweep steals the lock, so the
+victim's completion was fenced out and the run reported failed despite
+finishing (and with multi-attempt budgets, a false sweep means duplicate
+side-effect execution). All ownership decisions now read Redis TIME.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis", reason="fakeredis not installed")
+
+from agno.db.redis import RedisDb  # noqa: E402
+from agno.db.schemas.jobs import QueuedJob  # noqa: E402
+
+
+def make_job(job_id: str = "r1") -> dict:
+    return QueuedJob(
+        id=job_id,
+        component_type="agent",
+        component_id="a1",
+        session_id="s1",
+        payload={"input": "hello"},
+        max_attempts=1,
+    ).to_dict()
+
+
+@pytest.fixture()
+def db():
+    return RedisDb(redis_client=fakeredis.FakeRedis(), db_prefix="clk")
+
+
+def _skew_local_clock(monkeypatch, offset_seconds: float) -> None:
+    """Skew the module-local wall clock the queue section used to trust."""
+    import time as real_time
+
+    real = real_time.time
+    monkeypatch.setattr(
+        "agno.db.redis.redis.time",
+        SimpleNamespace(time=lambda: real() + offset_seconds),
+    )
+
+
+class TestSkewedWorkerCannotSweepHealthyLease:
+    def test_sweep_detector_ignores_fast_local_clock(self, db, monkeypatch):
+        db.enqueue_job(make_job("r1"))
+        assert db.claim_job("w1", lock_grace_seconds=60) is not None
+
+        _skew_local_clock(monkeypatch, 3600)
+
+        stale = db.sweep_exhausted_jobs(lock_grace_seconds=60)
+        assert stale == [], (
+            f"a healthy just-claimed lease was judged stale by a skewed WORKER clock: {stale} - "
+            "staleness must be measured on the Redis server's clock"
+        )
+
+    def test_acquire_sweep_refuses_healthy_lease_under_skew(self, db, monkeypatch):
+        db.enqueue_job(make_job("r1"))
+        assert db.claim_job("w1", lock_grace_seconds=60) is not None
+
+        _skew_local_clock(monkeypatch, 3600)
+
+        assert db.acquire_sweep("r1", "sweeper", 60) is False, (
+            "a skewed replica stole a healthy lease - the steal fences out the live "
+            "worker's completion and falsely fails the run"
+        )
+
+    def test_genuinely_stale_lease_is_still_sweepable(self, db):
+        """No false negatives either: grace 0 makes the fresh claim stale on
+        ANY clock - the sweep path must keep working."""
+        db.enqueue_job(make_job("r1"))
+        assert db.claim_job("w1", lock_grace_seconds=60) is not None
+
+        stale = db.sweep_exhausted_jobs(lock_grace_seconds=0)
+        assert [j["id"] for j in stale] == ["r1"]
+        assert db.acquire_sweep("r1", "sweeper", 0) is True

--- a/libs/agno/tests/unit/os/test_sse_error_frames.py
+++ b/libs/agno/tests/unit/os/test_sse_error_frames.py
@@ -1,0 +1,58 @@
+"""SSE error frames must be valid JSON regardless of the exception text.
+
+The hand-built frames interpolated str(e) straight into an f-string JSON
+literal: any exception message containing a quote, backslash, or newline
+emitted an invalid-JSON data payload on the wire (and a raw newline would
+additionally break SSE framing). Every error frame now goes through
+json.dumps via the shared sse_error_frame helper.
+"""
+
+import json
+
+import pytest
+
+HOSTILE = 'backend said "boom" \\ and\nnewline'
+
+
+def _parse_error_frame(frame: str) -> dict:
+    assert frame.startswith("event: error\ndata: "), f"not an error frame: {frame!r}"
+    data_line, _, rest = frame[len("event: error\n") :].partition("\n")
+    assert rest == "\n", "the data payload must stay a single SSE data line"
+    return json.loads(data_line[len("data: ") :])
+
+
+class TestSseErrorFrameHelper:
+    def test_hostile_message_round_trips(self):
+        from agno.os.utils import sse_error_frame
+
+        payload = _parse_error_frame(sse_error_frame(HOSTILE))
+        assert payload == {"event": "error", "error": HOSTILE}
+
+
+class TestTailFailureFrameIsParseable:
+    @pytest.mark.asyncio
+    async def test_dying_tail_emits_valid_json(self, monkeypatch):
+        """Drive the real queued tail streamer with a backend whose tail
+        raises a hostile exception: the emitted error frame must parse."""
+        from agno.os.utils import queued_run_tail_streamer
+
+        class BoomStream:
+            def tail(self, run_id, last_event_index=None):
+                async def _gen():
+                    raise Exception(HOSTILE)
+                    yield  # pragma: no cover - makes this an async generator
+
+                return _gen()
+
+            async def get_run_status(self, run_id):
+                return None
+
+        monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: BoomStream())
+
+        frames = [chunk async for chunk in queued_run_tail_streamer("r-frame")]
+
+        error_frames = [f for f in frames if f.startswith("event: error")]
+        assert error_frames, f"a dying tail must emit an error frame, got {frames!r}"
+        payload = _parse_error_frame(error_frames[0])
+        assert payload["event"] == "error"
+        assert 'backend said "boom"' in payload["error"]

--- a/libs/agno/tests/unit/os/test_ws_replay_floor.py
+++ b/libs/agno/tests/unit/os/test_ws_replay_floor.py
@@ -1,0 +1,101 @@
+"""Workflow WS subscription DB-fallback replay honors the client floor.
+
+The SSE resume routes replay stored events through a floor-honoring helper
+(stamped events filtered under last_event_index, replayed under their REAL
+stream indices). The WS sibling renumbered every stored event positionally
+from zero and ignored the floor: a partially-caught-up client got the full
+history back with fabricated indices, destroying dedup and index
+continuity (stream indices are not gapless).
+"""
+
+import json
+from types import SimpleNamespace
+from typing import Any, List
+
+import pytest
+
+from agno.run.base import RunStatus
+from agno.workflow.workflow import Workflow
+
+
+class FakeWebSocket:
+    def __init__(self):
+        self.sent: List[dict] = []
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(json.loads(text))
+
+
+class StampedEvent:
+    def __init__(self, index: int, content: str):
+        self._d = {"event": "WorkflowRunContent", "event_index": index, "content": content, "run_id": "r-ws"}
+
+    def to_dict(self) -> dict:
+        return dict(self._d)
+
+
+@pytest.mark.asyncio
+async def test_ws_db_fallback_replay_honors_floor_and_stored_indices(monkeypatch):
+    from agno.os.event_streams.in_memory import InMemoryEventStream
+    from agno.os.managers import EventsBuffer, SSESubscriberManager
+    from agno.os.routers.workflows.router import handle_workflow_subscription
+
+    # The stream does not know the run -> DB fallback path
+    fresh_stream = InMemoryEventStream(events_buffer=EventsBuffer(), subscriber_manager=SSESubscriberManager())
+    monkeypatch.setattr("agno.os.routers.workflows.router.get_event_stream", lambda: fresh_stream)
+
+    workflow = Workflow(id="wf1", name="WF")
+    run_output: Any = SimpleNamespace(
+        status=RunStatus.completed,
+        events=[StampedEvent(4, "old"), StampedEvent(6, "new-a"), StampedEvent(8, "new-b")],
+    )
+
+    async def fake_aget_run_output(run_id, session_id, user_id=None):
+        return run_output
+
+    monkeypatch.setattr(workflow, "aget_run_output", fake_aget_run_output)
+    monkeypatch.setattr("agno.os.routers.workflows.router.get_workflow_by_id", lambda **kwargs: workflow)
+
+    ws = FakeWebSocket()
+    os_stub = SimpleNamespace(workflows=[workflow], db=None, registry=None)
+    await handle_workflow_subscription(
+        ws,
+        {"run_id": "r-ws", "workflow_id": "wf1", "session_id": "s1", "last_event_index": 5},
+        os_stub,
+    )
+
+    assert ws.sent, "the subscription must answer"
+    meta = ws.sent[0]
+    assert meta["event"] == "replay"
+    replayed = ws.sent[1:]
+    indices = [d["event_index"] for d in replayed]
+    assert indices == [6, 8], (
+        f"stamped events must be floor-filtered (>5) and keep their STORED stream indices, got {indices}"
+    )
+    assert meta["total_events"] == 2, "the meta total must reflect what is actually replayed"
+
+
+@pytest.mark.asyncio
+async def test_ws_db_fallback_without_floor_replays_everything(monkeypatch):
+    from agno.os.event_streams.in_memory import InMemoryEventStream
+    from agno.os.managers import EventsBuffer, SSESubscriberManager
+    from agno.os.routers.workflows.router import handle_workflow_subscription
+
+    fresh_stream = InMemoryEventStream(events_buffer=EventsBuffer(), subscriber_manager=SSESubscriberManager())
+    monkeypatch.setattr("agno.os.routers.workflows.router.get_event_stream", lambda: fresh_stream)
+
+    workflow = Workflow(id="wf1", name="WF")
+    run_output: Any = SimpleNamespace(status=RunStatus.completed, events=[StampedEvent(4, "a"), StampedEvent(6, "b")])
+
+    async def fake_aget_run_output(run_id, session_id, user_id=None):
+        return run_output
+
+    monkeypatch.setattr(workflow, "aget_run_output", fake_aget_run_output)
+    monkeypatch.setattr("agno.os.routers.workflows.router.get_workflow_by_id", lambda **kwargs: workflow)
+
+    ws = FakeWebSocket()
+    os_stub = SimpleNamespace(workflows=[workflow], db=None, registry=None)
+    await handle_workflow_subscription(ws, {"run_id": "r-ws", "workflow_id": "wf1", "session_id": "s1"}, os_stub)
+
+    indices = [d["event_index"] for d in ws.sent[1:]]
+    assert indices == [4, 6], f"a fresh subscriber gets everything, under stored indices: {indices}"


### PR DESCRIPTION
## Summary

Wave 2 of the AgentOS reliability review follow-ups: the consolidated batch of thirteen review findings (both external reviews - the N/P series and the F route-matrix series), plus the agreed comment-truth fix for the workflow continue transport asymmetry. One commit per item, each with a regression test proven failing on unfixed source (stash-proof), reviewable commit by commit.

### Correctness / safety

1. **Idempotency keys are component-scoped** (N2/P3) - the dedup namespace is `(key, user_id)` only, so a key reused across components answered with the *other* component's run: a 202 (or live stream attach) whose ids then 404 through the replaying route's poll endpoint. All six duplicate branches now verify the ticket's component identity and refuse mismatched reuse with 409 (identity detail kept out of the response body - shared key namespace in unauthenticated deployments).
2. **Queue wiring never replaces an explicitly configured transport** (N9) - the `isinstance(..., InMemoryEventStream)` sniff could not tell an explicit in-memory stream (or a test-double subclass) from the process default, so `AgentOS(event_stream=my_stream, queue=QueueConfig(redis=...))` silently replaced it. Both transport registries now carry an explicit-set flag and the wiring consults that instead of the type.
3. **Alternate doors carry the REST continue/cancel obligations** (N6+F10) - the MCP, AG-UI, and Slack continue doors never synced the event stream, leaving a stream-PAUSED run paused forever (with Redis TTLs refreshed indefinitely - every `/resume` replayed the stale snapshot); each now does the REST door's status-only sync. The MCP and A2A cancel doors registered intent without tombstoning a still-queued ticket (a worker would claim and burn an attempt before dying at the first checkpoint); the shared cancel service now tombstones first and both A2A handlers route through it.
4. **`enqueue_job` raises on an existing job id** (N3) - Redis SET the job document unconditionally and in-memory assigned into its dict, so re-enqueueing a live id silently reset the ticket to queued/attempt-0: two executors, the first one's completion fenced out. Both now mirror the Postgres primary-key contract.
5. **Redis lease math anchored to the server clock** (N5/F7) - staleness and lease stamps used each worker's wall clock; skew beyond the grace let a replica sweep a healthy peer's live run (and with multi-attempt budgets, duplicate side-effect execution). All twelve ownership/settlement sites now read Redis `TIME`, with the same doctrine comment the Postgres store has. Stats/retention deliberately stay on the wall clock (they shift reporting, never ownership).
6. **Declined stream reopen no longer stamped RUNNING** (N12) - `amark_continue_stream_running` ignored `reopen_run`'s "the status already moved on, do not overwrite" contract and resurrected settled streams until the streamer's finally healed them.

### API honesty

7. **Explicit scoping mode for the ticket poll fallback** (P4) - `get_scoped_user_id()` returns `None` for admins/unscoped deployments ("no filtering"), but the fallback treated that as an anonymous owner and 404ed accepted user-owned runs for every admin poll inside the ticket-before-run-row window. `aticket_poll_fallback` now takes a required `user_scoped` keyword; unscoped mode applies no user filter, exactly like the session read it mirrors. (One existing test had pinned the buggy behavior under a tenant-isolation rationale; rewritten - true tenant isolation between scoped principals stays pinned at the helper level.)
8. **Duplicate-202 bodies speak the poll's status vocabulary** (F8/N10) - no more invented `"FAILED"` (the API's value is `ERROR`) and no flattening of a RUNNING original to `PENDING`; one shared ticket-to-API mapping now serves the poll fallback and all three duplicate branches.
9. **Every durability bypass warns** (F9) - factory-backed / db-resolved / version-pinned background submissions dropped to the non-durable path with no log line while payload/media bypasses warned; the client got a 202 and believed acceptance was durable. All bypass reasons now log, with the actual reason.
10. **SSE error frames JSON-escape exception text** (F16/N14) - seven hand-built frames interpolated `str(e)` into f-string JSON; a quote or backslash emitted invalid JSON on the wire (a newline also broke SSE framing). All go through a shared `json.dumps`-based helper now.
11. **`stop_timeout` configurable and validated at config construction** (F6/P5) - `lock_grace_seconds` 3-30 passed validation and then crashed the app at lifespan startup against the worker's fixed 30s drain default, with no way to pass a different value through AgentOS (effective minimum 31, documented nowhere). `QueueConfig.stop_timeout_seconds` is validated strictly below the grace at construction; `None` derives a clamped default so every accepted `lock_grace` boots.
12. **Workflow WS DB-fallback replay honors the client floor** (N7) - the WS subscription renumbered stored events positionally from zero and ignored `last_event_index`, re-sending full history with fabricated indices; it now replays through the same floor-honoring, stored-index core as the SSE resume routes (`stored_event_replay_dicts`, with `stored_event_replay_frames` as its SSE wrapper).
13. **Postgres `continue_job` returns concrete timestamp ints** (N4) - both adapters copied the `_db_epoch()` SQL expression into the returned dict (unserializable `Cast` objects where Redis/in-memory return ints); the UPDATE now RETURNINGs the stamped columns.

### Comment truth (behavior unchanged)

14. **Workflow continue transport asymmetry documented as deliberate** (F2, option A) - the HTTP refusal's self-contradictory comment and the agents-side comment's false claim ("the workflow continue endpoint never had the background param") are rewritten; all three sites (HTTP refusal, agents-side contrast, WS fallback) now state consistently why HTTP refuses while the WS door falls back: the socket is itself the live event channel the detached machinery streams into, and HTTP has no workflow resumable-continue streamer yet.

Plus one style commit (import ordering from `format.sh`).

## Type of change

- [x] Bug fix
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Every fix commit carries a regression test demonstrated to fail on the unfixed source (stash-proof), plus no-regression pins where behavior had to be preserved (same-component dedup, lazy-default wiring, genuinely-stale sweeps, queued->PENDING vocabulary, the durable path staying warning-free).
- Test surface: 2278 unit tests green across `unit/os` + `unit/run`, 120 integration tests green against live Postgres (5532) and Redis (6379), including the four-store parity matrix.
- `validate.sh` mypy reports only the known ambient stub noise (redis-py 7.4.1 stubs in the local venv - the documented N13 condition; ruff fully clean, changed files mypy-clean).
- The P4 commit intentionally rewrites one existing test that had pinned the buggy admin-404 behavior; the commit message explains why its premise (tenant isolation) did not apply to an unscoped harness.
- Review commit-by-commit: each commit message carries the failure mode, the fix shape, and the test evidence for exactly one finding.
