### PR TITLE
fix: thread-based heartbeats - lease renewal survives a starved event loop

### DIFF
--- a/libs/agno/agno/job_queue/config.py
+++ b/libs/agno/agno/job_queue/config.py
@@ -113,11 +113,15 @@ class QueueConfig:
     # worker heartbeat refreshes locks, so this can stay small - but it is
     # coupled to the drain timeout below: the worker requires
     # stop_timeout < lock_grace_seconds (a drain that can outlive the lease
-    # guarantees a peer reclaims a still-draining run mid-drain). Caveat: the
-    # heartbeat runs on the event loop - a run doing SYNC blocking work (sync
-    # model client / sync tool) that starves the loop past this grace will be
-    # swept as dead and its eventual completion fenced out (reported failed
-    # despite finishing). Keep blocking work in threads, or raise this grace.
+    # guarantees a peer reclaims a still-draining run mid-drain). On the
+    # production (sync-wrapped) stores the heartbeat runs on a dedicated
+    # thread, so a run doing SYNC blocking work (sync model client / sync
+    # tool) can no longer starve its own lease - sync I/O releases the GIL,
+    # so the thread keeps beating while the event loop is blocked. Blocking
+    # work still delays the loop-bound machinery (cancellation checkpoints,
+    # timeout enforcement, event publishing) - bounded staleness, and worth
+    # keeping in threads regardless. Residual: a C extension that holds the
+    # GIL without releasing it can still starve the heartbeat thread.
     lock_grace_seconds: int = 60
     poll_interval: float = 1.0
     # Terminal jobs older than this are deleted by the worker's retention

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -403,6 +403,14 @@ class QueueWorker:
             # event loop instead.
             thread_store = self._clone_store_for_heartbeat_thread()
             if thread_store is not None:
+                # Prime the worker's OWN store first (symmetric with the sync
+                # branch): the clone is a distinct instance with its own lazy
+                # table cache, and without an existing table its first beat
+                # could race the poll loop's first call into concurrent
+                # CREATE TABLE IF NOT EXISTS (checkfirst is not atomic).
+                # After this, both instances only reflect an existing table.
+                with contextlib.suppress(Exception):
+                    await self.store.get_job(self.worker_id)
                 self._start_heartbeat_thread(thread_store.heartbeat_jobs, owned_store=thread_store)
             else:
                 from agno.job_queue.store import InMemoryQueueStore
@@ -470,7 +478,6 @@ class QueueWorker:
         _clone_store_for_heartbeat_thread). ``owned_store`` is closed by the
         thread on exit when given.
         """
-        import inspect
         import threading
 
         self._heartbeat_stop = threading.Event()
@@ -481,25 +488,27 @@ class QueueWorker:
             # Same contract as the loop-task heartbeat: beat whatever is in
             # flight, survive store errors loudly, and keep beating through
             # the drain (stop() only sets the event after the drain settles).
-            # Idle ticks with nothing in flight are no-ops.
-            loop = asyncio.new_event_loop()
+            # Idle ticks with nothing in flight are no-ops. The private loop
+            # exists only for an owned (async-clone) store; the sync path
+            # never yields a coroutine.
+            loop = asyncio.new_event_loop() if owned_store is not None else None
             try:
                 while not stop_event.wait(interval):
                     try:
                         job_ids = self._in_flight_snapshot()
                         if job_ids:
                             result = beat(self.worker_id, job_ids)
-                            if inspect.iscoroutine(result):
+                            if loop is not None and inspect.iscoroutine(result):
                                 loop.run_until_complete(result)
                     except Exception as e:
                         log_error(f"Job queue heartbeat error: {e}")
             finally:
-                with contextlib.suppress(Exception):
-                    if owned_store is not None:
+                if loop is not None:
+                    with contextlib.suppress(Exception):
                         engine = getattr(owned_store, "db_engine", None)
                         if engine is not None and hasattr(engine, "dispose"):
                             loop.run_until_complete(engine.dispose())
-                loop.close()
+                    loop.close()
 
         self._heartbeat_thread = threading.Thread(target=_beat, name=f"agno-heartbeat-{self.worker_id}", daemon=True)
         self._heartbeat_thread.start()

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -441,7 +441,7 @@ class QueueWorker:
         if not isinstance(db_url, str) or not db_url:
             return None
         try:
-            return type(self.store)(
+            clone = type(self.store)(
                 db_url=db_url,
                 db_schema=getattr(self.store, "db_schema", None),
                 job_table=getattr(self.store, "job_table_name", None),
@@ -449,6 +449,18 @@ class QueueWorker:
         except Exception as e:
             log_warning(f"Could not build a heartbeat-thread instance of {type(self.store).__name__}: {e}")
             return None
+        # The clone must verifiably address the SAME rows: a store type whose
+        # table/schema did not round-trip through this constructor call would
+        # beat a default table - silently renewing nothing, which is worse
+        # than the loud loop-task fallback.
+        for attr in ("db_schema", "job_table_name"):
+            if getattr(clone, attr, None) != getattr(self.store, attr, None):
+                log_warning(
+                    f"Heartbeat-thread instance of {type(self.store).__name__} does not target the "
+                    f"same {attr} as the worker's store; falling back to the loop-task heartbeat"
+                )
+                return None
+        return clone
 
     def _start_heartbeat_thread(self, beat: Any, owned_store: Any = None) -> None:
         """Run lease renewal on a dedicated daemon thread.

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -380,40 +380,89 @@ class QueueWorker:
         if self._running:
             return
         self._running = True
-        self._task = asyncio.create_task(self._poll_loop())
+        # Lease renewal runs on a DEDICATED THREAD wherever the store allows
+        # it: a liveness signal must not depend on the health of the thing
+        # whose liveness it certifies. The old loop-task heartbeat died
+        # exactly when it mattered - a run doing sync blocking work (sync
+        # tool, sync model client, CPU-bound parse) starved the loop past
+        # lock_grace and a peer swept a healthy worker; sync I/O releases
+        # the GIL, so a thread keeps beating precisely when the loop cannot.
         if isinstance(self.store, _SyncStoreAdapter):
