### PR TITLE
[fix] avoid draining the current team task

### DIFF
--- a/libs/agno/agno/run/cancel.py
+++ b/libs/agno/agno/run/cancel.py
@@ -150,7 +150,8 @@ def register_member_drain_task(team_run_id: str, task: asyncio.Task) -> None:
 
 async def adrain_member_tasks(team_run_id: str, timeout: float = 5.0) -> None:
     """Await all in-flight delegate tasks for a team run, bounded by timeout."""
-    tasks = {t for t in _member_drain_tasks.get(team_run_id, set()) if not t.done()}
+    current_task = asyncio.current_task()
+    tasks = {t for t in _member_drain_tasks.get(team_run_id, set()) if not t.done() and t is not current_task}
     if not tasks:
         return
     try:

--- a/libs/agno/tests/unit/run/test_cancel.py
+++ b/libs/agno/tests/unit/run/test_cancel.py
@@ -1,0 +1,30 @@
+"""Unit tests for run cancellation helpers."""
+
+import asyncio
+
+import pytest
+
+from agno.run.cancel import adrain_member_tasks, cleanup_member_runs, register_member_drain_task
+
+
+@pytest.mark.asyncio
+async def test_adrain_member_tasks_does_not_await_current_task(monkeypatch):
+    """The drain helper must not wait on the task that is performing the drain."""
+    run_id = "run-current-task"
+    current_task = asyncio.current_task()
+    assert current_task is not None
+    register_member_drain_task(run_id, current_task)
+
+    gathered_tasks = []
+
+    async def fake_gather(*tasks, **kwargs):
+        gathered_tasks.extend(tasks)
+
+    monkeypatch.setattr(asyncio, "gather", fake_gather)
+
+    try:
+        await adrain_member_tasks(run_id)
+    finally:
+        cleanup_member_runs(run_id)
+
+    assert current_task not in gathered_tasks


### PR DESCRIPTION
## Summary

Fixes #9489 by keeping the team's cancellation drain from awaiting the task that is performing the drain itself.

`adelegate_task_to_member` registers its current task so cancellation can wait for member cleanup. When the team later calls `adrain_member_tasks`, the current task was included in the `asyncio.gather` set. A timeout on that self-wait can cancel the team run and leave a streaming run without a terminal event. The drain now excludes `asyncio.current_task()` while continuing to await other unfinished member tasks.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] This PR was prepared with AI assistance. I reviewed the change, reproduced the pre-fix failure, and verified the focused regression coverage and repository checks below.

## Additional Notes

Tests:

- `PYTHONPATH=libs/agno pytest libs/agno/tests/unit/run/test_cancel.py -q`
- `PYTHONPATH=libs/agno pytest libs/agno/tests/unit/run libs/agno/tests/unit/team/test_paused_member_persistence.py libs/agno/tests/unit/models/test_async_generator_exception_handling.py -q` (248 passed)
- `./scripts/format.sh`
- `./scripts/validate.sh`

The regression test registers the current task as a drain candidate and asserts that `adrain_member_tasks` does not pass it to `asyncio.gather`.
