### PR TITLE
[fix] Scrub stored tool results when store_tool_messages is off

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -81,6 +81,7 @@ from agno.utils.agent import (
     await_for_thread_tasks_stream,
     collect_background_metrics,
     isolate_media_scrub_targets,
+    isolate_tool_scrub_targets,
     scrub_history_messages_from_run_output,
     scrub_media_from_run_output,
     scrub_tool_results_from_run_output,
@@ -5750,6 +5751,8 @@ def _scrub_and_propagate_session_state(
     storage_copy = copy.copy(run_response)
     if isolate_inflight and not agent.store_media:
         isolate_media_scrub_targets(storage_copy)
+    if isolate_inflight and not agent.store_tool_messages:
+        isolate_tool_scrub_targets(storage_copy)
     scrub_run_output_for_storage(agent, storage_copy)
 
     if run_context is not None and run_context.session_state is not None:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -4595,7 +4595,7 @@ def _persist_team_run_in_session(
     import copy
 
     from agno.team._session import update_session_metrics
-    from agno.utils.agent import isolate_media_scrub_targets
+    from agno.utils.agent import isolate_media_scrub_targets, isolate_tool_scrub_targets
 
     storage_copy = copy.copy(run_response)
     # Mid-run checkpoint: scrubbing mutates shared objects in place, and the
@@ -4603,6 +4603,8 @@ def _persist_team_run_in_session(
     # checkpoint never strips state off the still-running team run.
     if not team.store_media:
         isolate_media_scrub_targets(storage_copy)
+    if not team.store_tool_messages:
+        isolate_tool_scrub_targets(storage_copy)
     if storage_copy.member_responses and team.store_member_responses:
         # save_session -> _scrub_member_responses scrubs each member in place;
         # deep-copy so it operates on the storage copy, not the live member runs.
@@ -4635,7 +4637,7 @@ async def _apersist_team_run_in_session(
     import copy
 
     from agno.team._session import update_session_metrics
-    from agno.utils.agent import isolate_media_scrub_targets
+    from agno.utils.agent import isolate_media_scrub_targets, isolate_tool_scrub_targets
 
     storage_copy = copy.copy(run_response)
     # Mid-run checkpoint: scrubbing mutates shared objects in place, and the
@@ -4643,6 +4645,8 @@ async def _apersist_team_run_in_session(
     # checkpoint never strips state off the still-running team run.
     if not team.store_media:
         isolate_media_scrub_targets(storage_copy)
+    if not team.store_tool_messages:
+        isolate_tool_scrub_targets(storage_copy)
     if storage_copy.member_responses and team.store_member_responses:
         # save_session -> _scrub_member_responses scrubs each member in place;
         # deep-copy so it operates on the storage copy, not the live member runs.

--- a/libs/agno/agno/utils/agent.py
+++ b/libs/agno/agno/utils/agent.py
@@ -21,7 +21,7 @@ from agno.db.base import AsyncBaseDb
 from agno.media import Audio, File, Image, Video
 from agno.metrics import RunMetrics, SessionMetrics
 from agno.models.message import Message
-from agno.models.response import ModelResponse
+from agno.models.response import ModelResponse, ToolExecution
 from agno.run import RunContext
 from agno.run.agent import RunEvent, RunInput, RunOutput, RunOutputEvent
 from agno.run.team import RunOutputEvent as TeamRunOutputEvent
@@ -514,38 +514,74 @@ def scrub_media_from_message(message: Message) -> None:
     message.video_output = None
 
 
+def _tool_call_ids_awaiting_resolution(run_response: Union[RunOutput, TeamRunOutput]) -> set:
+    """Tool call ids whose stored result is still load-bearing for resuming a paused run.
+
+    An unresolved requirement is one the run is still waiting on. For external execution the
+    caller's answer arrives as the tool result, so blanking it would discard the payload
+    ``continue_run`` needs to finish the run.
+    """
+    awaiting = set()
+    for requirement in run_response.requirements or []:
+        if requirement.is_resolved():
+            continue
+        tool_execution = requirement.tool_execution
+        if tool_execution is not None and tool_execution.tool_call_id:
+            awaiting.add(tool_execution.tool_call_id)
+    return awaiting
+
+
 def scrub_tool_results_from_run_output(run_response: Union[RunOutput, TeamRunOutput]) -> None:
     """
     Remove all tool-related data from RunOutput when store_tool_messages=False.
     This removes both the tool call and its corresponding result to maintain API consistency.
+
+    The tool's return value is stored outside ``messages`` as well — on ``run_response.tools``
+    and on ``requirements[*].tool_execution`` — so those results are blanked too. A result that
+    a paused run still needs in order to resume is kept; see
+    :func:`_tool_call_ids_awaiting_resolution`.
     """
-    if not run_response.messages:
-        return
+    if run_response.messages:
+        # Step 1: Collect all tool_call_ids from tool result messages
+        tool_call_ids_to_remove = set()
+        for message in run_response.messages:
+            if message.role == "tool" and message.tool_call_id:
+                tool_call_ids_to_remove.add(message.tool_call_id)
 
-    # Step 1: Collect all tool_call_ids from tool result messages
-    tool_call_ids_to_remove = set()
-    for message in run_response.messages:
-        if message.role == "tool" and message.tool_call_id:
-            tool_call_ids_to_remove.add(message.tool_call_id)
+        # Step 2: Remove tool result messages (role="tool")
+        run_response.messages = [msg for msg in run_response.messages if msg.role != "tool"]
 
-    # Step 2: Remove tool result messages (role="tool")
-    run_response.messages = [msg for msg in run_response.messages if msg.role != "tool"]
+        # Step 3: Remove assistant messages that made those tool calls
+        filtered_messages = []
+        for message in run_response.messages:
+            # Check if this assistant message made any of the tool calls we're removing
+            should_remove = False
+            if message.role == "assistant" and message.tool_calls:
+                for tool_call in message.tool_calls:
+                    if tool_call.get("id") in tool_call_ids_to_remove:
+                        should_remove = True
+                        break
 
-    # Step 3: Remove assistant messages that made those tool calls
-    filtered_messages = []
-    for message in run_response.messages:
-        # Check if this assistant message made any of the tool calls we're removing
-        should_remove = False
-        if message.role == "assistant" and message.tool_calls:
-            for tool_call in message.tool_calls:
-                if tool_call.get("id") in tool_call_ids_to_remove:
-                    should_remove = True
-                    break
+            if not should_remove:
+                filtered_messages.append(message)
 
-        if not should_remove:
-            filtered_messages.append(message)
+        run_response.messages = filtered_messages
 
-    run_response.messages = filtered_messages
+    # Step 4: Blank the results stored outside `messages`.
+    awaiting_resolution = _tool_call_ids_awaiting_resolution(run_response)
+
+    def _blank_result(tool_execution: Optional[ToolExecution]) -> None:
+        if tool_execution is None or tool_execution.result is None:
+            return
+        if tool_execution.tool_call_id in awaiting_resolution:
+            return
+        tool_execution.result = None
+
+    for tool_execution in run_response.tools or []:
+        _blank_result(tool_execution)
+
+    for requirement in run_response.requirements or []:
+        _blank_result(requirement.tool_execution)
 
 
 def scrub_history_messages_from_run_output(run_response: Union[RunOutput, TeamRunOutput]) -> None:
@@ -582,6 +618,45 @@ def isolate_media_scrub_targets(run_response: Union[RunOutput, TeamRunOutput]) -
         run_response.reasoning_messages = [copy.copy(message) for message in run_response.reasoning_messages]
     if run_response.input is not None:
         run_response.input = copy.copy(run_response.input)
+
+
+def isolate_tool_scrub_targets(run_response: Union[RunOutput, TeamRunOutput]) -> None:
+    """Give ``run_response`` its own copies of the objects that tool-result scrubbing
+    mutates in place (ToolExecution, and the RunRequirement objects holding them).
+
+    ``scrub_tool_results_from_run_output`` (store_tool_messages=False) blanks
+    ``ToolExecution.result`` in place. A shallow ``copy.copy`` of a RunOutput shares those
+    objects with the source, so scrubbing a *storage copy* on a mid-run checkpoint would
+    strip the results off the still-running run. Call this on the storage copy before
+    scrubbing on the in-flight (checkpoint) path — the same hazard, and the same remedy, as
+    :func:`isolate_media_scrub_targets`.
+
+    A ToolExecution reached through both ``tools`` and a requirement is copied once and
+    shared by both copies, so the isolated run keeps the aliasing the live run has.
+    """
+    import copy
+
+    copies_by_identity: Dict[int, ToolExecution] = {}
+
+    def _isolated(tool_execution: ToolExecution) -> ToolExecution:
+        already_copied = copies_by_identity.get(id(tool_execution))
+        if already_copied is not None:
+            return already_copied
+        duplicate = copy.copy(tool_execution)
+        copies_by_identity[id(tool_execution)] = duplicate
+        return duplicate
+
+    if run_response.tools is not None:
+        run_response.tools = [_isolated(tool_execution) for tool_execution in run_response.tools]
+
+    if run_response.requirements is not None:
+        isolated_requirements = []
+        for requirement in run_response.requirements:
+            duplicate_requirement = copy.copy(requirement)
+            if requirement.tool_execution is not None:
+                duplicate_requirement.tool_execution = _isolated(requirement.tool_execution)
+            isolated_requirements.append(duplicate_requirement)
+        run_response.requirements = isolated_requirements
 
 
 def get_run_output_util(

--- a/libs/agno/tests/unit/agent/test_store_tool_result_scrub_leak.py
+++ b/libs/agno/tests/unit/agent/test_store_tool_result_scrub_leak.py
@@ -1,0 +1,178 @@
+"""Reproduction tests for the tool-result leak through scrub_tool_results_from_run_output.
+
+store_tool_messages=False removes tool messages from run_response.messages, but the tool's
+return value is stored in two other places in the same session row: run_response.tools[*].result
+and requirements[*].tool_execution.result. These tests prove both are blanked.
+
+They also cover the in-place hazard the fix introduces: blanking mutates ToolExecution objects
+that a shallow storage copy shares with the live run, so the mid-run checkpoint path has to
+isolate them first — the same hazard isolate_media_scrub_targets already handles for media.
+"""
+
+from agno.agent.agent import Agent
+from agno.models.response import ToolExecution
+from agno.run.agent import RunOutput
+from agno.run.requirement import RunRequirement
+from agno.run.team import TeamRunOutput
+from agno.utils.agent import (
+    isolate_tool_scrub_targets,
+    scrub_tool_results_from_run_output,
+)
+
+SECRET = "SSN-000-11-2222-BASELINE"
+
+
+def _tool_execution(tool_call_id: str = "call_1", **kwargs) -> ToolExecution:
+    return ToolExecution(tool_call_id=tool_call_id, tool_name="peek", result=SECRET, **kwargs)
+
+
+# -- Core scrub function tests --
+
+
+def test_scrub_tool_results_blanks_stored_tool_result():
+    """The tool's return value on run_response.tools must not survive the scrub."""
+    run_output = RunOutput(tools=[_tool_execution()])
+
+    scrub_tool_results_from_run_output(run_output)
+
+    assert run_output.tools[0].result is None, "tools[0].result should be None after scrub"
+
+
+def test_scrub_tool_results_blanks_requirement_tool_result():
+    """requirements[*].tool_execution.result is a second copy of the same value."""
+    tool_execution = _tool_execution()
+    run_output = RunOutput(requirements=[RunRequirement(tool_execution=tool_execution)])
+
+    scrub_tool_results_from_run_output(run_output)
+
+    assert run_output.requirements[0].tool_execution.result is None
+
+
+def test_scrub_tool_results_blanks_results_with_no_messages():
+    """A run with no messages still has to be scrubbed.
+
+    The message-filtering step returns early when messages is empty; the stored results
+    must be blanked regardless, or a run whose messages were already stripped keeps its
+    tool output.
+    """
+    run_output = RunOutput(messages=None, tools=[_tool_execution()])
+
+    scrub_tool_results_from_run_output(run_output)
+
+    assert run_output.tools[0].result is None
+
+
+def test_scrub_tool_results_blanks_team_run_output():
+    """The same leak exists on TeamRunOutput."""
+    team_output = TeamRunOutput(tools=[_tool_execution()])
+
+    scrub_tool_results_from_run_output(team_output)
+
+    assert team_output.tools[0].result is None
+
+
+# -- The external-execution carve-out --
+
+
+def test_scrub_tool_results_keeps_result_an_unresolved_requirement_still_needs():
+    """An unresolved requirement's result is load-bearing for resume, so it is kept.
+
+    For external execution the caller's answer arrives as the tool result; blanking it
+    would discard the payload continue_run needs to finish the run.
+    """
+    tool_execution = _tool_execution(external_execution_required=True)
+    requirement = RunRequirement(tool_execution=tool_execution)
+    assert not requirement.is_resolved()
+
+    run_output = RunOutput(tools=[tool_execution], requirements=[requirement])
+    scrub_tool_results_from_run_output(run_output)
+
+    assert run_output.tools[0].result == SECRET
+    assert run_output.requirements[0].tool_execution.result == SECRET
+
+
+def test_scrub_tool_results_blanks_result_once_the_requirement_is_resolved():
+    """Once the requirement is resolved the result is a record, not a resume payload."""
+    tool_execution = _tool_execution(external_execution_required=True)
+    requirement = RunRequirement(tool_execution=tool_execution)
+    requirement.external_execution_result = "client answer"
+    assert requirement.is_resolved()
+
+    run_output = RunOutput(tools=[tool_execution], requirements=[requirement])
+    scrub_tool_results_from_run_output(run_output)
+
+    assert run_output.tools[0].result is None
+
+
+# -- Storage-flag wiring --
+
+
+def test_scrub_run_output_for_storage_blanks_result_when_flag_is_off():
+    """The agent-level entry point applies it, which is what the DB write path calls."""
+    from agno.agent._run import scrub_run_output_for_storage
+
+    agent = Agent(store_tool_messages=False)
+    run_output = RunOutput(agent_id=agent.id, tools=[_tool_execution()])
+
+    scrub_run_output_for_storage(agent, run_output)
+
+    assert run_output.tools[0].result is None
+
+
+def test_scrub_run_output_for_storage_keeps_result_when_flag_is_on():
+    """store_tool_messages=True must be untouched by this change."""
+    from agno.agent._run import scrub_run_output_for_storage
+
+    agent = Agent(store_tool_messages=True)
+    run_output = RunOutput(agent_id=agent.id, tools=[_tool_execution()])
+
+    scrub_run_output_for_storage(agent, run_output)
+
+    assert run_output.tools[0].result == SECRET
+
+
+# -- In-flight isolation --
+
+
+def test_isolate_tool_scrub_targets_protects_the_live_run():
+    """Scrubbing an isolated storage copy must not blank the live run's results."""
+    import copy
+
+    live_run = RunOutput(tools=[_tool_execution()])
+
+    storage_copy = copy.copy(live_run)
+    isolate_tool_scrub_targets(storage_copy)
+    scrub_tool_results_from_run_output(storage_copy)
+
+    assert storage_copy.tools[0].result is None, "storage copy should be scrubbed"
+    assert live_run.tools[0].result == SECRET, "live run must keep its tool result"
+
+
+def test_isolate_tool_scrub_targets_keeps_tools_and_requirements_aliased():
+    """A ToolExecution reached through both tools and a requirement stays one object."""
+    import copy
+
+    tool_execution = _tool_execution()
+    live_run = RunOutput(tools=[tool_execution], requirements=[RunRequirement(tool_execution=tool_execution)])
+
+    storage_copy = copy.copy(live_run)
+    isolate_tool_scrub_targets(storage_copy)
+
+    assert storage_copy.tools[0] is storage_copy.requirements[0].tool_execution
+    assert storage_copy.tools[0] is not tool_execution
+
+
+def test_checkpoint_storage_copy_does_not_strip_the_live_run():
+    """The real mid-run checkpoint path, which is where the hazard would bite."""
+    from agno.agent._run import _scrub_and_propagate_session_state
+
+    agent = Agent(store_tool_messages=False)
+    live_run = RunOutput(agent_id=agent.id, tools=[_tool_execution()])
+
+    storage_copy = _scrub_and_propagate_session_state(agent, live_run, None, isolate_inflight=True)
+
+    assert storage_copy.tools[0].result is None, "the persisted copy should carry no result"
+    assert live_run.tools[0].result == SECRET, (
+        "the still-running run must keep its tool result; without isolation the checkpoint "
+        "strips it in place and the run continues without its own tool output"
+    )

--- a/libs/agno/tests/unit/agent/test_store_tool_result_storage_leak.py
+++ b/libs/agno/tests/unit/agent/test_store_tool_result_storage_leak.py
@@ -1,0 +1,189 @@
+"""End-to-end storage evidence for the store_tool_messages=False tool-result leak (#9426).
+
+The unit tests in test_store_tool_result_scrub_leak.py prove the scrub function blanks the
+stored results. This one proves the thing the issue actually reported: after a real run
+through the real tool loop and a real SqliteDb write, the tool's return value is not in the
+session row.
+
+The model is scripted at the provider seam (`_process_model_response`) so the framework's own
+tool loop still runs, executes the tool and populates `run_response.tools` — the leak has to
+reach storage the same way it does in production, not be planted by the test.
+"""
+
+from typing import Any
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.base import Model
+from agno.models.message import Message, MessageMetrics
+from agno.models.response import ModelResponse
+
+SECRET = "SSN-000-11-2222-BASELINE"
+
+
+def peek() -> str:
+    """Return a sensitive value the caller does not want persisted."""
+    return SECRET
+
+
+class ScriptedToolCallModel(Model):
+    """Calls `peek` once, then answers. No network, real tool loop."""
+
+    def __init__(self):
+        super().__init__(id="scripted-model", name="scripted-model", provider="test")
+        self.instructions = None
+        self._turn = 0
+
+    def _script_turn(self, assistant_message: Message, model_response: ModelResponse) -> None:
+        assistant_message.metrics = assistant_message.metrics or MessageMetrics()
+        if self._turn == 0:
+            self._turn += 1
+            assistant_message.tool_calls = [
+                {"id": "call_1", "type": "function", "function": {"name": "peek", "arguments": "{}"}}
+            ]
+        else:
+            assistant_message.content = "done"
+            model_response.content = "done"
+
+    def _process_model_response(
+        self,
+        messages,
+        assistant_message: Message,
+        model_response: ModelResponse,
+        response_format=None,
+        tools=None,
+        tool_choice=None,
+        run_response=None,
+        compress_tool_results: bool = False,
+    ) -> None:
+        self._script_turn(assistant_message, model_response)
+
+    async def _aprocess_model_response(
+        self,
+        messages,
+        assistant_message: Message,
+        model_response: ModelResponse,
+        response_format=None,
+        tools=None,
+        tool_choice=None,
+        run_response=None,
+        compress_tool_results: bool = False,
+    ) -> None:
+        self._script_turn(assistant_message, model_response)
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> Any:
+        return ModelResponse()
+
+    async def ainvoke(self, *args, **kwargs) -> Any:
+        return ModelResponse()
+
+    def invoke_stream(self, *args, **kwargs):
+        yield ModelResponse()
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        yield ModelResponse()
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return ModelResponse()
+
+
+def _stored_bytes(db_file: str) -> str:
+    """Every row of every table, stringified — the row as it actually landed on disk."""
+    import sqlite3
+
+    connection = sqlite3.connect(db_file)
+    try:
+        tables = [row[0] for row in connection.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()]
+        dumped = []
+        for table in tables:
+            for row in connection.execute(f"SELECT * FROM {table}").fetchall():  # noqa: S608
+                dumped.append(str(row))
+        return "\n".join(dumped)
+    finally:
+        connection.close()
+
+
+def _run_agent(db_file: str, *, store_tool_messages: bool) -> Agent:
+    agent = Agent(
+        model=ScriptedToolCallModel(),
+        tools=[peek],
+        db=SqliteDb(db_file=db_file),
+        store_tool_messages=store_tool_messages,
+        session_id="leak-session",
+        telemetry=False,
+    )
+    agent.run("go")
+    return agent
+
+
+def test_tool_result_is_not_in_the_session_row_when_flag_is_off(tmp_path):
+    """The reported symptom: `sensitive paths: ['$[0].tools[0].result']` in the stored row."""
+    db_file = str(tmp_path / "leak.db")
+
+    agent = _run_agent(db_file, store_tool_messages=False)
+
+    # The tool really did run and really did return the secret on this run.
+    last_run = agent.get_last_run_output()
+    assert last_run is not None
+    assert any(tool.tool_name == "peek" for tool in last_run.tools or []), (
+        "the scripted model must actually drive the tool loop, or this test proves nothing"
+    )
+
+    assert SECRET not in _stored_bytes(db_file), "the tool result must not reach the database"
+
+
+def test_tool_result_is_in_the_session_row_when_flag_is_on(tmp_path):
+    """Control: with the flag on the value is stored, so the test above is not vacuous."""
+    db_file = str(tmp_path / "kept.db")
+
+    _run_agent(db_file, store_tool_messages=True)
+
+    assert SECRET in _stored_bytes(db_file), (
+        "with store_tool_messages=True the result should still be persisted; if this fails the "
+        "other test passes for the wrong reason"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_result_is_not_in_the_session_row_on_the_async_path(tmp_path):
+    """arun writes through the same scrub; both variants are covered."""
+    db_file = str(tmp_path / "leak_async.db")
+
+    agent = Agent(
+        model=ScriptedToolCallModel(),
+        tools=[peek],
+        db=SqliteDb(db_file=db_file),
+        store_tool_messages=False,
+        session_id="leak-session-async",
+        telemetry=False,
+    )
+    await agent.arun("go")
+
+    last_run = agent.get_last_run_output()
+    assert last_run is not None
+    assert any(tool.tool_name == "peek" for tool in last_run.tools or []), (
+        "the async path must actually drive the tool loop, or this test proves nothing"
+    )
+
+    assert SECRET not in _stored_bytes(db_file)


### PR DESCRIPTION
## Summary

`store_tool_messages=False` removed tool messages from `run_response.messages` but never touched the tool's return value where it is *also* stored: `run_response.tools[*].result`, and `requirements[*].tool_execution.result`. For anyone who turns the flag off to keep sensitive tool output out of the database, the value stayed in the same session row in two other places.

(Issue number: #9426)

This takes the narrow route described in the issue — blank the result on stored `ToolExecution` objects at every level of the run tree, keying on whether the call is already resolved — rather than the storage-policy/provenance redesign raised in the issue comments. That larger design may well be right, but it changes how retention is modelled framework-wide; this closes the leak against the current model without committing to it.

**What changed**

- `scrub_tool_results_from_run_output` now blanks `result` on `run_response.tools` and on `requirements[*].tool_execution`, in addition to the existing message filtering.
- The message-filtering step used to `return` early when `messages` was empty. That early return now guards only the message step, so a run whose messages were already stripped still gets its stored results blanked.
- **The external-execution carve-out the issue asks for.** A result that an *unresolved* requirement still needs is kept: for external execution the caller's answer arrives as the tool result, so blanking it would discard what `continue_run` needs to finish the run. The predicate is the existing `RunRequirement.is_resolved()`, so this follows the definition of "still waiting" the codebase already uses rather than inventing one.

**The part that is not in the issue, and is the reason this is not a two-line change**

Blanking mutates `ToolExecution` in place, and the mid-run checkpoint path persists a *shallow* `copy.copy` of the run that aliases the live run's objects. Without isolation, a checkpoint would strip the results off the still-running run — it would continue without its own tool output.

This is the same hazard `isolate_media_scrub_targets` already exists to handle for media, so it gets the same remedy: a sibling `isolate_tool_scrub_targets`, called on the checkpoint paths in `agent/_run.py` and `team/_run.py`. The existing comment at those sites already says "isolate what the scrubs touch"; this makes that true for tool results too. Terminal paths keep the existing behaviour of skipping the copy, since the run is finished by then.

A `ToolExecution` reached through both `tools` and a requirement is copied once and shared by both, so the isolated copy keeps the aliasing the live run has.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

**On the AI checkbox:** this was written with AI assistance (Claude Code). I selected the issue, directed the approach, ran and read the verification myself, and reviewed every line. Flagging it because CONTRIBUTING asks, and I would rather over-disclose.

---

## Additional Notes

**Verification** — `libs/agno/tests/unit/{agent,team,utils,run}`: `main` **1656 passed / 0 failed**, this branch **1670 passed / 0 failed**, FAILED/ERROR sets identical (both empty), +14 = exactly the new tests. `./scripts/format.sh` and `./scripts/validate.sh` clean; mypy reports the same 28 pre-existing errors on this branch as on `main`, with none in the changed files.

**Fail-first** — with the tests in place and only the behaviour reverted (the helper left defined, so collection still succeeds), **8 fail and 3 pass**. The 3 that pass both ways are the deliberate negative controls: the unresolved-requirement carve-out, `store_tool_messages=True`, and the aliasing check.

**Storage-level evidence** (`test_store_tool_result_storage_leak.py`, 3). The scrub-function tests prove the functions behave; these prove the symptom the issue actually reported — `sensitive paths: ['$[0].tools[0].result']` in the session row. A model scripted at the provider seam (`_process_model_response` / `_aprocess_model_response`) drives the framework's own tool loop, so the tool really executes and `run_response.tools` is populated the way it is in production rather than planted by the test; each test asserts the tool ran. After a real `SqliteDb` write the value is absent from every row of every table, on both the sync and async paths. A `store_tool_messages=True` control asserts the value *is* stored, so the negative assertions cannot pass for the wrong reason.

**Tests added** (`libs/agno/tests/unit/agent/test_store_tool_result_scrub_leak.py`, 11):

- results blanked on `tools`, on `requirements[*].tool_execution`, on `TeamRunOutput`, and on a run with no messages;
- the unresolved-requirement result is kept, and blanked once resolved;
- `scrub_run_output_for_storage` applies it with the flag off and leaves it alone with the flag on;
- isolation protects the live run, keeps `tools`/requirement aliasing, and the real checkpoint path (`_scrub_and_propagate_session_state(..., isolate_inflight=True)`) leaves the live run's results intact.

**Relationship to #9419.** That issue is the history twin of this one — the same shape of retention flag missing a container the content also reaches — and I have opened #9510 for it. The two touch the same file but different functions, so they are independent and either merge order works; whichever lands second may need a trivial rebase of `libs/agno/agno/utils/agent.py`.

**Scope note.** `requirements[*].tool_execution` is what `_propagate_member_pause` copies up into ancestor team runs, so fixing it in the shared scrub covers the ancestor copies through the existing call sites rather than needing a separate pass. I have not touched `user_input_schema[*].value`, which is a different field with its own resume semantics — happy to look at it separately if you consider it in the same class.