### PR TITLE
fix: sqlite run_data serialization, v2 to v3 migration, and merge drops

### DIFF
--- a/libs/agno/agno/db/migrations/versions/v3_0_0.py
+++ b/libs/agno/agno/db/migrations/versions/v3_0_0.py
@@ -337,8 +337,7 @@ def _build_run_rows(
     run_data_as_string: bool,
 ) -> List[Dict[str, Any]]:
     """Build runs-table rows from the runs found in a sessions table `runs` column."""
-    if isinstance(runs, str):
-        runs = json.loads(runs)
+    runs = _decode_run_data(runs)
     if not runs:
         return []
 
@@ -394,7 +393,7 @@ def _forget_runs_table(db) -> None:
 
 
 def _decode_run_data(value: Any) -> Any:
-    """Decode a run_data payload read back through a raw SQL SELECT.
+    """Decode a run_data or legacy runs payload read back through a raw SQL SELECT.
 
     A raw select skips the column's JSON deserializer, so SQLite — which stores
     the payload as a JSON string inside a JSON column — hands back both layers.
@@ -633,7 +632,7 @@ def _migrate_sqlite_sessions(db: BaseDb, table_name: str) -> bool:
 
             rows: List[Dict[str, Any]] = []
             for session_id, user_id, runs in batch:
-                rows.extend(_build_run_rows(runs, session_id, user_id, run_data_as_string=True))
+                rows.extend(_build_run_rows(runs, session_id, user_id, run_data_as_string=False))
 
             if rows:
                 insert_stmt = sqlite.insert(runs_table).on_conflict_do_nothing(index_elements=["run_id"])
@@ -683,7 +682,7 @@ async def _migrate_async_sqlite_sessions(db: AsyncBaseDb, table_name: str) -> bo
 
             rows: List[Dict[str, Any]] = []
             for session_id, user_id, runs in batch:
-                rows.extend(_build_run_rows(runs, session_id, user_id, run_data_as_string=True))
+                rows.extend(_build_run_rows(runs, session_id, user_id, run_data_as_string=False))
 
             if rows:
                 insert_stmt = sqlite.insert(runs_table).on_conflict_do_nothing(index_elements=["run_id"])

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -4275,10 +4275,7 @@ class PostgresDb(BaseDb):
                 raise ValueError("Components table not found")
 
             with self.Session() as sess, sess.begin():
-                existing_stmt = select(table).where(
-                    table.c.component_id == component_id,
-                    table.c.deleted_at.is_(None),
-                )
+                existing_stmt = select(table).where(table.c.component_id == component_id)
                 if user_id is not None:
                     existing_stmt = existing_stmt.where(table.c.user_id == user_id)
                 existing = sess.execute(existing_stmt).fetchone()

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -34,13 +34,13 @@ from agno.db.sqlite.utils import (
 )
 from agno.db.utils import (
     HISTORY_SKIP_STATUSES,
-    CustomJSONEncoder,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
     deserialize_session_json_fields,
     deserialize_sessions,
     filter_context_runs,
+    json_serializer,
     merge_runs_table_with_legacy_blob,
     serialize_session_json_fields,
     validate_pagination,
@@ -147,16 +147,16 @@ class AsyncSqliteDb(AsyncBaseDb):
         _engine: Optional[AsyncEngine] = db_engine
         if _engine is None:
             if db_url is not None:
-                _engine = create_async_engine(db_url)
+                _engine = create_async_engine(db_url, json_serializer=json_serializer)
             elif db_file is not None:
                 db_path = Path(db_file).resolve()
                 db_path.parent.mkdir(parents=True, exist_ok=True)
                 db_file = str(db_path)
-                _engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+                _engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", json_serializer=json_serializer)
             else:
                 # If none of db_engine, db_url, or db_file are provided, create a db in the current directory
                 default_db_path = Path("./agno.db").resolve()
-                _engine = create_async_engine(f"sqlite+aiosqlite:///{default_db_path}")
+                _engine = create_async_engine(f"sqlite+aiosqlite:///{default_db_path}", json_serializer=json_serializer)
                 db_file = str(default_db_path)
                 log_debug(f"Created SQLite database: {default_db_path}")
 
@@ -757,7 +757,6 @@ class AsyncSqliteDb(AsyncBaseDb):
                 user_id=user_id,
                 run_index=run_index,
             )