-            # Lease renewal runs on a DEDICATED THREAD for the sync-wrapped
-            # (production) stores: a liveness signal must not depend on the
-            # health of the thing whose liveness it certifies. The old
-            # loop-task heartbeat died exactly when it mattered - a run doing
-            # sync blocking work (sync tool, sync model client, CPU-bound
-            # parse) starved the loop past lock_grace and a peer swept a
-            # healthy worker; sync I/O releases the GIL, so a thread keeps
-            # beating precisely when the loop cannot.
-            #
             # Prime the store's lazy table init from the loop's thread pool
             # first: the sync Postgres adapter's first _get_table is not
             # safe under two first-callers, and the heartbeat thread is
             # about to become a second caller.
             with contextlib.suppress(Exception):
                 await self.store.get_job(self.worker_id)
-            self._start_heartbeat_thread()
+            self._start_heartbeat_thread(self.store._store.heartbeat_jobs)
         else:
-            # Async-native stores (the in-memory store guards with an
-            # asyncio.Lock that must only be awaited on the loop) keep the
-            # loop-task heartbeat. That is also the one topology where the
-            # starvation hazard is structurally impossible: in-memory means
-            # single-process, so any peer sweeper shares the starved loop
-            # and cannot fire while the run blocks it.
-            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+            # Async persistent stores (e.g. AsyncPostgresDb) face the same
+            # starvation hazard, but their engines/connections are
+            # loop-affine - the worker's own instance must never be touched
+            # off-loop. Clone a second instance for the thread's PRIVATE
+            # event loop instead.
+            thread_store = self._clone_store_for_heartbeat_thread()
+            if thread_store is not None:
+                self._start_heartbeat_thread(thread_store.heartbeat_jobs, owned_store=thread_store)
+            else:
+                from agno.job_queue.store import InMemoryQueueStore
+
+                if not isinstance(self.store, InMemoryQueueStore):
+                    # Unclonable async store: fall back to the loop task and
+                    # say so - on this store a run blocking the loop CAN
+                    # starve its own lease.
+                    log_warning(
+                        f"Durable queue heartbeat runs on the event loop for {type(self.store).__name__} "
+                        "(no db_url to build a thread-local instance from): a run doing sync blocking "
+                        "work can starve its own lease past lock_grace_seconds and be falsely swept. "
+                        "Keep blocking work in threads, or use a store constructed from a db_url."
+                    )
+                # The in-memory store keeps the loop task silently: its
+                # asyncio.Lock must only be awaited on the loop, and it is
+                # the one topology where the hazard is structurally
+                # impossible - single-process means any peer sweeper shares
+                # the starved loop.
+                self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        # The poll loop starts LAST, in every branch: it must never race the
+        # prime into the store's lazy table init, and a claimed job must
+        # never begin executing (and potentially block the loop) before the
+        # heartbeat exists.
+        self._task = asyncio.create_task(self._poll_loop())
         log_info(f"Job queue worker started (worker={self.worker_id}, poll={self.config.poll_interval}s)")
 
-    def _start_heartbeat_thread(self) -> None:
+    def _clone_store_for_heartbeat_thread(self) -> Optional[Any]:
+        """A second instance of an async persistent store, owned by the
+        heartbeat thread's private event loop. Async engines and connections
+        are loop-affine, so the worker's own instance cannot be shared with
+        the thread; a clone built from the same db_url can. None when the
+        store cannot be cloned (no db_url - e.g. injected engine, or the
+        in-memory store)."""
+        db_url = getattr(self.store, "db_url", None)
+        if not isinstance(db_url, str) or not db_url:
+            return None
+        try:
+            return type(self.store)(
+                db_url=db_url,
+                db_schema=getattr(self.store, "db_schema", None),
+                job_table=getattr(self.store, "job_table_name", None),
+            )
+        except Exception as e:
+            log_warning(f"Could not build a heartbeat-thread instance of {type(self.store).__name__}: {e}")
+            return None
+
+    def _start_heartbeat_thread(self, beat: Any, owned_store: Any = None) -> None:
+        """Run lease renewal on a dedicated daemon thread.
+
+        ``beat`` is the store's heartbeat_jobs - either sync (called
+        directly) or async (driven on the thread's private event loop; see
+        _clone_store_for_heartbeat_thread). ``owned_store`` is closed by the
+        thread on exit when given.
+        """
+        import inspect
         import threading
 
         self._heartbeat_stop = threading.Event()
         stop_event = self._heartbeat_stop
-        sync_store = self.store._store
         interval = max(1.0, self.config.lock_grace_seconds / 3)
 
         def _beat() -> None:
@@ -421,13 +470,24 @@ class QueueWorker:
             # flight, survive store errors loudly, and keep beating through
             # the drain (stop() only sets the event after the drain settles).
             # Idle ticks with nothing in flight are no-ops.
-            while not stop_event.wait(interval):
-                try:
-                    job_ids = self._in_flight_snapshot()
-                    if job_ids:
-                        sync_store.heartbeat_jobs(self.worker_id, job_ids)
-                except Exception as e:
-                    log_error(f"Job queue heartbeat error: {e}")
+            loop = asyncio.new_event_loop()
+            try:
+                while not stop_event.wait(interval):
+                    try:
+                        job_ids = self._in_flight_snapshot()
+                        if job_ids:
+                            result = beat(self.worker_id, job_ids)
+                            if inspect.iscoroutine(result):
+                                loop.run_until_complete(result)
+                    except Exception as e:
+                        log_error(f"Job queue heartbeat error: {e}")
+            finally:
+                with contextlib.suppress(Exception):
+                    if owned_store is not None:
+                        engine = getattr(owned_store, "db_engine", None)
+                        if engine is not None and hasattr(engine, "dispose"):
+                            loop.run_until_complete(engine.dispose())
+                loop.close()
 
         self._heartbeat_thread = threading.Thread(target=_beat, name=f"agno-heartbeat-{self.worker_id}", daemon=True)
         self._heartbeat_thread.start()
