### PR TITLE
feat: add Speko voice toolkit and model provider

### DIFF
--- a/cookbook/90_models/speko/README.md
+++ b/cookbook/90_models/speko/README.md
@@ -1,0 +1,19 @@
+# Speko
+
+Cookbook examples for `cookbook/90_models/speko`.
+
+[Speko](https://speko.ai) is a voice router with an OpenAI-compatible chat
+completions endpoint. `id="auto"` (the default) routes each request to the best
+available LLM by live benchmarks; any routable `provider:model` ID can be pinned
+instead, e.g. `Speko(id="openai:gpt-4.1-mini")`. Model catalog:
+`GET https://api.speko.ai/v1/models`. Set your API key first:
+
+```bash
+export SPEKO_API_KEY=***
+```
+
+Run examples with:
+
+```bash
+.venvs/demo/bin/python cookbook/90_models/speko/<example>.py
+```

--- a/cookbook/90_models/speko/basic.py
+++ b/cookbook/90_models/speko/basic.py
@@ -1,0 +1,47 @@
+"""
+Speko Basic
+===========
+
+Cookbook example for `speko/basic.py`.
+
+Speko is a voice router with an OpenAI-compatible chat completions endpoint.
+id="auto" (the default) routes each request to the best available LLM by live
+benchmarks; any routable "provider:model" ID can be pinned instead, e.g.
+Speko(id="openai:gpt-4.1-mini"). Requires the SPEKO_API_KEY environment variable.
+"""
+
+from agno.agent import Agent, RunOutput  # noqa
+from agno.models.speko import Speko
+import asyncio
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(model=Speko(id="auto"), markdown=True)
+
+# The string syntax works too, and pinned IDs keep their provider prefix:
+# agent = Agent(model="speko:auto", markdown=True)
+# agent = Agent(model="speko:openai:gpt-4.1-mini", markdown=True)
+
+# Get the response in a variable
+# run: RunOutput = agent.run("Share a 2 sentence horror story")
+# print(run.content)
+
+# Print the response in the terminal
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # --- Sync ---
+    agent.print_response("Share a 2 sentence horror story")
+
+    # --- Sync + Streaming ---
+    agent.print_response("Share a 2 sentence horror story", stream=True)
+
+    # --- Async ---
+    asyncio.run(agent.aprint_response("Share a 2 sentence horror story"))
+
+    # --- Async + Streaming ---
+    asyncio.run(agent.aprint_response("Share a 2 sentence horror story", stream=True))

--- a/cookbook/91_tools/speko_tools.py
+++ b/cookbook/91_tools/speko_tools.py
@@ -1,0 +1,78 @@
+"""
+Speko voice router tools: text-to-speech, speech-to-text, and voice discovery.
+
+Requires the SPEKO_API_KEY environment variable.
+Get an API key at https://platform.speko.ai (sign up, then mint a key under Keys).
+
+Also requires GOOGLE_API_KEY for the agent's model. Use a model with audio input
+support (Gemini here) so the agent can hear the audio it generates across multi-turn
+conversations, instead of losing it after the first response.
+
+Speko is a voice router: one API in front of many TTS/STT providers. Requests with
+model="auto" (the default) are routed to the best provider by live benchmarks, with
+automatic failover. Any routable "provider:model" ID can be pinned instead, and the
+routing objective can be set to "latency", "quality", "cost", or "balanced".
+
+Docs: https://speko.ai/docs (models and voices: GET https://api.speko.ai/v1/models)
+"""
+
+import base64
+from textwrap import dedent
+
+from agno.agent import Agent
+from agno.models.google import Gemini
+from agno.tools.speko import SpekoTools
+from agno.utils.media import save_base64_data
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+
+voice_agent = Agent(
+    model=Gemini(id="gemini-pro-latest"),
+    tools=[SpekoTools()],
+    description="You are an AI agent that can generate and transcribe audio using the Speko voice router.",
+    instructions=[
+        dedent(
+            """
+            You have access to the Speko voice toolkit:
+            - Use the `text_to_speech` tool to convert text into natural voice audio.
+            - Use the `transcribe_audio` tool to transcribe an audio file to text.
+            - Use the `list_voices` tool to see the available voices.
+            Keep the audio prompt as defined by the user.
+            """
+        ),
+    ],
+    markdown=True,
+)
+
+# Pinned routing: a specific voice, latency-first objective
+# pinned_voice_agent = Agent(
+#     model=Gemini(id="gemini-pro-latest"),
+#     tools=[
+#         SpekoTools(
+#             tts_model="deepgram:aura-2",
+#             voice="aura-2-thalia-en",
+#             objective="latency",
+#         )
+#     ],
+#     description="You are an AI agent that generates audio with a pinned Speko voice.",
+#     markdown=True,
+# )
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    response = voice_agent.run(
+        "Generate a short audio welcoming listeners to a podcast about the history of aviation.",
+    )
+
+    if response.audio:
+        print("Agent response:", response.content)
+        base64_audio = base64.b64encode(response.audio[0].content).decode("utf-8")
+        save_base64_data(base64_audio, "tmp/podcast_welcome.wav")
+
+    # response2 = voice_agent.run("Transcribe the audio file tmp/podcast_welcome.wav.")
+    # print("Transcript:", response2.content)

--- a/libs/agno/agno/models/speko/__init__.py
+++ b/libs/agno/agno/models/speko/__init__.py
@@ -1,0 +1,5 @@
+from agno.models.speko.speko import Speko
+
+__all__ = [
+    "Speko",
+]

--- a/libs/agno/agno/models/speko/speko.py
+++ b/libs/agno/agno/models/speko/speko.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from os import getenv
+from typing import Any, Dict, Optional
+
+from agno.exceptions import ModelAuthenticationError
+from agno.models.openai.like import OpenAILike
+
+
+@dataclass
+class Speko(OpenAILike):
+    """
+    A class for interacting with LLMs via the Speko voice router.
+
+    Speko exposes an OpenAI-compatible chat completions endpoint that routes
+    model="auto" requests to the best available provider by live benchmarks,
+    or passes pinned "provider:model" IDs (e.g. "openai:gpt-4.1-mini") through
+    to that provider. Available models: GET https://api.speko.ai/v1/models
+
+    Attributes:
+        id (str): The id of the model to use. Default is "auto" (benchmark-routed).
+        name (str): The name of this chat model instance. Default is "Speko".
+        provider (str): The provider of the model. Default is "Speko".
+        api_key (str): The api key to authorize request to Speko.
+        base_url (str): The base url to which the requests are sent. Defaults to "https://api.speko.ai/v1".
+    """
+
+    id: str = "auto"
+    name: str = "Speko"
+    provider: str = "Speko"
+    api_key: Optional[str] = None
+    base_url: str = "https://api.speko.ai/v1"
+
+    def _get_client_params(self) -> Dict[str, Any]:
+        """
+        Returns client parameters for API requests, checking for SPEKO_API_KEY.
+
+        Returns:
+            Dict[str, Any]: A dictionary of client parameters for API requests.
+        """
+        if not self.api_key:
+            self.api_key = getenv("SPEKO_API_KEY")
+            if not self.api_key:
+                raise ModelAuthenticationError(
+                    message="SPEKO_API_KEY not set. Please set the SPEKO_API_KEY environment variable.",
+                    model_name=self.name,
+                )
+        return super()._get_client_params()

--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -64,6 +64,7 @@ _PROVIDERS: Dict[str, Tuple[str, str, str, str]] = {
     "requesty": ("agno.models.requesty", "Requesty", "Requesty", "requesty"),
     "sambanova": ("agno.models.sambanova", "Sambanova", "Sambanova", "sambanova"),
     "siliconflow": ("agno.models.siliconflow", "Siliconflow", "Siliconflow", "siliconflow"),
+    "speko": ("agno.models.speko", "Speko", "Speko", "speko"),
     "together": ("agno.models.together", "Together", "Together", "together"),
     "tokenlab": ("agno.models.tokenlab", "TokenLab", "TokenLab", "tokenlab"),
     "trustedrouter": ("agno.models.trustedrouter", "TrustedRouter", "TrustedRouter", "trustedrouter"),

--- a/libs/agno/agno/tools/speko.py
+++ b/libs/agno/agno/tools/speko.py
@@ -1,0 +1,291 @@
+import json
+from os import getenv, path
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional, Union, get_args
+from uuid import uuid4
+
+import httpx
+
+from agno.agent import Agent
+from agno.media import Audio
+from agno.team.team import Team
+from agno.tools import Toolkit
+from agno.tools.function import ToolResult
+from agno.utils.log import log_error, log_info
+
+SPEKO_BASE_URL = "https://api.speko.ai/v1"
+
+SpekoOutputFormat = Literal["wav", "pcm"]
+SPEKO_OUTPUT_FORMATS = get_args(SpekoOutputFormat)
+
+SpekoObjective = Literal["latency", "quality", "cost", "balanced"]
+SPEKO_OBJECTIVES = get_args(SpekoObjective)
+
+# Speko normalizes every TTS provider to 16-bit mono PCM at 24 kHz
+# (raw for "pcm", RIFF-wrapped for "wav"), so the sample rate is fixed.
+SPEKO_SAMPLE_RATE = 24000
+
+MIME_TYPES: Dict[str, str] = {
+    "wav": "audio/wav",
+    "pcm": "audio/pcm",
+}
+
+
+class SpekoTools(Toolkit):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        tts_model: str = "auto",
+        stt_model: str = "auto",
+        voice: Optional[str] = None,
+        output_format: SpekoOutputFormat = "wav",
+        language: Optional[str] = None,
+        objective: Optional[SpekoObjective] = None,
+        target_directory: Optional[str] = None,
+        base_url: str = SPEKO_BASE_URL,
+        enable_text_to_speech: bool = True,
+        enable_transcribe_audio: bool = True,
+        enable_list_voices: bool = True,
+        enable_list_models: bool = False,
+        all: bool = False,
+        timeout: float = 30,
+        **kwargs,
+    ):
+        self.api_key = api_key or getenv("SPEKO_API_KEY")
+        if not self.api_key:
+            log_error("SPEKO_API_KEY not set. Please set the SPEKO_API_KEY environment variable.")
+
+        if output_format not in SPEKO_OUTPUT_FORMATS:
+            raise ValueError(
+                f"Invalid output_format '{output_format}'. Valid options are: {', '.join(SPEKO_OUTPUT_FORMATS)}"
+            )
+
+        if objective is not None and objective not in SPEKO_OBJECTIVES:
+            raise ValueError(f"Invalid objective '{objective}'. Valid options are: {', '.join(SPEKO_OBJECTIVES)}")
+
+        self.tts_model = tts_model
+        self.stt_model = stt_model
+        self.voice = voice
+        self.output_format = output_format
+        self.language = language
+        self.objective = objective
+        self.target_directory = target_directory
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+        if self.target_directory:
+            target_path = Path(self.target_directory)
+            target_path.mkdir(parents=True, exist_ok=True)
+
+        tools: List[Any] = []
+        if all or enable_text_to_speech:
+            tools.append(self.text_to_speech)
+        if all or enable_transcribe_audio:
+            tools.append(self.transcribe_audio)
+        if all or enable_list_voices:
+            tools.append(self.list_voices)
+        if all or enable_list_models:
+            tools.append(self.list_models)
+
+        super().__init__(name="speko_tools", tools=tools, **kwargs)
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "X-Source": "agno",
+        }
+        if self.language:
+            headers["X-Speko-Language"] = self.language
+        if self.objective:
+            headers["X-Speko-Objective"] = self.objective
+        return headers
+
+    def _save_audio(self, audio_data: bytes) -> bytes:
+        # Save to disk if target_directory exists
+        if self.target_directory:
+            output_filename = f"{uuid4()}.{self.output_format}"
+            output_path = path.join(self.target_directory, output_filename)
+
+            with open(output_path, "wb") as f:
+                f.write(audio_data)
+
+            log_info(f"Audio saved to: {output_path}")
+
+        return audio_data
+
+    def text_to_speech(self, agent: Union[Agent, Team], prompt: str, voice: Optional[str] = None) -> ToolResult:
+        """
+        Convert text to natural speech using the Speko voice router. Speko routes the
+        request to the best TTS provider for the configured objective and falls over
+        automatically, always returning 16-bit mono audio at 24 kHz.
+
+        Args:
+            prompt (str): Text to generate audio from.
+            voice (optional): The ID of the voice to use, e.g. "aura-2-thalia-en". If None,
+                uses the voice configured in the tool, or lets Speko pick a provider default.
+                Use the `list_voices` tool to see the available voices.
+        Returns:
+            ToolResult: A ToolResult containing the generated audio or error message.
+        """
+        try:
+            mime_type = MIME_TYPES.get(self.output_format, "audio/wav")
+
+            payload: Dict[str, Any] = {
+                "model": self.tts_model,
+                "input": prompt,
+                "response_format": self.output_format,
+            }
+            if voice or self.voice:
+                payload["voice"] = voice or self.voice
+
+            response = httpx.post(
+                f"{self.base_url}/audio/speech",
+                headers={
+                    **self._headers(),
+                    "Content-Type": "application/json",
+                    "Accept": mime_type,
+                },
+                json=payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+
+            content_type = response.headers.get("content-type", "")
+            if "audio" not in content_type and "octet-stream" not in content_type:
+                raise ValueError(f"Expected audio response but got content-type '{content_type}': {response.text}")
+
+            audio_data = self._save_audio(response.content)
+
+            audio_artifact = Audio(
+                id=str(uuid4()),
+                content=audio_data,
+                mime_type=mime_type,
+                format=self.output_format,
+                sample_rate=SPEKO_SAMPLE_RATE,
+            )
+
+            return ToolResult(
+                content="Audio generated successfully",
+                audios=[audio_artifact],
+            )
+
+        except Exception as e:
+            log_error(f"Failed to generate audio: {str(e)}")
+            return ToolResult(content=f"Error: {e}")
+
+    def transcribe_audio(self, audio_path: str) -> str:
+        """
+        Transcribe an audio file to text using the Speko voice router. Speko routes the
+        request to the best speech-to-text provider for the configured objective.
+
+        Args:
+            audio_path (str): Path to the audio file to transcribe.
+        Returns:
+            result (str): The transcribed text, or an error message.
+        """
+        try:
+            file_path = Path(audio_path)
+            with open(file_path, "rb") as audio_file:
+                response = httpx.post(
+                    f"{self.base_url}/audio/transcriptions",
+                    headers=self._headers(),
+                    files={"file": (file_path.name, audio_file)},
+                    data={"model": self.stt_model},
+                    timeout=self.timeout,
+                )
+            response.raise_for_status()
+
+            transcript = response.json().get("text", "")
+            log_info(f"Transcribed {audio_path}: {transcript}")
+            return transcript
+        except Exception as e:
+            log_error(f"Failed to transcribe audio: {str(e)}")
+            return f"Error: {e}"
+
+    def list_voices(self) -> str:
+        """
+        List the text-to-speech voices available on the Speko voice router, across
+        all routable TTS providers.
+
+        Returns:
+            result (str): JSON string containing a list of voices with their metadata.
+        """
+        try:
+            response = httpx.get(
+                f"{self.base_url}/models",
+                headers=self._headers(),
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+
+            models_data = response.json()
+            models = models_data.get("data", []) if isinstance(models_data, dict) else models_data
+
+            result = []
+            for model in models:
+                if not isinstance(model, dict):
+                    continue
+                if model.get("api") != "tts" or not model.get("routable"):
+                    continue
+                for voice in model.get("voices") or []:
+                    if not isinstance(voice, dict):
+                        continue
+                    result.append(
+                        {
+                            "id": voice.get("id"),
+                            "name": voice.get("name"),
+                            "gender": voice.get("gender"),
+                            "styles": voice.get("styles"),
+                            "model": model.get("id"),
+                            "provider": model.get("provider"),
+                        }
+                    )
+            return json.dumps(result)
+        except Exception as e:
+            log_error(f"Failed to fetch voices: {str(e)}")
+            return f"Error: {e}"
+
+    def list_models(self, api: Optional[str] = None) -> str:
+        """
+        List the models available on the Speko voice router, optionally filtered by API
+        stage. Any routable model ID can be pinned instead of "auto" routing.
+
+        Args:
+            api (optional): Filter by stage: "tts", "stt", or "llm". If None, lists all models.
+        Returns:
+            result (str): JSON string containing a list of models with their metadata.
+        """
+        try:
+            response = httpx.get(
+                f"{self.base_url}/models",
+                headers=self._headers(),
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+
+            models_data = response.json()
+            models = models_data.get("data", []) if isinstance(models_data, dict) else models_data
+
+            result = []
+            for model in models:
+                if not isinstance(model, dict):
+                    continue
+                if api and model.get("api") != api:
+                    continue
+                result.append(
+                    {
+                        "id": model.get("id"),
+                        "api": model.get("api"),
+                        "provider": model.get("provider"),
+                        "routable": model.get("routable"),
+                        "languages": model.get("languages"),
+                        "latencyMs": model.get("latencyMs"),
+                        "costPerMinUsd": model.get("costPerMinUsd"),
+                        "quality": model.get("quality"),
+                        "qualityUnit": model.get("qualityUnit"),
+                    }
+                )
+            return json.dumps(result)
+        except Exception as e:
+            log_error(f"Failed to fetch models: {str(e)}")
+            return f"Error: {e}"

--- a/libs/agno/tests/unit/models/speko_model/test_speko.py
+++ b/libs/agno/tests/unit/models/speko_model/test_speko.py
@@ -1,0 +1,54 @@
+"""Unit tests for the Speko model class.
+
+Speko is an OpenAI-compatible voice router, so the class is a thin OpenAILike
+subclass. These tests pin the defaults and the missing-key behavior without any
+network access. (The to_dict/from_dict round-trip is covered generically by
+``test_provider_resolution.py`` via the provider registry.)
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from agno.exceptions import ModelAuthenticationError
+from agno.models.openai.like import OpenAILike
+from agno.models.speko import Speko
+
+
+def test_defaults():
+    """Defaults match the Speko OpenAI-compatible endpoint with benchmark routing."""
+    model = Speko(api_key="test-key")
+    assert isinstance(model, OpenAILike)
+    assert model.id == "auto"
+    assert model.name == "Speko"
+    assert model.provider == "Speko"
+    assert model.base_url == "https://api.speko.ai/v1"
+
+
+def test_api_key_from_env(monkeypatch):
+    """The API key is read from SPEKO_API_KEY when not passed explicitly."""
+    monkeypatch.setenv("SPEKO_API_KEY", "env-key")
+    model = Speko()
+    params = model._get_client_params()
+    assert model.api_key == "env-key"
+    assert params["api_key"] == "env-key"
+
+
+def test_pinned_model_id():
+    """A pinned provider:model ID is kept verbatim instead of being re-parsed."""
+    model = Speko(id="openai:gpt-4.1-mini", api_key="test-key")
+    assert model.id == "openai:gpt-4.1-mini"
+
+
+def test_client_params_include_base_url():
+    """Client params carry the configured key and base URL through to the SDK."""
+    params = Speko(api_key="test-key")._get_client_params()
+    assert params["api_key"] == "test-key"
+    assert params["base_url"] == "https://api.speko.ai/v1"
+
+
+def test_missing_api_key_raises():
+    """A missing API key raises ModelAuthenticationError rather than a client error."""
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ModelAuthenticationError, match="SPEKO_API_KEY not set"):
+            Speko(api_key=None)._get_client_params()

--- a/libs/agno/tests/unit/tools/test_speko.py
+++ b/libs/agno/tests/unit/tools/test_speko.py
@@ -1,0 +1,444 @@
+"""Unit tests for Speko tools."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from agno.agent import Agent
+from agno.tools.function import ToolResult
+from agno.tools.speko import SPEKO_BASE_URL, SPEKO_SAMPLE_RATE, SpekoTools
+
+MODELS_RESPONSE = {
+    "object": "list",
+    "data": [
+        {
+            "id": "deepgram:aura-2",
+            "api": "tts",
+            "provider": "deepgram",
+            "routable": True,
+            "languages": ["en"],
+            "latencyMs": 150,
+            "costPerMinUsd": 15.0,
+            "quality": 4.2,
+            "qualityUnit": "MOS",
+            "voices": [
+                {"id": "aura-2-thalia-en", "name": "Thalia", "gender": "female", "styles": ["clear", "confident"]},
+                {"id": "aura-2-orion-en", "name": "Orion", "gender": "male", "styles": ["deep"]},
+            ],
+        },
+        {
+            "id": "fishaudio:s2.1-pro",
+            "api": "tts",
+            "provider": "fishaudio",
+            "routable": False,
+            "voices": [{"id": "fish-1", "name": "Fish", "gender": "neutral", "styles": []}],
+        },
+        {
+            "id": "soniox:stt-rt-v5",
+            "api": "stt",
+            "provider": "soniox",
+            "routable": True,
+            "languages": ["en", "es"],
+            "latencyMs": 300,
+            "costPerMinUsd": 0.1,
+            "quality": 5.4,
+            "qualityUnit": "% WER",
+        },
+    ],
+    "languages": ["en", "es"],
+}
+
+
+@pytest.fixture
+def mock_agent():
+    agent = MagicMock(spec=Agent)
+    return agent
+
+
+@pytest.fixture
+def speko_tools():
+    """Create SpekoTools instance with a test API key."""
+    with patch.dict("os.environ", {"SPEKO_API_KEY": "test_key"}):
+        return SpekoTools()
+
+
+def test_init_with_api_key():
+    """Test initialization with API key."""
+    tools = SpekoTools(api_key="test_key")
+    assert tools.api_key == "test_key"
+    assert tools.tts_model == "auto"
+    assert tools.stt_model == "auto"
+    assert tools.voice is None
+    assert tools.output_format == "wav"
+    assert tools.language is None
+    assert tools.objective is None
+
+
+def test_init_with_env_var():
+    """Test initialization with environment variable."""
+    with patch.dict("os.environ", {"SPEKO_API_KEY": "env_key"}):
+        tools = SpekoTools()
+        assert tools.api_key == "env_key"
+
+
+def test_init_missing_api_key():
+    """Test initialization with missing API key logs an error but does not raise."""
+    with patch("agno.tools.speko.getenv", return_value=None):
+        tools = SpekoTools()
+        assert tools.api_key is None
+
+
+def test_init_override_defaults():
+    """Test initialization overriding defaults."""
+    tools = SpekoTools(
+        api_key="test_key",
+        tts_model="deepgram:aura-2",
+        stt_model="soniox:stt-rt-v5",
+        voice="aura-2-thalia-en",
+        output_format="pcm",
+        language="es",
+        objective="latency",
+    )
+    assert tools.tts_model == "deepgram:aura-2"
+    assert tools.stt_model == "soniox:stt-rt-v5"
+    assert tools.voice == "aura-2-thalia-en"
+    assert tools.output_format == "pcm"
+    assert tools.language == "es"
+    assert tools.objective == "latency"
+
+
+def test_init_invalid_output_format_raises():
+    """Test that an invalid output format raises a clear error instead of failing later."""
+    with pytest.raises(ValueError, match="Invalid output_format"):
+        SpekoTools(api_key="test_key", output_format="mp3")
+
+
+def test_init_invalid_objective_raises():
+    """Test that an invalid routing objective raises a clear error instead of failing later."""
+    with pytest.raises(ValueError, match="Invalid objective"):
+        SpekoTools(api_key="test_key", objective="cheapest")
+
+
+def test_init_default_base_url():
+    """Test that base_url defaults to the Speko API endpoint."""
+    tools = SpekoTools(api_key="test_key")
+    assert tools.base_url == SPEKO_BASE_URL
+
+
+def test_init_custom_base_url(mock_agent):
+    """Test that a custom base_url is used for text-to-speech requests."""
+    custom_url = "https://self-hosted.example.com/v1"
+    tools = SpekoTools(api_key="test_key", base_url=custom_url)
+    assert tools.base_url == custom_url
+
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/wav"}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.speko.httpx.post", return_value=mock_response) as mock_post:
+        tools.text_to_speech(mock_agent, "Hello world")
+
+    args, _ = mock_post.call_args
+    assert args[0] == f"{custom_url}/audio/speech"
+
+
+def test_feature_registration(speko_tools):
+    """Test that the expected tools are registered."""
+    assert "text_to_speech" in speko_tools.functions
+    assert "transcribe_audio" in speko_tools.functions
+    assert "list_voices" in speko_tools.functions
+    assert "list_models" not in speko_tools.functions
+
+
+def test_feature_registration_disabled():
+    """Test disabling and enabling tools."""
+    tools = SpekoTools(api_key="test_key", enable_list_voices=False, enable_list_models=True)
+    assert "list_voices" not in tools.functions
+    assert "list_models" in tools.functions
+    assert "text_to_speech" in tools.functions
+
+    tools = SpekoTools(api_key="test_key", all=True)
+    assert "list_models" in tools.functions
+
+
+def test_text_to_speech_success(speko_tools, mock_agent):
+    """Test successful text-to-speech generation."""
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/wav"}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.speko.httpx.post", return_value=mock_response) as mock_post:
+        result = speko_tools.text_to_speech(mock_agent, "Hello world")
+
+    assert isinstance(result, ToolResult)
+    assert result.content == "Audio generated successfully"
+    assert result.audios is not None
+    assert len(result.audios) == 1
+    assert result.audios[0].content == b"audio data"
+    assert result.audios[0].mime_type == "audio/wav"
+    assert result.audios[0].sample_rate == SPEKO_SAMPLE_RATE
+
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert args[0] == f"{SPEKO_BASE_URL}/audio/speech"
+    assert kwargs["json"]["model"] == "auto"
+    assert kwargs["json"]["input"] == "Hello world"
+    assert kwargs["json"]["response_format"] == "wav"
+    assert "voice" not in kwargs["json"]
+    assert kwargs["headers"]["Authorization"] == "Bearer test_key"
+    assert kwargs["headers"]["X-Source"] == "agno"
+    assert "X-Speko-Language" not in kwargs["headers"]
+    assert "X-Speko-Objective" not in kwargs["headers"]
+
+
+def test_text_to_speech_voice_override(speko_tools, mock_agent):
+    """Test text-to-speech with a per-call voice override."""
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/wav"}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.speko.httpx.post", return_value=mock_response) as mock_post:
+        speko_tools.text_to_speech(mock_agent, "Hello world", voice="aura-2-thalia-en")
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["json"]["voice"] == "aura-2-thalia-en"
+
+
+def test_text_to_speech_routing_headers(mock_agent):
+    """Test that configured language and objective are sent as Speko routing headers."""
+    tools = SpekoTools(api_key="test_key", language="es", objective="latency", voice="aura-2-thalia-en")
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/wav"}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.speko.httpx.post", return_value=mock_response) as mock_post:
+        tools.text_to_speech(mock_agent, "Hola mundo")
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["headers"]["X-Speko-Language"] == "es"
+    assert kwargs["headers"]["X-Speko-Objective"] == "latency"
+    assert kwargs["json"]["voice"] == "aura-2-thalia-en"
+
+
+def test_text_to_speech_pcm_mime_type(mock_agent):
+    """Test that pcm output format sets the correct mime type."""
+    tools = SpekoTools(api_key="test_key", output_format="pcm")
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/pcm;rate=24000"}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.speko.httpx.post", return_value=mock_response) as mock_post:
+        result = tools.text_to_speech(mock_agent, "Hello world")
+
+    assert result.audios[0].mime_type == "audio/pcm"
+    assert result.audios[0].format == "pcm"
+    _, kwargs = mock_post.call_args
+    assert kwargs["headers"]["Accept"] == "audio/pcm"
+    assert kwargs["json"]["response_format"] == "pcm"
+
+
+def test_text_to_speech_saves_to_target_directory(mock_agent, tmp_path):
+    """Test that audio is saved to disk when target_directory is set."""
+    target_dir = tmp_path / "audio"
+    tools = SpekoTools(api_key="test_key", target_directory=str(target_dir))
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/wav"}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.speko.httpx.post", return_value=mock_response):
+        tools.text_to_speech(mock_agent, "Hello world")
+
+    saved_files = list(target_dir.glob("*.wav"))
+    assert len(saved_files) == 1
+    assert saved_files[0].read_bytes() == b"audio data"
+
+
+def test_text_to_speech_saves_multiple_times_without_overwriting(mock_agent, tmp_path):
+    """Test that repeated saves get unique filenames instead of overwriting each other."""
+    target_dir = tmp_path / "audio"
+    tools = SpekoTools(api_key="test_key", target_directory=str(target_dir))
+    mock_response = MagicMock()
+    mock_response.content = b"audio data"
+    mock_response.headers = {"content-type": "audio/wav"}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.speko.httpx.post", return_value=mock_response):
+        tools.text_to_speech(mock_agent, "Hello world")
+        tools.text_to_speech(mock_agent, "Hello again")
+
+    saved_files = list(target_dir.glob("*.wav"))
+    assert len(saved_files) == 2
+
+
+def test_text_to_speech_error(speko_tools, mock_agent):
+    """Test text-to-speech error handling against a real HTTP error response."""
+    request = httpx.Request("POST", f"{SPEKO_BASE_URL}/audio/speech")
+    error_response = httpx.Response(
+        401, json={"error": {"code": "invalid_api_key", "message": "Provide a valid Speko API key."}}, request=request
+    )
+
+    with patch("agno.tools.speko.httpx.post", return_value=error_response):
+        result = speko_tools.text_to_speech(mock_agent, "Hello world")
+
+    assert isinstance(result, ToolResult)
+    assert "Error" in result.content
+    assert not result.audios
+
+
+def test_text_to_speech_unexpected_content_type(speko_tools, mock_agent):
+    """Test that a non-audio 200 response (e.g. a JSON error body) is treated as an error."""
+    mock_response = MagicMock()
+    mock_response.content = b'{"error": "invalid voice"}'
+    mock_response.text = '{"error": "invalid voice"}'
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("agno.tools.speko.httpx.post", return_value=mock_response):
+        result = speko_tools.text_to_speech(mock_agent, "Hello world")
+
+    assert isinstance(result, ToolResult)
+    assert "Error" in result.content
+    assert not result.audios
+
+
+def test_transcribe_audio_success(speko_tools, tmp_path):
+    """Test successful audio transcription with a multipart upload."""
+    audio_file = tmp_path / "clip.wav"
+    audio_file.write_bytes(b"RIFF fake wav bytes")
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {"text": "Hello from Speko."}
+
+    with patch("agno.tools.speko.httpx.post", return_value=mock_response) as mock_post:
+        result = speko_tools.transcribe_audio(str(audio_file))
+
+    assert result == "Hello from Speko."
+    args, kwargs = mock_post.call_args
+    assert args[0] == f"{SPEKO_BASE_URL}/audio/transcriptions"
+    assert kwargs["data"]["model"] == "auto"
+    assert kwargs["files"]["file"][0] == "clip.wav"
+    assert kwargs["headers"]["Authorization"] == "Bearer test_key"
+    assert kwargs["headers"]["X-Source"] == "agno"
+
+
+def test_transcribe_audio_pinned_model(tmp_path):
+    """Test that a pinned STT model is sent in the multipart form."""
+    audio_file = tmp_path / "clip.wav"
+    audio_file.write_bytes(b"RIFF fake wav bytes")
+
+    tools = SpekoTools(api_key="test_key", stt_model="soniox:stt-rt-v5")
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {"text": "Pinned."}
+
+    with patch("agno.tools.speko.httpx.post", return_value=mock_response) as mock_post:
+        result = tools.transcribe_audio(str(audio_file))
+
+    assert result == "Pinned."
+    _, kwargs = mock_post.call_args
+    assert kwargs["data"]["model"] == "soniox:stt-rt-v5"
+
+
+def test_transcribe_audio_missing_file(speko_tools):
+    """Test that a missing audio file returns an error instead of raising."""
+    result = speko_tools.transcribe_audio("/nonexistent/clip.wav")
+    assert result.startswith("Error")
+
+
+def test_transcribe_audio_http_error(speko_tools, tmp_path):
+    """Test transcription error handling against a real HTTP error response."""
+    audio_file = tmp_path / "clip.wav"
+    audio_file.write_bytes(b"RIFF fake wav bytes")
+
+    request = httpx.Request("POST", f"{SPEKO_BASE_URL}/audio/transcriptions")
+    error_response = httpx.Response(413, json={"error": {"code": "request_too_large"}}, request=request)
+
+    with patch("agno.tools.speko.httpx.post", return_value=error_response):
+        result = speko_tools.transcribe_audio(str(audio_file))
+
+    assert result.startswith("Error")
+
+
+def test_list_voices_success(speko_tools):
+    """Test successful voice listing flattened from the routable TTS models."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = MODELS_RESPONSE
+
+    with patch("agno.tools.speko.httpx.get", return_value=mock_response) as mock_get:
+        result = speko_tools.list_voices()
+
+    args, kwargs = mock_get.call_args
+    assert args[0] == f"{SPEKO_BASE_URL}/models"
+    assert kwargs["headers"]["Authorization"] == "Bearer test_key"
+    assert kwargs["headers"]["X-Source"] == "agno"
+
+    voices = json.loads(result)
+    assert len(voices) == 2  # non-routable fishaudio voice excluded
+    assert voices[0]["id"] == "aura-2-thalia-en"
+    assert voices[0]["name"] == "Thalia"
+    assert voices[0]["gender"] == "female"
+    assert voices[0]["model"] == "deepgram:aura-2"
+    assert voices[0]["provider"] == "deepgram"
+    assert voices[1]["id"] == "aura-2-orion-en"
+
+
+def test_list_voices_error(speko_tools):
+    """Test voice listing error handling against a real HTTP error response."""
+    request = httpx.Request("GET", f"{SPEKO_BASE_URL}/models")
+    error_response = httpx.Response(500, json={"error": "internal"}, request=request)
+
+    with patch("agno.tools.speko.httpx.get", return_value=error_response):
+        result = speko_tools.list_voices()
+
+    assert result.startswith("Error")
+
+
+def test_list_models_success(speko_tools):
+    """Test model listing returns all stages by default."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = MODELS_RESPONSE
+
+    with patch("agno.tools.speko.httpx.get", return_value=mock_response):
+        result = speko_tools.list_models()
+
+    models = json.loads(result)
+    assert len(models) == 3
+    assert models[0]["id"] == "deepgram:aura-2"
+    assert models[2]["api"] == "stt"
+
+
+def test_list_models_api_filter(speko_tools):
+    """Test model listing filtered to a single API stage."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = MODELS_RESPONSE
+
+    with patch("agno.tools.speko.httpx.get", return_value=mock_response):
+        result = speko_tools.list_models(api="stt")
+
+    models = json.loads(result)
+    assert len(models) == 1
+    assert models[0]["id"] == "soniox:stt-rt-v5"
+    assert models[0]["languages"] == ["en", "es"]
+
+
+def test_list_models_error(speko_tools):
+    """Test model listing error handling against a real HTTP error response."""
+    request = httpx.Request("GET", f"{SPEKO_BASE_URL}/models")
+    error_response = httpx.Response(503, json={"error": "unavailable"}, request=request)
+
+    with patch("agno.tools.speko.httpx.get", return_value=error_response):
+        result = speko_tools.list_models()
+
+    assert result.startswith("Error")


### PR DESCRIPTION
Adds Speko (https://speko.ai) to agno in two pieces: a voice toolkit and a chat model provider. Speko is a voice router - one OpenAI-compatible API (https://api.speko.ai/v1) in front of 17 TTS, 15 STT, and 16 LLM models, where `auto` routes each request to the best provider by live benchmarks (https://speko.ai/benchmarks) with automatic failover.

closes #9522
closes #9523

Happy to split this into two PRs if you would rather review them separately - the commits are already clean along that line.

---

## 1. `SpekoTools` voice toolkit (commit `5092418`)

`libs/agno/agno/tools/speko.py` (+291), `libs/agno/tests/unit/tools/test_speko.py` (+444), `cookbook/91_tools/speko_tools.py` (+78)

- `text_to_speech` - POST /v1/audio/speech; returns `ToolResult` with an `agno.media.Audio` artifact (wav default, pcm optional)
- `transcribe_audio` - POST /v1/audio/transcriptions (multipart); returns the transcript string
- `list_voices` - flattens the 104-voice catalog from the public GET /v1/models (routable TTS models only)
- `list_models` - lists model IDs/latency/cost/quality so agents can pin a `provider:model` instead of auto-routing (off by default, `enable_list_models=True` to enable)

Design follows `SmallestTools` (#9015): plain `httpx` (no new dependency), `SPEKO_API_KEY` env var (log-not-raise on missing), `enable_*` flags + `all`, `target_directory` disk save, `X-Source: agno` attribution header, errors returned as values. Extra Speko knobs: `objective` (latency|quality|cost|balanced) and `language` map to the `X-Speko-Objective`/`X-Speko-Language` routing headers.

A normalized output contract (16-bit mono 24 kHz from every TTS vendor) means failover never changes the audio format under the agent.

## 2. `Speko` model provider (commit `30efd06`)

`libs/agno/agno/models/speko/speko.py` (+47), `libs/agno/agno/models/speko/__init__.py` (+5), `libs/agno/agno/models/utils.py` (+1 registry row), `libs/agno/tests/unit/models/speko_model/test_speko.py` (+54), `cookbook/90_models/speko/README.md` (+19), `cookbook/90_models/speko/basic.py` (+47)

```python
agent = Agent(model=Speko(id="auto"))             # benchmark-routed
agent = Agent(model="speko:openai:gpt-4.1-mini")  # string syntax, pinned
```

Follows the Together pattern exactly: `@dataclass` subclass of `OpenAILike`, lazy `SPEKO_API_KEY` resolution in `_get_client_params` raising `ModelAuthenticationError`, one `_PROVIDERS` row (auto-covered by the parametrized provider-resolution tests). Dedicated unit tests and a cookbook README match the TrustedRouter provider PR (#9100) file set. No new dependency - uses the existing optional `openai` SDK.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [x] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Verification

Re-run today against current main (`26bb90c6`) in a fresh clone and a clean `./scripts/dev_setup.sh` venv:

- `pytest libs/agno/tests/unit/tools/test_speko.py` -> **27 passed** (all HTTP mocked, no network)
- `pytest libs/agno/tests/unit/models/speko_model/test_speko.py` -> **5 passed**
- `pytest libs/agno/tests/unit/models/test_provider_resolution.py` -> **130 passed, 44 skipped** (registration drift gate green)
- `./scripts/format.sh` -> clean, no files reformatted
- `./scripts/validate.sh` -> ruff clean, mypy `no issues found in 962 source files`, cookbook pattern check 0 violations

Live-tested against https://api.speko.ai before filing:

- `text_to_speech("Hello from the agno Speko integration smoke test.")` -> 200, 153,644-byte RIFF wav (24 kHz mono PCM16), 1.9s
- `transcribe_audio` on that wav -> `"Hello from the AgNos Speco integration smoke test."`, 1.6s (full round-trip; the brand-word drift is the STT model, not the transport)
- `list_voices` -> 104 voices across 15 routable TTS models, 0.3s
- `list_models(api="tts")` -> 17 models, 0.14s
- `Agent(model=Speko(id="auto"))` -> routed non-streaming completion, 1.4s
- `Agent(model="speko:openai:gpt-4.1-mini")` -> 200, 1.5s; streaming SSE chunks correct
- `cookbook/90_models/speko/basic.py` runs end to end (sync, sync+stream, async, async+stream)

## Additional notes

AI assistance disclosure: this PR was written with Claude Code, then reviewed and live-tested before filing.

API keys are self-serve at https://platform.speko.ai with a USD 100 signup credit, so the cookbooks are runnable without contacting us - but we are glad to hand maintainers a credited test key if that is easier for review. Full API reference: https://speko.ai/llms.txt and https://api.speko.ai/openapi.json.

Disclosure: I work at Speko, on the team that built this integration.