-            row["run_data"] = json.dumps(row["run_data"], cls=CustomJSONEncoder)
 
             async with self.async_session_factory() as sess, sess.begin():
                 # Backfill a monotonic run_index when the run arrives without one
@@ -2248,7 +2247,7 @@ class AsyncSqliteDb(AsyncBaseDb):
             # Stamp first so failed runs are throttled too instead of retried on every read
             self._metrics_refreshed_at = time.time()
 
-            table = await self._get_table(table_type="metrics")
+            table = await self._get_table(table_type="metrics", create_table_if_not_found=True)
             if table is None:
                 return None
 
@@ -2344,7 +2343,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                 except Exception as e:
                     log_warning(f"Could not refresh metrics before reading them: {str(e)}")
 
-            table = await self._get_table(table_type="metrics")
+            table = await self._get_table(table_type="metrics", create_table_if_not_found=True)
             if table is None:
                 return [], None
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -41,13 +41,13 @@ from agno.db.sqlite.utils import (
 )
 from agno.db.utils import (
     HISTORY_SKIP_STATUSES,
-    CustomJSONEncoder,
     build_single_run_row,
     deserialize_run,
     deserialize_session,
     deserialize_session_json_fields,
     deserialize_sessions,
     filter_context_runs,
+    json_serializer,
     learning_search_patterns,
     merge_runs_table_with_legacy_blob,
     serialize_session_json_fields,
@@ -177,16 +177,16 @@ class SqliteDb(BaseDb):
         _engine: Optional[Engine] = db_engine
         if _engine is None:
             if db_url is not None:
-                _engine = create_engine(db_url)
+                _engine = create_engine(db_url, json_serializer=json_serializer)
             elif db_file is not None:
                 db_path = Path(db_file).resolve()
                 db_path.parent.mkdir(parents=True, exist_ok=True)
                 db_file = str(db_path)
-                _engine = create_engine(f"sqlite:///{db_path}")
+                _engine = create_engine(f"sqlite:///{db_path}", json_serializer=json_serializer)
             else:
                 # If none of db_engine, db_url, or db_file are provided, create a db in the current directory
                 default_db_path = Path("./agno.db").resolve()
-                _engine = create_engine(f"sqlite:///{default_db_path}")
+                _engine = create_engine(f"sqlite:///{default_db_path}", json_serializer=json_serializer)
                 db_file = str(default_db_path)
                 log_debug(f"Created SQLite database: {default_db_path}")
 
@@ -956,7 +956,6 @@ class SqliteDb(BaseDb):
                 user_id=user_id,
                 run_index=run_index,
             )
-            row["run_data"] = json.dumps(row["run_data"], cls=CustomJSONEncoder)
 
             with self.Session() as sess, sess.begin():
                 # Backfill a monotonic run_index when the run arrives without one

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -623,6 +623,9 @@ class Knowledge(RemoteKnowledge):
             _max_results = max_results or self.max_results
             log_debug(f"Getting {_max_results} relevant documents for query: {query}")
             return self.vector_db.search(query=query, limit=_max_results, filters=search_filters, user_id=user_id)
+        except ValueError:
+            # The adapters raise these outside their own catch-alls on purpose.
+            raise
         except Exception as e:
             log_error(f"Error searching for documents: {str(e)}")
             return []
@@ -662,6 +665,9 @@ class Knowledge(RemoteKnowledge):
             except NotImplementedError:
                 log_info("Vector db does not support async search")
                 return self.vector_db.search(query=query, limit=_max_results, filters=search_filters, user_id=user_id)
+        except ValueError:
+            # See the matching comment in ``search``.
+            raise
         except Exception as e:
             log_error(f"Error searching for documents: {str(e)}")
             return []

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -1959,7 +1959,7 @@ def get_agent_router(
                     registry=os.registry,
                     create_fresh=True,
                     user_id=get_scoped_user_id(request),
-                    strict=False
+                    strict=False,
                 )  # type: ignore[assignment]
             except Exception as e:
                 log_error(f"Error resolving agent '{agent_id}': {e}")
@@ -2026,7 +2026,7 @@ def get_agent_router(
                     registry=os.registry,
                     create_fresh=True,
                     user_id=get_scoped_user_id(request),
-                    strict=False
+                    strict=False,
                 )  # type: ignore[assignment]
             except Exception as e:
                 log_error(f"Error resolving agent '{agent_id}': {e}")