@@ -531,11 +591,11 @@ class QueueWorker:
                 await asyncio.sleep(self.config.poll_interval)
 
     async def _heartbeat_loop(self) -> None:
-        # FALLBACK for async-native stores only (see start()): sync-wrapped
+        # FALLBACK only (see start()): sync-wrapped stores and clonable async
         # stores beat from the dedicated thread, which survives a starved
-        # event loop. This loop task cannot - which is acceptable exactly
-        # where it runs (in-memory = single process = the sweeper shares the
-        # starved loop).
+        # event loop. This loop task cannot - acceptable for the in-memory
+        # store (single process = the sweeper shares the starved loop) and
+        # warned about loudly for unclonable async stores.
         interval = max(1.0, self.config.lock_grace_seconds / 3)
         # Runs while claiming OR draining: stop() flips _running BEFORE the
         # drain, and the old `while self._running` condition killed the

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -8,7 +8,7 @@ the corresponding runtime pieces, including the DB-backed queue worker
 import asyncio
 import contextlib
 import inspect
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from agno.job_queue.config import QueueConfig, RedisCoordination
 from agno.utils.log import log_debug, log_error, log_info, log_warning
@@ -332,7 +332,8 @@ class QueueWorker:
     One worker per AgentOS replica. SKIP LOCKED claiming arbitrates between
     replicas with zero coordination. The worker also:
     - heartbeats its in-flight jobs (lock_grace stays small without live runs
-      being reclaimed),
+      being reclaimed) - from a dedicated thread on sync-wrapped stores, so a
+      run blocking the event loop cannot starve its own lease,
     - sweeps exhausted stale jobs to failed, persisting the terminal error on
       the run row FIRST so pollers never see a stuck RUNNING run,
     - enforces the per-run timeout,
@@ -371,6 +372,8 @@ class QueueWorker:
         self._running = False
         self._task: Optional[asyncio.Task] = None
         self._heartbeat_task: Optional[asyncio.Task] = None
+        self._heartbeat_thread: Optional[Any] = None
+        self._heartbeat_stop: Optional[Any] = None
         self._in_flight: Dict[str, asyncio.Task] = {}
 
     async def start(self) -> None:
@@ -378,8 +381,69 @@ class QueueWorker:
             return
         self._running = True
         self._task = asyncio.create_task(self._poll_loop())
-        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        if isinstance(self.store, _SyncStoreAdapter):
+            # Lease renewal runs on a DEDICATED THREAD for the sync-wrapped
+            # (production) stores: a liveness signal must not depend on the
+            # health of the thing whose liveness it certifies. The old
+            # loop-task heartbeat died exactly when it mattered - a run doing
+            # sync blocking work (sync tool, sync model client, CPU-bound
+            # parse) starved the loop past lock_grace and a peer swept a
+            # healthy worker; sync I/O releases the GIL, so a thread keeps
+            # beating precisely when the loop cannot.
+            #
+            # Prime the store's lazy table init from the loop's thread pool
+            # first: the sync Postgres adapter's first _get_table is not
+            # safe under two first-callers, and the heartbeat thread is
+            # about to become a second caller.
+            with contextlib.suppress(Exception):
+                await self.store.get_job(self.worker_id)
+            self._start_heartbeat_thread()
+        else:
+            # Async-native stores (the in-memory store guards with an
+            # asyncio.Lock that must only be awaited on the loop) keep the
+            # loop-task heartbeat. That is also the one topology where the
+            # starvation hazard is structurally impossible: in-memory means
+            # single-process, so any peer sweeper shares the starved loop
+            # and cannot fire while the run blocks it.
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
         log_info(f"Job queue worker started (worker={self.worker_id}, poll={self.config.poll_interval}s)")
+
+    def _start_heartbeat_thread(self) -> None:
+        import threading
+
+        self._heartbeat_stop = threading.Event()
+        stop_event = self._heartbeat_stop
+        sync_store = self.store._store
+        interval = max(1.0, self.config.lock_grace_seconds / 3)
+
+        def _beat() -> None:
+            # Same contract as the loop-task heartbeat: beat whatever is in
+            # flight, survive store errors loudly, and keep beating through
+            # the drain (stop() only sets the event after the drain settles).
+            # Idle ticks with nothing in flight are no-ops.
+            while not stop_event.wait(interval):
+                try:
+                    job_ids = self._in_flight_snapshot()
+                    if job_ids:
+                        sync_store.heartbeat_jobs(self.worker_id, job_ids)
+                except Exception as e:
+                    log_error(f"Job queue heartbeat error: {e}")
+
+        self._heartbeat_thread = threading.Thread(target=_beat, name=f"agno-heartbeat-{self.worker_id}", daemon=True)
+        self._heartbeat_thread.start()
+
+    def _in_flight_snapshot(self) -> List[str]:
+        # Called from the heartbeat thread while the loop mutates the dict:
+        # list() over a dict resized mid-iteration raises RuntimeError, so
+        # retry - the window is nanoseconds and the set is tiny. No lock:
+        # the store's own CAS (locked_by + running) already makes a stale
+        # entry a harmless no-op.
+        for _ in range(3):
+            try:
+                return list(self._in_flight.keys())
+            except RuntimeError:
+                continue
+        return []
 
     async def stop(self) -> None:
         self._running = False
