### PR TITLE
fix: Wave 3 reliability polish - fourteen review findings, one commit each

### DIFF
--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -3026,18 +3026,33 @@ class RedisDb(BaseDb):
     def sweep_exhausted_jobs(self, lock_grace_seconds: int = 60, limit: int = 20) -> List[Dict[str, Any]]:
         stale = self._q_server_now() - lock_grace_seconds
         exhausted: List[Dict[str, Any]] = []
-        for raw_id in self.redis_client.zrangebyscore(self._q_key("running"), "-inf", stale, start=0, num=limit * 2):
-            job = self._q_load_job(_q_to_str(raw_id))
-            if (
-                job is not None
-                and job["status"] == "running"
-                and job.get("locked_at") is not None
-                and job["locked_at"] <= stale
-                and job["attempt"] >= job["max_attempts"]
-            ):
-                exhausted.append(job)
-                if len(exhausted) >= limit:
-                    break
+        # PAGE through the whole stale range: a fixed window (the old
+        # num=limit*2) made exhausted jobs sitting behind that many
+        # stale-but-reclaimable ones invisible on every tick - after a mass
+        # crash under a retry budget, terminal failures were starved
+        # indefinitely by the reclaim queue ahead of them. The stale range is
+        # finite and normally tiny (live jobs' heartbeats advance their zset
+        # score out of it), so walking it fully is bounded by the size of the
+        # very backlog the sweep exists to clear.
+        start = 0
+        page = max(limit * 2, 50)
+        while len(exhausted) < limit:
+            raw_ids = self.redis_client.zrangebyscore(self._q_key("running"), "-inf", stale, start=start, num=page)
+            if not raw_ids:
+                break
+            for raw_id in raw_ids:
+                job = self._q_load_job(_q_to_str(raw_id))
+                if (
+                    job is not None
+                    and job["status"] == "running"
+                    and job.get("locked_at") is not None
+                    and job["locked_at"] <= stale
+                    and job["attempt"] >= job["max_attempts"]
+                ):
+                    exhausted.append(job)
+                    if len(exhausted) >= limit:
+                        break
+            start += len(raw_ids)
         return exhausted
 
     def acquire_sweep(self, job_id: str, worker_id: str, lock_grace_seconds: int = 60) -> bool:

--- a/libs/agno/agno/job_queue/config.py
+++ b/libs/agno/agno/job_queue/config.py
@@ -73,6 +73,20 @@ class QueueConfig:
             work from any replica. Only replaces in-memory defaults: an
             explicitly configured cancellation manager or event stream is never
             overridden. Also works against Valkey (Redis-protocol compatible).
+
+    Multi-replica uniformity: the timing and budget fields
+    (``lock_grace_seconds``, ``stop_timeout_seconds``, ``retention_seconds``,
+    ``max_attempts``, ``timeout_seconds``) must be configured UNIFORMLY across
+    every replica sharing one queue table. Each is applied by whichever
+    replica performs the action - the claimer's grace sets its heartbeat
+    cadence while the sweeper's grace judges staleness, ``max_attempts`` is
+    stamped per-ticket by the accepting replica, and the smallest
+    ``retention_seconds`` in the fleet wins the hourly cleanup - so divergent
+    values (including transiently, during a rolling deploy) can falsely sweep
+    a healthy peer's runs or delete tickets early. When changing
+    ``lock_grace_seconds`` on a live fleet, only ever RAISE it, and roll the
+    sweeping replicas first: a replica sweeping with a smaller grace than its
+    peers heartbeat with judges their live leases stale.
     """
 
     max_concurrency: Optional[int] = None

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1252,9 +1252,17 @@ class AgentOS:
 
                 log_error(f"Unhandled exception:\n{traceback.format_exc(limit=5)}")
 
+                status_code = getattr(exc, "status_code", 500)
+                # 4xx exceptions that carry their own status wrote their
+                # message for the client; 5xx details must never echo
+                # str(exc) - unhandled server errors are routinely store or
+                # driver failures whose text carries connection strings, SQL
+                # fragments, and hostnames. The full traceback is in the
+                # server log above; the wire gets the exception type only.
+                detail = str(exc) if status_code < 500 else f"Internal server error ({type(exc).__name__})"
                 return JSONResponse(
-                    status_code=getattr(exc, "status_code", 500),
-                    content={"detail": str(exc)},
+                    status_code=status_code,
+                    content={"detail": detail},
                 )
 
         # Update CORS middleware

--- a/libs/agno/agno/os/event_streams/redis.py
+++ b/libs/agno/agno/os/event_streams/redis.py
@@ -97,9 +97,12 @@ class RedisEventStream(BaseEventStream):
         async_redis_client: Async Redis client (``Redis`` or ``RedisCluster``).
         key_prefix: Prefix for all keys. Defaults to ``agno:os:events:``.
         ttl_seconds: TTL for per-run keys, refreshed while the run is active.
-            Mirrors the in-memory buffer's cleanup interval. Defaults to 3600.
+            Mirrors the wired in-memory buffer's cleanup interval (1800s) -
+            actually mirrors it: the old default of 3600 diverged.
         maxlen: Approximate max events retained per stream (XADD MAXLEN ~).
-            Mirrors the in-memory buffer's max_events_per_run. Defaults to 1000.
+            Mirrors the wired in-memory buffer's max_events_per_run (10000).
+            The old default of 1000 silently cut how far a reconnecting
+            /resume client could fall behind by 10x when switching backends.
         block_ms: How long ``tail()`` blocks per XREAD before re-checking run
             status. Bounds how long a tail can outlive a dead producer.
     """
@@ -108,8 +111,8 @@ class RedisEventStream(BaseEventStream):
         self,
         async_redis_client: Union["AsyncRedis", "AsyncRedisCluster"],
         key_prefix: str = "agno:os:events:",
-        ttl_seconds: int = 3600,
-        maxlen: int = 1000,
+        ttl_seconds: int = 1800,
+        maxlen: int = 10000,
         block_ms: int = 15000,
     ):
         if not _redis_available:

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -1180,20 +1180,23 @@ class QueueWorker:
         return RunPersistOutcome.UPDATED
 
     def _retry_delay(self, attempt: int) -> int:
-        """Exponential backoff with jitter, capped at 10x the base (the base
-        acts as the minimum delay; the shutdown-drain requeue intentionally
-        uses the flat base with no backoff).
+        """FULL-jitter exponential backoff, capped at 10x the base (the
+        shutdown-drain requeue intentionally uses the flat base with no
+        backoff).
 
-        config.retry_delay_seconds is the BASE delay; attempt N waits up to
-        base * 2**(N-1), jittered uniformly to avoid a thundering herd of
-        retries when many workers fail together."""
+        config.retry_delay_seconds is the BASE delay; attempt N waits
+        uniformly in [0, min(base * 2**(N-1), base * 10)] - the AWS
+        full-jitter shape. The old lower bound of `base` made attempt 1's
+        range [base, base]: zero jitter, so a fleet-wide failure retried in
+        lockstep at exactly base seconds - precisely the herd the jitter
+        exists to break up."""
         import random
 
         base = self.config.retry_delay_seconds
         if base <= 0:
             return 0  # explicit no-backoff configuration (tests, dev loops)
         ceiling = min(base * (2 ** max(0, attempt - 1)), base * 10)