@@ -2126,7 +2126,7 @@ def get_agent_router(
             registry=os.registry,
             create_fresh=True,
             user_id=get_scoped_user_id(request),
-            strict=False
+            strict=False,
         )
         if agent is None:
             raise HTTPException(status_code=404, detail="Agent not found")
@@ -2190,7 +2190,7 @@ def get_agent_router(
                     registry=os.registry,
                     create_fresh=True,
                     user_id=get_scoped_user_id(request),
-                    strict=False
+                    strict=False,
                 )  # type: ignore[assignment]
             except Exception as e:
                 log_error(f"Error resolving agent '{agent_id}': {e}")

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -1068,7 +1068,7 @@ def get_team_router(
                 registry=registry,
                 create_fresh=True,
                 user_id=get_scoped_user_id(request),
-                strict=False
+                strict=False,
             )  # type: ignore[assignment]
         except Exception as e:
             logger.error(f"Error resolving team '{team_id}': {e}")
@@ -1166,7 +1166,7 @@ def get_team_router(
             registry=registry,
             create_fresh=True,
             user_id=get_scoped_user_id(request),
-            strict=False
+            strict=False,
         )
         if team is None:
             raise HTTPException(status_code=404, detail="Team not found")
@@ -1297,7 +1297,6 @@ def get_team_router(
                     registry=registry,
                     create_fresh=True,
                     user_id=get_scoped_user_id(request),
-                    strict=False
                 )  # type: ignore[assignment]
             except ComponentRehydrationError as rehydration_error:
                 raise HTTPException(status_code=rehydration_error.status_code, detail=str(rehydration_error))
@@ -1591,7 +1590,7 @@ def get_team_router(
                 registry=registry,
                 create_fresh=True,
                 user_id=get_scoped_user_id(request),
-                strict=False
+                strict=False,
             )
         except Exception as e:
             logger.error(f"Error resolving team '{team_id}': {e}")