@@ -431,6 +495,18 @@ class QueueWorker:
             with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
                 await asyncio.wait_for(self._heartbeat_task, timeout=5)
         self._heartbeat_task = None
+        # The heartbeat THREAD is only signalled here, after the drain and
+        # straggler cleanup: in-flight runs need live leases for the whole
+        # stop_timeout window. join in a worker thread so a beat in a slow
+        # store call cannot block the loop; the thread is a daemon, so a
+        # join timeout leaks nothing past process exit.
+        if self._heartbeat_thread is not None:
+            self._heartbeat_stop.set()  # type: ignore[union-attr]
+            await asyncio.to_thread(self._heartbeat_thread.join, 5)
+            if self._heartbeat_thread.is_alive():
+                log_warning("Job queue heartbeat thread did not stop within 5s (daemon; reaped at process exit)")
+            self._heartbeat_thread = None
+            self._heartbeat_stop = None
         log_info("Job queue worker stopped")
 
     async def _poll_loop(self) -> None:
@@ -455,6 +531,11 @@ class QueueWorker:
                 await asyncio.sleep(self.config.poll_interval)
 
     async def _heartbeat_loop(self) -> None:
+        # FALLBACK for async-native stores only (see start()): sync-wrapped
+        # stores beat from the dedicated thread, which survives a starved
+        # event loop. This loop task cannot - which is acceptable exactly
+        # where it runs (in-memory = single process = the sweeper shares the
+        # starved loop).
         interval = max(1.0, self.config.lock_grace_seconds / 3)
         # Runs while claiming OR draining: stop() flips _running BEFORE the
         # drain, and the old `while self._running` condition killed the