-        return random.randint(base, max(base, ceiling))
+        return random.randint(0, ceiling)
 
     @staticmethod
     def _is_permanent_failure(exc: BaseException, continuation_component: Optional[str] = None) -> bool:

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -1964,8 +1964,11 @@ async def acontinue_via_queue(
 
 def validate_seam_input(component: Any, input: Any) -> None:
     """Mirror arun's input_schema validation at the durable seams: the inline
-    path 422s on schema violations, so a 202 for the same payload (failing
-    only later, inside the worker) would be a contract divergence."""
+    non-stream path answers 400 on schema violations (InputCheckError /
+    ValueError from the run dispatch), so a 202 for the same payload (failing
+    only later, inside the worker) would be a contract divergence - and so
+    would a different status. This helper used to answer 422 on the false
+    premise that the inline path did; one payload, one status: 400."""
     schema = getattr(component, "input_schema", None)
     if schema is None:
         return
@@ -1978,7 +1981,7 @@ def validate_seam_input(component: Any, input: Any) -> None:
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=422, detail=f"Input failed schema validation: {str(e)[:300]}")
+        raise HTTPException(status_code=400, detail=f"Input failed schema validation: {str(e)[:300]}")
 
 
 async def _atomic_append_run(

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -2219,9 +2219,13 @@ async def aprepare_accepted_or_abort(
             await event_stream.register_run(run_id, RunStatus.pending)
             await asyncio.shield(event_stream.complete_run(run_id, RunStatus.cancelled))
         log_error(f"Run {run_id}: acceptance aborted - run-row prepare failed ({e}); ticket cancelled")
+        # The detail names the exception TYPE only: prepare failures are
+        # store failures, and their str() carries driver internals
+        # (connection strings, SQL fragments, hostnames) that belong in the
+        # server log above, never on the wire.
         raise HTTPException(
             status_code=500,
-            detail=f"Run acceptance aborted: the run row could not be prepared ({str(e)[:200]}); "
+            detail=f"Run acceptance aborted: the run row could not be prepared ({type(e).__name__}); "
             "the queued job was cancelled and will not execute. Retry the submission.",
         )
 

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -1360,6 +1360,42 @@ class QueueWorker:
             extra.pop(reserved, None)
         return extra
 
+    async def _ahonor_terminal_row(self, component: Any, job: Dict[str, Any]) -> None:
+        """A claimed FRESH job whose run row is already terminal: never
+        execute (see the RUNNING-stamp refusal in _execute_claimed for the
+        crash window that produces this state). Settle the ticket to match
+        the row and close the stream view with the same status.
+
+        The row read resolves WHICH terminal status wins the ticket; if it
+        cannot be read, cancelled is assumed - the cancel crash window is
+        the only known producer of this state (completed rows cannot regain
+        a queued fresh ticket: enqueue refuses existing ids).
+        """
+        from agno.run.base import RunStatus
+
+        job_id = job["id"]
+        row_status: Optional[str] = None
+        with contextlib.suppress(Exception):
+            run_output = await component.aget_run_output(job_id, job["session_id"], user_id=job.get("user_id"))
+            raw = getattr(run_output, "status", None)
+            row_status = raw.value if isinstance(raw, RunStatus) else raw
+        ticket_status = "completed" if str(row_status).lower() == "completed" else "cancelled"
+        await self._asettle_ticket(job_id, job["attempt"], ticket_status)
+        with contextlib.suppress(Exception):
+            from agno.os.event_streams import get_event_stream
+
+            await asyncio.shield(
+                get_event_stream().complete_run(
+                    job_id,
+                    RunStatus.completed if ticket_status == "completed" else RunStatus.cancelled,
+                    generation=job.get("attempt"),
+                )
+            )
+        log_warning(
+            f"Job queue: claimed job {job_id} has a terminal run row ({row_status}); "
+            f"skipped execution and settled the ticket {ticket_status}"
+        )
+
     async def _asettle_ticket(
         self, job_id: str, attempt: int, status: str, error: Optional[str] = None, shielded: bool = False
     ) -> bool:
@@ -1558,10 +1594,12 @@ class QueueWorker:
             # its own status once it actually starts executing.
             if component is not None and not payload.get("continue"):
                 from agno.run.base import RunStatus as _RS
+                from agno.run.status_persist import RunPersistOutcome as _RPO
                 from agno.run.status_persist import apersist_run_status as _aps
 
+                stamp_outcome = None
                 try:
-                    await _aps(
+                    stamp_outcome = await _aps(
                         component,
                         job.get("component_type", ""),
                         session_id=job["session_id"],
@@ -1577,6 +1615,19 @@ class QueueWorker:
                         f"Job queue: RUNNING stamp failed for job {job_id} (worker={self.worker_id}, "
                         f"attempt={attempt}): {e}"
                     )
+                if stamp_outcome is _RPO.TERMINAL_REFUSED:
+                    # The run row is already COMPLETED/CANCELLED (the guard's
+                    # exact terminal set - ERROR rows pass, so operator
+                    # requeue re-drives are unaffected). The canonical
+                    # producer is the cancel crash window: acancel_queued
+                    # persists the CANCELLED row first, and a crash before
+                    # the ticket tombstone leaves a queued ticket over the
+                    # terminal row. Executing it ran a cancelled run's side
+                    # effects and settled the ticket completed over a
+                    # CANCELLED row - a permanent divergence nothing
+                    # revisits. Honor the row instead.
+                    await self._ahonor_terminal_row(component, job)
+                    return
             if is_stream:
                 execution = self._execute_streaming(component, job)
             elif payload.get("continue"):

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -1789,10 +1789,17 @@ async def araise_if_ticket_owns_continue(
         return
     status = job.get("status")
     if status == "paused":
+        # The message carries its own escape hatch: when the run ROW is
+        # missing while this paused ticket survives (a lost row after a
+        # session-store fault), background=true itself fails not-found and
+        # falls through to this gate - without the second sentence the 409
+        # told the caller to do exactly what it just did, a dead end.
         raise HTTPException(
             status_code=409,
             detail=f"Run {run_id} was submitted through the durable queue; continue it with "
-            "background=true (the queue owns its continuations)",
+            "background=true (the queue owns its continuations). If background=true cannot "
+            "find the run, its row is missing while the ticket survives: cancel the run and "
+            "requeue the ticket from the /queue operations surface.",
         )
     if status in ("queued", "running"):
         raise HTTPException(

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -246,11 +246,16 @@ def payload_is_queueable(payload: Any) -> bool:
     cannot carry (media BaseModel instances, dynamically-built output_schema
     classes, arbitrary objects in kwargs) would either fail the enqueue INSERT
     or come back as lossy strings - such submissions must fall back to the
-    non-durable path instead of 500ing or corrupting the run."""
+    non-durable path instead of 500ing or corrupting the run.
+
+    allow_nan=False: Python's json serializes NaN/Infinity by default, but
+    they are NOT valid JSON - Postgres JSONB rejects them at INSERT, so a
+    NaN-carrying payload would pass this gate and then 500 the submit, the
+    exact failure the gate exists to prevent."""
     import json as _json
 
     try:
-        _json.dumps(payload)
+        _json.dumps(payload, allow_nan=False)
         return True
     except (TypeError, ValueError):
         return False

--- a/libs/agno/agno/os/job_queue.py
+++ b/libs/agno/agno/os/job_queue.py
@@ -1366,10 +1366,14 @@ class QueueWorker:
         crash window that produces this state). Settle the ticket to match
         the row and close the stream view with the same status.
 
-        The row read resolves WHICH terminal status wins the ticket; if it
-        cannot be read, cancelled is assumed - the cancel crash window is
-        the only known producer of this state (completed rows cannot regain
-        a queued fresh ticket: enqueue refuses existing ids).
+        The row read resolves WHICH terminal status wins the ticket. If the
+        row cannot be read (or reads back non-terminal - a race), NOTHING is
+        settled: manufacturing a terminal status here could stamp a
+        cancelled ticket over a COMPLETED row (multi-attempt reclaim of a
+        run whose first attempt committed but crashed before settling).
+        Leaving the claim to go stale hands the job to the reconciling
+        sweep, which pre-reads the row and settles ticket and stream from
+        the truth.
         """
         from agno.run.base import RunStatus
 
@@ -1379,7 +1383,15 @@ class QueueWorker:
             run_output = await component.aget_run_output(job_id, job["session_id"], user_id=job.get("user_id"))
             raw = getattr(run_output, "status", None)
             row_status = raw.value if isinstance(raw, RunStatus) else raw
-        ticket_status = "completed" if str(row_status).lower() == "completed" else "cancelled"
+        normalized = str(row_status).lower() if row_status is not None else None
+        if normalized not in ("completed", "cancelled"):
+            log_error(
+                f"Job queue: claimed job {job_id} refused the RUNNING stamp as terminal but its run "
+                f"row could not be read back ({row_status!r}); leaving the claim to go stale for the "
+                "reconciling sweep instead of guessing a terminal status"
+            )
+            return
+        ticket_status = normalized
         await self._asettle_ticket(job_id, job["attempt"], ticket_status)
         with contextlib.suppress(Exception):
             from agno.os.event_streams import get_event_stream

--- a/libs/agno/agno/os/managers.py
+++ b/libs/agno/agno/os/managers.py
@@ -421,6 +421,17 @@ class EventsBuffer:
                 completed_at = metadata.get("completed_at", metadata["last_updated"])
                 if current_time - completed_at > self.cleanup_interval:
                     runs_to_cleanup.append(run_id)
+            elif metadata["status"] == RunStatus.pending:
+                # Accept-side registrations whose runs execute on ANOTHER
+                # replica never advance past PENDING here and used to
+                # accumulate forever (that config is warned against at
+                # worker startup, but the warning must not mean a leak).
+                # Stale-pending reap is safe in-process too: a long-queued
+                # local run's stream state is rebuilt at claim time, and a
+                # tail of a reaped registration gets the honest
+                # stream_expired close while the ticket still vouches.
+                if current_time - metadata.get("last_updated", current_time) > self.cleanup_interval:
+                    runs_to_cleanup.append(run_id)
 
         for run_id in runs_to_cleanup:
             self.cleanup_run(run_id)

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -638,9 +638,7 @@ def get_agent_router(
         files: Optional[List[UploadFile]] = File(
             None, description="Files to upload (images, audio, video, or documents)"
         ),
-        # int like teams/workflows: the old str declaration with a bare
-        # int(version) cast 500ed on non-numeric input where siblings 422
-        version: Optional[int] = Form(None, description="Agent version to use for this run"),
+        version: Optional[str] = Form(None, description="Agent version to use for this run"),
         background: bool = Form(
             False, description="Run in background and return immediately with run metadata (requires database)"
         ),
@@ -685,7 +683,7 @@ def get_agent_router(
             os.agents,
             os.db,
             registry,
-            version=version,
+            version=int(version) if version else None,
             request=request,
             user_id=user_id,
             session_id=session_id,

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -638,7 +638,9 @@ def get_agent_router(
         files: Optional[List[UploadFile]] = File(
             None, description="Files to upload (images, audio, video, or documents)"
         ),
-        version: Optional[str] = Form(None, description="Agent version to use for this run"),
+        # int like teams/workflows: the old str declaration with a bare
+        # int(version) cast 500ed on non-numeric input where siblings 422
+        version: Optional[int] = Form(None, description="Agent version to use for this run"),
         background: bool = Form(
             False, description="Run in background and return immediately with run metadata (requires database)"
         ),
@@ -683,7 +685,7 @@ def get_agent_router(
             os.agents,
             os.db,
             registry,
-            version=int(version) if version else None,
+            version=version,
             request=request,
             user_id=user_id,
             session_id=session_id,

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -783,7 +783,7 @@ def get_agent_router(
                     )
                 )
                 if stream_queueable:
-                    # 202/stream-accept must honor input_schema like the inline path
+                    # 202/stream-accept must honor input_schema like the inline path (400)
                     validate_seam_input(agent, message)
                     assert queue_worker is not None  # narrowed by stream_queueable
                     from agno.os.event_streams import get_event_stream as _ges
@@ -905,7 +905,7 @@ def get_agent_router(
                 # than 400ing a submission that worked before durable mode
                 and not (base64_images or base64_audios or base64_videos or input_files)
             ):
-                # 202 must honor input_schema exactly like the inline path 422s
+                # 202 must honor input_schema exactly like the inline path (400)
                 validate_seam_input(agent, message)
                 queued_run_id = str(uuid4())
                 queued_session_id = session_id or str(uuid4())
@@ -987,21 +987,27 @@ def get_agent_router(
                         "accepting replica instead - bounded and observable, but NOT durable."
                     )
 
-            run_response = cast(
-                RunOutput,
-                await agent.arun(  # type: ignore[misc]
-                    input=message,
-                    session_id=session_id,
-                    user_id=user_id,
-                    images=base64_images if base64_images else None,
-                    audio=base64_audios if base64_audios else None,
-                    videos=base64_videos if base64_videos else None,
-                    files=input_files if input_files else None,
-                    stream=False,
-                    background=True,
-                    **kwargs,
-                ),
-            )
+            # Same input-error contract as the inline path: without this,
+            # the non-durable background fallback answered 500 for the exact
+            # payload the other doors answer 400
+            try:
+                run_response = cast(
+                    RunOutput,
+                    await agent.arun(  # type: ignore[misc]
+                        input=message,
+                        session_id=session_id,
+                        user_id=user_id,
+                        images=base64_images if base64_images else None,
+                        audio=base64_audios if base64_audios else None,
+                        videos=base64_videos if base64_videos else None,
+                        files=input_files if input_files else None,
+                        stream=False,
+                        background=True,
+                        **kwargs,
+                    ),
+                )
+            except (InputCheckError, ValueError) as e:
+                raise HTTPException(status_code=400, detail=str(e))
             return JSONResponse(
                 status_code=202,
                 content={
@@ -1051,7 +1057,9 @@ def get_agent_router(
                 )
                 return run_response.to_dict()
 
-            except InputCheckError as e:
+            # ValueError alongside InputCheckError: a bare schema ValueError
+            # from the dispatch is the same client mistake and must not 500
+            except (InputCheckError, ValueError) as e:
                 raise HTTPException(status_code=400, detail=str(e))
 
     @router.post(

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -774,7 +774,6 @@ def get_agent_router(
                     queue_worker is not None
                     and getattr(agent, "db", None) is not None
                     and payload_is_queueable(queued_stream_payload)
-                    and not isinstance(agent, RemoteAgent)
                     and version is None
                     and not (base64_images or base64_audios or base64_videos or input_files)
                     and any(
@@ -790,7 +789,7 @@ def get_agent_router(
                     from agno.run.base import RunStatus as _RS
 
                     queued_run_id = str(uuid4())
-                    queued_session_id = session_id or str(uuid4())
+                    queued_session_id = session_id  # non-empty: defaulted at the top of the endpoint
                     job = QueuedJob(
                         id=queued_run_id,
                         component_type="agent",
@@ -896,7 +895,6 @@ def get_agent_router(
             queued_payload = {"input": message, "kwargs": kwargs}
             if (
                 queue_worker is not None
-                and not isinstance(agent, RemoteAgent)
                 and agent_is_queueable
                 and version is None  # version-pinned resolution differs from the worker's registry instance
                 and payload_is_queueable(queued_payload)
@@ -908,7 +906,7 @@ def get_agent_router(
                 # 202 must honor input_schema exactly like the inline path (400)
                 validate_seam_input(agent, message)
                 queued_run_id = str(uuid4())
-                queued_session_id = session_id or str(uuid4())
+                queued_session_id = session_id  # non-empty: defaulted at the top of the endpoint
                 job = QueuedJob(
                     id=queued_run_id,
                     component_type="agent",

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -638,7 +638,10 @@ def get_agent_router(
         files: Optional[List[UploadFile]] = File(
             None, description="Files to upload (images, audio, video, or documents)"
         ),
-        version: Optional[str] = Form(None, description="Agent version to use for this run"),
+        # int like teams/workflows: component versions are integers, and the
+        # old str declaration's bare int(version) cast 500ed on non-numeric
+        # input where the siblings answer a clean 422
+        version: Optional[int] = Form(None, description="Agent version to use for this run"),
         background: bool = Form(
             False, description="Run in background and return immediately with run metadata (requires database)"
         ),
@@ -683,7 +686,7 @@ def get_agent_router(
             os.agents,
             os.db,
             registry,
-            version=int(version) if version else None,
+            version=version,
             request=request,
             user_id=user_id,
             session_id=session_id,

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -987,9 +987,12 @@ def get_agent_router(
                         "accepting replica instead - bounded and observable, but NOT durable."
                     )
 
-            # Same input-error contract as the inline path: without this,
-            # the non-durable background fallback answered 500 for the exact
-            # payload the other doors answer 400
+            # Same input-error contract as the inline path: schema violations
+            # are refused up front (the dispatch's own schema ValueError is
+            # indistinguishable from an internal one, so it is not caught -
+            # internal failures keep their generic 500), and guardrail
+            # refusals from the dispatch answer 400.
+            validate_seam_input(agent, message)
             try:
                 run_response = cast(
                     RunOutput,
@@ -1006,7 +1009,7 @@ def get_agent_router(
                         **kwargs,
                     ),
                 )
-            except (InputCheckError, ValueError) as e:
+            except InputCheckError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             return JSONResponse(
                 status_code=202,
@@ -1039,6 +1042,13 @@ def get_agent_router(
             if auth_token and isinstance(agent, RemoteAgent):
                 kwargs["auth_token"] = auth_token
 
+            # Schema violations are refused up front with the seams' shared
+            # check: the dispatch's own schema ValueError is
+            # indistinguishable from an internal one (e.g. storage code), so
+            # catching ValueError here would misclassify server failures as
+            # client errors and echo their internals - internal failures
+            # keep their generic 500 instead.
+            validate_seam_input(agent, message)
             try:
                 run_response = cast(
                     RunOutput,
@@ -1057,9 +1067,7 @@ def get_agent_router(
                 )
                 return run_response.to_dict()
 
-            # ValueError alongside InputCheckError: a bare schema ValueError
-            # from the dispatch is the same client mistake and must not 500
-            except (InputCheckError, ValueError) as e:
+            except InputCheckError as e:
                 raise HTTPException(status_code=400, detail=str(e))
 
     @router.post(

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -752,6 +752,15 @@ def get_agent_router(
         if background:
             if isinstance(agent, RemoteAgent):
                 raise HTTPException(status_code=400, detail="Background execution is not supported for remote agents")
+            # The db requirement gates BOTH shapes here: the non-stream
+            # branch always 400ed, while the stream branch used to enter the
+            # detached streamer and let arun(background=True) raise - the
+            # same misconfiguration answered 200 + SSE error frame,
+            # indistinguishable from a runtime failure.
+            if not getattr(agent, "db", None):
+                raise HTTPException(
+                    status_code=400, detail="Background execution requires a database to be configured on the agent"
+                )
 
             if stream:
                 # Durable queued streaming: the queue row is the acceptance,
@@ -869,12 +878,9 @@ def get_agent_router(
                     media_type="text/event-stream",
                 )
 
-            # background=True, stream=False: return 202 immediately with run metadata
-            if not getattr(agent, "db", None):
-                raise HTTPException(
-                    status_code=400, detail="Background execution requires a database to be configured on the agent"
-                )
-
+            # background=True, stream=False: return 202 immediately with run
+            # metadata (the db requirement was enforced at the top of the
+            # background branch, for both shapes)
             # Durable queue path: acceptance is a committed row; whichever
             # replica's worker claims the job executes it, surviving crashes
             # and deploys. Client contract identical: 202 + poll.

--- a/libs/agno/agno/os/routers/job_queue/router.py
+++ b/libs/agno/agno/os/routers/job_queue/router.py
@@ -53,7 +53,12 @@ async def _require_queue_admin(request: Request) -> None:
 def _get_store(request: Request):
     worker = getattr(request.app.state, "queue_worker", None)
     if worker is None:
-        raise HTTPException(status_code=404, detail="Durable job queue is not enabled")
+        # 503, not 404: "no active queue worker" is a service-availability
+        # condition (queue not configured, or the worker not running on this
+        # replica), not a missing resource - and the requeue path already
+        # answered 503 for the same condition, so one operational state got
+        # two different statuses depending on the endpoint.
+        raise HTTPException(status_code=503, detail="Durable job queue is not enabled on this replica")
     return worker.store
 
 
@@ -67,6 +72,7 @@ def get_queue_router(os: "AgentOS", settings: AgnoAPISettings = AgnoAPISettings(
             401: {"description": "Unauthorized", "model": UnauthenticatedResponse},
             404: {"description": "Not Found", "model": NotFoundResponse},
             500: {"description": "Internal Server Error", "model": InternalServerErrorResponse},
+            503: {"description": "Durable job queue not enabled on this replica"},
         },
     )
 

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -475,6 +475,10 @@ async def team_continue_response_streamer(
         )
         yield format_sse_event(error_response)
 
+    except asyncio.CancelledError:
+        # Sibling-streamer parity: every other streamer ends quietly on
+        # client disconnect (the finalizer above already settled the stream)
+        return
     except Exception as e:
         import traceback
 
@@ -653,7 +657,12 @@ def get_team_router(
                 log_warning("Metadata parameter passed in both request state and kwargs, using request state")
             kwargs["metadata"] = metadata
 
-        logger.debug(f"Creating team run: {message=} {session_id=} {monitor=} {user_id=} {team_id=} {files=} {kwargs=}")
+        # No raw message content in logs: user input can carry PII/secrets
+        # and belongs in the run record, not the log stream
+        logger.debug(
+            f"Creating team run: {session_id=} {monitor=} {user_id=} {team_id=} "
+            f"files={len(files) if files else 0} message_len={len(message) if message else 0}"
+        )
 
         team = await resolve_team(
             team_id,
@@ -708,9 +717,15 @@ def get_team_router(
                         logger.exception(f"Error processing video {file.filename}")
                         continue
                 elif file_category == "document":
-                    document_file = process_document(file)
-                    if document_file is not None:
-                        document_files.append(document_file)
+                    # Agents parity: one unparseable document must not 500
+                    # the whole submission - skip it, loudly
+                    try:
+                        document_file = process_document(file)
+                        if document_file is not None:
+                            document_files.append(document_file)
+                    except Exception as e:
+                        logger.error(f"Error processing file {file.filename}: {str(e)}")
+                        continue
                 else:
                     raise HTTPException(status_code=400, detail="Unsupported file type")
 

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -967,9 +967,12 @@ def get_team_router(
                         "accepting replica instead - bounded and observable, but NOT durable."
                     )
 
-            # Same input-error contract as the inline path: without this,
-            # the non-durable background fallback answered 500 for the exact
-            # payload the other doors answer 400
+            # Same input-error contract as the inline path: schema violations
+            # are refused up front (the dispatch's own schema ValueError is
+            # indistinguishable from an internal one, so it is not caught -
+            # internal failures keep their generic 500), and guardrail
+            # refusals from the dispatch answer 400.
+            validate_seam_input(team, message)
             try:
                 run_response = await team.arun(  # type: ignore[misc]
                     input=message,
@@ -983,7 +986,7 @@ def get_team_router(
                     background=True,
                     **kwargs,
                 )
-            except (InputCheckError, ValueError) as e:
+            except InputCheckError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             return JSONResponse(
                 status_code=202,
@@ -1016,6 +1019,11 @@ def get_team_router(
             if auth_token and isinstance(team, RemoteTeam):
                 kwargs["auth_token"] = auth_token
 
+            # Schema violations are refused up front with the seams' shared
+            # check: the dispatch's own schema ValueError is
+            # indistinguishable from an internal one, so it is not caught -
+            # internal failures keep their generic 500.
+            validate_seam_input(team, message)
             try:
                 run_response = await team.arun(  # type: ignore[misc]
                     input=message,
@@ -1031,9 +1039,7 @@ def get_team_router(
                 )
                 return run_response.to_dict()
 
-            # ValueError alongside InputCheckError: a bare schema ValueError
-            # from the dispatch is the same client mistake and must not 500
-            except (InputCheckError, ValueError) as e:
+            except InputCheckError as e:
                 raise HTTPException(status_code=400, detail=str(e))
 
     @router.post(

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -878,7 +878,6 @@ def get_team_router(
             queued_payload = {"input": message, "kwargs": kwargs}
             if (
                 queue_worker is not None
-                and not isinstance(team, RemoteTeam)
                 and component_is_queueable
                 and version is None  # version-pinned resolution differs from the worker's registry instance
                 and payload_is_queueable(queued_payload)
@@ -1388,6 +1387,11 @@ def get_team_router(
             )
             if (
                 queue_worker is not None
+                # LIVE, unlike the submit gates' dead twin: the teams continue
+                # endpoint has no up-front remote rejection, so this is what
+                # routes remote teams past the durable branch (and narrows
+                # the union for the row read below)
+                and not isinstance(team, RemoteTeam)
                 and team_is_queueable
                 and not fork
                 and not regenerate

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -729,6 +729,15 @@ def get_team_router(
         if background:
             if isinstance(team, RemoteTeam):
                 raise HTTPException(status_code=400, detail="Background execution is not supported for remote teams")
+            # The db requirement gates BOTH shapes here: the non-stream
+            # branch always 400ed, while the stream branch used to enter the
+            # detached streamer and let arun(background=True) raise - the
+            # same misconfiguration answered 200 + SSE error frame,
+            # indistinguishable from a runtime failure.
+            if not team.db:
+                raise HTTPException(
+                    status_code=400, detail="Background execution requires a database to be configured on the team"
+                )
 
             if stream:
                 # Durable queued streaming: the queue row is the acceptance,
@@ -837,12 +846,9 @@ def get_team_router(
                     media_type="text/event-stream",
                 )
 
-            # background=True, stream=False: return 202 immediately with run metadata
-            if not team.db:
-                raise HTTPException(
-                    status_code=400, detail="Background execution requires a database to be configured on the team"
-                )
-
+            # background=True, stream=False: return 202 immediately with run
+            # metadata (the db requirement was enforced at the top of the
+            # background branch, for both shapes)
             # Durable queue path: acceptance is a committed row; whichever
             # replica's worker claims the job executes it, surviving crashes
             # and deploys. Client contract identical: 202 + poll.

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -760,7 +760,7 @@ def get_team_router(
                     )
                 )
                 if stream_queueable:
-                    # 202/stream-accept must honor input_schema like the inline path
+                    # 202/stream-accept must honor input_schema like the inline path (400)
                     validate_seam_input(team, message)
                     assert queue_worker is not None  # narrowed by stream_queueable
                     queued_run_id = str(uuid4())
@@ -872,7 +872,7 @@ def get_team_router(
                 # bounded in-process path (parity with the stream seam)
                 and not (base64_images or base64_audios or base64_videos or document_files)
             ):
-                # 202 must honor input_schema exactly like the inline path 422s
+                # 202 must honor input_schema exactly like the inline path (400)
                 validate_seam_input(team, message)
                 queued_run_id = str(uuid4())
                 queued_session_id = session_id or str(uuid4())
@@ -954,18 +954,24 @@ def get_team_router(
                         "accepting replica instead - bounded and observable, but NOT durable."
                     )
 
-            run_response = await team.arun(  # type: ignore[misc]
-                input=message,
-                session_id=session_id,
-                user_id=user_id,
-                images=base64_images if base64_images else None,
-                audio=base64_audios if base64_audios else None,
-                videos=base64_videos if base64_videos else None,
-                files=document_files if document_files else None,
-                stream=False,
-                background=True,
-                **kwargs,
-            )
+            # Same input-error contract as the inline path: without this,
+            # the non-durable background fallback answered 500 for the exact
+            # payload the other doors answer 400
+            try:
+                run_response = await team.arun(  # type: ignore[misc]
+                    input=message,
+                    session_id=session_id,
+                    user_id=user_id,
+                    images=base64_images if base64_images else None,
+                    audio=base64_audios if base64_audios else None,
+                    videos=base64_videos if base64_videos else None,
+                    files=document_files if document_files else None,
+                    stream=False,
+                    background=True,
+                    **kwargs,
+                )
+            except (InputCheckError, ValueError) as e:
+                raise HTTPException(status_code=400, detail=str(e))
             return JSONResponse(
                 status_code=202,
                 content={
@@ -1012,7 +1018,9 @@ def get_team_router(
                 )
                 return run_response.to_dict()
 
-            except InputCheckError as e:
+            # ValueError alongside InputCheckError: a bare schema ValueError
+            # from the dispatch is the same client mistake and must not 500
+            except (InputCheckError, ValueError) as e:
                 raise HTTPException(status_code=400, detail=str(e))
 
     @router.post(

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -751,7 +751,6 @@ def get_team_router(
                     queue_worker is not None
                     and getattr(team, "db", None) is not None
                     and payload_is_queueable(queued_stream_payload)
-                    and not isinstance(team, RemoteTeam)
                     and version is None
                     and not (base64_images or base64_audios or base64_videos or document_files)
                     and any(
@@ -764,7 +763,7 @@ def get_team_router(
                     validate_seam_input(team, message)
                     assert queue_worker is not None  # narrowed by stream_queueable
                     queued_run_id = str(uuid4())
-                    queued_session_id = session_id or str(uuid4())
+                    queued_session_id = session_id  # non-empty: defaulted at the top of the endpoint
                     job = QueuedJob(
                         id=queued_run_id,
                         component_type="team",
@@ -875,7 +874,7 @@ def get_team_router(
                 # 202 must honor input_schema exactly like the inline path (400)
                 validate_seam_input(team, message)
                 queued_run_id = str(uuid4())
-                queued_session_id = session_id or str(uuid4())
+                queued_session_id = session_id  # non-empty: defaulted at the top of the endpoint
                 job = QueuedJob(
                     id=queued_run_id,
                     component_type="team",
@@ -1374,7 +1373,6 @@ def get_team_router(
             )
             if (
                 queue_worker is not None
-                and not isinstance(team, RemoteTeam)
                 and team_is_queueable
                 and not fork
                 and not regenerate

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1563,7 +1563,6 @@ def get_workflow_router(
                 stream_queueable = (
                     queue_worker is not None
                     and getattr(workflow, "db", None) is not None
-                    and not isinstance(workflow, RemoteWorkflow)
                     and version is None
                     and payload_is_queueable(queued_stream_payload)
                     and any(
@@ -1578,7 +1577,7 @@ def get_workflow_router(
                     from agno.run.base import RunStatus as _RS
 
                     queued_run_id = str(uuid4())
-                    queued_session_id = session_id or str(uuid4())
+                    queued_session_id = session_id  # non-empty: defaulted at the top of the endpoint
                     job = QueuedJob(
                         id=queued_run_id,
                         component_type="workflow",
@@ -1676,7 +1675,6 @@ def get_workflow_router(
             queued_payload = {"input": message, "kwargs": kwargs}
             if (
                 queue_worker is not None
-                and not isinstance(workflow, RemoteWorkflow)
                 and component_is_queueable
                 and version is None  # version-pinned resolution differs from the worker's registry instance
                 and payload_is_queueable(queued_payload)
@@ -1684,7 +1682,7 @@ def get_workflow_router(
                 # 202 must honor input_schema exactly like the inline path (400)
                 validate_seam_input(workflow, message)
                 queued_run_id = str(uuid4())
-                queued_session_id = session_id or str(uuid4())
+                queued_session_id = session_id  # non-empty: defaulted at the top of the endpoint
                 job = QueuedJob(
                     id=queued_run_id,
                     component_type="workflow",
@@ -1918,6 +1916,7 @@ def get_workflow_router(
         if not getattr(existing_run, "is_paused", False):
             status = getattr(existing_run, "status", None)
             _status_to_detail = {
+                RunStatus.pending: "run is already pending",
                 RunStatus.running: "run is already running",
                 RunStatus.completed: "run is already completed",
                 RunStatus.error: "run has errored",
@@ -1957,12 +1956,7 @@ def get_workflow_router(
                 getattr(candidate, "id", None) == workflow_id and not isinstance(candidate, WorkflowFactory)
                 for candidate in (os.workflows or [])
             )
-            if (
-                queue_worker is not None
-                and not isinstance(workflow, RemoteWorkflow)
-                and workflow_is_queueable
-                and payload_is_queueable(continue_payload)
-            ):
+            if queue_worker is not None and workflow_is_queueable and payload_is_queueable(continue_payload):
                 # The endpoint already proved the run row is PAUSED above
                 continue_outcome = await acontinue_via_queue(
                     queue_worker,

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1572,7 +1572,7 @@ def get_workflow_router(
                     )
                 )
                 if stream_queueable:
-                    # 202/stream-accept must honor input_schema like the inline path
+                    # 202/stream-accept must honor input_schema like the inline path (400)
                     validate_seam_input(workflow, message)
                     assert queue_worker is not None  # narrowed by stream_queueable
                     from agno.run.base import RunStatus as _RS
@@ -1681,7 +1681,7 @@ def get_workflow_router(
                 and version is None  # version-pinned resolution differs from the worker's registry instance
                 and payload_is_queueable(queued_payload)
             ):
-                # 202 must honor input_schema exactly like the inline path 422s
+                # 202 must honor input_schema exactly like the inline path (400)
                 validate_seam_input(workflow, message)
                 queued_run_id = str(uuid4())
                 queued_session_id = session_id or str(uuid4())
@@ -1757,15 +1757,21 @@ def get_workflow_router(
                         "accepting replica instead - bounded and observable, but NOT durable."
                     )
 
-            run_response = await workflow.arun(
-                input=message,
-                session_id=session_id,
-                user_id=user_id,
-                stream=False,
-                background=True,
-                background_tasks=background_tasks,
-                **kwargs,
-            )
+            # Same input-error contract as the inline path: without this,
+            # the non-durable background fallback answered 500 for the exact
+            # payload the other doors answer 400
+            try:
+                run_response = await workflow.arun(
+                    input=message,
+                    session_id=session_id,
+                    user_id=user_id,
+                    stream=False,
+                    background=True,
+                    background_tasks=background_tasks,
+                    **kwargs,
+                )
+            except (InputCheckError, ValueError) as e:
+                raise HTTPException(status_code=400, detail=str(e))
             return JSONResponse(
                 status_code=202,
                 content={
@@ -1805,7 +1811,9 @@ def get_workflow_router(
                 )
                 return run_response.to_dict()
 
-        except InputCheckError as e:
+        # ValueError alongside InputCheckError: a bare schema ValueError
+        # from the dispatch is the same client mistake and must not 500
+        except (InputCheckError, ValueError) as e:
             raise HTTPException(status_code=400, detail=str(e))
         # No blanket 500 (agents parity): the old except Exception swallowed
         # every typed error - including HTTPException itself, converting 4xx

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1755,9 +1755,12 @@ def get_workflow_router(
                         "accepting replica instead - bounded and observable, but NOT durable."
                     )
 
-            # Same input-error contract as the inline path: without this,
-            # the non-durable background fallback answered 500 for the exact
-            # payload the other doors answer 400
+            # Same input-error contract as the inline path: schema violations
+            # are refused up front (the dispatch's own schema ValueError is
+            # indistinguishable from an internal one, so it is not caught -
+            # internal failures keep their generic 500), and guardrail
+            # refusals from the dispatch answer 400.
+            validate_seam_input(workflow, message)
             try:
                 run_response = await workflow.arun(
                     input=message,
@@ -1768,7 +1771,7 @@ def get_workflow_router(
                     background_tasks=background_tasks,
                     **kwargs,
                 )
-            except (InputCheckError, ValueError) as e:
+            except InputCheckError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             return JSONResponse(
                 status_code=202,
@@ -1799,6 +1802,11 @@ def get_workflow_router(
                 if auth_token and isinstance(workflow, RemoteWorkflow):
                     kwargs["auth_token"] = auth_token
 
+                # Schema violations are refused up front with the seams'
+                # shared check: the dispatch's own schema ValueError is
+                # indistinguishable from an internal one, so it is not
+                # caught - internal failures keep their generic 500.
+                validate_seam_input(workflow, message)
                 run_response = await workflow.arun(
                     input=message,
                     session_id=session_id,
@@ -1809,9 +1817,7 @@ def get_workflow_router(
                 )
                 return run_response.to_dict()
 
-        # ValueError alongside InputCheckError: a bare schema ValueError
-        # from the dispatch is the same client mistake and must not 500
-        except (InputCheckError, ValueError) as e:
+        except InputCheckError as e:
             raise HTTPException(status_code=400, detail=str(e))
         # No blanket 500 (agents parity): the old except Exception swallowed
         # every typed error - including HTTPException itself, converting 4xx

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -21,7 +21,13 @@ from pydantic import BaseModel
 
 from agno.db.base import BaseDb
 from agno.db.schemas.jobs import QueuedJob
-from agno.exceptions import ComponentRehydrationError, InputCheckError, OutputCheckError
+from agno.exceptions import (
+    ComponentRehydrationError,
+    InputCheckError,
+    OutputCheckError,
+    RunNotContinuableError,
+    RunNotFoundError,
+)
 from agno.factory import FactoryContextRequired
 from agno.os.auth import (
     get_auth_token_from_request,
@@ -1795,9 +1801,10 @@ def get_workflow_router(
 
         except InputCheckError as e:
             raise HTTPException(status_code=400, detail=str(e))
-        except Exception as e:
-            # Handle unexpected runtime errors
-            raise HTTPException(status_code=500, detail=f"Error running workflow: {str(e)}")
+        # No blanket 500 (agents parity): the old except Exception swallowed
+        # every typed error - including HTTPException itself, converting 4xx
+        # into 500 - and echoed raw internals in the detail. Uncaught
+        # exceptions propagate to FastAPI's generic 500.
 
     @router.post(
         "/workflows/{workflow_id}/runs/{run_id}/continue",
@@ -2060,10 +2067,17 @@ def get_workflow_router(
                     final_status=getattr(run_response, "status", None),
                 )
                 return run_response.to_dict()
-            except InputCheckError as e:
+            # Same typed mapping as the agents continue endpoint: a
+            # race-losing continue (the run moved past PAUSED between the
+            # pre-check and dispatch) must answer 404/409/400 like the
+            # pre-check would have, never a blanket 500. Anything untyped
+            # propagates (FastAPI's 500, without echoing internals).
+            except RunNotFoundError as e:
+                raise HTTPException(status_code=404, detail=str(e))
+            except RunNotContinuableError as e:
+                raise HTTPException(status_code=409, detail=str(e))
+            except (InputCheckError, ValueError) as e:
                 raise HTTPException(status_code=400, detail=str(e))
-            except Exception as e:
-                raise HTTPException(status_code=500, detail=f"Error continuing workflow run: {str(e)}")
 
     @router.post(
         "/workflows/{workflow_id}/runs/{run_id}/cancel",

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1541,6 +1541,16 @@ def get_workflow_router(
                 raise HTTPException(
                     status_code=400, detail="Background execution is not supported for remote workflows"
                 )
+            # The db requirement gates BOTH shapes here: the non-stream
+            # branch always 400ed, while the stream branch used to enter the
+            # detached streamer and let arun(background=True) raise - the
+            # same misconfiguration answered 200 + SSE error frame,
+            # indistinguishable from a runtime failure.
+            if not workflow.db:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Background execution requires a database to be configured on the workflow",
+                )
 
             if stream:
                 # Durable queued streaming: the queue row is the acceptance,
@@ -1648,13 +1658,9 @@ def get_workflow_router(
                     media_type="text/event-stream",
                 )
 
-            # background=True, stream=False: return 202 immediately with run metadata
-            if not workflow.db:
-                raise HTTPException(
-                    status_code=400,
-                    detail="Background execution requires a database to be configured on the workflow",
-                )
-
+            # background=True, stream=False: return 202 immediately with run
+            # metadata (the db requirement was enforced at the top of the
+            # background branch, for both shapes)
             # Durable queue path: acceptance is a committed row; whichever
             # replica's worker claims the job executes it, surviving crashes
             # and deploys. Client contract identical: 202 + poll.

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -274,6 +274,11 @@ def format_sse_event_with_index(
         return f"event: message\ndata: {clean_json}\n\n"
 
 
+# Idle window between tail items before a keepalive (and the settled-ticket
+# truth probe) fires; module-level so tests can shrink it.
+_TAIL_IDLE_RECHECK_SECONDS = 30.0
+
+
 def sse_error_frame(message: str) -> str:
     """A wire-safe SSE error frame.
 
@@ -331,8 +336,39 @@ async def queued_run_tail_streamer(run_id: str, from_index: Optional[int] = None
     try:
         while True:
             try:
-                item = await asyncio.wait_for(tail_queue.get(), timeout=30.0)
+                item = await asyncio.wait_for(tail_queue.get(), timeout=_TAIL_IDLE_RECHECK_SECONDS)
             except asyncio.TimeoutError:
+                # Idle recheck. If the durable ticket has SETTLED while the
+                # stream never received its terminal sentinel (a lost
+                # terminal write - the producer died between settling the
+                # ticket and closing the stream), nothing will ever end this
+                # tail: it used to keepalive silently until the stream state
+                # expired. Tell the client the truth instead, once, and end -
+                # the complete output is guaranteed via the run row.
+                closed_frame: Optional[str] = None
+                with contextlib.suppress(Exception):
+                    from agno.os.job_queue import get_active_queue_worker, ticket_status_to_api
+
+                    worker = get_active_queue_worker()
+                    job = await worker.store.get_job(run_id) if worker is not None else None
+                    if (
+                        job is not None
+                        and job.get("job_type", "run") == "run"
+                        and job.get("status") in ("completed", "failed", "cancelled")
+                    ):
+                        stream_status = await event_stream.get_run_status(run_id)
+                        if stream_status is None or stream_status in (RunStatus.pending, RunStatus.running):
+                            payload = {
+                                "event": "stream_expired",
+                                "run_id": run_id,
+                                "status": ticket_status_to_api(job.get("status", "")) or "ERROR",
+                                "message": "The run finished but its stream lost the terminal event; "
+                                "poll the run for the complete output.",
+                            }
+                            closed_frame = f"event: stream_expired\ndata: {json.dumps(payload)}\n\n"
+                if closed_frame is not None:
+                    yield closed_frame
+                    return
                 yield ": keepalive\n\n"
                 continue
             if item is None:

--- a/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
+++ b/libs/agno/tests/unit/os/test_acceptance_truthfulness.py
@@ -430,3 +430,38 @@ class TestSubmitBackgroundBodyParity:
             f"{path}: the non-durable 202 body must match the durable seam's shape exactly, got {body}"
         )
         assert body["status"] in ("PENDING", "RUNNING")
+
+
+class TestServerErrorsDoNotEchoInternals:
+    """N17: seam store failures and unhandled server errors surfaced as raw
+    500s whose detail embedded str(exc) - store/driver text carries
+    connection strings, SQL fragments, and hostnames. The wire gets the
+    exception type; the full detail stays in the server log."""
+
+    SECRET = "postgresql://ai:supersecret@db.internal:5532/ai"
+
+    def test_prepare_failure_500_names_the_type_not_the_driver_text(self, harness, monkeypatch):
+        async def broken_prepare(component, component_type, run_id, session_id, user_id, input):
+            raise RuntimeError(f"connection refused at {TestServerErrorsDoNotEchoInternals.SECRET}")
+
+        monkeypatch.setattr("agno.os.job_queue.aprepare_queued_run", broken_prepare)
+        resp = harness.client.post(
+            "/agents/qa-agent/runs", data={"message": "hi", "stream": "false", "background": "true"}
+        )
+        assert resp.status_code == 500
+        assert self.SECRET not in resp.text, "the 500 detail must not echo driver internals"
+        assert "RuntimeError" in resp.json()["detail"], "the type name is the client-safe breadcrumb"
+
+    def test_unhandled_exception_500_names_the_type_not_the_message(self, harness, monkeypatch):
+        from agno.agent import Agent
+
+        async def broken_arun(self, **kwargs):
+            raise RuntimeError(f"cannot reach {TestServerErrorsDoNotEchoInternals.SECRET}")
+
+        monkeypatch.setattr(Agent, "arun", broken_arun)
+        resp = harness.client.post(
+            "/agents/qa-agent/runs", data={"message": "hi", "stream": "false", "background": "false"}
+        )
+        assert resp.status_code == 500
+        assert self.SECRET not in resp.text, "the app-level handler must not echo str(exc) on 5xx"
+        assert "RuntimeError" in resp.json()["detail"]

--- a/libs/agno/tests/unit/os/test_continue_seam.py
+++ b/libs/agno/tests/unit/os/test_continue_seam.py
@@ -948,3 +948,36 @@ class TestInlineContinueSeedsExpiredCounter:
         assert reads == [], "a live counter must not cost a session read"
         idx = await stream.add_event("r1", RunContentEvent(content="b", run_id="r1"))
         assert idx == 1
+
+
+class TestPausedGate409CarriesEscapeHatch:
+    @pytest.mark.asyncio
+    async def test_paused_ticket_409_names_the_row_missing_escape(self):
+        """When the run ROW is lost while its paused ticket survives,
+        background=true fails not-found and falls through to this gate:
+        without the escape-hatch sentence, the 409 told the caller to do
+        exactly what it just did (a self-referential dead end)."""
+        from types import SimpleNamespace
+
+        from fastapi import HTTPException
+
+        from agno.os.job_queue import araise_if_ticket_owns_continue
+
+        store = InMemoryQueueStore()
+        store._jobs["r-lostrow"] = QueuedJob(
+            id="r-lostrow",
+            component_type="agent",
+            component_id="a1",
+            session_id="s1",
+            payload={},
+            status="paused",
+        ).to_dict()
+        worker = SimpleNamespace(store=store)
+
+        with pytest.raises(HTTPException) as excinfo:
+            await araise_if_ticket_owns_continue(worker, "r-lostrow", component_type="agent", component_id="a1")
+
+        assert excinfo.value.status_code == 409
+        assert "requeue the ticket" in excinfo.value.detail, (
+            "the 409 must carry the cancel+requeue escape hatch for the lost-row corner"
+        )

--- a/libs/agno/tests/unit/os/test_events_buffer.py
+++ b/libs/agno/tests/unit/os/test_events_buffer.py
@@ -155,3 +155,48 @@ class TestMultipleRuns:
         assert len(events_b) == 2
         assert events_b[0][0] == 6
         assert events_b[0][1].content == "b6"
+
+
+class TestPendingReap:
+    """Accept-side PENDING registrations for runs that execute on another
+    replica never advance locally; without a reap they accumulated forever
+    (the in-memory-stream-with-multi-replica config is warned against, but
+    a warning must not mean a leak)."""
+
+    def test_stale_pending_registration_is_reaped(self):
+        buf = EventsBuffer(max_events_per_run=10, cleanup_interval=60)
+        buf.register_run("r-pending")
+        buf.run_metadata["r-pending"]["last_updated"] -= 3600  # registered an hour ago
+
+        buf.cleanup_runs()
+
+        assert "r-pending" not in buf.run_metadata, "a stale PENDING registration must be reaped"
+
+    def test_fresh_pending_registration_is_kept(self):
+        buf = EventsBuffer(max_events_per_run=10, cleanup_interval=60)
+        buf.register_run("r-pending")
+
+        buf.cleanup_runs()
+
+        assert "r-pending" in buf.run_metadata, "a fresh PENDING registration must survive"
+
+
+class TestBackendRetentionParity:
+    def test_redis_defaults_mirror_the_wired_in_memory_buffer(self):
+        """The Redis stream's docstring claims its retention mirrors the
+        in-memory buffer; the old defaults (1000 events / 3600s) silently cut
+        a /resume client's replay depth 10x when switching backends."""
+        import inspect as _inspect
+
+        pytest = __import__("pytest")
+        pytest.importorskip("fakeredis", reason="fakeredis not installed")
+        from agno.os.event_streams.redis import RedisEventStream
+        from agno.os.managers import event_buffer
+
+        sig = _inspect.signature(RedisEventStream.__init__)
+        assert sig.parameters["maxlen"].default == event_buffer.max_events_per_run, (
+            "Redis maxlen default must mirror the wired in-memory buffer"
+        )
+        assert sig.parameters["ttl_seconds"].default == event_buffer.cleanup_interval, (
+            "Redis ttl default must mirror the wired in-memory cleanup interval"
+        )

--- a/libs/agno/tests/unit/os/test_input_validation_status_parity.py
+++ b/libs/agno/tests/unit/os/test_input_validation_status_parity.py
@@ -1,0 +1,77 @@
+"""One invalid payload, one status: 400 on every pre-acceptance door.
+
+The same schema-violating input used to answer four different shapes:
+422 from the durable seams (whose comments falsely claimed the inline path
+422s), 400 from the inline non-stream door (InputCheckError only - a bare
+schema ValueError was uncaught and 500ed), 500 from the non-durable
+background fallback (no try/except at all), and 200 + SSE error frame when
+streaming. The streaming shape is the SSE contract (headers already sent);
+every other pre-acceptance door now answers 400.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.exceptions import InputCheckError
+from agno.job_queue.config import QueueConfig
+from agno.job_queue.store import InMemoryQueueStore
+from agno.os import AgentOS
+
+
+class StrictInput(BaseModel):
+    quantity: int
+    reason: str
+
+
+@pytest.fixture()
+def harness(tmp_path):
+    db = SqliteDb(db_file=str(tmp_path / "t.db"))
+    agent = Agent(id="qa-agent", name="QA Agent", db=db, input_schema=StrictInput)
+    app = AgentOS(agents=[agent], telemetry=False).get_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    return SimpleNamespace(app=app, client=client)
+
+
+class TestSeamAnswers400:
+    def test_durable_seam_schema_violation_is_400(self, harness):
+        """The seam used to 422 on the false premise that the inline path
+        did; the inline contract is 400 and the seam must match it."""
+        harness.app.state.queue_worker = SimpleNamespace(store=InMemoryQueueStore(), config=QueueConfig(durable=True))
+        resp = harness.client.post(
+            "/agents/qa-agent/runs",
+            data={"message": "not the schema shape", "stream": "false", "background": "true"},
+        )
+        assert resp.status_code == 400, f"expected 400, got {resp.status_code}: {resp.text[:200]}"
+        assert "schema" in resp.json()["detail"].lower()
+
+
+class TestInlineDoorsAnswer400:
+    def test_inline_bare_value_error_is_400(self, harness, monkeypatch):
+        """A bare schema ValueError from the dispatch was uncaught -> 500."""
+
+        async def raising_arun(self, **kwargs):
+            raise ValueError("Input required when input_schema is set")
+
+        monkeypatch.setattr(Agent, "arun", raising_arun)
+        resp = harness.client.post(
+            "/agents/qa-agent/runs", data={"message": "hi", "stream": "false", "background": "false"}
+        )
+        assert resp.status_code == 400, f"expected 400, got {resp.status_code}: {resp.text[:200]}"
+
+    def test_background_fallback_input_error_is_400(self, harness, monkeypatch):
+        """No queue worker: background=true drops to the non-durable
+        in-process fallback, which had no try/except at all -> 500."""
+
+        async def raising_arun(self, **kwargs):
+            raise InputCheckError("input not allowed by schema")
+
+        monkeypatch.setattr(Agent, "arun", raising_arun)
+        resp = harness.client.post(
+            "/agents/qa-agent/runs", data={"message": "hi", "stream": "false", "background": "true"}
+        )
+        assert resp.status_code == 400, f"expected 400, got {resp.status_code}: {resp.text[:200]}"

--- a/libs/agno/tests/unit/os/test_input_validation_status_parity.py
+++ b/libs/agno/tests/unit/os/test_input_validation_status_parity.py
@@ -51,27 +51,52 @@ class TestSeamAnswers400:
 
 
 class TestInlineDoorsAnswer400:
-    def test_inline_bare_value_error_is_400(self, harness, monkeypatch):
-        """A bare schema ValueError from the dispatch was uncaught -> 500."""
-
-        async def raising_arun(self, **kwargs):
-            raise ValueError("Input required when input_schema is set")
-
-        monkeypatch.setattr(Agent, "arun", raising_arun)
+    def test_inline_schema_violation_is_400(self, harness):
+        """The inline non-stream door pre-validates with the seams' shared
+        check: a schema violation answers 400 BEFORE dispatch (it used to
+        surface as the dispatch's bare ValueError -> 500)."""
         resp = harness.client.post(
-            "/agents/qa-agent/runs", data={"message": "hi", "stream": "false", "background": "false"}
+            "/agents/qa-agent/runs",
+            data={"message": "not the schema shape", "stream": "false", "background": "false"},
         )
         assert resp.status_code == 400, f"expected 400, got {resp.status_code}: {resp.text[:200]}"
+        assert "schema" in resp.json()["detail"].lower()
 
-    def test_background_fallback_input_error_is_400(self, harness, monkeypatch):
+    def test_background_fallback_schema_violation_is_400(self, harness):
         """No queue worker: background=true drops to the non-durable
-        in-process fallback, which had no try/except at all -> 500."""
-
-        async def raising_arun(self, **kwargs):
-            raise InputCheckError("input not allowed by schema")
-
-        monkeypatch.setattr(Agent, "arun", raising_arun)
+        fallback, which had no input handling at all -> 500."""
         resp = harness.client.post(
-            "/agents/qa-agent/runs", data={"message": "hi", "stream": "false", "background": "true"}
+            "/agents/qa-agent/runs",
+            data={"message": "not the schema shape", "stream": "false", "background": "true"},
         )
         assert resp.status_code == 400, f"expected 400, got {resp.status_code}: {resp.text[:200]}"
+
+    def test_background_fallback_guardrail_refusal_is_400(self, harness, monkeypatch):
+        async def refusing_arun(self, **kwargs):
+            raise InputCheckError("input not allowed")
+
+        monkeypatch.setattr(Agent, "arun", refusing_arun)
+        resp = harness.client.post(
+            "/agents/qa-agent/runs",
+            data={"message": '{"quantity": 1, "reason": "ok"}', "stream": "false", "background": "true"},
+        )
+        assert resp.status_code == 400, f"expected 400, got {resp.status_code}: {resp.text[:200]}"
+
+
+class TestInternalValueErrorStays500:
+    def test_dispatch_value_error_is_not_misclassified_as_client_error(self, harness, monkeypatch):
+        """A downstream ValueError (e.g. storage code) is a SERVER failure:
+        catching ValueError at the router would answer 400 with the raw
+        message - misclassifying the failure and echoing internals the 5xx
+        policy suppresses."""
+
+        async def broken_arun(self, **kwargs):
+            raise ValueError("db not initialized at postgresql://ai:secret@db.internal/ai")
+
+        monkeypatch.setattr(Agent, "arun", broken_arun)
+        resp = harness.client.post(
+            "/agents/qa-agent/runs",
+            data={"message": '{"quantity": 1, "reason": "ok"}', "stream": "false", "background": "false"},
+        )
+        assert resp.status_code == 500, f"an internal ValueError must stay a 500, got {resp.status_code}"
+        assert "secret" not in resp.text, "the 500 body must not echo the exception message"

--- a/libs/agno/tests/unit/os/test_missing_db_background_submit.py
+++ b/libs/agno/tests/unit/os/test_missing_db_background_submit.py
@@ -1,0 +1,41 @@
+"""Missing-db background submits answer 400 on BOTH stream shapes.
+
+The non-stream branch always 400ed; the stream branch entered the detached
+streamer, where arun(background=True) raised and the generator converted
+it into an SSE error frame under HTTP 200 - the same misconfiguration was
+a clean 400 or a 200-then-error depending on stream, and the streaming
+client could not distinguish it from a runtime failure.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.os import AgentOS
+from agno.team import Team
+from agno.workflow import Workflow
+
+
+@pytest.fixture()
+def harness():
+    agent = Agent(id="qa-agent", name="QA Agent")
+    team = Team(id="qa-team", name="QA Team", members=[agent])
+    workflow = Workflow(id="qa-wf", name="QA Workflow", steps=[])
+    app = AgentOS(agents=[agent], teams=[team], workflows=[workflow], telemetry=False).get_app()
+    return SimpleNamespace(client=TestClient(app, raise_server_exceptions=False))
+
+
+PATHS = ["/agents/qa-agent/runs", "/teams/qa-team/runs", "/workflows/qa-wf/runs"]
+
+
+@pytest.mark.parametrize("path", PATHS)
+@pytest.mark.parametrize("stream", ["true", "false"])
+def test_background_submit_without_db_is_400_on_both_shapes(harness, path, stream):
+    resp = harness.client.post(path, data={"message": "hi", "stream": stream, "background": "true"})
+    assert resp.status_code == 400, (
+        f"{path} stream={stream}: expected a clean 400, got {resp.status_code} - "
+        "a 200-then-SSE-error is indistinguishable from a runtime failure"
+    )
+    assert "requires a database" in resp.json()["detail"]

--- a/libs/agno/tests/unit/os/test_queue_worker.py
+++ b/libs/agno/tests/unit/os/test_queue_worker.py
@@ -2348,3 +2348,38 @@ class TestTerminalRowClaim:
 
         assert len(agent.calls) == 1, f"{outcome_name}: execution must proceed"
         assert (await store.get_job("r1"))["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_row_leaves_claim_stale_instead_of_guessing(self, monkeypatch):
+        """Review catch: with max_attempts > 1, a COMPLETED row whose worker
+        crashed before settling reaches this branch on the reclaim - if the
+        row read then transiently fails, guessing 'cancelled' would settle
+        the ticket and stream as CANCELLED over a COMPLETED row. An
+        unreadable row must leave the claim to go stale for the reconciling
+        sweep, which settles from the truth."""
+        from agno.run.status_persist import RunPersistOutcome
+
+        store = InMemoryQueueStore()
+        agent = FakeAgent()
+
+        async def broken_read(run_id, session_id, user_id=None):
+            raise RuntimeError("session store briefly unreachable")
+
+        agent.aget_run_output = broken_read  # type: ignore[attr-defined]
+
+        async def refused_stamp(*args, **kwargs):
+            return RunPersistOutcome.TERMINAL_REFUSED
+
+        monkeypatch.setattr("agno.run.status_persist.apersist_run_status", refused_stamp)
+
+        worker = make_worker(store, agent, make_config())
+        await store.enqueue_job(make_job("r1"))
+        claimed = await store.claim_job(worker.worker_id)
+        await worker._execute_claimed(claimed)
+
+        assert agent.calls == [], "execution must still be refused - the row IS terminal"
+        job = await store.get_job("r1")
+        assert job["status"] == "running", (
+            f"an unreadable row must leave the claim stale for the sweep, got {job['status']!r} - "
+            "never a manufactured terminal status"
+        )

--- a/libs/agno/tests/unit/os/test_queue_worker.py
+++ b/libs/agno/tests/unit/os/test_queue_worker.py
@@ -2254,3 +2254,21 @@ class TestDrainLifecycle:
             f"ticket must settle failed after the persisted drain, got {(await store.get_job('r1'))['status']} - "
             "RUNNING here means the second cancel interrupted the persist and the drain guarantee broke"
         )
+
+
+class TestPayloadQueueableGate:
+    def test_nan_and_infinity_are_not_queueable(self):
+        """Python's json serializes NaN/Infinity by default but they are NOT
+        valid JSON: Postgres JSONB rejects them at INSERT, so a NaN payload
+        passing this gate 500s the submit instead of falling back to the
+        non-durable path the gate exists to provide."""
+        from agno.os.job_queue import payload_is_queueable
+
+        assert payload_is_queueable({"input": "hi", "kwargs": {"x": float("nan")}}) is False
+        assert payload_is_queueable({"input": "hi", "kwargs": {"x": float("inf")}}) is False
+
+    def test_plain_json_payloads_still_pass(self):
+        from agno.os.job_queue import payload_is_queueable
+
+        assert payload_is_queueable({"input": "hi", "kwargs": {"x": 1.5, "y": [1, "a", None, True]}}) is True
+        assert payload_is_queueable({"input": "hi", "kwargs": {"obj": object()}}) is False

--- a/libs/agno/tests/unit/os/test_queue_worker.py
+++ b/libs/agno/tests/unit/os/test_queue_worker.py
@@ -2290,3 +2290,61 @@ class TestPayloadQueueableGate:
 
         assert payload_is_queueable({"input": "hi", "kwargs": {"x": 1.5, "y": [1, "a", None, True]}}) is True
         assert payload_is_queueable({"input": "hi", "kwargs": {"obj": object()}}) is False
+
+
+class TestTerminalRowClaim:
+    """The cancel crash window: acancel_queued persists the CANCELLED row
+    first, crashes before the ticket tombstone lands, and a worker later
+    claims the still-queued ticket. Executing it ran a cancelled run's side
+    effects and settled the ticket completed over a CANCELLED row - a
+    permanent ticket/row divergence nothing revisits. The RUNNING stamp's
+    TERMINAL_REFUSED outcome already detects the state for free."""
+
+    @pytest.mark.asyncio
+    async def test_cancelled_row_skips_execution_and_settles_ticket(self, monkeypatch):
+        from agno.run.status_persist import RunPersistOutcome
+
+        store = InMemoryQueueStore()
+        agent = FakeAgent()
+
+        async def fake_get_run_output(run_id, session_id, user_id=None):
+            return SimpleNamespace(status=RunStatus.cancelled)
+
+        agent.aget_run_output = fake_get_run_output  # type: ignore[attr-defined]
+
+        async def refused_stamp(*args, **kwargs):
+            return RunPersistOutcome.TERMINAL_REFUSED
+
+        monkeypatch.setattr("agno.run.status_persist.apersist_run_status", refused_stamp)
+
+        worker = make_worker(store, agent, make_config())
+        await store.enqueue_job(make_job("r1"))
+        claimed = await store.claim_job(worker.worker_id)
+        await worker._execute_claimed(claimed)
+
+        assert agent.calls == [], "a cancelled run's side effects must never execute"
+        job = await store.get_job("r1")
+        assert job["status"] == "cancelled", f"the ticket must honor the terminal row, got {job['status']!r}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("outcome_name", ["UPDATED", "UNAVAILABLE", "MISSING"])
+    async def test_non_terminal_stamp_outcomes_still_execute(self, monkeypatch, outcome_name):
+        """Only the guard's exact terminal set (completed/cancelled) skips:
+        ERROR rows and unfenced stores keep executing - the operator requeue
+        re-drive depends on it."""
+        from agno.run.status_persist import RunPersistOutcome
+
+        store = InMemoryQueueStore()
+        agent = FakeAgent()
+
+        async def stamping(*args, **kwargs):
+            return getattr(RunPersistOutcome, outcome_name)
+
+        monkeypatch.setattr("agno.run.status_persist.apersist_run_status", stamping)
+        worker = make_worker(store, agent, make_config())
+        await store.enqueue_job(make_job("r1"))
+        claimed = await store.claim_job(worker.worker_id)
+        await worker._execute_claimed(claimed)
+
+        assert len(agent.calls) == 1, f"{outcome_name}: execution must proceed"
+        assert (await store.get_job("r1"))["status"] == "completed"

--- a/libs/agno/tests/unit/os/test_queue_worker.py
+++ b/libs/agno/tests/unit/os/test_queue_worker.py
@@ -2256,6 +2256,24 @@ class TestDrainLifecycle:
         )
 
 
+class TestRetryDelayFullJitter:
+    def test_first_retry_actually_jitters(self):
+        """The old lower bound of `base` made attempt 1's range [base, base]:
+        zero jitter, so a fleet failing together retried in lockstep at
+        exactly base seconds - the herd the config's promised "full jitter"
+        exists to break up."""
+        worker = make_worker(InMemoryQueueStore(), None, make_config(retry_delay_seconds=30))
+        samples = {worker._retry_delay(1) for _ in range(200)}
+        assert all(0 <= s <= 30 for s in samples)
+        assert len(samples) > 1, "attempt 1 must jitter, not return exactly base every time"
+
+    def test_backoff_grows_and_caps(self):
+        worker = make_worker(InMemoryQueueStore(), None, make_config(retry_delay_seconds=30))
+        assert all(0 <= worker._retry_delay(3) <= 120 for _ in range(50))
+        assert all(0 <= worker._retry_delay(50) <= 300 for _ in range(50)), "capped at 10x base"
+        assert make_worker(InMemoryQueueStore(), None, make_config(retry_delay_seconds=0))._retry_delay(1) == 0
+
+
 class TestPayloadQueueableGate:
     def test_nan_and_infinity_are_not_queueable(self):
         """Python's json serializes NaN/Infinity by default but they are NOT

--- a/libs/agno/tests/unit/os/test_redis_sweep_window.py
+++ b/libs/agno/tests/unit/os/test_redis_sweep_window.py
@@ -1,0 +1,62 @@
+"""Redis sweep detection pages the whole stale range.
+
+The old fixed scan window (num=limit*2) made exhausted jobs invisible on
+every tick when that many stale-but-reclaimable jobs sat ahead of them in
+the running zset - after a mass crash under a retry budget, terminal
+failures were starved indefinitely by the reclaim backlog in front.
+"""
+
+import json
+import time
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis", reason="fakeredis not installed")
+
+from agno.db.redis import RedisDb  # noqa: E402
+from agno.db.schemas.jobs import QueuedJob  # noqa: E402
+
+
+def _seed_stale_running(db: RedisDb, job_id: str, score: int, attempt: int, max_attempts: int, locked_at: int) -> None:
+    job = QueuedJob(
+        id=job_id, component_type="agent", component_id="a1", session_id="s1", payload={}, max_attempts=max_attempts
+    ).to_dict()
+    job.update(status="running", locked_by="w-dead", locked_at=locked_at, attempt=attempt)
+    db.redis_client.set(db._q_job_key(job_id), json.dumps(job))
+    db.redis_client.zadd(db._q_key("running"), {job_id: score})
+
+
+def test_exhausted_job_behind_many_reclaimables_is_found():
+    db = RedisDb(redis_client=fakeredis.FakeRedis(), db_prefix="sweepwin")
+    stale_at = int(time.time()) - 1000
+
+    # 45 stale RECLAIMABLE jobs (attempt < max_attempts) with earlier zset
+    # scores - more than the old fixed window of limit*2 = 40
+    for i in range(45):
+        _seed_stale_running(db, f"reclaim-{i:03d}", score=stale_at + i, attempt=1, max_attempts=2, locked_at=stale_at)
+    # One stale EXHAUSTED job behind them all
+    _seed_stale_running(db, "exhausted-1", score=stale_at + 100, attempt=1, max_attempts=1, locked_at=stale_at)
+
+    swept = db.sweep_exhausted_jobs(lock_grace_seconds=60, limit=20)
+
+    assert "exhausted-1" in [j["id"] for j in swept], (
+        "an exhausted job behind the reclaim backlog must still be detected - the fixed window starved it on every tick"
+    )
+
+
+def test_limit_is_still_respected():
+    db = RedisDb(redis_client=fakeredis.FakeRedis(), db_prefix="sweepwin2")
+    stale_at = int(time.time()) - 1000
+    for i in range(30):
+        _seed_stale_running(db, f"exhausted-{i:03d}", score=stale_at + i, attempt=1, max_attempts=1, locked_at=stale_at)
+
+    swept = db.sweep_exhausted_jobs(lock_grace_seconds=60, limit=20)
+    assert len(swept) == 20
+
+
+def test_healthy_leases_are_not_swept():
+    db = RedisDb(redis_client=fakeredis.FakeRedis(), db_prefix="sweepwin3")
+    now = int(time.time())
+    _seed_stale_running(db, "healthy-1", score=now, attempt=1, max_attempts=1, locked_at=now)
+
+    assert db.sweep_exhausted_jobs(lock_grace_seconds=60, limit=20) == []

--- a/libs/agno/tests/unit/os/test_requeue_zombie_gate.py
+++ b/libs/agno/tests/unit/os/test_requeue_zombie_gate.py
@@ -75,3 +75,20 @@ class TestRequeueZombieGate:
         resp = harness.client.post("/queue/jobs/j4/requeue")
         assert resp.status_code == 200
         assert resp.json()["status"] == "queued"
+
+
+class TestNoWorkerAnswers503:
+    """One operational condition, one status: with no active queue worker,
+    every /queue endpoint answers 503 (service availability) - the old
+    _get_store 404 made the same state a missing resource on read
+    endpoints while the requeue path already said 503."""
+
+    def test_queue_endpoints_answer_503_without_worker(self):
+        app = FastAPI()
+        app.include_router(get_queue_router(SimpleNamespace()))
+        client = TestClient(app, raise_server_exceptions=False)
+
+        for path in ("/queue/jobs", "/queue/jobs/some-id", "/queue/stats"):
+            resp = client.get(path)
+            assert resp.status_code == 503, f"{path}: expected 503, got {resp.status_code}"
+            assert "not enabled" in resp.json()["detail"]

--- a/libs/agno/tests/unit/os/test_stream_expired_close.py
+++ b/libs/agno/tests/unit/os/test_stream_expired_close.py
@@ -98,3 +98,57 @@ class TestHonestClose:
         frames = await collect("r-ok")
         assert any("data:" in f for f in frames), "the real events must replay"
         assert not any(f.startswith("event: stream_expired") for f in frames)
+
+
+class TestSettledTicketBoundsTheKeepalives:
+    """A lost terminal write: the producer died between settling the ticket
+    and closing the stream. Nothing would ever end the tail - it used to
+    keepalive silently until the stream state expired (tens of minutes).
+    The idle recheck now probes the ticket and closes truthfully."""
+
+    @pytest.mark.asyncio
+    async def test_terminal_ticket_with_running_stream_closes_honestly(self, monkeypatch):
+        import asyncio
+
+        import agno.os.job_queue as jq
+        from agno.job_queue.store import InMemoryQueueStore
+        from agno.os.event_streams.in_memory import InMemoryEventStream
+        from agno.os.managers import EventsBuffer, SSESubscriberManager
+        from agno.run.base import RunStatus
+
+        stream = InMemoryEventStream(events_buffer=EventsBuffer(), subscriber_manager=SSESubscriberManager())
+        monkeypatch.setattr("agno.os.event_streams.get_event_stream", lambda: stream)
+        monkeypatch.setattr("agno.os.utils._TAIL_IDLE_RECHECK_SECONDS", 0.05, raising=False)
+
+        # The stream believes the run is still RUNNING (terminal write lost)
+        await stream.register_run("r-lost", RunStatus.pending)
+        await stream.set_run_status("r-lost", RunStatus.running)
+
+        # The ticket settled: the run actually finished
+        store = InMemoryQueueStore()
+        from agno.db.schemas.jobs import QueuedJob
+
+        store._jobs["r-lost"] = QueuedJob(
+            id="r-lost", component_type="agent", component_id="a1", session_id="s1", payload={}, status="completed"
+        ).to_dict()
+        original = jq.get_active_queue_worker()
+        jq.set_active_queue_worker(SimpleNamespace(store=store))
+        try:
+            from agno.os.utils import queued_run_tail_streamer
+
+            frames = []
+
+            async def consume():
+                async for frame in queued_run_tail_streamer("r-lost"):
+                    frames.append(frame)
+                    if len(frames) >= 5:
+                        break
+
+            await asyncio.wait_for(consume(), timeout=5)
+        finally:
+            jq.set_active_queue_worker(original)
+
+        expired = [f for f in frames if f.startswith("event: stream_expired")]
+        assert expired, f"a settled ticket over a running stream must close honestly, got {frames!r}"
+        assert "poll the run" in expired[0]
+        assert frames[-1] == expired[0], "the honest close must END the tail, not keep keepaliving"

--- a/libs/agno/tests/unit/os/test_teams_agents_parity.py
+++ b/libs/agno/tests/unit/os/test_teams_agents_parity.py
@@ -54,6 +54,19 @@ class TestBadDocumentIsSkipped:
         )
 
 
+class TestVersionParamIsTyped:
+    def test_non_numeric_version_is_422_not_500(self, harness):
+        """Component versions are integers; a non-numeric value must fail
+        validation like teams/workflows, not 500 in a bare int() cast."""
+        resp = harness.client.post(
+            "/agents/qa-agent/runs",
+            data={"message": "hi", "stream": "false", "version": "not-a-number"},
+        )
+        assert resp.status_code == 422, (
+            f"non-numeric version must fail validation like teams/workflows, got {resp.status_code}"
+        )
+
+
 class TestDebugLogOmitsMessageContent:
     def test_team_submit_does_not_log_raw_message(self, harness, benign_team_run):
         """Handler attached DIRECTLY to the agno loggers: they do not

--- a/libs/agno/tests/unit/os/test_teams_agents_parity.py
+++ b/libs/agno/tests/unit/os/test_teams_agents_parity.py
@@ -1,0 +1,98 @@
+"""Small teams/agents endpoint divergences: input robustness and log hygiene.
+
+- One unparseable uploaded document must not 500 a team submission (agents
+  skip the file and continue; teams processed it bare).
+- The agents version param is an int like teams/workflows: the old str
+  declaration with a bare int() cast 500ed on non-numeric input where the
+  siblings answer a clean 422.
+- The teams debug line logged raw message content (PII/secrets belong in
+  the run record, not the log stream).
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.os import AgentOS
+from agno.team import Team
+
+
+@pytest.fixture()
+def harness(tmp_path):
+    db = SqliteDb(db_file=str(tmp_path / "t.db"))
+    agent = Agent(id="qa-agent", name="QA Agent", db=db)
+    team = Team(id="qa-team", name="QA Team", members=[agent], db=db)
+    app = AgentOS(agents=[agent], teams=[team], telemetry=False).get_app()
+    return SimpleNamespace(client=TestClient(app, raise_server_exceptions=False))
+
+
+@pytest.fixture()
+def benign_team_run(monkeypatch):
+    async def fake_arun(self, **kwargs):
+        return SimpleNamespace(to_dict=lambda: {"run_id": "r1", "status": "COMPLETED"})
+
+    monkeypatch.setattr(Team, "arun", fake_arun)
+
+
+class TestBadDocumentIsSkipped:
+    def test_unparseable_document_does_not_500_the_submission(self, harness, benign_team_run, monkeypatch):
+        def broken_process_document(file):
+            raise ValueError("unparseable document")
+
+        monkeypatch.setattr("agno.os.routers.teams.router.process_document", broken_process_document)
+        resp = harness.client.post(
+            "/teams/qa-team/runs",
+            data={"message": "hi", "stream": "false"},
+            files={"files": ("bad.pdf", b"\x00garbage", "application/pdf")},
+        )
+        assert resp.status_code == 200, (
+            f"one bad document must be skipped (agents parity), got {resp.status_code}: {resp.text[:200]}"
+        )
+
+
+class TestVersionParamIsTyped:
+    def test_non_numeric_version_is_422_not_500(self, harness):
+        resp = harness.client.post(
+            "/agents/qa-agent/runs",
+            data={"message": "hi", "stream": "false", "version": "not-a-number"},
+        )
+        assert resp.status_code == 422, (
+            f"non-numeric version must fail validation like teams/workflows, got {resp.status_code}"
+        )
+
+
+class TestDebugLogOmitsMessageContent:
+    def test_team_submit_does_not_log_raw_message(self, harness, benign_team_run):
+        """Handler attached DIRECTLY to the agno loggers: they do not
+        propagate to root, so caplog alone captures nothing and the test
+        would pass vacuously."""
+        records = []
+        handler = logging.Handler(level=logging.DEBUG)
+        handler.emit = lambda record: records.append(record)  # type: ignore[method-assign]
+        import agno.utils.log as agno_log
+
+        touched = []
+        # The router's `logger` binding is whichever module-global object was
+        # current at import; cover both concrete loggers.
+        for logger_obj in (agno_log.agent_logger, agno_log.team_logger):
+            old_level = logger_obj.level
+            logger_obj.addHandler(handler)
+            logger_obj.setLevel(logging.DEBUG)
+            touched.append((logger_obj, old_level))
+        try:
+            resp = harness.client.post(
+                "/teams/qa-team/runs",
+                data={"message": "SECRET-PAYLOAD-42", "stream": "false"},
+            )
+        finally:
+            for logger_obj, old_level in touched:
+                logger_obj.removeHandler(handler)
+                logger_obj.setLevel(old_level)
+        assert resp.status_code == 200
+        assert records, "the debug line must have been captured - otherwise this test proves nothing"
+        offending = [r for r in records if "SECRET-PAYLOAD-42" in str(r.getMessage())]
+        assert offending == [], "user message content must not appear in the log stream"

--- a/libs/agno/tests/unit/os/test_teams_agents_parity.py
+++ b/libs/agno/tests/unit/os/test_teams_agents_parity.py
@@ -54,17 +54,6 @@ class TestBadDocumentIsSkipped:
         )
 
 
-class TestVersionParamIsTyped:
-    def test_non_numeric_version_is_422_not_500(self, harness):
-        resp = harness.client.post(
-            "/agents/qa-agent/runs",
-            data={"message": "hi", "stream": "false", "version": "not-a-number"},
-        )
-        assert resp.status_code == 422, (
-            f"non-numeric version must fail validation like teams/workflows, got {resp.status_code}"
-        )
-
-
 class TestDebugLogOmitsMessageContent:
     def test_team_submit_does_not_log_raw_message(self, harness, benign_team_run):
         """Handler attached DIRECTLY to the agno loggers: they do not

--- a/libs/agno/tests/unit/os/test_workflow_typed_errors.py
+++ b/libs/agno/tests/unit/os/test_workflow_typed_errors.py
@@ -48,7 +48,7 @@ def harness(tmp_path):
                 created_at=int(time.time()),
             )
         )
-    return SimpleNamespace(client=client)
+    return SimpleNamespace(client=client, db=db)
 
 
 class TestContinueTypedErrorMapping:
@@ -93,3 +93,32 @@ class TestSubmitBlanket500Removed:
         )
         assert resp.status_code == 429, f"typed HTTPException must propagate, got {resp.status_code}: {resp.text}"
         assert resp.json()["detail"] == "model rate limited"
+
+
+class TestPendingWordingInPausedGate:
+    def test_queued_pending_run_gets_specific_wording(self, harness):
+        """The workflow continue status map had no pending entry: a
+        queued-PENDING run answered the generic not-paused wording while
+        agents say "run is already pending"."""
+        runs_table = harness.db._get_table(table_type="runs", create_table_if_not_found=True)
+        with harness.db.Session() as sess, sess.begin():
+            sess.execute(
+                runs_table.insert().values(
+                    run_id="r-wf-pending",
+                    session_id="s-wf",
+                    run_type="workflow",
+                    workflow_id="qa-wf",
+                    status="PENDING",
+                    run_index=1,
+                    run_data=json.dumps(
+                        {"run_id": "r-wf-pending", "session_id": "s-wf", "workflow_id": "qa-wf", "status": "PENDING"}
+                    ),
+                    created_at=int(time.time()),
+                )
+            )
+        resp = harness.client.post(
+            "/workflows/qa-wf/runs/r-wf-pending/continue",
+            data={"session_id": "s-wf", "stream": "false", "background": "false"},
+        )
+        assert resp.status_code == 409
+        assert resp.json()["detail"] == "run is already pending", f"got {resp.json()['detail']!r}"

--- a/libs/agno/tests/unit/os/test_workflow_typed_errors.py
+++ b/libs/agno/tests/unit/os/test_workflow_typed_errors.py
@@ -1,0 +1,95 @@
+"""Workflow inline endpoints map typed errors like the agents endpoints.
+
+The non-stream inline continue caught only InputCheckError and blanket-500ed
+everything else: a race-losing continue (RunNotFoundError,
+RunNotContinuableError, or the core's not-paused ValueError slipping past
+the pre-check) surfaced as 500 "Error continuing workflow run: ..." where
+agents answer 404/409/400. The inline submit's blanket except additionally
+swallowed HTTPException itself and echoed raw internals in the detail.
+"""
+
+import json
+import time
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.db.sqlite import SqliteDb
+from agno.exceptions import RunNotContinuableError, RunNotFoundError
+from agno.os import AgentOS
+from agno.workflow import Workflow
+
+
+@pytest.fixture()
+def harness(tmp_path):
+    db = SqliteDb(db_file=str(tmp_path / "t.db"))
+    workflow = Workflow(id="qa-wf", name="QA Workflow", db=db, steps=[])
+    app = AgentOS(workflows=[workflow], telemetry=False).get_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    sessions_table = db._get_table(table_type="sessions", create_table_if_not_found=True)
+    runs_table = db._get_table(table_type="runs", create_table_if_not_found=True)
+    with db.Session() as sess, sess.begin():
+        sess.execute(
+            sessions_table.insert().values(session_id="s-wf", session_type="workflow", created_at=int(time.time()))
+        )
+        sess.execute(
+            runs_table.insert().values(
+                run_id="r-wf-paused",
+                session_id="s-wf",
+                run_type="workflow",
+                workflow_id="qa-wf",
+                status="PAUSED",
+                run_index=0,
+                run_data=json.dumps(
+                    {"run_id": "r-wf-paused", "session_id": "s-wf", "workflow_id": "qa-wf", "status": "PAUSED"}
+                ),
+                created_at=int(time.time()),
+            )
+        )
+    return SimpleNamespace(client=client)
+
+
+class TestContinueTypedErrorMapping:
+    @pytest.mark.parametrize(
+        "raised,expected_status",
+        [
+            (RunNotFoundError("run r-wf-paused not found"), 404),
+            (RunNotContinuableError("run r-wf-paused is not continuable"), 409),
+            (ValueError("Cannot continue a workflow run that is not paused"), 400),
+        ],
+    )
+    def test_race_losing_continue_answers_typed(self, harness, monkeypatch, raised, expected_status):
+        """The pre-check passes (the seeded run is PAUSED); the dispatch then
+        loses the race and raises - the answer must be the same status the
+        pre-check would have given, never a blanket 500."""
+
+        async def racing_continue(self, **kwargs):
+            raise raised
+
+        monkeypatch.setattr(Workflow, "acontinue_run", racing_continue)
+        resp = harness.client.post(
+            "/workflows/qa-wf/runs/r-wf-paused/continue",
+            data={"session_id": "s-wf", "stream": "false", "background": "false"},
+        )
+        assert resp.status_code == expected_status, f"expected {expected_status}, got {resp.status_code}: {resp.json()}"
+
+
+class TestSubmitBlanket500Removed:
+    def test_http_exception_is_not_flattened_to_500(self, harness, monkeypatch):
+        """The old blanket except Exception caught HTTPException itself,
+        flattening any typed 4xx raised inside the dispatch into a 500
+        "Error running workflow: ..." - agents let it propagate."""
+        from fastapi import HTTPException
+
+        async def refusing_arun(self, **kwargs):
+            raise HTTPException(status_code=429, detail="model rate limited")
+
+        monkeypatch.setattr(Workflow, "arun", refusing_arun)
+        resp = harness.client.post(
+            "/workflows/qa-wf/runs",
+            data={"message": "hi", "stream": "false", "background": "false"},
+        )
+        assert resp.status_code == 429, f"typed HTTPException must propagate, got {resp.status_code}: {resp.text}"
+        assert resp.json()["detail"] == "model rate limited"


### PR DESCRIPTION
## Summary

Wave 3 of the AgentOS reliability review follow-ups: the polish tier - the findings both external reviews rated real but low-stakes. One commit per item, each fix commit with a regression test proven failing on unfixed source. Nothing here can corrupt state; the theme is consistent behavior, honest errors, and truthful docs. Fifteen commits (fourteen items + one self-caught correction).

### Queue-engine smalls

1. **Payload gate rejects NaN/Infinity** - Python's `json.dumps` serializes them by default but Postgres JSONB rejects them at INSERT: a NaN payload passed the queueable gate and then 500ed the submit, the exact failure the gate exists to route to the non-durable fallback.
2. **Retry backoff delivers real full jitter** - attempt 1's range was `randint(base, base)`: zero jitter, so a fleet-wide failure retried in lockstep at exactly `base` seconds. Now uniform in `[0, min(base·2^(N-1), 10·base)]`, the AWS full-jitter shape the config always promised.
3. **Redis sweep pages the whole stale range** - the fixed `num=limit*2` window made exhausted jobs invisible on every tick when that many stale-but-reclaimable jobs sat ahead of them; after a mass crash under a retry budget, terminal failures were starved indefinitely.
4. **A claimed job never executes over a terminal run row** - the cancel crash window (row CANCELLED persisted, crash before the ticket tombstone) left a queued ticket whose execution ran a cancelled run's side effects and settled the ticket completed over a CANCELLED row. The worker's pre-execution RUNNING stamp already detects this for free (the fenced primitive's `TERMINAL_REFUSED` fires on exactly completed/cancelled); it was just being ignored. ERROR rows are not in that set, so operator requeue re-drives are unaffected (pinned).
5. **A settled ticket bounds the tail's silent keepalives** - when the producer died between settling the ticket and writing the stream sentinel, the tail kept keepaliving until stream-state expiry (tens of minutes). The idle recheck now probes the ticket and closes with one honest `stream_expired` frame carrying the poll-the-run guidance.

### Error-shape hygiene

6. **Workflow inline endpoints map typed errors like agents** - race-losing continues (`RunNotFoundError`/`RunNotContinuableError`/not-paused `ValueError`) answered blanket-500s where agents answer 404/409/400; the submit's blanket except additionally swallowed `HTTPException` itself, flattening typed 4xx into 500.
7. **Missing-db background submit answers 400 on both stream shapes** - the stream branch used to enter the detached streamer and convert the inevitable failure into an SSE error frame under HTTP 200, indistinguishable from a runtime failure. Three routers.
8. **One status for invalid input on every pre-acceptance door** - the same schema-violating payload answered 422 (seams), 400 (inline, `InputCheckError` only - a bare `ValueError` 500ed), or 500 (background fallback, no try/except at all). Everything pre-acceptance now answers 400, matching the long-standing inline contract; `validate_seam_input`'s false "the inline path 422s" docstring corrected. (The streaming 200-plus-error-frame stays: headers already sent - that is the SSE contract.)
9. **5xx responses never echo exception internals** - the app-level handler and the seam's prepare-abort detail embedded `str(exc)`; store/driver failure text carries connection strings, SQL fragments, hostnames. 5xx details now name the exception type only; full tracebacks stay in the server log. 4xx exceptions keep their client-facing messages.
10. **`/queue` answers 503 consistently when no worker is active** - read endpoints 404ed while the requeue path already answered 503 for the same operational condition.

### Consistency, dead code, docs

11. **Stream backends actually mirror retention; stale PENDING reap** - Redis defaults (1000 events/3600s) silently cut `/resume` replay depth 10x versus the wired in-memory buffer (10000/1800) its docstring claimed to mirror; now aligned and pinned by a parity test. The in-memory cleanup also reaps stale PENDING registrations (accept-side entries for runs executed on other replicas accumulated forever).
12. **Dead branches, stale bits, dead-end message** - unreachable `not isinstance(x, Remote*)` conditions inside the background gates (remote is rejected above them) and the dead `session_id or uuid4()` fallbacks removed; the workflow continue status map gains its missing `pending` wording; the lost-row 409 (paused ticket, missing run row) no longer instructs the caller to do what it just did - it carries the cancel-plus-requeue escape hatch.
13. **Teams/agents divergences** - teams' document processing wrapped (one bad upload 500ed the submission; agents skip it), the teams continue streamer gains the `except CancelledError` every sibling has, and the teams debug line stops logging raw message content. **One sub-item deliberately deferred for a product call:** teams filter accumulator `RunOutput` chunks off the SSE wire while agents yield them - either direction is a wire-format change for existing clients. **Settled after some back-and-forth (visible in the commit history):** component versions are integers - the agents `version` param is `Optional[int]` like teams/workflows, replacing the old str declaration whose bare `int()` cast 500ed on non-numeric input.
14. **QueueConfig states the multi-replica uniformity doctrine** - the timing/budget fields must be uniform across replicas sharing a queue table, and rolling changes to `lock_grace_seconds` should only ever raise it, sweepers first. This was documented nowhere; the misconfiguration mode existed only for `deployment_id`.
15. **Correction (self-caught during the mypy gate):** the dead-branch cleanup initially deleted the remote guard from the wrong teams gate - the continue gate's check is live (teams continue has no up-front remote rejection). Restored with a comment naming why it is not dead; the submit gate's genuinely dead twin removed instead.

## Type of change

- [x] Bug fix
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Test surface: 2,323 unit tests green across `unit/os` + `unit/run`; 122 integration tests green against live Postgres and Redis, including the four-store parity matrix and the heartbeat-thread starvation suites.
- Every behavior-changing commit carries a stash-proven regression test; the dead-code commit relies on the existing suites (deletions of unreachable code) plus tests for its two message fixes.
- `validate.sh` mypy: only the known ambient stub noise (redis-py 7.4.1 in the local venv; CI's pin is clean). The Redis sweep refactor shifts two errors of the same pre-existing stub pattern onto new lines - same class, same exemption.
- Two client-visible status changes to be aware of when reviewing: seam schema violations moved 422 -> 400 (unifying on the long-standing inline contract; nothing pinned the seam's 422), and `/queue` no-worker moved 404 -> 503. Both are called out in their commit messages.
- With this wave, every finding from both external reviews is fixed, pinned, or closed as a documented decision. Remaining board: the accumulator-framing product call (item 13), the docs-repo taxonomy handoff, and the step-checkpoint design doc.