### PR TITLE
[fix] Register async generator tools with framework parameters

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1321,13 +1321,11 @@ class Function(BaseModel):
         elif getattr(func, "_wrapped_for_validation", False):
             return func
 
-        # Don't wrap functions with framework-injected parameters
-        # These parameters (agent, team) are
-        # injected by the framework at runtime and shouldn't be validated by Pydantic
+        # Agent and Team parameters cannot be passed to validate_call as-is because
+        # Pydantic tries to resolve annotations from their class hierarchies.
         sig = signature(func)
         framework_params = {"agent", "team"}
-        if framework_params & set(sig.parameters.keys()):
-            return func
+        pydantic_unsafe_params = framework_params & set(sig.parameters.keys())
 
         # Also skip validation when a PARAMETER's type is Agent or Team, even
         # if the parameter name differs (e.g. my_agent: Agent) or the annotation
@@ -1336,13 +1334,14 @@ class Function(BaseModel):
         # from Agent/Team class hierarchies (like BaseDb) in the user's module globals.
         # The return annotation is not a parameter: validate_call is called
         # without validate_return, so it never introspects one.
+        resolved_hints = None
         try:
-            hints = get_type_hints(func)
+            resolved_hints = get_type_hints(func, include_extras=True)
             from agno.agent.agent import Agent
             from agno.team.team import Team
 
             framework_types = (Agent, Team)
-            for name, hint in hints.items():
+            for name, hint in resolved_hints.items():
                 if name == "return" or name not in sig.parameters:
                     continue
                 # The same structural search the schema rule uses. Reading only
@@ -1351,9 +1350,12 @@ class Function(BaseModel):
                 # Agent's own forward references and took registration of the
                 # whole tool down.
                 if _annotation_reaches(hint, framework_types):
-                    return func
+                    pydantic_unsafe_params.add(name)
         except Exception:
             pass
+
+        if pydantic_unsafe_params and not isasyncgenfunction(func):
+            return func
 
         # Async generators need special handling: validate_call turns an `async def ... yield`
         # into a plain function that returns an async_generator, which makes
@@ -1362,7 +1364,21 @@ class Function(BaseModel):
         # validated callable in an outer `async def ... yield` shim that preserves the
         # async-generator identity while still coercing arguments through Pydantic.
         if isasyncgenfunction(func):
-            validated = validate_call(func, config=dict(arbitrary_types_allowed=True))  # type: ignore
+            validation_target = func
+            if pydantic_unsafe_params:
+                if resolved_hints is None:
+                    return func
+
+                @wraps(func)
+                def validation_proxy(*args: Any, **kwargs: Any) -> Any:
+                    return func(*args, **kwargs)
+
+                validation_proxy.__annotations__ = dict(resolved_hints)
+                for name in pydantic_unsafe_params:
+                    validation_proxy.__annotations__[name] = Any
+                validation_target = validation_proxy
+
+            validated = validate_call(validation_target, config=dict(arbitrary_types_allowed=True))  # type: ignore
 
             @wraps(func)
             async def async_gen_wrapper(*args, **kwargs):

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1310,29 +1310,6 @@ class Function(BaseModel):
 
         pydantic_version = _get_pydantic_version()
 