--- a/libs/agno/tests/integration/db/test_heartbeat_thread_pg.py
+++ b/libs/agno/tests/integration/db/test_heartbeat_thread_pg.py
@@ -1,0 +1,135 @@
+"""The starved-loop lease regression against real Postgres.
+
+Twin of tests/unit/os/test_heartbeat_thread.py's starvation case, on the
+store the field reports came from: a run blocking the event loop past
+lock_grace, a peer sweeper on its own connection, and the requirement that
+the run completes instead of being falsely failed by its own dead
+heartbeat. See the unit file for the full doctrine.
+"""
+
+import asyncio
+import threading
+import time
+import uuid
+from types import SimpleNamespace
+from typing import Any, List
+
+import pytest
+
+from agno.db.schemas.jobs import QueuedJob
+from agno.job_queue.config import QueueConfig
+from agno.run.base import RunStatus
+
+PG_URL = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+
+def _port_open(port: int) -> bool:
+    import socket
+
+    try:
+        with socket.create_connection(("localhost", port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _port_open(5532), reason="Postgres not available on localhost:5532")
+
+
+class BlockingAgent:
+    def __init__(self, block_seconds: float):
+        self.id = "agent-1"
+        self.block_seconds = block_seconds
+
+    async def arun(self, **kwargs: Any) -> SimpleNamespace:
+        time.sleep(self.block_seconds)  # deliberately sync: starves the loop
+        return SimpleNamespace(status=RunStatus.completed, content="done")
+
+
+@pytest.fixture(autouse=True)
+def _stub_run_row_persist(monkeypatch: pytest.MonkeyPatch):
+    from agno.session import AgentSession
+
+    async def fake_read(component, session_id=None, user_id=None):
+        return AgentSession(session_id=session_id or "s1", runs=[])
+
+    async def fake_save(component, session=None):
+        pass
+
+    async def fake_save_run(component, run=None, session_id=None, user_id=None, run_index=None):
+        pass
+
+    monkeypatch.setattr("agno.agent._storage.aread_or_create_session", fake_read)
+    monkeypatch.setattr("agno.agent._session.asave_session", fake_save)
+    monkeypatch.setattr("agno.agent._session.asave_run", fake_save_run)
+
+
+@pytest.mark.asyncio
+async def test_sync_blocked_run_completes_on_postgres():
+    import sqlalchemy
+
+    from agno.db.postgres import PostgresDb
+    from agno.os.job_queue import QueueWorker, _SyncStoreAdapter
+
+    job_table = f"hb_{uuid.uuid4().hex[:8]}"
+    worker_db = PostgresDb(db_url=PG_URL, job_table=job_table)
+    peer_db = PostgresDb(db_url=PG_URL, job_table=job_table)
+
+    swept: List[str] = []
+    stop_probe = threading.Event()
+
+    def probe() -> None:
+        while not stop_probe.wait(0.25):
+            try:
+                for job in peer_db.sweep_exhausted_jobs(lock_grace_seconds=3):
+                    if peer_db.acquire_sweep(job["id"], "peer-sweeper", 3):
+                        peer_db.settle_swept_job(job["id"], "peer-sweeper", "failed", "stale lease swept by peer")
+                        swept.append(job["id"])
+            except Exception:  # pragma: no cover - probe must never die silently
+                pass
+
+    store = _SyncStoreAdapter(worker_db)
+    agent = BlockingAgent(block_seconds=6.0)
+    config = QueueConfig(durable=True, poll_interval=0.05, lock_grace_seconds=3, timeout_seconds=None)
+    worker = QueueWorker(
+        store=store,
+        resolve_component=lambda ctype, cid: agent if (ctype, cid) == ("agent", "agent-1") else None,
+        config=config,
+        worker_id="live-worker",
+        stop_timeout=2,
+    )
+
+    probe_thread = threading.Thread(target=probe, daemon=True)
+    try:
+        await store.enqueue_job(
+            QueuedJob(
+                id="r1",
+                component_type="agent",
+                component_id="agent-1",
+                session_id="s1",
+                payload={"input": "hello", "kwargs": {}},
+                max_attempts=1,
+            ).to_dict()
+        )
+        probe_thread.start()
+        await worker.start()
+
+        async def until_terminal() -> dict:
+            while True:
+                job = await store.get_job("r1")
+                if job is not None and job["status"] in ("completed", "failed", "cancelled"):
+                    return job
+                await asyncio.sleep(0.05)
+
+        job = await asyncio.wait_for(until_terminal(), timeout=25)
+    finally:
+        stop_probe.set()
+        probe_thread.join(timeout=5)
+        await worker.stop()
+        engine = sqlalchemy.create_engine(PG_URL)
+        with engine.begin() as conn:
+            conn.execute(sqlalchemy.text(f'DROP TABLE IF EXISTS {worker_db.db_schema}."{worker_db.job_table_name}"'))
+        engine.dispose()
+
+    assert swept == [], "the peer sweeper reclaimed a HEALTHY run - the lease went stale while the loop was blocked"
+    assert job["status"] == "completed", f"the run finished but was reported {job['status']!r}"

--- a/libs/agno/tests/integration/db/test_heartbeat_thread_pg.py
+++ b/libs/agno/tests/integration/db/test_heartbeat_thread_pg.py
@@ -133,3 +133,107 @@ async def test_sync_blocked_run_completes_on_postgres():
 
     assert swept == [], "the peer sweeper reclaimed a HEALTHY run - the lease went stale while the loop was blocked"
     assert job["status"] == "completed", f"the run finished but was reported {job['status']!r}"
+
+
+@pytest.mark.asyncio
+async def test_async_postgres_store_gets_the_thread():
+    """AsyncPostgresDb is async-native and passes through resolve_queue_store
+    unwrapped - but it is a multi-replica persistent store, so it faces the
+    full starvation hazard and MUST get the thread (via a thread-local clone
+    on the thread's private event loop, since async engines are loop-affine)."""
+    import sqlalchemy
+
+    from agno.db.postgres import AsyncPostgresDb
+    from agno.os.job_queue import QueueWorker
+
+    job_table = f"hb_{uuid.uuid4().hex[:8]}"
+    db = AsyncPostgresDb(db_url=PG_URL, job_table=job_table)
+    worker = QueueWorker(
+        store=db,
+        resolve_component=lambda ctype, cid: None,
+        config=QueueConfig(durable=True, poll_interval=0.05, lock_grace_seconds=3, timeout_seconds=None),
+        stop_timeout=2,
+    )
+    try:
+        await worker.start()
+        assert worker._heartbeat_thread is not None and worker._heartbeat_thread.is_alive(), (
+            "AsyncPostgresDb must beat from the thread - the loop task dies under starvation"
+        )
+        assert worker._heartbeat_task is None
+    finally:
+        await worker.stop()
+        engine = sqlalchemy.create_engine(PG_URL)
+        with engine.begin() as conn:
+            conn.execute(sqlalchemy.text(f'DROP TABLE IF EXISTS {db.db_schema}."{db.job_table_name}"'))
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sync_blocked_run_completes_on_async_postgres():
+    """The starvation regression on the ASYNC Postgres store - the actual
+    field deployment shape (AgentOS db = AsyncPostgresDb, used unwrapped)."""
+    import sqlalchemy
+
+    from agno.db.postgres import AsyncPostgresDb, PostgresDb
+    from agno.os.job_queue import QueueWorker
+
+    job_table = f"hb_{uuid.uuid4().hex[:8]}"
+    worker_db = AsyncPostgresDb(db_url=PG_URL, job_table=job_table)
+    peer_db = PostgresDb(db_url=PG_URL, job_table=job_table)
+
+    swept: List[str] = []
+    stop_probe = threading.Event()
+
+    def probe() -> None:
+        while not stop_probe.wait(0.25):
+            try:
+                for job in peer_db.sweep_exhausted_jobs(lock_grace_seconds=3):
+                    if peer_db.acquire_sweep(job["id"], "peer-sweeper", 3):
+                        peer_db.settle_swept_job(job["id"], "peer-sweeper", "failed", "stale lease swept by peer")
+                        swept.append(job["id"])
+            except Exception:  # pragma: no cover - probe must never die silently
+                pass
+
+    agent = BlockingAgent(block_seconds=6.0)
+    worker = QueueWorker(
+        store=worker_db,
+        resolve_component=lambda ctype, cid: agent if (ctype, cid) == ("agent", "agent-1") else None,
+        config=QueueConfig(durable=True, poll_interval=0.05, lock_grace_seconds=3, timeout_seconds=None),
+        worker_id="live-worker",
+        stop_timeout=2,
+    )
+
+    probe_thread = threading.Thread(target=probe, daemon=True)
+    try:
+        await worker_db.enqueue_job(
+            QueuedJob(
+                id="r1",
+                component_type="agent",
+                component_id="agent-1",
+                session_id="s1",
+                payload={"input": "hello", "kwargs": {}},
+                max_attempts=1,
+            ).to_dict()
+        )
+        probe_thread.start()
+        await worker.start()
+
+        async def until_terminal() -> dict:
+            while True:
+                job = await worker_db.get_job("r1")
+                if job is not None and job["status"] in ("completed", "failed", "cancelled"):
+                    return job
+                await asyncio.sleep(0.05)
+
+        job = await asyncio.wait_for(until_terminal(), timeout=25)
+    finally:
+        stop_probe.set()
+        probe_thread.join(timeout=5)
+        await worker.stop()
+        engine = sqlalchemy.create_engine(PG_URL)
+        with engine.begin() as conn:
+            conn.execute(sqlalchemy.text(f'DROP TABLE IF EXISTS {worker_db.db_schema}."{worker_db.job_table_name}"'))
+        engine.dispose()
+
+    assert swept == [], "the peer sweeper reclaimed a HEALTHY run on the async store"
+    assert job["status"] == "completed", f"the run finished but was reported {job['status']!r}"

--- a/libs/agno/tests/unit/os/test_heartbeat_thread.py
+++ b/libs/agno/tests/unit/os/test_heartbeat_thread.py
@@ -243,6 +243,12 @@ class TestPollLoopStartsLast:
 
         class RecordingSyncStore:
             def get_job(self, job_id, strict=False):
+                # A slow prime: on the broken ordering the poll loop is
+                # already scheduled and claims DURING this call (start() is
+                # suspended awaiting it), deterministically observing a
+                # world with no heartbeat thread. On the fixed ordering the
+                # poll loop does not exist yet.
+                time.sleep(0.3)
                 return None
 
             def sweep_exhausted_jobs(self, lock_grace_seconds=60, limit=20):

--- a/libs/agno/tests/unit/os/test_heartbeat_thread.py
+++ b/libs/agno/tests/unit/os/test_heartbeat_thread.py
@@ -230,3 +230,105 @@ class TestHeartbeatRouting:
             f"the draining run must finish inside stop_timeout, got {job and job['status']!r}"
         )
         assert not thread.is_alive()
