### PR TITLE
fix: merge AG-UI context with Agent.dependencies

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -70,18 +70,21 @@ async def run_entity(
 
         ui_deps = extract_context(run_input.context)
 
-        # 3. Build RunContext with client_tools and session_state
+        # 3. Build RunContext with client_tools and session_state.
+        # Do NOT pre-seed run_context.dependencies: that bypasses resolve_run_options
+        # merge and clobbers Agent/Team.dependencies whenever the client sends context
+        # (e.g. assistant-ui system items). Pass UI deps via the public kwargs instead.
         run_context = RunContext(
             run_id=run_id,
             session_id=run_input.thread_id,
             user_id=user_id,
             client_tools=client_tools,
-            dependencies=ui_deps,
             session_state=session_state,
         )
 
         run_kwargs: dict = {}
         if ui_deps:
+            run_kwargs["dependencies"] = ui_deps
             run_kwargs["add_dependencies_to_context"] = True
 
         # 4. Determine if this is a resume (trailing ToolMessages) or fresh run

--- a/libs/agno/tests/unit/os/interfaces/test_agui_router.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_router.py
@@ -1,3 +1,4 @@
+from typing import Any, AsyncIterator, Iterator
 from unittest.mock import MagicMock
 
 import pytest
@@ -6,7 +7,59 @@ pytest.importorskip("ag_ui", reason="ag_ui not installed")
 
 from ag_ui.core.types import Tool as AGUITool
 
+from agno.agent.agent import Agent
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
 from agno.os.interfaces.agui.router import run_entity
+from agno.run.base import RunContext
+
+
+class MockModel(Model):
+    """Minimal offline model for AG-UI dependency merge regression tests."""
+
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.instructions = None
+        self._mock_response = ModelResponse(
+            content="ok",
+            role="assistant",
+            response_usage=MessageMetrics(),
+        )
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._mock_response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._mock_response
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._mock_response
 
 
 class FakeRunInput:
@@ -61,8 +114,12 @@ async def test_run_entity_no_context_omits_add_dependencies_flag():
 
 
 @pytest.mark.asyncio
-async def test_run_entity_with_context_passes_run_context_with_dependencies():
-    """Context items are passed via run_context.dependencies with add_dependencies_to_context=True."""
+async def test_run_entity_with_context_passes_dependencies_kwarg():
+    """UI context is passed as dependencies= so resolve_run_options can merge with Agent deps.
+
+    Regression for #9517: pre-seeding run_context.dependencies bypassed the merge and
+    dropped Agent-configured dependencies whenever the client sent non-empty context.
+    """
     fake_entity = CaptureKwargsEntity()
     context = [MagicMock(description="user_name", value="Alice")]
     run_input = FakeRunInput(context=context)
@@ -71,9 +128,11 @@ async def test_run_entity_with_context_passes_run_context_with_dependencies():
         pass
 
     assert fake_entity.captured_kwargs.get("add_dependencies_to_context") is True
+    assert fake_entity.captured_kwargs.get("dependencies") == {"user_name": "Alice"}
     run_context = fake_entity.captured_kwargs.get("run_context")
     assert run_context is not None
-    assert run_context.dependencies == {"user_name": "Alice"}
+    # Left unset so apply_to_context fills the merged result from resolve_run_options
+    assert run_context.dependencies is None
 
 
 @pytest.mark.asyncio
@@ -150,3 +209,31 @@ async def test_run_entity_fresh_run_calls_arun():
         pass
 
     assert fake_entity.arun_called is True
+
+
+@pytest.mark.asyncio
+async def test_agui_call_pattern_merges_agent_dependencies_with_ui_context():
+    """Regression #9517: AG-UI call shape must preserve Agent.dependencies when UI context is set.
+
+    Mirrors what run_entity now does: pass UI deps via dependencies=, leave
+    run_context.dependencies unset so resolve_run_options merge applies.
+    """
+    agent = Agent(
+        model=MockModel(),
+        dependencies={"writing_snapshot": "SNAPSHOT_FROM_AGENT"},
+        instructions="SNAP={writing_snapshot} SYS={system}",
+    )
+    run_context = RunContext(run_id="r1", session_id="t1")
+    response = await agent.arun(
+        "hi",
+        dependencies={"system": "you are helpful"},
+        add_dependencies_to_context=True,
+        run_context=run_context,
+    )
+
+    system_content = response.messages[0].content
+    assert "SNAP=SNAPSHOT_FROM_AGENT" in system_content
+    assert "SYS=you are helpful" in system_content
+    assert run_context.dependencies is not None
+    assert run_context.dependencies["writing_snapshot"] == "SNAPSHOT_FROM_AGENT"
+    assert run_context.dependencies["system"] == "you are helpful"


### PR DESCRIPTION
## Summary

- AG-UI `run_entity` no longer pre-seeds `RunContext.dependencies` from `RunAgentInput.context`
- UI context is passed via `dependencies=` so `resolve_run_options` merges with Agent/Team deps (call-site keys win)
- Adds regression tests for the adapter contract and full merge path

Fixes #9517

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

When clients (e.g. assistant-ui) send non-empty `context`, Agent-configured `dependencies` (including callables used with `add_dependencies_to_context=True`) were silently dropped. This matches the Slack/WhatsApp merge fix covered by `test_dependencies_merge.py`, but for the AG-UI path that previously bypassed merge by pre-seeding `RunContext`.

## Test plan

- [x] `pytest libs/agno/tests/unit/os/interfaces/test_agui_router.py -v`
- [ ] Verify AG-UI / DynamicAGUI run with Agent deps + client `context` shows both in model context


Made with [Cursor](https://cursor.com)