### PR TITLE
[fix] Scrub history reaching a member through input_content

### DIFF
--- a/libs/agno/agno/utils/agent.py
+++ b/libs/agno/agno/utils/agent.py
@@ -548,14 +548,51 @@ def scrub_tool_results_from_run_output(run_response: Union[RunOutput, TeamRunOut
     run_response.messages = filtered_messages
 
 
+def _scrub_history_from_input_content(run_response: Union[RunOutput, TeamRunOutput]) -> None:
+    """Drop history messages from ``run_response.input.input_content``.
+
+    ``input_content`` is filtered only when it is a list; every other form it can take (a
+    string, a dict, a single Message, a BaseModel) carries no history entries. Items that are
+    not Messages are left alone, and so is the current task -- the delegate path appends it to
+    the history list without ``from_history``, and it is input rather than history.
+
+    The RunInput is replaced rather than edited in place: a shallow storage copy shares it with
+    the live run, so mutating it would strip the history off a run that is still executing.
+    """
+    import copy
+
+    run_input = run_response.input
+    if run_input is None:
+        return
+
+    input_content = run_input.input_content
+    if not isinstance(input_content, list):
+        return
+
+    retained = [item for item in input_content if not (isinstance(item, Message) and item.from_history)]
+    if len(retained) == len(input_content):
+        return
+
+    isolated_input = copy.copy(run_input)
+    isolated_input.input_content = retained
+    run_response.input = isolated_input  # type: ignore[assignment]
+
+
 def scrub_history_messages_from_run_output(run_response: Union[RunOutput, TeamRunOutput]) -> None:
     """
     Remove all history messages from TeamRunOutput when store_history_messages=False.
     This removes messages that were loaded from the team's memory.
+
+    History also reaches a team member as its *input*: the delegate path passes the member's
+    prior conversation as ``input=history``, so for a member run it is stored on
+    ``input.input_content`` and never appears in ``messages``. That copy is filtered too, or
+    the member's opt-out has no effect on the row it is actually stored in.
     """
     # Remove messages with from_history=True
     if run_response.messages:
         run_response.messages = [msg for msg in run_response.messages if not msg.from_history]
+
+    _scrub_history_from_input_content(run_response)
 
 
 def isolate_media_scrub_targets(run_response: Union[RunOutput, TeamRunOutput]) -> None:

--- a/libs/agno/tests/unit/agent/test_store_history_input_content_leak.py
+++ b/libs/agno/tests/unit/agent/test_store_history_input_content_leak.py
@@ -1,0 +1,162 @@
+"""Reproduction tests for the history leak through scrub_history_messages_from_run_output.
+
+A team delegates by passing the member's prior conversation as the member's *input*
+(`input=member_agent_task if not history else history` in team/_default_tools.py), so for a
+member run the history is stored on `input.input_content` and never reaches
+`run_response.messages`. Filtering only `messages` therefore left `store_history_messages=False`
+with no effect on the row the member is actually stored in.
+"""
+
+import copy
+
+from agno.agent.agent import Agent
+from agno.models.message import Message
+from agno.run.agent import RunInput, RunOutput
+from agno.run.team import TeamRunInput, TeamRunOutput
+from agno.utils.agent import scrub_history_messages_from_run_output
+
+SECRET = "MARKER-SECRET-IN-HISTORY"
+
+
+def _history_message(content: str = SECRET) -> Message:
+    message = Message(role="user", content=content)
+    message.from_history = True
+    return message
+
+
+def _delegated_input(*, task: str = "summarize the quarter") -> list:
+    """The shape team/_default_tools.py builds: history, then the task appended untagged."""
+    return [_history_message(), Message(role="user", content=task)]
+
+
+# -- Core scrub function tests --
+
+
+def test_scrub_history_drops_history_from_input_content():
+    """The member's history must not survive on input.input_content."""
+    run_output = RunOutput(input=RunInput(input_content=_delegated_input()))
+
+    scrub_history_messages_from_run_output(run_output)
+
+    contents = [message.content for message in run_output.input.input_content]
+    assert SECRET not in contents, "history content should be gone from input_content"
+
+
+def test_scrub_history_keeps_the_current_task():
+    """The task is appended to the history list without from_history; it is input, not history."""
+    run_output = RunOutput(input=RunInput(input_content=_delegated_input(task="summarize the quarter")))
+
+    scrub_history_messages_from_run_output(run_output)
+
+    assert len(run_output.input.input_content) == 1
+    assert run_output.input.input_content[0].content == "summarize the quarter"
+
+
+def test_scrub_history_still_filters_messages():
+    """The existing messages behaviour is unchanged."""
+    run_output = RunOutput(
+        messages=[_history_message(), Message(role="user", content="live")],
+    )
+
+    scrub_history_messages_from_run_output(run_output)
+
+    assert [message.content for message in run_output.messages] == ["live"]
+
+
+def test_scrub_history_handles_team_run_output():
+    """The same path exists on TeamRunOutput."""
+    team_output = TeamRunOutput(input=TeamRunInput(input_content=_delegated_input()))
+
+    scrub_history_messages_from_run_output(team_output)
+
+    contents = [message.content for message in team_output.input.input_content]
+    assert SECRET not in contents
+
+
+# -- Shapes that must be left alone --
+
+
+def test_scrub_history_leaves_a_string_input_untouched():
+    """input_content is usually a plain string; it carries no history entries."""
+    run_output = RunOutput(input=RunInput(input_content="just a task"))
+
+    scrub_history_messages_from_run_output(run_output)
+
+    assert run_output.input.input_content == "just a task"
+
+
+def test_scrub_history_preserves_non_message_list_items():
+    """A list of dicts or strings is a legitimate input shape and is not history."""
+    run_output = RunOutput(input=RunInput(input_content=[{"role": "user"}, "plain", _history_message()]))
+
+    scrub_history_messages_from_run_output(run_output)
+
+    assert run_output.input.input_content == [{"role": "user"}, "plain"]
+
+
+def test_scrub_history_handles_a_missing_input():
+    """A run with no input must not raise."""
+    run_output = RunOutput(input=None)
+
+    scrub_history_messages_from_run_output(run_output)
+
+    assert run_output.input is None
+
+
+# -- The live run must not be mutated --
+
+
+def test_scrub_history_does_not_mutate_the_shared_run_input():
+    """A shallow storage copy shares its RunInput with the live run.
+
+    Filtering in place would strip the history off a run that is still executing, so the
+    RunInput is replaced on the copy instead.
+    """
+    live_run = RunOutput(input=RunInput(input_content=_delegated_input()))
+    original_input = live_run.input
+
+    storage_copy = copy.copy(live_run)
+    scrub_history_messages_from_run_output(storage_copy)
+
+    assert storage_copy.input is not original_input, "the copy should get its own RunInput"
+    assert len(live_run.input.input_content) == 2, "the live run must keep its history"
+    assert live_run.input.input_content[0].content == SECRET
+
+
+def test_scrub_history_keeps_the_same_run_input_when_nothing_is_filtered():
+    """No history means no copy, so the common path allocates nothing."""
+    run_output = RunOutput(input=RunInput(input_content=[Message(role="user", content="task")]))
+    original_input = run_output.input
+
+    scrub_history_messages_from_run_output(run_output)
+
+    assert run_output.input is original_input
+
+
+# -- Storage-flag wiring --
+
+
+def test_scrub_run_output_for_storage_drops_input_history_when_flag_is_off():
+    """The delegate path calls this entry point on the member run before upsert_run."""
+    from agno.agent._run import scrub_run_output_for_storage
+
+    member_agent = Agent(store_history_messages=False)
+    member_run = RunOutput(agent_id=member_agent.id, input=RunInput(input_content=_delegated_input()))
+
+    scrub_run_output_for_storage(member_agent, member_run)
+
+    contents = [message.content for message in member_run.input.input_content]
+    assert SECRET not in contents
+
+
+def test_scrub_run_output_for_storage_keeps_input_history_when_flag_is_on():
+    """store_history_messages=True must be untouched by this change."""
+    from agno.agent._run import scrub_run_output_for_storage
+
+    member_agent = Agent(store_history_messages=True)
+    member_run = RunOutput(agent_id=member_agent.id, input=RunInput(input_content=_delegated_input()))
+
+    scrub_run_output_for_storage(member_agent, member_run)
+
+    contents = [message.content for message in member_run.input.input_content]
+    assert SECRET in contents

--- a/libs/agno/tests/unit/agent/test_store_history_input_content_storage_leak.py
+++ b/libs/agno/tests/unit/agent/test_store_history_input_content_storage_leak.py
@@ -1,0 +1,188 @@
+"""End-to-end storage evidence for the store_history_messages=False history leak (#9419).
+
+The unit tests in test_store_history_input_content_leak.py prove the scrub function filters
+`input.input_content`. This one proves the symptom the issue reported: after a real team
+delegation and a real SqliteDb write, the member's opted-out history is not in the stored row
+at `input.input_content`.
+
+The assertion is on the JSON *path* the marker appears at, not on its mere presence: the same
+marker legitimately survives elsewhere in the session (the member's own run-1 output and
+messages, and the team's own copy of the delegate result), and only the member's history copy
+is opted out. A whole-row substring search would fail for the wrong reason.
+"""
+
+import json
+import sqlite3
+from typing import Any, List
+
+from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.base import Model
+from agno.models.message import Message, MessageMetrics
+from agno.models.response import ModelResponse
+from agno.team.team import Team
+
+MARKER = "MARKER-SECRET-IN-HISTORY"
+
+
+class ScriptedModel(Model):
+    """Replays a fixed script of turns: ("tool", name, args) or ("text", content)."""
+
+    def __init__(self, script: List[tuple]):
+        super().__init__(id="scripted", name="scripted", provider="test")
+        self.instructions = None
+        self._script = list(script)
+        self._index = 0
+
+    def _script_turn(self, assistant_message: Message, model_response: ModelResponse) -> None:
+        assistant_message.metrics = assistant_message.metrics or MessageMetrics()
+        step = self._script[min(self._index, len(self._script) - 1)]
+        self._index += 1
+        if step[0] == "tool":
+            assistant_message.tool_calls = [
+                {
+                    "id": f"call_{self._index}",
+                    "type": "function",
+                    "function": {"name": step[1], "arguments": json.dumps(step[2])},
+                }
+            ]
+        else:
+            assistant_message.content = step[1]
+            model_response.content = step[1]
+
+    def _process_model_response(self, messages, assistant_message, model_response, **kwargs) -> None:
+        self._script_turn(assistant_message, model_response)
+
+    async def _aprocess_model_response(self, messages, assistant_message, model_response, **kwargs) -> None:
+        self._script_turn(assistant_message, model_response)
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> Any:
+        return ModelResponse()
+
+    async def ainvoke(self, *args, **kwargs) -> Any:
+        return ModelResponse()
+
+    def invoke_stream(self, *args, **kwargs):
+        yield ModelResponse()
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        yield ModelResponse()
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return ModelResponse()
+
+
+def _marker_paths(db_file: str) -> List[str]:
+    """JSON paths, inside the stored `runs` column, at which the marker appears."""
+    found: List[str] = []
+    connection = sqlite3.connect(db_file)
+    try:
+        for (runs,) in connection.execute("SELECT runs FROM agno_sessions"):
+            if not runs:
+                continue
+            parsed = json.loads(runs)
+            if isinstance(parsed, str):
+                parsed = json.loads(parsed)
+
+            def walk(node: Any, path: str = "") -> None:
+                if isinstance(node, dict):
+                    for key, value in node.items():
+                        walk(value, f"{path}.{key}")
+                elif isinstance(node, list):
+                    for index, value in enumerate(node):
+                        walk(value, f"{path}[{index}]")
+                elif isinstance(node, str) and MARKER in node:
+                    found.append(path)
+
+            walk(parsed)
+    finally:
+        connection.close()
+    return found
+
+
+def _delegate_twice(db_file: str, *, store_history_messages: bool) -> None:
+    """Run a team twice so the member's second run receives its own history as input."""
+    db = SqliteDb(db_file=db_file)
+    member = Agent(
+        id="researcher",
+        name="researcher",
+        model=ScriptedModel([("text", MARKER)]),
+        db=db,
+        add_history_to_context=True,
+        store_history_messages=store_history_messages,
+        telemetry=False,
+    )
+    team = Team(
+        id="lead",
+        name="lead",
+        members=[member],
+        db=db,
+        model=ScriptedModel(
+            [("tool", "delegate_task_to_member", {"member_id": "researcher", "task": "go"}), ("text", "ok")]
+        ),
+        telemetry=False,
+    )
+    team.run("first", session_id="shared-session")
+
+    # Second turn: the member now has history, which the delegate path passes as its input.
+    member.model = ScriptedModel([("text", "second answer")])
+    team.model = ScriptedModel(
+        [("tool", "delegate_task_to_member", {"member_id": "researcher", "task": "again"}), ("text", "ok2")]
+    )
+    team.run("second", session_id="shared-session")
+
+
+def test_member_history_is_not_stored_on_input_content(tmp_path):
+    """The reported symptom: the marker in the raw runs column at input.input_content."""
+    db_file = str(tmp_path / "history.db")
+
+    _delegate_twice(db_file, store_history_messages=False)
+
+    paths = _marker_paths(db_file)
+    leaked = [path for path in paths if ".input.input_content" in path]
+    assert not leaked, f"history reached storage through input_content at {leaked}"
+
+
+def test_the_delegation_actually_happened(tmp_path):
+    """Guard against the leak test passing because nothing ran.
+
+    The marker must still be present somewhere -- the member's own run-1 output is stored
+    legitimately -- so an empty result set would mean the scenario never executed.
+    """
+    db_file = str(tmp_path / "sanity.db")
+
+    _delegate_twice(db_file, store_history_messages=False)
+
+    assert _marker_paths(db_file), "the scenario stored nothing; the leak test would be vacuous"
+
+
+def test_history_is_stored_on_input_content_when_the_flag_is_on(tmp_path):
+    """Control: with the flag on the history is kept, so the negative assertion has teeth."""
+    db_file = str(tmp_path / "kept.db")
+
+    _delegate_twice(db_file, store_history_messages=True)
+
+    paths = _marker_paths(db_file)
+    assert any(".input.input_content" in path for path in paths), (
+        "with store_history_messages=True the history should still be persisted on input_content; "
+        "if this fails, the leak test passes for the wrong reason"
+    )


### PR DESCRIPTION
## Summary

A team delegates by passing the member's prior conversation as the member's **input** — `input=member_agent_task if not history else history` in `team/_default_tools.py` — so for a member run the history is stored on `input.input_content` and never reaches `run_response.messages`. `scrub_history_messages_from_run_output` filtered only `messages`, so a member's `store_history_messages=False` had no effect on the row the member is actually stored in.

(Issue number: #9419)

This is the narrow fix named in the issue: filter the history entries out of `input.input_content` in the shared scrub, so the sibling paused-member row and every embedded copy inherit it through the existing call sites. The provenance-tagging redesign raised in the issue comments would be a broader change to how history is modelled; this closes the leak without it.

**What changed**

- `scrub_history_messages_from_run_output` now also drops `from_history` messages from `run_response.input.input_content`.
- Only *list* `input_content` is touched. The other shapes it can take — a string, a dict, a single `Message`, a `BaseModel` — carry no history entries, and non-`Message` items inside a list are left alone.
- **The current task is kept.** `_setup_delegate_task_to_member` appends it to the history list as a plain `Message` without `from_history`, so filtering on that flag keeps the input and drops only the history, which is exactly the distinction the flag is about.
- **The `RunInput` is replaced rather than edited in place.** A shallow storage copy shares its `RunInput` with the live run, so mutating `input_content` would strip the history off a run that is still executing. Copy-on-write keeps this correct on every call site, including the delegate site and `_scrub_member_responses`, which do not isolate; and when there is nothing to filter the original object is kept, so the common path allocates nothing.

For contrast, `store_media=False` already works in this topology because the delegate path applies the member's scrub in place before the run is embedded or upserted — the gap was specific to history entering through `input_content`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

**On the AI checkbox:** this was written with AI assistance (Claude Code). I selected the issue, directed the approach, ran and read the verification myself, and reviewed every line. Flagging it because CONTRIBUTING asks, and I would rather over-disclose.

---

## Additional Notes

**Verification** — `libs/agno/tests/unit/{agent,team,utils,run}`: `main` **1656 passed / 0 failed**, this branch **1670 passed / 0 failed**, FAILED/ERROR sets identical (both empty), +14 = exactly the new tests. `./scripts/format.sh` and `./scripts/validate.sh` clean; mypy reports the same 28 pre-existing errors on this branch as on `main`, with none in the changed file.

**Fail-first** — with the tests in place and only the new call removed, **6 fail and 5 pass**. The 5 that pass both ways are the deliberate negative controls: string `input_content`, absent `input`, the existing `messages` filtering, the no-copy-when-nothing-is-filtered check, and `store_history_messages=True`.

**Storage-level evidence** (`test_store_history_input_content_storage_leak.py`, 3). The scrub-function tests prove the function behaves; these reproduce the symptom the issue reported. A scripted team delegates to a member twice against a real `SqliteDb`, so the second delegation passes the member's own history as its input exactly as production does, and the assertion is read back out of the raw `runs` column.

**The assertion is on the JSON path, not on the marker's presence**, and that distinction matters: the same marker legitimately survives elsewhere in the session, so a whole-row substring search would fail for the wrong reason. Measured on this branch versus the same scenario with the fix disabled:

| Path in the stored `runs` column | Without the fix | With the fix |
| --- | --- | --- |
| `[0].content`, `[0].messages[1].content` | present | present (the member's own run, not history) |
| `[1].messages[3].content`, `[1].tools[0].result` | present | present (the team's own copy) |
| **`[2].input.input_content[1].content`** | **present** | **gone** |

That last row is the leak, and it is the only path that changes. A `store_history_messages=True` control asserts the `input_content` path *is* present, and a sanity check asserts the scenario stored something at all.

**Tests added** (`libs/agno/tests/unit/agent/test_store_history_input_content_leak.py`, 11):

- history dropped from `input_content` on `RunOutput` and `TeamRunOutput`, with the current task kept;
- the existing `messages` filtering still applies;
- string `input_content`, absent `input`, and non-`Message` list items are left untouched;
- the live run's `RunInput` is not mutated, and the same object is reused when nothing is filtered;
- `scrub_run_output_for_storage` — the entry point the delegate path calls before `upsert_run` — drops it with the flag off and keeps it with the flag on.

**Relationship to #9426.** That issue is the tool-result twin of this one, and I have opened #9509 for it. The two touch the same file but different functions, so they are independent and either merge order works; whichever lands second may need a trivial rebase of `libs/agno/agno/utils/agent.py`.