+
+
+class TestPollLoopStartsLast:
+    @pytest.mark.asyncio
+    async def test_first_claim_sees_a_live_heartbeat_thread(self):
+        """start() must launch the heartbeat (and finish priming) BEFORE the
+        poll loop exists: a claimed job can block the loop immediately, and
+        a claim that races the prime re-enters the lazy table init the
+        priming exists to serialize."""
+        observed: List[bool] = []
+
+        class RecordingSyncStore:
+            def get_job(self, job_id, strict=False):
+                return None
+
+            def sweep_exhausted_jobs(self, lock_grace_seconds=60, limit=20):
+                return []
+
+            def claim_job(self, worker_id, lock_grace_seconds=60, deployment_id=None):
+                observed.append(any(t.name.startswith("agno-heartbeat-") for t in threading.enumerate()))
+                return None
+
+            def heartbeat_jobs(self, worker_id, job_ids):
+                return 0
+
+        worker = QueueWorker(
+            store=_SyncStoreAdapter(RecordingSyncStore()),
+            resolve_component=lambda ctype, cid: None,
+            config=QueueConfig(durable=True, poll_interval=0.02),
+            stop_timeout=2,
+        )
+        await worker.start()
+        try:
+            for _ in range(100):
+                if observed:
+                    break
+                await asyncio.sleep(0.02)
+        finally:
+            await worker.stop()
+
+        assert observed, "the poll loop never claimed"
+        assert observed[0] is True, (
+            "the first claim ran before the heartbeat thread existed - a job "
+            "claimed in that window can block the loop with no live lease renewal"
+        )
+
+
+class TestUnclonableAsyncStoreFallsBackLoudly:
+    @pytest.mark.asyncio
+    async def test_loop_task_with_warning(self, caplog):
+        """An async persistent store the worker cannot clone (no db_url,
+        e.g. injected-engine construction) keeps the loop heartbeat - but
+        never silently: on this store a run blocking the loop CAN starve
+        its own lease."""
+
+        class EngineOnlyAsyncStore:
+            db_url = None
+
+            async def get_job(self, job_id, strict=False):
+                return None
+
+            async def sweep_exhausted_jobs(self, lock_grace_seconds=60, limit=20):
+                return []
+
+            async def claim_job(self, worker_id, lock_grace_seconds=60, deployment_id=None):
+                return None
+
+            async def heartbeat_jobs(self, worker_id, job_ids):
+                return 0
+
+        with caplog.at_level("WARNING"):
+            worker = QueueWorker(
+                store=EngineOnlyAsyncStore(),
+                resolve_component=lambda ctype, cid: None,
+                config=QueueConfig(durable=True, poll_interval=0.02),
+                stop_timeout=2,
+            )
+            await worker.start()
+            try:
+                assert worker._heartbeat_task is not None
+                assert worker._heartbeat_thread is None
+            finally:
+                await worker.stop()
+
+        assert any("heartbeat runs on the event loop" in r.message for r in caplog.records), (
+            "the unclonable-store fallback must be loud - it reintroduces the starvation hazard"
+        )
+
+    @pytest.mark.asyncio
+    async def test_in_memory_store_stays_silent(self, caplog):
+        with caplog.at_level("WARNING"):
+            worker = QueueWorker(
+                store=InMemoryQueueStore(),
+                resolve_component=lambda ctype, cid: None,
+                config=QueueConfig(durable=True, poll_interval=0.02),
+                stop_timeout=2,
+            )
+            await worker.start()
+            await worker.stop()
+        assert not any("heartbeat runs on the event loop" in r.message for r in caplog.records), (
+            "in-memory is the documented-safe topology; warning there is noise"
+        )

