### PR TITLE
fix(workflow): apply parallel session-state changes when the state starts empty

### DIFF
--- a/libs/agno/agno/utils/merge_dict.py
+++ b/libs/agno/agno/utils/merge_dict.py
@@ -25,7 +25,7 @@ def merge_parallel_session_states(original_state: Dict[str, Any], modified_state
     Smart merge for parallel session states that only applies actual changes.
     This prevents parallel steps from overwriting each other's changes.
     """
-    if not original_state or not modified_states:
+    if original_state is None or not modified_states:
         return
 
     # Collect all actual changes (keys where value differs from original)

--- a/libs/agno/tests/unit/utils/test_merge_dict.py
+++ b/libs/agno/tests/unit/utils/test_merge_dict.py
@@ -1,0 +1,35 @@
+from agno.utils.merge_dict import merge_dictionaries, merge_parallel_session_states
+
+
+def test_merge_dictionaries_nested_override():
+    a = {"x": {"a": 1, "b": 2}, "y": 3}
+    b = {"x": {"b": 20, "c": 30}, "z": 4}
+    merge_dictionaries(a, b)
+    assert a == {"x": {"a": 1, "b": 20, "c": 30}, "y": 3, "z": 4}
+
+
+def test_merge_parallel_applies_changes_to_nonempty_state():
+    original = {"x": 0}
+    merge_parallel_session_states(original, [{"a": 1}, {"b": 2}])
+    assert original == {"x": 0, "a": 1, "b": 2}
+
+
+def test_merge_parallel_applies_changes_to_empty_state():
+    # Regression: an empty starting state must still receive parallel changes.
+    # `if not original_state` previously returned early for {}, so every parallel
+    # step's writes were dropped whenever the workflow began with no session state.
+    original: dict = {}
+    merge_parallel_session_states(original, [{"a": 1}, {"b": 2}])
+    assert original == {"a": 1, "b": 2}
+
+
+def test_merge_parallel_only_applies_actual_changes():
+    original = {"shared": 1}
+    merge_parallel_session_states(original, [{"shared": 1}, {"new": 2}])
+    assert original == {"shared": 1, "new": 2}
+
+
+def test_merge_parallel_noops_without_modified_states():
+    original = {"x": 1}
+    merge_parallel_session_states(original, [])
+    assert original == {"x": 1}


### PR DESCRIPTION
## Bug

`merge_parallel_session_states` (`libs/agno/agno/utils/merge_dict.py`) merges each parallel step's session-state copy back into the workflow's session state. Its guard is:

```python
if not original_state or not modified_states:
    return
```

`not original_state` is `True` for an empty dict, so when a workflow starts with **no session state**, `original_state` is `{}` and the function returns immediately, silently discarding every parallel step's writes.

This is reachable on the normal path. In `workflow/parallel.py` the merge is called as:

```python
if run_context is None and session_state is not None:
    merge_parallel_session_states(session_state, modified_session_states)
```

The caller deliberately only skips when `session_state is None`, so `{}` is an expected input. And when there is no session state, each parallel step is handed a fresh `{}` copy to write into, so an empty starting state is exactly the case where the merge matters most.

### Repro

```python
from agno.utils.merge_dict import merge_parallel_session_states

state = {}                       # workflow started with no session state
merge_parallel_session_states(state, [{"a": 1}, {"b": 2}])
print(state)                     # {}  -> both parallel writes lost
```

A non-empty starting state merges correctly, which is why this hides easily.

## Fix

Guard on `original_state is None` rather than falsiness, so an empty dict is merged normally:

```python
if original_state is None or not modified_states:
    return
```

Added `libs/agno/tests/unit/utils/test_merge_dict.py` covering the empty-state regression plus non-empty merge, changes-only merge, and the no-modified-states no-op.