-        # Async generators need special handling: validate_call turns an `async def ... yield`
-        # into a plain function that returns an async_generator, which makes
-        # inspect.isasyncgenfunction return False. Downstream dispatch (models/base.py,
-        # FunctionCall.aexecute) uses that predicate to route the call, so we wrap the
-        # validated callable in an outer `async def ... yield` shim that preserves the
-        # async-generator identity while still coercing arguments through Pydantic.
-        if isasyncgenfunction(func):
-            if getattr(func, "_wrapped_for_validation", False):
-                return func
-            validated = validate_call(func, config=dict(arbitrary_types_allowed=True))  # type: ignore
-
-            @wraps(func)
-            async def async_gen_wrapper(*args, **kwargs):
-                inner = validated(*args, **kwargs)
-                try:
-                    async for item in inner:
-                        yield item
-                finally:
-                    await inner.aclose()
-
-            async_gen_wrapper._wrapped_for_validation = True  # type: ignore[attr-defined]
-            return async_gen_wrapper
-
         # Don't wrap coroutines with validate_call if pydantic version is less than 2.10.0
         if iscoroutinefunction(func) and pydantic_version < Version("2.10.0"):
             log_debug(
@@ -1377,6 +1354,27 @@ class Function(BaseModel):
                     return func
         except Exception:
             pass
+
+        # Async generators need special handling: validate_call turns an `async def ... yield`
+        # into a plain function that returns an async_generator, which makes
+        # inspect.isasyncgenfunction return False. Downstream dispatch (models/base.py,
+        # FunctionCall.aexecute) uses that predicate to route the call, so we wrap the
+        # validated callable in an outer `async def ... yield` shim that preserves the
+        # async-generator identity while still coercing arguments through Pydantic.
+        if isasyncgenfunction(func):
+            validated = validate_call(func, config=dict(arbitrary_types_allowed=True))  # type: ignore
+
+            @wraps(func)
+            async def async_gen_wrapper(*args, **kwargs):
+                inner = validated(*args, **kwargs)
+                try:
+                    async for item in inner:
+                        yield item
+                finally:
+                    await inner.aclose()
+
+            async_gen_wrapper._wrapped_for_validation = True  # type: ignore[attr-defined]
+            return async_gen_wrapper
 
         # Wrap the callable with validate_call
         wrapped = validate_call(func, config=dict(arbitrary_types_allowed=True))  # type: ignore

--- a/libs/agno/tests/unit/tools/test_async_generator_deserialize.py
+++ b/libs/agno/tests/unit/tools/test_async_generator_deserialize.py
@@ -19,11 +19,13 @@ async generator function, and (b) argument coercion works end-to-end through
 """
 
 from inspect import isasyncgen, isasyncgenfunction, iscoroutinefunction, isgeneratorfunction
-from typing import Literal
+from typing import Annotated, Any, Literal
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, ValidationError
 
+from agno.agent.agent import Agent
+from agno.team.team import Team
 from agno.tools.function import Function, FunctionCall
 
 
@@ -34,6 +36,22 @@ class SearchParams(BaseModel):
 
 async def async_gen_tool(params: SearchParams):
     yield {"query": params.query, "time_range": params.time_range}
+
+
+class FrameworkToolParams(BaseModel):
+    count: int
+
+
+async def async_gen_agent_tool(agent: Any, params: FrameworkToolParams):
+    yield {"owner": agent.name, "count": params.count}
+
+
+async def async_gen_team_tool(host_team: Team, params: FrameworkToolParams):
+    yield {"owner": host_team.name, "count": params.count}
+
+
+async def async_gen_agent_annotated_tool(agent: Any, count: Annotated[int, Field(gt=0)]):
+    yield {"owner": agent.name, "count": count}
 
 
 def test_async_gen_wrapped_still_reports_as_async_gen_function():
@@ -109,6 +127,50 @@ async def test_async_gen_full_dispatch_through_function_call_aexecute():
     assert items == [{"query": "hello", "time_range": "OneWeek"}]
 
 
+@pytest.mark.parametrize(
+    ("entrypoint", "framework_attr", "framework_value"),
+    [
+        (async_gen_agent_tool, "_agent", Agent(name="host-agent")),
+        (async_gen_team_tool, "_team", Team(name="host-team", members=[])),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_gen_with_framework_parameter_validates_user_arguments(entrypoint, framework_attr, framework_value):
+    """Framework injection must not disable Pydantic conversion for model arguments."""
+    func = Function.from_callable(entrypoint)
+    setattr(func, framework_attr, framework_value)
+    call = FunctionCall(function=func, arguments={"params": {"count": "3"}})
+
+    exec_result = await call.aexecute()
+
+    assert exec_result.status == "success", f"error: {exec_result.error}"
+    assert isasyncgen(call.result)
+    items = [item async for item in call.result]
+    assert items == [{"owner": framework_value.name, "count": 3}]
+
+
+@pytest.mark.asyncio
+async def test_async_gen_with_framework_parameter_preserves_annotated_validation():
+    """Masking framework parameters must preserve user-facing Annotated metadata."""
+    func = Function.from_callable(async_gen_agent_annotated_tool)
+    func._agent = Agent(name="host-agent")
+
+    valid_call = FunctionCall(function=func, arguments={"count": "3"})
+    exec_result = await valid_call.aexecute()
+
+    assert exec_result.status == "success", f"error: {exec_result.error}"
+    items = [item async for item in valid_call.result]
+    assert items == [{"owner": "host-agent", "count": 3}]
+
+    invalid_call = FunctionCall(function=func, arguments={"count": "-1"})
+    exec_result = await invalid_call.aexecute()
+
+    assert exec_result.status == "success", f"error: {exec_result.error}"
+    with pytest.raises(ValidationError, match="greater_than"):
+        async for _ in invalid_call.result:
+            pass
+
+
 @pytest.mark.asyncio
 async def test_async_gen_shim_propagates_aclose_to_inner_generator():
     """``aclose()`` on the outer shim must run the inner generator's ``finally``.
@@ -162,8 +224,6 @@ async def test_async_gen_validation_error_surfaces_on_iteration():
     This confirms the wrapping is actually doing validation, not just passing
     dicts straight through.
     """
-    from pydantic import ValidationError
-
     func = Function(name="async_gen_tool", entrypoint=async_gen_tool)
     func.process_entrypoint()
 

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -890,6 +890,56 @@ def test_tool_decorator_async_generator():
     assert async_gen_func.entrypoint is not None
 
 
+@pytest.mark.asyncio
+async def test_agent_registers_async_generator_tool_with_framework_parameter():
+    """A bare async-generator tool with an Agent parameter reaches the model."""
+    from inspect import isasyncgenfunction
+    from typing import AsyncIterator, Iterator
+
+    from agno.agent.agent import Agent
+    from agno.metrics import MessageMetrics
+    from agno.models.base import Model
+    from agno.models.response import ModelResponse
+
+    seen_tools = []
+    response = ModelResponse(content="ok", role="assistant", response_usage=MessageMetrics())
+
+    class RecordingModel(Model):
+        async def aresponse(self, *args, tools=None, **kwargs) -> ModelResponse:
+            seen_tools[:] = [candidate for candidate in tools or [] if isinstance(candidate, Function)]
+            return response
+
+        def invoke(self, *args, **kwargs) -> ModelResponse:
+            return response
+
+        async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+            return response
+
+        def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+            yield response
+
+        async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+            yield response
+
+        def _parse_provider_response(self, provider_response: Any, **kwargs) -> ModelResponse:
+            return response
+
+        def _parse_provider_response_delta(self, response_delta: Any) -> ModelResponse:
+            return response
+
+    async def gen_tool(agent: Agent, msg: str):
+        yield f"{agent.name}: {msg}"
+
+    agent = Agent(name="host", model=RecordingModel(id="recording-model"), tools=[gen_tool])
+    run_output = await agent.arun("hello")
+
+    assert run_output.content == "ok"
+    assert [function.name for function in seen_tools] == ["gen_tool"]
+    assert set(seen_tools[0].parameters["properties"]) == {"msg"}
+    assert seen_tools[0].entrypoint is not None
+    assert isasyncgenfunction(seen_tools[0].entrypoint)
+
+
 def test_tool_decorator_invalid_config():
     """Test @tool decorator with invalid configuration."""
     with pytest.raises(ValueError, match="Invalid tool configuration arguments"):


### PR DESCRIPTION
## Summary

- Move async-generator validation after the framework parameter exclusions so `Agent` and `Team` parameters do not trigger Pydantic forward-reference resolution during tool registration.
- Add a public `Agent.arun()` regression test with an offline recording model, confirming that the tool reaches the model, framework parameters stay out of its schema, and the entrypoint remains an async-generator function.

Fixes #9416

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Async generators keep their async-generator identity while `validate_call` validates user arguments. Framework-injected `Agent` and `Team` parameters are masked from Pydantic without discarding the remaining annotations, including `Annotated` constraints.

Validation covered the affected function tests, the full unit suite, formatting, validation, and package build. Codex assisted with implementation and testing.