@@ -1733,7 +1732,12 @@ def get_team_router(
 
             # Exclude teams whose IDs are owned by the registry
             exclude_ids = registry.get_team_ids() if registry else None
-            db_teams = get_teams(db=os.db, registry=registry, exclude_component_ids=exclude_ids or None, user_id=get_scoped_user_id(request))
+            db_teams = get_teams(
+                db=os.db,
+                registry=registry,
+                exclude_component_ids=exclude_ids or None,
+                user_id=get_scoped_user_id(request),
+            )
             if db_teams:
                 # Apply the same RBAC filtering to DB-loaded teams: without
                 # it, a caller whose scope excludes a team still saw its
@@ -1838,7 +1842,14 @@ def get_team_router(
             return TeamResponse.from_factory(factory)
 
         try:
-            team = get_team_by_id(team_id=team_id, teams=os.teams, db=os.db, registry=registry, create_fresh=True, user_id=get_scoped_user_id(request))  # type: ignore[assignment]
+            team = get_team_by_id(
+                team_id=team_id,
+                teams=os.teams,
+                db=os.db,
+                registry=registry,
+                create_fresh=True,
+                user_id=get_scoped_user_id(request),
+            )  # type: ignore[assignment]
         except ComponentRehydrationError as rehydration_error:
             raise HTTPException(status_code=rehydration_error.status_code, detail=str(rehydration_error))
         except Exception as e:
@@ -1891,7 +1902,7 @@ def get_team_router(
                     registry=registry,
                     create_fresh=True,
                     user_id=get_scoped_user_id(request),
-                    strict=False
+                    strict=False,
                 )  # type: ignore[assignment]
             except Exception as e:
                 logger.error(f"Error resolving team '{team_id}': {e}")
@@ -1976,7 +1987,7 @@ def get_team_router(
                     registry=registry,
                     create_fresh=True,
                     user_id=get_scoped_user_id(request),
-                    strict=False
+                    strict=False,
                 )  # type: ignore[assignment]
             except Exception as e:
                 logger.error(f"Error resolving team '{team_id}': {e}")
@@ -2043,7 +2054,7 @@ def get_team_router(
                     registry=registry,
                     create_fresh=True,
                     user_id=get_scoped_user_id(request),
-                    strict=False
+                    strict=False,
                 )  # type: ignore[assignment]
             except Exception as e:
                 logger.error(f"Error resolving team '{team_id}': {e}")
@@ -2110,7 +2121,7 @@ def get_team_router(
                     registry=registry,
                     create_fresh=True,
                     user_id=get_scoped_user_id(request),
-                    strict=False
+                    strict=False,
                 )  # type: ignore[assignment]
             except Exception as e:
                 logger.error(f"Error resolving team '{team_id}': {e}")

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -1217,7 +1217,9 @@ def get_agent_by_id(
         from agno.agent.agent import get_agent_by_id as get_agent_by_id_db
 
         try:
-            db_agent = get_agent_by_id_db(db=db, id=agent_id, version=version, registry=registry, user_id=user_id, strict=strict)
+            db_agent = get_agent_by_id_db(
+                db=db, id=agent_id, version=version, registry=registry, user_id=user_id, strict=strict
+            )
             return db_agent
         except ComponentRehydrationError:
             # Broken is not "not found": propagate so the caller can refuse loudly.
@@ -1268,7 +1270,9 @@ async def get_agent_by_id_async(
         from agno.agent.agent import get_agent_by_id as get_agent_by_id_db
 
         try:
-            db_agent = get_agent_by_id_db(db=db, id=agent_id, version=version, registry=registry, user_id=user_id, strict=strict)
+            db_agent = get_agent_by_id_db(
+                db=db, id=agent_id, version=version, registry=registry, user_id=user_id, strict=strict
+            )
             return db_agent
         except ComponentRehydrationError:
             # Broken is not "not found": propagate so the caller can refuse loudly.
@@ -1336,7 +1340,9 @@ def get_team_by_id(
         from agno.team.team import get_team_by_id as get_team_by_id_db
 
         try:
-            db_team = get_team_by_id_db(db=db, id=team_id, version=version, registry=registry, user_id=user_id, strict=strict)
+            db_team = get_team_by_id_db(
+                db=db, id=team_id, version=version, registry=registry, user_id=user_id, strict=strict
+            )
             return db_team
         except ComponentRehydrationError:
             # Broken is not "not found": propagate so the caller can refuse loudly.
@@ -1381,7 +1387,9 @@ async def get_team_by_id_async(
         from agno.team.team import get_team_by_id as get_team_by_id_db
 
         try:
-            db_team = get_team_by_id_db(db=db, id=team_id, version=version, registry=registry, user_id=user_id, strict=strict)
+            db_team = get_team_by_id_db(
+                db=db, id=team_id, version=version, registry=registry, user_id=user_id, strict=strict
+            )
             return db_team
         except ComponentRehydrationError:
             # Broken is not "not found": propagate so the caller can refuse loudly.
@@ -2402,7 +2410,16 @@ async def resolve_agent(
             raise HTTPException(status_code=500, detail=f"Error in agent factory: {e}")
     else:
         try:
-            agent = get_agent_by_id(agent_id, agents, db, registry, version=version, create_fresh=True, user_id=scoped_user_id, strict=strict)
+            agent = get_agent_by_id(
+                agent_id,
+                agents,
+                db,
+                registry,
+                version=version,
+                create_fresh=True,
+                user_id=scoped_user_id,
+                strict=strict,
+            )
         except ComponentRehydrationError as e:
             # Broken is not "not found": answer with the error's own status so
             # the refusal survives on caller-supplied apps with no handlers.
@@ -2464,7 +2481,14 @@ async def resolve_team(
     else:
         try:
             team = get_team_by_id(
-                team_id, teams, db=db, version=version, registry=registry, create_fresh=True, user_id=scoped_user_id, strict=strict
+                team_id,
+                teams,
+                db=db,
+                version=version,
+                registry=registry,
+                create_fresh=True,
+                user_id=scoped_user_id,
+                strict=strict,
             )
         except ComponentRehydrationError as e:
             # Broken is not "not found": answer with the error's own status so
@@ -2527,7 +2551,14 @@ async def resolve_workflow(
     else:
         try:
             workflow = get_workflow_by_id(
-                workflow_id, workflows, db=db, version=version, registry=registry, create_fresh=True, user_id=scoped_user_id, strict=strict
+                workflow_id,
+                workflows,
+                db=db,
+                version=version,
+                registry=registry,
+                create_fresh=True,
+                user_id=scoped_user_id,
+                strict=strict,
             )
         except ComponentRehydrationError as e:
             # Broken is not "not found": answer with the error's own status so

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -985,7 +985,9 @@ def from_dict(
                         "was not found in the db; loading the member's current version instead."
                     )
                     if db is not None:
-                        agent = get_agent_by_id(id=agent_id, db=db, registry=registry, strict=False)
+                        agent = get_agent_by_id(
+                            id=agent_id, db=db, registry=registry, strict=False, user_id=owner_user_id
+                        )
                 # Fall back to a code-defined agent registered in the registry.
                 # These are legitimately not persisted as DB components (e.g. agents
                 # passed to AgentOS(agents=[...])), so a DB lookup returns nothing.
@@ -1049,7 +1051,9 @@ def from_dict(
                         "was not found in the db; loading the member's current version instead."
                     )
                     if db is not None:
-                        nested_team = get_team_by_id(id=team_id, db=db, registry=registry, strict=False)
+                        nested_team = get_team_by_id(
+                            id=team_id, db=db, registry=registry, strict=False, user_id=owner_user_id
+                        )
                 # Fall back to a code-defined team registered in the registry.
                 # Deep copy so the shared registry singleton isn't mutated on run.
                 if nested_team is None and registry is not None:

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -1836,7 +1836,9 @@ def get_team_by_id(
         except NotImplementedError:
             links = []
 
-        team = Team.from_dict(cfg, db=db, registry=registry, links=links, strict=strict)
+        # Resolve DB-backed members under the same owner scope as the team.
+        with component_owner_scope(user_id):
+            team = Team.from_dict(cfg, db=db, registry=registry, links=links, strict=strict)
         # Ensure team.id is set to the component_id
         team.id = id
         # Only fall back to the caller-provided db if the config didn't
@@ -1896,7 +1898,9 @@ def get_teams(
                         # components so they stay visible and fixable. Listings
                         # also show members at their current version; the
                         # per-version pin links are a detail-read concern.
-                        team = Team.from_dict(team_config, db=db, registry=registry, strict=False)
+                        # Resolve DB-backed members under the same owner scope as the team.
+                        with component_owner_scope(user_id):
+                            team = Team.from_dict(team_config, db=db, registry=registry, strict=False)
                         team.id = component_id
                         team._version = component.get("current_version")
                         team._stage = config.get("stage")

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -9,8 +9,8 @@ from agno.utils.string import generate_id
 try:
     from sqlalchemy import and_, not_, or_, update
     from sqlalchemy.dialects import postgresql
-    from sqlalchemy.exc import NoSuchTableError
     from sqlalchemy.engine import Engine, create_engine
+    from sqlalchemy.exc import NoSuchTableError
     from sqlalchemy.inspection import inspect
     from sqlalchemy.orm import Session, scoped_session, sessionmaker
     from sqlalchemy.schema import Column, Index, MetaData, Table

--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -409,7 +409,14 @@ class Step:
                 from agno.utils.component_scope import get_component_owner_scope
 
                 try:
-                    agent = get_agent_by_id(db=db, id=agent_id, version=pinned, registry=registry, strict=strict, user_id=get_component_owner_scope())
+                    agent = get_agent_by_id(
+                        db=db,
+                        id=agent_id,
+                        version=pinned,
+                        registry=registry,
+                        strict=strict,
+                        user_id=get_component_owner_scope(),
+                    )
                 except ComponentRehydrationError as step_member_error:
                     if pinned is not None:
                         raise ComponentPinError(
@@ -429,7 +436,9 @@ class Step:
                         f"Step '{config.get('name')}' pins agent '{agent_id}' at version {pinned}, which "
                         "was not found in the db; loading the agent's current version instead."
                     )
-                    agent = get_agent_by_id(db=db, id=agent_id, registry=registry, strict=False)
+                    agent = get_agent_by_id(
+                        db=db, id=agent_id, registry=registry, strict=False, user_id=get_component_owner_scope()
+                    )
 
             # A pinned lenient load may still fall back to a code-defined agent.
             if agent is None and pinned is not None and registry and agent_id:
@@ -507,7 +516,14 @@ class Step:
                 from agno.utils.component_scope import get_component_owner_scope
 
                 try:
-                    team = get_team_by_id(db=db, id=team_id, version=pinned, registry=registry, strict=strict, user_id=get_component_owner_scope())
+                    team = get_team_by_id(
+                        db=db,
+                        id=team_id,
+                        version=pinned,
+                        registry=registry,
+                        strict=strict,
+                        user_id=get_component_owner_scope(),
+                    )
                 except ComponentRehydrationError as step_member_error:
                     if pinned is not None:
                         raise ComponentPinError(
@@ -527,7 +543,9 @@ class Step:
                         f"Step '{config.get('name')}' pins team '{team_id}' at version {pinned}, which "
                         "was not found in the db; loading the team's current version instead."
                     )
-                    team = get_team_by_id(db=db, id=team_id, registry=registry, strict=False)
+                    team = get_team_by_id(
+                        db=db, id=team_id, registry=registry, strict=False, user_id=get_component_owner_scope()
+                    )
 
             # A pinned lenient load may still fall back to a code-defined team.
             if team is None and pinned is not None and registry and team_id:

--- a/libs/agno/tests/unit/db/test_postgres_component_reactivation.py
+++ b/libs/agno/tests/unit/db/test_postgres_component_reactivation.py
@@ -26,6 +26,7 @@ def postgres_components_db(tmp_path):
         Column("created_at", BigInteger, nullable=False),
         Column("updated_at", BigInteger),
         Column("deleted_at", BigInteger),
+        Column("user_id", String),
     )
     metadata.create_all(engine)
 

--- a/libs/agno/tests/unit/db/test_v3_migration_compat.py
+++ b/libs/agno/tests/unit/db/test_v3_migration_compat.py
@@ -52,13 +52,23 @@ def _add_legacy_runs_column(db_file: str) -> None:
         conn.close()
 
 
-def _insert_legacy_session(db_file: str, session_id: str, runs: list[dict]) -> None:
+def _insert_legacy_session(db_file: str, session_id: str, runs: list[dict], double_encoded: bool = False) -> None:
+    """Insert a v2-shaped session row.
+
+    ``double_encoded`` reproduces what v2 SQLite actually wrote: the adapter
+    dumped `runs` to a string and handed it to a JSON column, which dumped it
+    again. Postgres never did this, which is why the migration only loses runs
+    on SQLite.
+    """
+    blob = json.dumps(runs)
+    if double_encoded:
+        blob = json.dumps(blob)
     conn = sqlite3.connect(db_file)
     try:
         conn.execute(
             "INSERT INTO agno_sessions (session_id, session_type, agent_id, user_id, runs, created_at) "
             "VALUES (?, 'agent', 'agent-1', 'u1', ?, 1700000000)",
-            (session_id, json.dumps(runs)),
+            (session_id, blob),
         )
         conn.commit()
     finally:
@@ -301,6 +311,36 @@ def test_v3_migration_is_non_destructive():
         # And it still holds the original data (not nulled by the migration itself)
         blob = conn.execute("SELECT runs FROM agno_sessions WHERE session_id='s6'").fetchone()[0]
         assert blob is not None
+    finally:
+        conn.close()
+
+
+def test_v3_migration_reads_the_double_encoded_v2_blob():
+    """The blob v2 SQLite really wrote must migrate, not silently copy zero runs.
+
+    A single json.loads leaves a str, which is truthy, so the row loop iterates
+    characters and every one is skipped as "not a dict" — no rows, no error.
+    """
+    db, db_file = _new_db()
+    db.upsert_session(AgentSession(session_id="seed", agent_id="agent-1", user_id="u1"))
+    _add_legacy_runs_column(db_file)
+
+    runs = [_make_run(f"r{i}", "s8", f"c{i}").to_dict() for i in range(2)]
+    _insert_legacy_session(db_file, "s8", runs, double_encoded=True)
+
+    db = SqliteDb(db_file=db_file)
+    asyncio.run(MigrationManager(db).up())
+
+    conn = sqlite3.connect(db_file)
+    try:
+        run_ids = [r[0] for r in conn.execute("SELECT run_id FROM agno_runs WHERE session_id='s8'").fetchall()]
+        assert sorted(run_ids) == ["r0", "r1"]
+
+        # Stored as a real object, so json_extract-based queries (metrics) can read into it
+        extracted = conn.execute(
+            "SELECT json_extract(run_data, '$.run_id') FROM agno_runs WHERE session_id='s8'"
+        ).fetchall()
+        assert sorted(e[0] for e in extracted) == ["r0", "r1"], "run_data must be a JSON object, not a JSON string"
     finally:
         conn.close()
 

--- a/libs/agno/tests/unit/os/test_list_endpoints_rbac.py
+++ b/libs/agno/tests/unit/os/test_list_endpoints_rbac.py
@@ -47,14 +47,17 @@ def harness(tmp_path, monkeypatch):
     # The DB hands back one out-of-scope component per type
     monkeypatch.setattr(
         "agno.agent.agent.get_agents",
-        lambda db, registry=None, exclude_component_ids=None: [Agent(id="db-agent", name="DB Agent")],
+        lambda db, registry=None, exclude_component_ids=None, user_id=None: [Agent(id="db-agent", name="DB Agent")],
     )
     monkeypatch.setattr(
         "agno.team.team.get_teams",
-        lambda db, registry=None, exclude_component_ids=None: [Team(id="db-team", name="DB Team", members=[])],
+        lambda db, registry=None, exclude_component_ids=None, user_id=None: [
+            Team(id="db-team", name="DB Team", members=[])
+        ],
     )
     monkeypatch.setattr(
-        "agno.workflow.workflow.get_workflows", lambda db, registry=None: [Workflow(id="db-wf", name="DB WF", steps=[])]
+        "agno.workflow.workflow.get_workflows",
+        lambda db, registry=None, user_id=None: [Workflow(id="db-wf", name="DB WF", steps=[])],
     )
     return SimpleNamespace(client=TestClient(app, raise_server_exceptions=False))
 

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -525,7 +525,9 @@ class TestTeamFromDict:
 
             team = Team.from_dict(config, db=mock_db, strict=True)
 
-            mock_get_agent.assert_called_once_with(id="agent-1", db=mock_db, version=None, registry=None, user_id=None, strict=True)
+            mock_get_agent.assert_called_once_with(
+                id="agent-1", db=mock_db, version=None, registry=None, user_id=None, strict=True
+            )
             assert team.members == [mock_agent]
 
     def test_from_dict_falls_back_to_registry_for_member_agent(self, mock_db, member_agent):


### PR DESCRIPTION
## Summary

Fixes the SQLite `model_metrics: []` bug reported during user-isolation testing, the v2 -> v3 SQLite migration bug found while verifying it, and code that the `feat/v3.0` merge (`7d3c94d4f`) dropped from one side.

Stacked on `feat/extending-user-isolation` (#8245), which is where the merge commit lives.

### 1. SQLite stored `run_data` double-encoded

`run_data` is a `JSON` column, so SQLAlchemy serializes it on the way in. `upsert_run` also serialized it by hand, so a JSON *string* was stored instead of an object and `json_extract(run_data, '$.model')` in the metrics query returned `NULL`.

```
before   stored '"{\"run_id\": \"27bdd5e6...'   $.model -> None      model_metrics: []
after    stored '{"run_id": "77d8d328...'       $.model -> gpt-5.5   model_metrics: [{"model_id": "gpt-5.5", "model_provider": "OpenAI", "count": 1}]
```

Run counts and token totals were unaffected, because neither reads into `run_data` — which is why the metrics response looked almost correct. SQLite and async SQLite were the only two of seven SQLAlchemy adapters not passing `json_serializer` to the engine; they now match postgres, mysql and singlestore. `json_serializer` is `json.dumps(obj, cls=CustomJSONEncoder)`, so the encoder itself is unchanged.

Also fixes `AsyncSqliteDb`, the only one of eight metrics call sites missing `create_table_if_not_found=True`. Without it `agno_metrics` is never created and `calculate_metrics()` returns `None` forever on a fresh database — all metrics empty, not just `model_metrics`.

### 2. The v2 -> v3 SQLite migration copied zero runs

v2 SQLite stored `agno_sessions.runs` double-encoded for the same reason. `_build_run_rows` unwrapped one layer and got a string back; a non-empty string is truthy, so the guard did not fire and the row loop iterated **characters**, skipping each as "not a dict".

Measured against a database written by the published `agno==2.5.6`:

```
INFO -- Copied 0 runs from agno_sessions into the runs table
agno_runs count : 0   (expected 121)
schema version  : 3.0.0

get_session('s0').runs BEFORE cleanup -> ['s0-r0','s0-r1']   # legacy fallback masks it
get_session('s0').runs AFTER  cleanup -> []
```

Reads kept working off the legacy column, so the failure was invisible until step 3 of the upgrade guide (`cleanup_legacy_runs_column(force=True)`) dropped that column.

`_decode_run_data` in the same file already unwraps both layers and documents why, so `_build_run_rows` now uses it. The two SQLite call sites also stop passing `run_data_as_string=True`; that flag existed because the SQLite engine had no serializer, and with one wired it reproduces the double-encode across the whole migrated history.

Postgres is unaffected throughout — v2 passed the raw list into JSONB and psycopg decodes either way.

### 3. Code dropped by the `feat/v3.0` merge

Found by recomputing the merge with `git merge-tree --write-tree 7d3c94d4f^1 7d3c94d4f^2` (17 conflicted files) and diffing that against what was committed.

- **`team.py`** — `get_team_by_id` and `get_teams` lost the `component_owner_scope` wrapper while keeping the import, so DB-backed members were rehydrated unscoped. A leak probe returned `['alice_agent', 'bob_agent']` before and `['alice_agent']` after. `ruff check --select F401` on the merge commit flags the stranded import at both sites.
- **`_storage.py`, `step.py`** — the lenient "pinned version not found" fallback re-resolved without the owner. An ownership miss and a missing version both return `None`, so the miss was read as the latter and the fallback then loaded the component unscoped.
- **`postgres.py`** — `upsert_component` regained the `deleted_at` filter, so the lookup skipped soft-deleted rows and the reactivation branch below became unreachable; recreating a deleted component collided on the primary key (reproduced on a real server: `UniqueViolation`). This restores parity with `sqlite.py`, which has no such filter.
- **`teams/router.py`** — `continue_team_run` gained `strict=False`, which neither parent had (`parent1: 0, parent2: 7, merge: 8` occurrences in the file). The router calls `agno.os.utils.get_team_by_id`, whose default is `strict=True`, so continuing a run on a team with unresolvable members returned 200 with members missing instead of 422. #9381 added `strict=False` to seven call sites here and deliberately omitted it on `continue_team_run` and `get_team`; the agents router keeps the identical split.

### 4. Knowledge search swallowed the pre-v3 gate

The vector-db adapters raise `ValueError` outside their own catch-alls on purpose — six of them say so in comments. `Knowledge.search`/`asearch` then caught `Exception` and returned `[]`, so the agent saw an empty knowledge base indistinguishable from "you own nothing".

```
POST /knowledge/search   before -> HTTP 200 {"data": [], "total_count": 0}
                         after  -> HTTP 500 {"detail": "user_id='alice' was passed but table 'ai.vectors'
                                             predates per-user isolation... Run the v2 -> v3 migration"}
```

Everything that is not a `ValueError` is still swallowed exactly as before. In `asearch` the clause sits on the outer `try`, so a gate raised by the sync fallback still propagates for the adapters without async search.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Test coverage.** The migration test helper only ever wrote a single-encoded blob — a shape v2 never produced — which is why nothing caught the migration bug. It now takes a `double_encoded` flag, and a new test asserts both the row count and that `json_extract` can read into `run_data`. On the same input the old decoding produces 0 rows and the new one produces 2, with no change for single-encoded, already-a-list, or `None` inputs.

**Existing databases still need a repair, which is not in this PR.** `3.0.0a1` is published on PyPI (visible with `pip index versions agno --pre`), and it contains the double-encode. SQLite users on it have unattributable history. Rewriting `run_data` alone is not sufficient — past dates are stored `completed=True` and are never recomputed:

```
repaired run_data only                 -> model_metrics: []
repaired + DELETE FROM agno_metrics    -> model_metrics: [{"model_id": "gpt-5.5", ...}]
```

Anyone who ran the v2 -> v3 SQLite migration on the alpha and has **not** yet run `cleanup_legacy_runs_column(force=True)` still has their runs in the legacy column and is recoverable; anyone who has run it is not. This belongs with the metrics migration.

**Two findings not addressed here.**

- `migrations/manager.py:100-103` assigns `latest_version` before the `if migration_executed:` check, so the branch is a no-op and tables are stamped as migrated even when the migration was skipped (observed: 11 tables stamped `3.0.0`, 3 actually present, including `agno_metrics`). A later real migration on those tables will see the stamp and skip — worth fixing before the metrics migration ships.
- `serialize_session_json_fields` still hand-serializes `session_data`, `agent_data`, `team_data`, `workflow_data`, `metadata` and `summary` on SQLite, so those columns are still double-encoded. Nothing reads them with `json_extract` today, so nothing is broken, but it is why `sqlite.py:1404` filters sessions with a blunt `session_data.like('%name%')` where postgres and mysql can query the field directly.
