### PR TITLE
fix: honor selected workflow version over WebSocket

### DIFF
--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -75,6 +75,7 @@ async def handle_workflow_via_websocket(
         session_id = message.get("session_id")
         user_message = message.get("message", "")
         user_id = message.get("user_id")
+        version = message.get("version")
         factory_input = message.get("factory_input")
 
         # Defense-in-depth: if the caller authenticated via JWT, ensure user_id
@@ -125,6 +126,7 @@ async def handle_workflow_via_websocket(
                     workflow_id=workflow_id,
                     workflows=os.workflows,
                     db=os.db,
+                    version=version,
                     registry=os.registry,
                     create_fresh=True,
                     ctx=ctx,
@@ -135,7 +137,12 @@ async def handle_workflow_via_websocket(
         else:
             try:
                 workflow = get_workflow_by_id(
-                    workflow_id=workflow_id, workflows=os.workflows, db=os.db, registry=os.registry, create_fresh=True
+                    workflow_id=workflow_id,
+                    workflows=os.workflows,
+                    db=os.db,
+                    version=version,
+                    registry=os.registry,
+                    create_fresh=True,
                 )
             except Exception as e:
                 await websocket.send_text(json.dumps({"event": "error", "error": f"Error resolving workflow: {e}"}))

--- a/libs/agno/tests/integration/os/test_workflow_runs.py
+++ b/libs/agno/tests/integration/os/test_workflow_runs.py
@@ -371,7 +371,7 @@ def test_websocket_workflow_factory_rejects_missing_scope(
 
 @pytest.mark.asyncio
 async def test_websocket_workflow_start_forwards_version_to_resolver():
-    """A Studio WebSocket start must resolve the requested workflow version."""
+    """A Studio WebSocket start action must resolve the requested workflow version."""
     websocket = AsyncMock()
     workflow = Mock(session_id=None)
     workflow.arun = AsyncMock()

--- a/libs/agno/tests/integration/os/test_workflow_runs.py
+++ b/libs/agno/tests/integration/os/test_workflow_runs.py
@@ -2,7 +2,8 @@
 
 import json
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import jwt
@@ -15,6 +16,7 @@ from agno.db.base import ComponentType
 from agno.db.sqlite import SqliteDb
 from agno.os import AgentOS
 from agno.os.config import AuthorizationConfig
+from agno.os.routers.workflows.router import handle_workflow_via_websocket
 from agno.workflow.factory import WorkflowFactory
 from agno.workflow.step import Step
 from agno.workflow.types import StepInput, StepOutput
@@ -365,6 +367,53 @@ def test_websocket_workflow_factory_rejects_missing_scope(
         assert "permission" in error_frame["error"].lower()
 
     assert factory_calls == [], "Factory must not be invoked when RBAC rejects the call"
+
+
+@pytest.mark.asyncio
+async def test_websocket_workflow_start_forwards_version_to_resolver():
+    """A Studio WebSocket start must resolve the requested workflow version."""
+    websocket = AsyncMock()
+    workflow = Mock(session_id=None)
+    workflow.arun = AsyncMock()
+    agent_os = SimpleNamespace(workflows=None, db=Mock(), registry=None)
+
+    with patch(
+        "agno.os.routers.workflows.router.get_workflow_by_id",
+        return_value=workflow,
+    ) as get_workflow_by_id:
+        await handle_workflow_via_websocket(
+            websocket,
+            {"workflow_id": "versioned-wf", "message": "go", "version": 1},
+            agent_os,
+        )
+
+    assert get_workflow_by_id.call_args.kwargs["version"] == 1
+    workflow.arun.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_websocket_factory_workflow_start_forwards_version_to_resolver():
+    """WebSocket factory resolution must preserve a requested workflow version."""
+    websocket = AsyncMock()
+    workflow = Mock(session_id=None)
+    workflow.arun = AsyncMock()
+    db = Mock()
+    factory = WorkflowFactory(id="versioned-factory-wf", db=db, factory=lambda _: workflow)
+    agent_os = SimpleNamespace(workflows=[factory], db=db, registry=None)
+
+    with patch(
+        "agno.os.routers.workflows.router.get_workflow_by_id_async",
+        new_callable=AsyncMock,
+        return_value=workflow,
+    ) as get_workflow_by_id_async:
+        await handle_workflow_via_websocket(
+            websocket,
+            {"workflow_id": "versioned-factory-wf", "message": "go", "version": 1},
+            agent_os,
+        )
+
+    assert get_workflow_by_id_async.await_args.kwargs["version"] == 1
+    workflow.arun.assert_awaited_once()
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Forward the `version` in a `start-workflow` WebSocket message to the existing workflow resolver.
- This makes Studio workflow runs load the selected stored version instead of falling back to the current/published version.
- Add regression coverage for both normal and factory workflow resolution paths.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — not run
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — not applicable
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — not applicable
- [ ] Tested in clean environment — targeted tests ran in the existing development environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach — no similar PR found
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — AI-assisted and reviewed

---

## Additional Notes

Targeted regression tests passed:

```
libs/agno/tests/integration/os/test_workflow_runs.py -k 'websocket and forwards_version'
2 passed, 16 deselected
```

Full format and validation scripts were not run.