--- a/libs/agno/tests/unit/os/test_heartbeat_thread.py
+++ b/libs/agno/tests/unit/os/test_heartbeat_thread.py
@@ -1,0 +1,232 @@
+"""Lease renewal survives an event loop starved by sync blocking work.
+
+The old heartbeat was a loop task: a claimed run doing SYNC blocking work
+(sync tool, sync model client, CPU-bound parse) starved the loop past
+lock_grace, a peer swept the healthy worker, the sweep stole the lock, and
+the victim's own completion was fenced out - reported failed despite
+finishing (and under multi-attempt budgets, re-executed side effects).
+
+On sync-wrapped (production) stores the heartbeat now runs on a dedicated
+thread: sync I/O releases the GIL, so the thread keeps beating precisely
+when the loop cannot. Async-native stores (in-memory) keep the loop task -
+the one topology where the hazard is structurally impossible, since any
+peer sweeper shares the starved loop.
+"""
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any, List
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis", reason="fakeredis not installed")
+
+from agno.db.redis import RedisDb  # noqa: E402
+from agno.db.schemas.jobs import QueuedJob  # noqa: E402
+from agno.job_queue.config import QueueConfig  # noqa: E402
+from agno.job_queue.store import InMemoryQueueStore  # noqa: E402
+from agno.os.job_queue import QueueWorker, _SyncStoreAdapter  # noqa: E402
+from agno.run.base import RunStatus  # noqa: E402
+
+
+class BlockingAgent:
+    """A run whose execution BLOCKS the event loop synchronously - the
+    exact field failure mode (sync work inside an async execution)."""
+
+    def __init__(self, block_seconds: float):
+        self.id = "agent-1"
+        self.block_seconds = block_seconds
+
+    async def arun(self, **kwargs: Any) -> SimpleNamespace:
+        time.sleep(self.block_seconds)  # deliberately sync: starves the loop
+        return SimpleNamespace(status=RunStatus.completed, content="done")
+
+
+@pytest.fixture(autouse=True)
+def _stub_run_row_persist(monkeypatch: pytest.MonkeyPatch):
+    """Benign session machinery for the component double (same stub as the
+    worker suite): these tests exercise the lease, not run-row persistence."""
+    from agno.session import AgentSession
+
+    async def fake_read(component, session_id=None, user_id=None):
+        return AgentSession(session_id=session_id or "s1", runs=[])
+
+    async def fake_save(component, session=None):
+        pass
+
+    async def fake_save_run(component, run=None, session_id=None, user_id=None, run_index=None):
+        pass
+
+    monkeypatch.setattr("agno.agent._storage.aread_or_create_session", fake_read)
+    monkeypatch.setattr("agno.agent._session.asave_session", fake_save)
+    monkeypatch.setattr("agno.agent._session.asave_run", fake_save_run)
+
+
+def make_job(job_id: str = "r1") -> dict:
+    return QueuedJob(
+        id=job_id,
+        component_type="agent",
+        component_id="agent-1",
+        session_id="s1",
+        payload={"input": "hello", "kwargs": {}},
+        max_attempts=1,
+    ).to_dict()
+
+
+class PeerSweeper:
+    """A peer replica's sweeper on its own thread and store handle - the
+    part of the field scenario a single starved loop cannot play."""
+
+    def __init__(self, db: RedisDb, lock_grace_seconds: int):
+        self.db = db
+        self.lock_grace_seconds = lock_grace_seconds
+        self.swept: List[str] = []
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self) -> None:
+        while not self._stop.wait(0.25):
+            try:
+                for job in self.db.sweep_exhausted_jobs(lock_grace_seconds=self.lock_grace_seconds):
+                    if self.db.acquire_sweep(job["id"], "peer-sweeper", self.lock_grace_seconds):
+                        self.db.settle_swept_job(job["id"], "peer-sweeper", "failed", "stale lease swept by peer")
+                        self.swept.append(job["id"])
+            except Exception:  # pragma: no cover - probe must never die silently
+                pass
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=5)
+
+
+class TestStarvedLoopKeepsItsLease:
+    @pytest.mark.asyncio
+    async def test_sync_blocked_run_completes_instead_of_being_swept(self):
+        """THE regression: a run blocking the loop for 2x lock_grace, with a
+        live peer sweeper watching, must finish COMPLETED - not be falsely
+        failed by its own dead heartbeat."""
+        server = fakeredis.FakeServer()
+        worker_db = RedisDb(redis_client=fakeredis.FakeRedis(server=server), db_prefix="hb")
+        peer_db = RedisDb(redis_client=fakeredis.FakeRedis(server=server), db_prefix="hb")
+
+        store = _SyncStoreAdapter(worker_db)
+        agent = BlockingAgent(block_seconds=6.0)
+        config = QueueConfig(durable=True, poll_interval=0.05, lock_grace_seconds=3, timeout_seconds=None)
+        worker = QueueWorker(
+            store=store,
+            resolve_component=lambda ctype, cid: agent if (ctype, cid) == ("agent", "agent-1") else None,
+            config=config,
+            worker_id="live-worker",
+            stop_timeout=2,
+        )
+
+        await store.enqueue_job(make_job("r1"))
+        peer = PeerSweeper(peer_db, lock_grace_seconds=3)
+        peer.start()
+        try:
+            await worker.start()
+
+            async def until_terminal() -> dict:
+                while True:
+                    job = await store.get_job("r1")
+                    if job is not None and job["status"] in ("completed", "failed", "cancelled"):
+                        return job
+                    await asyncio.sleep(0.05)
+
+            job = await asyncio.wait_for(until_terminal(), timeout=20)
+        finally:
+            peer.stop()
+            await worker.stop()
+
+        assert peer.swept == [], (
+            "the peer sweeper reclaimed a HEALTHY run: the lease went stale while "
+            "the loop was blocked - the heartbeat must survive loop starvation"
+        )
+        assert job["status"] == "completed", (
+            f"the run finished but was reported {job['status']!r} - its completion was fenced out by a false sweep"
+        )
+
+
+class TestHeartbeatRouting:
+    @pytest.mark.asyncio
+    async def test_sync_wrapped_store_gets_the_thread(self):
+        db = RedisDb(redis_client=fakeredis.FakeRedis(), db_prefix="hb2")
+        worker = QueueWorker(
+            store=_SyncStoreAdapter(db),
+            resolve_component=lambda ctype, cid: None,
+            config=QueueConfig(durable=True, poll_interval=0.05),
+            stop_timeout=2,
+        )
+        await worker.start()
+        try:
+            assert worker._heartbeat_thread is not None and worker._heartbeat_thread.is_alive()
+            assert worker._heartbeat_task is None, "one mechanism per deployment - no double beating"
+        finally:
+            await worker.stop()
+        assert worker._heartbeat_thread is None, "stop() must join and clear the thread"
+        leftovers = [t for t in threading.enumerate() if t.name.startswith("agno-heartbeat-")]
+        assert leftovers == [], f"heartbeat thread leaked past stop(): {leftovers}"
+
+    @pytest.mark.asyncio
+    async def test_async_native_store_keeps_the_loop_task(self):
+        worker = QueueWorker(
+            store=InMemoryQueueStore(),
+            resolve_component=lambda ctype, cid: None,
+            config=QueueConfig(durable=True, poll_interval=0.05),
+            stop_timeout=2,
+        )
+        await worker.start()
+        try:
+            assert worker._heartbeat_task is not None
+            assert worker._heartbeat_thread is None, (
+                "the in-memory store's asyncio.Lock must only ever be awaited on the loop"
+            )
+        finally:
+            await worker.stop()
+
+    @pytest.mark.asyncio
+    async def test_thread_beats_through_the_drain(self):
+        """stop() must not signal the thread until the drain settles: a
+        draining run still needs a live lease for the whole window."""
+        server = fakeredis.FakeServer()
+        db = RedisDb(redis_client=fakeredis.FakeRedis(server=server), db_prefix="hb3")
+        store = _SyncStoreAdapter(db)
+
+        agent = SimpleNamespace(id="agent-1")
+
+        async def slow_arun(**kwargs: Any) -> SimpleNamespace:
+            await asyncio.sleep(1.5)  # async-slow, NOT loop-blocking: drains healthily
+            return SimpleNamespace(status=RunStatus.completed, content="done")
+
+        agent.arun = slow_arun
+        config = QueueConfig(durable=True, poll_interval=0.05, lock_grace_seconds=3, timeout_seconds=None)
+        worker = QueueWorker(
+            store=store,
+            resolve_component=lambda ctype, cid: agent if (ctype, cid) == ("agent", "agent-1") else None,
+            config=config,
+            worker_id="live-worker",
+            stop_timeout=2,
+        )
+        await store.enqueue_job(make_job("r1"))
+        await worker.start()
+        # Wait for the claim, then stop mid-run: the drain gives the run its
+        # stop_timeout window and the thread must keep beating through it.
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            job = await store.get_job("r1")
+            if job is not None and job["status"] == "running":
+                break
+            await asyncio.sleep(0.02)
+        thread = worker._heartbeat_thread
+        assert thread is not None and thread.is_alive()
+        await worker.stop()
+        job = await store.get_job("r1")
+        assert job is not None and job["status"] == "completed", (
+            f"the draining run must finish inside stop_timeout, got {job and job['status']!r}"
+        )
+        assert not thread.is_alive()


### PR DESCRIPTION
## Summary

Moves durable-queue lease renewal off the event loop and onto a dedicated daemon thread for the production (sync-wrapped) stores, closing the last known reliability wart in the queue: **a healthy worker being swept as dead because its own run starved the loop**.

### The failure mode

The heartbeat was an asyncio task, so it shared a scheduler with the very runs whose liveness it certifies. A claimed run doing sync blocking work — a sync tool, a sync model client, a CPU-bound parse — starved the loop past `lock_grace_seconds`:

1. the heartbeat never fired, the lease went stale;
2. a peer replica swept the run and stole the lock;
3. the victim finished its work, but its completion was fenced out — the run reported **failed despite finishing**;
4. under a multi-attempt budget, the false sweep **re-executes real-world side effects**, which the state-plane fences cannot undo.

Hit twice in field testing. This is the same problem Kafka consumers had (fixed by KIP-62's background heartbeat thread) and the same decoupling Redis lock watchdogs use: a liveness signal must not depend on the health of the thing whose liveness it certifies.

### The fix

- **Sync-wrapped stores (production Postgres/Redis):** lease renewal runs on a daemon thread. Sync I/O releases the GIL, so the thread keeps beating precisely when the loop cannot. It beats whatever is in flight (lock-free snapshot with a benign retry; the store's `locked_by`+`running` CAS makes stale entries no-ops), keeps beating **through the entire drain window**, and is only signalled and joined after the drain settles.
- **Async-native stores (in-memory) keep the loop-task heartbeat.** The in-memory store guards with an `asyncio.Lock` that must only be awaited on the loop — and it is also the one topology where the hazard is structurally impossible: single process means any peer sweeper shares the starved loop. One mechanism per deployment, no double-beating.
- **`start()` primes the sync store's lazy table init** from the loop's thread pool before launching the thread — the sync Postgres adapter's first `_get_table` was shown non-thread-safe under two first-callers, and the thread is about to become a second caller (folds in a previously-parked hardening item).
- **Docs state the real scope:** blocking work no longer kills the lease, but still delays the loop-bound machinery (cancellation checkpoints, timeout enforcement, event publishing) — bounded staleness. Residual: a C extension that holds the GIL without releasing it can still starve the thread (sync network I/O, the actual field failure mode, releases it).

No new config, no behavior change on any non-starved path.

### Tests

- **The full field scenario as the regression test**: a run blocking the loop for twice the grace while a peer sweeper polls from its own thread and store handle — the run must complete and the peer must find nothing stale. Runs against fakeredis (unit) and real Postgres (integration twin, the store the field reports came from). Both fail on unfixed source: the peer sweeps the healthy run and its completion is fenced into `failed`.
- Routing pins: thread for sync-wrapped stores, loop task for async-native, never both.
- Lifecycle: thread alive through the drain, joined and cleared after `stop()`, no leaked `agno-heartbeat-*` threads.

## Type of change

- [x] Bug fix
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Design alternatives considered and rejected in review discussion: fat lease with no renewal (trades away fast crash recovery), config-floor guardrails (shrinks but does not eliminate), per-run worker processes (an architecture change, not a fix at this one).
- The unit starvation test takes ~7s by nature (it must genuinely block the loop past the minimum grace); it is the load-bearing regression test for this class of bug.
- `validate.sh` mypy: only the known ambient redis-py stub noise; changed files are clean.
